### PR TITLE
Feat/variable registration

### DIFF
--- a/angr/engines/vex/dirty.py
+++ b/angr/engines/vex/dirty.py
@@ -29,7 +29,7 @@ def amd64g_dirtyhelper_RDTSC(state):
     if o.USE_SYSTEM_TIMES in state.options:
         val = state.solver.BVV(int(time.clock() * 1000000) + 12345678, 64)
     else:
-        val = state.solver.BVS('RDTSC', 64)
+        val = state.solver.BVS('RDTSC', 64, key=('hardware', 'rdtsc'))
     return val, []
 
 x86g_dirtyhelper_RDTSC = amd64g_dirtyhelper_RDTSC
@@ -136,7 +136,7 @@ def CORRECT_amd64g_dirtyhelper_CPUID_avx_and_cx16(state, _):
     return None, [ ]
 
 def amd64g_dirtyhelper_IN(state, portno, sz): #pylint:disable=unused-argument
-    return state.se.Unconstrained('IN', 64), [ ]
+    return state.se.Unconstrained('IN', 64, key=('hardware', 'in')), [ ]
 
 def amd64g_dirtyhelper_OUT(state, portno, data, sz): #pylint:disable=unused-argument
     return None, [ ]
@@ -228,7 +228,7 @@ def CORRECT_x86g_dirtyhelper_CPUID_sse2(state, _):
     return None, [ ]
 
 def x86g_dirtyhelper_IN(state, portno, sz): #pylint:disable=unused-argument
-    return state.se.Unconstrained('IN', 32), [ ]
+    return state.se.Unconstrained('IN', 32, key=('hardware', 'in')), [ ]
 
 def x86g_dirtyhelper_OUT(state, portno, data, sz): #pylint:disable=unused-argument
     return None, [ ]

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -227,7 +227,7 @@ class SimEngineVEX(SimEngine):
                     raise
                 if stmt.tmp not in (0xffffffff, -1):
                     retval_size = state.scratch.tyenv.sizeof(stmt.tmp)
-                    retval = state.se.Unconstrained("unsupported_dirty_%s" % stmt.cee.name, retval_size)
+                    retval = state.se.Unconstrained("unsupported_dirty_%s" % stmt.cee.name, retval_size, key=('dirty', stmt.cee.name))
                     state.scratch.store_tmp(stmt.tmp, retval, None, None)
                 state.history.add_event('resilience', resilience_type='dirty', dirty=stmt.cee.name,
                                     message='unsupported Dirty call')

--- a/angr/procedures/cgc/fdwait.py
+++ b/angr/procedures/cgc/fdwait.py
@@ -18,7 +18,7 @@ class fdwait(angr.SimProcedure):
             if angr.options.CGC_NON_BLOCKING_FDS in self.state.options:
                 sym_bit = self.state.se.BVV(1, 1)
             else:
-                sym_bit = self.state.se.Unconstrained('fdwait_read_%d_%d'%(run_count,fd), 1)
+                sym_bit = self.state.se.Unconstrained('fdwait_read_%d_%d'%(run_count,fd), 1, key=('syscall', 'fdwait', fd, 'read_ready'))
             fd = self.state.se.BVV(fd, self.state.arch.bits)
             sym_newbit = self.state.se.If(self.state.se.ULT(fd, nfds), sym_bit, 0)
             total_ready += sym_newbit.zero_extend(self.state.arch.bits - 1)
@@ -30,7 +30,7 @@ class fdwait(angr.SimProcedure):
             if angr.options.CGC_NON_BLOCKING_FDS in self.state.options:
                 sym_bit = self.state.se.BVV(1, 1)
             else:
-                sym_bit = self.state.se.Unconstrained('fdwait_write_%d_%d' % (run_count, fd), 1)
+                sym_bit = self.state.se.Unconstrained('fdwait_write_%d_%d' % (run_count, fd), 1, key=('syscall', 'fdwait', fd, 'write_ready'))
 
             fd = self.state.se.BVV(fd, self.state.arch.bits)
             sym_newbit = self.state.se.If(self.state.se.ULT(fd, nfds), sym_bit, 0)

--- a/angr/procedures/cgc/random.py
+++ b/angr/procedures/cgc/random.py
@@ -34,7 +34,7 @@ class random(angr.SimProcedure):
             ), self.state.se.BVV(0, self.state.arch.bits))
 
         if self.state.satisfiable(extra_constraints=[count!=0]):
-            self.state.memory.store(buf, self.state.se.Unconstrained('random_%d' % rand_count.next(), self.state.se.max_int(count*8)), size=count)
+            self.state.memory.store(buf, self.state.se.Unconstrained('random_%d' % rand_count.next(), self.state.se.max_int(count*8)), size=count, key=('syscall', 'random'))
         self.state.memory.store(rnd_bytes, count, endness='Iend_LE', condition=rnd_bytes != 0)
 
         return r

--- a/angr/procedures/cgc/receive.py
+++ b/angr/procedures/cgc/receive.py
@@ -51,7 +51,7 @@ class receive(angr.SimProcedure):
             if ABSTRACT_MEMORY in self.state.options:
                 actual_size = count
             else:
-                actual_size = self.state.se.Unconstrained('receive_length', self.state.arch.bits)
+                actual_size = self.state.se.Unconstrained('receive_length', self.state.arch.bits, key=('syscall', 'receive', 'length'))
                 self.state.add_constraints(self.state.se.ULE(actual_size, count), action=True)
 
             if self.state.se.solution(count != 0, True):

--- a/angr/procedures/libc/puts.py
+++ b/angr/procedures/libc/puts.py
@@ -21,4 +21,4 @@ class puts(angr.SimProcedure):
         self.state.posix.write(1, self.state.se.BVV(0x0a, 8), 1)
 
         # TODO: return values
-        return self.state.se.Unconstrained('puts', self.state.arch.bits)
+        return self.state.se.Unconstrained('puts', self.state.arch.bits, key=('api', 'puts'))

--- a/angr/procedures/libc/rand.py
+++ b/angr/procedures/libc/rand.py
@@ -2,5 +2,5 @@ import angr
 
 class rand(angr.SimProcedure):
     def run(self):
-        rval = self.state.se.BVS('rand', 31)
+        rval = self.state.se.BVS('rand', 31, key=('api', 'rand'))
         return rval.zero_extend(self.state.arch.bits - 31)

--- a/angr/procedures/libc/strncmp.py
+++ b/angr/procedures/libc/strncmp.py
@@ -24,7 +24,7 @@ class strncmp(angr.SimProcedure):
 
         match_constraints = [ ]
         variables = a_len.variables | b_len.variables | limit.variables
-        ret_expr = self.state.se.Unconstrained("strncmp_ret", self.state.arch.bits)
+        ret_expr = self.state.se.Unconstrained("strncmp_ret", self.state.arch.bits, key=('api', 'strncmp'))
 
         # determine the maximum number of bytes to compare
         concrete_run = False

--- a/angr/procedures/libc/system.py
+++ b/angr/procedures/libc/system.py
@@ -13,5 +13,5 @@ class system(angr.SimProcedure):
         self.argument_types = {0: self.ty_ptr(SimTypeTop())}
         self.return_type = SimTypeInt(self.state.arch.bits, True)
 
-        retcode = self.state.se.Unconstrained('system_returncode', 8)
+        retcode = self.state.se.Unconstrained('system_returncode', 8, key=('api', 'system'))
         return retcode.zero_extend(self.state.arch.bits - 8)

--- a/angr/procedures/linux_kernel/futex.py
+++ b/angr/procedures/linux_kernel/futex.py
@@ -18,4 +18,4 @@ class futex(angr.SimProcedure):
             return 0
         else:
             l.debug('futex(futex_op=%d)', op)
-            return self.state.se.Unconstrained("futex", self.state.arch.bits)
+            return self.state.se.Unconstrained("futex", self.state.arch.bits, key=('api', 'futex'))

--- a/angr/procedures/linux_kernel/getrlimit.py
+++ b/angr/procedures/linux_kernel/getrlimit.py
@@ -17,8 +17,8 @@ class getrlimit(angr.SimProcedure):
         if self.state.se.eval(resource) == 3:  # RLIMIT_STACK
             l.debug('running getrlimit(RLIMIT_STACK)')
             self.state.memory.store(rlim, 8388608, 8) # rlim_cur
-            self.state.memory.store(rlim+8, self.state.se.Unconstrained("rlim_max", 8*8))
+            self.state.memory.store(rlim+8, self.state.se.Unconstrained("rlim_max", 8*8), key=('api', 'rlimit', 'stack'))
             return 0
         else:
             l.debug('running getrlimit(other)')
-            return self.state.se.Unconstrained("rlimit", self.state.arch.bits)
+            return self.state.se.Unconstrained("rlimit", self.state.arch.bits, key=('api', 'rlimit', 'other'))

--- a/angr/procedures/linux_kernel/time.py
+++ b/angr/procedures/linux_kernel/time.py
@@ -13,7 +13,7 @@ class time(angr.SimProcedure):
         self.state.globals[self.KEY] = v
 
     def run(self, pointer):
-        result = self.state.se.BVS('sys_time', self.state.arch.bits)
+        result = self.state.se.BVS('sys_time', self.state.arch.bits, key=('api', 'time'))
         if self.last_time is not None:
             self.state.add_constraints(result >= self.last_time)
         self.last_time = result

--- a/angr/procedures/posix/bind.py
+++ b/angr/procedures/posix/bind.py
@@ -10,4 +10,4 @@ class bind(angr.SimProcedure):
     #pylint:disable=arguments-differ
 
     def run(self, fd): #pylint:disable=unused-argument
-        return self.state.se.Unconstrained('bind', self.state.arch.bits)
+        return self.state.se.Unconstrained('bind', self.state.arch.bits, key=('api', 'bind'))

--- a/angr/procedures/posix/gethostbyname.py
+++ b/angr/procedures/posix/gethostbyname.py
@@ -4,9 +4,9 @@ class gethostbyname(angr.SimProcedure):
     def run(self, name):
         malloc = angr.SIM_PROCEDURES['libc']['malloc']
         place = self.inline_call(malloc, 32).ret_expr
-        self.state.memory.store(place, self.state.se.BVS('h_name', 64), endness='Iend_LE')
-        self.state.memory.store(place, self.state.se.BVS('h_aliases', 64), endness='Iend_LE')
-        self.state.memory.store(place, self.state.se.BVS('h_addrtype', 64), endness='Iend_LE')
-        self.state.memory.store(place, self.state.se.BVS('h_length', 64), endness='Iend_LE')
-        self.state.memory.store(place, self.state.se.BVS('h_addr_list', 64), endness='Iend_LE')
+        self.state.memory.store(place, self.state.se.BVS('h_name', 64, key=('api', 'gethostbyname', 'h_name')), endness='Iend_LE')
+        self.state.memory.store(place, self.state.se.BVS('h_aliases', 64, key=('api', 'gethostbyname', 'h_aliases')), endness='Iend_LE')
+        self.state.memory.store(place, self.state.se.BVS('h_addrtype', 64, key=('api', 'gethostbyname', 'h_addrtype')), endness='Iend_LE')
+        self.state.memory.store(place, self.state.se.BVS('h_length', 64, key=('api', 'gethostbyname', 'h_length')), endness='Iend_LE')
+        self.state.memory.store(place, self.state.se.BVS('h_addr_list', 64, key=('api', 'gethostbyname', 'h_addr_list')), endness='Iend_LE')
         return place

--- a/angr/procedures/posix/listen.py
+++ b/angr/procedures/posix/listen.py
@@ -10,5 +10,5 @@ class listen(angr.SimProcedure):
     #pylint:disable=arguments-differ
 
     def run(self, sockfd, backlog): #pylint:disable=unused-argument
-        return self.state.se.Unconstrained('listen', self.state.arch.bits)
+        return self.state.se.Unconstrained('listen', self.state.arch.bits, key=('api', 'listen'))
 

--- a/angr/procedures/posix/readdir.py
+++ b/angr/procedures/posix/readdir.py
@@ -35,10 +35,10 @@ class readdir(angr.SimProcedure):
     def _build_amd64(self):
         self.struct = Dirent(self.state.se.BVV(0, 64), # d_ino
                              self.state.se.BVV(0, 64), # d_off
-                             self.state.se.BVS('d_reclen', 16), # d_reclen
-                             self.state.se.BVS('d_type', 8), # d_type
-                             self.state.se.BVS('d_name', 255*8)) # d_name
-        self.condition = self.state.se.BoolS('readdir_cond')
+                             self.state.se.BVS('d_reclen', 16, key=('api', 'readdir', 'd_reclen')), # d_reclen
+                             self.state.se.BVS('d_type', 8, key=('api', 'readdir', 'd_type')), # d_type
+                             self.state.se.BVS('d_name', 255*8, key=('api', 'readdir', 'd_name'))) # d_name
+        self.condition = self.state.se.BoolS('readdir_cond', key) # TODO: variable key
 
     def _store_amd64(self, ptr):
         stores = lambda offset, val: self.state.memory.store(ptr + offset, val, endness='Iend_BE')

--- a/angr/procedures/stubs/ReturnChar.py
+++ b/angr/procedures/stubs/ReturnChar.py
@@ -6,6 +6,6 @@ import angr
 
 class ReturnChar(angr.SimProcedure):
     def run(self):
-        s_var = self.state.se.Unconstrained("char_ret", self.state.arch.bits)
+        s_var = self.state.se.Unconstrained("char_ret", self.state.arch.bits, key=('api', '?', self.display_name))
         self.state.add_constraints(self.state.se.And(self.state.se.ULE(s_var, 126), self.state.se.UGE(s_var, 9)))
         return s_var

--- a/angr/procedures/stubs/ReturnUnconstrained.py
+++ b/angr/procedures/stubs/ReturnUnconstrained.py
@@ -8,9 +8,8 @@ class ReturnUnconstrained(angr.SimProcedure):
     def run(self, return_val=None): #pylint:disable=arguments-differ
         #pylint:disable=attribute-defined-outside-init
 
-
         if return_val is None:
-            o = self.state.se.Unconstrained("unconstrained_ret_%s" % self.display_name, self.state.arch.bits)
+            o = self.state.se.Unconstrained("unconstrained_ret_%s" % self.display_name, self.state.arch.bits, key=('api', '?', self.display_name))
         else:
             o = return_val
 

--- a/angr/procedures/stubs/syscall_stub.py
+++ b/angr/procedures/stubs/syscall_stub.py
@@ -15,7 +15,7 @@ class syscall(angr.SimProcedure):
 
         self.successors.artifacts['resolves'] = resolves
 
-        return self.state.se.Unconstrained("syscall_stub", self.state.arch.bits)
+        return self.state.se.Unconstrained("syscall_stub", self.state.arch.bits, key=('syscall', '?', self.display_name))
 
     def __repr__(self):
         if 'resolves' in self.kwargs:

--- a/angr/procedures/win32/sim_time.py
+++ b/angr/procedures/win32/sim_time.py
@@ -19,7 +19,7 @@ class GetSystemTimeAsFileTime(angr.SimProcedure):
                     # convert to microseconds, convert to nanoseconds, convert to 100ns intervals
 
     def fill_symbolic(self):
-        self.timestamp = self.state.se.BVS('SystemTimeAsFileTime', 64)
+        self.timestamp = self.state.se.BVS('SystemTimeAsFileTime', 64, key=('api', 'SystemTimeAsFileTime'))
 
 
 class GetLocalTime(angr.SimProcedure):
@@ -62,14 +62,14 @@ class GetLocalTime(angr.SimProcedure):
         """
         Fill the class with constrained symbolic values.
         """
-        self.wYear = self.state.solver.BVS('cur_year', 16)
-        self.wMonth = self.state.solver.BVS('cur_month', 16)
-        self.wDayOfWeek = self.state.solver.BVS('cur_dayofweek', 16)
-        self.wDay = self.state.solver.BVS('cur_day', 16)
-        self.wHour = self.state.solver.BVS('cur_hour', 16)
-        self.wMinute = self.state.solver.BVS('cur_minute', 16)
-        self.wSecond = self.state.solver.BVS('cur_second', 16)
-        self.wMilliseconds = self.state.solver.BVS('cur_millisecond', 16)
+        self.wYear = self.state.solver.BVS('cur_year', 16, key=('api', 'GetLocalTime', 'cur_year'))
+        self.wMonth = self.state.solver.BVS('cur_month', 16, key=('api', 'GetLocalTime', 'cur_month'))
+        self.wDayOfWeek = self.state.solver.BVS('cur_dayofweek', 16, key=('api', 'GetLocalTime', 'cur_dayofweek'))
+        self.wDay = self.state.solver.BVS('cur_day', 16, key=('api', 'GetLocalTime', 'cur_day'))
+        self.wHour = self.state.solver.BVS('cur_hour', 16, key=('api', 'GetLocalTime', 'cur_hour'))
+        self.wMinute = self.state.solver.BVS('cur_minute', 16, key=('api', 'GetLocalTime', 'cur_minute'))
+        self.wSecond = self.state.solver.BVS('cur_second', 16, key=('api', 'GetLocalTime', 'cur_second'))
+        self.wMilliseconds = self.state.solver.BVS('cur_millisecond', 16, key=('api', 'GetLocalTime', 'cur_millisecond'))
 
         self.state.add_constraints(self.wYear >= 1601)
         self.state.add_constraints(self.wYear <= 30827)
@@ -105,7 +105,7 @@ class QueryPerformanceCounter(angr.SimProcedure):
             val = int(time.clock() * 1000000) + 12345678
             self.state.mem[ptr].qword = val
         else:
-            self.state.mem[ptr].qword = self.state.solver.BVS('QueryPerformanceCounter_result', 64)
+            self.state.mem[ptr].qword = self.state.solver.BVS('QueryPerformanceCounter_result', 64, key=('api', 'QueryPerformanceCounter'))
         return 1
 
 class GetTickCount(angr.SimProcedure):
@@ -113,7 +113,7 @@ class GetTickCount(angr.SimProcedure):
         if angr.options.USE_SYSTEM_TIMES in self.state.options:
             return int(time.clock() * 1000) + 12345
         else:
-            val = self.state.solver.BVS('GetTickCount_result', 32)
+            val = self.state.solver.BVS('GetTickCount_result', 32, key=('api', 'GetTickCount'))
             return val
 
 class GetTickCount64(angr.SimProcedure):
@@ -122,4 +122,4 @@ class GetTickCount64(angr.SimProcedure):
         if angr.options.USE_SYSTEM_TIMES in self.state.options:
             return int(time.clock() * 1000) + 12345
         else:
-            return self.state.solver.BVS('GetTickCount64_result', 64)
+            return self.state.solver.BVS('GetTickCount64_result', 64, key=('api', 'GetTickCount64'))

--- a/angr/procedures/win_user32/messagebox.py
+++ b/angr/procedures/win_user32/messagebox.py
@@ -8,7 +8,7 @@ class MessageBoxA(angr.SimProcedure):
         else:
             caption = 'Error'
 
-        result = self.state.solver.If(uType & 0xf == 0, 1, self.state.solver.BVS('messagebox_button', 32))
+        result = self.state.solver.If(uType & 0xf == 0, 1, self.state.solver.BVS('messagebox_button', 32), key=('api', 'messagebox', 'button'))
         self.state.history.add_event('message_box', text=text, caption=caption, result=result)
         return result
 

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -289,7 +289,10 @@ class SimProcedure(object):
 
             if self.symbolic_return:
                 size = len(expr)
-                new_expr = self.state.se.Unconstrained("symbolic_return_" + self.__class__.__name__, size) #pylint:disable=maybe-no-member
+                new_expr = self.state.solver.Unconstrained(
+                        "symbolic_return_" + self.display_name,
+                        size,
+                        key=('symbolic_return', self.display_name)) #pylint:disable=maybe-no-member
                 self.state.add_constraints(new_expr == expr)
                 expr = new_expr
 

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -125,9 +125,12 @@ class SimOS(object):
 
         if initial_prefix is not None:
             for reg in state.arch.default_symbolic_registers:
-                state.registers.store(reg, claripy.BVS(initial_prefix + "_" + reg,
-                                                       state.arch.bits,
-                                                       explicit_name=True))
+                state.registers.store(reg, state.solver.BVS(
+                    initial_prefix + "_" + reg,
+                    state.arch.bits,
+                    explicit_name=True,
+                    key=('reg', reg),
+                    eternal=True))
 
         for reg, val, is_addr, mem_region in state.arch.default_register_values:
 
@@ -220,7 +223,7 @@ class SimOS(object):
         # Preconstrain
         state.preconstrainer.preconstrain_state()
 
-        state.cgc.flag_bytes = [claripy.BVS("cgc-flag-byte-%d" % i, 8) for i in xrange(0x1000)]
+        state.cgc.flag_bytes = [state.solver.BVS("cgc-flag-byte-%d" % i, 8, key=('flag', i), eternal=True) for i in xrange(0x1000)]
 
         return state
 

--- a/angr/state_plugins/fast_memory.py
+++ b/angr/state_plugins/fast_memory.py
@@ -44,7 +44,7 @@ class SimFastMemory(SimMemory):
         The default uninitialized read handler. Returns symbolic bytes.
         """
         if self._uninitialized_read_handler is None:
-            v = self.state.se.BVS("%s_%s" % (self.id, addr), self.width*self.state.arch.byte_width, inspect=inspect, events=events)
+            v = self.state.se.BVS("%s_%s" % (self.id, addr), self.width*self.state.arch.byte_width, key=self.variable_key_prefix + (addr,), inspect=inspect, events=events)
             return v.reversed if self.endness == "Iend_LE" else v
         else:
             return self._uninitialized_read_handler(self, addr, inspect=inspect, events=events)

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -273,10 +273,10 @@ class SimStateSystem(SimStatePlugin):
         # sizes are AMD64-specific for now
         # TODO: import results from concrete FS, if using concrete FS
         if self.state.solver.symbolic(fd):
-            mode = self.state.se.BVS('st_mode', 32)
+            mode = self.state.se.BVS('st_mode', 32, key=('api', 'fstat', 'st_mode'))
         else:
             fd = self.state.se.eval(fd)
-            mode = self.state.se.BVS('st_mode', 32) if not self.files[fd].name.startswith('/dev/') else self.state.se.BVV(0, 32)
+            mode = self.state.se.BVS('st_mode', 32, key=('api', 'fstat', 'st_mode')) if not self.files[fd].name.startswith('/dev/') else self.state.se.BVV(0, 32)
             # return this weird bogus zero value to keep code paths in libc simple :\
 
         return Stat(self.state.se.BVV(0, 64), # st_dev
@@ -286,7 +286,7 @@ class SimStateSystem(SimStatePlugin):
                     self.state.se.BVV(0, 32), # st_uid (lol root)
                     self.state.se.BVV(0, 32), # st_gid
                     self.state.se.BVV(0, 64), # st_rdev
-                    self.state.se.BVS('st_size', 64), # st_size
+                    self.state.se.BVS('st_size', 64, key=('api', 'fstat', 'st_size')), # st_size
                     self.state.se.BVV(0, 64), # st_blksize
                     self.state.se.BVV(0, 64), # st_blocks
                     self.state.se.BVV(0, 64), # st_atime
@@ -371,9 +371,9 @@ class SimStateSystem(SimStatePlugin):
             if sigsetsize is not None:
                 sc = self.state.se.eval(sigsetsize)
                 self.state.add_constraints(sc == sigsetsize)
-                self._sigmask = self.state.se.BVS('initial_sigmask', sc*self.state.arch.byte_width)
+                self._sigmask = self.state.se.BVS('initial_sigmask', sc*self.state.arch.byte_width, key=('initial_sigmask',), eternal=True)
             else:
-                self._sigmask = self.state.se.BVS('initial_sigmask', self.sigmask_bits)
+                self._sigmask = self.state.se.BVS('initial_sigmask', self.sigmask_bits, key=('initial_sigmask',), eternal=True)
         return self._sigmask
 
     def sigprocmask(self, how, new_mask, sigsetsize, valid_ptr=True):

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -300,7 +300,7 @@ class SimSolver(SimStatePlugin):
         # should this be locked for multithreading?
         if key is not None and eternal and key in self.eternal_tracked_variables:
             r = self.eternal_tracked_variables[key]
-            if min != r.args[1] or max != r.args[2] or stride != r.args[3] or uninitialized != r.args[4] or bool(explicit_name) ^ (r.args[0] == name):
+            if size != r.length or min != r.args[1] or max != r.args[2] or stride != r.args[3] or uninitialized != r.args[4] or bool(explicit_name) ^ (r.args[0] == name):
                 l.warning("Variable %s being retrieved with differnt settings than it was tracked with", name)
         else:
             r = claripy.BVS(name, size, min=min, max=max, stride=stride, uninitialized=uninitialized, explicit_name=explicit_name, **kwargs)

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -249,7 +249,7 @@ class SimSolver(SimStatePlugin):
     #
     # Get unconstrained stuff
     #
-    def Unconstrained(self, name, bits, uninitialized=True, inspect=True, events=True, **kwargs):
+    def Unconstrained(self, name, bits, uninitialized=True, inspect=True, events=True, key=None, eternal=False, **kwargs):
         if o.SYMBOLIC_INITIAL_VALUES in self.state.options:
             # Return a symbolic value
             if o.ABSTRACT_MEMORY in self.state.options:
@@ -258,9 +258,9 @@ class SimSolver(SimStatePlugin):
             else:
                 l.debug("Creating new unconstrained BV named %s", name)
                 if o.UNDER_CONSTRAINED_SYMEXEC in self.state.options:
-                    r = self.BVS(name, bits, uninitialized=uninitialized, inspect=inspect, events=events, **kwargs)
+                    r = self.BVS(name, bits, uninitialized=uninitialized, key=key, eternal=eternal, inspect=inspect, events=events, **kwargs)
                 else:
-                    r = self.BVS(name, bits, uninitialized=uninitialized, inspect=inspect, events=events, **kwargs)
+                    r = self.BVS(name, bits, uninitialized=uninitialized, key=key, eternal=eternal, inspect=inspect, events=events, **kwargs)
 
             return r
         else:

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -433,8 +433,14 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
     def _fill_missing(self, addr, num_bytes, inspect=True, events=True):
         name = "%s_%x" % (self.id, addr)
         all_missing = [
-            self.get_unconstrained_bytes(name, min(self.mem._page_size, num_bytes)*self.state.arch.byte_width, source=i, inspect=inspect,
-                                         events=events, key=self.variable_key_prefix + (addr,), eternal=True)
+            self.get_unconstrained_bytes(
+                name,
+                min(self.mem._page_size, num_bytes)*self.state.arch.byte_width,
+                source=i,
+                inspect=inspect,
+                events=events,
+                key=self.variable_key_prefix + (addr,),
+                eternal=False) # :(
             for i in range(addr, addr+num_bytes, self.mem._page_size)
         ]
         if self.category == 'reg' and self.state.arch.register_endness == 'Iend_LE':
@@ -464,9 +470,9 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             if not mo.includes(last_missing):
                 # add missing bytes
                 start_addr = mo.last_addr + 1
-                end_addr = last_missing - mo.last_addr
-                fill_mo = self._fill_missing(start_addr, end_addr, inspect=inspect, events=events)
-                segments.append(fill_mo.bytes_at(start_addr, end_addr).reversed)
+                length = last_missing - mo.last_addr
+                fill_mo = self._fill_missing(start_addr, length, inspect=inspect, events=events)
+                segments.append(fill_mo.bytes_at(start_addr, length).reversed)
                 last_missing = mo.last_addr
 
             # add the normal segment
@@ -993,7 +999,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
 
     # Unconstrain a byte
     def unconstrain_byte(self, addr, inspect=True, events=True):
-        unconstrained_byte = self.get_unconstrained_bytes("%s_unconstrain_0x%x" % (self.id, addr), self.state.arch.byte_width, inspect=inspect,
+        unconstrained_byte = self.get_unconstrained_bytes("%s_unconstrain_%#x" % (self.id, addr), self.state.arch.byte_width, inspect=inspect,
                                                           events=events, key=('manual_unconstrain', addr))
         self.store(addr, unconstrained_byte)
 

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -434,7 +434,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         name = "%s_%x" % (self.id, addr)
         all_missing = [
             self.get_unconstrained_bytes(name, min(self.mem._page_size, num_bytes)*self.state.arch.byte_width, source=i, inspect=inspect,
-                                         events=events)
+                                         events=events, key=self.variable_key_prefix + (addr,), eternal=True)
             for i in range(addr, addr+num_bytes, self.mem._page_size)
         ]
         if self.category == 'reg' and self.state.arch.register_endness == 'Iend_LE':
@@ -966,7 +966,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
 
         return req
 
-    def get_unconstrained_bytes(self, name, bits, source=None, inspect=True, events=True):
+    def get_unconstrained_bytes(self, name, bits, source=None, key=None, inspect=True, events=True, **kwargs):
         """
         Get some consecutive unconstrained bytes.
         :param name: Name of the unconstrained variable
@@ -984,18 +984,17 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         elif options.SPECIAL_MEMORY_FILL in self.state.options and self.state._special_memory_filler is not None:
             return self.state._special_memory_filler(name, bits, self.state)
         else:
-            kwargs = { }
             if options.UNDER_CONSTRAINED_SYMEXEC in self.state.options:
                 if source is not None and type(source) in (int, long):
                     alloc_depth = self.state.uc_manager.get_alloc_depth(source)
                     kwargs['uc_alloc_depth'] = 0 if alloc_depth is None else alloc_depth + 1
-            r = self.state.se.Unconstrained(name, bits, inspect=inspect, events=events, **kwargs)
+            r = self.state.se.Unconstrained(name, bits, key=key, inspect=inspect, events=events, **kwargs)
             return r
 
     # Unconstrain a byte
     def unconstrain_byte(self, addr, inspect=True, events=True):
         unconstrained_byte = self.get_unconstrained_bytes("%s_unconstrain_0x%x" % (self.id, addr), self.state.arch.byte_width, inspect=inspect,
-                                                          events=events)
+                                                          events=events, key=('manual_unconstrain', addr))
         self.store(addr, unconstrained_byte)
 
     # Replaces the differences between self and other with unconstrained bytes.

--- a/angr/storage/memory.py
+++ b/angr/storage/memory.py
@@ -331,6 +331,13 @@ class SimMemory(SimStatePlugin):
         else:
             raise SimMemoryError('Unknown SimMemory category for memory_id "%s"' % self.id)
 
+    @property
+    def variable_key_prefix(self):
+        s = self.category
+        if s == 'file':
+            return (s, self.id)
+        return (s,)
+
     def set_state(self, state):
         """
         Call the set_state method in SimStatePlugin class, and then perform the delayed initialization.

--- a/tests/test_variable_registration.py
+++ b/tests/test_variable_registration.py
@@ -1,0 +1,36 @@
+import angr
+import nose
+
+def test_registration():
+    s = angr.SimState(arch='AMD64')
+
+    a1 = s.solver.BVS('a', 64, key=(1,), eternal=True)
+    a2 = s.solver.BVS('a', 64, key=(1,), eternal=True)
+    nose.tools.assert_is(a1, a2)
+
+    b1 = s.solver.BVS('b', 64, key=(2,), eternal=False)
+    s1 = s.copy()
+    s2 = s.copy()
+
+    b2 = s1.solver.BVS('b', 64, key=(2,), eternal=False)
+    b3 = s2.solver.BVS('b', 64, key=(2,), eternal=False)
+    nose.tools.assert_is_not(b1, b2)
+    nose.tools.assert_is_not(b2, b3)
+    nose.tools.assert_is_not(b1, b3)
+
+    a3 = s1.solver.BVS('a', 64, key=(1,), eternal=True)
+    a4 = s2.solver.BVS('a', 64, key=(1,), eternal=True)
+    nose.tools.assert_is(a2, a3)
+    nose.tools.assert_is(a3, a4)
+
+    nose.tools.assert_equal(len(list(s.solver.get_variables(1))), 1)
+    nose.tools.assert_equal(len(list(s1.solver.get_variables(1))), 1)
+    nose.tools.assert_equal(len(list(s2.solver.get_variables(1))), 1)
+
+    nose.tools.assert_equal(len(list(s.solver.get_variables(2))), 1)
+    nose.tools.assert_equal(len(list(s1.solver.get_variables(2))), 2)
+    nose.tools.assert_equal(len(list(s2.solver.get_variables(2))), 2)
+
+    nose.tools.assert_equal(list(s.solver.describe_variables(a1)), [(1,)])
+    nose.tools.assert_equal(list(s.solver.describe_variables(b1)), [(2, 1)])
+    nose.tools.assert_equal(sorted(list(s.solver.describe_variables(a1 + b1))), [(1,), (2, 1)])


### PR DESCRIPTION
You can now tell where the symbols that angr creates implicitly come from.

- adds two parameters to `solver.BVS` and `solver.Unconstrained`: `key` and `eternal`
- `key` is a tuple used to semantically identify the meaning of the variable being created
- `eternal`, if set to True, will cause the created variable to be propagated to all states with the same ancestry, all of which will return the same identical variable if they too ask for an variable with the same key. This is useful for making it so appear that all states have the same unconstrained memory to start off with.
- If set to false (default), the variable is _temporal_ or _sequential_, and an incrementing counter will be appended to the key, and the variable registration will only appear in states descending from this one.
- adds `solver.get_variables()`, which can be passed a prefix to some registered variable keys, and will iterate over all the registered variables, temporal and eternal, matching that prefix.
- modifies almost all implicit variable creations in angr to register their variables. Common naming schemes include `(domain, name, member)` e.g. `('file', 1, 0)` or `('api', 'readdir', 'd_name')`

```python
In [1]: import angr
In [2]: p = angr.Project('/bin/true')
In [3]: s = p.factory.entry_state()

In [4]: list(s.solver.get_variables())
Out[4]: []

In [6]: s.regs.rdi
Out[6]: <BV64 reg_48_0_64{UNINITIALIZED}>

In [7]: list(s.solver.get_variables())
Out[7]: [(('reg', 72), <BV64 reg_48_0_64{UNINITIALIZED}>)]

In [8]: s.mem[0x1000].long.resolved
Out[8]: <BV64 mem_1000_1_64{UNINITIALIZED}>

In [9]: list(s.solver.get_variables())
Out[9]:
[(('reg', 72), <BV64 reg_48_0_64{UNINITIALIZED}>),
 (('mem', 4096L), <BV64 mem_1000_1_64{UNINITIALIZED}>)]

In [10]: list(s.solver.get_variables('reg'))
Out[10]: [(('reg', 72), <BV64 reg_48_0_64{UNINITIALIZED}>)]

In [11]: s1 = s.copy()

In [12]: s2 = s.copy()

In [13]: s1.solver.BVS('asdf', 64, key=('asdf',))
Out[13]: <BV64 asdf_2_64>

In [14]: s1.solver.BVS('asdf', 64, key=('asdf',))
Out[14]: <BV64 asdf_3_64>

In [15]: s2.solver.BVS('asdf', 64, key=('asdf',))
Out[15]: <BV64 asdf_4_64>

In [16]: s2.solver.BVS('asdf', 64, key=('asdf',))
Out[16]: <BV64 asdf_5_64>

In [17]: s1.solver.BVS('qwer', 64, key=('qwer',), eternal=True)
Out[17]: <BV64 qwer_6_64>

In [18]: s1.solver.BVS('qwer', 64, key=('qwer',), eternal=True)
Out[18]: <BV64 qwer_6_64>

In [19]: s2.solver.BVS('qwer', 64, key=('qwer',), eternal=True)
Out[19]: <BV64 qwer_6_64>

In [20]: s.solver.BVS('qwer', 64, key=('qwer',), eternal=True)
Out[20]: <BV64 qwer_6_64>

In [23]: list(s1.solver.get_variables())
Out[23]:
[(('reg', 72), <BV64 reg_48_0_64{UNINITIALIZED}>),
 (('mem', 4096L), <BV64 mem_1000_1_64{UNINITIALIZED}>),
 (('qwer',), <BV64 qwer_6_64>),
 (('asdf', 1), <BV64 asdf_2_64>),
 (('asdf', 2), <BV64 asdf_3_64>)]

In [24]: list(s2.solver.get_variables())
Out[24]:
[(('reg', 72), <BV64 reg_48_0_64{UNINITIALIZED}>),
 (('mem', 4096L), <BV64 mem_1000_1_64{UNINITIALIZED}>),
 (('qwer',), <BV64 qwer_6_64>),
 (('asdf', 1), <BV64 asdf_4_64>),
 (('asdf', 2), <BV64 asdf_5_64>)]
```