### PR TITLE
Fix CFGFast copy() for incorrect attribute type

### DIFF
--- a/angr/analyses/cfg_fast.py
+++ b/angr/analyses/cfg_fast.py
@@ -3345,7 +3345,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         n._show_progressbar = self._show_progressbar
 
         n._exec_mem_regions = self._exec_mem_regions[::]
-        n._exec_mem_region_size = self._exec_mem_region_size[::]
+        n._exec_mem_region_size = self._exec_mem_region_size
 
         n._memory_data = self._memory_data.copy()
 


### PR DESCRIPTION
`_exec_mem_region_size` is treated as a list, but it is really an integer.

This bug was triggered when generating a CDG after CFG here: https://github.com/angr/angr/blob/80527f5a9d4acb7947804cc87a7bbf0c28ba5709/angr/analyses/cdg.py#L135