### PR TITLE
Fix minor bugs in congruency checker

### DIFF
--- a/angr/analyses/congruency_check.py
+++ b/angr/analyses/congruency_check.py
@@ -79,14 +79,16 @@ class CongruencyCheck(Analysis):
             l.debug("... synced")
             return simgr
         elif simgr.left[0].history.block_count < simgr.right[0].history.block_count:
-            l.debug("... right is ahead; stepping left up to %s times", max_steps)
+            l.debug("... right is ahead; stepping left %s times",
+                    simgr.right[0].history.block_count - simgr.left[0].history.block_count)
             npg = simgr.step(
                 stash='left',
                 until=lambda lpg: lpg.left[0].history.block_count >= simgr.right[0].history.block_count,
                 n=max_steps
             )
         elif simgr.right[0].history.block_count < simgr.left[0].history.block_count:
-            l.debug("... left is ahead; stepping right up to %s times", max_steps)
+            l.debug("... left is ahead; stepping right %s times",
+                    simgr.left[0].history.block_count - simgr.right[0].history.block_count)
             npg = simgr.step(
                 stash='right',
                 until=lambda lpg: lpg.right[0].history.block_count >= simgr.left[0].history.block_count,
@@ -219,7 +221,7 @@ class CongruencyCheck(Analysis):
 
             # do a step
             l.debug(
-                "Stepping right path with weighted length %d/%s",
+                "Stepping right path with weighted length %d/%d",
                 self.simgr.right[0].history.block_count,
                 depth
             )
@@ -321,7 +323,7 @@ class CongruencyCheck(Analysis):
                     return False
 
         # make sure the flags are the same
-        if sl.arch.name in ("AMD64", "X86", "ARM", "AARCH64"):
+        if sl.arch.name in ("AMD64", "X86", "ARM", "ARMEL", "ARMHF", "AARCH64"):
             if sl.arch.name in ('AMD64', 'X86'):
                 n_flags = sr.regs.eflags.canonicalize(var_map=n_map, counter=n_counter)[-1]
                 u_flags = sl.regs.eflags.canonicalize(var_map=u_map, counter=u_counter)[-1]


### PR DESCRIPTION
Apparently, the `test_similarity_fauxware` in `test_unicorn.py` that test our `CongruencyCheck` detects a "Different flags" incongruency error (even before my changes which do not touch that part of code). I don't know if the incongruency is intended, and why this is not reported in other PR. Maybe because of the `@attr(speed='slow')` decorator? Please let me know if I have to fix something. I think I should address this to @rhelmot 