### PR TITLE
Add function to BlockNode in LoopFinder

### DIFF
--- a/angr/codenode.py
+++ b/angr/codenode.py
@@ -4,13 +4,12 @@ l = logging.getLogger("angr.codenode")
 
 class CodeNode(object):
 
-    __slots__ = ['addr', 'size', 'function', '_graph', 'thumb']
+    __slots__ = ['addr', 'size', '_graph', 'thumb']
 
     def __init__(self, addr, size, graph=None, thumb=False):
         self.addr = addr
         self.size = size
         self.thumb = thumb
-        self.function = None
         self._graph = graph
 
     def __len__(self):

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -599,7 +599,6 @@ class Function(object):
             raise AngrValueError('_register_nodes(): the "is_local" parameter must be a bool')
 
         for node in nodes:
-            node.function = self
             self.transition_graph.add_node(node)
             node._graph = self.transition_graph
             if node.addr not in self or self._block_sizes[node.addr] == 0:


### PR DESCRIPTION
Hello,

I just found out that in `LoopFinder`, every `BlockNode` that comes from `subg.nodes()` doesn't have the `function` argument set correctly (it's None instead). I tried to modify the `setstate` `getstate` method of `CodeNode` and `BlockNode`, but the `CodeNode.__init__` method doesn't want to take a `function` as parameter (I don't know why btw). So this PR is a way to fix this issue for `LoopFinder`.

@rhelmot @ltfish please let me know if this (a bit) hackish way is ok? Or can you please tell me how to change things in `setstate` and `getstate` (I guess that is the best way to fix the issue btw)?