### PR TITLE
setup.py: fix version for capstone

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         'ana',
         'bintrees',
         'cachetools',
-        'capstone>=3.0.5.rc2',
+        'capstone>=3.0.5rc2',
         'cooldict',
         'dpkt-fix',
         'futures',


### PR DESCRIPTION
There should be never more than two dots: https://pypi.python.org/pypi/capstone/3.0.5rc2