### PR TITLE
CFGFast: Special handling of calls targeting the next instruction.

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1744,6 +1744,14 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                     jobs.extend(ent)
                 return jobs
 
+        # Special handling:
+        # If a call instruction has a target that points to the immediate next instruction, we treat it as a boring jump
+        if jumpkind == "Ijk_Call" and \
+                cfg_node.instruction_addrs and \
+                ins_addr == cfg_node.instruction_addrs[-1] and \
+                target_addr == irsb.addr + irsb.size:
+            jumpkind = "Ijk_Boring"
+
         # pylint: disable=too-many-nested-blocks
         if jumpkind == 'Ijk_Boring':
             if target_addr is not None:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1299,6 +1299,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 self._insert_job(job)
                 return
 
+            self._clean_pending_exits()
+
         # did we finish analyzing any function?
         # fill in self._completed_functions
         self._make_completed_functions()
@@ -1367,6 +1369,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 self._register_analysis_job(addr, job)
 
     def _post_analysis(self):
+
+        self._make_completed_functions()
 
         self._analyze_all_function_features()
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1751,6 +1751,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         # Special handling:
         # If a call instruction has a target that points to the immediate next instruction, we treat it as a boring jump
         if jumpkind == "Ijk_Call" and \
+                not self.project.arch.call_pushes_ret and \
                 cfg_node.instruction_addrs and \
                 ins_addr == cfg_node.instruction_addrs[-1] and \
                 target_addr == irsb.addr + irsb.size:


### PR DESCRIPTION
In ARM firmware samples, we sometimes see the following pattern:

0034897c:    BL 348980
00348980:    BL 348984
00348984:    BL 348988
...

Now we treat all of them as boring jumps, instead of treating them as
calls.