### PR TITLE
Fixed an issue preventing `GirlScout` from being instantiated properly

### DIFF
--- a/angr/analyses/girlscout.py
+++ b/angr/analyses/girlscout.py
@@ -76,10 +76,6 @@ class GirlScout(Analysis):
         # Start working!
         self._reconnoiter()
 
-    @property
-    def call_map(self):
-        return self.call_map
-
     def _get_next_addr_to_search(self, alignment=None):
         # TODO: Take care of those functions that are already generated
         curr_addr = self._next_addr

--- a/angr/analyses/girlscout.py
+++ b/angr/analyses/girlscout.py
@@ -14,6 +14,7 @@ import simuvex
 import cle
 import pyvex
 
+from .cfg_fast import SegmentList
 from ..errors import AngrError
 from ..analysis import Analysis, register_analysis
 from ..surveyors import Explorer, Slicecutor


### PR DESCRIPTION
Previously, the `call_map` property was just a read-only accessor to the `_call_map` attribute; however, as the `results` dict became nuked, the attribute had been renamed to be equal to the property itself effectively preventing `GirlScout` from being instantiated. It seems safe to just remove the property anyway! :)