### PR TITLE
fix bug in _func_addrs_from_prologues() in cfg_fast.py

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1493,8 +1493,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 for mo in regex.finditer(bytes_):
                     position = mo.start() + start_
                     if position % self.project.arch.instruction_alignment == 0:
-                        if self._addr_in_exec_memory_regions(position):
-                            unassured_functions.append(AT.from_rva(position, self._binary).to_mva())
+                        mapped_position = AT.from_rva(position, self._binary).to_mva()
+                        if self._addr_in_exec_memory_regions(mapped_position):
+                            unassured_functions.append(mapped_position)
 
         return unassured_functions
 


### PR DESCRIPTION
When resolve func_addrs from prologues in `_func_addrs_from_prologues()`, the position is rva, but the items of `self._exec_mem_regions` are mva, so the call to `self._addr_in_exec_memory_regions(position)` always returns False.
See https://github.com/angr/angr/blob/1e335a20f87a8f7fa24ab27c71b7209b5f3dfb3b/angr/analyses/cfg/cfg_fast.py#L1490-L1497