### PR TITLE
Modified naming scheme for CFG nodes

### DIFF
--- a/angr/analyses/cfg_node.py
+++ b/angr/analyses/cfg_node.py
@@ -41,7 +41,9 @@ class CFGNode(object):
         if function_address and self.name is None:
             self.name = cfg.project.loader.find_symbol_name(function_address)
             if self.name is not None:
-                self.name = "%s+0x%x" % (self.name, (addr - function_address))
+                offset = addr - function_address
+                direction = "+" if offset >= 0 else "-"
+                self.name = "%s%s0x%x" % (self.name, direction, abs(offset))
 
         # If this CFG contains an Ijk_Call, `return_target` stores the returning site.
         # Note: this is regardless of whether the call returns or not. You should always check the `no_ret` property if


### PR DESCRIPTION
Occasionally `addr - function_address` results in a negative offset, which causes the CFG to get a weird name (e.g. `FunctionName+0x-cafebb`). Modified so that if the calculated offset is negative the name is something like `FunctionName-0xcafebb`.