### PR TITLE
Cache the result of SimActionOperations

### DIFF
--- a/angr/engines/vex/expressions/op.py
+++ b/angr/engines/vex/expressions/op.py
@@ -23,7 +23,7 @@ class SimIRExpr_Op(SimIRExpr):
                         action_objects.append(SimActionObject(ex.expr, reg_deps=frozenset({arg.offset})))
                     else:
                         action_objects.append(SimActionObject(ex.expr))
-                r = SimActionOperation(self.state, self._expr.op, action_objects)
+                r = SimActionOperation(self.state, self._expr.op, action_objects, self.expr)
                 self.actions.append(r)
 
         except UnsupportedIROpError as e:

--- a/angr/state_plugins/sim_action.py
+++ b/angr/state_plugins/sim_action.py
@@ -154,11 +154,13 @@ class SimActionOperation(SimAction):
     An action representing an operation between variables and/or constants.
     """
 
-    def __init__(self, state, op, exprs):
+    def __init__(self, state, op, exprs, result):
         super(SimActionOperation, self).__init__(state, 'operation')
 
         self.op = op
         self.exprs = exprs
+
+        self.result = result
 
     @property
     def all_objects(self):
@@ -167,6 +169,7 @@ class SimActionOperation(SimAction):
     def _copy_objects(self, c):
         c.op = self.op
         c.exprs = self.exprs[::]
+        c.result = self.result
 
     def _desc(self):
         return "operation/%s" % (self.op)


### PR DESCRIPTION
@rhelmot as discussed on slack. Currently, the result of `SimActionOperations` is not stored anywhere, making it hard for consumers of `SimActionOperation`s to convert them to ASTs. This PR changes the constructor for `SimActionOperation`s to require a result AST.