### PR TITLE
Fix to hooking logs where trying to hook an address twice threw an unrelated error.

### DIFF
--- a/angr/project.py
+++ b/angr/project.py
@@ -268,11 +268,11 @@ class Project(object):
                             :class:`SimProcedure`'s run function.
         """
 
-        if self.is_hooked(addr):
-            l.warning("Address is already hooked [hook(%#x, %s, %s()]", addr, func, kwargs.get('funcname'))
-            return
-
         if kwargs is None: kwargs = {}
+
+        if self.is_hooked(addr):
+            l.warning("Address is already hooked [hook(%#x, %s, %s()]", addr, func, kwargs.get('funcname', func.__name__))
+            return
 
         if isinstance(func, type):
             proc = func


### PR DESCRIPTION
If kwargs were not specified and the address of a project was already hooked, the get method would be called on a None object - throwing an error. Additionally, the name of the hooked function is the default name if no name was specified.