### PR TITLE
add `endness` enum with constants for Iend_LE and Iend_BE

### DIFF
--- a/angr/__init__.py
+++ b/angr/__init__.py
@@ -41,6 +41,7 @@ from .state_hierarchy import StateHierarchy
 from .sim_state import SimState
 from .engines import SimEngineVEX
 from .calling_conventions import DEFAULT_CC, SYSCALL_CC, PointerWrapper
+from .enums import *
 
 # now that we have everything loaded, re-grab the list of loggers
 loggers.load_all_loggers()

--- a/angr/enums.py
+++ b/angr/enums.py
@@ -1,0 +1,10 @@
+# This module contains enums for constants used by angr
+
+class endness:
+    """ Endness specifies the byte order for integer values
+
+    :cvar LE:      little endian, least significant byte is stored at lowest address
+    :cvar BE:      big endian, most significant byte is stored at lowest address 
+    """
+    LE = "Iend_LE"
+    BE = "Iend_BE"


### PR DESCRIPTION
This way, you will at least get a runtime error about a missing attribute
if you mistype the name (previously, if you wrote `IEnd_LE` it would be silently
ignored)