### PR TITLE
Make quasi_topological_sort work for both networks versions

### DIFF
--- a/angr/analyses/cfg/cfg_utils.py
+++ b/angr/analyses/cfg/cfg_utils.py
@@ -148,7 +148,7 @@ class CFGUtils(object):
             graph_copy.add_edge(src, dst)
 
         # add loners
-        out_degree_zero_nodes = [node for (node, degree) in dict(graph.out_degree()).iteritems() if degree == 0]
+        out_degree_zero_nodes = [node for (node, degree) in graph.out_degree() if degree == 0]
         for node in out_degree_zero_nodes:
             if graph.in_degree(node) == 0:
                 graph_copy.add_node(node)

--- a/angr/analyses/cfg/cfg_utils.py
+++ b/angr/analyses/cfg/cfg_utils.py
@@ -148,7 +148,7 @@ class CFGUtils(object):
             graph_copy.add_edge(src, dst)
 
         # add loners
-        out_degree_zero_nodes = [node for (node, degree) in graph.out_degree() if degree == 0]
+        out_degree_zero_nodes = [node for (node, degree) in dict(graph.out_degree()).iteritems() if degree == 0]
         for node in out_degree_zero_nodes:
             if graph.in_degree(node) == 0:
                 graph_copy.add_node(node)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cooldict
 dpkt-fix
 futures
 mulpyplexer
-networkx
+networkx>=2.0
 progressbar
 pyvex>=7.8.2.21
 rpyc

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
         'dpkt-fix',
         'futures; python_version == "2.7"',
         'mulpyplexer',
-        'networkx',
+        'networkx>=2.0',
         'progressbar',
         'rpyc',
         'cffi>=1.7.0',


### PR DESCRIPTION
@ltfish please review this. Your change in https://github.com/angr/angr/commit/00822d158ca9800875cda9c159a22acda060508e#diff-93e27aa7a6a6b0cfb8d92d0d42184d3b doesn't work for networkx 1.11

Thank you