### PR TITLE
Enables SimProcedure guessing

### DIFF
--- a/angr/project.py
+++ b/angr/project.py
@@ -236,6 +236,11 @@ class Project(object):
             if not func.is_function and func.type != cle.backends.symbol.Symbol.TYPE_NONE:
                 continue
             if not reloc.resolved:
+                # This is a hack, effectively to support Binary Ninja, which doesn't provide access to dependency
+                # library names. The backend creates the Relocation objects, but leaves them unresolved so that
+                # we can try to guess them here. Once the Binary Ninja API starts supplying the dependencies,
+                # The if/else, along with Project._guess_simlib() can be removed if it has no other utility,
+                # just leave behind the 'unresolved' debug statement from the else clause.
                 if hasattr(reloc.owner_obj, "guess_simprocs"):
                     l.debug("Looking for matching SimProcedure for unresolved %s from %s with hint %s",
                             func.name, reloc.owner_obj, reloc.owner_obj.guess_simprocs)
@@ -317,7 +322,9 @@ class Project(object):
     @staticmethod
     def _guess_simlib(f, hint):
         """
-        Does symbol name `f` exist as a SIM_PROCEDURE? If so, return it. Else return None
+        Does symbol name `f` exist as a SIM_PROCEDURE? If so, return it, else return None. 
+        Narrows down the set of libraries to search based on hint.
+        Part of the hack to enable Binary Ninja support. Remove if _register_objects() stops using it.
         """
         # First, filter the SIM_LIBRARIES to a reasonable subset based on the hint
         hinted_libs = []

--- a/angr/project.py
+++ b/angr/project.py
@@ -313,8 +313,9 @@ class Project(object):
             elif not func.is_weak:
                 l.info("Using stub SimProcedure for unresolved %s", export.name)
                 self.hook_symbol(export.rebased_addr, SIM_PROCEDURES['stubs']['ReturnUnconstrained'](display_name=export.name, is_stub=True))
-
-    def _guess_simlib(self, f, hint):
+    
+    @staticmethod
+    def _guess_simlib(f, hint):
         """
         Does symbol name `f` exist as a SIM_PROCEDURE? If so, return it. Else return None
         """

--- a/angr/project.py
+++ b/angr/project.py
@@ -313,7 +313,7 @@ class Project(object):
             elif not func.is_weak:
                 l.info("Using stub SimProcedure for unresolved %s", export.name)
                 self.hook_symbol(export.rebased_addr, SIM_PROCEDURES['stubs']['ReturnUnconstrained'](display_name=export.name, is_stub=True))
-    
+
     @staticmethod
     def _guess_simlib(f, hint):
         """


### PR DESCRIPTION
Enables SimProcedure guessing when encountering an unresolved relocation from a backend that has a `guess_simprocs` attribute. Tries to guess between *nix and Windows SimProcedures based on hint from the backend. Will need to be updated if/when SimProcedures are added to support other platforms (i.e., .dylib).