### PR TITLE
LoopSeer upgrade

### DIFF
--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -94,21 +94,9 @@ class LoopSeer(ExplorationTechnique):
                         counts = state.loop_data.back_edge_trip_counts[header][-1] if not self.use_header else \
                                  state.loop_data.header_trip_counts[header][-1]
                         state.loop_data.back_edge_trip_counts[state.addr][-1] += 1
-                    #   print loop
-                    #   print hex(state.addr)
-                    #   print hex(state.history.addr)
                     state.loop_data.header_trip_counts[state.addr][-1] += 1
 
                 elif state.addr in state.loop_data.current_loop[-1][1]:
-                    for src, dst in loop.continue_edges:
-                        src_block = self.project.factory.block(src.addr)
-                        dst_block = self.project.factory.block(dst.addr)
-                        src_insns = len(src_block.instruction_addrs)
-                        dst_insns = len(dst_block.instruction_addrs)
-                    #   print hex(header), 'src'
-                    #   src_block.pp()
-                    #   print 'dst'
-                    #   dst_block.pp()
                     state.loop_data.current_loop.pop()
 
                 if self.bound is not None:

--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -2,6 +2,7 @@ import logging
 
 from . import ExplorationTechnique
 from ..analyses.loopfinder import Loop
+from ..errors import AngrExplorationTechniqueError
 from ..knowledge_base import KnowledgeBase
 from ..knowledge_plugins.functions import Function
 
@@ -16,11 +17,12 @@ class LoopSeer(ExplorationTechnique):
     free to add something else).
     """
 
-    def __init__(self, cfg=None, functions=None, loops=None, bound=None, bound_reached=None, discard_stash='spinning'):
+    def __init__(self, cfg=None, functions=None, loops=None, use_header=False, bound=None, bound_reached=None, discard_stash='spinning'):
         """
         :param cfg:             Normalized CFG is required.
         :param functions:       Function(s) containing the loop(s) to be analyzed.
         :param loops:           Loop(s) to be analyzed.
+        :param use_header:      Whether to use header based trip counter to compare with the bound limit.
         :param bound:           Limit the number of iteration a loop may be executed.
         :param bound_reached:   If provided, should be a function that takes a SimulationManager and returns
                                 a SimulationManager. Will be called when loop execution reach the given bound.
@@ -34,9 +36,9 @@ class LoopSeer(ExplorationTechnique):
         self.bound = bound
         self.bound_reached = bound_reached
         self.discard_stash = discard_stash
+        self.use_header = use_header
 
         self.loops = {}
-
         if type(loops) is Loop:
             loops = [loops]
 
@@ -46,7 +48,7 @@ class LoopSeer(ExplorationTechnique):
                     self.loops[loop.entry_edges[0][0].addr] = loop
 
         elif loops is not None:
-            raise TypeError('What type of loop is it?')
+            raise AngrExplorationTechniqueError("Invalid type for 'loops' parameter!")
 
     def setup(self, simgr):
         if self.cfg is None:
@@ -56,36 +58,20 @@ class LoopSeer(ExplorationTechnique):
             l.warning("LoopSeer uses normalized CFG. Recomputing the CFG...")
             self.cfg.normalize()
 
-        if type(self.functions) is str:
-            func = [self.cfg.kb.functions.function(name=self.functions)]
+        func = []
+        if type(self.functions) in (str, int, Function):
+            func.extend(self._get_function(self.functions))
 
-        elif type(self.functions) is int:
-            func = [self.cfg.kb.functions.function(addr=self.functions)]
-
-        elif type(self.functions) is Function:
-            func = [self.functions]
-
-        elif type(self.functions) in (list, tuple):
-            func = []
+        elif type(self.functions) in (list, tuple) and all(type(f) in (str, int, Function) for f in self.functions):
             for f in self.functions:
-                if type(f) is str:
-                    func.append(self.cfg.kb.functions.function(name=f))
+                func.extend(self._get_function(f))
 
-                elif type(f) is int:
-                    func.append(self.cfg.kb.functions.function(addr=f))
+        elif self.functions is not None:
+            raise AngrExplorationTechniqueError("Invalid type for 'functions' parameter!")
 
-                elif type(f) is Function:
-                    func.append(f)
+        func = None if not func else func
 
-                else:
-                    raise TypeError("What type of function is it?")
-        elif self.functions is None:
-            func = None
-
-        else:
-            raise TypeError("What type of function is it?")
-
-        if not self.loops or func is not None:
+        if not self.loops:
             loop_finder = self.project.analyses.LoopFinder(kb=self.cfg.kb, normalize=True, functions=func)
 
             for loop in loop_finder.loops:
@@ -94,7 +80,7 @@ class LoopSeer(ExplorationTechnique):
                     self.loops[entry.addr] = loop
 
     def step(self, simgr, stash='active', **kwargs):
-        kwargs['successor_func'] = self.normalized_step
+        kwargs['successor_func'] = self._normalized_step
 
         for state in simgr.stashes[stash]:
             # Processing a currently running loop
@@ -103,37 +89,40 @@ class LoopSeer(ExplorationTechnique):
                 header = loop.entry.addr
 
                 if state.addr == header:
-                    state.loop_data.trip_counts[state.addr][-1] += 1
+                    continue_addrs = [e[0].addr for e in loop.continue_edges]
+                    if state.history.addr in continue_addrs:
+                        counts = state.loop_data.back_edge_trip_counts[header][-1] if not self.use_header else \
+                                 state.loop_data.header_trip_counts[header][-1]
+                        state.loop_data.back_edge_trip_counts[state.addr][-1] += 1
+                    #   print loop
+                    #   print hex(state.addr)
+                    #   print hex(state.history.addr)
+                    state.loop_data.header_trip_counts[state.addr][-1] += 1
 
                 elif state.addr in state.loop_data.current_loop[-1][1]:
-                    # This is for unoptimized while/for loops.
-                    #
-                    # 0x10812: movs r3, #0          -> this block dominates the loop
-                    # 0x10814: str  r3, [r7, #20]
-                    # 0x10816: b    0x10868
-                    # 0x10818: movs r3, #0          -> the real loop body starts here
-                    # ...
-                    # 0x10868: ldr  r3, [r7, #20]   -> the loop header is executed the first time without executing the loop body
-                    # 0x1086a: cmp  r3, #3
-                    # 0x1086c: ble  0x10818
-
-                    back_edge_src = loop.continue_edges[0][0].addr
-                    back_edge_dst = loop.continue_edges[0][1].addr
-                    block = self.project.factory.block(back_edge_src)
-                    if back_edge_src != back_edge_dst and back_edge_dst in block.instruction_addrs:
-                        state.loop_data.trip_counts[header][-1] -= 1
-
+                    for src, dst in loop.continue_edges:
+                        src_block = self.project.factory.block(src.addr)
+                        dst_block = self.project.factory.block(dst.addr)
+                        src_insns = len(src_block.instruction_addrs)
+                        dst_insns = len(dst_block.instruction_addrs)
+                    #   print hex(header), 'src'
+                    #   src_block.pp()
+                    #   print 'dst'
+                    #   dst_block.pp()
                     state.loop_data.current_loop.pop()
 
                 if self.bound is not None:
-                    if state.loop_data.trip_counts[header][-1] > self.bound:
+                    counts = state.loop_data.back_edge_trip_counts[header][-1] if not self.use_header else \
+                             state.loop_data.header_trip_counts[header][-1]
+                    if counts > self.bound:
                         if self.bound_reached is not None:
                             simgr = self.bound_reached(simgr)
                         else:
                             simgr.stashes[stash].remove(state)
                             simgr.stashes[self.discard_stash].append(state)
 
-                l.debug("%s trip counts %s", state, state.loop_data.trip_counts)
+                l.debug("%s back edge based trip counts %s", state, state.loop_data.back_edge_trip_counts)
+                l.debug("%s header based trip counts %s", state, state.loop_data.header_trip_counts)
 
             # Loop entry detected. This test is put here because in case of
             # nested loops, we want to handle the outer loop before proceeding
@@ -143,13 +132,30 @@ class LoopSeer(ExplorationTechnique):
                 header = loop.entry.addr
                 exits = [e[1].addr for e in loop.break_edges]
 
-                state.loop_data.trip_counts[header].append(0)
+                state.loop_data.back_edge_trip_counts[header].append(0)
+                state.loop_data.header_trip_counts[header].append(0)
                 state.loop_data.current_loop.append((loop, exits))
 
         simgr.step(stash=stash, **kwargs)
 
         return simgr
 
-    def normalized_step(self, state):
+    def _normalized_step(self, state):
         node = self.cfg.get_any_node(state.addr)
         return state.step(num_inst=len(node.instruction_addrs) if node is not None else None)
+
+    def _get_function(self, func):
+        if type(func) is str:
+            f = self.cfg.kb.functions.function(name=func)
+            if f is None:
+                l.warning("Function '%s' doesn't exist in the CFG. Skipping...", func)
+
+        elif type(func) is int:
+            f = self.cfg.kb.functions.function(addr=func)
+            if f is None:
+                l.warning("Function at 0x%x doesn't exist in the CFG. Skipping...", func)
+
+        elif type(func) is Function:
+            f = func
+
+        return [] if f is None else [f]

--- a/angr/state_plugins/loop_data.py
+++ b/angr/state_plugins/loop_data.py
@@ -11,60 +11,61 @@ l = logging.getLogger('angr.state_plugins.loop_data')
 class SimStateLoopData(SimStatePlugin):
     """
     This class keeps track of loop-related information for states.
-    
     Note that we have 2 counters for loop iterations (trip counts): the first
     recording the number of times one of the back edges (or continue edges) of
     a loop is taken, whereas the second recording the number of times the loop
     header (or loop entry) is executed. These 2 counters may differ since
     compilers usually optimize loops hence completely change the loop structure
     at the binary level.
-
-    This is why header based trip counter is not always accurate:
-    
-    0x10812: movs r3, #0          -> this block dominates the loop
-    0x10814: str  r3, [r7, #20]
-    0x10816: b    0x10868
-
-    0x10818: movs r3, #0          -> the real loop body starts here
-    ...
-
-    0x10868: ldr  r3, [r7, #20]   -> the loop header is executed the first time without executing the loop body
-    0x1086a: cmp  r3, #3
-    0x1086c: ble  0x10818         -> the back edge
-
-    This is why back edge based trip counter is not always accurate. The
-    compiler divides the logic of the loop body in 2 parts A and B. This loop
-    structure implies that the back edge is taken one time less than the number
-    of times the full loop body is executed.
-    
-    0x10768: movs r3, #0          -> this block contains part A of the logic
-    ...                              for the first iteration and dominates the loop
-    0x10816: b    0x10868
-
-    0x10818: movs r3, #0          -> part A of the logic for other iterations is put in this block
-    ...
-
-    0x10868: add  r2, r0, r1      -> part B of the logic for all iterations is put in the loop header
-    ...
-    0x10898: ldr  r3, [r7, #20]
-    0x1089a: cmp  r3, #3
-    0x1089c: ble  0x10818         -> the back edge
-
-    And yes, another example for the latter case is a do-while loop!
+    This is supposed to be used with `LoopSeer` exploration technique, which
+    monitors loop execution. For the moment, the only thing we want to analyze
+    is loop trip counts, but nothing prevents us from extending this plugin for
+    other loop analyses.
     """
 
     def __init__(self, back_edge_trip_counts=None, header_trip_counts=None, current_loop=None):
         """
         :param back_edge_trip_counts: Dictionary that stores back edge based trip counts for each loop.
                                       Keys are address of loop headers.
-        :param header_trip_counts   : Dictionary that stores header based trip counts for each loop.
+        :param header_trip_counts:    Dictionary that stores header based trip counts for each loop.
                                       Keys are address of loop headers.
-        :param current_loop         : List of currently running loops. Each element is a tuple
+        :param current_loop:          List of currently running loops. Each element is a tuple
                                       (loop object, list of loop exits).
         """
+        # This is why header based trip counter is not always accurate:
+        #
+        # 0x10812: movs r3, #0          -> this block dominates the loop
+        # 0x10814: str  r3, [r7, #20]
+        # 0x10816: b    0x10868
+        #
+        # 0x10818: movs r3, #0          -> the real loop body starts here
+        # ...
+        #
+        # 0x10868: ldr  r3, [r7, #20]   -> the loop header is executed the first time without executing the loop body
+        # 0x1086a: cmp  r3, #3
+        # 0x1086c: ble  0x10818         -> the back edge
+        #
+        # This is why back edge based trip counter is not always accurate. The
+        # compiler divides the logic of the loop body in 2 parts A and B. This loop
+        # structure implies that the back edge is taken one time less than the number
+        # of times the full loop body is executed.
+        #
+        # 0x10768: movs r3, #0          -> this block contains part A of the logic
+        # ...                              for the first iteration and dominates the loop
+        # 0x10816: b    0x10868
+        #
+        # 0x10818: movs r3, #0          -> part A of the logic for other iterations is put in this block
+        # ...
+        #
+        # 0x10868: add  r2, r0, r1      -> part B of the logic for all iterations is put in the loop header
+        # ...
+        # 0x10898: ldr  r3, [r7, #20]
+        # 0x1089a: cmp  r3, #3
+        # 0x1089c: ble  0x10818         -> the back edge
+        #
+        # And yes, another example for the latter case is a do-while loop!
 
         SimStatePlugin.__init__(self)
-
         self.back_edge_trip_counts = defaultdict(list) if back_edge_trip_counts is None else back_edge_trip_counts
         self.header_trip_counts = defaultdict(list) if header_trip_counts is None else header_trip_counts
         self.current_loop = [] if current_loop is None else current_loop

--- a/angr/state_plugins/loop_data.py
+++ b/angr/state_plugins/loop_data.py
@@ -11,17 +11,62 @@ l = logging.getLogger('angr.state_plugins.loop_data')
 class SimStateLoopData(SimStatePlugin):
     """
     This class keeps track of loop-related information for states.
+    
+    Note that we have 2 counters for loop iterations (trip counts): the first
+    recording the number of times one of the back edges (or continue edges) of
+    a loop is taken, whereas the second recording the number of times the loop
+    header (or loop entry) is executed. These 2 counters may differ since
+    compilers usually optimize loops hence completely change the loop structure
+    at the binary level.
+
+    This is why header based trip counter is not always accurate:
+    
+    0x10812: movs r3, #0          -> this block dominates the loop
+    0x10814: str  r3, [r7, #20]
+    0x10816: b    0x10868
+
+    0x10818: movs r3, #0          -> the real loop body starts here
+    ...
+
+    0x10868: ldr  r3, [r7, #20]   -> the loop header is executed the first time without executing the loop body
+    0x1086a: cmp  r3, #3
+    0x1086c: ble  0x10818         -> the back edge
+
+    This is why back edge based trip counter is not always accurate. The
+    compiler divides the logic of the loop body in 2 parts A and B. This loop
+    structure implies that the back edge is taken one time less than the number
+    of times the full loop body is executed.
+    
+    0x10768: movs r3, #0          -> this block contains part A of the logic
+    ...                              for the first iteration and dominates the loop
+    0x10816: b    0x10868
+
+    0x10818: movs r3, #0          -> part A of the logic for other iterations is put in this block
+    ...
+
+    0x10868: add  r2, r0, r1      -> part B of the logic for all iterations is put in the loop header
+    ...
+    0x10898: ldr  r3, [r7, #20]
+    0x1089a: cmp  r3, #3
+    0x1089c: ble  0x10818         -> the back edge
+
+    And yes, another example for the latter case is a do-while loop!
     """
 
-    def __init__(self, trip_counts=None, current_loop=None):
+    def __init__(self, back_edge_trip_counts=None, header_trip_counts=None, current_loop=None):
         """
-        :param trip_counts : Dictionary that stores trip counts for each loop. Keys are address of loop headers.
-        :param current_loop: List of currently running loops. Each element is a tuple (loop object, list of loop exits).
+        :param back_edge_trip_counts: Dictionary that stores back edge based trip counts for each loop.
+                                      Keys are address of loop headers.
+        :param header_trip_counts   : Dictionary that stores header based trip counts for each loop.
+                                      Keys are address of loop headers.
+        :param current_loop         : List of currently running loops. Each element is a tuple
+                                      (loop object, list of loop exits).
         """
 
         SimStatePlugin.__init__(self)
 
-        self.trip_counts = defaultdict(list) if trip_counts is None else trip_counts
+        self.back_edge_trip_counts = defaultdict(list) if back_edge_trip_counts is None else back_edge_trip_counts
+        self.header_trip_counts = defaultdict(list) if header_trip_counts is None else header_trip_counts
         self.current_loop = [] if current_loop is None else current_loop
 
     def merge(self, others, merge_conditions, common_ancestor=None): # pylint: disable=unused-argument
@@ -34,7 +79,8 @@ class SimStateLoopData(SimStatePlugin):
 
     @SimStatePlugin.memo
     def copy(self, memo): # pylint: disable=unused-argument
-        return SimStateLoopData(trip_counts=copy.deepcopy(self.trip_counts),
+        return SimStateLoopData(back_edge_trip_counts=copy.deepcopy(self.back_edge_trip_counts),
+                                header_trip_counts=copy.deepcopy(self.header_trip_counts),
                                 current_loop=list(self.current_loop))
 
 

--- a/tests/test_loop_seer.py
+++ b/tests/test_loop_seer.py
@@ -26,76 +26,76 @@ def test_various_loops():
     simgr.run()
 
     nose.tools.assert_equals(len(simgr.deadended), 10)
-    nose.tools.assert_equals(len(simgr.deadended[0].loop_data.trip_counts), 14)
+    nose.tools.assert_equals(len(simgr.deadended[0].loop_data.back_edge_trip_counts), 14)
 
     for i, d in enumerate(simgr.deadended):
         f = p.kb.functions.function(name='symbolic_loop')
         l = p.analyses.LoopFinder(functions=[f]).loops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[l.entry.addr][0], i)
+        nose.tools.assert_equals(d.loop_data.back_edge_trip_counts[l.entry.addr][0], i)
 
         f = p.kb.functions.function(name='for_loop')
         l = p.analyses.LoopFinder(functions=[f]).loops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[l.entry.addr][0], 9)
+        nose.tools.assert_equals(d.loop_data.back_edge_trip_counts[l.entry.addr][0], 9)
 
         f = p.kb.functions.function(name='while_loop')
         l = p.analyses.LoopFinder(functions=[f]).loops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[l.entry.addr][0], 9)
+        nose.tools.assert_equals(d.loop_data.back_edge_trip_counts[l.entry.addr][0], 9)
 
         f = p.kb.functions.function(name='do_while_loop')
         l = p.analyses.LoopFinder(functions=[f]).loops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[l.entry.addr][0], 9)
+        nose.tools.assert_equals(d.loop_data.header_trip_counts[l.entry.addr][0], 9)
 
         f = p.kb.functions.function(name='nullify')
         l = p.analyses.LoopFinder(functions=[f]).loops[0]
-        nose.tools.assert_equals(len(d.loop_data.trip_counts[l.entry.addr]), 8)
-        nose.tools.assert_equals(d.loop_data.trip_counts[l.entry.addr][0], 9)
+        nose.tools.assert_equals(len(d.loop_data.back_edge_trip_counts[l.entry.addr]), 8)
+        nose.tools.assert_equals(d.loop_data.back_edge_trip_counts[l.entry.addr][0], 9)
 
         f = p.kb.functions.function(name='nested_for_loop')
         ol = p.analyses.LoopFinder(functions=[f]).loops[0]
         il = ol.subloops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[ol.entry.addr][0], 3)
-        nose.tools.assert_equals(len(d.loop_data.trip_counts[il.entry.addr]), 3)
-        nose.tools.assert_true(all(s == 3 for s in d.loop_data.trip_counts[il.entry.addr]))
+        nose.tools.assert_equals(d.loop_data.back_edge_trip_counts[ol.entry.addr][0], 3)
+        nose.tools.assert_equals(len(d.loop_data.back_edge_trip_counts[il.entry.addr]), 3)
+        nose.tools.assert_true(all(s == 3 for s in d.loop_data.back_edge_trip_counts[il.entry.addr]))
 
         f = p.kb.functions.function(name='nested_while_loop')
         ol = p.analyses.LoopFinder(functions=[f]).loops[0]
         il = ol.subloops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[ol.entry.addr][0], 3)
-        nose.tools.assert_equals(len(d.loop_data.trip_counts[il.entry.addr]), 3)
-        nose.tools.assert_true(all(s == 3 for s in d.loop_data.trip_counts[il.entry.addr]))
+        nose.tools.assert_equals(d.loop_data.back_edge_trip_counts[ol.entry.addr][0], 3)
+        nose.tools.assert_equals(len(d.loop_data.back_edge_trip_counts[il.entry.addr]), 3)
+        nose.tools.assert_true(all(s == 3 for s in d.loop_data.back_edge_trip_counts[il.entry.addr]))
 
         f = p.kb.functions.function(name='nested_do_while_loop')
         ol = p.analyses.LoopFinder(functions=[f]).loops[0]
         il = ol.subloops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[ol.entry.addr][0], 3)
-        nose.tools.assert_equals(len(d.loop_data.trip_counts[il.entry.addr]), 3)
-        nose.tools.assert_true(all(s == 3 for s in d.loop_data.trip_counts[il.entry.addr]))
+        nose.tools.assert_equals(d.loop_data.header_trip_counts[ol.entry.addr][0], 3)
+        nose.tools.assert_equals(len(d.loop_data.header_trip_counts[il.entry.addr]), 3)
+        nose.tools.assert_true(all(s == 3 for s in d.loop_data.header_trip_counts[il.entry.addr]))
 
         f = p.kb.functions.function(name='break_for_loop')
         l = p.analyses.LoopFinder(functions=[f]).loops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[l.entry.addr][0], 9)
+        nose.tools.assert_equals(d.loop_data.back_edge_trip_counts[l.entry.addr][0], 9)
 
         f = p.kb.functions.function(name='break_do_while_loop')
         l = p.analyses.LoopFinder(functions=[f]).loops[0]
-        nose.tools.assert_equals(d.loop_data.trip_counts[l.entry.addr][0], 9)
+        nose.tools.assert_equals(d.loop_data.header_trip_counts[l.entry.addr][0], 9)
 
 
-def test_loops():
+def test_loops_with_invalid_parameter():
     p = angr.Project(os.path.join(test_location, 'x86_64', 'test_loops'), auto_load_libs=False)
 
     state = p.factory.entry_state()
     state.register_plugin('loop_data', angr.state_plugins.SimStateLoopData())
     simgr = p.factory.simgr(state)
 
-    simgr.use_technique(angr.exploration_techniques.LoopSeer(functions='main', bound=None))
+    simgr.use_technique(angr.exploration_techniques.LoopSeer(functions=['main', 0x1234], bound=None))
 
     simgr.run()
 
-    nose.tools.assert_equals(len(simgr.deadended[0].loop_data.trip_counts), 3)
-    nose.tools.assert_equals(simgr.deadended[0].loop_data.trip_counts[0x400665][0], 10)
-    nose.tools.assert_equals(len(simgr.deadended[0].loop_data.trip_counts[0x400665]), 10)
-    nose.tools.assert_equals(simgr.deadended[0].loop_data.trip_counts[0x400675][0], 10)
-    nose.tools.assert_equals(simgr.deadended[0].loop_data.trip_counts[0x4006b2][0], 100)
+    nose.tools.assert_equals(len(simgr.deadended[0].loop_data.back_edge_trip_counts), 3)
+    nose.tools.assert_equals(simgr.deadended[0].loop_data.back_edge_trip_counts[0x400665][0], 10)
+    nose.tools.assert_equals(len(simgr.deadended[0].loop_data.back_edge_trip_counts[0x400665]), 10)
+    nose.tools.assert_equals(simgr.deadended[0].loop_data.back_edge_trip_counts[0x400675][0], 10)
+    nose.tools.assert_equals(simgr.deadended[0].loop_data.back_edge_trip_counts[0x4006b2][0], 100)
 
 
 def test_arrays():
@@ -111,9 +111,9 @@ def test_arrays():
 
     simgr.run()
 
-    nose.tools.assert_equals(len(simgr.deadended[0].loop_data.trip_counts), 2)
-    nose.tools.assert_equals(simgr.deadended[0].loop_data.trip_counts[0x400636][0], 26)
-    nose.tools.assert_equals(simgr.deadended[0].loop_data.trip_counts[0x4005fd][0], 26)
+    nose.tools.assert_equals(len(simgr.deadended[0].loop_data.back_edge_trip_counts), 2)
+    nose.tools.assert_equals(simgr.deadended[0].loop_data.back_edge_trip_counts[0x400636][0], 26)
+    nose.tools.assert_equals(simgr.deadended[0].loop_data.back_edge_trip_counts[0x4005fd][0], 26)
 
 
 def test_loop_limiter():
@@ -130,7 +130,7 @@ def test_loop_limiter():
     simgr.run()
 
     nose.tools.assert_true('spinning' in simgr.stashes)
-    nose.tools.assert_equals(simgr.spinning[0].loop_data.trip_counts[0x4005fd][0], 6)
+    nose.tools.assert_equals(simgr.spinning[0].loop_data.back_edge_trip_counts[0x4005fd][0], 6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi all,

This PR does 2 things:

- When we say __loop iteration__, we are not sure if it refers to the number of times one of the loop back edges is taken or if it refers to the number of times the loop header is executed (this is the definition that we have arbitrary used until now). So we now have 2 types of trip counts in `LoopSeer` corresponding to these 2 definitions. Furthermore, compilers may transform loop structures of the binary, so sometimes the __header based trip counter__ does not yield accurate result. That's when we have to use the new __back edge based trip counter__.

- `LoopSeer` now will not crash when we accidentally give it invalid parameter.

@ltfish, what do you think?