### PR TITLE
The ARM CFG Party: Numerous correctness fixes regarding ARM and conditional execution

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1388,9 +1388,11 @@ class CFGBase(Analysis):
             if self._show_progressbar or self._progress_callback:
                 progress = min_stage_2_progress + (max_stage_2_progress - min_stage_2_progress) * (i * 1.0 / nodes_count)
                 self._update_progress(progress)
+
             self._graph_bfs_custom(self.graph, [ fn ], self._graph_traversal_handler, blockaddr_to_function,
                                    tmp_functions, traversed_cfg_nodes
                                    )
+
         # Don't forget those small function chunks that are not called by anything.
         # There might be references to them from data, or simply references that we cannot find via static analysis
 
@@ -1418,6 +1420,7 @@ class CFGBase(Analysis):
             if self._show_progressbar or self._progress_callback:
                 progress = min_stage_3_progress + (max_stage_3_progress - min_stage_3_progress) * (i * 1.0 / nodes_count)
                 self._update_progress(progress)
+
             self._graph_bfs_custom(self.graph, [fn], self._graph_traversal_handler, blockaddr_to_function,
                                    tmp_functions
                                    )
@@ -1430,6 +1433,7 @@ class CFGBase(Analysis):
                 addr = fn.addr - (fn.addr % 16)
                 if addr != fn.addr and addr in self.kb.functions and self.kb.functions[addr].is_plt:
                     to_remove.add(fn.addr)
+
         # remove empty functions
         for function in self.kb.functions.values():
             if function.startpoint is None:
@@ -1654,6 +1658,7 @@ class CFGBase(Analysis):
 
         while stack:
             n = stack.pop(last=False)  # type: CFGNode
+
             if n in traversed:
                 continue
 
@@ -1695,6 +1700,7 @@ class CFGBase(Analysis):
 
         src_addr = src.addr
         src_function = self._addr_to_function(src_addr, blockaddr_to_function, known_functions)
+
         if src_addr not in src_function.block_addrs_set:
             n = self.get_any_node(src_addr)
             if n is None: node = src_addr
@@ -1723,6 +1729,7 @@ class CFGBase(Analysis):
         stmt_idx = data.get('stmt_idx', None)
 
         if jumpkind == 'Ijk_Call' or jumpkind.startswith('Ijk_Sys'):
+
             is_syscall = jumpkind.startswith('Ijk_Sys')
 
             # It must be calling a function
@@ -2020,6 +2027,7 @@ class CFGBase(Analysis):
                     if there is one or None otherwise)
         :rtype:     tuple
         """
+
         jumpkind = irsb.jumpkind
         l.debug('(%s) IRSB %#x has an indirect jump as its default exit.', jumpkind, addr)
 

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2020,7 +2020,7 @@ class CFGBase(Analysis):
                     if there is one or None otherwise)
         :rtype:     tuple
         """
-       jumpkind = irsb.jumpkind
+        jumpkind = irsb.jumpkind
         l.debug('(%s) IRSB %#x has an indirect jump as its default exit.', jumpkind, addr)
 
         # try resolving it fast

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1388,11 +1388,9 @@ class CFGBase(Analysis):
             if self._show_progressbar or self._progress_callback:
                 progress = min_stage_2_progress + (max_stage_2_progress - min_stage_2_progress) * (i * 1.0 / nodes_count)
                 self._update_progress(progress)
-
             self._graph_bfs_custom(self.graph, [ fn ], self._graph_traversal_handler, blockaddr_to_function,
                                    tmp_functions, traversed_cfg_nodes
                                    )
-
         # Don't forget those small function chunks that are not called by anything.
         # There might be references to them from data, or simply references that we cannot find via static analysis
 
@@ -1420,7 +1418,6 @@ class CFGBase(Analysis):
             if self._show_progressbar or self._progress_callback:
                 progress = min_stage_3_progress + (max_stage_3_progress - min_stage_3_progress) * (i * 1.0 / nodes_count)
                 self._update_progress(progress)
-
             self._graph_bfs_custom(self.graph, [fn], self._graph_traversal_handler, blockaddr_to_function,
                                    tmp_functions
                                    )
@@ -1433,7 +1430,6 @@ class CFGBase(Analysis):
                 addr = fn.addr - (fn.addr % 16)
                 if addr != fn.addr and addr in self.kb.functions and self.kb.functions[addr].is_plt:
                     to_remove.add(fn.addr)
-
         # remove empty functions
         for function in self.kb.functions.values():
             if function.startpoint is None:
@@ -1658,7 +1654,6 @@ class CFGBase(Analysis):
 
         while stack:
             n = stack.pop(last=False)  # type: CFGNode
-
             if n in traversed:
                 continue
 
@@ -1666,8 +1661,10 @@ class CFGBase(Analysis):
 
             if n.has_return:
                 callback(n, None, {'jumpkind': 'Ijk_Ret'}, blockaddr_to_function, known_functions, None)
+            # NOTE: A block that has_return CAN have successors that aren't the return.
+            # This is particularly the case for ARM conditional instructions.  Yes, conditional rets are a thing.
 
-            elif g.out_degree(n) == 0:
+            if g.out_degree(n) == 0:
                 # it's a single node
                 callback(n, None, None, blockaddr_to_function, known_functions, None)
 
@@ -2023,8 +2020,7 @@ class CFGBase(Analysis):
                     if there is one or None otherwise)
         :rtype:     tuple
         """
-
-        jumpkind = irsb.jumpkind
+       jumpkind = irsb.jumpkind
         l.debug('(%s) IRSB %#x has an indirect jump as its default exit.', jumpkind, addr)
 
         # try resolving it fast

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1538,7 +1538,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         if self._normalize:
             # Normalize the control flow graph first before rediscovering all functions
             self.normalize()
-
         self.make_functions()
         # optional: remove functions that must be alignments
         self.remove_function_alignments()
@@ -1882,6 +1881,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 # FIXME: in some cases, a statementless irsb will be missing its instr addresses
                 # and this next part will fail. Use the real IRSB instead
                 irsb = cfg_node.block.vex
+                cfg_node.instruction_addrs = irsb.instruction_addresses
                 resolved, resolved_targets, ij = self._indirect_jump_encountered(addr, cfg_node, irsb,
                                                                                  current_function_addr, stmt_idx)
                 if resolved:
@@ -3361,7 +3361,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         if 'lr_saved_on_stack' not in function.info or not function.info['lr_saved_on_stack']:
             return
-
+        
         sp_offset = self.project.arch.sp_offset
         initial_sp = 0x7fff0000
         last_sp = None

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1593,7 +1593,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             regexes.append(r)
 
         # Construct the binary blob first
-        unassured_functions = []
+        unassured_functions = [ ]
 
         for start_, bytes_ in self._binary.memory.backers():
             for regex in regexes:
@@ -1604,7 +1604,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         mapped_position = AT.from_rva(position, self._binary).to_mva()
                         if self._addr_in_exec_memory_regions(mapped_position):
                             unassured_functions.append(mapped_position)
-        l.info("Found %d functions with prologue scanning." % len(unassured_functions))
+        l.info("Found %d functions with prologue scanning.", len(unassured_functions))
         return unassured_functions
 
     # Basic block scanning
@@ -2006,6 +2006,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         """
 
         jobs = [ ]
+
         if is_syscall:
             # Fix the target_addr for syscalls
             tmp_state = self.project.factory.blank_state(mode="fastpath", addr=cfg_node.addr)
@@ -2061,6 +2062,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                     func_edges.append(fakeret_edge)
                     ret_edge = FunctionReturnEdge(new_function_addr, return_site, current_function_addr)
                     func_edges.append(ret_edge)
+
                     # Also, keep tracing from the return site
                     ce = CFGJob(return_site, current_function_addr, 'Ijk_FakeRet', last_addr=addr, src_node=cfg_node,
                                 src_stmt_idx=stmt_idx, src_ins_addr=ins_addr, returning_source=new_function_addr,
@@ -3300,7 +3302,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         if 'lr_saved_on_stack' in function.info:
             return
 
-        #
         # if it does, we log it down to the Function object.
         lr_offset = self.project.arch.registers['lr'][0]
         sp_offset = self.project.arch.sp_offset
@@ -3361,7 +3362,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         if 'lr_saved_on_stack' not in function.info or not function.info['lr_saved_on_stack']:
             return
-        
+
         sp_offset = self.project.arch.sp_offset
         initial_sp = 0x7fff0000
         last_sp = None

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -221,9 +221,14 @@ class SimEngineVEX(SimEngine):
 
         insn_addrs = [ ]
 
+        if irsb.next is None:
+            l.warning("The .next property of IRSB %#x has an unexpected value None. has_default_exit will be set to False.",
+                      irsb.addr)
+            has_default_exit = False
+
         # if we've told the block to truncate before it ends, it will definitely have a default
         # exit barring errors
-        has_default_exit = (last_stmt == 'default' or num_stmts <= last_stmt) and irsb.next is not None
+        has_default_exit = has_default_exit and (last_stmt == 'default' or num_stmts <= last_stmt)
 
         # This option makes us only execute the last four instructions
         if o.SUPER_FASTPATH in state.options:

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -223,7 +223,8 @@ class SimEngineVEX(SimEngine):
 
         has_default_exit = True
         if irsb.next is None:
-            l.warning("The .next property of IRSB %#x has an unexpected value None. has_default_exit will be set to False.",
+            l.warning("The .next property of IRSB %#x has an unexpected value None. "
+                      "has_default_exit will be set to False.",
                       irsb.addr)
             has_default_exit = False
 

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -221,6 +221,7 @@ class SimEngineVEX(SimEngine):
 
         insn_addrs = [ ]
 
+        has_default_exit = True
         if irsb.next is None:
             l.warning("The .next property of IRSB %#x has an unexpected value None. has_default_exit will be set to False.",
                       irsb.addr)

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -223,7 +223,7 @@ class SimEngineVEX(SimEngine):
 
         # if we've told the block to truncate before it ends, it will definitely have a default
         # exit barring errors
-        has_default_exit = last_stmt == 'default' or num_stmts <= last_stmt
+        has_default_exit = (last_stmt == 'default' or num_stmts <= last_stmt) and irsb.next is not None
 
         # This option makes us only execute the last four instructions
         if o.SUPER_FASTPATH in state.options:


### PR DESCRIPTION
This is the result of my work-cation fixing the CFG results for nasty gross ARM binaries with heavy conditional execution optimizations applied. 

Caution, contains really nasty hacks, but we probably want to merge them before py3k and then make them more elegant later (e.g., we should build an UnresolvableCallTarget and associated semantics, but that's a whole thing I don't want to get into)

There is one outstanding bug remaining regarding conditional LDMFD instructions ending a function when they do not even target PC or LR; not sure what that's about, but if we fix it (could be in pyvex, actually...) then this is about as accurate as IDA's, if not more.

