### PR TITLE
CFGFast: Fix a rare case leading to incorrect function-returning decisions.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -857,24 +857,25 @@ class CFGBase(Analysis):
 
             bail_out = False
 
-            # if this function has jump out sites, it returns as long as any of the target function returns
-            for jump_out_site in func.jumpout_sites:
+            # if this function has jump-out sites or ret-out sites, it returns as long as any of the target function
+            # returns
+            for goout_site in func.jumpout_sites + func.retout_sites:
 
                 if func.returning:
                     # if there are multiple jump out sites and we have determined the "returning status" from one of
                     # the jump out sites, we can exit the loop early
                     continue
-                jump_out_site_successors = jump_out_site.successors()
-                if not jump_out_site_successors:
+                goout_site_successors = goout_site.successors()
+                if not goout_site_successors:
                     # not sure where it jumps to. bail out
                     bail_out = True
                     continue
-                jump_out_target = jump_out_site_successors[0]
-                if not self.kb.functions.contains_addr(jump_out_target.addr):
+                goout_target = goout_site_successors[0]
+                if not self.kb.functions.contains_addr(goout_target.addr):
                     # wait it does not jump to a function?
                     bail_out = True
                     continue
-                target_func = self.kb.functions[jump_out_target.addr]
+                target_func = self.kb.functions[goout_target.addr]
                 if target_func.returning is True:
                     func.returning = True
                     changes['functions_return'].append(func)


### PR DESCRIPTION
In CFGFast, we assume any function call should return to the same function
as its caller block as long as the callee returns. This holds in general,
but it does not hold in the following scenario during CFG recovery:

- We identify a function starting at address A. This function returns.
- We identify another function starting at address B. Unfortunately, many
  blocks of function B and function A overlap. This might be the result of
  multi-entry functions (in which case, both are correct), or function A
  starts at the alignment bytes ahead of function B (in which case,
  function B is the correct one, and function A should only contain the
  alignment bytes and a jumpout to the beginning of function B).
- At this time, all blocks other than the first block in function B belong
  to function A. Therefore, any transition going out of the first block of
  function B are outside transitions (they all transition to function A).

I noticed this issue a long time ago (probably before CGC), and added a
fix. However, I was only handling the cases when the first block of
function B jumps to its successors. The case where the first block calls
another function and then returns was not handled. This commit fixes this
issue.

Function 804a420 in the CGC binary CROMU_00071 can be used to test this
commit. It is included in Patcherex as a test case:
test_cfg.py:test_fullcfg_properties.