### PR TITLE
Fix instruction breakpoints, explorer and num_inst with unicorn enabled

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -53,6 +53,12 @@ class SimEngineUnicorn(SimEngine):
 
         self._countdown(state)
 
+        # should the countdown still be updated if we're not stepping a whole block?
+        # current decision: leave it updated, since we are moving forward
+        if kwargs.get("num_inst", None) is not None:
+            # we don't support single stepping with unicorn
+            return False
+
         unicorn = state.unicorn  # shorthand
         if state.regs.ip.symbolic:
             l.debug("symbolic IP!")

--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -126,6 +126,7 @@ class SimEngineUnicorn(SimEngine):
             successors.initial_state.unicorn.countdown_symbolic_memory = state.unicorn.countdown_symbolic_memory
             successors.initial_state.unicorn.countdown_symbolic_registers = state.unicorn.countdown_symbolic_registers
             successors.initial_state.unicorn.countdown_nonunicorn_blocks = state.unicorn.countdown_nonunicorn_blocks
+            successors.initial_state.unicorn.countdown_stop_point = state.unicorn.countdown_stop_point
             return
 
         description = 'Unicorn (%s after %d steps)' % (STOP.name_stop(state.unicorn.stop_reason), state.unicorn.steps)
@@ -153,6 +154,8 @@ class SimEngineUnicorn(SimEngine):
         state.unicorn.countdown_nonunicorn_blocks -= 1
         state.unicorn.countdown_symbolic_registers -= 1
         state.unicorn.countdown_symbolic_memory -= 1
+        state.unicorn.countdown_symbolic_memory -= 1
+        state.unicorn.countdown_stop_point -= 1
 
     #
     # Pickling

--- a/angr/exploration_techniques/__init__.py
+++ b/angr/exploration_techniques/__init__.py
@@ -60,16 +60,19 @@ class ExplorationTechnique(object):
 
     def _condition_to_lambda(self, condition, default=False):
         """
-        Translates an integer, set or list into a lambda that checks a state address against the given addresses, and the
+        Translates an integer, set, list or lambda into a lambda that checks a state address against the given addresses, and the
         other ones from the same basic block
 
-        :param condition:   An integer, set, or list to convert to a lambda.
+        :param condition:   An integer, set, list or lambda to convert to a lambda.
         :param default:     The default return value of the lambda (in case condition is None). Default: false.
 
         :returns:           A lambda that takes a state and returns the set of addresses that it matched from the condition
+                            The lambda has an `.addrs` attribute that contains the full set of the addresses at which it matches if that
+                            can be determined statically.
         """
         if condition is None:
             condition_function = lambda p: default
+            condition_function.addrs = set()
 
         elif isinstance(condition, (int, long)):
             return self._condition_to_lambda((condition,))
@@ -89,6 +92,7 @@ class ExplorationTechnique(object):
                     return addrs.intersection(set(self.project.factory.block(p.addr).instruction_addrs))
                 except (AngrError, SimError):
                     return False
+            condition_function.addrs = addrs
         elif hasattr(condition, '__call__'):
             condition_function = condition
         else:

--- a/angr/exploration_techniques/explorer.py
+++ b/angr/exploration_techniques/explorer.py
@@ -1,4 +1,5 @@
 from . import ExplorationTechnique
+from .. import sim_options
 
 import logging
 l = logging.getLogger("angr.exploration_techniques.explorer")
@@ -31,6 +32,16 @@ class Explorer(ExplorationTechnique):
         self.avoid_priority = avoid_priority
         self._project = None
 
+        find_addrs = getattr(self.find, "addrs", None)
+        avoid_addrs = getattr(self.avoid, "addrs", None)
+
+        # it is safe to use unicorn only if all addresses at which we should stop are statically known
+        self._warn_unicorn = (find_addrs is None) or (avoid_addrs is None)
+
+        # even if avoid or find addresses are not statically known, stop on those that we do know
+        self._extra_stop_points = (find_addrs or set()) | (avoid_addrs or set())
+
+
         # TODO: This is a hack for while CFGFast doesn't handle procedure continuations
         from .. import analyses
         if isinstance(cfg, analyses.CFGFast):
@@ -39,22 +50,15 @@ class Explorer(ExplorationTechnique):
             self.cfg = None
 
         if self.cfg is not None:
-            if isinstance(avoid, (int, long)):
-                avoid = (avoid,)
-            elif isinstance(avoid, set):
-                avoid = list(avoid)
-            elif not isinstance(avoid, (list, tuple)):
-                avoid = ()
+            avoid = avoid_addrs or set()
 
-            if isinstance(find, (int, long)):
-                find = (find,)
-            elif isinstance(find, set):
-                find = list(find)
-            elif not isinstance(find, (list, tuple)):
+            # we need the find addresses to be determined statically
+            if find_addrs is None:
                 l.error("You must provide at least one 'find' address as a number, set, list, or tuple if you provide a CFG.")
                 l.error("Usage of the CFG has been disabled for this explorer.")
                 self.cfg = None
                 return
+            find = find.addrs
 
             for a in avoid:
                 if cfg.get_any_node(a) is None:
@@ -87,14 +91,22 @@ class Explorer(ExplorationTechnique):
                 return
 
             l.warning("Please be sure that the CFG you have passed in is complete.")
-            l.warning("Providng an incomplete CFG can cause viable paths to be discarded!")
+            l.warning("Providing an incomplete CFG can cause viable paths to be discarded!")
 
     def setup(self, pg):
         self._project = pg._project
         if not self.find_stash in pg.stashes: pg.stashes[self.find_stash] = []
         if not self.avoid_stash in pg.stashes: pg.stashes[self.avoid_stash] = []
 
+    def step(self, simgr, stash, **kwargs):
+        base_extra_stop_points = set(kwargs.get("extra_stop_points") or {})
+        return simgr.step(stash=stash, extra_stop_points=base_extra_stop_points | self._extra_stop_points, **kwargs)
+
     def filter(self, state):
+        if sim_options.UNICORN in state.options and self._warn_unicorn:
+            self._warn_unicorn = False # show warning only once
+            l.warning("Using unicorn with find or avoid conditions that are a lambda (not a number, set, tuple or list).")
+            l.warning("Unicorn may step over states that match the condition (find or avoid) without stopping.")
         rFind = self.find(state)
         if rFind:
             if not state.history.reachable:

--- a/angr/exploration_techniques/explorer.py
+++ b/angr/exploration_techniques/explorer.py
@@ -58,7 +58,7 @@ class Explorer(ExplorationTechnique):
                 l.error("Usage of the CFG has been disabled for this explorer.")
                 self.cfg = None
                 return
-            find = find.addrs
+            find = self.find.addrs
 
             for a in avoid:
                 if cfg.get_any_node(a) is None:

--- a/angr/exploration_techniques/oppologist.py
+++ b/angr/exploration_techniques/oppologist.py
@@ -40,6 +40,7 @@ class Oppologist(ExplorationTechnique):
         pn.unicorn.countdown_symbolic_registers = 0
         pn.unicorn.countdown_symbolic_memory = 0
         pn.unicorn.countdown_nonunicorn_blocks = 0
+        pn.unicorn.countdown_stop_point = 0
         ss = self.project.factory.successors(pn, extra_stop_points=stops, throw=True, **kwargs)
 
         fixup = functools.partial(self._restore_state, state)

--- a/angr/exploration_techniques/oppologist.py
+++ b/angr/exploration_techniques/oppologist.py
@@ -32,8 +32,6 @@ class Oppologist(ExplorationTechnique):
     def _oppologize(self, state, pn, **kwargs):
         l.debug("... pn: %s", pn)
 
-        stops = None
-
         pn.options.add(sim_options.UNICORN)
         pn.options.add(sim_options.UNICORN_AGGRESSIVE_CONCRETIZATION)
         pn.unicorn.max_steps = 1
@@ -41,7 +39,7 @@ class Oppologist(ExplorationTechnique):
         pn.unicorn.countdown_symbolic_memory = 0
         pn.unicorn.countdown_nonunicorn_blocks = 0
         pn.unicorn.countdown_stop_point = 0
-        ss = self.project.factory.successors(pn, extra_stop_points=stops, throw=True, **kwargs)
+        ss = self.project.factory.successors(pn, throw=True, **kwargs)
 
         fixup = functools.partial(self._restore_state, state)
 

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -231,6 +231,88 @@ def test_concrete_transmits():
 
     nose.tools.assert_equal(pg_unicorn.one_active.posix.dumps(1), '1) Add number to the array\n2) Add random number to the array\n3) Sum numbers\n4) Exit\nRandomness added\n1) Add number to the array\n2) Add random number to the array\n3) Sum numbers\n4) Exit\n  Index: \n1) Add number to the array\n2) Add random number to the array\n3) Sum numbers\n4) Exit\n')
 
+def test_inspect():
+    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
+
+    def main_state(argc, add_options=so.unicorn):
+        main_addr = p.loader.find_symbol("main").rebased_addr
+        return p.factory.call_state(main_addr, argc, [], add_options=add_options)
+
+    # test breaking on specific addresses
+    s_break_addr = main_state(1)
+    addr0 = 0x08048454 # at the beginning of a basic block, at end of stop_normal function
+    addr1 = 0x080484c7 # this is at the beginning of main, in the middle of a basic block
+    addr2 = 0x0804843e # another non-bb address, at the start of stop_normal
+    addr3 = 0x08048457 # address of a block that should not get hit (stop_symbolc function)
+    addr4 = 0x0804850b # another address that shouldn't get hit, near end of main
+    hits = { addr0 : 0, addr1: 0, addr2: 0, addr3: 0, addr4: 0 }
+
+    def create_addr_action(addr):
+        def action(state):
+            hits[addr] += 1
+        return action
+
+    for addr in [addr0, addr1, addr2]:
+        s_break_addr.inspect.b("instruction", instruction=addr, action=create_addr_action(addr))
+
+    pg_instruction = p.factory.simgr(s_break_addr)
+    pg_instruction.run()
+    nose.tools.assert_equal(hits[addr0], 1)
+    nose.tools.assert_equal(hits[addr1], 1)
+    nose.tools.assert_equal(hits[addr2], 1)
+    nose.tools.assert_equal(hits[addr3], 0)
+    nose.tools.assert_equal(hits[addr4], 0)
+
+    # test breaking on every instruction
+    def collect_trace(options):
+        s_break_every = main_state(1, add_options=options)
+        trace = []
+        def action_every(state):
+            trace.append(state.addr)
+        s_break_every.inspect.b("instruction", action=action_every)
+        pg_break_every = p.factory.simgr(s_break_every)
+        pg_break_every.run()
+    nose.tools.assert_equal(collect_trace(so.unicorn), collect_trace(set()))
+
+def test_explore():
+    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
+
+    def main_state(argc, add_options=so.unicorn):
+        main_addr = p.loader.find_symbol("main").rebased_addr
+        return p.factory.call_state(main_addr, argc, [], add_options=add_options)
+
+    addr = 0x08048454
+    s_explore = main_state(1)
+    pg_explore_find = p.factory.simgr(s_explore)
+    pg_explore_find.explore(find=addr)
+    nose.tools.assert_equal(len(pg_explore_find.found), 1)
+    nose.tools.assert_equal(pg_explore_find.found[0].addr, addr)
+
+    pg_explore_avoid = p.factory.simgr(s_explore)
+    pg_explore_avoid.explore(avoid=addr)
+    nose.tools.assert_equal(len(pg_explore_avoid.avoid), 1)
+    nose.tools.assert_equal(pg_explore_avoid.avoid[0].addr, addr)
+
+
+def test_single_step():
+    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
+
+    def main_state(argc, add_options=so.unicorn):
+        main_addr = p.loader.find_symbol("main").rebased_addr
+        return p.factory.call_state(main_addr, argc, [], add_options=add_options)
+
+    s_main = main_state(1)
+
+    step1 = s_main.block().instruction_addrs[1]
+    successors1 = s_main.step(num_inst=1).successors
+    nose.tools.assert_equal(len(successors1), 1)
+    nose.tools.assert_equal(successors1[0].addr, step1)
+
+    step5 = s_main.block().instruction_addrs[5]
+    successors2 = successors1[0].step(num_inst=4).successors
+    nose.tools.assert_equal(len(successors2), 1)
+    nose.tools.assert_equal(successors2[0].addr, step5)
+
 if __name__ == '__main__':
     #import logging
     #logging.getLogger('angr.state_plugins.unicorn_engine').setLevel('DEBUG')

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -2,13 +2,12 @@ import nose
 import angr
 import pickle
 import re
+from angr import options as so
 from nose.plugins.attrib import attr
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../'))
 
-import angr
-from angr import options as so
 
 
 def _remove_addr_from_trace_item(trace_item_str):
@@ -234,7 +233,8 @@ def test_concrete_transmits():
 def test_inspect():
     p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
 
-    def main_state(argc, add_options=so.unicorn):
+    def main_state(argc, add_options=None):
+        add_options = add_options or so.unicorn
         main_addr = p.loader.find_symbol("main").rebased_addr
         return p.factory.call_state(main_addr, argc, [], add_options=add_options)
 
@@ -248,7 +248,7 @@ def test_inspect():
     hits = { addr0 : 0, addr1: 0, addr2: 0, addr3: 0, addr4: 0 }
 
     def create_addr_action(addr):
-        def action(state):
+        def action(_state):
             hits[addr] += 1
         return action
 
@@ -277,7 +277,8 @@ def test_inspect():
 def test_explore():
     p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
 
-    def main_state(argc, add_options=so.unicorn):
+    def main_state(argc, add_options=None):
+        add_options = add_options or so.unicorn
         main_addr = p.loader.find_symbol("main").rebased_addr
         return p.factory.call_state(main_addr, argc, [], add_options=add_options)
 
@@ -297,7 +298,9 @@ def test_explore():
 def test_single_step():
     p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
 
-    def main_state(argc, add_options=so.unicorn):
+
+    def main_state(argc, add_options=None):
+        add_options = add_options or so.unicorn
         main_addr = p.loader.find_symbol("main").rebased_addr
         return p.factory.call_state(main_addr, argc, [], add_options=add_options)
 


### PR DESCRIPTION
This fixes three issues:

* explorer needs to use stop points for `find/avoid` to prevent unicorn stepping over them
* there need to be stop points for breakpoints 
* we should not use the unicorn engine when `num_inst` is set (as unicorn cannot do instruction-precise stepping)

I also added a cooldown for stop points, although I am not sure if it is really necessary.