### PR TITLE
Start veritesting only at conditional jumps

### DIFF
--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -173,6 +173,15 @@ class Veritesting(Analysis):
         :param path_callback:            A callback function that takes a path as parameter. Veritesting will call this
                                          function on every single path after their next_run is created.
         """
+        block = self.project.factory.block(input_path.addr)
+        branches = block.vex.constant_jump_targets_and_jumpkinds
+
+        # if we are not at a conditional jump, just do a normal path.step
+        if not branches.values() == ['Ijk_Boring', 'Ijk_Boring']:
+            self.result, self.final_path_group = False, None
+            return
+        # otherwise do a veritesting step
+
         self._input_path = input_path.copy()
         self._boundaries = boundaries if boundaries is not None else [ ]
         self._loop_unrolling_limit = loop_unrolling_limit


### PR DESCRIPTION
I noticed that there is a small difference between the veritesting implementation in angr and the algorithm described in the [Veritesting paper](https://users.ece.cmu.edu/~dbrumley/pdf/Avgerinos%20et%20al._2014_Enhancing%20Symbolic%20Execution%20with%20Veritesting.pdf).

In the paper, the algorithm performs a veritesting step (create CFG, find transition points, ...) only when the executor is at a conditional jump where both branches are satisfiable.
The veritesting analysis (initiated at each step of the veritesting exploration technique) in angr on the other hand always executes `_make_cfg()` in the constructor.

I modified the veritesting analysis to check if the current statement is a conditional branch (the basic block has two jump targets of jumpkind `Ijk_Boring`). If True, do a veritesting step, else do a "normal" step, which angr falls back to if the `step_path()` function in exploration_technique/veritesting.py returns `None`.

I did some testing with the following script:

```python
import angr
import time

p = angr.Project(FILE, load_options={'auto_load_libs': False})
pg = p.factory.path_group(p.factory.entry_state(), veritesting=True)

t1 = time.clock()
pg.explore(find=ADDR)
t2 = time.clock()
print(t2 - t1)
```

With `FILE='binaries/tests/x86_64/veritesting_a'` and `ADDR=0x400674` the time went from 8.82 seconds to 6.50 seconds.
With `FILE='binaries/tests/x86_64/veritesting_b'` and `ADDR=0x4006af` the time went from 18.85 seconds to 17.57 seconds.
With `FILE='binaries/tests/x86_64/fauxware'` and `ADDR=0x4006ed` the time went from 7.22 seconds to 2.93 seconds.

It would be great to find a faster way of determining if the current instruction is a conditional jump, because I think the `factory.block()` is more expensive than necessary.