### PR TITLE
Extend memory find to tolerate segmentation fault in reading

### DIFF
--- a/angr/state_plugins/abstract_memory.py
+++ b/angr/state_plugins/abstract_memory.py
@@ -430,7 +430,8 @@ class SimAbstractMemory(SimMemory): #pylint:disable=abstract-method
 
         return r
 
-    def _load(self, addr, size, condition=None, fallback=None, inspect=True, events=True):
+    def _load(self, addr, size, condition=None, fallback=None,
+            inspect=True, events=True, ret_on_segv=False):
         address_wrappers = self.normalize_address(addr, is_write=False)
 
         if isinstance(size, claripy.ast.BV) and isinstance(size._model_vsa, ValueSet):

--- a/angr/state_plugins/fast_memory.py
+++ b/angr/state_plugins/fast_memory.py
@@ -182,7 +182,8 @@ class SimFastMemory(SimMemory):
         req.stored_values = [ data ]
         return req
 
-    def _load(self, addr, size, condition=None, fallback=None, inspect=True, events=True):
+    def _load(self, addr, size, condition=None, fallback=None,
+            inspect=True, events=True, ret_on_segv=False):
         if not self._translate_cond(condition):
             l.debug("Received false condition. Returning fallback.")
             return fallback

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -450,8 +450,8 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         self.state.scratch.pop_priv()
         return default_mo
 
-    def _read_from(self, addr, num_bytes, inspect=True, events=True):
-        items = self.mem.load_objects(addr, num_bytes)
+    def _read_from(self, addr, num_bytes, inspect=True, events=True, ret_on_segv=False):
+        items = self.mem.load_objects(addr, num_bytes, ret_on_segv=ret_on_segv)
 
         # optimize the case where we have a single object return
         if len(items) == 1 and items[0][1].includes(addr) and items[0][1].includes(addr + num_bytes - 1):
@@ -491,7 +491,8 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             r = self.state.se.BVV(0, 0)
         return r
 
-    def _load(self, dst, size, condition=None, fallback=None, inspect=True, events=True):
+    def _load(self, dst, size, condition=None, fallback=None,
+            inspect=True, events=True, ret_on_segv=False):
         if self.state.se.symbolic(size):
             l.warning("Concretizing symbolic length. Much sad; think about implementing.")
 
@@ -518,7 +519,8 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             else:
                 raise
 
-        read_value = self._read_from(addrs[0], size, inspect=inspect, events=events)
+        read_value = self._read_from(addrs[0], size, inspect=inspect,
+                events=events, ret_on_segv=ret_on_segv)
         constraint_options = [ dst == addrs[0] ]
 
         for a in addrs[1:]:
@@ -571,7 +573,8 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             if i - chunk_start > chunk_size - seek_size:
                 l.debug("loading new chunk")
                 chunk_start += chunk_size - seek_size + 1
-                chunk = self.load(start+chunk_start, chunk_size, endness="Iend_BE")
+                chunk = self.load(start+chunk_start, chunk_size,
+                        endness="Iend_BE", ret_on_segv=True)
 
             chunk_off = i-chunk_start
             b = chunk[chunk_size*8 - chunk_off*8 - 1 : chunk_size*8 - chunk_off*8 - seek_size*8]

--- a/angr/storage/memory.py
+++ b/angr/storage/memory.py
@@ -803,7 +803,7 @@ class SimMemory(SimStatePlugin):
         """
         return [ addr ]
 
-    def _load(self, addr, size, condition=None, fallback=None, inspect=True, events=True):
+    def _load(self, addr, size, condition=None, fallback=None, inspect=True, events=True, ret_on_segv=False):
         raise NotImplementedError()
 
     def find(self, addr, what, max_search=None, max_symbolic_bytes=None, default=None, step=1):

--- a/angr/storage/memory.py
+++ b/angr/storage/memory.py
@@ -661,7 +661,7 @@ class SimMemory(SimStatePlugin):
             return self._store(req)
 
     def load(self, addr, size=None, condition=None, fallback=None, add_constraints=None, action=None, endness=None,
-             inspect=True, disable_actions=False):
+             inspect=True, disable_actions=False, ret_on_segv=False):
         """
         Loads size bytes from dst.
 
@@ -675,6 +675,7 @@ class SimMemory(SimStatePlugin):
         :param bool inspect:    Whether this store should trigger SimInspect breakpoints or not.
         :param bool disable_actions: Whether this store should avoid creating SimActions or not. When set to False,
                                      state options are respected.
+        :param bool ret_on_segv: Whether returns the memory that is already loaded before a segmentation fault is triggered. The default is False.
 
         There are a few possible return values. If no condition or fallback are passed in,
         then the return is the bytes at the address, in the form of a claripy expression.
@@ -725,7 +726,7 @@ class SimMemory(SimStatePlugin):
 
         try:
             a,r,c = self._load(addr_e, size_e, condition=condition_e, fallback=fallback_e, inspect=inspect,
-                               events=not disable_actions)
+                               events=not disable_actions, ret_on_segv=ret_on_segv)
         except SimSegfaultError as e:
             e.original_addr = addr_e
             raise


### PR DESCRIPTION
Finding `what` in memory is to read memory chunk by chunk and then find `what` in each chunk. The size of the chunk could exceed the memory of a binary and thus triggers a segmentation fault. In this case, we stop reading more bytes beyond the segmentation fault reading address. 