### PR TITLE
Fix bugs in disassembly for ARM

### DIFF
--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -226,6 +226,12 @@ class Instruction(DisassemblyPiece):
             i -= 1
 
         self.opcode = Opcode(self)
+
+        # This is a hack to fix a capstone bug.
+        if 'ARM' in self.project.arch.name and self.insn.mnemonic[:3] in arm_shift_ops:
+            shift = [', '] + self.operands.pop(-1)
+            self.operands[-1].extend(shift)
+
         self.operands.reverse()
 
         if len(self.operands) != len(self.insn.operands):

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -147,6 +147,7 @@ class Instruction(DisassemblyPiece):
         i = len(insn_pieces) - 1
         cs_op_num = -1
         nested_mem = False
+        arm_shift_ops = ['lsl', 'lsr', 'asr', 'ror', 'rrx']
 
         # iterate over operands in reverse order
         while i >= 0:
@@ -185,6 +186,7 @@ class Instruction(DisassemblyPiece):
                         prefix = insn_pieces[i-1]
                         insn_pieces[i-1] = ''
                     cur_operand.append(Register(c, prefix))
+
                 elif intc is not None:
                     with_sign = False
                     if i > 0 and insn_pieces[i-1] in ('+', '-'):
@@ -193,11 +195,12 @@ class Instruction(DisassemblyPiece):
                             intc = -intc
                         insn_pieces[i-1] = ''
                     cur_operand.append(Value(intc, with_sign))
+
                 else:
                     # XXX STILL A HACK
                     cur_operand.append(c if c[-1] == ':' else c + ' ')
 
-            elif c == ',' and not nested_mem:
+            elif c == ',' and not nested_mem and insn_pieces[i+1] not in arm_shift_ops:
                 cs_op_num -= 1
                 cur_operand = None
 
@@ -216,6 +219,7 @@ class Instruction(DisassemblyPiece):
                 if cur_operand is None:
                     cur_operand = [c]
                     self.operands.append(cur_operand)
+
                 else:
                     cur_operand.append(c if c[0] != ',' else c + ' ')
 


### PR DESCRIPTION
@ltfish @rhelmot This fixes 2 bugs:
- `sub     x0, x0, #0x1, lsl #0xc`: `lsl` part should not be considered as the 4th operand here.
- `lsl     r2, r2, #0x2`: for ARM 32-bit, `capstone` only returns 2 operands here, which is wrong imho. But as discussed with @rhelmot, it is easier to fix this here than in `capstone`.

Thank you