### PR TITLE
Fix `get_paths` bad indentation

### DIFF
--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -157,7 +157,7 @@ class VFG(Analysis):
         for p in paths:
             runs = map(self.irsb_from_node, p)
             a_paths.append(angr.path.make_path(self.project, runs))
-            return a_paths
+        return a_paths
 
     #
     # Operations


### PR DESCRIPTION
Fix a bad indentation in `get_paths`.
Without this PR, only one path is returned.