### PR TITLE
SimSolver: Do not return a symbolic solver if SYMBOLIC is absent from state options.

### DIFF
--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -523,7 +523,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                         # will lose some edges in this way, but in general it is acceptable.
                         new_dst.looping_times <= max_loop_unrolling_times):
                     # Log all successors of the dst node
-                    dst_successors = graph_copy.successors(dst)
+                    dst_successors = list(graph_copy.successors(dst))
                     # Add new_dst to the graph
                     edge_data = graph_copy.get_edge_data(src, dst)
                     graph_copy.add_edge(src, new_dst, **edge_data)

--- a/angr/block.py
+++ b/angr/block.py
@@ -11,7 +11,7 @@ DEFAULT_VEX_ENGINE = SimEngineVEX(None)  # this is only used when Block is not i
 class Block(object):
     BLOCK_MAX_SIZE = 4096
 
-    __slots__ = ['_project', '_bytes', '_vex', 'thumb', '_capstone', 'addr', 'size', 'arch', 'instructions',
+    __slots__ = ['_project', '_bytes', '_vex', 'thumb', '_capstone', 'addr', 'size', 'arch', '_instructions',
                  '_instruction_addrs', '_opt_level'
                  ]
 
@@ -64,7 +64,7 @@ class Block(object):
         self._capstone = None
         self.size = size
 
-        self.instructions = num_inst
+        self._instructions = num_inst
         self._instruction_addrs = []
 
         self._parse_vex_info()
@@ -89,7 +89,7 @@ class Block(object):
     def _parse_vex_info(self):
         vex = self._vex
         if vex is not None:
-            self.instructions = vex.instructions
+            self._instructions = vex.instructions
             self._instruction_addrs = []
             self.size = vex.size
 
@@ -140,7 +140,7 @@ class Block(object):
                     addr=self.addr,
                     thumb=self.thumb,
                     size=self.size,
-                    num_inst=self.instructions,
+                    num_inst=self._instructions,
                     opt_level=self._opt_level,
                     arch=self.arch,
             )
@@ -184,12 +184,21 @@ class Block(object):
         return self._bytes
 
     @property
+    def instructions(self):
+        if not self._instructions and self._vex is None:
+            # initialize from VEX
+            _ = self.vex
+
+        return self._instructions
+
+    @property
     def instruction_addrs(self):
         if not self._instruction_addrs and self._vex is None:
             # initialize instruction addrs
             _ = self.vex
 
         return self._instruction_addrs
+
 
 class CapstoneBlock(object):
     """

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -180,7 +180,7 @@ class SimSuccessors(object):
                     ret_addr = state.project.simos.unresolvable_target
             try:
                 state_addr = state.addr
-            except SimValueError:
+            except (SimValueError, SimSolverModeError):
                 state_addr = None
             new_frame = CallStack(
                     call_site_addr=state.history.recent_bbl_addrs[-1],

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -170,14 +170,15 @@ class SimSuccessors(object):
             if new_func_addr is not None and not claripy.is_true(new_func_addr == state.regs._ip):
                 state.regs._ip = new_func_addr
 
-            if state.arch.call_pushes_ret:
-                ret_addr = state.mem[state.regs._sp].long.concrete
-            else:
-                try:
+            try:
+                if state.arch.call_pushes_ret:
+                    ret_addr = state.mem[state.regs._sp].long.concrete
+                else:
                     ret_addr = state.se.eval(state.regs._lr)
-                except SimSolverModeError:
-                    # Use the address for UnresolvableTarget instead.
-                    ret_addr = state.project.simos.unresolvable_target
+            except SimSolverModeError:
+                # Use the address for UnresolvableTarget instead.
+                ret_addr = state.project.simos.unresolvable_target
+
             try:
                 state_addr = state.addr
             except (SimValueError, SimSolverModeError):

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -183,10 +183,16 @@ class SimSuccessors(object):
                 state_addr = state.addr
             except (SimValueError, SimSolverModeError):
                 state_addr = None
+
+            try:
+                stack_ptr = state.se.eval(state.regs._sp)
+            except SimSolverModeError:
+                stack_ptr = 0
+
             new_frame = CallStack(
                     call_site_addr=state.history.recent_bbl_addrs[-1],
                     func_addr=state_addr,
-                    stack_ptr=state.se.eval(state.regs._sp),
+                    stack_ptr=stack_ptr,
                     ret_addr=ret_addr,
                     jumpkind='Ijk_Call')
             state.callstack.push(new_frame)

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -267,11 +267,11 @@ class SimSolver(SimStatePlugin):
 
         if o.ABSTRACT_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverVSA()
-        elif o.REPLACEMENT_SOLVER in self.state.options:
+        elif o.SYMBOLIC in self.state.options and o.REPLACEMENT_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverReplacement(auto_replace=False)
-        elif o.CACHELESS_SOLVER in self.state.options:
+        elif o.SYMBOLIC in self.state.options and o.CACHELESS_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverCacheless(track=track)
-        elif o.COMPOSITE_SOLVER in self.state.options:
+        elif o.SYMBOLIC in self.state.options and o.COMPOSITE_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverComposite(track=track)
         elif o.SYMBOLIC in self.state.options and o.approximation & self.state.options:
             self._stored_solver = claripy.SolverHybrid(track=track)


### PR DESCRIPTION
This allows `fastpath` mode to work as expected: No Z3 solving should ever be done in `fastpath` mode.