### PR TITLE
Added _parent to list of pickled attributes in PathHistory

### DIFF
--- a/angr/path.py
+++ b/angr/path.py
@@ -167,7 +167,10 @@ class PathHistory(object):
 
     def __getstate__(self):
         attributes = ('_parent', 'addr', '_runstr', '_target', '_guard', '_jumpkind', '_events')
-        state = {name: getattr(self,name) for name in attributes}
+        state = {}
+        for name in attributes:
+            state[name] = getattr(self, name)
+
         return state
 
     def __setstate__(self, state):

--- a/angr/path.py
+++ b/angr/path.py
@@ -166,7 +166,7 @@ class PathHistory(object):
     __slots__ = ('_parent', 'addr', '_runstr', '_target', '_guard', '_jumpkind', '_events')
 
     def __getstate__(self):
-        attributes = ('addr', '_runstr', '_target', '_guard', '_jumpkind', '_events')
+        attributes = ('_parent', 'addr', '_runstr', '_target', '_guard', '_jumpkind', '_events')
         state = {name: getattr(self,name) for name in attributes}
         return state
 


### PR DESCRIPTION
Needed _parent to the list of attributes in _set_state in order to be able to pickle a path. 

Also determined that TRACK_ACTION_HISTORY must be set or else the _events attribute will be a weakref which will cause the following error, when you attempt to pickle the path.

``` python
ReferenceError: weakly-referenced object no longer exists
```
