### PR TITLE
Fix/cfg accurate crashes

### DIFF
--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -1642,8 +1642,9 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         # Fix target_addr for syscalls
         if suc_jumpkind.startswith("Ijk_Sys"):
-            if self.project.simos.syscall(new_state):
-                target_addr = self.project.simos.syscall(new_state).addr
+            syscall_proc = self.project.simos.syscall(new_state)
+            if syscall_proc is not None:
+                target_addr = syscall_proc.addr
 
         self._pre_handle_successor_state(job.extra_info, suc_jumpkind, target_addr)
 

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -1642,7 +1642,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         # Fix target_addr for syscalls
         if suc_jumpkind.startswith("Ijk_Sys"):
-            target_addr = self.project.simos.syscall(new_state).addr
+            if self.project.simos.syscall(new_state):
+                target_addr = self.project.simos.syscall(new_state).addr
 
         self._pre_handle_successor_state(job.extra_info, suc_jumpkind, target_addr)
 

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -1194,7 +1194,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         # We store the function hints first. Function hints will be checked at the end of the analysis to avoid
         # any duplication with existing jumping targets
         if self._enable_function_hints:
-            if sim_successors.sort == 'IRSB':
+            if sim_successors.sort == 'IRSB' and sim_successors.all_successors:
                 function_hints = self._search_for_function_hints(sim_successors.all_successors[0])
                 for f in function_hints:
                     self._pending_function_hints.add(f)


### PR DESCRIPTION
Fixed two bugs:
* When building the CFGAccurate using the function hints flag, it might happen that a block has no successors. I added a check to prevent the analysis to break.

* simos.syscall might return None, in which case self.project.simos.syscall(new_state).addr would fail. I added a check right before that statement. I am not 100% of the implications this has on the CFG, but I believe it is correct.