### PR TITLE
Don't execute junk blocks with nodecodes or no next expression

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3385,7 +3385,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         last_sp = tmps[stmt.data.tmp]
 
         if last_sp is not None and isinstance(tmp_irsb.next, pyvex.IRExpr.RdTmp):
-            val = tmps[tmp_irsb.next.tmp]
+            val = tmps.get(tmp_irsb.next.tmp, None)
+            # val being None means there are statements that we do not handle
             if isinstance(val, tuple) and val[0] == 'load':
                 # the value comes from memory
                 memory_addr = val[1]
@@ -3526,7 +3527,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 else:
                     irsb_size = irsb.size if irsb.size > 0 else 1
                 self._seg_list.occupy(addr, irsb_size, 'nodecode')
-                l.error("Decoding error occurred at address %#x of function %#x.", addr, current_function_addr)
+                l.error("Decoding error occurred at basic block address %#x of function %#x.",
+                        addr,
+                        current_function_addr
+                        )
                 return None, None, None, None
 
             is_thumb = False

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -222,7 +222,7 @@ class SimEngineVEX(SimEngine):
 
         # if we've told the block to truncate before it ends, it will definitely have a default
         # exit barring errors
-        has_default_exit = num_stmts <= last_stmt
+        has_default_exit = num_stmts <= last_stmt and irsb.next is not None
 
         # This option makes us only execute the last four instructions
         if o.SUPER_FASTPATH in state.options:


### PR DESCRIPTION
We sometimes lift some complete crap.  Data and code are hard to tell apart sometimes, especially in firmware.  Let's try not to crash while doing it (e.g., during CFG recovery) 

The underlying problem of "Don't lift junk" is next....