### PR TITLE
Logging: use module __name__ variable for logger name instead of hardcoded string

### DIFF
--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -7,7 +7,7 @@ import logging
 from ..errors import AngrAnalysisError
 from . import registered_analyses
 
-l = logging.getLogger("angr.analysis")
+l = logging.getLogger(name=__name__)
 
 
 class AnalysisLogEntry(object):

--- a/angr/analyses/backward_slice.py
+++ b/angr/analyses/backward_slice.py
@@ -11,7 +11,7 @@ from ..annocfg import AnnotatedCFG
 from ..errors import AngrBackwardSlicingError
 from ..state_plugins.sim_action import SimActionExit
 
-l = logging.getLogger("angr.analyses.backward_slice")
+l = logging.getLogger(name=__name__)
 
 class BackwardSlice(Analysis):
     """

--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -10,7 +10,7 @@ from .. import SIM_PROCEDURES
 from ..codenode import HookNode
 from ..sim_variable import SimConstantVariable, SimRegisterVariable, SimMemoryVariable, SimStackVariable
 
-l = logging.getLogger("angr.analyses.binary_optimizer")
+l = logging.getLogger(name=__name__)
 
 
 class ConstantPropagation(object):

--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -13,7 +13,7 @@ from ..errors import SimEngineError, SimMemoryError
 # todo include a method that detects any change other than constants
 # todo use function names / string references where available
 
-l = logging.getLogger("angr.analyses.bindiff")
+l = logging.getLogger(name=__name__)
 
 # basic block changes
 DIFF_TYPE = "type"

--- a/angr/analyses/boyscout.py
+++ b/angr/analyses/boyscout.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from . import Analysis, register_analysis
 from archinfo import all_arches
 
-l = logging.getLogger("angr.analyses.boyscout")
+l = logging.getLogger(name=__name__)
 
 class BoyScout(Analysis):
     """

--- a/angr/analyses/callee_cleanup_finder.py
+++ b/angr/analyses/callee_cleanup_finder.py
@@ -2,7 +2,7 @@ from . import Analysis, register_analysis
 from .. import SIM_PROCEDURES
 
 import logging
-l = logging.getLogger('angr.analyses.callee_cleanup_finder')
+l = logging.getLogger(name=__name__)
 
 class CalleeCleanupFinder(Analysis):
     def __init__(self, starts=None, hook_all=False):

--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -5,7 +5,7 @@ import networkx
 from ..utils.graph import compute_dominance_frontier, PostDominators, TemporaryNode
 from . import Analysis, register_analysis
 
-_l = logging.getLogger("angr.analyses.cdg")
+_l = logging.getLogger(name=__name__)
 
 
 class CDG(Analysis):

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -23,7 +23,7 @@ from ...sim_state import SimState
 from ...state_plugins.callstack import CallStack
 from ...state_plugins.sim_action import SimActionData
 
-l = logging.getLogger("angr.analyses.cfg.cfg_accurate")
+l = logging.getLogger(name=__name__)
 
 
 class CFGJob(CFGJobBase):

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -19,7 +19,7 @@ from ...knowledge_plugins import FunctionManager, Function
 from .. import Analysis
 from .cfg_node import CFGNode
 
-l = logging.getLogger("angr.analyses.cfg.cfg_base")
+l = logging.getLogger(name=__name__)
 
 
 class IndirectJump(object):

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -25,7 +25,7 @@ from ...errors import AngrCFGError, SimEngineError, SimMemoryError, SimTranslati
 
 VEX_IRSB_MAX_SIZE = 400
 
-l = logging.getLogger("angr.analyses.cfg.cfg_fast")
+l = logging.getLogger(name=__name__)
 
 
 class Segment(object):

--- a/angr/analyses/cfg/cfg_job_base.py
+++ b/angr/analyses/cfg/cfg_job_base.py
@@ -5,7 +5,7 @@ import logging
 from ...errors import SimValueError, SimSolverModeError
 from ...state_plugins.callstack import CallStack
 
-l = logging.getLogger("angr.analyses.cfg.cfg_job_base")
+l = logging.getLogger(name=__name__)
 
 # TODO: Make callsite an object and use it in BlockID and FunctionKey
 

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -13,7 +13,7 @@ from ....surveyors import Slicecutor
 from .resolver import IndirectJumpResolver
 
 
-l = logging.getLogger("angr.analyses.cfg.indirect_jump_resolvers.jumptable")
+l = logging.getLogger(name=__name__)
 
 
 class UninitReadMeta(object):

--- a/angr/analyses/cfg/indirect_jump_resolvers/mips_elf_fast.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/mips_elf_fast.py
@@ -13,7 +13,7 @@ from ....surveyors import Slicecutor
 from .resolver import IndirectJumpResolver
 
 
-l = logging.getLogger("angr.analyses.cfg.indirect_jump_resolvers.mips_elf_fast")
+l = logging.getLogger(name=__name__)
 
 
 class MipsElfFastResolver(IndirectJumpResolver):

--- a/angr/analyses/cfg/indirect_jump_resolvers/x86_elf_pic_plt.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/x86_elf_pic_plt.py
@@ -8,7 +8,7 @@ from ....engines import SimEngineVEX
 from .resolver import IndirectJumpResolver
 
 
-l = logging.getLogger("angr.analyses.cfg.indirect_jump_resolvers.x86_elf_pic_plt")
+l = logging.getLogger(name=__name__)
 
 
 class X86ElfPicPltResolver(IndirectJumpResolver):

--- a/angr/analyses/cfg/indirect_jump_resolvers/x86_pe_iat.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/x86_pe_iat.py
@@ -3,7 +3,7 @@ import logging
 from ....simos import SimWindows
 from .resolver import IndirectJumpResolver
 
-l = logging.getLogger("angr.analyses.cfg.indirect_jump_resolvers.x86_pe_iat")
+l = logging.getLogger(name=__name__)
 
 
 class X86PeIatResolver(IndirectJumpResolver):

--- a/angr/analyses/congruency_check.py
+++ b/angr/analyses/congruency_check.py
@@ -4,7 +4,7 @@ import claripy
 
 from . import Analysis, register_analysis
 
-l = logging.getLogger("angr.analyses.congruency_check")
+l = logging.getLogger(name=__name__)
 #l.setLevel(logging.DEBUG)
 
 

--- a/angr/analyses/datagraph_meta.py
+++ b/angr/analyses/datagraph_meta.py
@@ -3,7 +3,7 @@ import logging
 
 import simuvex
 
-l = logging.getLogger("angr.analyses.datagraph_meta")
+l = logging.getLogger(name=__name__)
 
 class DataGraphMeta(object):
     def __init__(self):

--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -10,7 +10,7 @@ from ..errors import SimSolverModeError, SimUnsatError, AngrDDGError
 from ..sim_variable import SimRegisterVariable, SimMemoryVariable, SimTemporaryVariable, SimConstantVariable, \
     SimStackVariable
 
-l = logging.getLogger("angr.analyses.ddg")
+l = logging.getLogger(name=__name__)
 
 
 class AST(object):

--- a/angr/analyses/dfg.py
+++ b/angr/analyses/dfg.py
@@ -4,7 +4,7 @@ from copy import copy
 from . import Analysis, register_analysis
 from networkx import DiGraph
 
-l = logging.getLogger("angr.analyses.dfg")
+l = logging.getLogger(name=__name__)
 
 class DFG(Analysis):
     def __init__(self, cfg=None, annocfg=None):

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -7,7 +7,7 @@ from . import Analysis, register_analysis
 from .disassembly_utils import decode_instruction
 from ..block import CapstoneInsn
 
-l = logging.getLogger("angr.analyses.disassembly")
+l = logging.getLogger(name=__name__)
 
 
 class DisassemblyPiece(object):

--- a/angr/analyses/disassembly_utils.py
+++ b/angr/analyses/disassembly_utils.py
@@ -1,7 +1,7 @@
 
 import logging
 
-l = logging.getLogger('angr.analyses.disassembly_utils')
+l = logging.getLogger(name=__name__)
 
 import capstone as cs
 

--- a/angr/analyses/girlscout.py
+++ b/angr/analyses/girlscout.py
@@ -20,7 +20,7 @@ from ..errors import SimMemoryError, SimEngineError, AngrError, SimValueError, S
 from ..state_plugins.sim_action import SimActionData
 from ..surveyors import Explorer, Slicecutor
 
-l = logging.getLogger("angr.analyses.girlscout")
+l = logging.getLogger(name=__name__)
 
 class GirlScout(Analysis):
     """

--- a/angr/analyses/identifier/custom_callable.py
+++ b/angr/analyses/identifier/custom_callable.py
@@ -5,7 +5,7 @@ from ...errors import AngrCallableError, AngrCallableMultistateError
 from ...calling_conventions import DEFAULT_CC
 
 
-l = logging.getLogger("identifier.custom_callable")
+l = logging.getLogger(name=__name__)
 # l.setLevel("DEBUG")
 
 

--- a/angr/analyses/identifier/functions/__init__.py
+++ b/angr/analyses/identifier/functions/__init__.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import importlib
 
 import logging
-l = logging.getLogger('angr.procedures')
+l = logging.getLogger(name=__name__)
 
 from ..func import Func
 

--- a/angr/analyses/identifier/functions/fdprintf.py
+++ b/angr/analyses/identifier/functions/fdprintf.py
@@ -8,7 +8,7 @@ import claripy
 from ..func import Func, TestData
 
 
-l = logging.getLogger("identifier.functions.printf")
+l = logging.getLogger(name=__name__)
 
 
 class fdprintf(Func):

--- a/angr/analyses/identifier/functions/free.py
+++ b/angr/analyses/identifier/functions/free.py
@@ -5,7 +5,7 @@ from ..func import Func, TestData
 from ..errors import IdentifierException
 
 
-l = logging.getLogger("angr.analyses.identifier.functions.free")
+l = logging.getLogger(name=__name__)
 
 
 class free(Func):

--- a/angr/analyses/identifier/functions/printf.py
+++ b/angr/analyses/identifier/functions/printf.py
@@ -8,7 +8,7 @@ import claripy
 from ..func import Func, TestData
 
 
-l = logging.getLogger("angr.analyses.identifier.functions.printf")
+l = logging.getLogger(name=__name__)
 
 
 class printf(Func):

--- a/angr/analyses/identifier/functions/skip_realloc.py
+++ b/angr/analyses/identifier/functions/skip_realloc.py
@@ -5,7 +5,7 @@ from ..func import Func, TestData
 from ....errors import SimMemoryError
 
 
-l = logging.getLogger("angr.analyses.identifier.functions.free")
+l = logging.getLogger(name=__name__)
 
 class realloc(Func):
     def __init__(self):

--- a/angr/analyses/identifier/identify.py
+++ b/angr/analyses/identifier/identify.py
@@ -12,7 +12,7 @@ from .runner import Runner
 from ... import options
 from ...errors import AngrError, SimSegfaultError, SimEngineError, SimMemoryError, SimError
 
-l = logging.getLogger("identifier.identify")
+l = logging.getLogger(name=__name__)
 
 
 NUM_TESTS = 5

--- a/angr/analyses/identifier/runner.py
+++ b/angr/analyses/identifier/runner.py
@@ -15,7 +15,7 @@ from .custom_callable import IdentifierCallable
 from ...procedures import SIM_LIBRARIES
 
 
-l = logging.getLogger("identifier.runner")
+l = logging.getLogger(name=__name__)
 
 flag_loc = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../example_flag_page'))
 try:

--- a/angr/analyses/loopfinder.py
+++ b/angr/analyses/loopfinder.py
@@ -3,7 +3,7 @@ import logging
 import networkx
 from . import Analysis, register_analysis
 
-l = logging.getLogger("angr.analyses.loopfinder")
+l = logging.getLogger(name=__name__)
 
 class Loop(object):
     def __init__(self, entry, entry_edges, break_edges, continue_edges, body_nodes, graph, subloops):

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -16,7 +16,7 @@ from . import Analysis, register_analysis
 from ..knowledge_base import KnowledgeBase
 from ..sim_variable import SimMemoryVariable, SimTemporaryVariable
 
-l = logging.getLogger("angr.analyses.reassembler")
+l = logging.getLogger(name=__name__)
 
 #
 # Exceptions

--- a/angr/analyses/static_hooker.py
+++ b/angr/analyses/static_hooker.py
@@ -6,7 +6,7 @@ from . import Analysis, register_analysis
 from .. import SIM_LIBRARIES
 from ..errors import AngrValueError
 
-l = logging.getLogger("angr.analyses.static_hooker")
+l = logging.getLogger(name=__name__)
 
 class StaticHooker(Analysis):
     """

--- a/angr/analyses/variable_recovery/variable_recovery.py
+++ b/angr/analyses/variable_recovery/variable_recovery.py
@@ -11,7 +11,7 @@ from ... import BP, BP_AFTER
 from ...keyed_region import KeyedRegion
 from ...sim_variable import SimRegisterVariable, SimStackVariable, SimStackVariablePhi
 
-l = logging.getLogger("angr.analyses.variable_recovery.variable_recovery")
+l = logging.getLogger(name=__name__)
 
 
 class VariableRecoveryState(object):

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -10,7 +10,7 @@ from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor
 from ...keyed_region import KeyedRegion
 from ...sim_variable import SimStackVariable, SimRegisterVariable
 
-l = logging.getLogger("angr.analyses.variable_recovery.variable_recovery_fast")
+l = logging.getLogger(name=__name__)
 
 
 class RegAndOffset(object):

--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -11,7 +11,7 @@ from ..manager import SimulationManager
 from ..utils.graph import shallow_reverse
 from . import Analysis, register_analysis
 
-l = logging.getLogger("angr.analyses.veritesting")
+l = logging.getLogger(name=__name__)
 
 
 class VeritestingError(Exception):

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -18,7 +18,7 @@ from ..errors import AngrVFGError, AngrError, AngrVFGRestartAnalysisNotice, Angr
 from ..procedures import SIM_PROCEDURES
 from ..state_plugins.callstack import CallStack
 
-l = logging.getLogger("angr.analyses.vfg")
+l = logging.getLogger(name=__name__)
 
 
 class VFGJob(CFGJobBase):

--- a/angr/analyses/vsa_ddg.py
+++ b/angr/analyses/vsa_ddg.py
@@ -8,7 +8,7 @@ from .code_location import CodeLocation
 from ..errors import AngrDDGError
 from ..sim_variable import SimRegisterVariable, SimMemoryVariable
 
-l = logging.getLogger("angr.analyses.vsa_ddg")
+l = logging.getLogger(name=__name__)
 
 class DefUseChain(object):
     """

--- a/angr/annocfg.py
+++ b/angr/annocfg.py
@@ -6,7 +6,7 @@ import networkx
 from .errors import AngrAnnotatedCFGError, AngrExitError
 from .analyses.cfg.cfg_node import CFGNode
 
-l = logging.getLogger("angr.annocfg")
+l = logging.getLogger(name=__name__)
 
 class AnnotatedCFG(object):
     """

--- a/angr/block.py
+++ b/angr/block.py
@@ -1,5 +1,5 @@
 import logging
-l = logging.getLogger("angr.block")
+l = logging.getLogger(name=__name__)
 
 import pyvex
 from archinfo import ArchARM

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -15,7 +15,7 @@ from .sim_type import SimStruct
 
 from .state_plugins.sim_action_object import SimActionObject
 
-l = logging.getLogger("angr.calling_conventions")
+l = logging.getLogger(name=__name__)
 
 # TODO: This file contains explicit and implicit byte size assumptions all over. A good attempt to fix them was made.
 # If your architecture hails from the astral plane, and you're reading this, start fixing here.

--- a/angr/codenode.py
+++ b/angr/codenode.py
@@ -1,5 +1,5 @@
 import logging
-l = logging.getLogger("angr.codenode")
+l = logging.getLogger(name=__name__)
 
 
 class CodeNode(object):

--- a/angr/engines/engine.py
+++ b/angr/engines/engine.py
@@ -1,7 +1,7 @@
 import sys
 import logging
 
-l = logging.getLogger("angr.engines.engine")
+l = logging.getLogger(name=__name__)
 
 
 class SimEngine(object):

--- a/angr/engines/failure.py
+++ b/angr/engines/failure.py
@@ -1,7 +1,7 @@
 from .engine import SimEngine
 
 import logging
-l = logging.getLogger("angr.engines.failure")
+l = logging.getLogger(name=__name__)
 
 class SimEngineFailure(SimEngine): #pylint:disable=abstract-method
     def __init__(self, project):

--- a/angr/engines/hook.py
+++ b/angr/engines/hook.py
@@ -2,7 +2,7 @@ import logging
 
 from .engine import SimEngine
 
-l = logging.getLogger("angr.engines.hook")
+l = logging.getLogger(name=__name__)
 
 
 # pylint: disable=abstract-method,unused-argument

--- a/angr/engines/procedure.py
+++ b/angr/engines/procedure.py
@@ -1,5 +1,5 @@
 import logging
-l = logging.getLogger("angr.engines.procedure")
+l = logging.getLogger(name=__name__)
 
 from .engine import SimEngine
 

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -1,7 +1,7 @@
 import claripy
 
 import logging
-l = logging.getLogger("angr.engines.successors")
+l = logging.getLogger(name=__name__)
 
 class SimSuccessors(object):
     """

--- a/angr/engines/syscall.py
+++ b/angr/engines/syscall.py
@@ -1,6 +1,6 @@
 import angr
 import logging
-l = logging.getLogger("angr.engines.syscall")
+l = logging.getLogger(name=__name__)
 
 from .engine import SimEngine
 

--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -5,7 +5,7 @@ from ..state_plugins.inspect import BP_AFTER
 
 #pylint: disable=arguments-differ
 
-l = logging.getLogger("angr.engines.unicorn")
+l = logging.getLogger(name=__name__)
 
 
 class SimEngineUnicorn(SimEngine):

--- a/angr/engines/vex/ccall.py
+++ b/angr/engines/vex/ccall.py
@@ -1,6 +1,6 @@
 import claripy
 import logging
-l = logging.getLogger("angr.engines.vex.ccall")
+l = logging.getLogger(name=__name__)
 #l.setLevel(logging.DEBUG)
 
 # pylint: disable=R0911

--- a/angr/engines/vex/dirty.py
+++ b/angr/engines/vex/dirty.py
@@ -5,7 +5,7 @@ import time
 
 from ... import sim_options as o
 
-l = logging.getLogger("angr.engines.vex.dirty")
+l = logging.getLogger(name=__name__)
 
 
 #####################

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -16,7 +16,7 @@ from .statements import translate_stmt
 from .expressions import translate_expr
 
 import logging
-l = logging.getLogger("angr.engines.vex.engine")
+l = logging.getLogger(name=__name__)
 
 #pylint: disable=arguments-differ
 

--- a/angr/engines/vex/expressions/__init__.py
+++ b/angr/engines/vex/expressions/__init__.py
@@ -18,7 +18,7 @@ from ....errors import UnsupportedIRExprError
 from .... import sim_options as o
 
 import logging
-l = logging.getLogger("angr.engines.vex.expressions.")
+l = logging.getLogger(name=__name__)
 
 from .base import SimIRExpr
 

--- a/angr/engines/vex/expressions/base.py
+++ b/angr/engines/vex/expressions/base.py
@@ -1,7 +1,7 @@
 """This module handles constraint generation."""
 
 import logging
-l = logging.getLogger("angr.engines.vex.expressions.base")
+l = logging.getLogger(name=__name__)
 from pyvex.const import get_type_size
 _nonset = frozenset()
 

--- a/angr/engines/vex/expressions/ccall.py
+++ b/angr/engines/vex/expressions/ccall.py
@@ -4,7 +4,7 @@ from .. import ccall
 from ....errors import SimCCallError, UnsupportedCCallError
 
 import logging
-l = logging.getLogger("angr.engines.vex.expressions.ccall")
+l = logging.getLogger(name=__name__)
 
 class SimIRExpr_CCall(SimIRExpr):
     def _execute(self):

--- a/angr/engines/vex/expressions/unsupported.py
+++ b/angr/engines/vex/expressions/unsupported.py
@@ -1,7 +1,7 @@
 from .base import SimIRExpr
 
 import logging
-l = logging.getLogger("angr.engines.vex.expressions.unsupported")
+l = logging.getLogger(name=__name__)
 
 class SimIRExpr_Unsupported(SimIRExpr):
     def _execute(self):

--- a/angr/engines/vex/expressions/vecret.py
+++ b/angr/engines/vex/expressions/vecret.py
@@ -1,7 +1,7 @@
 from .base import SimIRExpr
 
 import logging
-l = logging.getLogger("angr.engines.vex.expressions.vecret")
+l = logging.getLogger(name=__name__)
 
 class SimIRExpr_VECRET(SimIRExpr):
     def _execute(self):

--- a/angr/engines/vex/irop.py
+++ b/angr/engines/vex/irop.py
@@ -9,7 +9,7 @@ import itertools
 import operator
 
 import logging
-l = logging.getLogger("angr.engines.vex.irop")
+l = logging.getLogger(name=__name__)
 
 import pyvex
 import claripy

--- a/angr/engines/vex/statements/__init__.py
+++ b/angr/engines/vex/statements/__init__.py
@@ -18,7 +18,7 @@ from .llsc import SimIRStmt_LLSC
 from .puti import SimIRStmt_PutI
 
 import logging
-l = logging.getLogger("angr.engines.vex.statements.")
+l = logging.getLogger(name=__name__)
 
 def translate_stmt(stmt, state):
     stmt_name = 'SimIRStmt_' +  type(stmt).__name__.split('IRStmt')[-1].split('.')[-1]

--- a/angr/engines/vex/statements/base.py
+++ b/angr/engines/vex/statements/base.py
@@ -1,6 +1,6 @@
 import logging
 from pyvex.const import get_type_size
-l = logging.getLogger("angr.engines.vex.statements.base")
+l = logging.getLogger(name=__name__)
 
 class SimIRStmt(object):
     """A class for symbolically translating VEX IRStmts."""

--- a/angr/engines/vex/statements/dirty.py
+++ b/angr/engines/vex/statements/dirty.py
@@ -4,7 +4,7 @@ from .... import sim_options as o
 from ....errors import UnsupportedDirtyError
 
 import logging
-l = logging.getLogger("angr.engines.vex.statements.dirty")
+l = logging.getLogger(name=__name__)
 
 class SimIRStmt_Dirty(SimIRStmt):
     # Example:

--- a/angr/engines/vex/statements/llsc.py
+++ b/angr/engines/vex/statements/llsc.py
@@ -2,7 +2,7 @@ from pyvex import get_type_size
 from . import SimIRStmt
 
 import logging
-l = logging.getLogger("angr.engines.vex.statements.llsc")
+l = logging.getLogger(name=__name__)
 
 # TODO: memory read SimActions
 # TODO: tmp write SimActions

--- a/angr/exploration_techniques/cacher.py
+++ b/angr/exploration_techniques/cacher.py
@@ -7,7 +7,7 @@ import logging
 from . import ExplorationTechnique
 
 
-l = logging.getLogger("angr.exploration_techniques.cacher")
+l = logging.getLogger(name=__name__)
 
 
 class Cacher(ExplorationTechnique):

--- a/angr/exploration_techniques/crash_monitor.py
+++ b/angr/exploration_techniques/crash_monitor.py
@@ -6,7 +6,7 @@ from . import ExplorationTechnique
 from .. import BP_AFTER, BP_BEFORE
 
 
-l = logging.getLogger("angr.exploration_techniques.crash_monitor")
+l = logging.getLogger(name=__name__)
 
 
 EXEC_STACK = 'EXEC_STACK'

--- a/angr/exploration_techniques/director.py
+++ b/angr/exploration_techniques/director.py
@@ -12,7 +12,7 @@ from ..knowledge_base import KnowledgeBase
 from ..errors import AngrDirectorError
 from . import ExplorationTechnique
 
-l = logging.getLogger("angr.exploration_techniques.director")
+l = logging.getLogger(name=__name__)
 
 
 class BaseGoal(object):

--- a/angr/exploration_techniques/driller_core.py
+++ b/angr/exploration_techniques/driller_core.py
@@ -5,7 +5,7 @@ from itertools import islice, izip
 from . import ExplorationTechnique
 
 
-l = logging.getLogger("angr.exploration_techniques.driller_core")
+l = logging.getLogger(name=__name__)
 
 
 class DrillerCore(ExplorationTechnique):

--- a/angr/exploration_techniques/explorer.py
+++ b/angr/exploration_techniques/explorer.py
@@ -2,7 +2,7 @@ from . import ExplorationTechnique
 from .. import sim_options
 
 import logging
-l = logging.getLogger("angr.exploration_techniques.explorer")
+l = logging.getLogger(name=__name__)
 
 class Explorer(ExplorationTechnique):
     """

--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -6,7 +6,7 @@ from ..knowledge_base import KnowledgeBase
 from ..knowledge_plugins.functions import Function
 
 
-l = logging.getLogger("angr.exploration_techniques.loop_seer")
+l = logging.getLogger(name=__name__)
 
 
 class LoopSeer(ExplorationTechnique):

--- a/angr/exploration_techniques/manual_mergepoint.py
+++ b/angr/exploration_techniques/manual_mergepoint.py
@@ -2,7 +2,7 @@ import logging
 
 from . import ExplorationTechnique
 
-l = logging.getLogger('angr.exploration_techniques.manual_mergepoint')
+l = logging.getLogger(name=__name__)
 
 class ManualMergepoint(ExplorationTechnique):
     def __init__(self, address, wait_counter=10):

--- a/angr/exploration_techniques/oppologist.py
+++ b/angr/exploration_techniques/oppologist.py
@@ -4,7 +4,7 @@ import claripy
 import functools
 
 import logging
-l = logging.getLogger("angr.exploration_techniques.oppologist")
+l = logging.getLogger(name=__name__)
 
 from ..errors import AngrError, SimError, SimUnsupportedError, SimCCallError
 from .. import sim_options

--- a/angr/exploration_techniques/spiller.py
+++ b/angr/exploration_techniques/spiller.py
@@ -1,6 +1,6 @@
 import logging
 
-l = logging.getLogger("angr.exploration_techniques.spiller")
+l = logging.getLogger(name=__name__)
 
 import ana
 from . import ExplorationTechnique

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -11,7 +11,7 @@ from ..errors import AngrTracerError, SimMemoryError, SimEngineError
 from ..storage.file import SimFile
 
 
-l = logging.getLogger("angr.exploration_techniques.tracer")
+l = logging.getLogger(name=__name__)
 
 
 class Tracer(ExplorationTechnique):

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -5,7 +5,7 @@ from .calling_conventions import DEFAULT_CC, SimRegArg, SimStackArg, PointerWrap
 from .callable import Callable
 
 
-l = logging.getLogger("angr.factory")
+l = logging.getLogger(name=__name__)
 
 
 _deprecation_cache = set()

--- a/angr/keyed_region.py
+++ b/angr/keyed_region.py
@@ -4,7 +4,7 @@ import logging
 from bintrees import AVLTree
 
 
-l = logging.getLogger("angr.knowledge.keyed_region")
+l = logging.getLogger(name=__name__)
 
 
 class LocationAndVariable(object):

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 import claripy
 from ...errors import SimEngineError, SimMemoryError
 
-l = logging.getLogger("angr.knowledge.function")
+l = logging.getLogger(name=__name__)
 
 
 class Function(object):

--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -9,7 +9,7 @@ from ..plugin import KnowledgeBasePlugin
 
 from .function import Function
 
-l = logging.getLogger("angr.knowledge.function_manager")
+l = logging.getLogger(name=__name__)
 
 
 class FunctionDict(dict):

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -12,7 +12,7 @@ from .variable_access import VariableAccess
 
 from ..plugin import KnowledgeBasePlugin
 
-l = logging.getLogger("angr.knowledge.variable_manager")
+l = logging.getLogger(name=__name__)
 
 
 class VariableType(object):

--- a/angr/manager.py
+++ b/angr/manager.py
@@ -10,7 +10,7 @@ import mulpyplexer
 
 from .errors import SimError, SimMergeError
 
-l = logging.getLogger("angr.manager")
+l = logging.getLogger(name=__name__)
 
 
 class SimulationManager(ana.Storable):

--- a/angr/misc/autoimport.py
+++ b/angr/misc/autoimport.py
@@ -2,7 +2,7 @@ import os
 import importlib
 import logging
 
-l = logging.getLogger('angr.misc.autoimport')
+l = logging.getLogger(name=__name__)
 
 def auto_import_packages(base_module, base_path, ignore_dirs=(), ignore_files=(), scan_modules=True):
     for lib_module_name in os.listdir(base_path):

--- a/angr/procedures/cgc/allocate.py
+++ b/angr/procedures/cgc/allocate.py
@@ -2,7 +2,7 @@ import claripy
 import angr
 import logging
 
-l = logging.getLogger("angr.procedures.cgc.allocate")
+l = logging.getLogger(name=__name__)
 
 class allocate(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/cgc/deallocate.py
+++ b/angr/procedures/cgc/deallocate.py
@@ -1,7 +1,7 @@
 import angr
 
 import logging
-l = logging.getLogger("angr.procedures.cgc.deallocate")
+l = logging.getLogger(name=__name__)
 
 class deallocate(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/definitions/__init__.py
+++ b/angr/procedures/definitions/__init__.py
@@ -9,7 +9,7 @@ from ..stubs.syscall_stub import syscall as stub_syscall
 from ...calling_conventions import DEFAULT_CC
 from ...misc import autoimport
 
-l = logging.getLogger("angr.procedures.definitions")
+l = logging.getLogger(name=__name__)
 SIM_LIBRARIES = {}
 
 class SimLibrary(object):

--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -4,7 +4,7 @@ import logging
 import pyvex
 import angr
 
-l = logging.getLogger("angr.procedures.glibc.__libc_start_main")
+l = logging.getLogger(name=__name__)
 
 ######################################
 # __libc_start_main

--- a/angr/procedures/libc/atoi.py
+++ b/angr/procedures/libc/atoi.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeString, SimTypeInt
 
 import logging
-l = logging.getLogger("angr.procedures.libc.atoi")
+l = logging.getLogger(name=__name__)
 
 
 class atoi(angr.SimProcedure):

--- a/angr/procedures/libc/fflush.py
+++ b/angr/procedures/libc/fflush.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeFd, SimTypeLength
 
 import logging
-l = logging.getLogger("angr.procedures.libc.fflush")
+l = logging.getLogger(name=__name__)
 
 class fflush(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/fprintf.py
+++ b/angr/procedures/libc/fprintf.py
@@ -4,7 +4,7 @@ from angr.procedures.stubs.format_parser import FormatParser
 
 from . import io_file_data_for_arch
 
-l = logging.getLogger("angr.procedures.libc.fprintf")
+l = logging.getLogger(name=__name__)
 
 ######################################
 # fprintf

--- a/angr/procedures/libc/memcmp.py
+++ b/angr/procedures/libc/memcmp.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeTop, SimTypeLength, SimTypeInt
 
 import logging
-l = logging.getLogger("angr.procedures.libc.memcmp")
+l = logging.getLogger(name=__name__)
 
 class memcmp(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/memcpy.py
+++ b/angr/procedures/libc/memcpy.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeTop, SimTypeLength
 
 import logging
-l = logging.getLogger("angr.procedures.libc.memcpy")
+l = logging.getLogger(name=__name__)
 
 class memcpy(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/memset.py
+++ b/angr/procedures/libc/memset.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeTop, SimTypeInt, SimTypeLength
 
 import logging
-l = logging.getLogger("angr.procedures.libc.memset")
+l = logging.getLogger(name=__name__)
 
 ######################################
 # memset

--- a/angr/procedures/libc/printf.py
+++ b/angr/procedures/libc/printf.py
@@ -2,7 +2,7 @@ import logging
 
 from angr.procedures.stubs.format_parser import FormatParser
 
-l = logging.getLogger("angr.procedures.libc.printf")
+l = logging.getLogger(name=__name__)
 
 class printf(FormatParser):
 

--- a/angr/procedures/libc/realloc.py
+++ b/angr/procedures/libc/realloc.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeLength, SimTypeTop
 
 import logging
-l = logging.getLogger("angr.procedures.libc.realloc")
+l = logging.getLogger(name=__name__)
 
 ######################################
 # realloc

--- a/angr/procedures/libc/scanf.py
+++ b/angr/procedures/libc/scanf.py
@@ -3,7 +3,7 @@ import logging
 from angr.procedures.stubs.format_parser import FormatParser
 from angr.sim_type import SimTypeInt, SimTypeString
 
-l = logging.getLogger("angr.procedures.libc.scanf")
+l = logging.getLogger(name=__name__)
 
 class scanf(FormatParser):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/snprintf.py
+++ b/angr/procedures/libc/snprintf.py
@@ -2,7 +2,7 @@ import logging
 
 from angr.procedures.stubs.format_parser import FormatParser
 
-l = logging.getLogger("angr.procedures.libc.snprintf")
+l = logging.getLogger(name=__name__)
 
 ######################################
 # snprintf

--- a/angr/procedures/libc/sprintf.py
+++ b/angr/procedures/libc/sprintf.py
@@ -2,7 +2,7 @@ import logging
 
 from angr.procedures.stubs.format_parser import FormatParser
 
-l = logging.getLogger("angr.procedures.libc.sprintf")
+l = logging.getLogger(name=__name__)
 
 ######################################
 # sprintf

--- a/angr/procedures/libc/sscanf.py
+++ b/angr/procedures/libc/sscanf.py
@@ -4,7 +4,7 @@ import logging
 from angr.procedures.stubs.format_parser import FormatParser
 from angr.sim_type import SimTypeInt, SimTypeString
 
-l = logging.getLogger("angr.procedures.libc.sscanf")
+l = logging.getLogger(name=__name__)
 
 class sscanf(FormatParser):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/strchr.py
+++ b/angr/procedures/libc/strchr.py
@@ -3,7 +3,7 @@ from angr.state_plugins.symbolic_memory import MultiwriteAnnotation
 from angr.sim_type import SimTypeString, SimTypeInt, SimTypeChar
 
 import logging
-l = logging.getLogger("angr.procedures.libc.strchr")
+l = logging.getLogger(name=__name__)
 
 class strchr(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/strcmp.py
+++ b/angr/procedures/libc/strcmp.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeString, SimTypeInt
 
 import logging
-l = logging.getLogger("angr.procedures.libc.strcmp")
+l = logging.getLogger(name=__name__)
 
 class strcmp(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/strlen.py
+++ b/angr/procedures/libc/strlen.py
@@ -3,7 +3,7 @@ import angr
 from angr.sim_type import SimTypeString, SimTypeLength
 
 import logging
-l = logging.getLogger("angr.procedures.libc.strlen")
+l = logging.getLogger(name=__name__)
 
 class strlen(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/strncmp.py
+++ b/angr/procedures/libc/strncmp.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeString, SimTypeLength, SimTypeInt
 
 import logging
-l = logging.getLogger("angr.procedures.libc.strncmp")
+l = logging.getLogger(name=__name__)
 
 class strncmp(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/strncpy.py
+++ b/angr/procedures/libc/strncpy.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeString, SimTypeLength
 
 import logging
-l = logging.getLogger("angr.procedures.libc.strncpy")
+l = logging.getLogger(name=__name__)
 
 class strncpy(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/strstr.py
+++ b/angr/procedures/libc/strstr.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeString
 
 import logging
-l = logging.getLogger("angr.procedures.libc.strstr")
+l = logging.getLogger(name=__name__)
 
 class strstr(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/strtol.py
+++ b/angr/procedures/libc/strtol.py
@@ -3,7 +3,7 @@ from angr.sim_type import SimTypeString, SimTypeInt
 from angr.errors import SimProcedureError
 
 import logging
-l = logging.getLogger("angr.procedures.libc.strtol")
+l = logging.getLogger(name=__name__)
 
 
 # note: this does not handle skipping white space

--- a/angr/procedures/libc/system.py
+++ b/angr/procedures/libc/system.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeInt, SimTypeTop
 
 import logging
-l = logging.getLogger("angr.procedures.libc.system")
+l = logging.getLogger(name=__name__)
 
 class system(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/libc/tolower.py
+++ b/angr/procedures/libc/tolower.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeInt
 
 import logging
-l = logging.getLogger("angr.procedures.libc.tolower")
+l = logging.getLogger(name=__name__)
 
 
 class tolower(angr.SimProcedure):

--- a/angr/procedures/libc/toupper.py
+++ b/angr/procedures/libc/toupper.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeInt
 
 import logging
-l = logging.getLogger("angr.procedures.libc.toupper")
+l = logging.getLogger(name=__name__)
 
 
 class toupper(angr.SimProcedure):

--- a/angr/procedures/linux_kernel/brk.py
+++ b/angr/procedures/linux_kernel/brk.py
@@ -1,7 +1,7 @@
 import angr
 import logging
 
-l = logging.getLogger('angr.procedures.linux_kernel.brk')
+l = logging.getLogger(name=__name__)
 
 class brk(angr.SimProcedure):
     """

--- a/angr/procedures/linux_kernel/futex.py
+++ b/angr/procedures/linux_kernel/futex.py
@@ -5,7 +5,7 @@ import angr
 # futex
 ######################################
 
-l = logging.getLogger("simuvex.SimProcedures")
+l = logging.getLogger(name=__name__)
 #pylint:disable=redefined-builtin,arguments-differ
 class futex(angr.SimProcedure):
 

--- a/angr/procedures/linux_kernel/getrlimit.py
+++ b/angr/procedures/linux_kernel/getrlimit.py
@@ -5,7 +5,7 @@ import angr
 # getrlimit
 ######################################
 
-l = logging.getLogger("angr.SimProcedures")
+l = logging.getLogger(name=__name__)
 #pylint:disable=redefined-builtin,arguments-differ
 class getrlimit(angr.SimProcedure):
 

--- a/angr/procedures/linux_kernel/lseek.py
+++ b/angr/procedures/linux_kernel/lseek.py
@@ -1,7 +1,7 @@
 import angr
 
 import logging
-l = logging.getLogger("angr.procedures.syscalls.lseek")
+l = logging.getLogger(name=__name__)
 
 class lseek(angr.SimProcedure):
 

--- a/angr/procedures/linux_kernel/mmap.py
+++ b/angr/procedures/linux_kernel/mmap.py
@@ -1,7 +1,7 @@
 import angr
 
 import logging
-l = logging.getLogger("angr.procedures.syscalls.mmap")
+l = logging.getLogger(name=__name__)
 
 
 PROT_READ       = 0x1  #    /* Page can be read.  */

--- a/angr/procedures/linux_kernel/mprotect.py
+++ b/angr/procedures/linux_kernel/mprotect.py
@@ -1,7 +1,7 @@
 import angr
 import logging
 
-l = logging.getLogger('angr.procedures.linux_kernel.mprotect')
+l = logging.getLogger(name=__name__)
 
 class mprotect(angr.SimProcedure):
 

--- a/angr/procedures/linux_loader/sim_loader.py
+++ b/angr/procedures/linux_loader/sim_loader.py
@@ -2,7 +2,7 @@ import angr
 import claripy
 import logging
 
-l = logging.getLogger('angr.procedures.linux_loader.sim_loader')
+l = logging.getLogger(name=__name__)
 
 class LinuxLoader(angr.SimProcedure):
     NO_RET = True

--- a/angr/procedures/msvcr/__getmainargs.py
+++ b/angr/procedures/msvcr/__getmainargs.py
@@ -3,7 +3,7 @@ import logging
 import angr
 from angr.sim_type import SimTypeInt, SimTypeTop
 
-l = logging.getLogger("angr.procedures.msvcr.__getmainargs")
+l = logging.getLogger(name=__name__)
 
 ######################################
 # __getmainargs

--- a/angr/procedures/msvcr/_initterm.py
+++ b/angr/procedures/msvcr/_initterm.py
@@ -3,7 +3,7 @@ import logging
 import angr
 from angr.sim_type import SimTypeInt
 
-l = logging.getLogger("angr.procedures.msvcr._initterm")
+l = logging.getLogger(name=__name__)
 
 ######################################
 # __initterm

--- a/angr/procedures/posix/bind.py
+++ b/angr/procedures/posix/bind.py
@@ -4,7 +4,7 @@ import angr
 # bind (but not really)
 ######################################
 import logging
-l = logging.getLogger("angr.procedures.posix.bind")
+l = logging.getLogger(name=__name__)
 
 class bind(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/posix/fileno.py
+++ b/angr/procedures/posix/fileno.py
@@ -4,7 +4,7 @@ from angr.sim_type import SimTypeFd, SimTypeTop
 from ..libc import io_file_data_for_arch
 
 import logging
-l = logging.getLogger("angr.procedures.posix.fileno")
+l = logging.getLogger(name=__name__)
 
 
 ######################################

--- a/angr/procedures/posix/inet_ntoa.py
+++ b/angr/procedures/posix/inet_ntoa.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeString
 import logging
 
-l = logging.getLogger("angr.procedures.posix.inet_ntoa")
+l = logging.getLogger(name=__name__)
 
 
 class inet_ntoa(angr.SimProcedure):

--- a/angr/procedures/posix/listen.py
+++ b/angr/procedures/posix/listen.py
@@ -4,7 +4,7 @@ import angr
 # listen (but not really)
 ######################################
 import logging
-l = logging.getLogger("angr.procedures.posix.listen")
+l = logging.getLogger(name=__name__)
 
 class listen(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/posix/readdir.py
+++ b/angr/procedures/posix/readdir.py
@@ -2,7 +2,7 @@ import angr
 from collections import namedtuple
 
 import logging
-l = logging.getLogger('angr.procedures.posix.readdir')
+l = logging.getLogger(name=__name__)
 
 Dirent = namedtuple('dirent', ('d_ino', 'd_off', 'd_reclen', 'd_type', 'd_name'))
 

--- a/angr/procedures/posix/sleep.py
+++ b/angr/procedures/posix/sleep.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeInt
 
 import logging
-l = logging.getLogger("angr.procedures.posix.sleep")
+l = logging.getLogger(name=__name__)
 
 class sleep(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/posix/strcasecmp.py
+++ b/angr/procedures/posix/strcasecmp.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeString, SimTypeInt
 
 import logging
-l = logging.getLogger("angr.procedures.posix.strcasecmp")
+l = logging.getLogger(name=__name__)
 
 class strcasecmp(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/posix/strtok_r.py
+++ b/angr/procedures/posix/strtok_r.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeString
 
 import logging
-l = logging.getLogger("angr.procedures.posix.strtok_r")
+l = logging.getLogger(name=__name__)
 
 class strtok_r(angr.SimProcedure):
     #pylint:disable=arguments-differ

--- a/angr/procedures/posix/usleep.py
+++ b/angr/procedures/posix/usleep.py
@@ -2,7 +2,7 @@ import angr
 from angr.sim_type import SimTypeInt
 import logging
 
-l = logging.getLogger("angr.procedures.posix.usleep")
+l = logging.getLogger(name=__name__)
 
 
 class usleep(angr.SimProcedure):

--- a/angr/procedures/procedure_dict.py
+++ b/angr/procedures/procedure_dict.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-l = logging.getLogger("angr.procedures.procedure_dict")
+l = logging.getLogger(name=__name__)
 
 from ..misc import autoimport
 from ..sim_procedure import SimProcedure

--- a/angr/procedures/stubs/CallReturn.py
+++ b/angr/procedures/stubs/CallReturn.py
@@ -1,7 +1,7 @@
 import angr
 import logging
 
-l = logging.getLogger('angr.procedures.stubs.CallReturn')
+l = logging.getLogger(name=__name__)
 
 class CallReturn(angr.SimProcedure):
     NO_RET = True

--- a/angr/procedures/stubs/format_parser.py
+++ b/angr/procedures/stubs/format_parser.py
@@ -5,7 +5,7 @@ import logging
 
 from angr import sim_type
 
-l = logging.getLogger("angr.procedures.stubs.format_parser")
+l = logging.getLogger(name=__name__)
 
 class FormatString(object):
     """

--- a/angr/procedures/tracer/receive.py
+++ b/angr/procedures/tracer/receive.py
@@ -3,7 +3,7 @@ import logging
 from ..cgc.receive import receive as orig_receive
 
 
-l = logging.getLogger("angr.procedures.tracer.receive")
+l = logging.getLogger(name=__name__)
 
 
 class receive(orig_receive):

--- a/angr/procedures/tracer/transmit.py
+++ b/angr/procedures/tracer/transmit.py
@@ -3,7 +3,7 @@ import logging
 from ..cgc.transmit import transmit as orig_transmit
 
 
-l = logging.getLogger("angr.procedures.tracer.transmit")
+l = logging.getLogger(name=__name__)
 
 
 class transmit(orig_transmit):

--- a/angr/procedures/win32/GetModuleHandle.py
+++ b/angr/procedures/win32/GetModuleHandle.py
@@ -1,7 +1,7 @@
 import angr
 import logging
 
-l = logging.getLogger('angr.procedures.win32.GetModuleHandle')
+l = logging.getLogger(name=__name__)
 
 class GetModuleHandleA(angr.SimProcedure):
     def run(self, pointer):

--- a/angr/procedures/win32/VirtualAlloc.py
+++ b/angr/procedures/win32/VirtualAlloc.py
@@ -1,7 +1,7 @@
 import angr
 import logging
 
-l = logging.getLogger('angr.procedures.win32.VirtualAlloc')
+l = logging.getLogger(name=__name__)
 
 def convert_prot(prot):
     """

--- a/angr/procedures/win32/VirtualProtect.py
+++ b/angr/procedures/win32/VirtualProtect.py
@@ -3,7 +3,7 @@ import logging
 
 from .VirtualAlloc import convert_prot, deconvert_prot
 
-l = logging.getLogger('angr.procedures.win32.VirtualProtect')
+l = logging.getLogger(name=__name__)
 
 class VirtualProtect(angr.SimProcedure):
     def run(self, lpAddress, dwSize, flNewProtect, lpfOldProtect):

--- a/angr/procedures/win32/dynamic_loading.py
+++ b/angr/procedures/win32/dynamic_loading.py
@@ -2,7 +2,7 @@ import angr
 import claripy
 import logging
 
-l = logging.getLogger('angr.procedures.win32.dynamic_loading')
+l = logging.getLogger(name=__name__)
 
 class LoadLibraryA(angr.SimProcedure):
     def run(self, lib_ptr):

--- a/angr/project.py
+++ b/angr/project.py
@@ -13,7 +13,7 @@ from cle.address_translator import AT
 
 from .misc.ux import once, deprecated
 
-l = logging.getLogger("angr.project")
+l = logging.getLogger(name=__name__)
 
 # This holds the default execution engine for a given CLE loader backend.
 # All the builtins right now use SimEngineVEX.  This may not hold for long.

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -3,7 +3,7 @@ import copy
 import itertools
 
 import logging
-l = logging.getLogger("angr.sim_procedure")
+l = logging.getLogger(name=__name__)
 
 symbolic_count = itertools.count()
 

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -4,7 +4,7 @@ import contextlib
 import weakref
 
 import logging
-l = logging.getLogger("angr.sim_state")
+l = logging.getLogger(name=__name__)
 
 import claripy
 import ana

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -8,7 +8,7 @@ import os
 import claripy
 
 import logging
-l = logging.getLogger("angr.sim_type")
+l = logging.getLogger(name=__name__)
 
 try:
     import pycparser

--- a/angr/simos/cgc.py
+++ b/angr/simos/cgc.py
@@ -10,7 +10,7 @@ from ..state_plugins import SimStateSystem, SimActionData
 from .. import sim_options as o
 from .userland import SimUserland
 
-_l = logging.getLogger('angr.simos.cgc')
+_l = logging.getLogger(name=__name__)
 
 
 class SimCGC(SimUserland):

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -12,7 +12,7 @@ from ..state_plugins import SimStateSystem
 from ..errors import AngrSyscallError
 from .userland import SimUserland
 
-_l = logging.getLogger('angr.simos.linux')
+_l = logging.getLogger(name=__name__)
 
 
 class SimLinux(SimUserland):

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -19,7 +19,7 @@ from ..storage.file import SimFile
 from ..misc import IRange
 
 
-_l = logging.getLogger("angr.simos.simos")
+_l = logging.getLogger(name=__name__)
 
 
 class SimOS(object):

--- a/angr/simos/userland.py
+++ b/angr/simos/userland.py
@@ -5,7 +5,7 @@ from ..errors import AngrUnsupportedSyscallError
 from ..procedures import SIM_PROCEDURES as P
 from .simos import SimOS
 
-_l = logging.getLogger('angr.simos.userland')
+_l = logging.getLogger(name=__name__)
 
 
 class SimUserland(SimOS):

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -16,7 +16,7 @@ from ..tablespecs import StringTableSpec
 from ..procedures import SIM_LIBRARIES as L
 from .simos import SimOS
 
-_l = logging.getLogger('angr.simos.windows')
+_l = logging.getLogger(name=__name__)
 
 
 class SimWindows(SimOS):

--- a/angr/state_hierarchy.py
+++ b/angr/state_hierarchy.py
@@ -5,7 +5,7 @@ import itertools
 
 import claripy
 
-l = logging.getLogger("angr.state_hierarchy")
+l = logging.getLogger(name=__name__)
 
 
 class StateHierarchy(object):

--- a/angr/state_plugins/abstract_memory.py
+++ b/angr/state_plugins/abstract_memory.py
@@ -12,7 +12,7 @@ from .symbolic_memory import SimSymbolicMemory
 from ..state_plugins.sim_action_object import _raw_ast
 
 
-l = logging.getLogger("angr.state_plugins.abstract_memory")
+l = logging.getLogger(name=__name__)
 
 WRITE_TARGETS_LIMIT = 2048
 READ_TARGETS_LIMIT = 4096

--- a/angr/state_plugins/callstack.py
+++ b/angr/state_plugins/callstack.py
@@ -6,7 +6,7 @@ import logging
 from .plugin import SimStatePlugin
 from ..errors import AngrError, SimEmptyCallStackError
 
-l = logging.getLogger("angr.state_plugins.callstack")
+l = logging.getLogger(name=__name__)
 
 class CallStack(SimStatePlugin):
     """

--- a/angr/state_plugins/fast_memory.py
+++ b/angr/state_plugins/fast_memory.py
@@ -5,7 +5,7 @@ import claripy
 from ..storage.memory import SimMemory
 from ..errors import SimFastMemoryError
 
-l = logging.getLogger("angr.state_plugins.fast_memory")
+l = logging.getLogger(name=__name__)
 l.setLevel(logging.DEBUG)
 
 class SimFastMemory(SimMemory):

--- a/angr/state_plugins/gdb.py
+++ b/angr/state_plugins/gdb.py
@@ -7,7 +7,7 @@ import logging
 import claripy
 import binascii
 
-l = logging.getLogger("angr.state_plugins.gdb")
+l = logging.getLogger(name=__name__)
 
 #global heap_location
 

--- a/angr/state_plugins/globals.py
+++ b/angr/state_plugins/globals.py
@@ -3,7 +3,7 @@ import logging
 
 from .plugin import SimStatePlugin
 
-l = logging.getLogger('angr.state_plugins.globals')
+l = logging.getLogger(name=__name__)
 
 
 class SimStateGlobals(SimStatePlugin):

--- a/angr/state_plugins/history.py
+++ b/angr/state_plugins/history.py
@@ -8,7 +8,7 @@ from .plugin import SimStatePlugin
 from .. import sim_options
 from ..state_plugins.sim_action import SimActionObject
 
-l = logging.getLogger("angr.state_plugins.history")
+l = logging.getLogger(name=__name__)
 
 
 class SimStateHistory(SimStatePlugin):

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -1,7 +1,7 @@
 # TODO: SimValue being able to compare two symbolics for is_solution
 
 import logging
-l = logging.getLogger("angr.state_plugins.inspect")
+l = logging.getLogger(name=__name__)
 
 event_types = {
     'mem_read',

--- a/angr/state_plugins/log.py
+++ b/angr/state_plugins/log.py
@@ -1,5 +1,5 @@
 import logging
-l = logging.getLogger("angr.state_plugins.log")
+l = logging.getLogger(name=__name__)
 
 import sys
 import itertools

--- a/angr/state_plugins/loop_data.py
+++ b/angr/state_plugins/loop_data.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from .plugin import SimStatePlugin
 
 
-l = logging.getLogger('angr.state_plugins.loop_data')
+l = logging.getLogger(name=__name__)
 
 
 class SimStateLoopData(SimStatePlugin):

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -6,7 +6,7 @@ from ..storage.file import Flags
 
 import os
 import logging
-l = logging.getLogger("angr.state_plugins.posix")
+l = logging.getLogger(name=__name__)
 
 max_fds = 8192
 

--- a/angr/state_plugins/preconstrainer.py
+++ b/angr/state_plugins/preconstrainer.py
@@ -5,7 +5,7 @@ from .. import sim_options as o
 from ..storage.file import SimDialogue
 
 
-l = logging.getLogger("angr.state_plugins.preconstrainer")
+l = logging.getLogger(name=__name__)
 
 
 class SimStatePreconstrainer(SimStatePlugin):

--- a/angr/state_plugins/scratch.py
+++ b/angr/state_plugins/scratch.py
@@ -1,5 +1,5 @@
 import logging
-l = logging.getLogger("angr.state_plugins.scratch")
+l = logging.getLogger(name=__name__)
 
 import claripy
 

--- a/angr/state_plugins/sim_action.py
+++ b/angr/state_plugins/sim_action.py
@@ -1,7 +1,7 @@
 # This module contains data structures for handling memory, code, and register references.
 
 import logging
-l = logging.getLogger("angr.state_plugins.sim_action")
+l = logging.getLogger(name=__name__)
 
 _noneset = frozenset()
 

--- a/angr/state_plugins/sim_action_object.py
+++ b/angr/state_plugins/sim_action_object.py
@@ -1,5 +1,5 @@
 import logging
-l = logging.getLogger("angr.state_plugins.sim_action_object")
+l = logging.getLogger(name=__name__)
 
 import claripy
 import functools

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -7,7 +7,7 @@ from .plugin import SimStatePlugin
 from .sim_action_object import ast_stripping_decorator, SimActionObject
 from ..misc.ux import deprecated
 
-l = logging.getLogger("angr.state_plugins.solver")
+l = logging.getLogger(name=__name__)
 
 #pylint:disable=unidiomatic-typecheck
 

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import logging
 import itertools
 
-l = logging.getLogger("angr.state_plugins.symbolic_memory")
+l = logging.getLogger(name=__name__)
 
 import claripy
 from ..storage.memory import SimMemory

--- a/angr/state_plugins/trace_additions.py
+++ b/angr/state_plugins/trace_additions.py
@@ -3,7 +3,7 @@ import claripy
 import string
 import logging
 
-l = logging.getLogger("angr.state_plugins.trace_additions")
+l = logging.getLogger(name=__name__)
 
 
 #pylint:disable=pointless-string-statement

--- a/angr/state_plugins/uc_manager.py
+++ b/angr/state_plugins/uc_manager.py
@@ -1,6 +1,6 @@
 
 import logging
-l = logging.getLogger("angr.state_plugins.uc_manager")
+l = logging.getLogger(name=__name__)
 
 from .plugin import SimStatePlugin
 from ..errors import SimUCManagerAllocationError

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -16,7 +16,7 @@ from ..errors import SimValueError, SimUnicornUnsupport, SimSegfaultError, SimMe
 from .plugin import SimStatePlugin
 from ..misc.testing import is_testing
 
-l = logging.getLogger("angr.state_plugins.unicorn_engine")
+l = logging.getLogger(name=__name__)
 
 try:
     import unicorn

--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -2,7 +2,7 @@ import claripy
 from .plugin import SimStatePlugin
 
 import logging
-l = logging.getLogger("angr.state_plugins.view")
+l = logging.getLogger(name=__name__)
 
 class SimRegNameView(SimStatePlugin):
     def __init__(self):

--- a/angr/storage/file.py
+++ b/angr/storage/file.py
@@ -4,7 +4,7 @@ from .. import sim_options
 
 import claripy
 import logging
-l = logging.getLogger("angr.storage.file")
+l = logging.getLogger(name=__name__)
 
 # TODO: symbolic file positions
 import itertools

--- a/angr/storage/memory.py
+++ b/angr/storage/memory.py
@@ -1,6 +1,6 @@
 import logging
 
-l = logging.getLogger("angr.storage.memory")
+l = logging.getLogger(name=__name__)
 
 import claripy
 from ..state_plugins.plugin import SimStatePlugin

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -12,7 +12,7 @@ from claripy.ast.bv import BV
 _ffi = cffi.FFI()
 
 import logging
-l = logging.getLogger("angr.storage.paged_memory")
+l = logging.getLogger(name=__name__)
 
 class BasePage(object):
     """

--- a/angr/storage/pcap.py
+++ b/angr/storage/pcap.py
@@ -1,7 +1,7 @@
 import dpkt
 import socket
 import logging
-l = logging.getLogger("angr.storage.pcap")
+l = logging.getLogger(name=__name__)
 
 
 class PCAP(object):

--- a/angr/surveyors/escaper.py
+++ b/angr/surveyors/escaper.py
@@ -3,7 +3,7 @@ from . import Explorer
 
 import logging
 
-l = logging.getLogger("angr.surveyors.escaper")
+l = logging.getLogger(name=__name__)
 
 
 class Escaper(Surveyor):

--- a/angr/surveyors/executor.py
+++ b/angr/surveyors/executor.py
@@ -2,7 +2,7 @@ import logging
 
 from .surveyor import Surveyor
 
-l = logging.getLogger("angr.surveyors.executor")
+l = logging.getLogger(name=__name__)
 
 class Executor(Surveyor):
     """

--- a/angr/surveyors/explorer.py
+++ b/angr/surveyors/explorer.py
@@ -7,7 +7,7 @@ from ..errors import SimMemoryError, SimEngineError
 
 from .surveyor import Surveyor
 
-l = logging.getLogger("angr.surveyors.explorer")
+l = logging.getLogger(name=__name__)
 
 class Explorer(Surveyor):
     """

--- a/angr/surveyors/slicecutor.py
+++ b/angr/surveyors/slicecutor.py
@@ -1,5 +1,5 @@
 import logging
-l = logging.getLogger("angr.surveyors.slicecutor")
+l = logging.getLogger(name=__name__)
 
 from .surveyor import Surveyor
 from ..errors import AngrExitError

--- a/angr/surveyors/surveyor.py
+++ b/angr/surveyors/surveyor.py
@@ -8,7 +8,7 @@ import sys
 
 from ..sim_state import SimState
 
-l = logging.getLogger("angr.surveyor")
+l = logging.getLogger(name=__name__)
 
 #
 # Surveyor debugging

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -125,7 +125,7 @@ class PostDominators(object):
 
     def __init__(self, graph, entry_node, successors_func=None):
 
-        self._l = logging.getLogger("utils.graph.post_dominators")
+        self._l = logging.getLogger(name=__name__)
         self._graph_successors_func = successors_func
 
         # Temporary variables

--- a/tests/broken_loop.py
+++ b/tests/broken_loop.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import nose
 import angr

--- a/tests/broken_never.py
+++ b/tests/broken_never.py
@@ -2,7 +2,7 @@
 
 import nose
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 
 import angr

--- a/tests/broken_orwc.py
+++ b/tests/broken_orwc.py
@@ -5,7 +5,7 @@ This is the first of many syscall tests
 """
 
 import logging
-l = logging.getLogger("angr.tests")
+l = logging.getLogger(name=__name__)
 
 import angr
 import nose

--- a/tests/broken_simcc.py
+++ b/tests/broken_simcc.py
@@ -3,7 +3,7 @@ import angr
 from angr.calling_conventions import SimCCSystemVAMD64
 
 import logging
-l = logging.getLogger("angr.tests.test_simcc")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/broken_slicing.py
+++ b/tests/broken_slicing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import logging
-l = logging.getLogger("angr.tests.slicing")
+l = logging.getLogger(name=__name__)
 
 import time
 import nose

--- a/tests/broken_switch.py
+++ b/tests/broken_switch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import nose
 import angr

--- a/tests/broken_variableseekr.py
+++ b/tests/broken_variableseekr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import logging
-l = logging.getLogger("angr.tests")
+l = logging.getLogger(name=__name__)
 
 import nose
 import angr

--- a/tests/syscalls/test_lseek.py
+++ b/tests/syscalls/test_lseek.py
@@ -2,7 +2,7 @@ import nose
 import archinfo
 
 import logging
-l = logging.getLogger('angr.tests.syscalls.lseek')
+l = logging.getLogger(name=__name__)
 
 from angr import SIM_PROCEDURES
 from angr import SimState, SimPosixError

--- a/tests/syscalls/test_mmap.py
+++ b/tests/syscalls/test_mmap.py
@@ -4,7 +4,7 @@ import logging
 
 from angr import SimState
 
-l = logging.getLogger('angr.tests.syscalls.mmap')
+l = logging.getLogger(name=__name__)
 
 
 def test_mmap_base_copy():

--- a/tests/test_argc.py
+++ b/tests/test_argc.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_argc_sym.py
+++ b/tests/test_argc_sym.py
@@ -2,7 +2,7 @@ import angr
 import claripy
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -2,7 +2,7 @@ import nose
 import angr, claripy
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_bindiff.py
+++ b/tests/test_bindiff.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger("angr.tests.test_bindiff")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_block_cache.py
+++ b/tests/test_block_cache.py
@@ -1,7 +1,7 @@
 import angr
 
 import logging
-l = logging.getLogger("angr.tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_boyscout.py
+++ b/tests/test_boyscout.py
@@ -5,7 +5,7 @@ import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
 
 import logging
-l = logging.getLogger('angr.test_boyscout')
+l = logging.getLogger(name=__name__)
 
 entries = [
     ("i386/all", "X86", "Iend_LE"),

--- a/tests/test_cacher.py
+++ b/tests/test_cacher.py
@@ -7,7 +7,7 @@ import nose
 import angr
 
 
-l = logging.getLogger("angr_tests.managers")
+l = logging.getLogger(name=__name__)
 
 location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 

--- a/tests/test_callable.py
+++ b/tests/test_callable.py
@@ -5,7 +5,7 @@ from angr.sim_type import SimTypePointer, SimTypeFunction, SimTypeChar, SimTypeI
 from angr.errors import AngrCallableMultistateError
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import os
 location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_callstack.py
+++ b/tests/test_callstack.py
@@ -5,7 +5,7 @@ import nose
 
 from angr.state_plugins.callstack import CallStack
 
-l = logging.getLogger('angr.tests.test_callstack')
+l = logging.getLogger(name=__name__)
 
 def test_empty_stack():
     cs = CallStack()

--- a/tests/test_cfgaccurate.py
+++ b/tests/test_cfgaccurate.py
@@ -4,7 +4,7 @@ import pickle
 import networkx
 
 import logging
-l = logging.getLogger("angr.tests.test_cfg")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -8,7 +8,7 @@ import angr
 
 from angr.analyses.cfg.cfg_fast import SegmentList
 
-l = logging.getLogger("angr.tests.test_cfgfast")
+l = logging.getLogger(name=__name__)
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
 

--- a/tests/test_checkbyte.py
+++ b/tests/test_checkbyte.py
@@ -1,7 +1,7 @@
 import angr
 
 import logging
-l = logging.getLogger("angr.tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_ctype_locale.py
+++ b/tests/test_ctype_locale.py
@@ -5,7 +5,7 @@ import angr
 import subprocess
 
 import logging
-l = logging.getLogger('angr.tests.test_ctype_locale')
+l = logging.getLogger(name=__name__)
 
 test_location = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/test_ddg.py
+++ b/tests/test_ddg.py
@@ -5,7 +5,7 @@ import logging
 import time
 import sys
 
-l = logging.getLogger("angr.tests.test_ddg")
+l = logging.getLogger(name=__name__)
 
 import nose
 import angr

--- a/tests/test_dfg.py
+++ b/tests/test_dfg.py
@@ -6,7 +6,7 @@ import sys
 
 from os.path import join, dirname, realpath
 
-l = logging.getLogger("angr.tests.test_dfg")
+l = logging.getLogger(name=__name__)
 l.setLevel(logging.DEBUG)
 
 import nose

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -1,7 +1,7 @@
 import angr
 
 import logging
-l = logging.getLogger("angr.tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_fauxware.py
+++ b/tests/test_fauxware.py
@@ -9,7 +9,7 @@ import angr
 from nose.plugins.attrib import attr
 from angr.state_plugins.history import HistoryIter
 
-l = logging.getLogger("angr.tests")
+l = logging.getLogger(name=__name__)
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
 
 target_addrs = {

--- a/tests/test_file_struct_funcs.py
+++ b/tests/test_file_struct_funcs.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger('angr.tests.test_file_struct_funcs')
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/test_function_manager.py
+++ b/tests/test_function_manager.py
@@ -3,7 +3,7 @@ import angr
 from archinfo import ArchAMD64
 
 import logging
-l = logging.getLogger("angr.tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_gdb_plugin.py
+++ b/tests/test_gdb_plugin.py
@@ -3,7 +3,7 @@ import logging
 import nose
 import angr
 
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 this_file = str(os.path.dirname(os.path.realpath(__file__)))
 test_location = os.path.join(this_file, '../../binaries/tests')

--- a/tests/test_mem_funcs.py
+++ b/tests/test_mem_funcs.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_multi_open_file.py
+++ b/tests/test_multi_open_file.py
@@ -3,7 +3,7 @@ import angr
 import os
 
 import logging
-l = logging.getLogger('angr.tests.test_multi_open_file')
+l = logging.getLogger(name=__name__)
 
 test_location = str(os.path.dirname(os.path.realpath(__file__)))
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_rol.py
+++ b/tests/test_rol.py
@@ -3,7 +3,7 @@ import angr
 from angr.calling_conventions import SimCCSystemVAMD64
 
 import logging
-l = logging.getLogger("angr.tests.test_rol")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_scanf.py
+++ b/tests/test_scanf.py
@@ -6,7 +6,7 @@ import logging
 
 from nose.plugins.attrib import attr
 
-l = logging.getLogger('angr.tests.scanf')
+l = logging.getLogger(name=__name__)
 test_location = str(os.path.dirname(os.path.realpath(__file__)))
 
 class Checker(object):

--- a/tests/test_signed_div.py
+++ b/tests/test_signed_div.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 import logging
-l = logging.getLogger('angr.tests.test_signed_div')
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/test_simulation_manager.py
+++ b/tests/test_simulation_manager.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger("angr_tests.managers")
+l = logging.getLogger(name=__name__)
 
 import os
 location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_sprintf.py
+++ b/tests/test_sprintf.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger('angr_tests.dataflowgraph')
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/test_sscanf.py
+++ b/tests/test_sscanf.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 import logging
-l = logging.getLogger('angr.tests.sscanf')
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/test_str_funcs.py
+++ b/tests/test_str_funcs.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -27,7 +27,7 @@ getchar = make_func('getchar')
 scanf = make_func('scanf')
 
 import logging
-l = logging.getLogger('angr.tests.string')
+l = logging.getLogger(name=__name__)
 
 #@nose.tools.timed(10)
 def test_inline_strlen():

--- a/tests/test_strtol.py
+++ b/tests/test_strtol.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 import logging
-l = logging.getLogger('angr.tests.strtol')
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/test_syscall_override.py
+++ b/tests/test_syscall_override.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger("angr.tests")
+l = logging.getLogger(name=__name__)
 
 import os
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_tech_builder.py
+++ b/tests/test_tech_builder.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger("angr_tests.test_proxy")
+l = logging.getLogger(name=__name__)
 
 import os
 location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_variablerecovery.py
+++ b/tests/test_variablerecovery.py
@@ -9,7 +9,7 @@ from angr.sim_variable import SimStackVariable
 from angr.knowledge_plugins.variables import VariableType
 
 
-l = logging.getLogger('test_variablerecovery')
+l = logging.getLogger(name=__name__)
 
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/tests/test_veritesting.py
+++ b/tests/test_veritesting.py
@@ -4,7 +4,7 @@ import nose
 import angr
 
 import logging
-l = logging.getLogger('angr_tests.veritesting')
+l = logging.getLogger(name=__name__)
 
 import os
 location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -7,7 +7,7 @@ import claripy
 from angr import SimState, SimEngineVEX
 import angr.engines.vex.ccall as s_ccall
 
-l = logging.getLogger('angr.tests.test_vex')
+l = logging.getLogger(name=__name__)
 
 #@nose.tools.timed(10)
 def test_ccall():

--- a/tests/test_vfg.py
+++ b/tests/test_vfg.py
@@ -8,7 +8,7 @@ import nose
 import angr
 import claripy
 
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
 

--- a/tests/test_vfg_path.py
+++ b/tests/test_vfg_path.py
@@ -2,7 +2,7 @@ import angr
 import logging
 import os
 
-l = logging.getLogger("angr_tests")
+l = logging.getLogger(name=__name__)
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  '../../binaries/tests'))
 


### PR DESCRIPTION
... although the loggers are already named after the modules in which they're used, these changes would make code look cleaner.