### PR TITLE
Many improvements to make CFGFast fast again.

### DIFF
--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -1274,7 +1274,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             # Try to resolve indirect jumps
             irsb = input_state.block().vex
 
-            resolved, resolved_targets, ij = self._indirect_jump_encountered(addr, irsb, func_addr, stmt_idx='default')
+            resolved, resolved_targets, ij = self._indirect_jump_encountered(addr, cfg_node, irsb, func_addr, stmt_idx='default')
             if resolved:
                 successors = self._convert_indirect_jump_targets_to_states(job, resolved_targets)
                 if ij:

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2100,9 +2100,10 @@ class CFGBase(Analysis):
         resolved_by = None
         targets = None
 
+        block = self._lift(jump.addr, opt_level=1)
+
         for resolver in self.indirect_jump_resolvers:
             resolver.base_state = self._base_state
-            block = self._lift(jump.addr, opt_level=1)
 
             if not resolver.filter(self, jump.addr, jump.func_addr, block, jump.jumpkind):
                 continue

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -111,7 +111,7 @@ class CFGBase(Analysis):
 
         # Store all the functions analyzed before the set is cleared
         # Used for performance optimization
-        self._changed_functions = None
+        self._updated_nonreturning_functions = None
 
         self._normalize = normalize
         # Flag, whether the CFG has been normalized or not
@@ -660,8 +660,7 @@ class CFGBase(Analysis):
         :rtype:                  bool
         """
 
-
-        obj = self.project.loader.find_object_containing(region_start)
+        obj = self.project.loader.find_object_containing(region_start, membership_check=False)
         if obj is None:
             return False
         if isinstance(obj, PE):
@@ -768,11 +767,11 @@ class CFGBase(Analysis):
         :rtype:             bool
         """
 
-        obj = self.project.loader.find_object_containing(addr_a)
+        obj = self.project.loader.find_object_containing(addr_a, membership_check=False)
 
         if obj is None:
             # test if addr_b also does not belong to any object
-            obj_b = self.project.loader.find_object_containing(addr_b)
+            obj_b = self.project.loader.find_object_containing(addr_b, membership_check=False)
             if obj_b is None:
                 return True
             return False
@@ -913,20 +912,21 @@ class CFGBase(Analysis):
             'functions_do_not_return': []
         }
 
-        if self._changed_functions is not None:
-            all_functions = self._changed_functions
-            caller_functions = set()
+        if self._updated_nonreturning_functions is not None:
+            all_func_addrs = self._updated_nonreturning_functions
+            caller_func_addrs = set()
 
-            for func_addr in self._changed_functions:
+            for func_addr in self._updated_nonreturning_functions:
                 if func_addr not in self.kb.functions.callgraph:
                     continue
                 callers = self.kb.functions.callgraph.predecessors(func_addr)
                 for f in callers:
-                    caller_functions.add(f)
+                    caller_func_addrs.add(f)
 
-            all_functions |= caller_functions
-
-            all_functions = [ self.kb.functions.function(addr=f) for f in all_functions if f in self.kb.functions ]
+            # Add callers
+            all_func_addrs |= caller_func_addrs
+            # Convert addresses to objects
+            all_functions = [ self.kb.functions.get_by_addr(f) for f in all_func_addrs ]
 
         else:
             all_functions = self.kb.functions.values()
@@ -2041,7 +2041,6 @@ class CFGBase(Analysis):
         """
 
         jumpkind = irsb.jumpkind
-        stmts = irsb.statements
         l.debug('(%s) IRSB %#x has an indirect jump as its default exit.', jumpkind, addr)
 
         # try resolving it fast
@@ -2052,14 +2051,21 @@ class CFGBase(Analysis):
         # Add it to our set. Will process it later if user allows.
         # Create an IndirectJump instance
         if addr not in self.indirect_jumps:
-            tmp_statements = stmts if stmt_idx == 'default' else stmts[:stmt_idx]
+            # We need an IRSB *with* statements
+            if irsb.statements is None:
+                lifted_block = self._lift(addr, size=irsb.size)
+                irsb_with_stmts = lifted_block.vex
+            else:
+                irsb_with_stmts = irsb
+            tmp_statements = irsb_with_stmts.statements if stmt_idx == 'default' else \
+                irsb_with_stmts.statements[: stmt_idx]
             if jumpkind != "Ijk_Boring" and self.project.arch.branch_delay_slot:
                 ins_addr = next(itertools.islice(iter(stmt.addr for stmt in reversed(tmp_statements)
                                      if isinstance(stmt, pyvex.IRStmt.IMark)), 1, None
                                 ), None)
             else:
                 ins_addr = next(iter(stmt.addr for stmt in reversed(tmp_statements)
-                                     if isinstance(stmt, pyvex.IRStmt.IMark)), None
+                                     if type(stmt) is pyvex.IRStmt.IMark), None
                                 )
             ij = IndirectJump(addr, ins_addr, func_addr, jumpkind, stmt_idx, resolved_targets=[])
             self.indirect_jumps[addr] = ij

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1986,6 +1986,9 @@ class CFGBase(Analysis):
         :rtype: tuple
         """
 
+        if block.statements is None:
+            block = self.project.factory.block(block.addr, size=block.size).vex
+
         for res in self.timeless_indirect_jump_resolvers:
             if res.filter(self, addr, func_addr, block, jumpkind):
                 r, resolved_targets = res.resolve(self, addr, func_addr, block, jumpkind)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2100,6 +2100,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :return: None
         """
 
+        # FIXME: Move the data-reference-collection logic to PyVEX_C
+        if irsb.statements is None:
+            return
+
         if self.project.arch.name in ('X86', 'AMD64'):
             # first pass to see if there are any cross-statement optimizations. if so, we relift the basic block with
             # optimization level 0 to preserve as much constant references as possible
@@ -2155,9 +2159,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 self._add_data_reference(irsb_, irsb_addr, stmt_, stmt_idx_, insn_addr, val,
                                          data_size=data_size, data_type=data_type
                                          )
-
-        if irsb.statements is None:
-            return
 
         # get all instruction addresses
         instr_addrs = irsb.instruction_addresses

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2108,21 +2108,17 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             self._collect_data_references_by_scanning_stmts(irsb, irsb_addr)
 
     def _process_irsb_data_refs(self, irsb):
-
         for ref in irsb.data_refs:
-
-            data_addr, data_size, data_type, stmt_idx, insn_addr = ref
-
-            # Convert data_type from enums to strings
-            data_types = {
-                0x9000: 'unknown',
-                0x9001: 'integer',
-                0x9002: 'fp',
-            }
-            data_type = data_types.get(data_type)
-
-            self._add_data_reference(irsb, irsb.addr, None, stmt_idx, insn_addr, data_addr, data_size=data_size,
-                                     data_type=data_type)
+            self._add_data_reference(
+                    irsb,
+                    irsb.addr,
+                    None,
+                    ref.stmt_idx,
+                    ref.insn_addr,
+                    ref.data_addr,
+                    data_size=ref.data_size,
+                    data_type=ref.data_type_str
+            )
 
     def _unoptimize_irsb(self, irsb):
         if self.project.arch.name in ('X86', 'AMD64'):

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1893,7 +1893,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                                                   to_outside=False, stmt_idx=stmt_idx, ins_addr=ins_addr,
                                                   )
                     ce = CFGJob(resolved_target, current_function_addr, jumpkind,
-                                last_addr=resolved_target, src_node=cfg_node, src_stmt_idx=stmt_idx, ins_addr=ins_addr,
+                                last_addr=resolved_target, src_node=cfg_node, src_stmt_idx=stmt_idx, src_ins_addr=ins_addr,
                                 func_edges=[ edge ],
                                 )
                     jobs.append(ce)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3594,6 +3594,11 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 # check if gp is being written to
                 last_gp_setting_insn_id = None
                 insn_ctr = 0
+
+                if not irsb.statements:
+                    # Get an IRSB with statements
+                    irsb = self.project.factory.block(irsb.addr, size=irsb.size).vex
+
                 for stmt in irsb.statements:
                     if isinstance(stmt, pyvex.IRStmt.IMark):
                         insn_ctr += 1

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -479,6 +479,8 @@ class FunctionReturn(object):
     FunctionReturn describes a function call in a specific location and its return location. Hashable and equatable
     """
 
+    __slots__ = ('callee_func_addr', 'caller_func_addr', 'call_site_addr', 'return_to', )
+
     def __init__(self, callee_func_addr, caller_func_addr, call_site_addr, return_to):
         self.callee_func_addr = callee_func_addr
         self.caller_func_addr = caller_func_addr
@@ -610,14 +612,124 @@ class PendingJobs(object):
 
         self._returning_functions.add(func_addr)
 
+#
+# Descriptors of edges in individual function graphs
+#
+
+
+class FunctionEdge(object):
+    __slots__ = ('src_func_addr', 'stmt_idx', 'ins_addr',)
+
+    def apply(self, cfg):
+        raise NotImplementedError()
+
+
+class FunctionTransitionEdge(FunctionEdge):
+
+    __slots__ = ('src_node', 'dst_addr', 'src_func_addr', 'to_outside', 'dst_func_addr')
+
+    def __init__(self, src_node, dst_addr, src_func_addr, to_outside=False, dst_func_addr=None, stmt_idx=None,
+                 ins_addr=None):
+        self.src_node = src_node
+        self.dst_addr = dst_addr
+        self.src_func_addr = src_func_addr
+        self.to_outside = to_outside
+        self.dst_func_addr = dst_func_addr
+        self.stmt_idx = stmt_idx
+        self.ins_addr = ins_addr
+
+    def apply(self, cfg):
+        return cfg._function_add_transition_edge(
+            self.dst_addr,
+            self.src_node,
+            self.src_func_addr,
+            to_outside=self.to_outside,
+            dst_func_addr=self.dst_func_addr,
+            stmt_idx=self.stmt_idx,
+            ins_addr=self.ins_addr,
+        )
+
+
+class FunctionCallEdge(FunctionEdge):
+
+    __slots__ = ('src_node', 'dst_addr', 'ret_addr', 'syscall')
+
+    def __init__(self, src_node, dst_addr, ret_addr, src_func_addr, syscall=False, stmt_idx=None, ins_addr=None):
+        self.src_node = src_node
+        self.dst_addr = dst_addr
+        self.ret_addr = ret_addr
+        self.src_func_addr = src_func_addr
+        self.syscall = syscall
+        self.stmt_idx = stmt_idx
+        self.ins_addr = ins_addr
+
+    def apply(self, cfg):
+        return cfg._function_add_call_edge(
+            self.dst_addr,
+            self.src_node,
+            self.ret_addr,
+            self.src_func_addr,
+            syscall=self.syscall,
+            stmt_idx=self.stmt_idx,
+            ins_addr=self.ins_addr,
+        )
+
+
+class FunctionFakeRetEdge(FunctionEdge):
+
+    __slots__ = ('src_node', 'dst_addr', 'confirmed')
+
+    def __init__(self, src_node, dst_addr, src_func_addr, confirmed=None):
+        self.src_node = src_node
+        self.dst_addr = dst_addr
+        self.src_func_addr = src_func_addr
+        self.confirmed = confirmed
+
+    def apply(self, cfg):
+        return cfg._function_add_fakeret_edge(
+            self.dst_addr,
+            self.src_node,
+            self.src_func_addr,
+            confirmed=self.confirmed,
+        )
+
+
+class FunctionReturnEdge(FunctionEdge):
+
+    __slots__ = ('ret_from_addr', 'ret_to_addr', 'dst_func_addr')
+
+    def __init__(self, ret_from_addr, ret_to_addr, dst_func_addr):
+        self.ret_from_addr = ret_from_addr
+        self.ret_to_addr = ret_to_addr
+        self.dst_func_addr = dst_func_addr
+
+    def apply(self, cfg):
+        return cfg._function_add_return_edge(
+            self.ret_from_addr,
+            self.ret_to_addr,
+            self.dst_func_addr
+        )
+
+
+#
+# CFGJob
+#
+
 
 class CFGJob(object):
     """
     Defines a job to work on during the CFG recovery
     """
 
+    __slots__ = ('addr', 'func_addr', 'jumpkind', 'ret_target', 'last_addr', 'src_node', 'src_ins_addr', 'src_stmt_idx',
+                 'returning_source', 'syscall', '_func_edges', 'job_type')
+
+    JOB_TYPE_NORMAL = "Normal"
+    JOB_TYPE_FUNCTION_PROLOGUE = "Function-prologue"
+    JOB_TYPE_COMPLETE_SCANNING = "Complete-scanning"
+
     def __init__(self, addr, func_addr, jumpkind, ret_target=None, last_addr=None, src_node=None, src_ins_addr=None,
-                 src_stmt_idx=None, returning_source=None, syscall=False):
+                 src_stmt_idx=None, returning_source=None, syscall=False, func_edges=None, job_type=JOB_TYPE_NORMAL):
         self.addr = addr
         self.func_addr = func_addr
         self.jumpkind = jumpkind
@@ -628,6 +740,23 @@ class CFGJob(object):
         self.src_stmt_idx = src_stmt_idx
         self.returning_source = returning_source
         self.syscall = syscall
+        self.job_type = job_type
+
+        self._func_edges = func_edges
+
+    def add_function_edge(self, edge):
+
+        if self._func_edges is None:
+            self._func_edges = [ ]
+        self._func_edges.append(edge)
+
+    def apply_function_edges(self, cfg, clear=False):
+        if not self._func_edges:
+            return
+        for edge in self._func_edges:
+            edge.apply(cfg)
+        if clear:
+            self._func_edges = None
 
     def __repr__(self):
         return "<CFGJob%s %#08x @ func %#08x>" % (" syscall" if self.syscall else "", self.addr, self.func_addr)
@@ -1179,7 +1308,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         # Initialize variables used during analysis
         self._pending_jobs = PendingJobs(self.functions, self._deregister_analysis_job)
         self._traced_addresses = set()
-        self._function_returns = defaultdict(list)
+        self._function_returns = defaultdict(set)
 
         # Sadly, not all calls to functions are explicitly made by call
         # instruction - they could be a jmp or b, or something else. So we
@@ -1221,7 +1350,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             # register the job to function `sp`
             self._register_analysis_job(sp, job)
 
-        self._changed_functions = set()
+        self._updated_nonreturning_functions = set()
 
         self._nodes = {}
         self._nodes_by_addr = defaultdict(list)
@@ -1259,22 +1388,17 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
     def _get_successors(self, job):  # pylint:disable=arguments-differ
 
-        current_function_addr = job.func_addr
-        addr = job.addr
-        jumpkind = job.jumpkind
-        src_node = job.src_node
-        src_stmt_idx = job.src_stmt_idx
-        src_ins_addr = job.src_ins_addr
+        # current_function_addr = job.func_addr
+        # addr = job.addr
 
-        if current_function_addr != -1:
-            l.debug("Tracing new exit %#x in function %#x",
-                    addr, current_function_addr)
-        else:
-            l.debug("Tracing new exit %#x", addr)
+        # if current_function_addr != -1:
+        #    l.debug("Tracing new exit %#x in function %#x", addr, current_function_addr)
+        # else:
+        #    l.debug("Tracing new exit %#x", addr)
 
-        jobs = self._scan_block(addr, current_function_addr, jumpkind, src_node, src_ins_addr, src_stmt_idx)
+        jobs = self._scan_block(job)
 
-        l.debug("... got %d jobs: %s", len(jobs), jobs)
+        # l.debug("... got %d jobs: %s", len(jobs), jobs)
 
         for job_ in jobs:  # type: CFGJob
             # register those jobs
@@ -1327,7 +1451,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         self._analyze_all_function_features()
 
         # Clear _changed_functions set
-        self._changed_functions = set()
+        self._updated_nonreturning_functions = set()
 
         if self._pending_jobs:
             self._clean_pending_exits()
@@ -1365,7 +1489,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             addr = self._next_code_addr()
 
             if addr is not None:
-                job = CFGJob(addr, addr, "Ijk_Boring", last_addr=None)
+                job = CFGJob(addr, addr, "Ijk_Boring", last_addr=None, job_type=CFGJob.JOB_TYPE_COMPLETE_SCANNING)
                 self._insert_job(job)
                 self._register_analysis_job(addr, job)
 
@@ -1504,52 +1628,48 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
     # Basic block scanning
 
-    def _scan_block(self, addr, current_function_addr, previous_jumpkind, previous_src_node, previous_src_ins_addr,
-                    previous_src_stmt_idx):
+    def _scan_block(self, cfg_job):
         """
         Scan a basic block starting at a specific address
 
-        :param int addr: The address to begin scanning
-        :param int current_function_addr: Address of the current function
-        :param str previous_jumpkind: The jumpkind of the edge going to this node
-        :param CFGNode previous_src_node: The previous CFGNode
+        :param CFGJob cfg_job: The CFGJob instance.
         :return: a list of successors
         :rtype: list
         """
+
+        addr = cfg_job.addr
+        current_func_addr = cfg_job.func_addr
 
         # Fix the function address
         # This is for rare cases where we cannot successfully determine the end boundary of a previous function, and
         # as a consequence, our analysis mistakenly thinks the previous function goes all the way across the boundary,
         # resulting the missing of the second function in function manager.
         if addr in self._function_addresses_from_symbols:
-            current_function_addr = addr
+            current_func_addr = addr
 
         if self._addr_hooked_or_syscall(addr):
-            entries = self._scan_procedure(addr, current_function_addr, previous_jumpkind, previous_src_node,
-                                           previous_src_ins_addr, previous_src_stmt_idx)
+            entries = self._scan_procedure(cfg_job, current_func_addr)
 
         else:
-            entries = self._scan_irsb(addr, current_function_addr, previous_jumpkind, previous_src_node,
-                                      previous_src_ins_addr, previous_src_stmt_idx)
+            entries = self._scan_irsb(cfg_job, current_func_addr)
 
         return entries
 
-    def _scan_procedure(self, addr, current_function_addr, previous_jumpkind, previous_src_node, previous_src_ins_addr,
-                        previous_src_stmt_idx):
+    def _scan_procedure(self, cfg_job, current_func_addr):
         """
         Checks the hooking procedure for this address searching for new static
         exit points to add to successors (generating entries for them)
         if this address has not been traced before. Updates previous CFG nodes
         with edges.
 
-        :param int addr: The address to begin scanning
-        :param int current_function_addr: Address of the current function
-        :param str previous_jumpkind: The jumpkind of the edge going to this node
-        :param CFGNode previous_src_node: The previous CFGNode
-        :param int previous_src_stmt_idx: The previous ID of the statement.
+        :param CFGJob cfg_job:      The CFGJob instance.
+        :param int current_func_addr: Address of the current function.
         :return: List of successors
         :rtype: list
         """
+
+        addr = cfg_job.addr
+
         try:
             if self.project.is_hooked(addr):
                 procedure = self.project.hooked_by(addr)
@@ -1559,7 +1679,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 name = procedure.display_name
 
             if addr not in self._nodes:
-                cfg_node = CFGNode(addr, 0, self, function_address=current_function_addr,
+                cfg_node = CFGNode(addr, 0, self,
+                                   function_address=current_func_addr,
                                    simprocedure_name=name,
                                    no_ret=procedure.NO_RET,
                                    block_id=addr,
@@ -1574,11 +1695,13 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         except (SimMemoryError, SimEngineError):
             return [ ]
 
-        self._graph_add_edge(cfg_node, previous_src_node, previous_jumpkind, previous_src_ins_addr,
-                             previous_src_stmt_idx
+        self._graph_add_edge(cfg_node, cfg_job.src_node, cfg_job.jumpkind, cfg_job.src_ins_addr,
+                             cfg_job.src_stmt_idx
                              )
-        self._function_add_node(addr, current_function_addr)
-        self._changed_functions.add(current_function_addr)
+        self._function_add_node(cfg_node, current_func_addr)
+
+        # Add edges going to this node in function graphs
+        cfg_job.apply_function_edges(self, clear=True)
 
         # If we have traced it before, don't trace it anymore
         if addr in self._traced_addresses:
@@ -1591,13 +1714,13 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         if procedure.ADDS_EXITS:
             # Get two blocks ahead
-            grandparent_nodes = list(self.graph.predecessors(previous_src_node))
+            grandparent_nodes = list(self.graph.predecessors(cfg_job.src_node))
             if not grandparent_nodes:
                 l.warning("%s is supposed to yield new exits, but it fails to do so.", name)
                 return [ ]
             blocks_ahead = [
                 self._lift(grandparent_nodes[0].addr).vex,
-                self._lift(previous_src_node.addr).vex,
+                self._lift(cfg_job.src_node.addr).vex,
             ]
             procedure.project = self.project
             procedure.arch = self.project.arch
@@ -1608,34 +1731,36 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                     addr_ = addr_._model_concrete.value
                 if not isinstance(addr_, (int, long)):
                     continue
-                entries += self._create_jobs(addr_, jumpkind, current_function_addr, None, addr_, cfg_node, None,
+                entries += self._create_jobs(addr_, jumpkind, current_func_addr, None, addr_, cfg_node, None,
                                              None
                                              )
 
         if not procedure.NO_RET:
             # it returns
             cfg_node.has_return = True
-            self._function_exits[current_function_addr].add(addr)
-            self._function_add_return_site(addr, current_function_addr)
+            self._function_exits[current_func_addr].add(addr)
+            self._function_add_return_site(addr, current_func_addr)
+        else:
+            # the procedure does not return
+            self._updated_nonreturning_functions.add(current_func_addr)
 
         return entries
 
-    def _scan_irsb(self, addr, current_function_addr, previous_jumpkind, previous_src_node, previous_src_ins_addr,
-                   previous_src_stmt_idx):
+    def _scan_irsb(self, cfg_job, current_func_addr):
         """
         Generate a list of successors (generating them each as entries) to IRSB.
         Updates previous CFG nodes with edges.
 
-        :param int addr: The address to begin scanning
-        :param int current_function_addr: Address of the current function
-        :param str previous_jumpkind: The jumpkind of the edge going to this node
-        :param CFGNode previous_src_node: The previous CFGNode
-        :param int previous_src_stmt_idx: The previous ID of the statement
+        :param CFGJob cfg_job: The CFGJob instance.
+        :param int current_func_addr: Address of the current function
         :return: a list of successors
         :rtype: list
         """
 
-        addr, function_addr, cfg_node, irsb = self._generate_cfgnode(addr, current_function_addr)
+        addr, function_addr, cfg_node, irsb = self._generate_cfgnode(cfg_job, current_func_addr)
+
+        # Add edges going to this node in function graphs
+        cfg_job.apply_function_edges(self, clear=True)
 
         # function_addr and current_function_addr can be different. e.g. when tracing an optimized tail-call that jumps
         # into another function that has been identified before.
@@ -1644,11 +1769,13 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             # exceptions occurred, or we cannot get a CFGNode for other reasons
             return [ ]
 
-        self._graph_add_edge(cfg_node, previous_src_node, previous_jumpkind, previous_src_ins_addr,
-                             previous_src_stmt_idx
+        self._graph_add_edge(cfg_node, cfg_job.src_node, cfg_job.jumpkind, cfg_job.src_ins_addr,
+                             cfg_job.src_stmt_idx
                              )
-        self._function_add_node(addr, function_addr)
-        self._changed_functions.add(current_function_addr)
+        self._function_add_node(cfg_node, function_addr)
+
+        if self.functions.get_by_addr(current_func_addr).returning is not True:
+            self._updated_nonreturning_functions.add(current_func_addr)
 
         # If we have traced it before, don't trace it anymore
         real_addr = self._real_address(self.project.arch, addr)
@@ -1677,17 +1804,26 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         last_ins_addr = None
         ins_addr = addr
-        for i, stmt in enumerate(irsb.statements):
-            if isinstance(stmt, pyvex.IRStmt.Exit):
-                successors.append((i,
-                                   last_ins_addr if self.project.arch.branch_delay_slot else ins_addr,
-                                   stmt.dst,
-                                   stmt.jumpkind
-                                   )
-                                  )
-            elif isinstance(stmt, pyvex.IRStmt.IMark):
-                last_ins_addr = ins_addr
-                ins_addr = stmt.addr + stmt.delta
+        if irsb.statements:
+            for i, stmt in enumerate(irsb.statements):
+                if isinstance(stmt, pyvex.IRStmt.Exit):
+                    successors.append((i,
+                                       last_ins_addr if self.project.arch.branch_delay_slot else ins_addr,
+                                       stmt.dst,
+                                       stmt.jumpkind
+                                       )
+                                      )
+                elif isinstance(stmt, pyvex.IRStmt.IMark):
+                    last_ins_addr = ins_addr
+                    ins_addr = stmt.addr + stmt.delta
+        else:
+            for ins_addr, stmt_idx, exit_stmt in irsb.exit_statements:
+                successors.append((
+                    stmt_idx,
+                    last_ins_addr if self.project.arch.branch_delay_slot else ins_addr,
+                    exit_stmt.dst,
+                    exit_stmt.jumpkind
+                ))
 
         successors.append(('default',
                            last_ins_addr if self.project.arch.branch_delay_slot else ins_addr, irsb_next, jumpkind)
@@ -1746,17 +1882,21 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             jumpkind = "Ijk_Boring"
 
         if target_addr is None and (
-                        jumpkind in ('Ijk_Boring', 'Ijk_Call') or jumpkind.startswith('Ijk_Sys')) and \
-                        self._resolve_indirect_jumps:
+                jumpkind in ('Ijk_Boring', 'Ijk_Call') or jumpkind.startswith('Ijk_Sys')) and \
+                self._resolve_indirect_jumps:
+            # This is an indirect jump. Try to resolve it.
 
             resolved, resolved_targets, ij = self._indirect_jump_encountered(addr, irsb, current_function_addr, stmt_idx)
             if resolved:
-                for t in resolved_targets:
-                    self._function_add_transition_edge(t, cfg_node, current_function_addr, to_outside=False,
-                                                       stmt_idx=stmt_idx, ins_addr=ins_addr)
-                    ent = self._create_jobs(t, jumpkind, current_function_addr, irsb, addr, cfg_node, ins_addr,
-                                            stmt_idx)
-                    jobs.extend(ent)
+                for resolved_target in resolved_targets:
+                    edge = FunctionTransitionEdge(cfg_node, resolved_target, current_function_addr,
+                                                  to_outside=False, stmt_idx=stmt_idx, ins_addr=ins_addr,
+                                                  )
+                    ce = CFGJob(resolved_target, current_function_addr, jumpkind,
+                                last_addr=resolved_target, src_node=cfg_node, src_stmt_idx=stmt_idx, ins_addr=ins_addr,
+                                func_edges=[ edge ],
+                                )
+                    jobs.append(ce)
                 return jobs
 
             if jumpkind == "Ijk_Boring":
@@ -1771,19 +1911,15 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         jump_target = next(iter(ij.resolved_targets))
                         target_func_addr = jump_target  # TODO: FIX THIS
 
-                        r = self._function_add_transition_edge(jump_target, cfg_node, current_function_addr,
-                                                               ins_addr=ins_addr, stmt_idx=stmt_idx,
-                                                               to_outside=True
-                                                               )
-                        if r:
-                            ce = CFGJob(jump_target, target_func_addr, jumpkind, last_addr=jump_target,
-                                        src_node=cfg_node, src_stmt_idx=stmt_idx, src_ins_addr=ins_addr)
-                            jobs.append(ce)
-
-                            self._function_add_call_edge(jump_target, None, None, target_func_addr,
-                                                         stmt_idx=stmt_idx, ins_addr=ins_addr
-                                                         )
-                            resolved_as_plt = True
+                        edge = FunctionTransitionEdge(cfg_node, jump_target, current_function_addr,
+                                                      to_outside=True, dst_func_addr=jump_target,
+                                                      stmt_idx=stmt_idx, ins_addr=ins_addr,
+                                                      )
+                        ce = CFGJob(jump_target, target_func_addr, jumpkind, last_addr=jump_target,
+                                    src_node=cfg_node, src_stmt_idx=stmt_idx, src_ins_addr=ins_addr,
+                                    func_edges=[edge],
+                                    )
+                        jobs.append(ce)
 
                 if resolved_as_plt:
                     # has been resolved as a PLT entry. Remove it from indirect_jumps_to_resolve
@@ -1797,7 +1933,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                     # register it as a job for the current function
                     self._register_analysis_job(current_function_addr, ij)
 
-            else:
+            else:  # jumpkind == "Ijk_Call" or jumpkind.startswith('Ijk_Sys')
                 self._indirect_jumps_to_resolve.add(ij)
                 self._register_analysis_job(current_function_addr, ij)
 
@@ -1805,7 +1941,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                                       jumpkind, is_syscall=is_syscall
                                       )
 
-        else:
+        elif target_addr is not None:
+            # This is a direct jump with a concrete target.
+
             # pylint: disable=too-many-nested-blocks
             if jumpkind == 'Ijk_Boring':
                 # if the target address is at another section, it has to be jumping to a new function
@@ -1825,26 +1963,15 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
                     to_outside = not target_func_addr == current_function_addr
 
-                r = self._function_add_transition_edge(target_addr, cfg_node, current_function_addr, ins_addr=ins_addr,
-                                                       stmt_idx=stmt_idx, to_outside=to_outside
-                                                       )
-
-                if not r:
-                    if cfg_node is not None:
-                        l.debug("An angr exception occurred when adding a transition from %#x to %#x. "
-                                "Ignore this successor.",
-                                cfg_node.addr,
-                                target_addr
-                                )
-                    else:
-                        l.debug("SimTranslationError occurred when creating a new entry to %#x. "
-                                "Ignore this successor.",
-                                target_addr
-                                )
-                    return []
+                edge = FunctionTransitionEdge(cfg_node, target_addr, current_function_addr,
+                                              to_outside=to_outside,
+                                              dst_func_addr=target_func_addr,
+                                              ins_addr=ins_addr,
+                                              stmt_idx=stmt_idx,
+                                              )
 
                 ce = CFGJob(target_addr, target_func_addr, jumpkind, last_addr=addr, src_node=cfg_node,
-                            src_ins_addr=ins_addr, src_stmt_idx=stmt_idx)
+                            src_ins_addr=ins_addr, src_stmt_idx=stmt_idx, func_edges=[ edge ])
                 jobs.append(ce)
 
             elif jumpkind == 'Ijk_Call' or jumpkind.startswith("Ijk_Sys"):
@@ -1914,45 +2041,50 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         else:
             return_site = addr + irsb.size  # We assume the program will always return to the succeeding position
 
+        edge = None
         if new_function_addr is not None:
-            r = self._function_add_call_edge(new_function_addr, cfg_node, return_site, current_function_addr,
-                                             syscall=is_syscall, stmt_idx=stmt_idx, ins_addr=ins_addr)
-            if not r:
-                return [ ]
+            edge = FunctionCallEdge(cfg_node, new_function_addr, return_site, current_function_addr, syscall=is_syscall,
+                                    ins_addr=ins_addr, stmt_idx=ins_addr,
+                                    )
 
         if new_function_addr is not None:
             # Keep tracing from the call
             ce = CFGJob(target_addr, new_function_addr, jumpkind, last_addr=addr, src_node=cfg_node,
-                        src_stmt_idx=stmt_idx, src_ins_addr=ins_addr, syscall=is_syscall)
+                        src_stmt_idx=stmt_idx, src_ins_addr=ins_addr, syscall=is_syscall, func_edges=[ edge ]
+                        )
             jobs.append(ce)
 
-        if return_site is not None:
-            # Also, keep tracing from the return site
-            ce = CFGJob(return_site, current_function_addr, 'Ijk_FakeRet', last_addr=addr, src_node=cfg_node,
-                        src_stmt_idx=stmt_idx, src_ins_addr=ins_addr, returning_source=new_function_addr,
-                        syscall=is_syscall)
-            self._pending_jobs.add_job(ce)
-            # register this job to this function
-            self._register_analysis_job(current_function_addr, ce)
-
+        callee_might_return = True
+        callee_function = None
         if new_function_addr is not None:
             callee_function = self.kb.functions.function(addr=new_function_addr, syscall=is_syscall)
+            if callee_function is not None:
+                callee_might_return = not (callee_function.returning is False)
 
-            if callee_function.returning is True:
-                if return_site is not None:
-                    self._function_add_fakeret_edge(return_site, cfg_node, current_function_addr,
-                                                    confirmed=True)
-                    self._function_add_return_edge(new_function_addr, return_site, current_function_addr)
-            elif callee_function.returning is False:
-                # The function does not return - there is no fake ret edge
-                pass
-            else:
-                if return_site is not None:
-                    self._function_add_fakeret_edge(return_site, cfg_node, current_function_addr,
-                                                    confirmed=None)
+        if callee_might_return:
+            func_edges = [ ]
+            if return_site is not None:
+                if callee_function is not None and callee_function.returning is True:
+                    fakeret_edge = FunctionFakeRetEdge(cfg_node, return_site, current_function_addr, confirmed=True)
+                    func_edges.append(fakeret_edge)
+                    ret_edge = FunctionReturnEdge(new_function_addr, return_site, current_function_addr)
+                    func_edges.append(ret_edge)
+
+                else:
+                    fakeret_edge = FunctionFakeRetEdge(cfg_node, return_site, current_function_addr, confirmed=None)
+                    func_edges.append(fakeret_edge)
                     fr = FunctionReturn(new_function_addr, current_function_addr, addr, return_site)
                     if fr not in self._function_returns[new_function_addr]:
-                        self._function_returns[new_function_addr].append(fr)
+                        self._function_returns[new_function_addr].add(fr)
+
+            if return_site is not None:
+                # Also, keep tracing from the return site
+                ce = CFGJob(return_site, current_function_addr, 'Ijk_FakeRet', last_addr=addr, src_node=cfg_node,
+                            src_stmt_idx=stmt_idx, src_ins_addr=ins_addr, returning_source=new_function_addr,
+                            syscall=is_syscall, func_edges=func_edges)
+                self._pending_jobs.add_job(ce)
+                # register this job to this function
+                self._register_analysis_job(current_function_addr, ce)
 
         return jobs
 
@@ -2023,6 +2155,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 self._add_data_reference(irsb_, irsb_addr, stmt_, stmt_idx_, insn_addr, val,
                                          data_size=data_size, data_type=data_type
                                          )
+
+        if irsb.statements is None:
+            return
 
         # get all instruction addresses
         instr_addrs = [ (i.addr + i.delta) for i in irsb.statements if isinstance(i, pyvex.IRStmt.IMark) ]
@@ -2160,7 +2295,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 # goes until the end of the section/segment
                 # TODO: the logic needs more testing
 
-                obj = self.project.loader.find_object_containing(data_addr)
                 sec = self.project.loader.find_section_containing(data_addr)
                 next_sec_addr = None
                 if sec is not None:
@@ -2245,7 +2379,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         ptr = self._fast_memory_load_pointer(data_addr + j)
 
                         # is this pointer coming from the current binary?
-                        obj = self.project.loader.find_object_containing(ptr)
+                        obj = self.project.loader.find_object_containing(ptr, membership_check=False)
                         if obj is not self.project.loader.main_object:
                             # the pointer does not come from current binary. skip.
                             continue
@@ -2391,7 +2525,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             ip = simsucc.successors[0].ip
             if ip._model_concrete is not ip:
                 target_addr = ip._model_concrete.value
-                if (self.project.loader.find_object_containing(target_addr) is not
+                if (self.project.loader.find_object_containing(target_addr, membership_check=False) is not
                         self.project.loader.main_object) \
                         or self.project.is_hooked(target_addr):
                     # resolved!
@@ -2415,24 +2549,31 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         from .indirect_jump_resolvers.jumptable import JumpTableResolver
 
+        source_addr = jump.addr
+
         if isinstance(resolved_by, JumpTableResolver):
             # Fill in the jump_tables dict
             self.jump_tables[jump.addr] = jump
 
         jump.resolved_targets = targets
-        all_targets = set([t for t in targets])
+        all_targets = set(targets)
         for addr in all_targets:
             to_outside = addr in self.functions or not self._addrs_belong_to_same_section(jump.addr, addr)
 
-            r = self._function_add_transition_edge(addr, self._nodes[jump.addr], jump.func_addr, to_outside=to_outside)
-            if r:
-                # TODO: get a better estimate of the function address
-                target_func_addr = jump.func_addr if not to_outside else addr
-                job = CFGJob(addr, target_func_addr, jump.jumpkind, last_addr=jump.addr,
-                             src_node=self._nodes[jump.addr], src_stmt_idx=None,
-                             )
-                self._insert_job(job)
-                self._register_analysis_job(target_func_addr, job)
+            # TODO: get a better estimate of the function address
+            target_func_addr = jump.func_addr if not to_outside else addr
+            func_edge = FunctionTransitionEdge(self._nodes[source_addr], addr, jump.func_addr, to_outside=to_outside,
+                                               dst_func_addr=target_func_addr
+                                               )
+            job = CFGJob(addr, target_func_addr, jump.jumpkind,
+                         last_addr=source_addr,
+                         src_node=self._nodes[source_addr],
+                         src_ins_addr=None,
+                         src_stmt_idx=None,
+                         func_edges=[func_edge],
+                         )
+            self._insert_job(job)
+            self._register_analysis_job(target_func_addr, job)
 
         self._deregister_analysis_job(jump.func_addr, jump)
 
@@ -2444,8 +2585,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         :param IndirectJump jump: The unresolved indirect jump.
 
-        :return: An empty list
-        :rtype: list
+        :return:    None
         """
 
         # add a node from this node to the UnresolvableTarget node
@@ -2464,15 +2604,14 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         # mark it as a jumpout site for that function
         self._function_add_transition_edge(self._unresolvable_target_addr, src_node, jump.func_addr,
                                            to_outside=True,
-                                           to_function_addr=self._unresolvable_target_addr,
+                                           dst_func_addr=self._unresolvable_target_addr,
                                            ins_addr=jump.ins_addr,
                                            stmt_idx=jump.stmt_idx,
                                            )
 
         self._deregister_analysis_job(jump.func_addr, jump)
-        CFGBase._indirect_jump_unresolved(self, jump)
 
-        return []
+        CFGBase._indirect_jump_unresolved(self, jump)
 
     # Removers
 
@@ -2656,7 +2795,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
                     if new_b_size > 0:
                         # there are still some parts left in node b - we don't want to lose it
-                        self._scan_block(new_b_addr, a.function_address, None, None, None, None)
+                        dummy_job = CFGJob(new_b_addr, a.function_address, None)
+                        self._scan_block(dummy_job)
 
                     continue
 
@@ -2755,13 +2895,13 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
             if not remove_function:
                 # add functions back
-                self._function_add_node(node.addr, node.addr)
+                self._function_add_node(node, node.addr)
                 successor_node = self.get_any_node(successor_node_addr)
                 if successor_node and successor_node.function_address == node.addr:
                     # if there is absolutely no predecessors to successor_node, we'd like to add it as a new function
                     # so that it will not be left behind
                     if not list(self.graph.predecessors(successor_node)):
-                        self._function_add_node(successor_node_addr, successor_node_addr)
+                        self._function_add_node(successor_node, successor_node_addr)
 
         #if node.addr in self.kb.functions.callgraph:
         #    self.kb.functions.callgraph.remove_node(node.addr)
@@ -2786,8 +2926,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 if returning_function.addr in self._function_returns:
                     for fr in self._function_returns[returning_function.addr]:
                         # Confirm them all
-                        self._changed_functions.add(fr.caller_func_addr)
-
+                        if self.kb.functions.get_by_addr(fr.caller_func_addr).returning is not True:
+                            self._updated_nonreturning_functions.add(fr.caller_func_addr)
 
                         return_to_node = self._nodes.get(fr.return_to, None)
                         if return_to_node is None:
@@ -2804,7 +2944,13 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 if not_returning_function.addr in self._function_returns:
                     for fr in self._function_returns[not_returning_function.addr]:
                         # Remove all those FakeRet edges
-                        self._changed_functions.add(fr.caller_func_addr)
+
+                        if self.kb.functions.get_by_addr(fr.caller_func_addr).returning is not True:
+                            self._updated_nonreturning_functions.add(fr.caller_func_addr)
+
+                        continue
+
+                        # FIXME: Remove the following code
 
                         # convert them to codenodes
                         try:
@@ -2819,7 +2965,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         if type(return_to) in (int, long):
                             return_to = self._to_snippet(addr=return_to, base_state=self._base_state)
 
-                        self.kb.functions._remove_fakeret(fr.caller_func_addr, call_site_node, return_to)
+                        # self.kb.functions._remove_fakeret(fr.caller_func_addr, call_site_node, return_to)
 
                     del self._function_returns[not_returning_function.addr]
 
@@ -2951,54 +3097,50 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
     # Function utils
     #
 
-    def _function_add_node(self, addr, function_addr):
+    def _function_add_node(self, cfg_node, function_addr):
         """
         Adds node to function manager, converting address to CodeNode if
         possible
 
-        :param int addr: node address
-        :param int function_addr: address of function
+        :param CFGNode cfg_node:    A CFGNode instance.
+        :param int function_addr:   Address of the current function.
         :return: None
         """
-        node = self._nodes.get(addr, None)
-        if node is None:
-            snippet = self._to_snippet(addr=addr, base_state=self._base_state)
-        else:
-            snippet = self._to_snippet(cfg_node=self._nodes[addr])
+        snippet = self._to_snippet(cfg_node=cfg_node)
         self.kb.functions._add_node(function_addr, snippet)
 
-    def _function_add_transition_edge(self, addr, src_node, function_addr, to_outside=False, to_function_addr=None,
+    def _function_add_transition_edge(self, dst_addr, src_node, src_func_addr, to_outside=False, dst_func_addr=None,
                                       stmt_idx=None, ins_addr=None):
         """
         Add a transition edge to the function transiton map.
 
-        :param int addr: Address that the control flow transits to.
+        :param int dst_addr: Address that the control flow transits to.
         :param CFGNode src_node: The source node that the control flow transits from.
-        :param int function_addr: Function address.
+        :param int src_func_addr: Function address.
         :return: True if the edge is correctly added. False if any exception occurred (for example, the target address
                  does not exist)
         :rtype: bool
         """
 
         try:
-            target_node = self._nodes.get(addr, None)
+            target_node = self._nodes.get(dst_addr, None)
             if target_node is None:
-                target_snippet = self._to_snippet(addr=addr, base_state=self._base_state)
+                target_snippet = self._to_snippet(addr=dst_addr, base_state=self._base_state)
             else:
                 target_snippet = self._to_snippet(cfg_node=target_node)
 
             if src_node is None:
                 # Add this basic block into the function manager
-                self.kb.functions._add_node(function_addr, target_snippet)
+                self.kb.functions._add_node(src_func_addr, target_snippet)
             else:
                 src_snippet = self._to_snippet(cfg_node=src_node)
                 if not to_outside:
-                    self.kb.functions._add_transition_to(function_addr, src_snippet, target_snippet, stmt_idx=stmt_idx,
+                    self.kb.functions._add_transition_to(src_func_addr, src_snippet, target_snippet, stmt_idx=stmt_idx,
                                                          ins_addr=ins_addr
                                                          )
                 else:
-                    self.kb.functions._add_outside_transition_to(function_addr, src_snippet, target_snippet,
-                                                                 to_function_addr=to_function_addr,
+                    self.kb.functions._add_outside_transition_to(src_func_addr, src_snippet, target_snippet,
+                                                                 to_function_addr=dst_func_addr,
                                                                  stmt_idx=stmt_idx, ins_addr=ins_addr
                                                                  )
             return True
@@ -3029,15 +3171,16 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
                 return_to_outside = False
 
-                if ret_addr is None:
-                    ret_snippet = None
-                else:
-                    dst_node = self._nodes.get(ret_addr, None)
-                    if dst_node is None:
-                        ret_snippet = self._to_snippet(addr=ret_addr, base_state=self._base_state)
-                    else:
-                        ret_snippet = self._to_snippet(cfg_node=dst_node)
-                        return_to_outside = dst_node.function_address != function_addr
+                # if ret_addr is None:
+                #     ret_snippet = None
+                # else:
+                #     dst_node = self._nodes.get(ret_addr, None)
+                #     if dst_node is None:
+                #         ret_snippet = self._to_snippet(addr=ret_addr, base_state=self._base_state)
+                #     else:
+                #         ret_snippet = self._to_snippet(cfg_node=dst_node)
+                #         return_to_outside = dst_node.function_address != function_addr
+                ret_snippet = None
 
                 self.kb.functions._add_call_to(function_addr, src_snippet, addr, ret_snippet, syscall=syscall,
                                                stmt_idx=stmt_idx, ins_addr=ins_addr,
@@ -3047,14 +3190,14 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         except (SimMemoryError, SimEngineError):
             return False
 
-    def _function_add_fakeret_edge(self, addr, src_node, function_addr, confirmed=None):
+    def _function_add_fakeret_edge(self, addr, src_node, src_func_addr, confirmed=None):
         """
         Generate CodeNodes for target and source, if no source node add node
         for function, otherwise creates fake return to in function manager
 
         :param int addr: target address
         :param angr.analyses.CFGNode src_node: source node
-        :param int function_addr: address of function
+        :param int src_func_addr: address of function
         :param confirmed: used as attribute on eventual digraph
         :return: None
         """
@@ -3066,10 +3209,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             target_snippet = self._to_snippet(cfg_node=target_node)
 
         if src_node is None:
-            self.kb.functions._add_node(function_addr, target_snippet)
+            self.kb.functions._add_node(src_func_addr, target_snippet)
         else:
             src_snippet = self._to_snippet(cfg_node=src_node)
-            self.kb.functions._add_fakeret_to(function_addr, src_snippet, target_snippet, confirmed=confirmed)
+            self.kb.functions._add_fakeret_to(src_func_addr, src_snippet, target_snippet, confirmed=confirmed)
 
     def _function_add_return_site(self, addr, function_addr):
         """
@@ -3147,6 +3290,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :param Function function: The function instance.
         :return: None
         """
+
+        if irsb.statements is None:
+            return
 
         if 'lr_saved_on_stack' in function.info:
             return
@@ -3265,9 +3411,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
     # Other methods
     #
 
-    def _generate_cfgnode(self, addr, current_function_addr):
+    def _generate_cfgnode(self, cfg_job, current_function_addr):
         """
-        Generate a CFGNode that starts at `addr`.
+        Generate a CFGNode that starts at `cfg_job.addr`.
 
         Since lifting machine code to IRSBs is slow, self._nodes is used as a cache of CFGNodes.
 
@@ -3276,11 +3422,13 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         the other mode. If the basic block is successfully decoded in the other mode (different from the initial one),
          `addr` and `current_function_addr` are updated.
 
-        :param int addr: Address of the basic block.
+        :param CFGJob cfg_job: The CFGJob instance.
         :param int current_function_addr: Address of the current function.
         :return: A 4-tuple of (new address, new function address, CFGNode instance, IRSB object)
         :rtype: tuple
         """
+
+        addr = cfg_job.addr
 
         try:
 
@@ -3304,7 +3452,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
             # if possible, check the distance between `addr` and the end of this section
             distance = VEX_IRSB_MAX_SIZE
-            obj = self.project.loader.find_object_containing(addr)
+            obj = self.project.loader.find_object_containing(addr, membership_check=False)
             if obj:
                 # is there a section?
                 has_executable_section = len([ sec for sec in obj.sections if sec.is_executable ]) > 0  # pylint:disable=len-as-condition
@@ -3320,16 +3468,17 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                     distance = min(distance, VEX_IRSB_MAX_SIZE)
                 # TODO: handle segment information as well
 
-            # also check the distance between `addr` and the closest function.
-            # we don't want to have a basic block that spans across function boundaries
-            next_func = self.functions.ceiling_func(addr)
-            if next_func is not None:
-                distance_to_func = (next_func.addr & (~1) if is_arm_arch else next_func.addr) - real_addr
-                if distance_to_func != 0:
-                    if distance is None:
-                        distance = distance_to_func
-                    else:
-                        distance = min(distance, distance_to_func)
+            if cfg_job.job_type == CFGJob.JOB_TYPE_COMPLETE_SCANNING:
+                # also check the distance between `addr` and the closest function.
+                # we don't want to have a basic block that spans across function boundaries
+                next_func = self.functions.ceiling_func(addr)
+                if next_func is not None:
+                    distance_to_func = (next_func.addr & (~1) if is_arm_arch else next_func.addr) - real_addr
+                    if distance_to_func != 0:
+                        if distance is None:
+                            distance = distance_to_func
+                        else:
+                            distance = min(distance, distance_to_func)
 
             # in the end, check the distance between `addr` and the closest occupied region in segment list
             next_noncode_addr = self._seg_list.next_pos_with_sort_not_in(addr, { "code" }, max_distance=distance)
@@ -3343,7 +3492,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             irsb_string = None
             try:
                 lifted_block = self._lift(addr, size=distance)
-                irsb = lifted_block.vex
+                irsb = lifted_block.vex_nostmt
                 irsb_string = lifted_block.bytes[:irsb.size]
             except SimTranslationError:
                 nodecode = True
@@ -3385,6 +3534,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 else:
                     irsb_size = irsb.size if irsb.size > 0 else 1
                 self._seg_list.occupy(addr, irsb_size, 'nodecode')
+                l.error("Decoding error occurred at address %#x of function %#x.", addr, current_function_addr)
                 return None, None, None, None
 
             is_thumb = False

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1886,7 +1886,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 self._resolve_indirect_jumps:
             # This is an indirect jump. Try to resolve it.
 
-            resolved, resolved_targets, ij = self._indirect_jump_encountered(addr, irsb, current_function_addr, stmt_idx)
+            resolved, resolved_targets, ij = self._indirect_jump_encountered(addr, cfg_node, irsb,
+                                                                             current_function_addr, stmt_idx)
             if resolved:
                 for resolved_target in resolved_targets:
                     edge = FunctionTransitionEdge(cfg_node, resolved_target, current_function_addr,
@@ -2160,7 +2161,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             return
 
         # get all instruction addresses
-        instr_addrs = [ (i.addr + i.delta) for i in irsb.statements if isinstance(i, pyvex.IRStmt.IMark) ]
+        instr_addrs = irsb.instruction_addresses
 
         # for each statement, collect all constants that are referenced or used.
         instr_addr = None
@@ -2518,6 +2519,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             # restrict this heuristics to ELF files only
             if not any([ addr in obj.reverse_plt for obj in self.project.loader.all_elf_objects ]):
                 return False
+
+        # Make sure the IRSB has statements
+        if not irsb.has_statements:
+            irsb = self.project.factory.block(irsb.addr, size=irsb.size).vex
 
         # try to resolve the jump target
         simsucc = self.project.engines.default_engine.process(self._initial_state, irsb, force_addr=addr)
@@ -3345,13 +3350,12 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         if 'lr_saved_on_stack' not in function.info:
             function.info['lr_saved_on_stack'] = False
 
-    def _arm_track_read_lr_from_stack(self, addr, irsb, function):  # pylint:disable=unused-argument
+    def _arm_track_read_lr_from_stack(self, irsb, function):  # pylint:disable=unused-argument
         """
         At the end of a basic block, simulate the very last instruction to see if the return address is read from the
         stack and written in PC. If so, the jumpkind of this IRSB will be set to Ijk_Ret. For detailed explanations,
         please see the documentation of _arm_track_lr_on_stack().
 
-        :param int addr: The address of the basic block.
         :param pyvex.IRSB irsb: The basic block object.
         :param Function function: The function instance.
         :return: None
@@ -3364,11 +3368,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         initial_sp = 0x7fff0000
         last_sp = None
         tmps = {}
-        last_imark = next((stmt for stmt in reversed(irsb.statements)
-                           if isinstance(stmt, pyvex.IRStmt.IMark)
-                           ), 0
-                          )
-        tmp_irsb = self._lift(last_imark.addr + last_imark.delta, opt_level=self._iropt_level).vex
+        tmp_irsb = self._lift(irsb.instruction_addresses[-1], opt_level=self._iropt_level).vex
         # pylint:disable=too-many-nested-blocks
         for stmt in tmp_irsb.statements:
             if isinstance(stmt, pyvex.IRStmt.WrTmp):
@@ -3586,7 +3586,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         irsb.next is not None and \
                         isinstance(irsb.next, pyvex.IRExpr.RdTmp):
                     # do a bunch of checks to avoid unnecessary simulation from happening
-                    self._arm_track_read_lr_from_stack(addr, irsb, self.functions[func_addr])
+                    self._arm_track_read_lr_from_stack(irsb, self.functions[func_addr])
 
         elif self.project.arch.name == "MIPS32":
             function = self.kb.functions.function(func_addr)

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -73,8 +73,8 @@ class CFGNode(object):
 
         if not instruction_addrs and not self.is_simprocedure:
             # We have to collect instruction addresses by ourselves
-            if irsb is not None and irsb.statements is not None:
-                self.instruction_addrs = tuple(s.addr + s.delta for s in irsb.statements if type(s) is pyvex.IRStmt.IMark)  # pylint:disable=unidiomatic-typecheck
+            if irsb is not None:
+                self.instruction_addrs = irsb.instruction_addresses
 
         self.irsb = None #irsb
         self.has_return = False

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -1,6 +1,5 @@
 import traceback
 
-import pyvex
 import archinfo
 
 from ...codenode import BlockNode, HookNode

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -90,13 +90,13 @@ class CFGNode(object):
             sym = self._cfg.project.loader.find_symbol(self.addr - 1)
             if sym is not None:
                 self._name = sym.name
-        if self.function_address and self.name is None:
+        if self.function_address and self._name is None:
             sym = self._cfg.project.loader.find_symbol(self.function_address)
             if sym is not None:
                 self._name = sym.name
-            if self.name is not None:
+            if self._name is not None:
                 offset = self.addr - self.function_address
-                self._name = "%s%+#x" % (self.name, offset)
+                self._name = "%s%+#x" % (self._name, offset)
 
         return self._name
 

--- a/angr/block.py
+++ b/angr/block.py
@@ -12,7 +12,7 @@ class Block(object):
     BLOCK_MAX_SIZE = 4096
 
     __slots__ = ['_project', '_bytes', '_vex', 'thumb', '_capstone', 'addr', 'size', 'arch', '_instructions',
-                 '_instruction_addrs', '_opt_level'
+                 '_instruction_addrs', '_opt_level', '_vex_nostmt',
                  ]
 
     def __init__(self, addr, project=None, arch=None, size=None, byte_string=None, vex=None, thumb=False, backup_state=None,
@@ -62,6 +62,7 @@ class Block(object):
                 size = vex.size
 
         self._vex = vex
+        self._vex_nostmt = None
         self._capstone = None
         self.size = size
 
@@ -148,6 +149,27 @@ class Block(object):
             self._parse_vex_info()
 
         return self._vex
+
+    @property
+    def vex_nostmt(self):
+        if self._vex_nostmt:
+            return self._vex_nostmt
+
+        if self._vex:
+            return self._vex
+
+        self._vex_nostmt = self._vex_engine.lift(
+            clemory=self._project.loader.memory if self._project is not None else None,
+            insn_bytes=self._bytes,
+            addr=self.addr,
+            thumb=self.thumb,
+            size=self.size,
+            num_inst=self._instructions,
+            opt_level=self._opt_level,
+            arch=self.arch,
+            skip_stmts=True,
+        )
+        return self._vex_nostmt
 
     @property
     def capstone(self):

--- a/angr/block.py
+++ b/angr/block.py
@@ -12,11 +12,11 @@ class Block(object):
     BLOCK_MAX_SIZE = 4096
 
     __slots__ = ['_project', '_bytes', '_vex', 'thumb', '_capstone', 'addr', 'size', 'arch', '_instructions',
-                 '_instruction_addrs', '_opt_level', '_vex_nostmt',
+                 '_instruction_addrs', '_opt_level', '_vex_nostmt', '_collect_data_refs'
                  ]
 
     def __init__(self, addr, project=None, arch=None, size=None, byte_string=None, vex=None, thumb=False, backup_state=None,
-                 opt_level=None, num_inst=None, traceflags=0, strict_block_end=None):
+                 opt_level=None, num_inst=None, traceflags=0, strict_block_end=None, collect_data_refs=False):
 
         # set up arch
         if project is not None:
@@ -58,13 +58,16 @@ class Block(object):
                         opt_level=opt_level,
                         num_inst=num_inst,
                         traceflags=traceflags,
-                        strict_block_end=strict_block_end)
+                        strict_block_end=strict_block_end,
+                        collect_data_refs=collect_data_refs,
+                )
                 size = vex.size
 
         self._vex = vex
         self._vex_nostmt = None
         self._capstone = None
         self.size = size
+        self._collect_data_refs = collect_data_refs
 
         self._instructions = num_inst
         self._instruction_addrs = []
@@ -145,6 +148,7 @@ class Block(object):
                     num_inst=self._instructions,
                     opt_level=self._opt_level,
                     arch=self.arch,
+                    collect_data_refs=self._collect_data_refs,
             )
             self._parse_vex_info()
 
@@ -168,6 +172,7 @@ class Block(object):
             opt_level=self._opt_level,
             arch=self.arch,
             skip_stmts=True,
+            collect_data_refs=self._collect_data_refs,
         )
         return self._vex_nostmt
 

--- a/angr/codenode.py
+++ b/angr/codenode.py
@@ -4,13 +4,15 @@ l = logging.getLogger("angr.codenode")
 
 class CodeNode(object):
 
-    __slots__ = ['addr', 'size', '_graph', 'thumb']
+    __slots__ = ['addr', 'size', '_graph', 'thumb', '_hash']
 
     def __init__(self, addr, size, graph=None, thumb=False):
         self.addr = addr
         self.size = size
         self.thumb = thumb
         self._graph = graph
+
+        self._hash = None
 
     def __len__(self):
         return self.size
@@ -31,7 +33,9 @@ class CodeNode(object):
         raise TypeError("Comparison with a code node")
 
     def __hash__(self):
-        return hash((self.addr, self.size))
+        if self._hash is None:
+            self._hash = hash((self.addr, self.size))
+        return self._hash
 
     def successors(self):
         if self._graph is None:

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -477,8 +477,9 @@ class SimEngineVEX(SimEngine):
             thumb = 0
 
         # phase 3: check cache
-        cache_key = (addr, insn_bytes, size, num_inst, thumb, opt_level, strict_block_end)
+        cache_key = None
         if use_cache:
+            cache_key = (addr, insn_bytes, size, num_inst, thumb, opt_level, strict_block_end)
             if cache_key in self._block_cache:
                 self._block_cache_hits += 1
                 irsb = self._block_cache[cache_key]

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -381,17 +381,18 @@ class SimEngineVEX(SimEngine):
             state.scratch.guard = claripy.And(state.scratch.guard, cont_condition)
 
     def lift(self,
-            state=None,
-            clemory=None,
-            insn_bytes=None,
-            arch=None,
-            addr=None,
-            size=None,
-            num_inst=None,
-            traceflags=0,
-            thumb=False,
-            opt_level=None,
-            strict_block_end=None):
+             state=None,
+             clemory=None,
+             insn_bytes=None,
+             arch=None,
+             addr=None,
+             size=None,
+             num_inst=None,
+             traceflags=0,
+             thumb=False,
+             opt_level=None,
+             strict_block_end=None,
+             skip_stmts=False):
 
         """
         Lift an IRSB.
@@ -453,10 +454,16 @@ class SimEngineVEX(SimEngine):
             strict_block_end = self.default_strict_block_end
         if self._support_selfmodifying_code:
             if opt_level > 0:
-                l.warning("Self-modifying code is not always correctly optimized by PyVEX. To guarantee correctness, VEX optimizations have been disabled.")
+                l.warning("Self-modifying code is not always correctly optimized by PyVEX. "
+                          "To guarantee correctness, VEX optimizations have been disabled.")
                 opt_level = 0
                 if state and o.OPTIMIZE_IR in state.options:
                     state.options.remove(o.OPTIMIZE_IR)
+        if skip_stmts is not True:
+            skip_stmts = False
+            use_cache = self._use_cache
+        else:
+            use_cache = False
 
         # phase 2: thumb normalization
         thumb = int(thumb)
@@ -471,31 +478,32 @@ class SimEngineVEX(SimEngine):
 
         # phase 3: check cache
         cache_key = (addr, insn_bytes, size, num_inst, thumb, opt_level, strict_block_end)
-        if self._use_cache and cache_key in self._block_cache:
-            self._block_cache_hits += 1
-            irsb = self._block_cache[cache_key]
-            stop_point = self._first_stoppoint(irsb)
-            if stop_point is None:
-                return irsb
-            else:
-                size = stop_point - addr
-                # check the cache again
-                cache_key = (addr, insn_bytes, size, num_inst, thumb, opt_level, strict_block_end)
-                if cache_key in self._block_cache:
-                    self._block_cache_hits += 1
-                    return self._block_cache[cache_key]
+        if use_cache:
+            if cache_key in self._block_cache:
+                self._block_cache_hits += 1
+                irsb = self._block_cache[cache_key]
+                stop_point = self._first_stoppoint(irsb)
+                if stop_point is None:
+                    return irsb
                 else:
+                    size = stop_point - addr
+                    # check the cache again
+                    cache_key = (addr, insn_bytes, size, num_inst, thumb, opt_level, strict_block_end)
+                    if cache_key in self._block_cache:
+                        self._block_cache_hits += 1
+                        return self._block_cache[cache_key]
+                    else:
+                        self._block_cache_misses += 1
+            else:
+                # a special case: `size` is used as the maximum allowed size
+                tmp_cache_key = (addr, insn_bytes, VEX_IRSB_MAX_SIZE, num_inst, thumb, opt_level, strict_block_end)
+                try:
+                    irsb = self._block_cache[tmp_cache_key]
+                    if irsb.size <= size:
+                        self._block_cache_hits += 1
+                        return self._block_cache[tmp_cache_key]
+                except KeyError:
                     self._block_cache_misses += 1
-        else:
-            # a special case: `size` is used as the maximum allowed size
-            tmp_cache_key = (addr, insn_bytes, VEX_IRSB_MAX_SIZE, num_inst, thumb, opt_level, strict_block_end)
-            try:
-                irsb = self._block_cache[tmp_cache_key]
-                if irsb.size <= size:
-                    self._block_cache_hits += 1
-                    return self._block_cache[tmp_cache_key]
-            except KeyError:
-                self._block_cache_misses += 1
 
         # phase 4: get bytes
         if insn_bytes is not None:
@@ -507,25 +515,27 @@ class SimEngineVEX(SimEngine):
             raise SimEngineError("No bytes in memory for block starting at %#x." % addr)
 
         # phase 5: call into pyvex
-        l.debug("Creating pyvex.IRSB of arch %s at %#x", arch.name, addr)
+        # l.debug("Creating pyvex.IRSB of arch %s at %#x", arch.name, addr)
         try:
             for subphase in xrange(2):
-                irsb = pyvex.IRSB(buff, addr + thumb, arch,
-                                  num_bytes=size,
-                                  num_inst=num_inst,
+                irsb = pyvex.lift(arch, addr + thumb, buff,
+                                  max_bytes=size,
+                                  max_inst=num_inst,
                                   bytes_offset=thumb,
                                   traceflags=traceflags,
                                   opt_level=opt_level,
-                                  strict_block_end=strict_block_end)
+                                  strict_block_end=strict_block_end,
+                                  skip_stmts=skip_stmts,
+                                  )
 
-                if subphase == 0:
+                if subphase == 0 and irsb.statements is not None:
                     # check for possible stop points
                     stop_point = self._first_stoppoint(irsb)
                     if stop_point is not None:
                         size = stop_point - addr
                         continue
 
-                if self._use_cache:
+                if use_cache:
                     self._block_cache[cache_key] = irsb
                 return irsb
 

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -392,7 +392,8 @@ class SimEngineVEX(SimEngine):
              thumb=False,
              opt_level=None,
              strict_block_end=None,
-             skip_stmts=False):
+             skip_stmts=False,
+             collect_data_refs=False):
 
         """
         Lift an IRSB.
@@ -461,8 +462,10 @@ class SimEngineVEX(SimEngine):
                     state.options.remove(o.OPTIMIZE_IR)
         if skip_stmts is not True:
             skip_stmts = False
-            use_cache = self._use_cache
-        else:
+
+        use_cache = self._use_cache
+        if skip_stmts or collect_data_refs:
+            # Do not cache the blocks if skip_stmts or collect_data_refs are enabled
             use_cache = False
 
         # phase 2: thumb normalization
@@ -527,6 +530,7 @@ class SimEngineVEX(SimEngine):
                                   opt_level=opt_level,
                                   strict_block_end=strict_block_end,
                                   skip_stmts=skip_stmts,
+                                  collect_data_refs=collect_data_refs,
                                   )
 
                 if subphase == 0 and irsb.statements is not None:

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -522,7 +522,7 @@ class SimEngineVEX(SimEngine):
         # l.debug("Creating pyvex.IRSB of arch %s at %#x", arch.name, addr)
         try:
             for subphase in xrange(2):
-                irsb = pyvex.lift(arch, addr + thumb, buff,
+                irsb = pyvex.lift(buff, addr + thumb, arch,
                                   max_bytes=size,
                                   max_inst=num_inst,
                                   bytes_offset=thumb,

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -264,7 +264,7 @@ class AngrObjectFactory(object):
     def block(self, addr, size=None, max_size=None, byte_string=None, vex=None, thumb=False, backup_state=None,
               opt_level=None, num_inst=None, traceflags=0,
               insn_bytes=None, insn_text=None,  # backward compatibility
-              strict_block_end=None,
+              strict_block_end=None, collect_data_refs=False,
               ):
 
         if insn_bytes is not None and insn_text is not None:
@@ -285,7 +285,7 @@ class AngrObjectFactory(object):
             size = max_size
         return Block(addr, project=self.project, size=size, byte_string=byte_string, vex=vex, thumb=thumb,
                      backup_state=backup_state, opt_level=opt_level, num_inst=num_inst, traceflags=traceflags,
-                     strict_block_end=strict_block_end
+                     strict_block_end=strict_block_end, collect_data_refs=collect_data_refs,
                      )
 
     def fresh_block(self, addr, size, backup_state=None):

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -17,6 +17,17 @@ class Function(object):
     """
     A representation of a function and various information about it.
     """
+
+    __slots__ = ('transition_graph', '_local_transition_graph', 'normalized', '_ret_sites', '_jumpout_sites',
+                 '_callout_sites', '_endpoints', '_call_sites', '_retout_sites', 'addr', '_function_manager',
+                 'is_syscall', '_project', 'is_plt', 'addr', 'is_simprocedure', '_name', 'binary_name',
+                 '_argument_registers', '_argument_stack_variables',
+                 'bp_on_stack', 'retaddr_on_stack', 'sp_delta', 'calling_convention', 'prototype', '_returning',
+                 'prepared_registers', 'prepared_stack_variables', 'registers_read_afterwards',
+                 'startpoint', '_addr_to_block_node', '_block_sizes', '_block_cache', '_local_blocks',
+                 '_local_block_addrs', 'info'
+                 )
+
     def __init__(self, function_manager, addr, name=None, syscall=None):
         """
         Function constructor
@@ -467,7 +478,7 @@ class Function(object):
         :return: The object this function belongs to.
         """
 
-        return self._project.loader.find_object_containing(self.addr)
+        return self._project.loader.find_object_containing(self.addr, membership_check=False)
 
     def add_jumpout_site(self, node):
         """

--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -32,6 +32,12 @@ class FunctionDict(SortedDict):
             self._backref._function_added(t)
             return t
 
+    def __contains__(self, addr):
+        return super(FunctionDict, self).__contains__(addr)
+
+    def get(self, addr):
+        return super(FunctionDict, self).__getitem__(addr)
+
     def floor_addr(self, addr):
         try:
             return next(self.irange(maximum=addr, reverse=True))
@@ -93,7 +99,7 @@ class FunctionManager(KnowledgeBasePlugin, collections.Mapping):
         dst_func._register_nodes(True, node)
         self.block_map[node.addr] = node
 
-    def _add_call_to(self, function_addr, from_node, to_addr, retn_node, syscall=None, stmt_idx=None, ins_addr=None,
+    def _add_call_to(self, function_addr, from_node, to_addr, retn_node=None, syscall=None, stmt_idx=None, ins_addr=None,
                      return_to_outside=False):
 
         if type(from_node) in (int, long):  # pylint: disable=unidiomatic-typecheck
@@ -245,6 +251,9 @@ class FunctionManager(KnowledgeBasePlugin, collections.Mapping):
         for i in sorted(self._function_map.iterkeys()):
             yield i
 
+    def get_by_addr(self, addr):
+        return self._function_map.get(addr)
+
     def _function_added(self, func):
         """
         A callback method for adding a new function instance to the manager.
@@ -277,7 +286,7 @@ class FunctionManager(KnowledgeBasePlugin, collections.Mapping):
 
         try:
             next_addr = self._function_map.ceiling_addr(addr)
-            return self._function_map[next_addr]
+            return self._function_map.get(next_addr)
 
         except KeyError:
             return None

--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -32,9 +32,6 @@ class FunctionDict(SortedDict):
             self._backref._function_added(t)
             return t
 
-    def __contains__(self, addr):
-        return super(FunctionDict, self).__contains__(addr)
-
     def get(self, addr):
         return super(FunctionDict, self).__getitem__(addr)
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -840,7 +840,7 @@ public:
 			std::unique_ptr<uint8_t[]> instructions(new uint8_t[size]);
 			uc_mem_read(this->uc, address, instructions.get(), size);
 			VEXLiftResult *lift_ret = vex_lift(
-			    this->vex_guest, this->vex_archinfo, instructions.get(), address, 99, size, 1, 0, 0, 1
+			    this->vex_guest, this->vex_archinfo, instructions.get(), address, 99, size, 1, 0, 0, 1, 0
 			    );
 
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -839,12 +839,17 @@ public:
 
 			std::unique_ptr<uint8_t[]> instructions(new uint8_t[size]);
 			uc_mem_read(this->uc, address, instructions.get(), size);
-			IRSB *the_block = vex_lift(this->vex_guest, this->vex_archinfo, instructions.get(), address, 99, size, 1, 0, 0, 1);
+			VEXLiftResult *lift_ret = vex_lift(
+			    this->vex_guest, this->vex_archinfo, instructions.get(), address, 99, size, 1, 0, 0, 1
+			    );
 
-			if (the_block == NULL) {
+
+			if (lift_ret == NULL) {
 				// TODO: how to handle?
 				return false;
 			}
+
+			IRSB *the_block = lift_ret->irsb;
 
 			for (int i = 0; i < the_block->stmts_used; i++) {
 				if (!this->check_stmt(clobbered_registers, used_registers, the_block->tyenv, the_block->stmts[i])) {


### PR DESCRIPTION
This series of development work is inspired by the testing binary used in #1075 -- the binary is provided by @KevOrr, thanks! I realized that angr's CFG recovery (CFGFast, I mean) was obviously too slow to run on a 35-MB blob. I then did some intensive profiling and made quite a few improvements in angr, CLE, and PyVEX.

To give you a sense of what sort of improvement I am referring to, the following is the benchmark I've been using throughout the past three days, and the results of running CFGFast for the first 6% of code.

- Setup: the 35 MB blob (ARM big endian with a few unsupported co-processor instructions), CPython 2.7.14, and Windows 10.
- Before the refactor and enhancement: It was taking more than 8 minutes. I had to kill it before it finished running because I did not want to waste my life.
- After `block.statements` are made on-demand: 228.2 sec (over 3 minutes).
- Now (with more optimizations implemented): 92 sec (a minute and a half).

Here is an incomplete list of things that have been changed (improved, hopefully):

1. Implement `Block.vex_nostmt` so that we can get a VEX IRSB _without_ its statements. In CFGFast, we default to using statement-free IRSBs, unless the block contains an indirect jump.
1. Since irsb.statements don't exist any more, we dump exits in C, and save them in `irsb.exit_statements`.
1. Make sure CFGFast lifts every basic block at most once. `to_snippets()` no longer needs to lift/re-lift blocks.
1. Statement-free IRSBs will not be cached.
1. Edges in function graphs (`Function.transition_graph`) are no longer added immediately after the source node is traversed. The addition of these edges is delayed until the destination nodes are traversed (`CFGJob` has a new property `func_edges`).
1. As a side product of the above change, we do not need to remove any FakeRet edges from function graphs any more.
1. `._changed_functions` are renated to `._updated_nonreturning_functions`. If a function is already deemed as returning, it will not be added to this set any more.
1. PyVEX: Re-implemented the IRSB-lifting logic. Now we don't have to unnecessarily extend/copy the same block again and again before returning it to the user.

Thanks @rhelmot for going through much insanity for commiting her code as me ;)
