### PR TITLE
Fix a crash caseud by None type reference in Veritesting

### DIFF
--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -464,9 +464,10 @@ class Veritesting(Analysis):
             successors = path.successors
 
             # Get all unconstrained successors, and save them out
-            for s in path.next_run.unconstrained_successors:
-                u_path = Path(self._p, s, path=path)
-                path_group.stashes['unconstrained'].append(u_path)
+            if path.next_run:
+                for s in path.next_run.unconstrained_successors:
+                    u_path = Path(self._p, s, path=path)
+                    path_group.stashes['unconstrained'].append(u_path)
 
             # Record their guards :-)
             for successing_path in successors:


### PR DESCRIPTION
Fix a crash when path.next_run is None in veritesting#generate_successors

I think this crash occurs when there is no more active blocks to go.
```
Traceback (most recent call last):
  File "ci2.py", line 30, in <module>
    pg = ex.run()
  File "/usr/local/lib/python2.7/dist-packages/angr/surveyor.py", line 240, in run
    self.step()
  File "/usr/local/lib/python2.7/dist-packages/angr/surveyor.py", line 217, in step
    self.tick()
  File "/usr/local/lib/python2.7/dist-packages/angr/surveyor.py", line 321, in tick
    **self._veritesting_options)
  File "/usr/local/lib/python2.7/dist-packages/angr/analysis.py", line 69, in _analysis
    a = analysis(self._p, fail_fast, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/angr/analysis.py", line 125, in __core_init__
    self.__analysis_init__(*args, **kwargs)  # pylint:disable=no-member
  File "/usr/local/lib/python2.7/dist-packages/angr/analyses/veritesting.py", line 273, in __init__
    result, final_path_group = self._veritesting()
  File "/usr/local/lib/python2.7/dist-packages/angr/analyses/veritesting.py", line 291, in _veritesting
    new_path_group = self._execute_and_merge(p)
  File "/usr/local/lib/python2.7/dist-packages/angr/analyses/veritesting.py", line 530, in _execute_and_merge
    path_group.step(successor_func=generate_successors, check_func=is_path_errored)
  File "/usr/local/lib/python2.7/dist-packages/angr/path_group.py", line 509, in step
    pg = pg._one_step(stash=stash, selector_func=selector_func, successor_func=successor_func, check_func=check_func, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/angr/path_group.py", line 300, in _one_step
    successors = successor_func(a)
  File "/usr/local/lib/python2.7/dist-packages/angr/analyses/veritesting.py", line 467, in generate_successors
    for s in path.next_run.unconstrained_successors:
AttributeError: 'NoneType' object has no attribute 'unconstrained_successors'
```