### PR TITLE
CFG: Clean up the indirect jump resolving code.

### DIFF
--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -2214,7 +2214,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         Convert each concrete indirect jump target into a SimState.
 
         :param job:                     The CFGJob instance.
-        :param indirect_jump_targets:   A collection of concrte jump targets coming from a resolved indirect jump.
+        :param indirect_jump_targets:   A collection of concrete jump targets resolved from a indirect jump.
         :return:                        A list of SimStates.
         :rtype:                         list
         """

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -1274,18 +1274,22 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             # Try to resolve indirect jumps
             irsb = input_state.block().vex
 
-            resolved, result = self._indirect_jump_encountered(addr, irsb, func_addr, stmt_idx='default')
+            resolved, resolved_targets, ij = self._indirect_jump_encountered(addr, irsb, func_addr, stmt_idx='default')
             if resolved:
-                successors = self._indirect_jump_resolved(None, None, result, job)
+                successors = self._convert_indirect_jump_targets_to_states(job, resolved_targets)
+                if ij:
+                    self._indirect_jump_resolved(ij, ij.addr, None, resolved_targets)
             else:
-                if result.resolved_targets:
-                    successors = self._indirect_jump_resolved(None, None, result.resolved_targets, job)
-                else:
-                    self._indirect_jumps_to_resolve.add(result)
-                    successors = self._process_indirect_jumps(job)
+                # Try to resolve this indirect jump using heavier approaches
+                resolved_targets = self._process_one_indirect_jump(ij)
+                successors = self._convert_indirect_jump_targets_to_states(job, resolved_targets)
 
             if successors:
                 indirect_jump_resolved_by_resolvers = True
+            else:
+                # It's unresolved. Add it to the wait list (but apparently we don't have any better way to resolve it
+                # right now).
+                self._indirect_jumps_to_resolve.add(ij)
 
         if not successors:
             # Get all successors of this block
@@ -2205,42 +2209,23 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
     # Private methods - resolving indirect jumps
 
-    def _indirect_jump_resolved(self, jump, resolved_by, targets, job):
+    def _convert_indirect_jump_targets_to_states(self, job, indirect_jump_targets):
         """
-        Called when an indirect jump is successfully resolved.
+        Convert each concrete indirect jump target into a SimState.
 
-        :param IndirectJump jump:                   The resolved indirect jump.
-        :param IndirectJumpResolver resolved_by:    The resolver used to resolve this indirect jump.
-        :param list targets:                        List of indirect jump targets.
-        :param CFGJob job:                          The job at the start of the block containing the indirect jump.
-
-        :return: List containing the indirect jump successors.
-        :rtype: list
+        :param job:                     The CFGJob instance.
+        :param indirect_jump_targets:   A collection of concrte jump targets coming from a resolved indirect jump.
+        :return:                        A list of SimStates.
+        :rtype:                         list
         """
 
-        successors = []
-        for t in targets:
+        successors = [ ]
+        for t in indirect_jump_targets:
             # Insert new successors
             a = job.sim_successors.all_successors[0].copy()
             a.ip = t
             successors.append(a)
-
-        CFGBase._indirect_jump_resolved(self, jump, resolved_by, targets, job)
-
         return successors
-
-    def _indirect_jump_unresolved(self, jump):
-        """
-        Called when we cannot resolve an indirect jump.
-
-        :param IndirectJump jump: The unresolved indirect jump.
-
-        :return: None
-        """
-
-        CFGBase._indirect_jump_unresolved(self, jump)
-
-        return []
 
     def _try_resolving_indirect_jumps(self, sim_successors, cfg_node, func_addr, successors, exception_info, artifacts):
         """

--- a/angr/analyses/cfg/cfg_accurate.py
+++ b/angr/analyses/cfg/cfg_accurate.py
@@ -2209,7 +2209,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
     # Private methods - resolving indirect jumps
 
-    def _convert_indirect_jump_targets_to_states(self, job, indirect_jump_targets):
+    @staticmethod
+    def _convert_indirect_jump_targets_to_states(job, indirect_jump_targets):
         """
         Convert each concrete indirect jump target into a SimState.
 

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2007,7 +2007,7 @@ class CFGBase(Analysis):
         :return: None
         """
 
-        addr = jump.addr if jump is not None else job.addr
+        addr = jump.addr if jump is not None else jump_addr
         l.debug('The indirect jump at %#x is successfully resolved by %s. It has %d targets.', addr, resolved_by, len(targets))
         self.kb.resolved_indirect_jumps.add(addr)
 
@@ -2123,4 +2123,3 @@ class CFGBase(Analysis):
             self._indirect_jump_unresolved(jump)
 
         return set() if targets is None else set(targets)
-

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1993,11 +1993,13 @@ class CFGBase(Analysis):
                     return True, resolved_targets
         return False, [ ]
 
-    def _indirect_jump_resolved(self, jump, resolved_by, targets, job):
+    def _indirect_jump_resolved(self, jump, jump_addr, resolved_by, targets):
         """
         Called when an indirect jump is successfully resolved.
 
-        :param IndirectJump jump:                   The resolved indirect jump.
+        :param IndirectJump jump:                   The resolved indirect jump, or None if an IndirectJump instance is
+                                                    not available.
+        :param int jump_addr:                       Address of the resolved indirect jump.
         :param IndirectJumpResolver resolved_by:    The resolver used to resolve this indirect jump.
         :param list targets:                        List of indirect jump targets.
         :param CFGJob job:                          The job at the start of the block containing the indirect jump.
@@ -2006,7 +2008,7 @@ class CFGBase(Analysis):
         """
 
         addr = jump.addr if jump is not None else job.addr
-        l.debug('The indirect jump at %#x is successfully resolved by %s.It has %d targets.', addr, resolved_by, len(targets))
+        l.debug('The indirect jump at %#x is successfully resolved by %s. It has %d targets.', addr, resolved_by, len(targets))
         self.kb.resolved_indirect_jumps.add(addr)
 
     def _indirect_jump_unresolved(self, jump):
@@ -2025,15 +2027,17 @@ class CFGBase(Analysis):
 
     def _indirect_jump_encountered(self, addr, irsb, func_addr, stmt_idx='default'):
         """
-        Called when we encounter an indirect jump.
+        Called when we encounter an indirect jump. We will try to resolve this indirect jump using timeless (fast)
+        indirect jump resolvers. If it cannot be resolved, we will see if this indirect jump has been resolved before.
 
         :param int addr:                Address of the block containing the indirect jump.
         :param pyvex.block.IRSB irsb:   IRSB of the block containing the indirect jump.
         :param int func_addr:           Address of the current function.
         :param int or str stmt_idx:     ID of the source statement.
 
-        :return: Whether it was resolved fast, the targets if it's the case, or an IndirectJump object.
-        :rtype: tuple
+        :return:    A 3-tuple of (whether it is resolved or not, all resolved targets, an IndirectJump object
+                    if there is one or None otherwise)
+        :rtype:     tuple
         """
 
         jumpkind = irsb.jumpkind
@@ -2043,7 +2047,7 @@ class CFGBase(Analysis):
         # try resolving it fast
         resolved, resolved_targets = self._resolve_indirect_jump_timelessly(addr, irsb, func_addr, jumpkind)
         if resolved:
-            return True, resolved_targets
+            return True, resolved_targets, None
 
         # Add it to our set. Will process it later if user allows.
         # Create an IndirectJump instance
@@ -2059,51 +2063,64 @@ class CFGBase(Analysis):
                                 )
             ij = IndirectJump(addr, ins_addr, func_addr, jumpkind, stmt_idx, resolved_targets=[])
             self.indirect_jumps[addr] = ij
+            resolved = False
         else:
-            ij = self.indirect_jumps[addr]
+            ij = self.indirect_jumps[addr]  # type: IndirectJump
+            resolved = len(ij.resolved_targets) > 0
 
-        return False, ij
+        return resolved, ij.resolved_targets, ij
 
-    def _process_indirect_jumps(self, job=None):
+    def _process_unresolved_indirect_jumps(self):
         """
-        Resolve indirect jumps found in previous scanning.
+        Resolve all unresolved indirect jumps found in previous scanning.
 
         Currently we support resolving the following types of indirect jumps:
         - Ijk_Call (disabled now): indirect calls where the function address is passed in from a proceeding basic block
         - Ijk_Boring: jump tables
         - For an up-to-date list, see analyses/cfg/indirect_jump_resolvers
 
-        :param CFGJob job: The job at the start of the block containing the indirect jump.
-
-        :return: List containing the indirect jump targets (addresses for CFGFast/successors for CFGAccurate).
-        :rtype: list
+        :return:    A set of concrete indirect jump targets (ints).
+        :rtype:     set
         """
 
-        all_targets = None
         l.info("%d indirect jumps to resolve.", len(self._indirect_jumps_to_resolve))
 
+        all_targets = set()
         for jump in self._indirect_jumps_to_resolve:  # type: IndirectJump
-            resolved = False
-            resolved_by = None
-            targets = None
-
-            for resolver in self.indirect_jump_resolvers:
-                resolver.base_state = self._base_state
-                block = self._lift(jump.addr, opt_level=1)
-
-                if not resolver.filter(self, jump.addr, jump.func_addr, block, jump.jumpkind):
-                    continue
-
-                resolved, targets = resolver.resolve(self, jump.addr, jump.func_addr, block, jump.jumpkind)
-                if resolved:
-                    resolved_by = resolver
-                    break
-
-            if resolved:
-                all_targets = self._indirect_jump_resolved(jump, resolved_by, targets, job)
-            else:
-                all_targets = self._indirect_jump_unresolved(jump)
+            all_targets |= self._process_one_indirect_jump(jump)
 
         self._indirect_jumps_to_resolve.clear()
 
         return all_targets
+
+    def _process_one_indirect_jump(self, jump):
+        """
+        Resolve a given indirect jump.
+
+        :param IndirectJump jump:  The IndirectJump instance.
+        :return:        A set of resolved indirect jump targets (ints).
+        """
+
+        resolved = False
+        resolved_by = None
+        targets = None
+
+        for resolver in self.indirect_jump_resolvers:
+            resolver.base_state = self._base_state
+            block = self._lift(jump.addr, opt_level=1)
+
+            if not resolver.filter(self, jump.addr, jump.func_addr, block, jump.jumpkind):
+                continue
+
+            resolved, targets = resolver.resolve(self, jump.addr, jump.func_addr, block, jump.jumpkind)
+            if resolved:
+                resolved_by = resolver
+                break
+
+        if resolved:
+            self._indirect_jump_resolved(jump, jump.addr, resolved_by, targets)
+        else:
+            self._indirect_jump_unresolved(jump)
+
+        return set() if targets is None else set(targets)
+


### PR DESCRIPTION
- Split `_process_indirect_jumps()` into two methods:
  `_process_unresolved_indirect_jumps()` and `_process_one_indirect_jump()`.
  The former calls the latter.
- Make `_indirect_jump_resolved()` and `_indirect_jump_unresolved()` both
  notification methods, i.e., they should not return anything.
- Clean up the parameters that `_indirect_jump_resolved()` takes. Take out
  the redundant logic in `CFGAccurate._indirect_jump_resolved()` and make it
  a separate method `_convert_indirect_jump_targets_to_states()`.
- Make `_indirect_jump_encountered()` return a 3-tuple instead of a 2-tuple
  to avoid type confusion of the return values (explicit is always better
  than implicit).
- Other minor bug fixes.