### PR TITLE
catching StopIteration exception

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -970,6 +970,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             start_addr = next(self._regions.irange(maximum=address, reverse=True))
         except KeyError:
             return False
+	except StopIteration:
+	    return False
         else:
             return address < self._regions[start_addr]
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -968,10 +968,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         try:
             start_addr = next(self._regions.irange(maximum=address, reverse=True))
-        except KeyError:
+        except StopIteration:
             return False
-	except StopIteration:
-	    return False
         else:
             return address < self._regions[start_addr]
 


### PR DESCRIPTION
Hi

While experimenting with angr on arm32 elfs, i stumbled upon a bug, which caused CFG_Fast to throw a "StopIteration"-Exception.

`
import angr
`
`
p = angr.Project("test.so", auto_load_libs=False)
`
`
cfg = p.analyses.CFGFast()
`

If needed, i can supply the binary, but the fix is fairly simple. 