### PR TITLE
Fixed call error

### DIFF
--- a/angr/procedures/win32/local_storage.py
+++ b/angr/procedures/win32/local_storage.py
@@ -49,7 +49,7 @@ class TlsFree(angr.SimProcedure):
     KEY = 'win32_tls'
     SETTER = TlsSetValue
     def run(self, index):
-        set_val = self.inline_call(self.SETTER, (index, self.state.se.BVV(0, self.state.arch.bits)))
+        set_val = self.inline_call(self.SETTER, index, self.state.se.BVV(0, self.state.arch.bits))
         return set_val.ret_expr
 
 


### PR DESCRIPTION
  File "/usr/local/lib/python2.7/dist-packages/angr/procedures/win32/local_storage.py", line 52, in run
    set_val = self.inline_call(self.SETTER, (index, self.state.se.BVV(0, self.state.arch.bits)))
  File "/usr/local/lib/python2.7/dist-packages/angr/sim_procedure.py", line 264, in inline_call
    return p.execute(self.state, None, arguments=e_args)
  File "/usr/local/lib/python2.7/dist-packages/angr/sim_procedure.py", line 157, in execute
    r = getattr(inst, inst.run_func)(*sim_args, **inst.kwargs)
TypeError: run() takes exactly 3 arguments (2 given)