### PR TITLE
Converted the set of function prologues to a list to retain the order

### DIFF
--- a/angr/analyses/cfg_fast.py
+++ b/angr/analyses/cfg_fast.py
@@ -1017,10 +1017,10 @@ class CFGFast(ForwardAnalysis, CFGBase):
         """
 
         # Pre-compile all regexes
-        regexes = set()
+        regexes = list()
         for ins_regex in self.project.arch.function_prologs:
             r = re.compile(ins_regex)
-            regexes.add(r)
+            regexes.append(r)
 
         # TODO: Make sure self._start is aligned
 


### PR DESCRIPTION
Using a list instead of a set for the compiled regexs is important if one of the prefixes in function_prologs is a prologue of another and the order must be retained. 
Also see this pull request: https://github.com/angr/archinfo/pull/4