### PR TITLE
engine.successors(): test if assembling succeeds

### DIFF
--- a/angr/engines/hub.py
+++ b/angr/engines/hub.py
@@ -1,5 +1,5 @@
 from ..misc.plugins import PluginHub, PluginPreset
-from ..errors import AngrExitError, SimEngineError
+from ..errors import AngrExitError, AngrAssemblyError, SimEngineError
 
 class EngineHub(PluginHub):
     def __init__(self, project):
@@ -25,10 +25,14 @@ class EngineHub(PluginHub):
             raise SimEngineError("You cannot provide both 'insn_bytes' and 'insn_text'!")
         insn_text = kwargs.get('insn_text', None)
         if insn_text is not None:
-            kwargs['insn_bytes'] = self.project.arch.asm(insn_text,
-                                                         addr=kwargs.get('addr', 0),
-                                                         as_bytes=True,
-                                                         thumb=kwargs.get('thumb', False))
+            insn_bytes = self.project.arch.asm(insn_text,
+                                               addr=kwargs.get('addr', 0),
+                                               as_bytes=True,
+                                               thumb=kwargs.get('thumb', False))
+            if insn_bytes is None:
+                raise AngrAssemblyError("Assembling failed. Please make sure keystone is installed, and the assembly"
+                                        " string is correct.")
+            kwargs['insn_bytes'] = insn_bytes
 
         if addr is not None or jumpkind is not None:
             state = state.copy()


### PR DESCRIPTION
@ltfish You just added this for `factory.block()` in  https://github.com/angr/angr/commit/4ec2cc9e00d73a7ca41407358223414b21b15879, so I think we should add another test here too.