### PR TITLE
Remove unnecessary parameter to copy

### DIFF
--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -424,7 +424,7 @@ class SimState(PluginHub, ana.Storable):
             if id(p) in memo:
                 out[n] = memo[id(p)]
             else:
-                out[n] = p.copy(memo)
+                out[n] = p.copy()
                 memo[id(p)] = out[n]
 
         return out


### PR DESCRIPTION
I just stumbled over this, without looking further into this, it looks like there is just an unnecessary argument.