### PR TITLE
Adding an init $t9 for ReachingDefinitionAnalysis with MIPS. 

### DIFF
--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -1561,12 +1561,23 @@ class DDG(Analysis):
             return []
 
         consumers = []
-        out_edges = graph.out_edges(var_def, data=True)
-        for _, dst, data in out_edges:
-            if 'type' in data and data['type'] == 'kill':
-                # skip killing edges
-                continue
-            consumers.append(dst)
+        srcs = [var_def]
+        traversed = set()
+
+        while srcs:
+            src = srcs.pop()
+            out_edges = graph.out_edges(src, data=True)
+            for _, dst, data in out_edges:
+                if 'type' in data and data['type'] == 'kill':
+                    # skip killing edges
+                    continue
+                if isinstance(dst.variable, SimTemporaryVariable):
+                    if dst not in traversed:
+                        srcs.append(dst)
+                        traversed.add(dst)
+                else:
+                    if dst not in consumers:
+                        consumers.append(dst)
 
         return consumers
 

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -56,6 +56,12 @@ class LiveDefinitions(object):
         sp = Register(self.arch.sp_offset, self.arch.bytes)
         sp_def = Definition(sp, None, DataSet(self.arch.initial_sp, self.arch.bits))
         self.register_definitions.set_object(sp_def.offset, sp_def, sp_def.size)
+        if self.arch.name.startswith('MIPS'):
+            if func_addr is None:
+                l.warning("func_addr must not be None to initialize a function in mips")
+            t9 = Register(self.arch.registers['t9'][0],self.arch.bytes)
+            t9_def = Definition(t9, None, DataSet(func_addr,self.arch.bits))
+            self.register_definitions.set_object(t9_def.offset,t9_def,t9_def.size)
 
         if cc is not None:
             for arg in cc.args:


### PR DESCRIPTION
If $t9 isn't initialized to the address of the function in mips all the function calls will result in an undefined IP error in the engines. After this change the user is prompted to define their own function handlers (as expected)  