### PR TITLE
maximum_syscall_number() should not raise exception when an arch does not have any syscall.

### DIFF
--- a/angr/procedures/definitions/__init__.py
+++ b/angr/procedures/definitions/__init__.py
@@ -100,6 +100,9 @@ class SimSyscallLibrary(SimLibrary):
     fallback_proc = stub_syscall
 
     def maximum_syscall_number(self, arch_name):
+        if arch_name not in self.syscall_number_mapping or \
+                not self.syscall_number_mapping[arch_name]:
+            return 0
         return max(self.syscall_number_mapping[arch_name])
 
     def add_number_mapping(self, arch_name, number, name):


### PR DESCRIPTION

PS: I think this is the second time I'm fixing this exact issue... Am I hallucinating, or this is a real regression?