### PR TITLE
Consider extra constraints when concretizing symbolic addresses

### DIFF
--- a/angr/concretization_strategies/__init__.py
+++ b/angr/concretization_strategies/__init__.py
@@ -48,15 +48,15 @@ class SimConcretizationStrategy(object):
         """
         return (self._min(memory, addr, **kwargs), self._max(memory, addr, **kwargs))
 
-    def concretize(self, memory, addr):
+    def concretize(self, memory, addr, extra_constraints=()):
         """
         Concretizes the address into a list of values.
         If this strategy cannot handle this address, returns None.
         """
         if self._filter is None or self._filter(memory, addr):
-            return self._concretize(memory, addr)
+            return self._concretize(memory, addr, extra_constraints=extra_constraints)
 
-    def _concretize(self, memory, addr):
+    def _concretize(self, memory, addr, extra_constraints=()):
         """
         Should be implemented by child classes to handle concretization.
         """

--- a/angr/concretization_strategies/any.py
+++ b/angr/concretization_strategies/any.py
@@ -5,10 +5,10 @@ class SimConcretizationStrategyAny(SimConcretizationStrategy):
     Concretization strategy that returns any single solution.
     """
 
-    def _concretize(self, memory, addr):
+    def _concretize(self, memory, addr, extra_constraints=()):
         if self._exact:
-            return [ self._any(memory, addr) ]
+            return [ self._any(memory, addr, extra_constraints=extra_constraints) ]
         else:
-            mn,mx = self._range(memory, addr)
+            mn,mx = self._range(memory, addr, extra_constraints=extra_constraints)
             if mn == mx:
                 return [ mn ]

--- a/angr/concretization_strategies/max.py
+++ b/angr/concretization_strategies/max.py
@@ -5,5 +5,5 @@ class SimConcretizationStrategyMax(SimConcretizationStrategy):
     Concretization strategy that returns the maximum address.
     """
 
-    def _concretize(self, memory, addr):
-        return [ self._max(memory, addr) ]
+    def _concretize(self, memory, addr, extra_constraints=()):
+        return [ self._max(memory, addr, extra_constraints=extra_constraints) ]

--- a/angr/concretization_strategies/nonzero.py
+++ b/angr/concretization_strategies/nonzero.py
@@ -5,5 +5,7 @@ class SimConcretizationStrategyNonzero(SimConcretizationStrategy):
     Concretization strategy that returns any non-zero solution.
     """
 
-    def _concretize(self, memory, addr):
-        return [ self._any(memory, addr, extra_constraints=[addr != 0]) ]
+    def _concretize(self, memory, addr, extra_constraints=()):
+        if not extra_constraints:
+            extra_constraints = [ ]
+        return [ self._any(memory, addr, extra_constraints=[addr != 0] + extra_constraints) ]

--- a/angr/concretization_strategies/nonzero_range.py
+++ b/angr/concretization_strategies/nonzero_range.py
@@ -9,7 +9,9 @@ class SimConcretizationStrategyNonzeroRange(SimConcretizationStrategy):
         super(SimConcretizationStrategyNonzeroRange, self).__init__(**kwargs)
         self._limit = limit
 
-    def _concretize(self, memory, addr):
-        mn,mx = self._range(memory, addr)
+    def _concretize(self, memory, addr, extra_constraints=None):
+        if extra_constraints is None:
+            extra_constraints = [ ]
+        mn,mx = self._range(memory, addr, extra_constraints=extra_constraints)
         if mx - mn <= self._limit:
-            return self._eval(memory, addr, self._limit, extra_constraints=[addr != 0])
+            return self._eval(memory, addr, self._limit, extra_constraints=[addr != 0] + extra_constraints)

--- a/angr/concretization_strategies/norepeats.py
+++ b/angr/concretization_strategies/norepeats.py
@@ -12,10 +12,12 @@ class SimConcretizationStrategyNorepeats(SimConcretizationStrategy):
         self._repeat_constraints = [ ] if repeat_constraints is None else repeat_constraints
         self._repeat_expr = repeat_expr
 
-    def _concretize(self, memory, addr):
+    def _concretize(self, memory, addr, extra_constraints=()):
+        if not extra_constraints:
+            extra_constraints = [ ]
         c = self._any(
             memory, addr,
-            extra_constraints = self._repeat_constraints + [ addr == self._repeat_expr ]
+            extra_constraints = self._repeat_constraints + [ addr == self._repeat_expr ] + extra_constraints
         )
         self._repeat_constraints.append(self._repeat_expr != c)
         return [ c ]

--- a/angr/concretization_strategies/norepeats_range.py
+++ b/angr/concretization_strategies/norepeats_range.py
@@ -11,10 +11,12 @@ class SimConcretizationStrategyNorepeatsRange(SimConcretizationStrategy):
         self._repeat_min = min
         self._repeat_granularity = granularity
 
-    def _concretize(self, memory, addr):
+    def _concretize(self, memory, addr, extra_constraints=()):
+        if not extra_constraints:
+            extra_constraints = [ ]
         c = self._any(memory, addr, extra_constraints = [
             addr >= self._repeat_min, addr < self._repeat_min + self._repeat_granularity
-        ])
+        ] + extra_constraints)
         self._repeat_min = c + self._repeat_granularity
         return [ c ]
 

--- a/angr/concretization_strategies/range.py
+++ b/angr/concretization_strategies/range.py
@@ -9,7 +9,7 @@ class SimConcretizationStrategyRange(SimConcretizationStrategy):
         super(SimConcretizationStrategyRange, self).__init__(**kwargs)
         self._limit = limit
 
-    def _concretize(self, memory, addr):
-        mn,mx = self._range(memory, addr)
+    def _concretize(self, memory, addr, extra_constraints=()):
+        mn,mx = self._range(memory, addr, extra_constraints=extra_constraints)
         if mx - mn <= self._limit:
-            return self._eval(memory, addr, self._limit)
+            return self._eval(memory, addr, self._limit, extra_constraints=extra_constraints)

--- a/angr/concretization_strategies/single.py
+++ b/angr/concretization_strategies/single.py
@@ -5,7 +5,7 @@ class SimConcretizationStrategySingle(SimConcretizationStrategy):
     Concretization strategy that ensures a single solution for an address.
     """
 
-    def _concretize(self, memory, addr):
-        addrs = self._eval(memory, addr, 2)
+    def _concretize(self, memory, addr, extra_constraints=()):
+        addrs = self._eval(memory, addr, 2, extra_constraints=extra_constraints)
         if len(addrs) == 1:
             return addrs

--- a/angr/concretization_strategies/solutions.py
+++ b/angr/concretization_strategies/solutions.py
@@ -10,7 +10,7 @@ class SimConcretizationStrategySolutions(SimConcretizationStrategy):
         super(SimConcretizationStrategySolutions, self).__init__(**kwargs)
         self._limit = limit
 
-    def _concretize(self, memory, addr):
-        addrs = self._eval(memory, addr, self._limit + 1)
+    def _concretize(self, memory, addr, extra_constraints=()):
+        addrs = self._eval(memory, addr, self._limit + 1, extra_constraints=extra_constraints)
         if len(addrs) <= self._limit:
             return addrs

--- a/angr/procedures/libc/memset.py
+++ b/angr/procedures/libc/memset.py
@@ -40,7 +40,6 @@ class memset(angr.SimProcedure):
 
     def run(self, dst_addr, char, num):
         char = char[7:0]
-
         self.argument_types = {0: self.ty_ptr(SimTypeTop()),
                        1: SimTypeInt(32, True), # ?
                        2: SimTypeLength(self.state.arch)}

--- a/angr/procedures/libc/snprintf.py
+++ b/angr/procedures/libc/snprintf.py
@@ -15,7 +15,10 @@ class snprintf(FormatParser):
         # The format str is at index 2
         fmt_str = self._parse(2)
         out_str = fmt_str.replace(3, self.arg)
-        self.state.memory.store(dst_ptr, out_str)
+        try:
+            self.state.memory.store(dst_ptr, out_str)
+        except:
+            import ipdb; ipdb.set_trace()
 
         # place the terminating null byte
         self.state.memory.store(dst_ptr + (out_str.size() / 8), self.state.se.BVV(0, 8))

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -95,6 +95,7 @@ inspect_attributes = {
     'address_concretization_expr',
     'address_concretization_result',
     'address_concretization_add_constraints',
+    'address_concretization_extra_constraints',
 
     # syscall
     'syscall_name',


### PR DESCRIPTION
When concretizing symbolic memory addresses, we do the concretization first, without considering extra constraints that are added later to the state. Hence, the concretized address might conflict with newly added constraints. This is @badnack 's fix to the issue.