### PR TITLE
[WIP] Enable advanced backward slicing in CFGAccurate

### DIFF
--- a/angr/analyses/backward_slice.py
+++ b/angr/analyses/backward_slice.py
@@ -82,6 +82,8 @@ class BackwardSlice(Analysis):
         # IDs for all chosen exit statements as well as their corresponding targets
         self.chosen_exits = defaultdict(list)
 
+        if targets[0][0].addr == 0x4005d7:
+            import ipdb; ipdb.set_trace()
         if not no_construct:
             self._construct(self._targets, control_flow_slice=control_flow_slice)
 

--- a/angr/analyses/backward_slice.py
+++ b/angr/analyses/backward_slice.py
@@ -82,8 +82,6 @@ class BackwardSlice(Analysis):
         # IDs for all chosen exit statements as well as their corresponding targets
         self.chosen_exits = defaultdict(list)
 
-        if targets[0][0].addr == 0x4005d7:
-            import ipdb; ipdb.set_trace()
         if not no_construct:
             self._construct(self._targets, control_flow_slice=control_flow_slice)
 

--- a/angr/analyses/backward_slice.py
+++ b/angr/analyses/backward_slice.py
@@ -376,6 +376,8 @@ class BackwardSlice(Analysis):
                 taints.add(cl)
 
         while taints:
+            if self._targets[0][0].addr == 0x4005d7:
+                import ipdb; ipdb.set_trace()
             # Pop a tainted code location
             tainted_cl = taints.pop()
 
@@ -390,10 +392,10 @@ class BackwardSlice(Analysis):
             # Pick all its data dependencies from data dependency graph
             if self._ddg is not None and tainted_cl in self._ddg:
                 if isinstance(self._ddg, networkx.DiGraph):
-                    predecessors = self._ddg.predecessors(tainted_cl)
+                    predecessors = list(self._ddg.predecessors(tainted_cl))
                 else:
                     # angr.analyses.DDG
-                    predecessors = self._ddg.get_predecessors(tainted_cl)
+                    predecessors = list(self._ddg.get_predecessors(tainted_cl))
                 l.debug("Returned %d predecessors for %s from data dependence graph", len(predecessors), tainted_cl)
 
                 for p in predecessors:

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -22,7 +22,6 @@ from ...errors import AngrCFGError, AngrError, AngrSkipJobNotice, SimError, SimV
 from ...sim_state import SimState
 from ...state_plugins.callstack import CallStack
 from ...state_plugins.sim_action import SimActionData
-from ...exploration_techniques import Explorer
 from ...misc.graph import shallow_reverse
 
 l = logging.getLogger("angr.analyses.cfg.cfg_accurate")
@@ -2350,8 +2349,6 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             old_timeout = state.se._solver.timeout
             state.se._solver.timeout = 5000
 
-            if cfgnode.addr == 0x400704:
-                import ipdb; ipdb.set_trace()
             sc = self.project.surveyors.Slicecutor(annotated_cfg, start=state).run()
 
             # Restore the timeout!
@@ -2474,8 +2471,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                     )
 
                 simgr = self.project.factory.simgr(state)
-                simgr.use_technique(Explorer(find=(current_block.addr), avoid=avoid))
-                simgr.run()
+                simgr.explore(find=(current_block.addr), avoid=avoid)
                 if 'found' in simgr.stashes and simgr.found:
                     successors = self.project.factory.successors(simgr.one_found)
                     keep_running = False

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -23,6 +23,7 @@ from ...sim_state import SimState
 from ...state_plugins.callstack import CallStack
 from ...state_plugins.sim_action import SimActionData
 from ...exploration_techniques import Explorer
+from ...misc.graph import shallow_reverse
 
 l = logging.getLogger("angr.analyses.cfg.cfg_accurate")
 
@@ -2414,10 +2415,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         l.debug("Start back traversal from %s", current_block)
 
-        # Create a partial CFG first
-        temp_cfg = networkx.DiGraph(self.graph)
-        # Reverse it
-        temp_cfg.reverse(copy=False)
+        # Create a reverse partial CFG
+        temp_cfg = shallow_reverse(self.graph)
 
         path_length = 0
         concrete_exits = []
@@ -2427,10 +2426,10 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         keep_running = True
         while not concrete_exits and path_length < 5 and keep_running:
+            import ipdb; ipdb.set_trace()
             path_length += 1
             queue = [cfg_node]
             avoid = set()
-            import ipdb; ipdb.set_trace()
             for _ in xrange(path_length):
                 new_queue = []
                 for n in queue:

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -213,6 +213,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         self._max_steps = max_steps
         self._state_add_options = state_add_options if state_add_options is not None else set()
         self._state_remove_options = state_remove_options if state_remove_options is not None else set()
+        if self._advanced_backward_slicing:
+            self._state_add_options |= o.refs
 
         # more initialization
 
@@ -2269,7 +2271,6 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         cdg = self.project.analyses.CDG(cfg=self, fail_fast=self._fail_fast)
         ddg = self.project.analyses.DDG(cfg=self, start=current_function_addr, call_depth=0, fail_fast=self._fail_fast)
-
         bc = self.project.analyses.BackwardSlice(self,
                                                  cdg,
                                                  ddg,
@@ -2349,6 +2350,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             old_timeout = state.se._solver.timeout
             state.se._solver.timeout = 5000
 
+            if cfgnode.addr == 0x4005d7:
+                import ipdb; ipdb.set_trace()
             sc = self.project.surveyors.Slicecutor(annotated_cfg, start=state).run()
 
             # Restore the timeout!
@@ -2430,7 +2433,6 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             queue = [cfg_node]
             avoid = set()
             for _ in xrange(path_length):
-                import ipdb; ipdb.set_trace()
                 new_queue = []
                 for n in queue:
                     successors = list(temp_cfg.successors(n))

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -2269,7 +2269,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         stmt_id = [i for i, s in enumerate(irsb.statements)
                    if isinstance(s, pyvex.IRStmt.WrTmp) and s.tmp == next_tmp][0]
 
-        cdg = self.project.analyses.CDG(cfg=self, fail_fast=self._fail_fast)
+        cdg = self.project.analyses.CDG(cfg=self, start=current_function_addr, fail_fast=self._fail_fast)
         ddg = self.project.analyses.DDG(cfg=self, start=current_function_addr, call_depth=0, fail_fast=self._fail_fast)
         bc = self.project.analyses.BackwardSlice(self,
                                                  cdg,
@@ -2350,7 +2350,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             old_timeout = state.se._solver.timeout
             state.se._solver.timeout = 5000
 
-            if cfgnode.addr == 0x4005d7:
+            if cfgnode.addr == 0x400704:
                 import ipdb; ipdb.set_trace()
             sc = self.project.surveyors.Slicecutor(annotated_cfg, start=state).run()
 

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -1259,7 +1259,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         successors = self._resolve_indirect_jumps(sim_successors,
                                                   job.cfg_node,
                                                   job.func_addr,
-                                                  successors,
+                                                  all_successors,
                                                   job.exception_info,
                                                   self._block_artifacts
                                                   )
@@ -2124,10 +2124,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                 legit_successors = [suc for suc in successors if suc.history.jumpkind in ('Ijk_Boring', 'Ijk_Call')]
                 if legit_successors:
                     legit_successor = legit_successors[0]
-                    if legit_successor.ip.symbolic:
-                        if not legit_successor.history.jumpkind == 'Ijk_Call':
-                            should_resolve = False
-                    else:
+                    if not legit_successor.ip.symbolic:
                         if legit_successor.history.jumpkind == 'Ijk_Call':
                             should_resolve = False
                         else:
@@ -2298,6 +2295,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                 for n in nodes:
                     starts.add(n.block_addr)
 
+        if cfgnode.addr == 0x4005d7:
+            import ipdb; ipdb.set_trace()
         # Execute the slice
         successing_addresses = set()
         annotated_cfg = bc.annotated_cfg()
@@ -2351,11 +2350,13 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             old_timeout = p.state.se._solver.timeout
             p.state.se._solver.timeout = 5000
 
-            sc = self.project.surveyors.Slicecutor(annotated_cfg, start=p, max_loop_iterations=1).run()
+            sc = self.project.surveyors.Slicecutor(annotated_cfg, start=p).run()
 
             # Restore the timeout!
             p.state.se._solver.timeout = old_timeout
 
+            if cfgnode.addr == 0x4005d7:
+                import ipdb; ipdb.set_trace()
             if sc.cut or sc.deadended:
                 all_deadended_paths = sc.cut + sc.deadended
                 for p in all_deadended_paths:
@@ -2369,6 +2370,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                 l.debug("Cannot determine the exit. You need some better ways to recover the exits :-(")
 
         l.debug('Resolution is done, and we have %d new successors.', len(successing_addresses))
+        if cfgnode.addr == 0x4005d7:
+            import ipdb; ipdb.set_trace()
 
         return list(successing_addresses)
 

--- a/tests/test_cfgaccurate.py
+++ b/tests/test_cfgaccurate.py
@@ -440,7 +440,12 @@ def test_indirect_jump_resolving():
     cfg = p.analyses.CFGAccurate(enable_advanced_backward_slicing=True, keep_state=True, normalize=True)
     node = cfg.get_any_node(0x4005d7)
 
-    nose.tools.assert_equal(len(node.successors), 15)
+    nose.tools.assert_equal(len(node.successors), 8)
+
+    cfg = p.analyses.CFGAccurate(enable_symbolic_back_traversal=True, normalize=True)
+    node = cfg.get_any_node(0x4005d7)
+
+    nose.tools.assert_equal(len(node.successors), 8)
 
 
 def run_all():

--- a/tests/test_cfgaccurate.py
+++ b/tests/test_cfgaccurate.py
@@ -1,16 +1,20 @@
-import nose
+import os
+import sys
 import time
 import pickle
-import networkx
-
 import logging
-l = logging.getLogger("angr.tests.test_cfg")
 
-import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
 
 import angr
 from angr import options as o
+import nose
+import networkx
+
+
+l = logging.getLogger("angr.tests.test_cfg")
+
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
 
 
 def compare_cfg(standard, g, function_list):
@@ -80,6 +84,7 @@ def compare_cfg(standard, g, function_list):
             # Edge doesn't exist in our CFG
             l.error("Edge (%s-0x%x, %s-0x%x) only exists in angr's CFG.", get_function_name(src), src, get_function_name(dst), dst)
 
+
 def perform_single(binary_path, cfg_path=None):
     proj = angr.Project(binary_path,
                         use_sim_procedures=True,
@@ -105,30 +110,36 @@ def perform_single(binary_path, cfg_path=None):
     else:
         l.warning("No standard CFG specified.")
 
+
 def disabled_cfg_0():
     binary_path = test_location + "/x86_64/cfg_0"
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
+
 
 def disabled_cfg_1():
     binary_path = test_location + "/x86_64/cfg_1"
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
 
+
 def disabled_cfg_2():
     binary_path = test_location + "/armel/test_division"
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
+
 
 def disabled_cfg_3():
     binary_path = test_location + "/mips/test_arrays"
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
 
+
 def disabled_cfg_4():
     binary_path = test_location + "/mipsel/darpa_ping"
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
+
 
 def test_additional_edges():
     # Test the `additional_edges` parameter for CFG generation
@@ -147,6 +158,7 @@ def test_additional_edges():
     nose.tools.assert_not_equal(cfg.get_any_node(0x40058f), None)
     nose.tools.assert_not_equal(cfg.get_any_node(0x40059e), None)
     nose.tools.assert_equal(cfg.get_any_node(0x4005ad), None)
+
 
 def test_not_returning():
     # Make sure we are properly labeling functions that do not return in function manager
@@ -177,11 +189,13 @@ def test_not_returning():
     # function_d should not be reachable
     nose.tools.assert_equal(proj.kb.functions.function(name='function_d'), None)
 
+
 def disabled_cfg_5():
     binary_path = test_location + "/mipsel/busybox"
     cfg_path = binary_path + ".cfg"
 
     perform_single(binary_path, cfg_path)
+
 
 def test_cfg_6():
     function_addresses = [0xfa630, 0xfa683, 0xfa6d4, 0xfa707, 0xfa754, 0xfa779, 0xfa7a9, 0xfa7d6, 0xfa844, 0xfa857,
@@ -200,11 +214,13 @@ def test_cfg_6():
     nose.tools.assert_greater_equal(set(f for f in proj.kb.functions), set(function_addresses))
     o.modes['fastpath'] ^= {o.DO_CCALLS}
 
+
 def test_fauxware():
     binary_path = test_location + "/x86_64/fauxware"
     cfg_path = binary_path + ".cfg"
 
     perform_single(binary_path, cfg_path)
+
 
 def disabled_loop_unrolling():
     binary_path = test_location + "/x86_64/cfg_loop_unrolling"
@@ -216,6 +232,7 @@ def disabled_loop_unrolling():
     cfg.unroll_loops(5)
 
     nose.tools.assert_equal(len(cfg.get_all_nodes(0x400636)), 7)
+
 
 def test_thumb_mode():
     # In thumb mode, all addresses of instructions and in function manager should be odd numbers, which loyally
@@ -243,6 +260,7 @@ def test_thumb_mode():
         check_addr(f_addr)
         if f.startpoint is not None:
             check_addr(f.startpoint.addr)
+
 
 def test_fakeret_edges_0():
 
@@ -293,6 +311,7 @@ def test_fakeret_edges_0():
     jumpkinds = set([ jumpkind for _, jumpkind in edges_1 ])
     nose.tools.assert_set_equal(jumpkinds, { 'Ijk_Call', 'Ijk_FakeRet' })
 
+
 def test_string_references():
 
     # Test AttributeError on 'addr' which occurs when searching for string
@@ -308,6 +327,7 @@ def test_string_references():
 
     # test passes if hasn't thrown an exception
 
+
 def test_arrays():
 
     binary_path = os.path.join(test_location, "armhf", "test_arrays")
@@ -319,6 +339,7 @@ def test_arrays():
 
     successors = cfg.get_successors(node)
     nose.tools.assert_equal(len(successors), 2)
+
 
 def test_max_steps():
 
@@ -412,6 +433,16 @@ def test_armel_incorrect_function_detection_caused_by_branch():
     nose.tools.assert_equal(block_addrs, [0x8009, 0x8011, 0x801f, 0x8027])
 
 
+def test_indirect_jump_resolving():
+    b = os.path.join(test_location, 'x86_64', 'convert_accent')
+    p = angr.Project(b, auto_load_libs=False)
+
+    cfg = p.analyses.CFGAccurate(enable_advanced_backward_slicing=True, keep_state=True, normalize=True)
+    node = cfg.get_any_node(0x4005d7)
+
+    nose.tools.assert_equal(len(node.successors), 15)
+
+
 def run_all():
     functions = globals()
     all_functions = dict(filter((lambda (k, v): k.startswith('test_')), functions.items()))
@@ -419,6 +450,7 @@ def run_all():
         if hasattr(all_functions[f], '__call__'):
             print f
             all_functions[f]()
+
 
 if __name__ == "__main__":
     logging.getLogger("angr.state_plugins.abstract_memory").setLevel(logging.DEBUG)
@@ -430,7 +462,6 @@ if __name__ == "__main__":
     #logging.getLogger("claripy.backends.backend").setLevel(logging.ERROR)
     #logging.getLogger("claripy.claripy").setLevel(logging.ERROR)
 
-    import sys
     if len(sys.argv) > 1:
         globals()['test_' + sys.argv[1]]()
     else:


### PR DESCRIPTION
@ltfish Please use this to fix the jump table resolving code in `CFGAccurate`. In the call to `BackwardSlice`, I tried to set `control_flow_slice` to True but it doesn't work either. I let the debugging in the code, maybe it can help you? The block that has indirect jumps as exits is at `0x4005d7`