### PR TITLE
Set function name to the name passed as parameter

### DIFF
--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -308,6 +308,8 @@ class FunctionManager(KnowledgeBasePlugin, collections.Mapping):
             elif create:
                 # the function is not found
                 f = self._function_map[addr]
+                if name is not None:
+                    f.name = name
                 if syscall:
                     f.is_syscall=True
                 return f


### PR DESCRIPTION
If you passed proj.kb.functions.function both a name and an address to create a new function like:
`proj.kb.functions.function(name='main', addr=0x1337, create=True)`
The resulting function would not have that name set.