### PR TITLE
Do not fail state stepping if we cannot solve the return address.

### DIFF
--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -176,7 +176,7 @@ class SimSuccessors(object):
                 try:
                     ret_addr = state.se.eval(state.regs._lr)
                 except SimSolverModeError:
-                    # Give it a random address - in memory of the "constant analysis" guy.
+                    # Use the address for UnresolvableTarget instead.
                     ret_addr = state.project.simos.unresolvable_target
             try:
                 state_addr = state.addr

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -173,7 +173,11 @@ class SimSuccessors(object):
             if state.arch.call_pushes_ret:
                 ret_addr = state.mem[state.regs._sp].long.concrete
             else:
-                ret_addr = state.se.eval(state.regs._lr)
+                try:
+                    ret_addr = state.se.eval(state.regs._lr)
+                except SimSolverModeError:
+                    # Give it a random address - in memory of the "constant analysis" guy.
+                    ret_addr = 0xc0deb4be
             try:
                 state_addr = state.addr
             except SimValueError:

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -177,7 +177,7 @@ class SimSuccessors(object):
                     ret_addr = state.se.eval(state.regs._lr)
                 except SimSolverModeError:
                     # Give it a random address - in memory of the "constant analysis" guy.
-                    ret_addr = 0xc0deb4be
+                    ret_addr = state.project.simos.unresolvable_target
             try:
                 state_addr = state.addr
             except SimValueError:

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -32,6 +32,7 @@ class SimOS(object):
         self.project = project
         self.name = name
         self.return_deadend = None
+        self.unresolvable_target = None
 
     def configure_project(self):
         """
@@ -39,6 +40,9 @@ class SimOS(object):
         """
         self.return_deadend = self.project.loader.extern_object.allocate()
         self.project.hook(self.return_deadend, P['stubs']['CallReturn']())
+
+        self.unresolvable_target = self.project.loader.extern_object.allocate()
+        self.project.hook(self.unresolvable_target, P['stubs']['UnresolvableTarget'])
 
         def irelative_resolver(resolver_addr):
             # autohooking runs before this does, might have provided this already


### PR DESCRIPTION
This might happen when the return address is a symbolic value and we are
in fastpath mode (CFGAccurate). The hack is to use the address of
`UnresolvableTarget`.

This PR relies on PR #943.