### PR TITLE
add systemcall information for arch_prctl syscall added to simuves to…

### DIFF
--- a/angr/simos.py
+++ b/angr/simos.py
@@ -336,6 +336,7 @@ class SimLinux(SimOS):
             14: ('sigprocmask', 'sigprocmask'),
             39: ('getpid', 'getpid'),
             60: ('exit', 'exit'),
+            158: ('arch_prctl','arch_prctl'),
             186: ('gettid', 'gettid'),
             231: ('exit_group', 'exit'),  # really exit_group, but close enough
             234: ('tgkill', 'tgkill'),


### PR DESCRIPTION
… Linux amd64 simos system call table

Accompanying simuvex pull request https://github.com/angr/simuvex/pull/32 and issue https://github.com/angr/angr/issues/127 