### PR TITLE
Use SimProcedure instance for hook_symbol in cfg_base.py

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -94,7 +94,7 @@ class CFGBase(Analysis):
         # but we do not want to hook the same symbol multiple times
         if not self.project.is_symbol_hooked('UnresolvableTarget'):
             ut_addr = self.project.hook_symbol('UnresolvableTarget',
-                                               SIM_PROCEDURES['stubs']['UnresolvableTarget']
+                                               SIM_PROCEDURES['stubs']['UnresolvableTarget']()
                                                )
         else:
             ut_addr = self.project.hooked_symbol_addr('UnresolvableTarget')


### PR DESCRIPTION
A quick change to prevent this error in the logs when calling CFGAccurate():
```
CRITICAL | 2017-08-02 12:05:16,755 | angr.project | Hooking with a SimProcedure instance is deprecated! Please hook with an instance
```