### PR TITLE
Added simple emulation for __snprintf_chk

### DIFF
--- a/angr/procedures/libc/snprintf.py
+++ b/angr/procedures/libc/snprintf.py
@@ -24,3 +24,22 @@ class snprintf(FormatParser):
 
         # size_t has size arch.bits
         return self.state.se.BVV(out_str.size()/8, self.state.arch.bits)
+
+######################################
+# __snprintf_chk
+######################################
+
+class __snprintf_chk(FormatParser):
+
+    def run(self, dst_ptr, maxlen, size):  # pylint:disable=arguments-differ,unused-argument
+
+        # The format str is at index 4
+        fmt_str = self._parse(4)
+        out_str = fmt_str.replace(5, self.arg)
+        self.state.memory.store(dst_ptr, out_str)
+
+        # place the terminating null byte
+        self.state.memory.store(dst_ptr + (out_str.size() / 8), self.state.se.BVV(0, 8))
+
+        # size_t has size arch.bits
+        return self.state.se.BVV(out_str.size()/8, self.state.arch.bits)


### PR DESCRIPTION
Simple emulation for __snprintf_chk similar to the `__printf_chk` in `angr/procedures/libc/printf.py`.