### PR TITLE
Fix for htons

### DIFF
--- a/angr/procedures/posix/htonl.py
+++ b/angr/procedures/posix/htonl.py
@@ -1,13 +1,12 @@
 import angr
 ######################################
-# htons (yes, really)
+# htonl
 ######################################
 
-class htons(angr.SimProcedure):
-    #pylint:disable=arguments-differ
+class htonl(angr.SimProcedure):
 
     def run(self, to_convert):
         if self.state.arch.memory_endness == "Iend_LE":
-            return to_convert.reversed >> 16
+            return to_convert.reversed
         else:
             return to_convert

--- a/angr/procedures/posix/htonl.py
+++ b/angr/procedures/posix/htonl.py
@@ -4,9 +4,10 @@ import angr
 ######################################
 
 class htonl(angr.SimProcedure):
+    #pylint:disable=arguments-differ
 
     def run(self, to_convert):
         if self.state.arch.memory_endness == "Iend_LE":
-            return to_convert.reversed
+            return to_convert[31:0].reversed.zero_extend(len(to_convert) - 32)
         else:
             return to_convert

--- a/angr/procedures/posix/htons.py
+++ b/angr/procedures/posix/htons.py
@@ -8,6 +8,6 @@ class htons(angr.SimProcedure):
 
     def run(self, to_convert):
         if self.state.arch.memory_endness == "Iend_LE":
-            return to_convert.reversed >> 16
+            return to_convert[15:0].reversed.zero_extend(len(to_convert) - 16)
         else:
             return to_convert


### PR DESCRIPTION
Guys,

There is small problem with htons.

Here is an example:

Lets imagine port is 7777, that will be 0x00001E61. After reverse we get 0x611E0000, only lower word will be considered in return value and we would get 0, so the port is lost.

Added also htonl.