### PR TITLE
More polishing on the plugin refactor

### DIFF
--- a/angr/__init__.py
+++ b/angr/__init__.py
@@ -40,10 +40,9 @@ from . import type_backend
 from . import sim_type as types
 from .state_hierarchy import StateHierarchy
 
-from .sim_state import SimState, _finish_imports
+from .sim_state import SimState
 from .engines import SimEngineVEX, SimEngine
 from .calling_conventions import DEFAULT_CC, SYSCALL_CC, PointerWrapper, SimCC
-_finish_imports()
 
 # now that we have everything loaded, re-grab the list of loggers
 loggers.load_all_loggers()

--- a/angr/analyses/__init__.py
+++ b/angr/analyses/__init__.py
@@ -1,9 +1,9 @@
-from .analysis import Analysis
+from .analysis import Analysis, AnalysesHub
 from ..misc.ux import deprecated
 
 @deprecated('cls.register_default(name)')
 def register_analysis(cls, name):
-    cls.register_default(name)
+    AnalysesHub.register_default(name, cls)
 
 from .cfg import CFGFast, CFGAccurate, CFG, CFGArchOptions
 from .cdg import CDG

--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -116,7 +116,7 @@ class Analysis(object):
     :ivar project:  The project for this analysis.
     :type project:  angr.Project
     :ivar KnowledgeBase kb: The knowledgebase object.
-    :ivar callable _progress_callback: A callback function for receiving the progress of this analysis. It only takes
+    :ivar _progress_callback: A callback function for receiving the progress of this analysis. It only takes
                                         one argument, which is a float number from 0.0 to 100.0 indicating the current
                                         progress.
     :ivar bool _show_progressbar: If a progressbar should be shown during the analysis. It's independent from

--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import progressbar
 import logging
 
-from ..misc.plugins import PluginVendor, VendorPreset, Plugin
+from ..misc.plugins import PluginVendor, VendorPreset
 from ..misc.ux import deprecated
 from ..errors import AngrAnalysisError
 
@@ -63,8 +63,8 @@ class AnalysesHub(PluginVendor):
     def reload_analyses(self): # pylint: disable=no-self-use
         return
 
-    def _init_plugin(self, plugin):
-        return AnalysisFactory(self.project, plugin)
+    def _init_plugin(self, plugin_cls):
+        return AnalysisFactory(self.project, plugin_cls)
 
     def __getstate__(self):
         s = super(AnalysesHub, self).__getstate__()
@@ -109,7 +109,7 @@ class AnalysisFactory(object):
         return oself
 
 
-class Analysis(Plugin):
+class Analysis(object):
     """
     This class represents an analysis on the program.
 
@@ -123,8 +123,6 @@ class Analysis(Plugin):
                                     _progress_callback.
     :ivar progressbar.ProgressBar _progressbar: The progress bar object.
     """
-
-    _hub_type = AnalysesHub
 
     project = None
     kb = None
@@ -205,11 +203,6 @@ class Analysis(Plugin):
     def __repr__(self):
         return '<%s Analysis Result at %#x>' % (self._name, id(self))
 
-    @classmethod
-    def register_default(cls, name=None, preset='default'):
-        if name is None:
-            name = cls.__name__
-        super(Analysis, cls).register_default(name, preset)
 
 default_analyses = VendorPreset()
 AnalysesHub.register_preset('default', default_analyses)

--- a/angr/analyses/backward_slice.py
+++ b/angr/analyses/backward_slice.py
@@ -684,4 +684,5 @@ class BackwardSlice(Analysis):
 
         return cmp_stmt_id, cmp_tmp_id
 
-BackwardSlice.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('BackwardSlice', BackwardSlice)

--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -645,4 +645,5 @@ class BinaryOptimizer(Analysis):
                 da = DeadAssignment(reg)
                 self.dead_assignments.append(da)
 
-BinaryOptimizer.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('BinaryOptimizer', BinaryOptimizer)

--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -1204,4 +1204,5 @@ class BinDiff(Analysis):
 
         return matches
 
-BinDiff.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('BinDiff', BinDiff)

--- a/angr/analyses/boyscout.py
+++ b/angr/analyses/boyscout.py
@@ -61,4 +61,5 @@ class BoyScout(Analysis):
 
         l.debug("The architecture should be %s with %s", self.arch, self.endianness)
 
-BoyScout.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('BoyScout', BoyScout)

--- a/angr/analyses/callee_cleanup_finder.py
+++ b/angr/analyses/callee_cleanup_finder.py
@@ -61,4 +61,5 @@ class CalleeCleanupFinder(Analysis):
 
         return None
 
-CalleeCleanupFinder.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('CalleeCleanupFinder', CalleeCleanupFinder)

--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -188,4 +188,5 @@ class CDG(Analysis):
                     _l.debug("%s is not in post dominator dict.", b2)
 
 
-CDG.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('CDG', CDG)

--- a/angr/analyses/cfg/cfg.py
+++ b/angr/analyses/cfg/cfg.py
@@ -54,4 +54,5 @@ class CFG(CFGFast):     # pylint: disable=abstract-method
         # Now initializes CFGFast :-)
         CFGFast.__init__(self, **kwargs)
 
-CFG.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('CFG', CFG)

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -3309,4 +3309,5 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         state.options |= self._state_add_options
         state.options = state.options.difference(self._state_remove_options)
 
-CFGAccurate.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('CFGAccurate', CFGAccurate)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3608,4 +3608,5 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         lst = sorted(lst, key=lambda x: x[0])
         return lst
 
-CFGFast.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('CFGFast', CFGFast)

--- a/angr/analyses/congruency_check.py
+++ b/angr/analyses/congruency_check.py
@@ -353,4 +353,5 @@ class CongruencyCheck(Analysis):
         return True
 
 from ..errors import AngrIncongruencyError
-CongruencyCheck.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('CongruencyCheck', CongruencyCheck)

--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -1636,4 +1636,5 @@ class DDG(Analysis):
 
         return sources
 
-DDG.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('DDG', DDG)

--- a/angr/analyses/dfg.py
+++ b/angr/analyses/dfg.py
@@ -165,4 +165,5 @@ class DFG(Analysis):
                 dfgs[node.addr] = dfg
         return dfgs
 
-DFG.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('DFG', DFG)

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -631,4 +631,5 @@ class Disassembly(Analysis):
         return '\n'.join(sum((x.render(formatting) for x in self.raw_result), []))
 
 
-Disassembly.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('Disassembly', Disassembly)

--- a/angr/analyses/girlscout.py
+++ b/angr/analyses/girlscout.py
@@ -807,7 +807,8 @@ class GirlScout(Analysis):
 
         return lst
 
-GirlScout.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('GirlScout', GirlScout)
 
 from ..blade import Blade
 from ..errors import AngrGirlScoutError

--- a/angr/analyses/identifier/identify.py
+++ b/angr/analyses/identifier/identify.py
@@ -829,4 +829,5 @@ class Identifier(Analysis):
         return symbolic_state
 
 
-Identifier.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('Identifier', Identifier)

--- a/angr/analyses/loopfinder.py
+++ b/angr/analyses/loopfinder.py
@@ -169,4 +169,5 @@ class LoopFinder(Analysis):
                 outtop.append(thisloop)
         return outtop, outall
 
-LoopFinder.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('LoopFinder', LoopFinder)

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -2807,4 +2807,5 @@ class Reassembler(Analysis):
         else:
             return data
 
-Reassembler.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('Reassembler', Reassembler)

--- a/angr/analyses/static_hooker.py
+++ b/angr/analyses/static_hooker.py
@@ -45,4 +45,5 @@ class StaticHooker(Analysis):
             else:
                 l.debug("Failed to hook %s at %#x", func.name, func.rebased_addr)
 
-StaticHooker.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('StaticHooker', StaticHooker)

--- a/angr/analyses/variable_recovery/variable_recovery.py
+++ b/angr/analyses/variable_recovery/variable_recovery.py
@@ -503,4 +503,5 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
                                                                          )
 
 
-VariableRecovery.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('VariableRecovery', VariableRecovery)

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -608,4 +608,5 @@ class VariableRecoveryFast(ForwardAnalysis, Analysis):  #pylint:disable=abstract
         return phi_node
 
 
-VariableRecoveryFast.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('VariableRecoveryFast', VariableRecoveryFast)

--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -617,7 +617,8 @@ class Veritesting(Analysis):
 
         return [ (n.addr, n.looping_times) for n in nodes ]
 
-Veritesting.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('Veritesting', Veritesting)
 
 from ..errors import SimValueError, SimSolverModeError, SimError
 from ..sim_options import BYPASS_VERITESTING_EXCEPTIONS

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -1822,4 +1822,6 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
 
         return self._function_node_addrs[function_address]
 
-VFG.register_default()
+
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('VFG', VFG)

--- a/angr/analyses/vsa_ddg.py
+++ b/angr/analyses/vsa_ddg.py
@@ -418,4 +418,5 @@ class VSA_DDG(Analysis):
                 nodes.add(n)
         return nodes
 
-VSA_DDG.register_default()
+from angr.analyses import AnalysesHub
+AnalysesHub.register_default('VSA_DDG', VSA_DDG)

--- a/angr/engines/__init__.py
+++ b/angr/engines/__init__.py
@@ -1,5 +1,3 @@
-from collections import defaultdict, OrderedDict
-
 from .successors import SimSuccessors
 from .engine import SimEngine
 
@@ -12,12 +10,24 @@ from .hook import SimEngineHook
 
 from .hub import EngineHub, EnginePreset
 
-vex_preset = EnginePreset()
+
+# This is a basic preset of essential engines.
+# It is meant to serve as the boilerplate for other presets.
+basic_preset = EnginePreset(['failure', 'syscall', 'hook'])
+basic_preset.add_default_plugin('failure', SimEngineFailure)
+basic_preset.add_default_plugin('syscall', SimEngineSyscall)
+basic_preset.add_default_plugin('hook', SimEngineHook)
+basic_preset.add_default_plugin('procedure', SimEngineProcedure)
+
+basic_preset.procedure_engine = 'procedure'
+
+# This is a VEX engine preset.
+# It will be used as a default preset for engine hub.
+vex_preset = basic_preset.copy()
 EngineHub.register_preset('default', vex_preset)
-vex_preset.set_order(['unicorn', 'default_engine'])
+
 vex_preset.add_default_plugin('unicorn', SimEngineUnicorn)
-vex_preset.add_default_plugin('failure', SimEngineFailure)
-vex_preset.add_default_plugin('syscall', SimEngineSyscall)
-vex_preset.add_default_plugin('hook', SimEngineHook)
-vex_preset.add_default_plugin('default_engine', SimEngineVEX)
-vex_preset.add_default_plugin('procedure_engine', SimEngineProcedure)
+vex_preset.add_default_plugin('vex', SimEngineVEX)
+
+vex_preset.order = 'unicorn', 'vex'
+vex_preset.default_engine = 'vex'

--- a/angr/engines/engine.py
+++ b/angr/engines/engine.py
@@ -1,18 +1,14 @@
 import sys
 import logging
 
-from ..misc.plugins import Plugin
-from .hub import EngineHub
 
 l = logging.getLogger("angr.engines.engine")
 
 
-class SimEngine(Plugin):
+class SimEngine(object):
     """
     A SimEngine is a class which understands how to perform execution on a state. This is a base class.
     """
-
-    _hub_type = EngineHub
 
     def __init__(self, project=None):
         self.project = project

--- a/angr/engines/hub.py
+++ b/angr/engines/hub.py
@@ -1,39 +1,112 @@
 from ..misc.plugins import PluginHub, PluginPreset
-from ..errors import AngrExitError, AngrAssemblyError, SimEngineError
+from ..errors import AngrExitError
+
+import logging
+l = logging.getLogger(name=__name__)
+
 
 class EngineHub(PluginHub):
+
     def __init__(self, project):
         super(EngineHub, self).__init__()
         self.project = project
 
-    def _init_plugin(self, plugin):
-        return plugin(self.project)
+        self._order = None
+        self._default_engine = None
+        self._procedure_engine = None
 
-    def successors(self, state, addr=None, jumpkind=None, **kwargs):
+    def __getstate__(self):
+        s = super(EngineHub, self).__getstate__()
+        return s, self._order, self._default_engine, self._procedure_engine
+
+    def __setstate__(self, s):
+        super(EngineHub, self).__setstate__(s[0])
+        self._order, self._default_engine, self._procedure_engine = s[1:]
+
+    #
+    #   ...
+    #
+
+    def _init_plugin(self, plugin_cls):
+        return plugin_cls(self.project)
+
+    def use_plugin_preset(self, preset, adjust_order=True):  # pylint:disable=arguments-differ
+        super(EngineHub, self).use_plugin_preset(preset)
+
+        if adjust_order and self.plugin_preset.has_order():
+            self.order = self.plugin_preset.order
+
+        if self.plugin_preset.has_default_engine():
+            self.default_engine = self.plugin_preset.default_engine
+
+        if self.plugin_preset.has_procedure_engine():
+            self.procedure_engine = self.plugin_preset.procedure_engine
+
+    #
+    #   ...
+    #
+
+    @property
+    def order(self):
+        if self._order is None:
+            if self.has_plugin_preset:
+                self._order = self.plugin_preset.list_default_plugins()
+            else:
+                self._order = self._active_plugins.keys()
+        return self._order
+
+    @order.setter
+    def order(self, value):
+        self._order = list(value)
+
+    @property
+    def default_engine(self):
+        if self.has_default_engine():
+            return self.get_plugin(self._default_engine)
+        return None
+
+    @default_engine.setter
+    def default_engine(self, value):
+        self._default_engine = value
+
+    def has_default_engine(self):
+        return self._default_engine is not None
+
+    @property
+    def procedure_engine(self):
+        if self.has_procedure_engine():
+            return self.get_plugin(self._procedure_engine)
+        return None
+
+    @procedure_engine.setter
+    def procedure_engine(self, value):
+        self._procedure_engine = value
+
+    def has_procedure_engine(self):
+        return self._procedure_engine is not None
+
+    #
+    #   ...
+    #
+
+    def successors(self, state, addr=None, jumpkind=None, default_engine=False, procedure_engine=False,
+                   engines=None, **kwargs):
         """
         Perform execution using any applicable engine. Enumerate the current engines and use the
-        first one that works. Return a SimSuccessors object classifying the results of the run.
+        first one that works. Engines are enumerated in order, specified by the ``order`` attribute.
 
-        :param state:           The state to analyze
-        :param addr:            optional, an address to execute at instead of the state's ip
-        :param jumpkind:        optional, the jumpkind of the previous exit
-        :param inline:          This is an inline execution. Do not bother copying the state.
+        :param state:               The state to analyze
+        :param addr:                optional, an address to execute at instead of the state's ip
+        :param jumpkind:            optional, the jumpkind of the previous exit
+        :param default_engine:      Whether we should only attempt to use the default engine (usually VEX)
+        :param procedure_engine:    Whether we should only attempt to use the procedure engine
+        :param engines:             A list of engines to try to use, instead of the default.
+                                    This list is expected to contain engine names or engine instances.
 
         Additional keyword arguments will be passed directly into each engine's process method.
-        """
-        if kwargs.get('insn_bytes', None) is not None and kwargs.get('insn_text', None) is not None:
-            raise SimEngineError("You cannot provide both 'insn_bytes' and 'insn_text'!")
-        insn_text = kwargs.get('insn_text', None)
-        if insn_text is not None:
-            insn_bytes = self.project.arch.asm(insn_text,
-                                               addr=kwargs.get('addr', 0),
-                                               as_bytes=True,
-                                               thumb=kwargs.get('thumb', False))
-            if insn_bytes is None:
-                raise AngrAssemblyError("Assembling failed. Please make sure keystone is installed, and the assembly"
-                                        " string is correct.")
-            kwargs['insn_bytes'] = insn_bytes
 
+        :return SimSuccessors:      A SimSuccessors object classifying the results of the run.
+        """
         if addr is not None or jumpkind is not None:
             state = state.copy()
             if addr is not None:
@@ -41,40 +114,101 @@ class EngineHub(PluginHub):
             if jumpkind is not None:
                 state.history.jumpkind = jumpkind
 
-        if not self.has_plugin_preset:
-            raise SimEngineError("EngineHub preset must be present to choose execution...")
+        if default_engine and self.has_default_engine():
+            engines = [self.default_engine]
+        elif procedure_engine and self.has_procedure_engine():
+            engines = [self.procedure_engine]
+        elif engines is None:
+            engines = (self.get_plugin(name) for name in self.order)
+        else:
+            engines = (self.get_plugin(e) if isinstance(e, str) else e for e in engines)
 
-        for engine in self._choose_engine(state, **kwargs):
-            r = engine.process(state, **kwargs)
-            if r.processed:
-                return r
+        for engine in engines:
+            if engine.check(state, **kwargs):
+                r = engine.process(state, **kwargs)
+                if r.processed:
+                    return r
 
         raise AngrExitError("All engines failed to execute!")
 
-    def _choose_engine(self, state, **kwargs):
-        if self.failure.check(state, **kwargs): yield self.failure
-        if self.syscall.check(state, **kwargs): yield self.syscall
-        if self.hook.check(state, **kwargs): yield self.hook
-        for engine in self._active_preset.choose_engine(self, state, **kwargs):
-            yield engine
 
 class EnginePreset(PluginPreset):
-    def __init__(self):
+    """
+    This represents a preset of engines for an engine hub.
+
+    As was pointed out by @rhlemot (see https://github.com/angr/angr/pull/897), there's a lot of
+    behavior in angr which very very specifically assumes that failure/syscall/hook will happen
+    exactly the way we want them to.  This plugin preset addresses the issue by allowing a user to
+    specify a list of plugins that should be executed first using the ``predefined_order``
+    parameter. In that case, any other adjustment to order will be made with respect to the
+    specified predefined order.
+
+    If you want to use your custom preset with the angr's original analyses, you should
+    specify the following predefined order: _failure, syscall, hook_.
+    """
+
+    def __init__(self, predefined_order=None):
         super(EnginePreset, self).__init__()
 
-        self._order = []
+        self._order = predefined_order
+        self._predefined_order = predefined_order or []
 
-    def choose_engine(self, hub, state, **kwargs):
-        for engine_name in self._order:
-            engine = hub.get_plugin(engine_name)
-            if engine.check(state, **kwargs):
-                yield engine
+        self._default_engine = None
+        self._procedure_engine = None
 
-    def set_order(self, order):
-        self._order = list(order)
+    def activate(self, hub):
+        for plugin_name in self._order:
+            if plugin_name not in self._default_plugins:
+                l.warn("%s doesn't provide a plugin for %s. Expect execution to fail.",
+                       self, plugin_name)
+
+    #
+    #   ...
+    #
+
+    @property
+    def order(self):
+        if self._order is None:
+            return self.list_default_plugins()
+        return self._order
+
+    @order.setter
+    def order(self, value):
+        self._order = self._predefined_order + list(value)
+
+    def has_order(self):
+        return self._order is not None
+
+    @property
+    def default_engine(self):
+        return self._default_engine
+
+    @default_engine.setter
+    def default_engine(self, value):
+        if value not in self.list_default_plugins():
+            raise ValueError("%s not in list of default plugins")
+        self._default_engine = value
+
+    def has_default_engine(self):
+        return self._default_engine is not None
+
+    @property
+    def procedure_engine(self):
+        return self._procedure_engine
+
+    @procedure_engine.setter
+    def procedure_engine(self, value):
+        if value not in self.list_default_plugins():
+            raise ValueError("%s not in list of default plugins")
+        self._procedure_engine = value
+
+    def has_procedure_engine(self):
+        return self._procedure_engine is not None
 
     def copy(self):
-        out = EnginePreset()
-        out.default_plugins = dict(self.default_plugins)
-        out._order = list(self._order)
-        return out
+        result = super(EnginePreset, self).copy()
+        result._predefined_order = list(self._predefined_order)  # pylint:disable=protected-access
+        result._order = list(self._order)  # pylint:disable=protected-access
+        result._default_engine = self._default_engine  # pylint:disable=protected-access
+        result._procedure_engine = self._procedure_engine  # pylint:disable=protected-access
+        return result

--- a/angr/engines/hub.py
+++ b/angr/engines/hub.py
@@ -144,7 +144,7 @@ class EnginePreset(PluginPreset):
     specified predefined order.
 
     If you want to use your custom preset with the angr's original analyses, you should
-    specify the following predefined order: _failure, syscall, hook_.
+    specify the following predefined order: ``failure``, ``syscall``, and then ``hook``.
     """
 
     def __init__(self, predefined_order=None):

--- a/angr/errors.py
+++ b/angr/errors.py
@@ -380,5 +380,5 @@ class SimZeroDivisionException(SimException, SimOperationError):
     pass
 
 
-class NoPlugin(AngrError):
+class AngrNoPluginError(AngrError):
     pass

--- a/angr/misc/plugins.py
+++ b/angr/misc/plugins.py
@@ -1,25 +1,29 @@
+from angr.errors import AngrNoPluginError
+
 import logging
-
-from ..errors import NoPlugin
-
 l = logging.getLogger(name=__name__)
+
 
 class PluginHub(object):
     """
-    A plugin hub is an object which contains many plugins, as well as the notion of a "preset", or a backer that can
-    provide default implementations of plugins which cater to a certain circumstance.
+    A plugin hub is an object which contains many plugins, as well as the notion of a "preset", or a
+    backer that can provide default implementations of plugins which cater to a certain
+    circumstance.
 
-    Objects in angr like the SimState, the Analyses hub, the SimEngine selector, etc all use this model to unify their
-    mechanisms for automatically collecting and selecting components to use. If you're familiar with design patterns this is a configurable Strategy Pattern.
+    Objects in angr like the SimState, the Analyses hub, the SimEngine selector, etc all use this
+    model to unify their mechanisms for automatically collecting and selecting components to use. If
+    you're familiar with design patterns this is a configurable Strategy Pattern.
 
-    Each PluginHub subclass should have a corresponding Plugin subclass, and perhaps a PluginPreset subclass if it
-    wants its presets to be able to specify anything more interesting than a list of defaults.
+    Each PluginHub subclass should have a corresponding Plugin subclass, and perhaps a PluginPreset
+    subclass if it wants its presets to be able to specify anything more interesting than a list of
+    defaults.
     """
 
     def __init__(self):
         super(PluginHub, self).__init__()
         self._active_plugins = {}
         self._active_preset = None
+        self._provided_by_preset = []
 
     #
     #   Class methods for registration
@@ -28,7 +32,7 @@ class PluginHub(object):
     _presets = None # not a dict so different subclasses don't share instances
 
     @classmethod
-    def _register_default(cls, name, plugin_cls, preset):
+    def register_default(cls, name, plugin_cls, preset='default'):
         if cls._presets is None or preset not in cls._presets:
             l.error("Preset %s does not exist yet...", preset)
             return
@@ -50,7 +54,7 @@ class PluginHub(object):
     #
 
     def __getstate__(self):
-        return (self._active_plugins, self._active_preset)
+        return self._active_plugins, self._active_preset
 
     def __setstate__(self, s):
         plugins, preset = s
@@ -64,12 +68,12 @@ class PluginHub(object):
     def __getattr__(self, name):
         try:
             return self.get_plugin(name)
-        except NoPlugin:
+        except AngrNoPluginError:
             raise AttributeError(name)
 
     def __dir__(self):
         out = set(self._active_plugins)
-        if self._active_preset is not None:
+        if self.has_plugin_preset:
             out.update(self._active_preset.list_default_plugins())
 
         q = [type(self)]
@@ -106,16 +110,20 @@ class PluginHub(object):
 
         Preset can be either the string name of a preset or a PluginPreset instance.
         """
+        if isinstance(preset, str):
+            try:
+                preset = self._presets[preset]
+            except (AttributeError, KeyError):
+                raise AngrNoPluginError("There is no preset named %s" % preset)
+
+        elif not isinstance(preset, PluginPreset):
+            raise ValueError("Argument must be an instance of PluginPreset: %s" % preset)
+
         if self._active_preset:
             l.warning("Overriding active preset %s with %s", self._active_preset, preset)
             self.discard_plugin_preset()
 
-        if type(preset) is bytes:
-            try:
-                preset = self._presets[preset]
-            except (AttributeError, KeyError):
-                raise NoPlugin("There is no preset named %s" % preset)
-
+        preset.activate(self)
         self._active_preset = preset
 
     def discard_plugin_preset(self):
@@ -123,10 +131,10 @@ class PluginHub(object):
         Discard the current active preset. Will release any active plugins that could have come from the old preset.
         """
         if self.has_plugin_preset:
-            for plugin in self._active_preset.list_default_plugins():
-                if plugin in self._active_plugins and \
-                        type(self._active_plugins) is self._active_preset.default_plugins[plugin]:
-                    self.release_plugin(plugin)
+            for name, plugin in self._active_plugins.items():
+                if id(plugin) in self._provided_by_preset:
+                    self.release_plugin(name)
+            self._active_preset.deactivate(self)
         self._active_preset = None
 
     #
@@ -135,24 +143,32 @@ class PluginHub(object):
 
     def get_plugin(self, name):
         """
-        Get the plugin named ``name``. If no such plugin is currently active, try to activate a new one using the current preset.
+        Get the plugin named ``name``. If no such plugin is currently active, try to activate a new
+        one using the current preset.
         """
         if name in self._active_plugins:
             return self._active_plugins[name]
 
-        if self._active_preset is not None:
-            try:
-                plugin = self._init_plugin(self._active_preset.new_plugin(name))
-            except NoPlugin:
-                pass
-            else:
-                self.register_plugin(name, plugin)
-                return plugin
+        elif self.has_plugin_preset:
+            plugin_cls = self._active_preset.request_plugin(name)
+            plugin = self._init_plugin(plugin_cls)
 
-        raise NoPlugin("No such plugin: %s" % name)
+            # Remember that this plugin was provided by preset.
+            self._provided_by_preset.append(id(plugin))
 
-    def _init_plugin(self, plugin): # pylint: disable=no-self-use
-        return plugin()
+            self.register_plugin(name, plugin)
+            return plugin
+
+        else:
+            raise AngrNoPluginError("No such plugin: %s" % name)
+
+    def _init_plugin(self, plugin_cls):  # pylint: disable=no-self-use
+        """
+        Perform any initialization actions on plugin before it is added to the list of active plugins.
+
+        :param plugin_cls:
+        """
+        return plugin_cls()
 
     def has_plugin(self, name):
         """
@@ -174,22 +190,12 @@ class PluginHub(object):
         """
         Deactivate and remove the plugin with name ``name``.
         """
+        plugin = self._active_plugins[name]
+        if id(plugin) in self._provided_by_preset:
+            self._provided_by_preset.remove(id(plugin))
+
         del self._active_plugins[name]
         delattr(self, name)
-
-
-class Plugin(object):
-    """
-    This is the base class for all plugin objects.
-    It defines nothing but the ability to register itself with a hub.
-
-    Subclasses of this should at the very least set the class variable ``_hub_type`` to the type of the PluginHub they apply to.
-    """
-    _hub_type = None
-
-    @classmethod
-    def register_default(cls, name, preset='default'):
-        cls._hub_type._register_default(name, cls, preset)
 
 
 class PluginPreset(object):
@@ -200,35 +206,63 @@ class PluginPreset(object):
     Unlike Plugins and PluginHubs, instances of PluginPresets are defined on the module level for individual presets.
     You should register the preset instance with a hub to allow plugins to easily add themselves to the preset without an explicit reference to the preset itself.
     """
+
     def __init__(self):
-        self.default_plugins = {}
+        self._default_plugins = {}
+
+    def activate(self, hub):  # pylint:disable=no-self-use,unused-argument
+        """
+        This method is called when the preset becomes active on a hub.
+        """
+        return
+
+    def deactivate(self, hub):  # pylint:disable=no-self-use,unused-argument
+        """
+        This method is called when the preset is discarded from the hub.
+        """
+        return
 
     def add_default_plugin(self, name, plugin_cls):
         """
-        Add a plugin to the preset
+        Add a plugin to the preset.
         """
-        self.default_plugins[name] = plugin_cls
+        self._default_plugins[name] = plugin_cls
 
     def list_default_plugins(self):
         """
-        Return an iterator over the names of available default plugins
+        Return a list of the names of available default plugins.
         """
-        return self.default_plugins.keys()
+        return self._default_plugins.keys()
 
-    def new_plugin(self, name):
+    def request_plugin(self, name):
         """
-        Instanciate and return the plugin with the name ``name``, or raise NoPlugin if the name isn't availble
+        Return the plugin class which is registered under the name ``name``, or raise NoPlugin if
+        the name isn't available.
         """
-        if name not in self.default_plugins:
-            raise NoPlugin
+        try:
+            return self._default_plugins[name]
+        except KeyError:
+            raise AngrNoPluginError("There is no plugin named %s" % name)
 
-        return self.default_plugins[name]
+    def copy(self):
+        """
+        Return a copy of self.
+        """
+        cls = self.__class__
+        result = cls.__new__(cls)
+        result._default_plugins = dict(self._default_plugins)  # pylint:disable=protected-access
+        return result
+
 
 class PluginVendor(PluginHub):
     """
     A specialized hub which serves only as a plugin vendor, never having any "active" plugins.
     It will directly return the plugins provided by the preset instead of instanciating them.
     """
+
+    def release_plugin(self, name):
+        pass
+
     def register_plugin(self, name, plugin):
         pass
 
@@ -239,12 +273,10 @@ class PluginVendor(PluginHub):
         x.remove('has_plugin')
         return x
 
+
 class VendorPreset(PluginPreset):
     """
-    A specialized preset class for use with the PluginVendor
+    A specialized preset class for use with the PluginVendor.
     """
-    def new_plugin(self, name):
-        if name not in self.default_plugins:
-            raise NoPlugin
 
-        return self.default_plugins[name]
+    pass

--- a/angr/project.py
+++ b/angr/project.py
@@ -177,13 +177,13 @@ class Project(object):
         elif self.loader.main_object.engine_preset is not None:
             try:
                 engines.use_plugin_preset(self.loader.main_object.engine_preset)
-            except NoPlugin:
+            except AngrNoPluginError:
                 raise ValueError("The CLE loader asked to use a engine preset: %s" % \
                         self.loader.main_object.engine_preset)
         else:
             try:
                 engines.use_plugin_preset(self.arch.name)
-            except NoPlugin:
+            except AngrNoPluginError:
                 engines.use_plugin_preset('default')
 
         self.engines = engines
@@ -642,7 +642,7 @@ class Project(object):
         return self.simos
 
 
-from .errors import AngrError, NoPlugin
+from .errors import AngrError, AngrNoPluginError
 from .factory import AngrObjectFactory
 from angr.simos import SimOS, os_mapping
 from .analyses.analysis import AnalysesHub

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -79,26 +79,49 @@ class SimState(PluginHub, ana.Storable):
                 p.init_state()
 
         if not self.has_plugin('memory'):
-            # we don't set the memory endness because, unlike registers, it's hard to understand
-            # which endness the data should be read
+            # We don't set the memory endness because, unlike registers, it's hard to understand
+            # which endness the data should be read.
+
+            # If they didn't provide us with either a memory plugin or a plugin preset to use,
+            # we have no choice but to use the 'default' plugin preset.
+            if self.plugin_preset is None:
+                self.use_plugin_preset('default')
 
             if o.ABSTRACT_MEMORY in self.options:
-                # We use SimAbstractMemory in static mode
-                # Convert memory_backer into 'global' region
+                # We use SimAbstractMemory in static mode.
+                # Convert memory_backer into 'global' region.
                 if memory_backer is not None:
                     memory_backer = {'global': memory_backer}
 
                 # TODO: support permissions backer in SimAbstractMemory
-                self.register_plugin('memory', SimAbstractMemory(memory_backer=memory_backer, memory_id="mem"))
+                sim_memory_cls = self.plugin_preset.request_plugin('abs_memory')
+                sim_memory = sim_memory_cls(memory_backer=memory_backer, memory_id='mem')
+
             elif o.FAST_MEMORY in self.options:
-                self.register_plugin('memory', SimFastMemory(memory_backer=memory_backer, memory_id="mem"))
+                sim_memory_cls = self.plugin_preset.request_plugin('fast_memory')
+                sim_memory = sim_memory_cls(memory_backer=memory_backer, memory_id='mem')
+
             else:
-                self.register_plugin('memory', SimSymbolicMemory(memory_backer=memory_backer, permissions_backer=permissions_backer, memory_id="mem"))
+                sim_memory_cls = self.plugin_preset.request_plugin('sym_memory')
+                sim_memory = sim_memory_cls(memory_backer=memory_backer, memory_id='mem',
+                                            permissions_backer=permissions_backer)
+
+            self.register_plugin('memory', sim_memory)
+
         if not self.has_plugin('registers'):
+
+            # Same as for 'memory' plugin.
+            if self.plugin_preset is None:
+                self.use_plugin_preset('default')
+
             if o.FAST_REGISTERS in self.options:
-                self.register_plugin('registers', SimFastMemory(memory_id="reg", endness=self.arch.register_endness))
+                sim_registers_cls = self.plugin_preset.request_plugin('fast_memory')
+                sim_registers = sim_registers_cls(memory_id="reg", endness=self.arch.register_endness)
             else:
-                self.register_plugin('registers', SimSymbolicMemory(memory_id="reg", endness=self.arch.register_endness))
+                sim_registers_cls = self.plugin_preset.request_plugin('sym_memory')
+                sim_registers = sim_registers_cls(memory_id="reg", endness=self.arch.register_endness)
+
+            self.register_plugin('registers', sim_registers)
 
         # OS name
         self.os_name = os_name
@@ -126,7 +149,7 @@ class SimState(PluginHub, ana.Storable):
     def _ana_setstate(self, s):
         ana.Storable._ana_setstate(self, s)
         for p in self.plugins.values():
-            p.set_state(self._get_weakref() if not isinstance(p, SimAbstractMemory) else self)
+            p.set_state(self)
             if p.STRONGREF_STATE:
                 p.set_strongref_state(self)
 
@@ -227,13 +250,13 @@ class SimState(PluginHub, ana.Storable):
         self._set_plugin_state(plugin, inhibit_init=inhibit_init)
         return super(SimState, self).register_plugin(name, plugin)
 
-    def _init_plugin(self, plugin):
-        plugin = plugin()
+    def _init_plugin(self, plugin_cls):
+        plugin = plugin_cls()
         self._set_plugin_state(plugin)
         return plugin
 
     def _set_plugin_state(self, plugin, inhibit_init=False):
-        plugin.set_state(self._get_weakref() if not isinstance(plugin, SimAbstractMemory) else self)
+        plugin.set_state(self)
         if plugin.STRONGREF_STATE:
             plugin.set_strongref_state(self)
         if not inhibit_init:
@@ -801,24 +824,9 @@ class SimState(PluginHub, ana.Storable):
 default_state_plugin_preset = PluginPreset()
 SimState.register_preset('default', default_state_plugin_preset)
 
-# this is to resolve a really really really nasty import loop - SimState requres these plugins,
-# but the plugin base class requres SimState in order to know what its hub is
-_has_late_imports = False
-# pylint: disable=unused-variable,used-before-assignment,redefined-outer-name
-def _finish_imports():
-    from .state_plugins.symbolic_memory import SimSymbolicMemory
-    from .state_plugins.fast_memory import SimFastMemory
-    from .state_plugins.abstract_memory import SimAbstractMemory
-    from .state_plugins.history import SimStateHistory
-    from .state_plugins.inspect import BP_AFTER, BP_BEFORE
-    from .state_plugins.sim_action import SimActionConstraint
-    globals().update(locals())
+from .state_plugins.history import SimStateHistory
+from .state_plugins.inspect import BP_AFTER, BP_BEFORE
+from .state_plugins.sim_action import SimActionConstraint
 
 from . import sim_options as o
-from .errors import SimMergeError, SimValueError, SimStateError, SimSolverModeError, NoPlugin
-SimSymbolicMemory = None
-SimFastMemory = None
-SimAbstractMemory = None
-SimStateHistory = None
-BP_AFTER, BP_BEFORE = None, None
-SimActionConstraint = None
+from .errors import SimMergeError, SimValueError, SimStateError, SimSolverModeError, AngrNoPluginError

--- a/angr/state_plugins/abstract_memory.py
+++ b/angr/state_plugins/abstract_memory.py
@@ -671,3 +671,7 @@ class SimAbstractMemory(SimMemory): #pylint:disable=abstract-method
         for region_id, region in self.regions.items():
             print "Region [%s]:" % region_id
             region.dbg_print(indent=2)
+
+
+from angr.sim_state import SimState
+SimState.register_default('abs_memory', SimAbstractMemory)

--- a/angr/state_plugins/callstack.py
+++ b/angr/state_plugins/callstack.py
@@ -390,4 +390,6 @@ class CallStackAction(object):
         else: # pop
             return "<CallStackAction pop, ret site %#x>" % self.ret_site_addr
 
-CallStack.register_default('callstack')
+
+from angr.sim_state import SimState
+SimState.register_default('callstack', CallStack)

--- a/angr/state_plugins/cgc.py
+++ b/angr/state_plugins/cgc.py
@@ -147,4 +147,6 @@ class SimStateCGC(SimStatePlugin):
 
         self.sinkholes.add((address, length))
 
-SimStateCGC.register_default('cgc')
+
+from angr.sim_state import SimState
+SimState.register_default('cgc', SimStateCGC)

--- a/angr/state_plugins/fast_memory.py
+++ b/angr/state_plugins/fast_memory.py
@@ -226,4 +226,7 @@ class SimFastMemory(SimMemory):
 
         return changes
 
+from angr.sim_state import SimState
+SimState.register_default('fast_memory', SimFastMemory)
+
 from .. import sim_options as options

--- a/angr/state_plugins/gdb.py
+++ b/angr/state_plugins/gdb.py
@@ -136,4 +136,6 @@ class GDB(SimStatePlugin):
     def copy(self):
         return GDB()
 
-GDB.register_default('gdb')
+
+from angr.sim_state import SimState
+SimState.register_default('gdb', GDB)

--- a/angr/state_plugins/globals.py
+++ b/angr/state_plugins/globals.py
@@ -57,4 +57,6 @@ class SimStateGlobals(SimStatePlugin):
     def copy(self):
         return SimStateGlobals(dict(self._backer))
 
-SimStateGlobals.register_default('globals')
+
+from angr.sim_state import SimState
+SimState.register_default('globals', SimStateGlobals)

--- a/angr/state_plugins/history.py
+++ b/angr/state_plugins/history.py
@@ -518,6 +518,10 @@ class LambdaIterIter(LambdaAttrIter):
             for a in reversed(self._f(hist)) if self._reverse else self._f(hist):
                 yield a
 
-SimStateHistory.register_default('history')
+
+from angr.sim_state import SimState
+SimState.register_default('history', SimStateHistory)
+
+
 from .sim_action import SimAction, SimActionConstraint
 from .sim_event import SimEvent

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -333,4 +333,6 @@ class SimInspector(SimStatePlugin):
     def widen(self, others):
         return self._combine(others)
 
-SimInspector.register_default('inspect')
+
+from angr.sim_state import SimState
+SimState.register_default('inspect', SimInspector)

--- a/angr/state_plugins/libc.py
+++ b/angr/state_plugins/libc.py
@@ -266,7 +266,8 @@ class SimStateLibc(SimStatePlugin):
             self.state.memory.map_region(HEAP_LOCATION, 4096*64, 3)
 
 
-SimStateLibc.register_default('libc')
+from angr.sim_state import SimState
+SimState.register_default('libc', SimStateLibc)
 
 from ..errors import SimMemoryError
 from .. import sim_options as o

--- a/angr/state_plugins/log.py
+++ b/angr/state_plugins/log.py
@@ -76,4 +76,6 @@ from ..errors import SimEventError
 from .sim_event import SimEvent
 from .sim_action import SimAction, SimActionConstraint
 
-SimStateLog.register_default('log')
+
+from angr.sim_state import SimState
+SimState.register_default('log', SimStateLog)

--- a/angr/state_plugins/loop_data.py
+++ b/angr/state_plugins/loop_data.py
@@ -37,4 +37,5 @@ class SimStateLoopData(SimStatePlugin):
                                 current_loop=list(self.current_loop))
 
 
-SimStateLoopData.register_default("loop_data")
+from angr.sim_state import SimState
+SimState.register_default('loop_data', SimStateLoopData)

--- a/angr/state_plugins/plugin.py
+++ b/angr/state_plugins/plugin.py
@@ -1,19 +1,15 @@
 import logging
 
-from ..misc.plugins import Plugin
 from ..misc.ux import once
-from ..sim_state import SimState
 
 l = logging.getLogger(name=__name__)
 
-class SimStatePlugin(Plugin):
+class SimStatePlugin(object):
     """
     This is a base class for SimState plugins. A SimState plugin will be copied along with the state when the state is
     branched. They are intended to be used for things such as tracking open files, tracking heap details, and providing
     storage and persistence for SimProcedures.
     """
-
-    _hub_type = SimState
 
     STRONGREF_STATE = False
 
@@ -22,7 +18,7 @@ class SimStatePlugin(Plugin):
 
     # Sets a new state (for example, if the state has been branched)
     def set_state(self, state):
-        self.state = state
+        self.state = state._get_weakref()
 
     def set_strongref_state(self, state):
         pass
@@ -60,21 +56,25 @@ class SimStatePlugin(Plugin):
         :returns: True if the state plugin is actually widened.
         :rtype: bool
         """
-        raise Exception('widen() not implemented for %s', self.__class__.__name__)
+        raise Exception('widen() not implemented for %s' % self.__class__.__name__)
 
     @classmethod
-    def register_default(cls, name, xtr=None): # pylint: disable=arguments-differ
+    def register_default(cls, name, xtr=None):
         if cls is SimStatePlugin:
             if once('simstateplugin_register_default deprecation'):
-                l.critical("SimStatePlugin.register_default(name, cls) is deprecated, please use cls.register_default(name)")
+                l.critical("SimStatePlugin.register_default(name, cls) is deprecated, please use SimState.register_default(name)")
 
-            cls._hub_type._register_default(name, xtr, 'default')
+            from angr.sim_state import SimState
+            SimState.register_default(name, xtr)
+
         else:
             if xtr is cls:
                 if once('simstateplugin_register_default deprecation case 2'):
                     l.critical("SimStatePlugin.register_default(name, cls) is deprecated, please use cls.register_default(name)")
                 xtr = None
-            cls._hub_type._register_default(name, cls, xtr if xtr is not None else 'default')
+
+            from angr.sim_state import SimState
+            SimState.register_default(name, cls, xtr if xtr is not None else 'default')
 
     def init_state(self):
         pass

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -512,7 +512,8 @@ class SimStateSystem(SimStatePlugin):
         return os.path.join(self.chroot, normalized)
 
 
-SimStateSystem.register_default('posix')
+from angr.sim_state import SimState
+SimState.register_default('posix', SimStateSystem)
 
 from ..state_plugins.symbolic_memory import SimSymbolicMemory
 from ..errors import SimPosixError, SimError

--- a/angr/state_plugins/preconstrainer.py
+++ b/angr/state_plugins/preconstrainer.py
@@ -175,4 +175,5 @@ class SimStatePreconstrainer(SimStatePlugin):
                         l.warning("var %s not found in self.variable_map", var)
 
 
-SimStatePreconstrainer.register_default('preconstrainer')
+from angr.sim_state import SimState
+SimState.register_default('preconstrainer', SimStatePreconstrainer)

--- a/angr/state_plugins/scratch.py
+++ b/angr/state_plugins/scratch.py
@@ -147,4 +147,6 @@ from .sim_action import SimActionObject, SimActionData
 from ..errors import SimValueError
 from .. import sim_options as o
 from .inspect import BP_AFTER, BP_BEFORE
-SimStateScratch.register_default('scratch')
+
+from angr.sim_state import SimState
+SimState.register_default('scratch', SimStateScratch)

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -888,7 +888,9 @@ class SimSolver(SimStatePlugin):
         """
         return e.variables
 
-SimSolver.register_default('solver')
+from angr.sim_state import SimState
+SimState.register_default('solver', SimSolver)
+
 from .. import sim_options as o
 from .inspect import BP_AFTER
 from ..errors import SimValueError, SimUnsatError, SimSolverModeError, SimSolverOptionError

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -1190,8 +1190,10 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         """
         return self.mem.unmap_region(addr, length)
 
-SimSymbolicMemory.register_default('memory')
-SimSymbolicMemory.register_default('registers')
+
+from angr.sim_state import SimState
+SimState.register_default('sym_memory', SimSymbolicMemory)
+
 from ..errors import SimUnsatError, SimMemoryError, SimMemoryLimitError, SimMemoryAddressError, SimMergeError
 from .. import sim_options as options
 from .inspect import BP_AFTER, BP_BEFORE

--- a/angr/state_plugins/uc_manager.py
+++ b/angr/state_plugins/uc_manager.py
@@ -79,4 +79,6 @@ class SimUCManager(SimStatePlugin):
         SimStatePlugin.set_state(self, s)
         self._region_base = 0xd0 << (self.state.arch.bits - 8)
 
-SimUCManager.register_default('uc_manager')
+
+from angr.sim_state import SimState
+SimState.register_default('uc_manager', SimUCManager)

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1361,4 +1361,6 @@ class Unicorn(SimStatePlugin):
 
 from ..engines.vex import ccall
 from .. import sim_options as options
-Unicorn.register_default('unicorn')
+
+from angr.sim_state import SimState
+SimState.register_default('unicorn', Unicorn)

--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -252,5 +252,7 @@ class SimMemView(SimStatePlugin):
 from ..sim_type import ALL_TYPES, SimTypeFixedSizeArray, SimTypePointer
 SimMemView.types = ALL_TYPES # identity purposefully here
 
-SimRegNameView.register_default('regs')
-SimMemView.register_default('mem')
+
+from angr.sim_state import SimState
+SimState.register_default('mem', SimMemView)
+SimState.register_default('regs', SimRegNameView)

--- a/tests/test_spiller.py
+++ b/tests/test_spiller.py
@@ -8,6 +8,13 @@ def _bin(s):
     return os.path.join(os.path.dirname(__file__), '../../binaries', s)
 
 def setup():
+
+    # clean up AST cache in claripy, because a cached AST might believe it has been stored in ana after we clean up the
+    # ana storage
+    import claripy
+    claripy.ast.bv._bvv_cache.clear()
+    claripy.ast.bv.BV._hash_cache.clear()
+
     ana.set_dl(ana.DictDataLayer())
 def teardown():
     ana.set_dl(ana.SimpleDataLayer())


### PR DESCRIPTION
Following PR #797 

Sync with angr/angr-doc#186, angr/angr-platforms#18

@rhelmot I feel terrible for raising this issue again, but I've failed to give a proper review when there was time, and I've found some more things that I strongly suggest to change in the overall plugin architecture. I've described these changes in detail in the commit descriptions, but I will duplicate the most important of them here for your convenience.

#### More Polishing to the God of Polishing!

The main change here is how the `PluginHub` detects which plugins need to be released upon the preset deactivation. For that purpose, I've added the `PluginHub._provided_by_preset` attribute, which holds a list of active plugins that was provided by the preset. This is to avoid the case when a plugin, which was registered by an explicit call to `PluginHub.register_plugin`, gets removed because it has the same type, as the plugin that is provided by the preset.

Other changes include some minor refactoring, which doesn't change logic, and are present there just because I can't resist an urge to polish this a little bit more :-)

#### Resolve the circular dependencies between SimState and SimStatePlugin

As the subject suggests, the purpose of this commit is to get rid of the circular dependencies between `SimState` and `SimStatePlugin`. This is done in the following steps:

- Make state plugins register themselves directly with the `SimState.register_default()`, thus eliminating the need in 'SimState._hub_type`.
- Remove plugin imports from the state.py.
- SimState should obtain the 'memory' and the 'registers' plugins by making request to the active preset, instead of directly instantiating the `SimSymbolicMemory`, `SimFastMemory`, etc. classes. This brings more flexibility in deciding what exact memory implementation should be used when `o.ABSTRACT_MEMORY`, `o.FAST_MEMORY`, etc. options are engaged.
- Leave it for plugins to decide on how to store a state, when the `SimStatePlugin.set_state()` is called. For example, `SimAbstractMemory` should store a strong reference to a state, while other plugins should not.

#### Make EngineHub more flexible

First of all, this commit removes the `EngineHubPreset._choose_engine()` method from the `EngineHubPreset` class. Presets should definitely *not* contain any kind of processing logic. Instead, they should provide a list of default plugins, and, possibly, a number of other adjustments, that the hub should incorporate in order to work with the provided plugins properly.

Also, the current implementation of engine chooser limits the processing order to *failure* -> *syscall* -> *hook* -> *other-specified-in-the-preset*, thus not allowing one to include any user-specified engines, registered via the `PluginHub.register_plugin()`, in that order without altering the preset. This is not to mention that it is impossible to execute any engine before the 'failure' engine or others. I would say, the latter is crucial to me.

As an alternative to that, I suggest using the `EngineHub.order` property to define the order, in which engines to be enumerated. The `EngineHubPreset.order` property makes a complement to this by specifying in which order its plugins should be executed.

Second, this commit brings back the `default_engine` and the `procedure_engine` properties to the EngineHub, as well, as the `EngineHub.sucessors()` arguments under the same names. This allow one to specify any engine to go as default/procedure engine, without being bound to any particular engine name. This also allows one to use EngineHub.successors() processing logic without being bound by the current processing order that is set on the hub. 

Last, and not the least, this commit "un-inherits" Plugin base class from SimEngine class. It's natural, that the SimEngine seems like a plugin from the EngineHub perspective but, essentialy, they're not plugins. Of course, they could be plugged into the EngineHub, but other than that, they're stand-alone objects that could be used on their own. There're a lot of places in angr, where SimEngine is used without being accessed from what was the AngrFactory back then. So, for me, it seems like a bit of misunderstaing of what a plugin (and an engine) actually is.