### PR TITLE
Remove section/segment querying code from CFGBase

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -688,27 +688,6 @@ class CFGBase(Analysis):
                 return True
         return False
 
-    def _addr_belongs_to_section(self, addr):
-        """
-        Return the section object that the address belongs to.
-
-        :param int addr: The address to test
-        :return: The section that the address belongs to, or None if the address does not belong to any section, or if
-                section information is not available.
-        :rtype: cle.Section
-        """
-
-        obj = self.project.loader.find_object_containing(addr)
-
-        if obj is None:
-            return None
-
-        if isinstance(obj, (ExternObject, KernelObject, TLSObject)):
-            # the address is from a special CLE section
-            return None
-
-        return obj.find_section_containing(addr)
-
     def _addrs_belong_to_same_section(self, addr_a, addr_b):
         """
         Test if two addresses belong to the same section.

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -718,54 +718,6 @@ class CFGBase(Analysis):
 
         return src_section.contains_addr(addr_b)
 
-    def _addr_next_section(self, addr):
-        """
-        Return the next section object after the given address.
-
-        :param int addr: The address to test
-        :return: The next section that goes after the given address, or None if there is no section after the address,
-                 or if section information is not available.
-        :rtype: cle.Section
-        """
-
-        obj = self.project.loader.find_object_containing(addr)
-
-        if obj is None:
-            return None
-
-        if isinstance(obj, (ExternObject, KernelObject, TLSObject)):
-            # the address is from a special CLE section
-            return None
-
-        for section in obj.sections:
-            start = section.vaddr
-
-            if addr < start:
-                return section
-
-        return None
-
-    def _addr_belongs_to_segment(self, addr):
-        """
-        Return the section object that the address belongs to.
-
-        :param int addr: The address to test
-        :return: The section that the address belongs to, or None if the address does not belong to any section, or if
-                section information is not available.
-        :rtype: cle.Segment
-        """
-
-        obj = self.project.loader.find_object_containing(addr)
-
-        if obj is None:
-            return None
-
-        if isinstance(obj, (ExternObject, KernelObject, TLSObject)):
-            # the address is from a section allocated by angr.
-            return None
-
-        return obj.find_segment_containing(addr)
-
     def _addr_hooked_or_syscall(self, addr):
         """
         Check whether the address belongs to a hook or a syscall.

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2139,7 +2139,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 # TODO: the logic needs more testing
 
                 obj = self.project.loader.find_object_containing(data_addr)
-                sec = self._addr_belongs_to_section(data_addr)
+                sec = self.project.loader.find_section_containing(data_addr)
                 next_sec_addr = None
                 if sec is not None:
                     last_addr = sec.vaddr + sec.memsize
@@ -2292,7 +2292,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 #    # it's a code reference
                 #    # TODO: Further check if it's the beginning of an instruction
                 #    pass
-                if self._addr_belongs_to_section(ptr) is not None or self._addr_belongs_to_segment(ptr) is not None or \
+                if self.project.loader.find_section_containing(ptr) is not None or \
+                        self._addr_belongs_to_segment(ptr) is not None or \
                         (self._extra_memory_regions and
                          next(((a < ptr < b) for (a, b) in self._extra_memory_regions), None)
                          ):
@@ -3316,7 +3317,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             if obj:
                 # is there a section?
                 has_executable_section = len([ sec for sec in obj.sections if sec.is_executable ]) > 0  # pylint:disable=len-as-condition
-                section = self._addr_belongs_to_section(addr)
+                section = self.project.loader.find_section_containing(addr)
                 if has_executable_section and section is None:
                     # the basic block should not exist here...
                     return None, None, None, None

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2082,7 +2082,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         """
 
         # Make sure data_addr is within a valid memory range
-        if not self._addr_belongs_to_segment(data_addr):
+        if not self.project.loader.find_segment_containing(data_addr):
 
             # data might be at the end of some section or segment...
             # let's take a look
@@ -2146,11 +2146,11 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 else:
                     # it does not belong to any section. what's the next adjacent section? any memory data does not go
                     # beyong section boundaries
-                    next_sec = self._addr_next_section(data_addr)
+                    next_sec = self.project.loader.find_section_next_to(data_addr)
                     if next_sec is not None:
                         next_sec_addr = next_sec.vaddr
 
-                    seg = self._addr_belongs_to_segment(data_addr)
+                    seg = self.project.loader.find_segment_containing(data_addr)
                     if seg is not None:
                         last_addr = seg.vaddr + seg.memsize
                     else:
@@ -2293,7 +2293,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 #    # TODO: Further check if it's the beginning of an instruction
                 #    pass
                 if self.project.loader.find_section_containing(ptr) is not None or \
-                        self._addr_belongs_to_segment(ptr) is not None or \
+                        self.project.loader.find_segment_containing(ptr) is not None or \
                         (self._extra_memory_regions and
                          next(((a < ptr < b) for (a, b) in self._extra_memory_regions), None)
                          ):

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -186,8 +186,8 @@ class JumpTableResolver(IndirectJumpResolver):
 
                 # Both the min jump target and the max jump target should be within a mapped memory region
                 # i.e., we shouldn't be jumping to the stack or somewhere unmapped
-                if not cfg._addr_belongs_to_segment(min_jump_target) or \
-                        not cfg._addr_belongs_to_segment(max_jump_target):
+                if not project.loader.find_segment_containing(min_jump_target) or \
+                        not project.loader.find_segment_containing(max_jump_target):
                     l.debug("Jump table %#x might have jump targets outside mapped memory regions. "
                             "Continue to resolve it from the next data source.", addr)
                     continue

--- a/angr/analyses/cfg/indirect_jump_resolvers/mips_elf_fast.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/mips_elf_fast.py
@@ -60,7 +60,7 @@ class MipsElfFastResolver(IndirectJumpResolver):
 
         gp_offset = project.arch.registers['gp'][0]
         if 'gp' not in func.info:
-            sec = cfg._addr_belongs_to_section(func.addr)
+            sec = project.loader.find_section_containing(func.addr)
             if sec is None or sec.name != '.plt':
                 # this might a special case: gp is only used once in this function, and it can be initialized right before
                 # its use site.

--- a/angr/analyses/cfg/indirect_jump_resolvers/x86_elf_pic_plt.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/x86_elf_pic_plt.py
@@ -51,7 +51,7 @@ class X86ElfPicPltResolver(IndirectJumpResolver):
         if not isinstance(self.project.arch, archinfo.ArchX86):
             return False
 
-        section = cfg._addr_belongs_to_section(addr)
+        section = self.project.loader.find_section_containing(addr)
         if section.name != '.plt':
             return False
 

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -2552,7 +2552,8 @@ class Reassembler(Analysis):
 
     @staticmethod
     def _is_pointer(cfg, ptr):
-        if cfg.project.loader.find_section_containing(ptr) is not None or cfg._addr_belongs_to_segment(ptr) is not None or \
+        if cfg.project.loader.find_section_containing(ptr) is not None or \
+                cfg.project.loader.find_segment_containing(ptr) is not None or \
                 (cfg._extra_memory_regions and
                      next(((a < ptr < b) for (a, b) in cfg._extra_memory_regions), None)
                  ):

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -2552,7 +2552,7 @@ class Reassembler(Analysis):
 
     @staticmethod
     def _is_pointer(cfg, ptr):
-        if cfg._addr_belongs_to_section(ptr) is not None or cfg._addr_belongs_to_segment(ptr) is not None or \
+        if cfg.project.loader.find_section_containing(ptr) is not None or cfg._addr_belongs_to_segment(ptr) is not None or \
                 (cfg._extra_memory_regions and
                      next(((a < ptr < b) for (a, b) in cfg._extra_memory_regions), None)
                  ):
@@ -2722,7 +2722,7 @@ class Reassembler(Analysis):
         for candidate in candidates:
 
             # if the candidate is in .bss, we don't care about it
-            sec = self.cfg._addr_belongs_to_section(candidate.address)
+            sec = self.cfg.project.loader.find_section_containing(candidate.address)
             if sec.name in ('.bss', '.got.plt'):
                 continue
 


### PR DESCRIPTION
Those methods are moved to CLE so they can be reused by other classes and projects.

Related PR in CLE: https://github.com/angr/cle/pull/110