### PR TITLE
Specify Python 2 and IPython 5.x LTS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ angr is a platform-agnostic binary analysis framework developed by the Computer 
 
 # What?
 
-angr is a suite of python libraries that let you load a binary and do a lot of cool things to it:
+angr is a suite of Python 2 libraries that let you load a binary and do a lot of cool things to it:
 
 - Disassembly and intermediate-representation lifting
 - Program instrumentation
@@ -20,7 +20,7 @@ angr is a suite of python libraries that let you load a binary and do a lot of c
 - Data-dependency analysis
 - Value-set analysis (VSA)
 
-The most common angr operation is loading a binary: `p = angr.Project('/bin/bash')` If you do this in IPython, you can use tab-autocomplete to browse the [top-level-accessible methods](http://docs.angr.io/docs/toplevel.html) and their docstrings.
+The most common angr operation is loading a binary: `p = angr.Project('/bin/bash')` If you do this in IPython 5.x LTS, you can use tab-autocomplete to browse the [top-level-accessible methods](http://docs.angr.io/docs/toplevel.html) and their docstrings.
 
 The short version of "how to install angr" is `mkvirtualenv angr && pip install angr`.
 
@@ -36,7 +36,7 @@ project = angr.Project("angr-doc/examples/defcamp_r100/r100", auto_load_libs=Fal
 
 @project.hook(0x400844)
 def print_flag(state):
-    print "FLAG SHOULD BE:", state.posix.dump_fd(0)
+    print("FLAG SHOULD BE:", state.posix.dump_fd(0))
     project.terminate_execution()
 
 project.execute()

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ angr is a suite of Python 2 libraries that let you load a binary and do a lot of
 - Data-dependency analysis
 - Value-set analysis (VSA)
 
-The most common angr operation is loading a binary: `p = angr.Project('/bin/bash')` If you do this in IPython 5.x LTS, you can use tab-autocomplete to browse the [top-level-accessible methods](http://docs.angr.io/docs/toplevel.html) and their docstrings.
+The most common angr operation is loading a binary: `p = angr.Project('/bin/bash')` If you do this in IPython 5.x LTS or earlier, you can use tab-autocomplete to browse the [top-level-accessible methods](http://docs.angr.io/docs/toplevel.html) and their docstrings.
 
-The short version of "how to install angr" is `mkvirtualenv angr && pip install angr`.
+The short version of "how to install angr" is `mkvirtualenv angr && python2 -m pip install angr`.
 
 # Example
 


### PR DESCRIPTION
Angr is not yet compatible with Python 3 or [IPython 6 or 7](https://github.com/ipython/ipython).