### PR TITLE
Implement shallow_reverse() to reverse DiGraphs.

### DIFF
--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -2,13 +2,14 @@ import logging
 from collections import defaultdict
 
 import networkx
-from . import Analysis, register_analysis
 
 from .. import SIM_PROCEDURES
 from .. import options as o
 from ..knowledge_base import KnowledgeBase
 from ..errors import AngrError, AngrCFGError
 from ..manager import SimulationManager
+from ..misc.graph import shallow_reverse
+from . import Analysis, register_analysis
 
 l = logging.getLogger("angr.analyses.veritesting")
 
@@ -577,7 +578,7 @@ class Veritesting(Analysis):
         """
 
         graph = networkx.DiGraph(cfg.graph)
-        reversed_cyclic_graph = networkx.reverse(graph_with_loops)
+        reversed_cyclic_graph = shallow_reverse(graph_with_loops)
 
         # Remove all "FakeRet" edges
         fakeret_edges = [

--- a/angr/misc/__init__.py
+++ b/angr/misc/__init__.py
@@ -1,3 +1,4 @@
 from . import ux
 from . import autoimport
 from .loggers import Loggers
+from . import graph

--- a/angr/misc/graph.py
+++ b/angr/misc/graph.py
@@ -1,0 +1,21 @@
+
+import networkx
+
+
+def shallow_reverse(g):
+    """
+    Make a shallow copy of a directional graph and reverse the edges. This is a workaround to solve the issue that one
+    cannot easily make a shallow reversed copy of a graph in NetworkX 2. GraphViews are always read-only.
+
+    :param networkx.DiGraph g:  The graph to reverse.
+    :return:                    A new networkx.DiGraph that has all nodes and all edges of the original graph, with edges
+                                reversed.
+    """
+
+    new_g = networkx.DiGraph()
+
+    new_g.add_nodes_from(g.nodes)
+    for src, dst, data in g.edges(data=True):
+        new_g.add_edge(src, dst, **data)
+
+    return new_g

--- a/angr/misc/graph.py
+++ b/angr/misc/graph.py
@@ -5,7 +5,8 @@ import networkx
 def shallow_reverse(g):
     """
     Make a shallow copy of a directional graph and reverse the edges. This is a workaround to solve the issue that one
-    cannot easily make a shallow reversed copy of a graph in NetworkX 2. GraphViews are always read-only.
+    cannot easily make a shallow reversed copy of a graph in NetworkX 2, since networkx.reverse(copy=False) now returns
+    a GraphView, and GraphViews are always read-only.
 
     :param networkx.DiGraph g:  The graph to reverse.
     :return:                    A new networkx.DiGraph that has all nodes and all edges of the original graph, with edges


### PR DESCRIPTION
This method returns a shallow copy of a reversed graph. It should work for
both networkx 1.x and 2.x.