### PR TITLE
JumpTableResolver: Performs a stricter check on jump targets.

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -186,7 +186,8 @@ class JumpTableResolver(IndirectJumpResolver):
 
                 # Both the min jump target and the max jump target should be within a mapped memory region
                 # i.e., we shouldn't be jumping to the stack or somewhere unmapped
-                if not cfg._inside_regions(min_jump_target) or not cfg._inside_regions(max_jump_target):
+                if not cfg._addr_belongs_to_segment(min_jump_target) or \
+                        not cfg._addr_belongs_to_segment(max_jump_target):
                     l.debug("Jump table %#x might have jump targets outside mapped memory regions. "
                             "Continue to resolve it from the next data source.", addr)
                     continue

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -181,6 +181,16 @@ class JumpTableResolver(IndirectJumpResolver):
 
                 jump_table = []
 
+                min_jump_target = state.se.min(jump_addr)
+                max_jump_target = state.se.max(jump_addr)
+
+                # Both the min jump target and the max jump target should be within a mapped memory region
+                # i.e., we shouldn't be jumping to the stack or somewhere unmapped
+                if not cfg._inside_regions(min_jump_target) or not cfg._inside_regions(max_jump_target):
+                    l.debug("Jump table %#x might have jump targets outside mapped memory regions. "
+                            "Continue to resolve it from the next data source.", addr)
+                    continue
+
                 for idx, a in enumerate(state.se.eval_upto(jump_addr, total_cases)):
                     if idx % 100 == 0 and idx != 0:
                         l.debug("%d targets have been resolved for the indirect jump at %#x...", idx, addr)
@@ -189,7 +199,7 @@ class JumpTableResolver(IndirectJumpResolver):
                     all_targets.append(target)
                     jump_table.append(target)
 
-                l.info("Jump table resolution: resolved %d targets from %#x.", len(all_targets), addr)
+                l.info("Resolved %d targets from %#x.", len(all_targets), addr)
 
                 # write to the IndirectJump object in CFG
                 ij = cfg.indirect_jumps[addr]


### PR DESCRIPTION
This will reduce the number of incorrectly resolved jump tables,
especially in binaries with weird behaviors (e.g., jumping to stack/heap).
An example is the binary example provided here:
https://github.com/angr/identifier/issues/1 .