### PR TITLE
unicorn: support stop points that aren't starts of basic blocks

### DIFF
--- a/angr/exploration_techniques/oppologist.py
+++ b/angr/exploration_techniques/oppologist.py
@@ -35,10 +35,7 @@ class Oppologist(ExplorationTechnique):
 
         irsb = self.project.factory.block(pn.addr).vex
         addrs = [ s.addr for s in irsb.statements if isinstance(s, pyvex.IRStmt.IMark) ]
-        if len(addrs) > 1:
-            stops = [ addrs[1] ]
-        else:
-            stops = None
+        stops = None
 
         pn.options.add(sim_options.UNICORN)
         pn.options.add(sim_options.UNICORN_AGGRESSIVE_CONCRETIZATION)

--- a/angr/exploration_techniques/oppologist.py
+++ b/angr/exploration_techniques/oppologist.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-import pyvex
 import claripy
 import functools
 
@@ -33,8 +32,6 @@ class Oppologist(ExplorationTechnique):
     def _oppologize(self, state, pn, **kwargs):
         l.debug("... pn: %s", pn)
 
-        irsb = self.project.factory.block(pn.addr).vex
-        addrs = [ s.addr for s in irsb.statements if isinstance(s, pyvex.IRStmt.IMark) ]
         stops = None
 
         pn.options.add(sim_options.UNICORN)

--- a/tests/perf_unicorn.py
+++ b/tests/perf_unicorn.py
@@ -19,9 +19,6 @@ def perf_unicorn_0():
     pg_unicorn.run()
     elapsed = time.time() - start
 
-    if len(pg_unicorn.errored) > 0:
-        pg_unicorn.errored[0].debug()
-
     print "Elapsed %f sec" % elapsed
     print pg_unicorn.one_deadended
 
@@ -35,9 +32,6 @@ def perf_unicorn_1():
     start = time.time()
     pg_unicorn.run()
     elapsed = time.time() - start
-
-    if len(pg_unicorn.errored) > 0:
-        pg_unicorn.errored[0].debug()
 
     print "Elapsed %f sec" % elapsed
     print pg_unicorn.one_deadended

--- a/tests/perf_unicorn.py
+++ b/tests/perf_unicorn.py
@@ -4,7 +4,7 @@ import os
 import time
 
 import angr
-import angr.options as so
+from angr import options as so
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../'))
 
@@ -19,6 +19,9 @@ def perf_unicorn_0():
     pg_unicorn.run()
     elapsed = time.time() - start
 
+    if len(pg_unicorn.errored) > 0:
+        pg_unicorn.errored[0].debug()
+
     print "Elapsed %f sec" % elapsed
     print pg_unicorn.one_deadended
 
@@ -32,6 +35,9 @@ def perf_unicorn_1():
     start = time.time()
     pg_unicorn.run()
     elapsed = time.time() - start
+
+    if len(pg_unicorn.errored) > 0:
+        pg_unicorn.errored[0].debug()
 
     print "Elapsed %f sec" % elapsed
     print pg_unicorn.one_deadended

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -44,6 +44,22 @@ def test_stops():
     p_normal_angr = pg_normal_angr.one_deadended
     nose.tools.assert_equal(p_normal_angr.history.bbl_addrs.hardcopy, p_normal.history.bbl_addrs.hardcopy)
 
+    # test STOP_STOPPOINT on an address that is not a basic block start
+    s_stoppoints = p.factory.call_state(p.loader.find_symbol("main").rebased_addr, 1, [], add_options=so.unicorn)
+
+    # this address is right before/after the bb for the stop_normal() function ends
+    # we should not stop there, since that code is never hit
+    stop_fake = [0x08048436, 0x08048457]
+
+    # this is an address inside main that is not the beginning of a basic block. we should stop here
+    stop_in_bb = 0x08048511
+    stop_bb = 0x0804850c # basic block of the above address
+    pg_stoppoints = p.factory.simgr(s_stoppoints).step(n=1, extra_stop_points=stop_fake + [stop_in_bb])
+    nose.tools.assert_equal(len(pg_stoppoints.active), 1) # path should not branch
+    p_stoppoints = pg_stoppoints.one_active
+    nose.tools.assert_equal(p_stoppoints.addr, stop_bb) # should stop at bb before stop_in_bb
+    _compare_trace(p_stoppoints.history.descriptions, ['<Unicorn (STOP_STOPPOINT after 107 steps) from 0x80484b6: 1 sat>'])
+
     # test STOP_SYMBOLIC
     s_symbolic = p.factory.entry_state(args=['a', 'a'], add_options=so.unicorn)
     pg_symbolic = p.factory.simgr(s_symbolic).run()


### PR DESCRIPTION
Previously, if a stop point was not placed on the start of a basic point, then
unicorn simply ignored it. We now check if the current basic block contains any
of the stop points, and if it does, stop execution.

This also includes a small fix to the `perf_unicorn.py` script to adapt to current version of angr (plus a check to launch a debugger if execution errored).

This is the first step towards supporting `explore` and breakpoints with unicorn.