### PR TITLE
 Fix List Out of Range in Loop Seer

### DIFF
--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -87,7 +87,7 @@ class LoopSeer(ExplorationTechnique):
 
         if not self.loops or func is not None:
             loop_finder = self.project.analyses.LoopFinder(kb=self.cfg.kb, normalize=True, functions=func)
-            
+
             for loop in loop_finder.loops:
                 if loop.entry_edges:
                     entry = loop.entry_edges[0][0]


### PR DESCRIPTION
In some cases, Loop object has no entry_edges (i.e. loop in the start of angr function), leading to a crash in Loop Seer