### PR TITLE
Use sections instead of segments for calculating PE executable ranges

### DIFF
--- a/angr/analyses/cfg_accurate.py
+++ b/angr/analyses/cfg_accurate.py
@@ -129,7 +129,7 @@ class CFGAccurate(Analysis, ForwardAnalysis, CFGBase):
         self._sanitize_parameters()
 
         self._executable_address_ranges = []
-        self._initialize_executable_ranges()
+        self._executable_address_ranges = self._executable_memory_regions()
 
         if not no_construct:
             self._analyze()
@@ -616,18 +616,6 @@ class CFGAccurate(Analysis, ForwardAnalysis, CFGBase):
 
         if not self._starts:
             raise AngrCFGError("At least one start must be provided")
-
-    def _initialize_executable_ranges(self):
-        """
-        Collect all executable sections.
-        """
-
-        for b in self.project.loader.all_objects:
-            for seg in b.segments:
-                if seg.is_executable:
-                    min_addr = seg.min_addr + b.rebase_addr
-                    max_addr = seg.max_addr + b.rebase_addr
-                    self._executable_address_ranges.append((min_addr, max_addr))
 
     # CFG construction
     # The main loop and sub-methods


### PR DESCRIPTION
Hi all,

I was trying to figure out why valid return nodes were being prematurely discarded when trying to use `CFGAccurate` on PE files (i.e. "obviously incorrect successors" were being "ditched" during `_resolve_indirect_jumps(...)`). Turns out that the root cause is that only `segments` are currently being checked during `_initialise_executable_ranges(self)`, which aren't populated for PE files.

This pull request implements a simple fix by using `sections` instead of `segments` for PE files, and leaving the behaviour as-is for any other type (obviously including ELF files). I noticed that there's a much nicer implementation for calculating executable ranges within `cfg_fast.py`, and so my initial thought was just to move that method into `cfg_base.py` and have them share it. However, I then noticed that `CFGFast` doesn't inherit from `CFGBase`. Hence, I just opted for the lightweight fix rather than adding `cle` imports to `cfg_accurate.py`. However, I'm happy to fix this in a different way if you'd prefer... just let me know!

cheers,
Ben