### PR TITLE
Fix state attribute typo

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -840,7 +840,7 @@ class SimLyingRegArg(SimRegArg):
     def get_value(self, state, size=None, endness=None, **kwargs):  # pylint:disable=arguments-differ
         #val = super(SimLyingRegArg, self).get_value(state, **kwargs)
         val = getattr(state.regs, self.reg_name)
-        if endness and endness != state.args.register_endness:
+        if endness and endness != state.arch.register_endness:
             val = val.reversed
         if size == 4:
             val = claripy.fpToFP(claripy.fp.RM_RNE, val.raw_to_fp(), claripy.FSORT_FLOAT)
@@ -853,7 +853,7 @@ class SimLyingRegArg(SimRegArg):
                 val = claripy.fpToFP(claripy.fp.RM_RNE, val.reversed.raw_to_fp(), claripy.FSORT_DOUBLE).reversed
             else:
                 val = claripy.fpToFP(claripy.fp.RM_RNE, val.raw_to_fp(), claripy.FSORT_DOUBLE)
-        if endness and endness != state.args.register_endness:
+        if endness and endness != state.arch.register_endness:
             val = val.reversed
         setattr(state.regs, self.reg_name, val)
         #super(SimLyingRegArg, self).set_value(state, val, endness=endness, **kwargs)


### PR DESCRIPTION
The problem has been triggered on a CTF task.
Since the CTF is still ongoing, I will wait until it ends with uploading the example that triggered it.

Thx to @rhelmot for helping me finding out the issue and fixing it on angr's slack :).


Below you can see the stacktrace before the fix.

```
WARNING | 2018-09-15 14:31:31,374 | angr.analyses.disassembly_utils | Your version of capstone does not support MIPS instruction groups.
WARNING | 2018-09-15 14:31:32,402 | angr.state_plugins.posix | Tried to look up a symbolic fd - constrained to 3 and opened /tmp/angr_implicit_0
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/home/dc/doubletrouble/solv.py in <module>()
     17 explored_paths = simulation.explore(
     18     find=[addr1, addr2],
---> 19     avoid=[addr3]
     20 )
     21 
/usr/local/lib/python2.7/dist-packages/angr/misc/immutability.pyc in _wrapper(self, *args, **kwargs)
     22         def _wrapper(self, *args, **kwargs):
     23             with cls.context(self) as self: #pylint:disable=redefined-argument-from-local
---> 24                 if method(self, *args, **kwargs) is not self:
     25                     raise ImmutabilityMixinMisused
     26                 return self
/usr/local/lib/python2.7/dist-packages/angr/sim_manager.pyc in explore(self, stash, n, find, avoid, find_stash, avoid_stash, cfg, num_find, **kwargs)
    236 
    237         try:
--> 238             self.run(stash=stash, n=n, **kwargs)
    239         finally:
    240             self.remove_technique(tech)
/usr/local/lib/python2.7/dist-packages/angr/misc/immutability.pyc in _wrapper(self, *args, **kwargs)
     22         def _wrapper(self, *args, **kwargs):
     23             with cls.context(self) as self: #pylint:disable=redefined-argument-from-local
---> 24                 if method(self, *args, **kwargs) is not self:
     25                     raise ImmutabilityMixinMisused
     26                 return self
/usr/local/lib/python2.7/dist-packages/angr/sim_manager.pyc in run(self, stash, n, until, **kwargs)
    258         for _ in (itertools.count() if n is None else xrange(0, n)):
    259             if not self.complete() and self._stashes[stash]:
--> 260                 self.step(stash=stash, **kwargs)
    261                 if not (until and until(self)):
    262                     continue
/usr/local/lib/python2.7/dist-packages/angr/misc/hookset.pyc in __call__(self, *args, **kwargs)
     55                 next_hook = self.pending.pop()
     56                 self.pulled.append(next_hook)
---> 57                 result = next_hook(self.func.im_self, *args, **kwargs)
     58 
     59             else:
/usr/local/lib/python2.7/dist-packages/angr/exploration_techniques/explorer.pyc in step(self, simgr, stash, **kwargs)
     97     def step(self, simgr, stash='active', **kwargs):
     98         base_extra_stop_points = set(kwargs.get("extra_stop_points") or {})
---> 99         return simgr.step(stash=stash, extra_stop_points=base_extra_stop_points | self._extra_stop_points, **kwargs)
    100 
    101     def _classify(self, addr, findable, avoidable):
/usr/local/lib/python2.7/dist-packages/angr/misc/hookset.pyc in __call__(self, *args, **kwargs)
     58 
     59             else:
---> 60                 result = self.func(*args, **kwargs)
     61 
     62         finally:
/usr/local/lib/python2.7/dist-packages/angr/misc/immutability.pyc in _wrapper(self, *args, **kwargs)
     22         def _wrapper(self, *args, **kwargs):
     23             with cls.context(self) as self: #pylint:disable=redefined-argument-from-local
---> 24                 if method(self, *args, **kwargs) is not self:
     25                     raise ImmutabilityMixinMisused
     26                 return self
/usr/local/lib/python2.7/dist-packages/angr/sim_manager.pyc in step(self, n, selector_func, step_func, stash, successor_func, until, filter_func, **run_args)
    339 
    340             pre_errored = len(self._errored)
--> 341             successors = self.step_state(state, successor_func, **run_args)
    342             if not any(successors.itervalues()) and len(self._errored) == pre_errored:
    343                 bucket['deadended'].append(state)
/usr/local/lib/python2.7/dist-packages/angr/sim_manager.pyc in step_state(self, state, successor_func, **run_args)
    360         """
    361         try:
--> 362             successors = self.successors(state, successor_func, **run_args)
    363             stashes = {None: successors.flat_successors,
    364                        'unsat': successors.unsat_successors,
/usr/local/lib/python2.7/dist-packages/angr/sim_manager.pyc in successors(self, state, successor_func, **run_args)
    399         if successor_func is not None:
    400             return successor_func(state, **run_args)
--> 401         return self._project.factory.successors(state, **run_args)
    402 
    403     #
/usr/local/lib/python2.7/dist-packages/angr/factory.pyc in successors(self, *args, **kwargs)
     59         """
     60 
---> 61         return self.project.engines.successors(*args, **kwargs)
     62 
     63     def blank_state(self, **kwargs):
/usr/local/lib/python2.7/dist-packages/angr/engines/hub.pyc in successors(self, state, addr, jumpkind, default_engine, procedure_engine, engines, **kwargs)
    126         for engine in engines:
    127             if engine.check(state, **kwargs):
--> 128                 r = engine.process(state, **kwargs)
    129                 if r.processed:
    130                     return r
/usr/local/lib/python2.7/dist-packages/angr/engines/hook.pyc in process(self, state, procedure, force_addr, **kwargs)
     49 
     50         l.debug("Running %s (originally at %#x)", repr(procedure), addr)
---> 51         return self.project.factory.procedure_engine.process(state, procedure, force_addr=force_addr, **kwargs)
/usr/local/lib/python2.7/dist-packages/angr/engines/procedure.pyc in process(self, state, procedure, ret_to, inline, force_addr, **kwargs)
     29                 ret_to=ret_to,
     30                 inline=inline,
---> 31                 force_addr=force_addr)
     32 
     33     def _check(self, state, *args, **kwargs):
/usr/local/lib/python2.7/dist-packages/angr/engines/engine.pyc in process(***failed resolving arguments***)
     53         successors = new_state._inspect_getattr('sim_successors', successors)
     54         try:
---> 55             self._process(new_state, successors, *args, **kwargs)
     56         except SimException:
     57             if o.EXCEPTION_HANDLING not in old_state.options:
/usr/local/lib/python2.7/dist-packages/angr/engines/procedure.pyc in _process(self, state, successors, procedure, ret_to)
     63 
     64         # do it
---> 65         inst = procedure.execute(state, successors, ret_to=ret_to)
     66         successors.artifacts['procedure'] = inst
     67 
/usr/local/lib/python2.7/dist-packages/angr/sim_procedure.pyc in execute(self, state, successors, arguments, ret_to)
    170 
    171         if inst.returns and inst.is_function and not inst.inhibit_autoret:
--> 172             inst.ret(r)
    173 
    174         return inst
/usr/local/lib/python2.7/dist-packages/angr/sim_procedure.pyc in ret(self, expr)
    310                     self.state,
    311                     expr,
--> 312                     arg_types=[False]*self.num_args if self.cc.args is None else None)
    313 
    314         if not self.should_add_successors:
/usr/local/lib/python2.7/dist-packages/angr/calling_conventions.pyc in teardown_callsite(self, state, return_val, arg_types, force_callee_cleanup)
    575         """
    576         if return_val is not None:
--> 577             self.set_return_val(state, return_val)
    578 
    579         ret_addr = self.return_addr.get_value(state)
/usr/local/lib/python2.7/dist-packages/angr/calling_conventions.pyc in set_return_val(self, state, val, is_fp, size, stack_base)
    639         if loc is None:
    640             raise NotImplementedError("This SimCC doesn't know how to store this value - should be implemented")
--> 641         loc.set_value(state, betterval, endness='Iend_BE', stack_base=stack_base)
    642 
    643 
/usr/local/lib/python2.7/dist-packages/angr/calling_conventions.pyc in set_value(self, state, val, size, endness, **kwargs)
    854             else:
    855                 val = claripy.fpToFP(claripy.fp.RM_RNE, val.raw_to_fp(), claripy.FSORT_DOUBLE)
--> 856         if endness and endness != state.args.register_endness:
    857             val = val.reversed
    858         setattr(state.regs, self.reg_name, val)
/usr/local/lib/python2.7/dist-packages/angr/misc/plugins.pyc in __getattr__(self, name)
     71             return self.get_plugin(name)
     72         except AngrNoPluginError:
---> 73             raise AttributeError(name)
     74 
     75     def __dir__(self):
AttributeError: args
```