### PR TITLE
Refactor KB labels plugin

### DIFF
--- a/angr/knowledge_plugins/__init__.py
+++ b/angr/knowledge_plugins/__init__.py
@@ -4,5 +4,5 @@ from .variables import VariableManager
 from .comments import Comments
 from .data import Data
 from .indirect_jumps import IndirectJumps
-from .labels import Labels
+from .labels import LabelsPlugin
 from .plugin import KnowledgeBasePlugin

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -94,25 +94,41 @@ class LabelsPlugin(KnowledgeBasePlugin):
 
     @property
     def default_namespace(self):
+        """Get the default namespace name
+        
+        :return:    
+        """
         return self._default_ns
 
     @default_namespace.setter
     def default_namespace(self, name):
+        """Set the default namespace name.
+        
+        If the namespace with a given name does not exist, it will be created first.
+        
+        :param name:    The name of the the default namespace.
+        :return: 
+        """
         self._default_ns = name
         if self._default_ns not in self._namespaces:
             self.add_namespace(self._default_ns)
 
     def get_namespace(self, name=None):
-        """
+        """Get a namespace object
         
-        :param name: 
-        :return: 
+        :param name:    The name of the namespace to get.
+        :return:        LabelsNamespace
         """
         if name is None:
             name = self.default_namespace
         return self._namespaces[name]
 
     def add_namespace(self, name):
+        """Create a new namespace with the given name.
+        
+        :param name:    The name for the namespace which is to be created. 
+        :return:        
+        """
         if name in self._namespaces:
             raise ValueError("Namespace %r already exists" % name)
         self._namespaces[name] = LabelsNamespace(name)
@@ -201,6 +217,10 @@ class LabelsNamespace(object):
         return name
 
     def iter_labels(self):
+        """Iterate over the labels within this namespace.
+        
+        :return:    Tuples of (name, addr)
+        """
         return self._name_to_addr.iteritems()
 
     #
@@ -208,26 +228,26 @@ class LabelsNamespace(object):
     #
 
     def get_name(self, addr, default=None):
-        """
+        """Get the default name for an address.
         
-        :param addr: 
-        :param default: 
+        :param addr:        The address to look for.
+        :param default:     Default value to return, if the address is not present within the namespace.
         :return: 
         """
         return self._addr_to_names.get(addr, [default])[0]
 
     def get_all_names(self, addr):
-        """
+        """Get all names that a assigned to a given address.
         
-        :param addr: 
-        :return: 
+        :param addr:    The address to look for.
+        :return:        A list of all names for the given address.
         """
         return self._addr_to_names.get(addr, [])
 
     def del_name(self, name):
-        """
+        """Remove a name from the namespace.
         
-        :param name: 
+        :param name:    The name which is to be removed.
         :return: 
         """
         if name not in self._name_to_addr:
@@ -237,15 +257,15 @@ class LabelsNamespace(object):
         self._addr_to_names[addr].remove(name)
 
     def has_name(self, name):
-        """
+        """Check whether the given name is present within the namespace.
         
-        :param name: 
+        :param name:    A name to look for.
         :return: 
         """
         return name in self._name_to_addr
 
     def iter_names(self):
-        """
+        """Iterate over names that are present within the namespace.
         
         :return: 
         """
@@ -256,18 +276,19 @@ class LabelsNamespace(object):
     #
 
     def get_addr(self, name, default=None):
-        """
+        """Get the address to which the given name is assigned to.
         
-        :param name: 
-        :param default: 
+        :param name:        A name to look for.
+        :param default:     Default value to return, if the name is not present within the namespace.
         :return: 
         """
         return self._name_to_addr.get(name, default)
 
     def del_addr(self, addr):
-        """
+        """Remove the address from the namespace, thus effectivly removing all the names that 
+        are assigned to this address.
         
-        :param addr: 
+        :param addr:    The address which is to be removed.
         :return: 
         """
         if addr not in self._addr_to_names:
@@ -277,15 +298,15 @@ class LabelsNamespace(object):
         map(self._name_to_addr.pop, names_list)
 
     def has_addr(self, addr):
-        """
+        """Check whether the given address has any name assigned to it.
         
-        :param addr: 
+        :param addr:    An address to look for.
         :return: 
         """
         return addr in self._addr_to_names
 
     def iter_addrs(self):
-        """
+        """Iterate over the adresses that are present within the namespace.
         
         :return: 
         """
@@ -296,9 +317,9 @@ class LabelsNamespace(object):
     #
 
     def _add_suffix(self, name):
-        """
+        """Add an apropriate suffix to the name, if it is already present within the namespace. 
         
-        :param name: 
+        :param name:    A name to which to add the suffix.
         :return: 
         """
         new_name = '%s_%d' % (name, self._name_usage_cnt[name])

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -103,18 +103,18 @@ class LabelsPlugin(KnowledgeBasePlugin):
         """
         namespace = self._namespaces[ns]  # a shorthand
 
-        if name in namespace:
-            # Name is already present in the namespace.
-            # Here we forbid assigning different addresses with the same name.
-            if namespace[name] != addr:
-                raise ValueError("Label '%s' is already in present in the namespace "
-                                 "'%s' with an address %#x, different from %#x"
-                                 % (name, ns, namespace[name], addr))
-            # Specified address is already labeled.
-            # Here we forbid assigning different labels to a single address.
-            if addr in namespace.inv:
-                raise ValueError("Address %#x is already labeled with '%s' "
-                                 "in the namespace '%s'" % (addr, name, ns))
+        # Name is already present in the namespace.
+        # Here we forbid assigning different addresses with the same name.
+        if name in namespace and namespace[name] != addr:
+            raise ValueError("Label '%s' is already in present in the namespace "
+                             "'%s' with an address %#x, different from %#x"
+                             % (name, ns, namespace[name], addr))
+
+        # Specified address is already labeled.
+        # Here we forbid assigning different labels to a single address.
+        if addr in namespace.inv and namespace.inv[addr] != name:
+            raise ValueError("Address %#x is already labeled with '%s' "
+                             "in the namespace '%s'" % (addr, name, ns))
 
         # Create a new label!
         namespace[name] = addr

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -183,6 +183,20 @@ class LabelsPlugin(KnowledgeBasePlugin):
 
         return namespace.get(name, default)
 
+    def del_addr(self, addr, ns=_global_ns):
+        """Delete a label that is assigned to the given address within the given namespace.
+
+        :param addr:    The address from which to remove a label in the given namespace.
+        :param ns:      The namespace in which the given address is present.
+        :return: 
+        """
+        namespace = self._namespaces[ns]  # a shorthand
+
+        if addr not in namespace.inv:
+            raise ValueError("Namespace '%s' doesn't have a label on address %#x" % (ns, addr))
+
+        del namespace.inv[addr]
+
     def iter_addrs(self, name, ns_set=None):
         """Iterate over address that have a label with a given name in the given set of namespaces. 
         

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -142,7 +142,7 @@ class LabelsPlugin(KnowledgeBasePlugin):
             return namespace.inv.get(addr)
 
     def del_label(self, name, ns=_global_ns):
-        """Delete a label that is present within the given namespace and is assigned to the specified address.
+        """Delete a label that is present within the given namespace.
         
         :param name:    The name of the label which is to be deleted.
         :param ns:      The namespace in which the given label is present.

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -13,7 +13,7 @@ class LabelsPlugin(KnowledgeBasePlugin):
     An address is allowed to have a different labels within different namespace, but it is not allowed
     for address to have a different labels within a single namespace.
     
-    The global namespace is the empty string.
+    The global namespace defaults to empty string.
        
     :var _global_ns:    The name of the global namespace.
     :type _global_ns:   str

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -117,7 +117,7 @@ class LabelsPlugin(KnowledgeBasePlugin):
         if addr not in namespace.inv and default:
             if default is True:
                 default = self._generate_default_label(addr)
-            return namespace.setdefault(addr, default)
+            return namespace.setdefault(default, addr)
 
         else:
             return namespace.inv.get(addr)

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -183,7 +183,7 @@ class LabelsPlugin(KnowledgeBasePlugin):
     #
 
     def _generate_default_label(self, addr):
-        return 'lbl_%#x' % addr
+        return 'lbl_%x' % addr
 
 
 KnowledgeBasePlugin.register_default('labels', LabelsPlugin)

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -122,9 +122,13 @@ class LabelsPlugin(KnowledgeBasePlugin):
     def get_label(self, addr, ns=_global_ns, default=None):
         """Get a label that is present within the given namespace and is assigned to the specified address.
         
-        :param addr: 
-        :param ns: 
-        :param default:
+        :param addr:    The address for which the label is assigned.
+        :param ns:      The namespace to look into.
+        :param default: The name of the label to assign to the address, if there is no label present.
+                        This accepts the following values: 
+                            True - assign a new label with default name; 
+                            None - don't do anything, i.e. return None if the address is not labeled; 
+                            Any other value - create a new label with the given value.
         :return: 
         """
         namespace = self._namespaces[ns]  # a shorthand
@@ -140,8 +144,8 @@ class LabelsPlugin(KnowledgeBasePlugin):
     def del_label(self, name, ns=_global_ns):
         """Delete a label that is present within the given namespace and is assigned to the specified address.
         
-        :param name: 
-        :param ns: 
+        :param name:    The name of the label which is to be deleted.
+        :param ns:      The namespace in which the given label is present.
         :return: 
         """
         namespace = self._namespaces[ns]  # a shorthand
@@ -152,11 +156,11 @@ class LabelsPlugin(KnowledgeBasePlugin):
         del namespace[name]
 
     def iter_labels(self, addr, ns_set=None):
-        """
+        """Iterate over labels that are assigned to a given address in the given set of namespaces.
         
-        :param addr: 
-        :param ns_set: 
-        :return: 
+        :param addr:    An address for which to yield assigned labels.
+        :param ns_set:  A set of namespaces to work with.
+        :return:        Tuples of (namespace, label).
         """
         if ns_set is None:
             ns_set = set(self._namespaces)
@@ -173,11 +177,11 @@ class LabelsPlugin(KnowledgeBasePlugin):
     #
 
     def get_addr(self, name, ns=_global_ns, default=None):
-        """
+        """Get the address for the label in the given namespace.
         
-        :param name: 
-        :param ns: 
-        :param default: 
+        :param name:    The label name.
+        :param ns:      The namespace to look into.
+        :param default: Default value if the label is not present in the given namespace.
         :return: 
         """
         namespace = self._namespaces[ns]  # a shorthand
@@ -189,6 +193,11 @@ class LabelsPlugin(KnowledgeBasePlugin):
     #
 
     def _generate_default_label(self, addr):
+        """Generate a default label for the given address.
+        
+        :param addr:    The address to generate a label for.
+        :return:        A default label for the given address.
+        """
         return 'lbl_%x' % addr
 
 

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -162,12 +162,7 @@ class LabelsPlugin(KnowledgeBasePlugin):
         :param ns_set:  A set of namespaces to work with.
         :return:        Tuples of (namespace, label).
         """
-        if ns_set is None:
-            ns_set = set(self._namespaces)
-        elif isinstance(ns_set, Iterable):
-            ns_set = set(ns_set)
-        else:
-            raise TypeError("ns_set must be an Iterable")
+        ns_set = self._normalize_ns_set(ns_set)
 
         for ns in ns_set:
             yield ns, self.get_label(addr, ns)
@@ -188,6 +183,18 @@ class LabelsPlugin(KnowledgeBasePlugin):
 
         return namespace.get(name, default)
 
+    def iter_addrs(self, name, ns_set=None):
+        """Iterate over address that have a label with a given name in the given set of namespaces. 
+        
+        :param name:    The name of the labels.
+        :param ns_set:  A set of namespaces to work with.
+        :return:        Tuples of (namespace, addr).
+        """
+        ns_set = self._normalize_ns_set(ns_set)
+
+        for ns in ns_set:
+            yield ns, self.get_addr(name, ns)
+
     #
     #   ...
     #
@@ -199,6 +206,14 @@ class LabelsPlugin(KnowledgeBasePlugin):
         :return:        A default label for the given address.
         """
         return 'lbl_%x' % addr
+
+    def _normalize_ns_set(self, thing):
+        if thing is None:
+            return set(self._namespaces)
+        elif isinstance(thing, Iterable):
+            return set(thing)
+        else:
+            raise TypeError("ns_set must be an instance of Iterable")
 
 
 KnowledgeBasePlugin.register_default('labels', LabelsPlugin)

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -21,24 +21,30 @@ class LabelsPlugin(KnowledgeBasePlugin):
 
     _global_ns = ''
 
-    def __init__(self, kb):
+    def __init__(self, kb, copy=False):
         super(KnowledgeBasePlugin, self).__init__()
         self._namespaces = defaultdict(bidict)
 
-        # TODO: This should be done somewhere else. Here for compat reasons only.
-        for obj in kb._project.loader.all_objects:
-            for k, v in obj.symbols_by_addr.iteritems():
-                if v.name:
-                    # Original logic implies overwriting existing labels,
-                    # hence the force=True
-                    self.set_label(v.rebased_addr, v.name, force=True)
-            try:
-                for k, v in obj.plt.iteritems():
-                    # Original logic implies overwriting existing labels,
-                    # hence the force=True
-                    self.set_label(v, k, force=True)
-            except AttributeError:
-                pass
+        if not copy:
+            # TODO: This should be done somewhere else. Here for compat reasons only.
+            for obj in kb._project.loader.all_objects:
+                for k, v in obj.symbols_by_addr.iteritems():
+                    if v.name:
+                        # Original logic implies overwriting existing labels,
+                        # hence the force=True
+                        self.set_label(v.rebased_addr, v.name, force=True)
+                try:
+                    for k, v in obj.plt.iteritems():
+                        # Original logic implies overwriting existing labels,
+                        # hence the force=True
+                        self.set_label(v, k, force=True)
+                except AttributeError:
+                    pass
+
+    def copy(self):
+        o = LabelsPlugin(None, copy=True)
+        o._namespaces = self._namespaces.copy()
+        return o
 
     #
     #   ...

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -1,68 +1,180 @@
+from collections import defaultdict, Iterable
+
+from bidict import bidict
+
 from .plugin import KnowledgeBasePlugin
+from ..misc.ux import deprecated
 
 
-class Labels(KnowledgeBasePlugin):
+class LabelsPlugin(KnowledgeBasePlugin):
+    """Storage for program labels. Access with kb.labels.    
+    
+    A label "name" is a label named "name", duh. Labels can be grouped into the seperate namespaces.
+    An address is allowed to have a different labels within different namespace, but it is not allowed
+    for address to have a different labels within a single namespace.
+    
+    The global namespace is the empty string.
+       
+    :var _global_ns:    The name of the global namespace.
+    :type _global_ns:   str
+    """
+
+    _global_ns = ''
 
     def __init__(self, kb):
-        self._kb = kb
-        self._labels = {}
-        self._reverse_labels = {}
-        for obj in kb._project.loader.all_objects:
-            for k, v in obj.symbols_by_addr.iteritems():
-                if v.name:
-                    if v.is_import:
-                        continue
-                    self._labels[v.rebased_addr] = v.name
-                    self._reverse_labels[v.name] = v.rebased_addr
-            try:
-                for v, k in obj.plt.iteritems():
-                    self._labels[k] = v
-            except AttributeError:
-                pass
+        super(KnowledgeBasePlugin, self).__init__()
+        self._namespaces = defaultdict(bidict)
+
+        # # TODO: This should be done somewhere else. Here for compat reasons only.
+        # for obj in kb._project.loader.all_objects:
+        #     for k, v in obj.symbols_by_addr.iteritems():
+        #         if v.name:
+        #             self.set_label(v.rebased_addr, v.name)
+        #     if hasattr(obj, 'plt'):
+        #         for v, k in obj.plt.iteritems():
+        #             self.set_label(v, k)
+
+    #
+    #   ...
+    #
+
+    # NOTE: The following works only with global namespace for comptaibility reasons.
+
+    @property
+    def _global_namespace(self):
+        return self._namespaces[self._global_ns]
 
     def __iter__(self):
-        """
-        Iterate over all labels (the strings)
-        Use .lookup(name) if you need to find the address to it.
-        """
-        return self._reverse_labels.__iter__()
+        return iter(self._global_namespace)
 
     def __getitem__(self, k):
-        return self._labels[k]
+        return self._global_namespace[k]
 
     def __setitem__(self, k, v):
-        del self[k]
-        self._labels[k] = v
-        self._reverse_labels[v] = k
-        if k in self._kb.functions:
-            self._kb.functions[k]._name = v
+        self.set_label(v, k)
 
     def __delitem__(self, k):
-        if k in self._labels:
-            del self._reverse_labels[self._labels[k]]
-            del self._labels[k]
+        self.del_label(k)
 
     def __contains__(self, k):
-        return k in self._labels
+        return k in self._global_namespace
 
+    #
+    #   ...
+    #
+
+    @deprecated(replacement='get_label')
     def get(self, addr):
-        """
-        Get a label as string for a given address
-        Same as .labels[x]
-        """
         return self[addr]
 
+    @deprecated(replacement='get_addr')
     def lookup(self, name):
+        addr = self.get_addr(name)
+        if addr is None:
+            raise KeyError(name)
+        return addr
+
+    #
+    #   ...
+    #
+
+    def set_label(self, addr, name, ns=_global_ns):
+        """Label address `addr` as `name` within namespace `namespace`
+        
+        :param addr:        The address to put a label on.
+        :param name:        The name of the label.
+        :param ns:          The namespace to register label to.
+
+        :return: 
         """
-        Returns an address to a given label
-        To show all available labels, iterate over .labels or list(b.kb.labels)
+        namespace = self._namespaces[ns]  # a shorthand
+
+        if name in namespace:
+            # Name is already present in the namespace.
+            # Here we forbid to assigning different addresses with the same name.
+            if namespace.inv[name] != addr:
+                raise ValueError("Label '%s' is already in present in the namespace "
+                                 "'%s' with a different address %#x" % (name, ns, addr))
+
+        elif addr not in namespace.inv:
+            # Create a new label!
+            namespace[name] = addr
+
+        else:
+            raise ValueError("Address %#x is already labeled with '%s' "
+                             "in the namespace '%s'" % (addr, name, ns))
+
+    def get_label(self, addr, ns=_global_ns, default=None):
+        """Get a label that is present within the given namespace and is assigned to the specified address.
+        
+        :param addr: 
+        :param ns: 
+        :param default:
+        :return: 
         """
-        return self._reverse_labels[name]
+        namespace = self._namespaces[ns]  # a shorthand
 
-    def copy(self):
-        o = Labels(self._kb)
-        o._labels = {k: v for k, v in self._labels.iteritems()}
-        o._reverse_labels = {k: v for k, v in self._reverse_labels.iteritems()}
+        if addr not in namespace.inv and default:
+            if default is True:
+                default = self._generate_default_label(addr)
+            return namespace.setdefault(addr, default)
+
+        else:
+            return namespace.inv.get(addr)
+
+    def del_label(self, name, ns=_global_ns):
+        """Delete a label that is present within the given namespace and is assigned to the specified address.
+        
+        :param name: 
+        :param ns: 
+        :return: 
+        """
+        namespace = self._namespaces[ns]  # a shorthand
+
+        if name not in namespace:
+            raise ValueError("Namespace '%s' doesn't have a label named '%s'" % (ns, name))
+
+        del namespace[name]
+
+    def iter_labels(self, addr, ns_set=None):
+        """
+        
+        :param addr: 
+        :param ns_set: 
+        :return: 
+        """
+        if ns_set is None:
+            ns_set = set(self._namespaces)
+        elif isinstance(ns_set, Iterable):
+            ns_set = set(ns_set)
+        else:
+            raise TypeError("ns_set must be an Iterable")
+
+        for ns in ns_set:
+            yield ns, self.get_label(addr, ns)
+
+    #
+    #   ...
+    #
+
+    def get_addr(self, name, ns=_global_ns, default=None):
+        """
+        
+        :param name: 
+        :param ns: 
+        :param default: 
+        :return: 
+        """
+        namespace = self._namespaces[ns]  # a shorthand
+
+        return namespace.get(name, default)
+
+    #
+    #   ...
+    #
+
+    def _generate_default_label(self, addr):
+        return 'lbl_%#x' % addr
 
 
-KnowledgeBasePlugin.register_default('labels', Labels)
+KnowledgeBasePlugin.register_default('labels', LabelsPlugin)

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -65,6 +65,10 @@ class LabelsPlugin(KnowledgeBasePlugin):
         return self._global_namespace[k]
 
     def __setitem__(self, k, v):
+        if self.get_addr(k) is not None:
+            self.del_label(k)
+        elif self.get_label(v) is not None:
+            self.del_addr(v)
         self.set_label(v, k)
 
     def __delitem__(self, k):

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -200,6 +200,9 @@ class LabelsNamespace(object):
 
         return name
 
+    def iter_labels(self):
+        return self._name_to_addr.iteritems()
+
     #
     #   ...
     #

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -35,13 +35,13 @@ class LabelsPlugin(KnowledgeBasePlugin):
                     if v.name:
                         # Original logic implies overwriting existing labels.
                         if self.get_addr(v.name):
-                            self.del_label(v.name)
+                            self.del_name(v.name)
                         self.set_label(v.rebased_addr, v.name)
                 try:
                     for k, v in obj.plt.iteritems():
                         # Original logic implies overwriting existing labels.
                         if self.get_addr(k):
-                            self.del_label(k)
+                            self.del_name(k)
                         self.set_label(v, k)
                 except AttributeError:
                     pass
@@ -69,13 +69,13 @@ class LabelsPlugin(KnowledgeBasePlugin):
 
     def __setitem__(self, k, v):
         if self.get_addr(k) is not None:
-            self.del_label(k)
-        elif self.get_label(v) is not None:
+            self.del_name(k)
+        elif self.get_name(v) is not None:
             self.del_addr(v)
         self.set_label(v, k)
 
     def __delitem__(self, k):
-        self.del_label(k)
+        self.del_name(k)
 
     def __contains__(self, k):
         return k in self._global_namespace
@@ -138,7 +138,11 @@ class LabelsPlugin(KnowledgeBasePlugin):
         # Create a new label!
         namespace[name] = addr
 
-    def get_label(self, addr, ns=None, default=None):
+    #
+    #   ...
+    #
+
+    def get_name(self, addr, ns=None, default=None):
         """Get a label that is present within the given namespace and is assigned to the specified address.
         
         :param addr:    The address for which the label is assigned.
@@ -160,7 +164,7 @@ class LabelsPlugin(KnowledgeBasePlugin):
         else:
             return namespace.inv.get(addr)
 
-    def del_label(self, name, ns=None):
+    def del_name(self, name, ns=None):
         """Delete a label that is present within the given namespace.
         
         :param name:    The name of the label which is to be deleted.
@@ -174,7 +178,7 @@ class LabelsPlugin(KnowledgeBasePlugin):
 
         del namespace[name]
 
-    def iter_labels(self, addr, ns_set=None):
+    def iter_names(self, addr, ns_set=None):
         """Iterate over labels that are assigned to a given address in the given set of namespaces.
         
         :param addr:    An address for which to yield assigned labels.
@@ -184,7 +188,7 @@ class LabelsPlugin(KnowledgeBasePlugin):
         ns_set = self._normalize_ns_set(ns_set)
 
         for ns in ns_set:
-            yield ns, self.get_label(addr, ns)
+            yield ns, self.get_name(addr, ns)
 
     #
     #   ...

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ progressbar
 pyvex
 rpyc
 unicorn
+bidict

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ progressbar
 pyvex
 rpyc
 unicorn
-bidict

--- a/tests/test_kb_labels.py
+++ b/tests/test_kb_labels.py
@@ -32,5 +32,9 @@ def test_kb_plugins():
         nose.tools.assert_is_instance(name, (str, unicode, bytes))
         nose.tools.assert_is_instance(addr, (int, long))
 
+    # Copy check. 
+    labels_copy = labels.copy()
+    nose.tools.assert_equal(labels._namespaces, labels_copy._namespaces)
+
 if __name__ == '__main__':
     test_kb_plugins()

--- a/tests/test_kb_labels.py
+++ b/tests/test_kb_labels.py
@@ -1,0 +1,36 @@
+import nose
+import angr
+import networkx
+
+import os
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+
+
+def test_kb_plugins():
+    p = angr.Project(location + "/x86_64/fauxware")
+    labels = p.kb.labels
+
+    labels.set_label(0x1000, 'label1', 'foo')
+    labels.set_label(0x2000, 'label2', 'foo')
+    labels.set_label(0x1000, 'label2', 'bar')
+    labels.set_label(0x2000, 'label1', 'bar')
+
+    nose.tools.assert_equal(labels.get_label(0x1000, 'foo'), 'label1')
+    nose.tools.assert_equal(labels.get_label(0x1000, 'bar'), 'label2')
+    nose.tools.assert_equal(labels.get_label(0x2000, 'foo'), 'label2')
+    nose.tools.assert_equal(labels.get_label(0x2000, 'bar'), 'label1')
+
+    nose.tools.assert_is_none(labels.get_label(0x1000))
+    nose.tools.assert_is_not_none(labels.get_label(0x1000, default=True))
+
+    nose.tools.assert_equal(set(labels.iter_labels(0x1000)),
+                            {('foo', 'label1'), ('bar', 'label2'), ('', 'lbl_1000')})
+
+    # Compat checks.
+    for name in labels:
+        addr = labels[name]
+        nose.tools.assert_is_instance(name, (str, unicode, bytes))
+        nose.tools.assert_is_instance(addr, (int, long))
+
+if __name__ == '__main__':
+    test_kb_plugins()

--- a/tests/test_kb_labels.py
+++ b/tests/test_kb_labels.py
@@ -59,7 +59,7 @@ def test_kb_plugins():
     nose.tools.assert_not_equal(ns.get_addr('label1'), ns_foo.get_addr('label1'))
 
     # Test with project
-    p = angr.Project(location + "/x86_64/fauxware")
+    p = angr.Project(location + "/x86_64/fauxware", auto_load_libs=False)
     labels = p.kb.labels
 
 if __name__ == '__main__':

--- a/tests/test_kb_labels.py
+++ b/tests/test_kb_labels.py
@@ -15,6 +15,12 @@ def test_kb_plugins():
     labels.set_label(0x1000, 'label2', 'bar')
     labels.set_label(0x2000, 'label1', 'bar')
 
+    with nose.tools.assert_raises(ValueError):
+        labels.set_label(0x3000, 'label1', 'foo')
+
+    with nose.tools.assert_raises(ValueError):
+        labels.set_label(0x2000, 'label3', 'bar')
+
     nose.tools.assert_equal(labels.get_label(0x1000, 'foo'), 'label1')
     nose.tools.assert_equal(labels.get_label(0x1000, 'bar'), 'label2')
     nose.tools.assert_equal(labels.get_label(0x2000, 'foo'), 'label2')


### PR DESCRIPTION
A new implementation of the storage for program labels. Access with kb.labels.    

Major feature is that labels can be grouped into the separate name spaces.
An address is allowed to have a different labels within different name space, but it is not allowed
for address to have a different labels within a single name space. The global name space is the empty string.

This pull request introduces *bidict* package requirement.