### PR TITLE
Fixed the variables created by the ReturnUnconstrained simprocedure

### DIFF
--- a/angr/procedures/stubs/ReturnUnconstrained.py
+++ b/angr/procedures/stubs/ReturnUnconstrained.py
@@ -5,14 +5,13 @@ import angr
 ######################################
 
 class ReturnUnconstrained(angr.SimProcedure):
-    def run(self, resolves=None): #pylint:disable=arguments-differ
+    def run(self): #pylint:disable=arguments-differ
         #pylint:disable=attribute-defined-outside-init
-        self.resolves = resolves
 
         if self.successors is not None:
             self.successors.artifacts['resolves'] = resolves
 
-        o = self.state.se.Unconstrained("unconstrained_ret_%s" % self.resolves, self.state.arch.bits)
+        o = self.state.se.Unconstrained("unconstrained_ret_%s" % self.display_name, self.state.arch.bits)
         #if 'unconstrained_ret_9_64' in o.variables:
         #   __import__('ipdb').set_trace()
         return o


### PR DESCRIPTION
resolves is no longer being used as far as I know, use display_name instead.