### PR TITLE
Fix bug in simgr stepping

### DIFF
--- a/angr/exploration_techniques/driller_core.py
+++ b/angr/exploration_techniques/driller_core.py
@@ -5,7 +5,7 @@ from itertools import islice, izip
 from . import ExplorationTechnique
 
 
-l = logging.getLogger("angr.exploration_techniques.driller")
+l = logging.getLogger("angr.exploration_techniques.driller_core")
 
 
 class DrillerCore(ExplorationTechnique):

--- a/angr/manager.py
+++ b/angr/manager.py
@@ -600,7 +600,7 @@ class SimulationManager(ana.Storable):
         pg.stashes[stash] = new_active
 
         i = 0
-        while n is not None and i < n:
+        while (n is not None and i < n) or until is not None:
             i += 1
             l.debug("Round %d: stepping %s", i, pg)
 
@@ -940,8 +940,11 @@ class SimulationManager(ana.Storable):
         """
         if len(self._hooks_complete) == 0 and n is None:
             l.warn("No completion state defined for SimulationManager; stepping until all states deadend")
+            until_func = None
 
-        until_func = lambda pg: self.completion_mode(h(pg) for h in self._hooks_complete)
+        else:
+            until_func = lambda pg: self.completion_mode(h(pg) for h in self._hooks_complete)
+
         return self.step(n=n, step_func=step_func, until=until_func, stash=stash)
 
 

--- a/angr/manager.py
+++ b/angr/manager.py
@@ -941,6 +941,7 @@ class SimulationManager(ana.Storable):
         if len(self._hooks_complete) == 0 and n is None:
             l.warn("No completion state defined for SimulationManager; stepping until all states deadend")
             until_func = None
+            n = 100000 if n is None else n
 
         else:
             until_func = lambda pg: self.completion_mode(h(pg) for h in self._hooks_complete)

--- a/tests/test_driller_core.py
+++ b/tests/test_driller_core.py
@@ -6,7 +6,7 @@ import angr
 import tracer
 
 
-l = logging.getLogger("angr.exploration_techniques.driller").setLevel('DEBUG')
+l = logging.getLogger("angr.exploration_techniques.driller_core").setLevel('DEBUG')
 
 
 bin_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries'))


### PR DESCRIPTION
Hi @rhelmot, I think your latest commit https://github.com/angr/angr/commit/62cc44caff57bbabc8c7268773942a613b9df234 has a bug: simgr won't step when `until` is provided. Here's my solution, please tell me if it's ok with you.

Btw, why do you want to change all this? I still think that everything is working fine without this change. Because if this is to avoid executing 100k steps everytime, the `break` that you've added not long ago is enough, isn't it?

Thank you