### PR TITLE
cfg fast: fix double add for zero segment

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1186,7 +1186,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             if zeros_length:
                 self._seg_list.occupy(start_addr, zeros_length, "alignment")
                 start_addr += zeros_length
-            start_addr += zeros_length
 
             if string_length == 0 and cc_length == 0 and zeros_length == 0:
                 # umm now it's probably code


### PR DESCRIPTION
If zeros_length is not zero, the previous code added it twice to start_addr.

I haven't actually experienced any bug caused by this, but the code looked wrong to me. If it's not a bug, I can add a comment explaining why we add `zeros_length` twice.