### PR TITLE
Remove depricated concrete_parts() from symbolic memory

### DIFF
--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -1057,17 +1057,6 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
 
         return merged_val
 
-    def concrete_parts(self):
-        """
-        Return a dict containing the concrete values in memory.
-        """
-        d = { }
-        for k,v in self.mem.iteritems():
-            if not self.state.se.symbolic(v):
-                d[k] = self.state.se.simplify(v)
-
-        return d
-
     def dbg_print(self, indent=0):
         """
         Print out debugging information.


### PR DESCRIPTION
See Issue #871
This function is deprecated and in the current implementation would require to check the whole memory byte-by-byte.