### PR TITLE
BUGFIX: Fixed TypeError in function.py dbg_print

### DIFF
--- a/angr/knowledge/function.py
+++ b/angr/knowledge/function.py
@@ -716,7 +716,7 @@ class Function(object):
         """
         Returns a representation of the list of basic blocks in this function.
         """
-        return "[%s]" % (', '.join(('%#08x' % n) for n in self.transition_graph.nodes()))
+        return "[%s]" % (', '.join(('%#08x' % n.addr) for n in self.transition_graph.nodes()))
 
     def dbg_draw(self, filename):
         """


### PR DESCRIPTION
Fixed TypeError in function.py dbg_print method. self.transition_graph.nodes() returns BlockNode instance, not int.