### PR TITLE
Allow (a less-optimal) optimal state merging without EFFICIENT_STATE_MERGING

### DIFF
--- a/angr/manager.py
+++ b/angr/manager.py
@@ -736,7 +736,8 @@ class SimulationManager(ana.Storable):
             o = optimal[0]
             m, _, _ = o.merge(*optimal[1:],
                               merge_conditions=constraints,
-                              common_ancestor=common_history.strongref_state
+                              common_ancestor=common_history.strongref_state,
+                              common_ancestor_history=common_history
                               )
 
         else:

--- a/angr/manager.py
+++ b/angr/manager.py
@@ -736,6 +736,7 @@ class SimulationManager(ana.Storable):
             o = optimal[0]
             m, _, _ = o.merge(*optimal[1:],
                               merge_conditions=constraints,
+                              # history.strongref_state requires state option EFFICIENT_STATE_MERGING
                               common_ancestor=common_history.strongref_state,
                               common_ancestor_history=common_history
                               )

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -487,10 +487,16 @@ class SimState(ana.Storable): # pylint: disable=R0904
 
         :param states: the states to merge
         :param merge_conditions: a tuple of the conditions under which each state holds
-        :param common_ancestor: a state that represents the common history between the states being merged
+        :param common_ancestor:  a state that represents the common history between the states being merged. Usually it
+                                 is only available when EFFICIENT_STATE_MERGING is enabled, otherwise weak-refed states
+                                 might be dropped from state history instances.
         :param plugin_whitelist: a list of plugin names that will be merged. If this option is given and is not None,
                                  any plugin that is not inside this list will not be merged, and will be created as a
                                  fresh instance in the new state.
+        :param common_ancestor_history:
+                                 a SimStateHistory instance that represents the common history between the states being
+                                 merged. This is to allow optimal state merging when EFFICIENT_STATE_MERGING is
+                                 disabled.
         :return: (merged state, merge flag, a bool indicating if any merging occured)
         """
 

--- a/angr/state_plugins/history.py
+++ b/angr/state_plugins/history.py
@@ -119,13 +119,21 @@ class SimStateHistory(SimStatePlugin):
         # correct results when using constraints_since()
         self.parent = common_ancestor if common_ancestor is not None else self.parent
 
-        # recents_events must be the join of all recents events
-        # in order to keep constraints_since() correct
-        self.recent_events = [e.recent_events for e in itertools.chain([self], others)]
+        self.recent_events = [e.recent_events for e in itertools.chain([self], others)
+                              if not isinstance(e, SimActionConstraint)
+                              ]
+
+        # rebuild recent constraints
+        recent_constraints = [ h.constraints_since(common_ancestor) for h in itertools.chain([self], others) ]
+        combined_constraint = self.state.solver.Or(
+            *[ self.state.solver.simplify(self.state.solver.And(*history_constraints)) for history_constraints in recent_constraints ]
+        )
+        self.recent_events.append(SimActionConstraint(self.state, combined_constraint))
+
         # hard to say what we should do with these others list of things...
-        self.recent_bbl_addrs = [e.recent_bbl_addrs for e in itertools.chain([self], others)]
-        self.recent_ins_addrs = [e.recent_ins_addrs for e in itertools.chain([self], others)]
-        self.recent_stack_actions = [e.recent_stack_actions for e in itertools.chain([self], others)]
+        #self.recent_bbl_addrs = [e.recent_bbl_addrs for e in itertools.chain([self], others)]
+        #self.recent_ins_addrs = [e.recent_ins_addrs for e in itertools.chain([self], others)]
+        #self.recent_stack_actions = [e.recent_stack_actions for e in itertools.chain([self], others)]
 
         return True
 


### PR DESCRIPTION
Addressing [issue 170 in angr-doc](https://github.com/angr/angr-doc/issues/170).

Now without enabling `EFFICIENT_STATE_MERGING`, we can still do a semi-optimal state merging: Only `SimStateHistory`s know their ancestors, all other state plugins will be merged as in normal (less optimized) state merging. This might be a good balance between memory usage (we don't have to store a strong reference for all states anymore) and state merging performance.

@zardus @rhelmot Please review and comment. Thanks!