### PR TITLE
Fix two other cases where /tmp is hardcoded.

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import logging
 
 import claripy
@@ -72,7 +73,8 @@ class Tracer(ExplorationTechnique):
 
         if self.project.loader.main_object.os == 'cgc':
             if self._use_cache:
-                cache_file = os.path.join("/tmp", "%(name)s-%(binhash)s.tcache")
+                tmp_dir = tempfile.mkdtemp(prefix="tracer_cache")
+                cache_file = os.path.join(tmp_dir, "%(name)s-%(binhash)s.tcache")
                 cacher = Cacher(when=self._tracer_cache_cond,
                                 container=cache_file,
                                 dump_func=self._tracer_dump,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -61,7 +61,8 @@ def internaltest_project(p):
     nose.tools.assert_equals(p.entry, loaded_p.entry)
 
 def setup():
-    ana.set_dl(ana.DirDataLayer('/tmp/ana'))
+    tmp_dir = tempfile.mkdtemp(prefix='test_serialization_ana')
+    ana.set_dl(ana.DirDataLayer(tmp_dir))
 def teardown():
     ana.set_dl(ana.SimpleDataLayer())
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2,6 +2,7 @@ import logging
 import pickle
 import nose
 import gc
+import tempfile
 import os
 
 import ana
@@ -209,7 +210,8 @@ def test_state_merge_optimal():
 
 
 def setup():
-    ana.set_dl(ana.DirDataLayer('/tmp/picklez'))
+    tmp_dir = tempfile.mkdtemp(prefix='test_state_picklez')
+    ana.set_dl(ana.DirDataLayer(tmp_dir))
 def teardown():
     ana.set_dl(ana.SimpleDataLayer())
 


### PR DESCRIPTION
Use tempfile.mkdtemp() instead.