### PR TITLE
CFGFast: Disable switch_mode_on_nodecode by default.

### DIFF
--- a/angr/analyses/cfg/cfg_arch_options.py
+++ b/angr/analyses/cfg/cfg_arch_options.py
@@ -15,12 +15,19 @@ class CFGArchOptions(object):
     :ivar dict _options: Values of all CFG options that are specific to the current architecture.
     """
 
+    # option name: (option value type, default option value)
+
     OPTIONS = {
         'ARMEL': {
-            'ret_jumpkind_heuristics': (bool, True),  # option name: (option value type, default option value)
+            # Whether to perform some simple heuristics to detect returns that are incorrectly labeled as boring
+            # branches by VEX
+            'ret_jumpkind_heuristics': (bool, True),
+            # Whether to switch between ARM mode and THUMB mode when VEX fails to decode a block
+            'switch_mode_on_nodecode': (bool, False),
         },
         'ARMHF': {
             'ret_jumpkind_heuristics': (bool, True),
+            'switch_mode_on_nodecode': (bool, False),
         },
     }
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3371,7 +3371,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                     nodecode = True
 
                 if (nodecode or irsb.size == 0 or irsb.jumpkind == 'Ijk_NoDecode') and \
-                        self.project.arch.name in ('ARMHF', 'ARMEL'):
+                        self.project.arch.name in ('ARMHF', 'ARMEL') and \
+                        self._arch_options.switch_mode_on_nodecode:
                     # maybe the current mode is wrong?
                     nodecode = False
                     if addr % 2 == 0:


### PR DESCRIPTION
This option might produce undesirable results in ARM binaries that
contain legit instructions that VEX does not support. This option should
be disabled until we can use capstone to disassemble ARM instructions
for which VEX lacks support.