### PR TITLE
Reduce the memory footprint of CFGFast - Step A

### DIFF
--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -1868,12 +1868,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                 # TODO: Is it really OK?
                 func_addr = self._block_id_addr(node_key)
 
-            if node_key.jump_type == 'syscall':
-                # it's a syscall
-                is_syscall = True
-            else:
-                is_syscall = False
-
+            is_syscall = node_key.jump_type == 'syscall'
             if isinstance(self.project.arch, ArchARM) and addr % 2 == 1:
                 is_thumb = True
             else:
@@ -3322,7 +3317,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             n_begin = self.get_any_node(begin)
             n_end = self.get_any_node(end)
 
-        elif isinstance(begin, CFGNode) and isinstance(end, CFGNode):
+        elif isinstance(begin, CFGNodeA) and isinstance(end, CFGNodeA):
             n_begin = begin
             n_end = end
         else:

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -10,7 +10,7 @@ from archinfo import ArchARM
 
 from .cfg_base import CFGBase
 from .cfg_job_base import BlockID, CFGJobBase
-from .cfg_node import CFGNode
+from .cfg_node import CFGNodeA
 from .cfg_utils import CFGUtils
 from ..forward_analysis import ForwardAnalysis
 from ... import BP, BP_BEFORE, BP_AFTER, SIM_PROCEDURES, procedures
@@ -116,6 +116,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
     """
     This class represents a control-flow graph.
     """
+
+    tag = "CFGAccurate"
 
     def __init__(self,
                  context_sensitivity_level=1,
@@ -1877,17 +1879,17 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             else:
                 is_thumb = False
 
-            pt = CFGNode(self._block_id_addr(node_key),
-                         None,
-                         self,
-                         callstack=None,  # getting a callstack here is difficult, so we pass in a callstack key instead
-                         input_state=None,
-                         simprocedure_name="PathTerminator",
-                         function_address=func_addr,
-                         callstack_key=self._block_id_callstack_key(node_key),
-                         is_syscall=is_syscall,
-                         thumb=is_thumb
-                         )
+            pt = CFGNodeA(self._block_id_addr(node_key),
+                          None,
+                          self,
+                          callstack=None,  # getting a callstack here is difficult, so we pass in a callstack key instead
+                          input_state=None,
+                          simprocedure_name="PathTerminator",
+                          function_address=func_addr,
+                          callstack_key=self._block_id_callstack_key(node_key),
+                          is_syscall=is_syscall,
+                          thumb=is_thumb
+                          )
             if self._keep_state:
                 # We don't have an input state available for it (otherwise we won't have to create a
                 # PathTerminator). This is just a trick to make get_any_irsb() happy.
@@ -2978,38 +2980,38 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             if syscall is not None and sa['no_ret']:
                 no_ret = True
 
-            cfg_node = CFGNode(sim_successors.addr,
-                               None,
-                               self,
-                               callstack=call_stack,
-                               input_state=None,
-                               simprocedure_name=simproc_name,
-                               syscall_name=syscall,
-                               no_ret=no_ret,
-                               is_syscall=is_syscall,
-                               syscall=syscall,
-                               function_address=sim_successors.addr,
-                               block_id=block_id,
-                               depth=depth,
-                               creation_failure_info=exception_info,
-                               thumb=(isinstance(self.project.arch, ArchARM) and sim_successors.addr & 1),
-                               )
+            cfg_node = CFGNodeA(sim_successors.addr,
+                                None,
+                                self,
+                                callstack=call_stack,
+                                input_state=None,
+                                simprocedure_name=simproc_name,
+                                syscall_name=syscall,
+                                no_ret=no_ret,
+                                is_syscall=is_syscall,
+                                syscall=syscall,
+                                function_address=sim_successors.addr,
+                                block_id=block_id,
+                                depth=depth,
+                                creation_failure_info=exception_info,
+                                thumb=(isinstance(self.project.arch, ArchARM) and sim_successors.addr & 1),
+                                )
 
         else:
-            cfg_node = CFGNode(sim_successors.addr,
-                               sa['irsb_size'],
-                               self,
-                               callstack=call_stack,
-                               input_state=None,
-                               is_syscall=is_syscall,
-                               syscall=syscall,
-                               function_address=func_addr,
-                               block_id=block_id,
-                               depth=depth,
-                               irsb=sim_successors.artifacts['irsb'],
-                               creation_failure_info=exception_info,
-                               thumb=(isinstance(self.project.arch, ArchARM) and sim_successors.addr & 1),
-                               )
+            cfg_node = CFGNodeA(sim_successors.addr,
+                                sa['irsb_size'],
+                                self,
+                                callstack=call_stack,
+                                input_state=None,
+                                is_syscall=is_syscall,
+                                syscall=syscall,
+                                function_address=func_addr,
+                                block_id=block_id,
+                                depth=depth,
+                                irsb=sim_successors.artifacts['irsb'],
+                                creation_failure_info=exception_info,
+                                thumb=(isinstance(self.project.arch, ArchARM) and sim_successors.addr & 1),
+                                )
 
         return cfg_node
 

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -23,6 +23,11 @@ l = logging.getLogger("angr.analyses.cfg.cfg_base")
 
 
 class IndirectJump(object):
+
+    __slots__ = [ "addr", "ins_addr", "func_addr", "jumpkind", "stmt_idx", "resolved_targets", "jumptable",
+                  "jumptable_addr", "jumptable_entries"
+                  ]
+
     def __init__(self, addr, ins_addr, func_addr, jumpkind, stmt_idx, resolved_targets=None, jumptable=False,
                  jumptable_addr=None, jumptable_entries=None):
         self.addr = addr

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -17,7 +17,7 @@ from ...errors import AngrCFGError, SimTranslationError, SimMemoryError, SimIRSB
 from ...codenode import HookNode, BlockNode
 from ...knowledge_plugins import FunctionManager, Function
 from .. import Analysis
-from .cfg_node import CFGNode
+from .cfg_node import CFGNode, CFGNodeA
 
 l = logging.getLogger("angr.analyses.cfg.cfg_base")
 
@@ -25,7 +25,7 @@ l = logging.getLogger("angr.analyses.cfg.cfg_base")
 class IndirectJump(object):
 
     __slots__ = [ "addr", "ins_addr", "func_addr", "jumpkind", "stmt_idx", "resolved_targets", "jumptable",
-                  "jumptable_addr", "jumptable_entries"
+                  "jumptable_addr", "jumptable_entries",
                   ]
 
     def __init__(self, addr, ins_addr, func_addr, jumpkind, stmt_idx, resolved_targets=None, jumptable=False,
@@ -48,7 +48,7 @@ class IndirectJump(object):
             if self.jumptable_addr is not None:
                 status += "@%#08x" % self.jumptable_addr
             if self.jumptable_entries is not None:
-                status += " with %d entries" % self.jumptable_entries
+                status += " with %d entries" % len(self.jumptable_entries)
 
         return "<IndirectJump %#08x - ins %#08x%s>" % (self.addr, self.ins_addr, " " + status if status else "")
 
@@ -57,6 +57,9 @@ class CFGBase(Analysis):
     """
     The base class for control flow graphs.
     """
+
+    tag = None
+
     def __init__(self, sort, context_sensitivity_level, normalize=False, binary=None, force_segment=False, iropt_level=None, base_state=None):
         self.sort = sort
         self._context_sensitivity_level=context_sensitivity_level
@@ -339,7 +342,10 @@ class CFGBase(Analysis):
         #    self._node_lookup_index_warned = True
 
         for n in self.graph.nodes():
-            cond = n.looping_times == 0
+            if self.tag == "CFGAccurate":
+                cond = n.looping_times == 0
+            else:
+                cond = True
             if anyaddr and n.size is not None:
                 cond = cond and (addr >= n.addr and addr < n.addr + n.size)
             else:
@@ -1138,13 +1144,24 @@ class CFGBase(Analysis):
 
             if new_node is None:
                 # Create a new one
-                new_node = CFGNode(n.addr, new_size, self, callstack_key=callstack_key,
-                                   function_address=n.function_address, block_id=n.block_id,
-                                   instruction_addrs=[i for i in n.instruction_addrs
-                                                      if n.addr <= i <= n.addr + new_size
-                                                      ],
-                                   thumb=n.thumb
-                                   )
+                if self.tag == "CFGFast":
+                    new_node = CFGNode(n.addr, new_size, self,
+                                       function_address=n.function_address, block_id=n.block_id,
+                                       instruction_addrs=tuple([i for i in n.instruction_addrs
+                                                          if n.addr <= i <= n.addr + new_size
+                                                          ]),
+                                       thumb=n.thumb
+                                       )
+                elif self.tag == "CFGAccurate":
+                    new_node = CFGNodeA(n.addr, new_size, self, callstack_key=callstack_key,
+                                        function_address=n.function_address, block_id=n.block_id,
+                                        instruction_addrs=tuple([i for i in n.instruction_addrs
+                                                           if n.addr <= i <= n.addr + new_size
+                                                           ]),
+                                        thumb=n.thumb
+                                        )
+                else:
+                    raise ValueError("Unknown tag %s." % self.tag)
 
                 # Copy instruction addresses
                 new_node.instruction_addrs = [ins_addr for ins_addr in n.instruction_addrs

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2653,10 +2653,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         next_node_size = a.size - nop_length
                         next_node = CFGNode(next_node_addr, next_node_size, self,
                                             function_address=next_node_addr,
-                                            instruction_addrs=[i for i in a.instruction_addrs
-                                                               if next_node_addr <= i
-                                                                < next_node_addr + next_node_size
-                                                               ],
+                                            instruction_addrs=tuple(i for i in a.instruction_addrs
+                                                                      if next_node_addr <= i
+                                                                      < next_node_addr + next_node_size
+                                                                    ),
                                             thumb=a.thumb,
                                             byte_string=None if a.byte_string is None else a.byte_string[nop_length:],
                                             )
@@ -2812,9 +2812,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         # Generate the new node
         new_node = CFGNode(node.addr, new_size, self,
                            function_address=None if remove_function else node.function_address,
-                           instruction_addrs=[i for i in node.instruction_addrs
-                                              if node.addr <= i < node.addr + new_size
-                                              ],
+                           instruction_addrs=tuple(i for i in node.instruction_addrs
+                                                     if node.addr <= i < node.addr + new_size
+                                                   ),
                            thumb=node.thumb,
                            byte_string=None if node.byte_string is None else node.byte_string[:new_size]
                            )
@@ -2831,7 +2831,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             successor_size = node.size - new_size
             successor = CFGNode(successor_node_addr, successor_size, self,
                                 function_address=successor_node_addr if remove_function else node.function_address,
-                                instruction_addrs=[i for i in node.instruction_addrs if i >= node.addr + new_size],
+                                instruction_addrs=tuple(i for i in node.instruction_addrs if i >= node.addr + new_size),
                                 thumb=node.thumb,
                                 byte_string=None if node.byte_string is None else node.byte_string[new_size:]
                                 )

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -684,6 +684,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
     PRINTABLES = string.printable.replace("\x0b", "").replace("\x0c", "")
 
+    tag = "CFGFast"
+
     def __init__(self,
                  binary=None,
                  regions=None,

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -85,12 +85,12 @@ class CFGNode(object):
                 offset = addr - function_address
                 self.name = "%s%+#x" % (self.name, offset)
 
-        self.instruction_addrs = instruction_addrs if instruction_addrs is not None else [ ]
+        self.instruction_addrs = instruction_addrs if instruction_addrs is not None else tuple()
 
         if not instruction_addrs and not self.is_simprocedure:
             # We have to collect instruction addresses by ourselves
             if irsb is not None:
-                self.instruction_addrs = [ s.addr + s.delta for s in irsb.statements if type(s) is pyvex.IRStmt.IMark ]  # pylint:disable=unidiomatic-typecheck
+                self.instruction_addrs = tuple(s.addr + s.delta for s in irsb.statements if type(s) is pyvex.IRStmt.IMark)  # pylint:disable=unidiomatic-typecheck
 
         self.irsb = irsb
         self.has_return = False

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -27,10 +27,19 @@ class CFGNodeCreationFailure(object):
     def __hash__(self):
         return hash((self.short_reason, self.long_reason, self.traceback))
 
+
 class CFGNode(object):
     """
     This class stands for each single node in CFG.
     """
+
+    __slots__ = [ 'addr', 'input_state', 'simprocedure_name', 'syscall_name', 'size', 'looping_times', 'no_ret',
+                  'is_syscall', 'syscall', 'function_address', 'block_id', 'callstack', 'depth', 'thumb', 'byte_string',
+                  'creation_failure_info', '_callstack_key', 'name', 'return_target', 'instruction_addrs',
+                  'final_states', 'irsb', 'has_return',
+                  '_cfg',
+                  ]
+
     def __init__(self,
                  addr,
                  size,

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -34,18 +34,16 @@ class CFGNode(object):
     This class stands for each single node in CFG.
     """
 
-    __slots__ = [ 'addr', 'simprocedure_name', 'syscall_name', 'size', 'no_ret',
-                  'is_syscall', 'function_address', 'block_id', 'thumb', 'byte_string',
-                  'name', 'instruction_addrs',
-                  'irsb', 'has_return',
-                  '_cfg',
-                  ]
+    __slots__ = ( 'addr', 'simprocedure_name', 'syscall_name', 'size', 'no_ret', 'is_syscall', 'function_address',
+                  'block_id', 'thumb', 'byte_string', 'name', 'instruction_addrs', 'irsb', 'has_return', '_cfg',
+                  )
 
     def __init__(self,
                  addr,
                  size,
                  cfg,
                  simprocedure_name=None,
+                 is_syscall=False,
                  no_ret=False,
                  function_address=None,
                  block_id=None,
@@ -62,6 +60,7 @@ class CFGNode(object):
         self.simprocedure_name = simprocedure_name
         self.size = size
         self.no_ret = no_ret
+        self.is_syscall = is_syscall
         self._cfg = cfg
         self.function_address = function_address
         self.block_id = block_id
@@ -209,6 +208,7 @@ class CFGNodeA(CFGNode):
 
         super(CFGNodeA, self).__init__(addr, size, cfg,
                                        simprocedure_name=simprocedure_name,
+                                       is_syscall=is_syscall,
                                        no_ret=no_ret,
                                        function_address=function_address,
                                        block_id=block_id,
@@ -222,7 +222,6 @@ class CFGNodeA(CFGNode):
         self.input_state = input_state
         self.syscall_name = syscall_name
         self.looping_times = looping_times
-        self.is_syscall = is_syscall
         self.syscall = syscall
         self.depth = depth
 

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -284,3 +284,27 @@ class CFGNodeA(CFGNode):
 
     def __hash__(self):
         return hash((self.callstack_key, self.addr, self.looping_times, self.simprocedure_name, self.creation_failure_info))
+
+    def copy(self):
+        return CFGNodeA(
+            self.addr,
+            self.size,
+            self._cfg,
+            simprocedure_name=self.simprocedure_name,
+            no_ret=self.no_ret,
+            function_address=self.function_address,
+            block_id=self.block_id,
+            irsb=self.irsb,
+            instruction_addrs=self.instruction_addrs,
+            thumb=self.thumb,
+            byte_string=self.byte_string,
+            callstack=self.callstack,
+            input_state=self.input_state,
+            syscall_name=self.syscall_name,
+            looping_times=self.looping_times,
+            is_syscall=self.is_syscall,
+            syscall=self.syscall,
+            depth=self.depth,
+            final_states=self.final_states[::],
+            callstack_key=self.callstack_key,
+        )

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -228,8 +228,8 @@ class JumpTableResolver(IndirectJumpResolver):
                 ij = cfg.indirect_jumps[addr]
                 ij.jumptable = True
                 ij.jumptable_addr = state.se.min(jump_addr)
-                ij.jumptable_targets = jump_table
-                ij.jumptable_entries = total_cases
+                ij.resolved_targets = set(jump_table)
+                ij.jumptable_entries = jump_table
 
                 return True, all_targets
 

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -549,6 +549,6 @@ def main():
         run_all()
 
 if __name__ == "__main__":
-    logging.getLogger('angr.analyses.cfg.cfg_fast').setLevel(logging.DEBUG)
+    # logging.getLogger('angr.analyses.cfg.cfg_fast').setLevel(logging.DEBUG)
 
     main()


### PR DESCRIPTION
This commit greatly reduces the memory footprint of `CFGFast`, especially when recovering CFG on large binaries.

e.g.,

- `CFGNode` was taking 3352 bytes, now it takes 168 bytes.
