### PR TITLE
Fixed when `bound_reached` callback is triggered

### DIFF
--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -126,10 +126,10 @@ class LoopSeer(ExplorationTechnique):
                     state.loop_data.current_loop.pop()
 
                 if self.bound is not None:
-                    if self.bound_reached is not None:
-                        simgr = self.bound_reached(simgr)
-                    else:
-                        if state.loop_data.trip_counts[header][-1] >= self.bound:
+                    if state.loop_data.trip_counts[header][-1] >= self.bound:
+                        if self.bound_reached is not None:
+                            simgr = self.bound_reached(simgr)
+                        else:
                             simgr.stashes[stash].remove(state)
                             simgr.stashes[self.discard_stash].append(state)
 


### PR DESCRIPTION
`bound_reached` callback was being called before the specified bound argument is reached. My changes fixes that issues and calls **provided** `bound_reached` callback only when **provided** `bound` argument is reached by the loop.