### PR TITLE
Added option to list labels

### DIFF
--- a/angr/knowledge/labels.py
+++ b/angr/knowledge/labels.py
@@ -14,6 +14,13 @@ class Labels(object):
             except AttributeError:
                 pass
 
+    def __iter__(self):
+        """
+        Iterate over all labels (the strings)
+        Use .lookup(name) if you need to find the address to it.
+        """
+        return self._reverse_labels.__iter__()
+
     def __getitem__(self, k):
         return self._labels[k]
 
@@ -33,7 +40,15 @@ class Labels(object):
         return k in self._labels
 
     def get(self, addr):
+        """
+        Get a label as string for a given address
+        Same as .labels[x]
+        """
         return self[addr]
 
     def lookup(self, name):
+        """
+        Returns an address to a given label
+        To show all available labels, iterate over .labels or list(b.kb.labels)
+        """
         return self._reverse_labels[name]


### PR DESCRIPTION
Especially for unstripped binaries, it may make sense to be able to list all labels.
As an example use-case, you don't need to grep objdump anymore to see if functions made it into the binary but can do: `[x for x in b.kb.labels if "pinctrl" in x]` (without building the CFG)

Arguably though, this is not much more ipython accessible than trying to find `_labels`, so an alternative to this might be to add an `.items()` property instead/also?