### PR TITLE
CFGFast: Make popping pending jobs much faster.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -873,6 +873,7 @@ class CFGBase(Analysis):
             if func.has_return:
                 changes['functions_return'].append(func)
                 func.returning = True
+                self._add_returning_function(func.addr)
                 continue
 
             # This function does not have endpoints. It's either because it does not return, or we haven't analyzed all
@@ -893,6 +894,7 @@ class CFGBase(Analysis):
                     changes['functions_do_not_return'].append(func)
                 else:
                     func.returning = True
+                    self._add_returning_function(func.addr)
                     changes['functions_return'].append(func)
                 continue
 
@@ -906,6 +908,7 @@ class CFGBase(Analysis):
                 # the error will be corrected during post-processing. In fact at this moment we cannot say anything
                 # about whether this function returns or not. We always assume it returns.
                 func.returning = True
+                self._add_returning_function(func.addr)
                 changes['functions_return'].append(func)
                 continue
 
@@ -953,6 +956,7 @@ class CFGBase(Analysis):
                 target_func = self.kb.functions[goout_target.addr]
                 if target_func.returning is True:
                     func.returning = True
+                    self._add_returning_function(func.addr)
                     changes['functions_return'].append(func)
                     bail_out = True
                 elif target_func.returning is None:
@@ -1245,6 +1249,9 @@ class CFGBase(Analysis):
     #
     # Function identification and such
     #
+
+    def _add_returning_function(self, func_addr):
+        pass
 
     def remove_function_alignments(self):
         """

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1364,6 +1364,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 self._insert_job(job)
                 return
 
+            self._clean_pending_exits()
+
         # did we finish analyzing any function?
         # fill in self._completed_functions
         self._make_completed_functions()
@@ -1379,8 +1381,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             if job is not None:
                 self._insert_job(job)
                 return
-
-            self._clean_pending_exits()
 
             job = self._pop_pending_job(returning=False)
             if job is not None:

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -87,15 +87,6 @@ class Function(object):
             if hooker is not None:
                 binary_name = hooker.library_name
 
-        # set returning
-        hooker = None
-        if self.is_simprocedure:
-            hooker = project.hooked_by(addr)
-        elif self.is_syscall:
-            hooker = project.simos.syscall_from_addr(addr)
-        if hooker and hasattr(hooker, 'NO_RET'):
-            self.returning = hooker.NO_RET
-
         if binary_name is None and self.binary is not None:
             binary_name = os.path.basename(self.binary.binary)
 
@@ -118,6 +109,15 @@ class Function(object):
 
         # Whether this function returns or not. `None` means it's not determined yet
         self._returning = None
+
+        # Determine returning status for SimProcedures and Syscalls
+        hooker = None
+        if self.is_simprocedure:
+            hooker = project.hooked_by(addr)
+        elif self.is_syscall:
+            hooker = project.simos.syscall_from_addr(addr)
+        if hooker and hasattr(hooker, 'NO_RET'):
+            self.returning = hooker.NO_RET
 
         self.prepared_registers = set()
         self.prepared_stack_variables = set()

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -87,6 +87,15 @@ class Function(object):
             if hooker is not None:
                 binary_name = hooker.library_name
 
+        # set returning
+        hooker = None
+        if self.is_simprocedure:
+            hooker = project.hooked_by(addr)
+        elif self.is_syscall:
+            hooker = project.simos.syscall_from_addr(addr)
+        if hooker and hasattr(hooker, 'NO_RET'):
+            self.returning = hooker.NO_RET
+
         if binary_name is None and self.binary is not None:
             binary_name = os.path.basename(self.binary.binary)
 

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -117,7 +117,7 @@ class Function(object):
         elif self.is_syscall:
             hooker = project.simos.syscall_from_addr(addr)
         if hooker and hasattr(hooker, 'NO_RET'):
-            self.returning = hooker.NO_RET
+            self.returning = not hooker.NO_RET
 
         self.prepared_registers = set()
         self.prepared_stack_variables = set()


### PR DESCRIPTION
When job queue is empty, we used to unnecessarily check the returning
status of each function in self.kb.functions if there is a pending job
associated to it, which is really slow when there are many pending jobs
with many functions (it becomes really noticeable when > 5000). This
commit implements a PendingJobs class that records all functions that have
been marked as returning, so we don't have to query the returning state of
every function before popping a pending job.