### PR TITLE
angr/analyses: disambiguate types in docstrings

### DIFF
--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -124,7 +124,7 @@ class LiveDefinitions(object):
         Create a branch of the current live definition collection.
 
         :return: A new LiveDefinition instance.
-        :rtype: LiveDefinitions
+        :rtype: angr.analyses.ddg.LiveDefinitions
         """
 
         ld = LiveDefinitions()
@@ -139,7 +139,7 @@ class LiveDefinitions(object):
         Make a hard copy of `self`.
 
         :return: A new LiveDefinition instance.
-        :rtype: LiveDefinitions
+        :rtype: angr.analyses.ddg.LiveDefinitions
         """
 
         ld = LiveDefinitions()
@@ -799,7 +799,7 @@ class DDG(Analysis):
         :param live_defs:       All live definitions prior to reaching this program point.
         :param list statements: A list of VEX statements.
         :returns:               A list of new live definitions.
-        :rtype:                 LiveDefinitions
+        :rtype:                 angr.analyses.ddg.LiveDefinitions
         """
 
         # Make a copy of live_defs
@@ -862,7 +862,8 @@ class DDG(Analysis):
         This is a backward lookup in the previous defs. Note that, as we are using VSA, it is possible that `variable`
         is affected by several definitions.
 
-        :param LiveDefinitions live_defs: The collection of live definitions.
+        :param angr.analyses.ddg.LiveDefinitions live_defs:
+                            The collection of live definitions.
         :param SimVariable: The variable to lookup for definitions.
         :returns:           A dict {stmt:labels} where label is the number of individual addresses of `addr_list` (or
                             the actual set of addresses depending on the keep_addrs flag) that are definted by stmt.

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -243,7 +243,8 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
         :param iterable observation_points:     A collection of tuples of (ins_addr, OP_TYPE) defining where reaching
                                                 definitions should be copied and stored. OP_TYPE can be OP_BEFORE or
                                                 OP_AFTER.
-        :param LiveDefinitions init_state:  An optional initialization state. The analysis creates and works on a
+        :param angr.analyses.reaching_definitions.reaching_definitions.LiveDefinitions init_state:
+                                                An optional initialization state. The analysis creates and works on a
                                                 copy.
         :param bool init_func:                  Whether stack and arguments are initialized or not.
         :param SimCC cc:                        Calling convention of the function.

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -379,7 +379,8 @@ class SymbolManager(object):
         Mark a certain label as assigned (to an instruction or a block of data).
 
         :param int addr: The address of the label.
-        :param Label label: The label that is just assigned.
+        :param angr.analyses.reassembler.Label label:
+                         The label that is just assigned.
         :return: None
         """
 


### PR DESCRIPTION
Fixes "WARNING: more than one target found for cross-reference".

Actually Sphinx authors seem to agree that in the case similar to the
one that we are running into, Sphinx should prefer the type from the
current module.  But this is [not implemented yet](
sphinx-doc/sphinx#4961).