### PR TITLE
Ignoring SyscallError if Bypass Unsupported Syscall is set

### DIFF
--- a/angr/simos.py
+++ b/angr/simos.py
@@ -290,7 +290,11 @@ class SimOS(object):
             n = self.syscall_table.unknown_syscall_number
         elif not possible:
             # The state is not satisfiable
-            raise AngrUnsupportedSyscallError("The program state is not satisfiable")
+            if o.BYPASS_UNSUPPORTED_SYSCALL in state.options:
+                state.log.add_event('resilience', resilience_type='syscall', syscall=-1, message='unsatisfiable program state')
+                n = self.syscall_table.unknown_syscall_number
+            else:
+                raise AngrUnsupportedSyscallError("The program state is not satisfiable")
         else:
             n = possible[0]
 


### PR DESCRIPTION
The error `The program state is not satisfiable` occured for me while creating a CFG and sounds pretty bad, but I still want to carry on.
Someone with a deeper understanding might be able to give reasons to decline this pull request, in which case I'd be happy to hear them. 