### PR TITLE
Cfg fast perf

### DIFF
--- a/angr/analyses/cfg_base.py
+++ b/angr/analyses/cfg_base.py
@@ -826,17 +826,17 @@ class CFGBase(Analysis):
                     # if there are multiple jump out sites and we have determined the "returning status" from one of
                     # the jump out sites, we can exit the loop early
                     continue
-
-                if not jump_out_site.successors():
+                jump_out_site_successors = jump_out_site.successors()
+                if not jump_out_site_successors:
                     # not sure where it jumps to. bail out
                     bail_out = True
                     continue
-                jump_out_target = jump_out_site.successors()[0]
-                target_func = self.kb.functions.get(jump_out_target.addr, None)
-                if target_func is None:
+                jump_out_target = jump_out_site_successors[0]
+                if not self.kb.functions.contains_addr(jump_out_target.addr):
                     # wait it does not jump to a function?
                     bail_out = True
                     continue
+                target_func = self.kb.functions[jump_out_target.addr]
                 if target_func.returning is True:
                     func.returning = True
                     bail_out = True

--- a/angr/analyses/cfg_base.py
+++ b/angr/analyses/cfg_base.py
@@ -1376,7 +1376,7 @@ class CFGBase(Analysis):
         """
 
         stack = OrderedSet(starts)
-        traversed = set() if traversed_cfg_nodes is None else set(traversed_cfg_nodes)
+        traversed = set() if traversed_cfg_nodes is None else traversed_cfg_nodes
 
         while stack:
             n = stack.pop(last=False)  # type: CFGNode
@@ -1402,9 +1402,6 @@ class CFGBase(Analysis):
                         # Only follow none call edges
                         if dst not in stack and dst not in traversed:
                             stack.add(dst)
-
-        if traversed_cfg_nodes is not None:
-            traversed_cfg_nodes |= traversed
 
     def _graph_traversal_handler(self, src, dst, data, blockaddr_to_function, known_functions):
         """

--- a/angr/analyses/cfg_base.py
+++ b/angr/analyses/cfg_base.py
@@ -1227,6 +1227,9 @@ class CFGBase(Analysis):
             if not has_unresolved_jumps:
                 continue
 
+            if function.startpoint is None:
+                continue
+
             startpoint_addr = function.startpoint.addr
             if not function.endpoints:
                 # Function should have at least one endpoint

--- a/angr/analyses/cfg_fast.py
+++ b/angr/analyses/cfg_fast.py
@@ -2353,8 +2353,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         """
 
         # is the address identified by CLE as a PLT stub?
-        if not any([ addr in obj.reverse_plt for obj in self.project.loader.all_objects if isinstance(obj, cle.MetaELF) ]):
-            return False
+        if len(self.project.loader.all_elf_objects) > 0:
+            # restrict this heuristics to ELF files only
+            if not any([ addr in obj.reverse_plt for obj in self.project.loader.all_elf_objects ]):
+                return False
 
         # try to resolve the jump target
         simsucc = simuvex.SimEngineVEX().process(self._initial_state, irsb, force_addr=addr)

--- a/angr/analyses/cfg_fast.py
+++ b/angr/analyses/cfg_fast.py
@@ -210,9 +210,8 @@ class SegmentList(object):
                 new_end = max(previous_segment.end, segment.start + segment.size)
                 new_start = min(previous_segment.start, segment.start)
                 new_size = new_end - new_start
-                self._list = self._list[ : previous_segment_pos] + \
-                            [ Segment(new_start, new_end, segment.sort) ] + \
-                            self._list[ segment_pos + 1: ]
+                self._list[segment_pos] = Segment(new_start, new_end, segment.sort)
+                self._list.pop(previous_segment_pos)
                 bytes_changed = -(segment.size + previous_segment.size - new_size)
 
                 merged = True

--- a/angr/analyses/forward_analysis.py
+++ b/angr/analyses/forward_analysis.py
@@ -231,10 +231,10 @@ class ForwardAnalysis(object):
                 continue
             except AngrSkipEntryNotice:
                 # consume and skip this job
-                self._entries = self._entries[1:]
+                self._entries.pop(0)
                 continue
 
-            self._entries = self._entries[1:]
+            self._entries.pop(0)
 
             self._handle_entry(entry_info)
 

--- a/angr/knowledge/function_manager.py
+++ b/angr/knowledge/function_manager.py
@@ -199,6 +199,17 @@ class FunctionManager(collections.Mapping):
     def __iter__(self):
         for i in sorted(self._function_map.iterkeys()):
             yield i
+    
+    def contains_addr(self, addr):
+        """
+        Decide if an address is handled by the function manager.
+        
+        Note: this function is non-conformant with python programming idioms, but its needed for performance reasons.
+        
+        :param int addr: Address of the function.
+        """
+        return addr in self._function_map
+
 
     def function(self, addr=None, name=None, create=False, syscall=False, plt=None):
         """


### PR DESCRIPTION
Hi @ltfish!

Here are my modifications! I've tested it on an ELF binary with ~1000 symbols and compared the CFG graphs. They are the same. 

You should rewrite this, i've just added a check to run the plt heuristic on ELF files, its probably not correct. Checked for PLT in PE files documentation. It has a similar concept, called IAT, 'import address table'. Not sure at the moment how we should handle that explicitly.
https://github.com/axt/angr/commit/b2deb972cff25442e7f6c75f6e2dac8d99bf315d


This is the biggest modification. I've added comments of what is happening + left a FIXME for you. 
https://github.com/axt/angr/commit/128a2567cf5340e25cbfa35e4a3e10e636f811ce

For files with <= 1000 symbols/functions, the speedup is around 10%, but for files with ~30k functions, it goes up to 70%. 

Update:
Added some more commits:
I needed this in order to my test not quit. It probably needs further debugging while startpoint is None.
https://github.com/angr/angr/pull/413/commits/58ccec5023c85cfa963b0afbc40c99010a5f4c5a

This speeds up post-analysis, a lot, because there was some unnecessary copying back and forth.
https://github.com/angr/angr/pull/413/commits/9117f6a7c4b70465b937d5de28ce586119af3610

Now the analysis reaches 90% in 17mins, and then spends another 8 mins in `make_functions` + `get_any_node`. Somehow `_nodes_by_addr` is not populated with all the nodes, and the code ends up in the slowpath.
Please review!