### PR TITLE
Tweak `unreachable_history` to do the right thing

### DIFF
--- a/angr/state_hierarchy.py
+++ b/angr/state_hierarchy.py
@@ -182,10 +182,14 @@ class StateHierarchy(object):
     def unreachable_history(self, h):
         href = self.get_ref(h)
 
-        l.debug("Pruning tree given unreachable %s", h)
-        root = self._find_root_unreachable(href)
-        l.debug("... root is %s", root)
-        self._prune_subtree(href)
+        try:
+            l.debug("Pruning tree given unreachable %s", h)
+            root = self._find_root_unreachable(href)
+        except networkx.NetworkXError:
+            l.debug("... not present in graph")
+        else:
+            l.debug("... root is %s", root)
+            self._prune_subtree(root)
 
     #
     # Smart merging support


### PR DESCRIPTION
- I think prune_subtree(href) was a typo and it should be root
- When there's no merging going on and this gets called, everything will crash. I caught the networkx error to make this okay.