### PR TITLE
Adding rtld_local locker

### DIFF
--- a/angr/simos.py
+++ b/angr/simos.py
@@ -611,6 +611,12 @@ class SimLinux(SimOS):
             if _rtld_global_ro is not None:
                 pass
 
+            _rtld_local = ld_obj.get_symbol('_rtld_local')
+            if _rtld_local is not None:
+                if isinstance(self.proj.arch, ArchAMD64):
+                    self.proj.loader.memory.write_addr_at(_rtld_local.rebased_addr + 0xF00, self._loader_lock_addr)
+
+
         tls_obj = self.proj.loader.tls_object
         if tls_obj is not None:
             if isinstance(self.proj.arch, ArchAMD64):


### PR DESCRIPTION
When trying to trace on malloc on a RHEL binary it was trying to find this address and failing. Saw that you did something similar for the global lock, so I'm tacking on the local.

Not sure where the unlock is supposed to be... I didn't actually run into it somehow.