### PR TITLE
Fix returning absolute symbolic addrs from page

### DIFF
--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -891,7 +891,7 @@ class SimPagedMemory(object):
     def get_symbolic_addrs(self):
         symbolic_addrs = set()
         for page in self._symbolic_addrs:
-            symbolic_addrs.update(page*self._page_size + page_off for page_off in self._symbolic_addrs[page])
+            symbolic_addrs.update(self._symbolic_addrs[page])
         return symbolic_addrs
 
     def addrs_for_name(self, n):


### PR DESCRIPTION
As of commit ebc0a6f2331da0e3d38368943629dd0dad654df4 the addresses stored in paged memory are absolute. 
`get_symbolic_addrs()` still calculates page offsets resulting  in wrong addresses.