### PR TITLE
A faster method to evaluate symbolic targets coming from jump tables.

### DIFF
--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -388,7 +388,8 @@ class SimSuccessors(object):
         if len(self.flat_successors) == 1 and len(self.unconstrained_successors) == 0:
             self.flat_successors[0].scratch.avoidable = False
 
-    def _eval_target_jumptable(self, state, ip, limit):
+    @staticmethod
+    def _eval_target_jumptable(state, ip, limit):
         """
         A *very* fast method to evaluate symbolic jump targets if they are a) concrete targets, or b) targets coming
         from jump tables.
@@ -477,7 +478,8 @@ class SimSuccessors(object):
         else:
             return cond_and_targets[ : limit]
 
-    def _eval_target_brutal(self, state, ip, limit):
+    @staticmethod
+    def _eval_target_brutal(state, ip, limit):
         """
         The traditional way of evaluating symbolic jump targets.
 

--- a/angr/state_plugins/__init__.py
+++ b/angr/state_plugins/__init__.py
@@ -23,3 +23,4 @@ from .preconstrainer import *
 from .loop_data import *
 from .view import *
 from .filesystem import *
+from .configuration import SimStateConfiguration

--- a/angr/state_plugins/configuration.py
+++ b/angr/state_plugins/configuration.py
@@ -24,6 +24,12 @@ class SimStateConfiguration(SimStatePlugin):
 
         return s
 
+    def merge(self, _others, _merge_conditions, _common_ancestor=None):
+        return self.copy(None)
+
+    def widen(self, _others):
+        return self.copy(None)
+
 
 from ..sim_state import SimState
 SimState.register_default('config', SimStateConfiguration)

--- a/angr/state_plugins/configuration.py
+++ b/angr/state_plugins/configuration.py
@@ -4,18 +4,24 @@ from .plugin import SimStatePlugin
 
 class SimStateConfiguration(SimStatePlugin):
 
-    __slots__ = [ 'symbolic_ip_max_targets' ]
+    __slots__ = [ 'symbolic_ip_max_targets', 'jumptable_symbolic_ip_max_targets' ]
 
     def __init__(self,
-                 symbolic_ip_max_targets=None
+                 symbolic_ip_max_targets=None,
+                 jumptable_symbolic_ip_max_targets=None,
                  ):
         super(SimStateConfiguration, self).__init__()
 
-        self.symbolic_ip_max_targets = 16384 if symbolic_ip_max_targets is None else symbolic_ip_max_targets
+        self.symbolic_ip_max_targets = 256 if symbolic_ip_max_targets is None else symbolic_ip_max_targets
+        self.jumptable_symbolic_ip_max_targets = 16384 \
+            if jumptable_symbolic_ip_max_targets is None else jumptable_symbolic_ip_max_targets
 
     def copy(self):
         s = SimStateConfiguration()
-        s.symbolic_ip_max_targets = self.symbolic_ip_max_targets
+
+        for slot in SimStateConfiguration.__slots__:
+            setattr(s, slot, getattr(self, slot))
+
         return s
 
 

--- a/angr/state_plugins/configuration.py
+++ b/angr/state_plugins/configuration.py
@@ -1,0 +1,23 @@
+
+from .plugin import SimStatePlugin
+
+
+class SimStateConfiguration(SimStatePlugin):
+
+    __slots__ = [ 'symbolic_ip_max_targets' ]
+
+    def __init__(self,
+                 symbolic_ip_max_targets=None
+                 ):
+        super(SimStateConfiguration, self).__init__()
+
+        self.symbolic_ip_max_targets = 16384 if symbolic_ip_max_targets is None else symbolic_ip_max_targets
+
+    def copy(self):
+        s = SimStateConfiguration()
+        s.symbolic_ip_max_targets = self.symbolic_ip_max_targets
+        return s
+
+
+from ..sim_state import SimState
+SimState.register_default('config', SimStateConfiguration)

--- a/angr/state_plugins/configuration.py
+++ b/angr/state_plugins/configuration.py
@@ -16,7 +16,7 @@ class SimStateConfiguration(SimStatePlugin):
         self.jumptable_symbolic_ip_max_targets = 16384 \
             if jumptable_symbolic_ip_max_targets is None else jumptable_symbolic_ip_max_targets
 
-    def copy(self):
+    def copy(self, memo):  # pylint:disable=unused-argument
         s = SimStateConfiguration()
 
         for slot in SimStateConfiguration.__slots__:

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -526,10 +526,11 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             else:
                 raise
 
-        constraint_options = []
+        constraint_options = [ ]
 
         if len(addrs) == 1:
             # It's not an conditional reaed
+            constraint_options.append(dst == addrs[0])
             read_value = self._read_from(addrs[0], size, inspect=inspect, events=events)
         else:
             read_value = DUMMY_SYMBOLIC_READ_VALUE  # it's a sentinel value and should never be touched

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -526,13 +526,18 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             else:
                 raise
 
-        read_value = DUMMY_SYMBOLIC_READ_VALUE  # it will never be touched
-        constraint_options = [ ]
+        constraint_options = []
 
-        for a in addrs:
-            read_value = self.state.se.If(dst == a, self._read_from(a, size, inspect=inspect, events=events),
-                                          read_value)
-            constraint_options.append(dst == a)
+        if len(addrs) == 1:
+            # It's not an conditional reaed
+            read_value = self._read_from(addrs[0], size, inspect=inspect, events=events)
+        else:
+            read_value = DUMMY_SYMBOLIC_READ_VALUE  # it's a sentinel value and should never be touched
+
+            for a in addrs:
+                read_value = self.state.se.If(dst == a, self._read_from(a, size, inspect=inspect, events=events),
+                                              read_value)
+                constraint_options.append(dst == a)
 
         if len(constraint_options) > 1:
             load_constraint = [ self.state.se.Or(*constraint_options) ]

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -6,7 +6,7 @@ import itertools
 l = logging.getLogger("angr.state_plugins.symbolic_memory")
 
 import claripy
-from ..storage.memory import SimMemory
+from ..storage.memory import SimMemory, DUMMY_SYMBOLIC_READ_VALUE
 from ..storage.paged_memory import SimPagedMemory
 from ..storage.memory_object import SimMemoryObject
 
@@ -526,11 +526,10 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             else:
                 raise
 
-        read_value = self._read_from(addrs[0], size, inspect=inspect,
-                events=events, ret_on_segv=ret_on_segv)
-        constraint_options = [ dst == addrs[0] ]
+        read_value = DUMMY_SYMBOLIC_READ_VALUE  # it will never be touched
+        constraint_options = [ ]
 
-        for a in addrs[1:]:
+        for a in addrs:
             read_value = self.state.se.If(dst == a, self._read_from(a, size, inspect=inspect, events=events),
                                           read_value)
             constraint_options.append(dst == a)

--- a/angr/storage/memory.py
+++ b/angr/storage/memory.py
@@ -3,12 +3,14 @@ import claripy
 from sortedcontainers import SortedDict
 
 from ..state_plugins.plugin import SimStatePlugin
-from ..engines.vex.ccall import _get_flags
+
 
 l = logging.getLogger("angr.storage.memory")
 
 stn_map = { 'st%d' % n: n for n in xrange(8) }
 tag_map = { 'tag%d' % n: n for n in xrange(8) }
+
+DUMMY_SYMBOLIC_READ_VALUE = 0xc0deb4be
 
 
 class AddressWrapper(object):
@@ -363,6 +365,10 @@ class SimMemory(SimStatePlugin):
                 self._generic_region_map = None
 
     def _resolve_location_name(self, name, is_write=False):
+
+        # Delayed load so SimMemory does not rely on SimEngines
+        from ..engines.vex.ccall import _get_flags
+
         if self.category == 'reg':
             if self.state.arch.name in ('X86', 'AMD64'):
                 if name in stn_map:


### PR DESCRIPTION
With this commit, we can easily support 2048 symbolic jump targets on my laptop without overloading Z3.