### PR TITLE
Format strings: Add %z, %t. Fix signedness in ptrdiff_t

### DIFF
--- a/angr/procedures/stubs/format_parser.py
+++ b/angr/procedures/stubs/format_parser.py
@@ -256,7 +256,7 @@ class FormatParser(SimProcedure):
 
         # FIXME: intmax_t seems to be always 64 bit, but not too sure
         'j' : ('int64_t', 'uint64_t'),
-        'z' : ('ssize', 'size_t'), # TODO: implement in s_type
+        'z' : ('ssize', 'size_t'),
         't' : ('ptrdiff_t', 'ptrdiff_t'),
     }
 

--- a/angr/procedures/stubs/format_parser.py
+++ b/angr/procedures/stubs/format_parser.py
@@ -257,7 +257,7 @@ class FormatParser(SimProcedure):
         # FIXME: intmax_t seems to be always 64 bit, but not too sure
         'j' : ('int64_t', 'uint64_t'),
         'z' : ('ssize', 'size_t'), # TODO: implement in s_type
-        't' : ('ptrdiff_t', 'ptrdiff_t'), # TODO: implement in s_type
+        't' : ('ptrdiff_t', 'ptrdiff_t'),
     }
 
     # Types that are not known by sim_types

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -715,7 +715,7 @@ ALL_TYPES = {
     'uint64_t': SimTypeNum(64, False),
     'qword': SimTypeNum(64, False),
 
-    'ptrdiff_t': SimTypeLong(False),
+    'ptrdiff_t': SimTypeLong(True),
     'size_t': SimTypeLength(False),
     'ssize_t': SimTypeLength(True),
     'uintptr_t' : SimTypeLong(False),

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -477,9 +477,9 @@ class SimTypeFunction(SimType):
 
     def __init__(self, args, returnty, label=None):
         """
-        :param label:   The type label
-        :param args:    A tuple of types representing the arguments to the function
-        :param returns: The return type of the function, or none for void
+        :param label:    The type label
+        :param args:     A tuple of types representing the arguments to the function
+        :param returnty: The return type of the function, or none for void
         """
         super(SimTypeFunction, self).__init__(label=label)
         self.args = args

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -718,7 +718,8 @@ ALL_TYPES = {
     'ptrdiff_t': SimTypeLong(True),
     'size_t': SimTypeLength(False),
     'ssize_t': SimTypeLength(True),
-    'uintptr_t' : SimTypeLong(False),
+    'ssize': SimTypeLength(False),
+    'uintptr_t': SimTypeLong(False),
 
     'string': SimTypeString(),
 }


### PR DESCRIPTION
* Support for `%td` and `%zd` were already implemented in `s_format` so I added them to `s_type`.
* `ptrdiff_t` was erroneously set to unsigned. Changed to signed.
* Fixed a `param` entry in `SimTypeFunction`

This replaces [PR152 in Simuvex](https://github.com/angr/simuvex/pull/152), plus the param fix in d2600d2.