### PR TITLE
CFGFast: Mark a function as returning as early as possible.

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1363,8 +1363,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 self._insert_job(job)
                 return
 
-            self._clean_pending_exits()
-
         # did we finish analyzing any function?
         # fill in self._completed_functions
         self._make_completed_functions()
@@ -1376,6 +1374,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         self._changed_functions = set()
 
         if self._pending_jobs:
+            self._clean_pending_exits()
+
             job = self._pop_pending_job(returning=True)
             if job is not None:
                 self._insert_job(job)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1956,6 +1956,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             if current_function_addr != -1:
                 self._function_exits[current_function_addr].add(addr)
                 self._function_add_return_site(addr, current_function_addr)
+                self.functions[current_function_addr].returning = True
 
             cfg_node.has_return = True
 


### PR DESCRIPTION
This change reduces the number of times method `_analyze_all_function_features()` is called during CFG recovery, thus saving quite a bit time.