### PR TITLE
Missing mode parameter when calling open from opendir

### DIFF
--- a/angr/procedures/posix/opendir.py
+++ b/angr/procedures/posix/opendir.py
@@ -3,6 +3,6 @@ from .open import open
 
 class opendir(angr.SimProcedure):
     def run(self, fname):
-        p_open = self.inline_call(open, fname, 0o200000) # O_DIRECTORY
+        p_open = self.inline_call(open, fname, 0o200000, 0) # O_DIRECTORY
         # using the same hack we used to use for fopen etc... using the fd as a pointer
         return p_open.ret_expr


### PR DESCRIPTION
Mode parameter is missing for **open** call in **opendir**. When opendir is confronted in binary, exception appears:

```
File "/usr/local/lib/python2.7/dist-packages/angr/sim_procedure.py", line 167, in execute
    r = getattr(inst, inst.run_func)(*sim_args, **inst.kwargs)
  File "/usr/local/lib/python2.7/dist-packages/angr/procedures/posix/opendir.py", line 6, in run
    p_open = self.inline_call(open, fname, 0o200000) # O_DIRECTORY
  File "/usr/local/lib/python2.7/dist-packages/angr/sim_procedure.py", line 277, in inline_call
    return p.execute(self.state, None, arguments=e_args)
  File "/usr/local/lib/python2.7/dist-packages/angr/sim_procedure.py", line 167, in execute
    r = getattr(inst, inst.run_func)(*sim_args, **inst.kwargs)
TypeError: run() takes exactly 4 arguments (3 given)
```
