### PR TITLE
Add support for exit handlers

### DIFF
--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -128,6 +128,9 @@ class __libc_start_main(angr.SimProcedure):
         self.main, self.argc, self.argv, self.init, self.fini = self._extract_args(self.state, main, argc, argv, init,
                                                                                    fini)
 
+        self.state.libc._init = self.init
+        self.state.libc._finit = self.fini
+
         # TODO: __cxa_atexit calls for various at-exit needs
 
         self.call(self.init, (self.argc, self.argv, self.envp), 'after_init')
@@ -139,8 +142,22 @@ class __libc_start_main(angr.SimProcedure):
             self.state.regs.rsp = (self.state.regs.rsp & 0xfffffffffffffff0) - 8
         self.call(self.main, (self.argc, self.argv, self.envp), 'after_main')
 
+    def _run_exit_handler(self, exit_code):
+        if len(self.state.libc._exit_handlers) > 0:
+            addr = self.state.libc._exit_handlers[0]
+            addr = self.state.solver.eval(addr)
+            self.state.libc._exit_handlers = self.state.libc._exit_handlers[1:]
+            self.call(addr, (), '_run_exit_handler')
+        else:
+            if self.state.libc._finit != None:
+                self.call(self.state.libc._finit, (exit_code), '_finish')
+            self.exit(exit_code)
+
+    def _finish(self, exit_code):
+        self.exit(exit_code)
+
     def after_main(self, main, argc, argv, init, fini, exit_addr=0):
-        self.exit(0)
+        self._run_exit_handler(0)
 
     def static_exits(self, blocks):
         # Execute those blocks with a blank state, and then dump the arguments

--- a/angr/procedures/libc/atexit.py
+++ b/angr/procedures/libc/atexit.py
@@ -1,0 +1,9 @@
+import angr
+
+######################################
+# atexit: register exit handlers
+######################################
+
+class atexit(angr.SimProcedure):
+    def run(self, func):
+        self.state.libc._exit_handlers.append(func)

--- a/angr/procedures/libc/error.py
+++ b/angr/procedures/libc/error.py
@@ -1,0 +1,16 @@
+import angr
+
+from .exit import exit
+
+######################################
+# error
+######################################
+
+class error(exit):
+
+    def run(self, status, errnum, fmtstr, *args, **kwargs):
+
+        # TODO: output error message
+        status_c = self.state.solver.eval(status)
+        if status_c != 0:
+            self._run_exit_handlers()

--- a/angr/procedures/libc/exit.py
+++ b/angr/procedures/libc/exit.py
@@ -1,12 +1,14 @@
 import angr
 
+from ..glibc.__libc_start_main import __libc_start_main
+
 ######################################
 # exit
 ######################################
 
-class exit(angr.SimProcedure): #pylint:disable=redefined-builtin
-    #pylint:disable=arguments-differ
+class exit(__libc_start_main):
 
     NO_RET = True
     def run(self, exit_code):
+        self._run_exit_handler()
         self.exit(exit_code)

--- a/angr/state_plugins/libc.py
+++ b/angr/state_plugins/libc.py
@@ -204,6 +204,13 @@ class SimStateLibc(SimStatePlugin):
         # helpful stuff
         self.strdup_stack = [ ]
 
+        # support for atexit
+        self._exit_handlers = [ ]
+
+        # constructor and destructor
+        self._init = None
+        self._finit = None
+
         # as per Audrey:
         # the idea is that there's two abi versions, and for one of them, the
         # address passed to libc_start_main isn't actually the address of the
@@ -241,6 +248,14 @@ class SimStateLibc(SimStatePlugin):
         c.ctype_toupper_loc_table_ptr = self.ctype_toupper_loc_table_ptr
         c._errno_location = self._errno_location
         #c.aa = self.aa
+
+        # atexit support
+        c._exit_handlers = self._exit_handlers[:]
+
+
+        # constructor and destructor
+        c._init = self._init
+        c._finit = self._finit
 
         return c
 


### PR DESCRIPTION
Locations modified:
- add `atexit` simprocedure
- add a list in libc state plugin for storing the registered exit handlers
- in `error`, when status is not zero, it calls exit and thus exit handlers
- in `__libc_start_main`, after main is done and before `fini` handlers are called
- add `exit` sim procedure to make it call exit handlers and `fini` handlers. 