### PR TITLE
Cacher: Use mkdtemp() to create the container directory.

### DIFF
--- a/angr/exploration_techniques/cacher.py
+++ b/angr/exploration_techniques/cacher.py
@@ -1,6 +1,7 @@
 import os
 import string
 import hashlib
+import tempfile
 import logging
 
 from . import ExplorationTechnique
@@ -44,9 +45,10 @@ class Cacher(ExplorationTechnique):
         binary = simgr._project.filename
         binhash = hashlib.md5(open(binary).read()).hexdigest()
 
-        # By default, we dump data to a file in under /tmp/.
         if self.container is None:
-            self.container = os.path.join("/tmp", "%s-%s.cache" % (os.path.basename(binary), binhash))
+            # Create a temporary directory to hold the cache files
+            tmp_directory = tempfile.mkdtemp(prefix="angr_cacher_container")
+            self.container = os.path.join(tmp_directory, "%s-%s.cache" % (os.path.basename(binary), binhash))
 
         # Container is the file name.
         elif isinstance(self.container, str) and not self.container_pickle_str:

--- a/tests/test_cacher.py
+++ b/tests/test_cacher.py
@@ -9,8 +9,7 @@ import angr
 
 l = logging.getLogger("angr_tests.managers")
 
-import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_cacher():
     p = angr.Project(os.path.join(location, 'x86_64', 'fauxware'), load_options={'auto_load_libs': False})

--- a/tests/test_cacher.py
+++ b/tests/test_cacher.py
@@ -1,7 +1,12 @@
+import tempfile
+import os
+import logging
+
 import nose
+
 import angr
 
-import logging
+
 l = logging.getLogger("angr_tests.managers")
 
 import os
@@ -10,12 +15,15 @@ location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../
 def test_cacher():
     p = angr.Project(os.path.join(location, 'x86_64', 'fauxware'), load_options={'auto_load_libs': False})
 
+    tmp_dir = tempfile.mkdtemp(prefix='test_cacher_container')
+    container = os.path.join(tmp_dir, '%s.cache' % os.path.basename(p.filename))
+
     pg = p.factory.simgr(immutable=False)
-    pg.use_technique(angr.exploration_techniques.Cacher(when=0x4006ee))
+    pg.use_technique(angr.exploration_techniques.Cacher(when=0x4006ee, container=container))
     pg.run()
 
     pg2 = p.factory.simgr(immutable=False)
-    pg2.use_technique(angr.exploration_techniques.Cacher())
+    pg2.use_technique(angr.exploration_techniques.Cacher(container=container))
     nose.tools.assert_equal(pg2.active[0].addr, 0x4006ed)
 
     pg2.run()


### PR DESCRIPTION
"/tmp" does not exist on Windows.