### PR TITLE
Attempt to fix the explore find first block bug

### DIFF
--- a/angr/path_group.py
+++ b/angr/path_group.py
@@ -235,7 +235,7 @@ class PathGroup(ana.Storable):
         if len(self._hooks_filter) == 0:
             new_active.extend(successors)
         else:
-            for path in successors:
+            for i, path in enumerate([a] + successors):
                 for hook in self._hooks_filter:
                     goto = hook(path)
                     if goto is None:
@@ -251,6 +251,11 @@ class PathGroup(ana.Storable):
                         break
                 else:
                     new_active.append(path)
+                    continue
+
+                # If we found a solution on the pre-step path, return early.
+                if i == 0:
+                    return
 
         if self.save_unconstrained:
             new_stashes['unconstrained'] += unconstrained


### PR DESCRIPTION
I've stumbled onto this bug a few times now so figured I'd give it a shot at fixing.

Basically, the bug I'm seeing is in the explore(find=<ip>) method. angr will check if the IP it hit after stepping the path. This opens the execution up to a minor bug, but one that I have a strange tendency to hit. Basically, if you ask angr to find an IP that is within the same block as the starting block, then it will never be found.

My patch basically checks the starting path each time to see if it was found to be hit by some hook. This will add a slight overhead, but I think it corrects this problem.

Attaching the example exe: 
[a.zip](https://github.com/angr/angr/files/698027/a.zip)

Here's a test python script
```python
import angr, simuvex

proj = angr.Project("./a.out")

# Start at main
state = proj.factory.blank_state(addr=0x004004d6,remove_options={simuvex.o.LAZY_SOLVES})

pg = proj.factory.path_group(state)

# This address is within the starting block.
# The initial implementation would step, then check, and thus would always miss something like this.
pg.explore(find=0x004004e9)

assert len(pg.found) == 1
```

Here's the C source:
```c
#include <stdio.h>
#include <stdlib.h>

int main() {

    int x;
    x = 0;

    x += 1;

    x += 2;

    x += 3;

    return 0;
}
```