### PR TITLE
CFGFast: support generating CFG on multiple binaries.

### DIFF
--- a/angr/analyses/cfg_base.py
+++ b/angr/analyses/cfg_base.py
@@ -87,7 +87,7 @@ class CFGBase(Analysis):
         self.indirect_jumps = {}
 
         # Get all executable memory regions
-        self._exec_mem_regions = self._executable_memory_regions(self._binary, self._force_segment)
+        self._exec_mem_regions = self._executable_memory_regions(None, self._force_segment)
         self._exec_mem_region_size = sum([(end - start) for start, end in self._exec_mem_regions])
 
         # initialize an UnresolvableTarget SimProcedure


### PR DESCRIPTION
- Deprecate `start` and `end`. Please use `regions` instead.
- Control flow graph will span across all loaded binaries if not limited
  by `regions`.