### PR TITLE
setup.py: Limit futures to Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         'capstone>=3.0.5rc2',
         'cooldict',
         'dpkt-fix',
-        'futures',
+        'futures; python_version == "2.7"',
         'mulpyplexer',
         'networkx',
         'progressbar',


### PR DESCRIPTION
futures is a backport of Python 3's concurrent.futures package, so it is
not needed nor available as package on Python 3.

Signed-off-by: Andreas Färber <afaerber@suse.de>