### PR TITLE
CFGAccurate: Start CFG analysis for backward slicing at current function

### DIFF
--- a/angr/analyses/cfg_accurate.py
+++ b/angr/analyses/cfg_accurate.py
@@ -2050,7 +2050,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         stmt_id = [i for i, s in enumerate(simirsb.irsb.statements)
                    if isinstance(s, pyvex.IRStmt.WrTmp) and s.tmp == next_tmp][0]
 
-        cdg = self.project.analyses.CDG(cfg=self)
+        cdg = self.project.analyses.CDG(cfg=self, start=current_function_addr)
         ddg = self.project.analyses.DDG(cfg=self, start=current_function_addr, call_depth=0)
 
         bc = self.project.analyses.BackwardSlice(self, cdg, ddg, targets=[(cfgnode, stmt_id)], same_function=True)


### PR DESCRIPTION
Start CFG analysis for advanced backward slicing at the current function. The BackwardSlice only considers the current function anyhow.

(I had a problem where figuring out jump tables didn't work. The reason turned out to be that the CFG was empty because it started from the wrong point)