### PR TITLE
Add SimState support to CFGFast 

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -439,7 +439,7 @@ class CFGBase(Analysis):
         if edge in self._graph:
             self._graph.remove_edge(*edge)
 
-    def _to_snippet(self, cfg_node=None, addr=None, size=None, thumb=None, jumpkind=None, base_state=None):
+    def _to_snippet(self, cfg_node=None, addr=None, size=None, thumb=False, jumpkind=None, base_state=None):
         """
         Convert a CFGNode instance to a CodeNode object.
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2625,7 +2625,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 # They are overlapping
 
                 try:
-                    block = self.project.factory.fresh_block(a.addr, b.addr - a.addr)
+                    block = self.project.factory.fresh_block(a.addr, b.addr - a.addr, backup_state=self._base_state)
                 except SimTranslationError:
                     a = b
                     continue

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3051,7 +3051,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             if target_node is None:
                 target_snippet = self._to_snippet(addr=addr, base_state=self._base_state)
             else:
-                target_snippet = self._to_snippet(cfg_node=self._nodes[addr])
+                target_snippet = self._to_snippet(cfg_node=target_node)
 
             if src_node is None:
                 # Add this basic block into the function manager
@@ -3093,11 +3093,14 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             else:
                 src_snippet = self._to_snippet(cfg_node=src_node)
 
-                dst_node = self._nodes.get(ret_addr, None)
-                if dst_node is None:
-                    ret_snippet = self._to_snippet(addr=ret_addr, base_state=self._base_state)
+                if ret_addr is None:
+                    ret_snippet = None
                 else:
-                    ret_snippet = self._to_snippet(cfg_node=dst_node)
+                    dst_node = self._nodes.get(ret_addr, None)
+                    if dst_node is None:
+                        ret_snippet = self._to_snippet(addr=ret_addr, base_state=self._base_state)
+                    else:
+                        ret_snippet = self._to_snippet(cfg_node=dst_node)
 
                 self.kb.functions._add_call_to(function_addr, src_snippet, addr, ret_snippet, syscall=syscall,
                                                stmt_idx=stmt_idx, ins_addr=ins_addr,

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2650,11 +2650,11 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 # this is mostly because we misidentified the function beginning. In fact a is the function beginning,
                 # but somehow we thought b is the beginning
                 if a.addr + a.size == b.addr + b.size:
-                    in_edges = len([ _ for _, _, data in self.graph.in_edges(b, data=True) ])
+                    in_edges = len([ _ for _, _, data in self.graph.in_edges([b], data=True) ])
                     if in_edges == 0:
                         # we use node a to replace node b
                         # link all successors of b to a
-                        for _, dst, data in self.graph.out_edges(b, data=True):
+                        for _, dst, data in self.graph.out_edges([b], data=True):
                             self.graph.add_edge(a, dst, **data)
 
                         if b.addr in self._nodes:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -696,6 +696,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         self._regions = regions if regions is not None else self._executable_memory_regions(None, force_segment)
         # sort it
         self._regions = sorted(self._regions, key=lambda x: x[0])
+        self._regions_size = sum((b - a) for a, b in self._regions)
 
         self._pickle_intermediate_results = pickle_intermediate_results
         self._indirect_jump_target_limit = indirect_jump_target_limit
@@ -928,7 +929,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         # Make sure curr_addr exists in binary
         accepted = False
-        for start, end in self._exec_mem_regions:
+        for start, end in self._regions:
             if start <= curr_addr < end:
                 # accept
                 accepted = True
@@ -1101,7 +1102,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         # Do not calculate progress if the user doesn't care about the progress at all
         if self._show_progressbar or self._progress_callback:
             max_percentage_stage_1 = 50.0
-            percentage = self._seg_list.occupied_size * max_percentage_stage_1 / self._exec_mem_region_size
+            percentage = self._seg_list.occupied_size * max_percentage_stage_1 / self._regions_size
             if percentage > max_percentage_stage_1:
                 percentage = max_percentage_stage_1
 

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -51,7 +51,8 @@ class CFGNode(object):
                  depth=None,
                  callstack_key=None,
                  creation_failure_info=None,
-                 thumb=False):
+                 thumb=False,
+                 byte_string=None):
         """
         Note: simprocedure_name is not used to recreate the SimProcedure object. It's only there for better
         __repr__.
@@ -72,6 +73,7 @@ class CFGNode(object):
         self.block_id = block_id
         self.depth = depth
         self.thumb = thumb
+        self.byte_string = byte_string
 
         self.creation_failure_info = None
         if creation_failure_info is not None:

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -70,7 +70,10 @@ class JumpTableResolver(IndirectJumpResolver):
         self._max_targets = cfg._indirect_jump_target_limit
 
         # Perform a backward slicing from the jump target
-        b = Blade(cfg.graph, addr, -1, cfg=cfg, project=project, ignore_sp=False, ignore_bp=False, max_level=3)
+        b = Blade(cfg.graph, addr, -1,
+            cfg=cfg, project=project,
+            ignore_sp=False, ignore_bp=False,
+            max_level=3, base_state=self.base_state)
 
         stmt_loc = (addr, 'default')
         if stmt_loc not in b.slice:
@@ -83,7 +86,7 @@ class JumpTableResolver(IndirectJumpResolver):
             if len(preds) != 1:
                 return False, None
             block_addr, stmt_idx = stmt_loc = preds[0]
-            block = project.factory.block(block_addr).vex
+            block = project.factory.block(block_addr, backup_state=self.base_state).vex
             stmt = block.statements[stmt_idx]
             if isinstance(stmt, (pyvex.IRStmt.WrTmp, pyvex.IRStmt.Put)):
                 if isinstance(stmt.data, (pyvex.IRExpr.Get, pyvex.IRExpr.RdTmp)):
@@ -276,7 +279,7 @@ class JumpTableResolver(IndirectJumpResolver):
 
         for addr in sorted(stmts.keys()):
             stmt_ids = stmts[addr]
-            irsb = self.project.factory.block(addr).vex
+            irsb = self.project.factory.block(addr, backup_state=self.base_state).vex
 
             print "  ####"
             print "  #### Block %#x" % addr

--- a/angr/analyses/cfg/indirect_jump_resolvers/resolver.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/resolver.py
@@ -1,4 +1,6 @@
 
+from ....errors import SimMemoryError
+
 
 class IndirectJumpResolver(object):
     def __init__(self, arch=None, timeless=False, base_state=None):
@@ -53,10 +55,9 @@ class IndirectJumpResolver(object):
             try:
                 if self.base_state.solver.is_true((self.base_state.memory.permissions(target) & 4) == 4):
                     return True
-            except:
+            except SimMemoryError:
                 pass
-            finally:
-                return False
+            return False
 
         if cfg._addr_in_exec_memory_regions(target):
             # the jump target is executable

--- a/angr/analyses/cfg/indirect_jump_resolvers/resolver.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/resolver.py
@@ -1,9 +1,10 @@
 
 
 class IndirectJumpResolver(object):
-    def __init__(self, arch=None, timeless=False):
+    def __init__(self, arch=None, timeless=False, base_state=None):
         self.arch = arch
         self.timeless = timeless
+        self.base_state = base_state
 
     def filter(self, cfg, addr, func_addr, block, jumpkind):
         """
@@ -47,6 +48,15 @@ class IndirectJumpResolver(object):
         :return:            True if the target is valid. False otherwise.
         :rtype:             bool
         """
+
+        if self.base_state is not None:
+            try:
+                if self.base_state.solver.is_true((self.base_state.memory.permissions(target) & 4) == 4):
+                    return True
+            except:
+                pass
+            finally:
+                return False
 
         if cfg._addr_in_exec_memory_regions(target):
             # the jump target is executable

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -1557,9 +1557,8 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
         """
 
         func = self.project.loader.find_symbol(job.addr)
-        obj = self.project.loader.find_module_containing(job.addr)
         function_name = func.name if func is not None else None
-        module_name = obj.provides if obj is not None else obj
+        module_name = self.project.loader.find_module_name(job.addr)
 
         l.debug("VFGJob @ %#08x with callstack [ %s ]", job.addr,
                 job.callstack_repr(self.kb),

--- a/angr/blade.py
+++ b/angr/blade.py
@@ -11,7 +11,7 @@ class Blade(object):
     It is meant to be used in angr for small or on-the-fly analyses.
     """
     def __init__(self, graph, dst_run, dst_stmt_idx, direction='backward', project=None, cfg=None, ignore_sp=False,
-                 ignore_bp=False, ignored_regs=None, max_level=3):
+                 ignore_bp=False, ignored_regs=None, max_level=3, base_state=None):
         """
         :param networkx.DiGraph graph:  A graph representing the control flow graph. Note that it does not take
                                         angr.analyses.CFGAccurate or angr.analyses.CFGFast.
@@ -33,6 +33,7 @@ class Blade(object):
         self._ignore_sp = ignore_sp
         self._ignore_bp = ignore_bp
         self._max_level = max_level
+        self._base_state = base_state
 
         self._slice = networkx.DiGraph()
 
@@ -88,7 +89,7 @@ class Blade(object):
         for block_addr in block_addrs:
             block_str = "IRSB %#x\n" % block_addr
 
-            block = self.project.factory.block(block_addr).vex
+            block = self.project.factory.block(block_addr, backup_state=self._base_state).vex
 
             included_stmts = set([ stmt for _, stmt in self.slice.nodes_iter() if _ == block_addr ])
 
@@ -136,7 +137,7 @@ class Blade(object):
                 return self._run_cache[v]
 
             if self.project:
-                irsb = self.project.factory.block(v).vex
+                irsb = self.project.factory.block(v, backup_state=self._base_state).vex
                 self._run_cache[v] = irsb
                 return irsb
             else:
@@ -205,7 +206,10 @@ class Blade(object):
         regs = set()
 
         # Retrieve the target: are we slicing from a register(IRStmt.Put), or a temp(IRStmt.WrTmp)?
-        stmts = self._get_irsb(self._dst_run).statements
+        try:
+            stmts = self._get_irsb(self._dst_run).statements
+        except SimTranslationError:
+            return
 
         if self._dst_stmt_idx != -1:
             dst_stmt = stmts[self._dst_stmt_idx]
@@ -336,5 +340,5 @@ class Blade(object):
 
                 self._backward_slice_recursive(level - 1, pred, regs, stack_offsets, prev, data.get('stmt_idx', None))
 
-from .errors import AngrBladeError, AngrBladeSimProcError
+from .errors import AngrBladeError, AngrBladeSimProcError, SimTranslationError
 from .analyses.cfg.cfg_node import CFGNode

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -308,8 +308,8 @@ class AngrObjectFactory(object):
                      backup_state=backup_state, opt_level=opt_level, num_inst=num_inst, traceflags=traceflags
                      )
 
-    def fresh_block(self, addr, size):
-        return Block(addr, project=self._project, size=size)
+    def fresh_block(self, addr, size, backup_state=None):
+        return Block(addr, project=self._project, size=size, backup_state=backup_state)
 
     cc.SimRegArg = SimRegArg
     cc.SimStackArg = SimStackArg

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -150,7 +150,7 @@ class Function(object):
 
         for block_addr, block in self._local_blocks.iteritems():
             try:
-                yield self._get_block(block_addr, block.size)
+                yield self._get_block(block_addr, size=block.size, byte_string=block.bytestr)
             except (SimEngineError, SimMemoryError):
                 pass
 
@@ -175,7 +175,7 @@ class Function(object):
 
         return self._local_block_addrs
 
-    def _get_block(self, addr, size=None):
+    def _get_block(self, addr, size=None, byte_string=None):
         if addr in self._block_cache:
             b = self._block_cache[addr]
             if size is None or b.size == size:
@@ -188,9 +188,7 @@ class Function(object):
             # we know the size
             size = self._block_sizes[addr]
 
-
-
-        block = self._project.factory.block(addr, size=size)
+        block = self._project.factory.block(addr, size=size, byte_string=byte_string)
         if size is None:
             # update block_size dict
             self._block_sizes[addr] = block.size
@@ -762,7 +760,7 @@ class Function(object):
 
         for b in self._local_blocks.itervalues():
             # TODO: should I call get_blocks?
-            block = self._get_block(b.addr, size=b.size)
+            block = self._get_block(b.addr, size=b.size, byte_string=b.bytestr)
             common_insns = set(block.instruction_addrs).intersection(ins_addrs)
             if common_insns:
                 blocks.append(b)
@@ -800,7 +798,7 @@ class Function(object):
         """
 
         for b in self.blocks:
-            block = self._get_block(b.addr, size=b.size)
+            block = self._get_block(b.addr, size=b.size, byte_string=b.bytestr)
             if insn_addr in block.instruction_addrs:
                 index = block.instruction_addrs.index(insn_addr)
                 if index == len(block.instruction_addrs) - 1:

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -150,7 +150,8 @@ class Function(object):
 
         for block_addr, block in self._local_blocks.iteritems():
             try:
-                yield self._get_block(block_addr, size=block.size, byte_string=block.bytestr)
+                yield self._get_block(block_addr, size=block.size,
+                                      byte_string=block.bytestr if isinstance(block, BlockNode) else None)
             except (SimEngineError, SimMemoryError):
                 pass
 

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -951,7 +951,7 @@ class SimPagedMemory(object):
         """
         Returns the permissions for a page at address `addr`.
 
-        If optional arugment permissions is given, set page permissions to that prior to returning permissions.
+        If optional argument permissions is given, set page permissions to that prior to returning permissions.
         """
 
         if self.state.se.symbolic(addr):

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -2,7 +2,7 @@ import angr
 import nose
 
 import os
-bin_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries'))
+bin_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries'))
 
 import logging
 logging.getLogger("identifier").setLevel("DEBUG")
@@ -15,7 +15,7 @@ def test_comparison_identification():
 
     true_symbols = {0x804a3d0: 'strncmp', 0x804a0f0: 'strcmp', 0x8048e60: 'memcmp', 0x8049f40: 'strcasecmp'}
 
-    p = angr.Project(os.path.join(bin_location, "tests/i386/identifiable"))
+    p = angr.Project(os.path.join(bin_location, "tests", "i386", "identifiable"))
     idfer = p.analyses.Identifier(require_predecessors=False)
 
     seen = dict()


### PR DESCRIPTION
With this PR, CFGFast now supports generating a CFG from an angr SimState. This means you can use angr to generate CFGs on dynamically generated code!

We also fixed several bugs inside CFGFast.