### PR TITLE
Don't use labels that are imports

### DIFF
--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -10,6 +10,8 @@ class Labels(KnowledgeBasePlugin):
         for obj in kb._project.loader.all_objects:
             for k, v in obj.symbols_by_addr.iteritems():
                 if v.name:
+                    if v.is_import:
+                        continue
                     self._labels[v.rebased_addr] = v.name
                     self._reverse_labels[v.name] = v.rebased_addr
             try:


### PR DESCRIPTION
They are undefined, and have an address of 0 in the symbol table.  
  
In my case,
`cmp    DWORD PTR [ebp+0x8],0x0`
was being disassembled as:
`cmp     [ebp+0x8], _ITM_registerTMCloneTable`.

_ITM_registerTMCloneTable is the last symbol in the symbol table with an address of 0.