### PR TITLE
Loader: ELF non-zero based PIC binaries support

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -213,7 +213,7 @@ class JumpTableResolver(IndirectJumpResolver):
         # TODO: this is very hackish. fix it after the chaos.
         for section in self.project.loader.main_bin.sections:
             if section.name == '.bss':
-                self._bss_regions.append((self.project.loader.main_bin.rebase_addr + section.vaddr, section.memsize))
+                self._bss_regions.append((section.vaddr, section.memsize))
                 break
 
     def _bss_memory_read_hook(self, state):

--- a/angr/analyses/cfg/indirect_jump_resolvers/x86_elf_pic_plt.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/x86_elf_pic_plt.py
@@ -36,10 +36,10 @@ class X86ElfPicPltResolver(IndirectJumpResolver):
                 got_section = obj.sections_map.get('.got', None)
                 if got_plt_section is not None:
                     l.debug('Use address of .got.plt section as the GOT base for object %s.', obj)
-                    self._got_addr_cache[obj] = got_plt_section.vaddr + obj.rebase_addr
+                    self._got_addr_cache[obj] = got_plt_section.vaddr
                 elif got_section is not None:
                     l.debug('Use address of .got section as the GOT base for object %s.', obj)
-                    self._got_addr_cache[obj] = got_section.vaddr + obj.rebase_addr
+                    self._got_addr_cache[obj] = got_section.vaddr
                 else:
                     l.debug('Cannot find GOT base for object %s.', obj)
                     self._got_addr_cache[obj] = None

--- a/angr/analyses/girlscout.py
+++ b/angr/analyses/girlscout.py
@@ -36,8 +36,8 @@ class GirlScout(Analysis):
 
     def __init__(self, binary=None, start=None, end=None, pickle_intermediate_results=False, perform_full_code_scan=False):
         self._binary = binary if binary is not None else self.project.loader.main_bin
-        self._start = start if start is not None else (self._binary.rebase_addr + self._binary.get_min_addr())
-        self._end = end if end is not None else (self._binary.rebase_addr + self._binary.get_max_addr())
+        self._start = start if start is not None else self._binary.get_min_addr()
+        self._end = end if end is not None else self._binary.get_max_addr()
         self._pickle_intermediate_results = pickle_intermediate_results
         self._perform_full_code_scan = perform_full_code_scan
 
@@ -45,8 +45,7 @@ class GirlScout(Analysis):
 
         # Valid memory regions
         self._valid_memory_regions = sorted(
-            [ (self._binary.rebase_addr+start, self._binary.rebase_addr+start+len(cbacker))
-                for start, cbacker in self.project.loader.memory.cbackers ],
+            [ (start, start+len(cbacker)) for start, cbacker in self.project.loader.memory.cbackers ],
             key=lambda x: x[0]
         )
         self._valid_memory_region_size = sum([ (end - start) for start, end in self._valid_memory_regions ])

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -1723,8 +1723,8 @@ class Reassembler(Analysis):
             if obj.sections:
                 for sec in obj.sections:
                     if sec.is_executable:
-                        min_addr = sec.min_addr + obj.rebase_addr
-                        max_addr = sec.max_addr + obj.rebase_addr + 1
+                        min_addr = sec.min_addr
+                        max_addr = sec.max_addr + 1
                         if max_addr <= min_addr or min_addr == 0:
                             continue
                         self._main_executable_regions.append((min_addr, max_addr))
@@ -1732,8 +1732,8 @@ class Reassembler(Analysis):
             else:
                 for seg in obj.segments:
                     if seg.is_executable:
-                        min_addr = seg.min_addr + obj.rebase_addr
-                        max_addr = seg.max_addr + obj.rebase_addr + 1
+                        min_addr = seg.min_addr
+                        max_addr = seg.max_addr + 1
                         self._main_executable_regions.append((min_addr, max_addr))
 
         return self._main_executable_regions
@@ -1756,8 +1756,8 @@ class Reassembler(Analysis):
                         # hack for ELF binaries...
                         continue
                     if not sec.is_executable:
-                        min_addr = sec.min_addr + obj.rebase_addr
-                        max_addr = sec.max_addr + obj.rebase_addr + 1
+                        min_addr = sec.min_addr
+                        max_addr = sec.max_addr + 1
                         if max_addr <= min_addr or min_addr == 0:
                             continue
                         self._main_nonexecutable_regions.append((min_addr, max_addr))
@@ -1765,8 +1765,8 @@ class Reassembler(Analysis):
             else:
                 for seg in obj.segments:
                     if not seg.is_executable:
-                        min_addr = seg.min_addr + obj.rebase_addr
-                        max_addr = seg.max_addr + obj.rebase_addr + 1
+                        min_addr = seg.min_addr
+                        max_addr = seg.max_addr + 1
                         self._main_nonexecutable_regions.append((min_addr, max_addr))
 
         return self._main_nonexecutable_regions
@@ -1793,7 +1793,7 @@ class Reassembler(Analysis):
         :return:
         """
         for start, end in self.main_executable_regions:
-            if addr >= start and addr < end:
+            if start <= addr < end:
                 return True
         return False
 
@@ -1834,7 +1834,7 @@ class Reassembler(Analysis):
         :rtype: bool
         """
         for start, end in self.main_nonexecutable_regions:
-            if addr >= start and addr < end:
+            if start <= addr < end:
                 return True
         return False
 
@@ -1863,7 +1863,7 @@ class Reassembler(Analysis):
 
         if closest_region is not None:
             return closest_region
-        return (False, None)
+        return False, None
 
     def register_instruction_reference(self, insn_addr, ref_addr, sort, insn_size):
 
@@ -1912,7 +1912,6 @@ class Reassembler(Analysis):
 
         else:
             raise BinaryError('Unsupported sort "%s" in register_instruction_reference().' % sort)
-
 
         r = Relocation(addr, ref_addr, sort)
 
@@ -2302,24 +2301,23 @@ class Reassembler(Analysis):
         for section in self.project.loader.main_bin.sections:
             if isinstance(section, AngrExternObject):
                 continue
-            section_addr = section.vaddr + self.project.loader.main_bin.rebase_addr
             in_segment = False
             for segment in self.project.loader.main_bin.segments:
-                segment_addr = segment.vaddr + self.project.loader.main_bin.rebase_addr
-                if segment_addr <= section_addr < segment_addr + segment.memsize:
+                segment_addr = segment.vaddr
+                if segment_addr <= section.vaddr < segment_addr + segment.memsize:
                     in_segment = True
                     break
             if not in_segment:
                 continue
 
             # calculate alignments
-            if section_addr % 0x20 == 0:
+            if section.vaddr % 0x20 == 0:
                 alignment = 0x20
-            elif section_addr % 0x10 == 0:
+            elif section.vaddr % 0x10 == 0:
                 alignment = 0x10
-            elif section_addr % 0x8 == 0:
+            elif section.vaddr % 0x8 == 0:
                 alignment = 0x8
-            elif section_addr % 0x4 == 0:
+            elif section.vaddr % 0x4 == 0:
                 alignment = 0x4
             else:
                 alignment = 2
@@ -2384,7 +2382,6 @@ class Reassembler(Analysis):
         # Data
 
         has_sections = len(self.project.loader.main_bin.sections) > 0
-        rebase_addr = self.project.loader.main_bin.rebase_addr
 
         l.debug('Creating data entries...')
         for addr, memory_data in cfg._memory_data.iteritems():
@@ -2403,7 +2400,7 @@ class Reassembler(Analysis):
             if has_sections:
                 # Check which section the start address belongs to
                 section = next(iter(sec for sec in self.project.loader.main_bin.sections
-                                    if addr >= rebase_addr + sec.vaddr and addr < rebase_addr + sec.vaddr + sec.memsize
+                                    if sec.vaddr <= addr < sec.vaddr + sec.memsize
                                     ),
                                None
                                )
@@ -2414,7 +2411,7 @@ class Reassembler(Analysis):
                 elif memory_data.sort == 'segment-boundary':
                     # it just points to the end of the segment or a section
                     section = next(iter(sec for sec in self.project.loader.main_bin.sections
-                                        if addr == rebase_addr + sec.vaddr + sec.memsize),
+                                        if addr == sec.vaddr + sec.memsize),
                                    None
                                    )
                     if section is not None:
@@ -2430,7 +2427,7 @@ class Reassembler(Analysis):
                 # we use segment information instead
                 # TODO: this logic needs reviewing
                 segment = next(iter(seg for seg in self.project.loader.main_bin.segments
-                                    if addr >= rebase_addr + seg.vaddr and addr <= rebase_addr + seg.vaddr + seg.memsize
+                                    if seg.vaddr <= addr <= seg.vaddr + seg.memsize
                                     ),
                                None
                                )
@@ -2460,15 +2457,15 @@ class Reassembler(Analysis):
 
                 # make sure this section is inside a segment
                 for segment in self.project.loader.main_bin.segments:
-                    segment_start = rebase_addr + segment.vaddr
+                    segment_start = segment.vaddr
                     segment_end = segment_start + segment.memsize
-                    if segment_start <= rebase_addr + section.vaddr < segment_end:
+                    if segment_start <= section.vaddr < segment_end:
                         break
                 else:
                     # this section is not mapped into memory
                     continue
 
-                section_boundary_addr = rebase_addr+section.vaddr+section.memsize
+                section_boundary_addr = section.vaddr + section.memsize
                 if section_boundary_addr not in all_addrs:
                     data = Data(self, addr=section_boundary_addr, size=0, sort='segment-boundary',
                                 section_name=section.name
@@ -2525,7 +2522,7 @@ class Reassembler(Analysis):
                 if i + 1 == len(self.data):
                     if data.section is None:
                         continue
-                    data.size = rebase_addr + data.section.vaddr + data.section.memsize - data.addr
+                    data.size = data.section.vaddr + data.section.memsize - data.addr
                 else:
                     data.size = self.data[i + 1].addr - data.addr
 

--- a/angr/project.py
+++ b/angr/project.py
@@ -472,7 +472,6 @@ class Project(object):
 
         if not isinstance(obj, (int, long)):
             pseudo_addr = self._simos.prepare_function_symbol(ident)
-            pseudo_vaddr = pseudo_addr - self._extern_obj.rebase_addr
 
             if self.is_hooked(pseudo_addr):
                 l.warning("Re-hooking symbol " + symbol_name)
@@ -482,7 +481,6 @@ class Project(object):
         else:
             # This is pretty intensely sketchy
             pseudo_addr = obj
-            pseudo_vaddr = obj - self._extern_obj.rebase_addr
 
         self.loader.provide_symbol(self._extern_obj, symbol_name, pseudo_vaddr)
 
@@ -501,7 +499,6 @@ class Project(object):
             ident = self._symbol_name_to_ident(name, None)
 
             pseudo_addr = self._simos.prepare_function_symbol(ident)
-            pseudo_vaddr = pseudo_addr - self._extern_obj.rebase_addr
 
             if self.is_hooked(pseudo_addr):
                 l.warning("Re-hooking symbol " + name)

--- a/angr/project.py
+++ b/angr/project.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 
 import archinfo
 import cle
+from cle.address_translator import AT
 
 from . import engines, SIM_PROCEDURES, procedures
 from .sim_procedure import SimProcedure
@@ -482,7 +483,7 @@ class Project(object):
             # This is pretty intensely sketchy
             pseudo_addr = obj
 
-        self.loader.provide_symbol(self._extern_obj, symbol_name, pseudo_vaddr)
+        self.loader.provide_symbol(self._extern_obj, symbol_name, AT.from_mva(pseudo_addr, self._extern_obj).to_lva())
 
         return pseudo_addr
 
@@ -505,7 +506,7 @@ class Project(object):
                 self.unhook(pseudo_addr)
 
             self.hook(pseudo_addr, obj)
-            provisions[name] = (pseudo_vaddr, 0, None)
+            provisions[name] = (AT.from_mva(pseudo_addr, self._extern_obj).to_lva(), 0, None)
 
         self.loader.provide_symbol_batch(self._extern_obj, provisions)
 

--- a/angr/simos.py
+++ b/angr/simos.py
@@ -817,7 +817,8 @@ class SimLinux(SimOS):
         if self.arch.name == 'PPC64':
             pseudo_hookaddr = self.proj._extern_obj.get_pseudo_addr(symbol_name + '#func')
             pseudo_toc = self.proj._extern_obj.get_pseudo_addr(symbol_name + '#func', size=0x18)
-            self.proj._extern_obj.memory.write_addr_at(pseudo_toc - self.proj._extern_obj.rebase_addr, pseudo_hookaddr)
+            self.proj._extern_obj.memory.write_addr_at(
+                AT.from_va(pseudo_toc, self.proj._extern_obj).to_rva(), pseudo_hookaddr)
             return pseudo_hookaddr
         else:
             return self.proj._extern_obj.get_pseudo_addr(symbol_name)

--- a/tests/test_cle_gdb.py
+++ b/tests/test_cle_gdb.py
@@ -9,8 +9,8 @@ binpath = os.path.join(test_location, "x86_64/test_gdb_plugin")
 def check_addrs(p):
     libc = p.loader.shared_objects['libc.so.6']
     ld = p.loader.shared_objects['ld-linux-x86-64.so.2']
-    nose.tools.assert_equal(libc.rebase_addr, 0x7ffff7a17000)
-    nose.tools.assert_equal(ld.rebase_addr, 0x7ffff7ddc000)
+    nose.tools.assert_equal(libc.mapped_base, 0x7ffff7a17000)
+    nose.tools.assert_equal(ld.mapped_base, 0x7ffff7ddc000)
 
 def test_cle_gdb():
     """


### PR DESCRIPTION
This is the second PR for issue angr/cle#65.
While fixing angr, I've noticed that the addresses inside `Regions` are only needed in valid form w.r.t. top level `Clemory`, think there is no need to store a backreference to the owner. So the `Loader.add_object` is just need to "rebase" metadata described by `Regions` and `self._next_addr` and such in case of `AngrExternObject`-alike backends. 

P.S.: Someone has broken one of the tests
```bash
======================================================================
ERROR: test_cfgfast.test_cfg_0_pe('x86_64', 'cfg_0_pe', set([4199664]), {})
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/amatter/.virtualenvs/angr.io/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/amatter/repos/angr-dev/angr/tests/test_cfgfast.py", line 29, in cfg_fast_functions_check
    cfg = proj.analyses.CFGFast()
  File "/home/amatter/repos/angr-dev/angr/angr/analysis.py", line 99, in make_analysis
    oself.__init__(*args, **kwargs)
  File "/home/amatter/repos/angr-dev/angr/angr/analyses/cfg/cfg_fast.py", line 771, in __init__
    self._analyze()
  File "/home/amatter/repos/angr-dev/angr/angr/analyses/forward_analysis.py", line 507, in _analyze
    self._post_analysis()
  File "/home/amatter/repos/angr-dev/angr/angr/analyses/cfg/cfg_fast.py", line 1303, in _post_analysis
    r = self._tidy_data_references()
  File "/home/amatter/repos/angr-dev/angr/angr/analyses/cfg/cfg_fast.py", line 2101, in _tidy_data_references
    content_holder=content_holder
  File "/home/amatter/repos/angr-dev/angr/angr/analyses/cfg/cfg_fast.py", line 2196, in _guess_data_type
    plt_entry = self.project.loader.main_bin.reverse_plt.get(irsb_addr, None)
AttributeError: 'PE' object has no attribute 'reverse_plt'
```