### PR TITLE
Handle every address for 'find' argument in pg.explore

### DIFF
--- a/angr/path_group.py
+++ b/angr/path_group.py
@@ -240,7 +240,7 @@ class PathGroup(ana.Storable):
             if filter_func is not None:
                 res = filter_func(p)
 
-                # If result is a one-address-list, we are going to step until
+                # If result is a one-address-set, we are going to step until
                 # the path address is equal to this address (in case the one
                 # given to 'find' was not at the beginning of a basic block)
                 if isinstance(res, (list, set)):

--- a/angr/path_group.py
+++ b/angr/path_group.py
@@ -216,7 +216,7 @@ class PathGroup(ana.Storable):
 
         if isinstance(condition, (tuple, set, list)):
             addrs = set(condition)
-            condition = lambda p: len(addrs.intersection(set(self._project.factory.block(p.addr).instruction_addrs)))
+            condition = lambda p: addrs.intersection(set(self._project.factory.block(p.addr).instruction_addrs))
         return condition
 
 
@@ -236,7 +236,27 @@ class PathGroup(ana.Storable):
         nomatch = [ ]
 
         for p in paths:
-            if filter_func is None or filter_func(p):
+
+            if filter_func is not None:
+                res = filter_func(p)
+
+                # If result is a one-address-list, we are going to step until
+                # the path address is equal to this address (in case the one
+                # given to 'find' was not at the beginning of a basic block)
+                if isinstance(res, (list, set)):
+                    if len(res):
+                        elem = res.pop()
+                        while p.addr != elem:
+                            paths_stepped = p.step(num_inst=1)
+
+                            # We shouldn't go out of the basic block, so there
+                            # should only be one path
+                            p = paths_stepped[0]
+                        res = True
+                    else:
+                        res = False
+
+            if filter_func is None or res:
                 l.debug("... path %s matched!", p)
                 match.append(p)
             else:

--- a/angr/path_group.py
+++ b/angr/path_group.py
@@ -198,10 +198,10 @@ class PathGroup(ana.Storable):
         else:
             return self.copy(stashes=new_stashes)
 
-    @staticmethod
-    def _condition_to_lambda(condition, default=False):
+    def _condition_to_lambda(self, condition, default=False):
         """
-        Translates an integer, set or list into a lambda that checks a path address against the given addresses.
+        Translates an integer, set or list into a lambda that checks a path address against the given addresses, and the
+        other ones from the same basic block
 
         :param condition:   An integer, set, or list to convert to a lambda.
         :param default:     The default return value of the lambda (in case condition is None). Default: false.
@@ -212,13 +212,13 @@ class PathGroup(ana.Storable):
             condition = lambda p: default
 
         if isinstance(condition, (int, long)):
-            condition = { condition }
+            condition = [ condition ]
 
         if isinstance(condition, (tuple, set, list)):
             addrs = set(condition)
-            condition = lambda p: p.addr in addrs
-
+            condition = lambda p: len(addrs.intersection(set(self._project.factory.block(p.addr).instruction_addrs)))
         return condition
+
 
     @staticmethod
     def _filter_paths(filter_func, paths):


### PR DESCRIPTION
Pull request following this [discussion](https://github.com/angr/angr-doc/issues/61).

Any address can be specified in the `find` argument of `PathGroup.explore()`. No need for the address to be a block first instruction's one.

/!\ It does not stop at the specified instruction, but at the first instruction of the block containing the specified address