### PR TITLE
Adjust concretization to pass through extra_constraints

### DIFF
--- a/angr/concretization_strategies/any.py
+++ b/angr/concretization_strategies/any.py
@@ -5,10 +5,10 @@ class SimConcretizationStrategyAny(SimConcretizationStrategy):
     Concretization strategy that returns any single solution.
     """
 
-    def _concretize(self, memory, addr):
+    def _concretize(self, memory, addr, extra_constraints=()):
         if self._exact:
-            return [ self._any(memory, addr) ]
+            return [ self._any(memory, addr, extra_constraints=extra_constraints) ]
         else:
-            mn,mx = self._range(memory, addr)
+            mn,mx = self._range(memory, addr, extra_constraints=extra_constraints)
             if mn == mx:
                 return [ mn ]

--- a/angr/concretization_strategies/controlled_data.py
+++ b/angr/concretization_strategies/controlled_data.py
@@ -13,7 +13,7 @@ class SimConcretizationStrategyControlledData(SimConcretizationStrategy):
         self._limit = limit
         self._fixed_addrs = fixed_addrs
 
-    def _concretize(self, memory, addr):
+    def _concretize(self, memory, addr, extra_constraints=()):
         # Get all symbolic variables in memory
         symbolic_vars = filter(lambda key: not key.startswith("reg_") and not key.startswith("mem_"), memory.state.memory.mem._name_mapping.keys())
         controlled_addrs = sorted([_addr for s_var in symbolic_vars for _addr in memory.addrs_for_name(s_var)])
@@ -40,7 +40,11 @@ class SimConcretizationStrategyControlledData(SimConcretizationStrategy):
 
         # try to get solutions for controlled memory
         ored_constraints = memory.state.se.Or(*constraints)
-        solutions = self._eval(memory, addr, self._limit, extra_constraints=(ored_constraints,))
+        if extra_constraints:
+            final_constraints = [ ored_constraints ] + extra_constraints
+        else:
+            final_constraints = [ ored_constraints ]
+        solutions = self._eval(memory, addr, self._limit, extra_constraints=final_constraints)
         if not solutions:
             solutions = None
         return solutions

--- a/angr/concretization_strategies/eval.py
+++ b/angr/concretization_strategies/eval.py
@@ -12,6 +12,6 @@ class SimConcretizationStrategyEval(SimConcretizationStrategy):
         super(SimConcretizationStrategyEval, self).__init__(**kwargs)
         self._limit = limit
 
-    def _concretize(self, memory, addr):
-        addrs = self._eval(memory, addr, self._limit)
+    def _concretize(self, memory, addr, extra_constraints=()):
+        addrs = self._eval(memory, addr, self._limit, extra_constraints=extra_constraints)
         return addrs

--- a/angr/concretization_strategies/max.py
+++ b/angr/concretization_strategies/max.py
@@ -5,5 +5,5 @@ class SimConcretizationStrategyMax(SimConcretizationStrategy):
     Concretization strategy that returns the maximum address.
     """
 
-    def _concretize(self, memory, addr):
-        return [ self._max(memory, addr) ]
+    def _concretize(self, memory, addr, extra_constraints=()):
+        return [ self._max(memory, addr, extra_constraints=extra_constraints) ]

--- a/angr/concretization_strategies/nonzero.py
+++ b/angr/concretization_strategies/nonzero.py
@@ -5,5 +5,9 @@ class SimConcretizationStrategyNonzero(SimConcretizationStrategy):
     Concretization strategy that returns any non-zero solution.
     """
 
-    def _concretize(self, memory, addr):
-        return [ self._any(memory, addr, extra_constraints=[addr != 0]) ]
+    def _concretize(self, memory, addr, extra_constraints=()):
+        if extra_constraints:
+            constraints = [ addr != 0 ] + extra_constraints
+        else:
+            constraints = [ addr != 0 ]
+        return [ self._any(memory, addr, extra_constraints=constraints) ]

--- a/angr/concretization_strategies/nonzero_range.py
+++ b/angr/concretization_strategies/nonzero_range.py
@@ -9,7 +9,11 @@ class SimConcretizationStrategyNonzeroRange(SimConcretizationStrategy):
         super(SimConcretizationStrategyNonzeroRange, self).__init__(**kwargs)
         self._limit = limit
 
-    def _concretize(self, memory, addr):
+    def _concretize(self, memory, addr, extra_constraints=()):
         mn,mx = self._range(memory, addr)
         if mx - mn <= self._limit:
-            return self._eval(memory, addr, self._limit, extra_constraints=[addr != 0])
+            if extra_constraints:
+                constraints = [ addr != 0 ] + extra_constraints
+            else:
+                constraints = [ addr != 0 ]
+            return self._eval(memory, addr, self._limit, extra_constraints=constraints)

--- a/angr/concretization_strategies/norepeats.py
+++ b/angr/concretization_strategies/norepeats.py
@@ -12,11 +12,12 @@ class SimConcretizationStrategyNorepeats(SimConcretizationStrategy):
         self._repeat_constraints = [ ] if repeat_constraints is None else repeat_constraints
         self._repeat_expr = repeat_expr
 
-    def _concretize(self, memory, addr):
-        c = self._any(
-            memory, addr,
-            extra_constraints = self._repeat_constraints + [ addr == self._repeat_expr ]
-        )
+    def _concretize(self, memory, addr, extra_constraints=()):
+        if extra_constraints:
+            constraints = self._repeat_constraints + [ addr == self._repeat_expr ] + extra_constraints
+        else:
+            constraints = self._repeat_constraints + [ addr == self._repeat_expr ]
+        c = self._any( memory, addr, extra_constraints=constraints )
         self._repeat_constraints.append(self._repeat_expr != c)
         return [ c ]
 

--- a/angr/concretization_strategies/norepeats_range.py
+++ b/angr/concretization_strategies/norepeats_range.py
@@ -11,10 +11,12 @@ class SimConcretizationStrategyNorepeatsRange(SimConcretizationStrategy):
         self._repeat_min = min
         self._repeat_granularity = granularity
 
-    def _concretize(self, memory, addr):
-        c = self._any(memory, addr, extra_constraints = [
-            addr >= self._repeat_min, addr < self._repeat_min + self._repeat_granularity
-        ])
+    def _concretize(self, memory, addr, extra_constraints=()):
+        if extra_constraints:
+            constraints = [ addr >= self._repeat_min, addr < self._repeat_min + self._repeat_granularity ] + extra_constraints
+        else:
+            constraints = [ addr >= self._repeat_min, addr < self._repeat_min + self._repeat_granularity ]
+        c = self._any(memory, addr, extra_constraints=constraints)
         self._repeat_min = c + self._repeat_granularity
         return [ c ]
 

--- a/angr/concretization_strategies/range.py
+++ b/angr/concretization_strategies/range.py
@@ -9,7 +9,7 @@ class SimConcretizationStrategyRange(SimConcretizationStrategy):
         super(SimConcretizationStrategyRange, self).__init__(**kwargs)
         self._limit = limit
 
-    def _concretize(self, memory, addr):
+    def _concretize(self, memory, addr, extra_constraints=()):
         mn,mx = self._range(memory, addr)
         if mx - mn <= self._limit:
-            return self._eval(memory, addr, self._limit)
+            return self._eval(memory, addr, self._limit, extra_constraints=extra_constraints)

--- a/angr/concretization_strategies/single.py
+++ b/angr/concretization_strategies/single.py
@@ -5,7 +5,7 @@ class SimConcretizationStrategySingle(SimConcretizationStrategy):
     Concretization strategy that ensures a single solution for an address.
     """
 
-    def _concretize(self, memory, addr):
-        addrs = self._eval(memory, addr, 2)
+    def _concretize(self, memory, addr, extra_constraints=()):
+        addrs = self._eval(memory, addr, 2, extra_constraints=extra_constraints)
         if len(addrs) == 1:
             return addrs

--- a/angr/concretization_strategies/solutions.py
+++ b/angr/concretization_strategies/solutions.py
@@ -10,7 +10,7 @@ class SimConcretizationStrategySolutions(SimConcretizationStrategy):
         super(SimConcretizationStrategySolutions, self).__init__(**kwargs)
         self._limit = limit
 
-    def _concretize(self, memory, addr):
-        addrs = self._eval(memory, addr, self._limit + 1)
+    def _concretize(self, memory, addr, extra_constraints=()):
+        addrs = self._eval(memory, addr, self._limit + 1, extra_constraints=extra_constraints)
         if len(addrs) <= self._limit:
             return addrs

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -346,7 +346,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
     # Concretization strategies
     #
 
-    def _apply_concretization_strategies(self, addr, strategies, action):
+    def _apply_concretization_strategies(self, addr, strategies, action, extra_constaints=()):
         """
         Applies concretization strategies on the address until one of them succeeds.
         """
@@ -369,7 +369,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
 
             # let's try to apply it!
             try:
-                a = s.concretize(self, e)
+                a = s.concretize(self, e, extra_constaints=extra_constaints)
             except SimUnsatError:
                 a = None
 
@@ -389,7 +389,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             "Unable to concretize address for %s with the provided strategies." % action
         )
 
-    def concretize_write_addr(self, addr, strategies=None):
+    def concretize_write_addr(self, addr, strategies=None, extra_constaints=()):
         """
         Concretizes an address meant for writing.
 
@@ -404,9 +404,9 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             return [ self.state.se.eval(addr) ]
 
         strategies = self.write_strategies if strategies is None else strategies
-        return self._apply_concretization_strategies(addr, strategies, 'store')
+        return self._apply_concretization_strategies(addr, strategies, 'store', extra_constaints=extra_constaints)
 
-    def concretize_read_addr(self, addr, strategies=None):
+    def concretize_read_addr(self, addr, strategies=None, extra_constraints=()):
         """
         Concretizes an address meant for reading.
 
@@ -421,7 +421,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             return [ self.state.se.eval(addr) ]
 
         strategies = self.read_strategies if strategies is None else strategies
-        return self._apply_concretization_strategies(addr, strategies, 'load')
+        return self._apply_concretization_strategies(addr, strategies, 'load', extra_constraints=extra_constraints)
 
     def normalize_address(self, addr, is_write=False):
         return self.concretize_read_addr(addr)
@@ -684,7 +684,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         #
 
         try:
-            req.actual_addresses = sorted(self.concretize_write_addr(req.addr))
+            req.actual_addresses = sorted(self.concretize_write_addr(req.addr, req.constraints))
         except SimMemoryError:
             if options.CONSERVATIVE_WRITE_STRATEGY in self.state.options:
                 return req


### PR DESCRIPTION
Allow memory concretization to pass through extra_constraints.
Fixes a bug in store, that causes unsat states if size and addr are not
completely independent.
Should fix @badnack's issue