### PR TITLE
Fix SimState.jumpkind.

### DIFF
--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -793,7 +793,7 @@ class SimState(PluginHub, ana.Storable):
 
     @property
     def jumpkind(self):
-        return self.scratch.jumpkind
+        return None if not self.history.jumpkinds else self.history.jumpkinds[-1]
 
     @property
     def last_actions(self):


### PR DESCRIPTION
SimState.scratch.jumpkind is always None after copying a state, so we
cannot use SimState.jumpkind to retrieve the previous jumpkind in
history. Now it is correctly implemented by accessing state history.