### PR TITLE
avoid assigning multiple values to extra_stop_points when exploring

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -790,9 +790,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
     # Active scanning
 
         - If the binary has "function symbols" (TODO: this term is not accurate enough), they are starting points of
-            the code scanning
+          the code scanning
         - If the binary does not have any "function symbol", we will first perform a function prologue scanning on the
-            entire binary, and start from those places that look like function beginnings
+          entire binary, and start from those places that look like function beginnings
         - Otherwise, the binary's entry point will be the starting point for scanning
 
     # Passive scanning

--- a/angr/exploration_techniques/explorer.py
+++ b/angr/exploration_techniques/explorer.py
@@ -95,7 +95,7 @@ class Explorer(ExplorationTechnique):
         if not self.avoid_stash in simgr.stashes: simgr.stashes[self.avoid_stash] = []
 
     def step(self, simgr, stash='active', **kwargs):
-        base_extra_stop_points = set(kwargs.get("extra_stop_points") or {})
+        base_extra_stop_points = set(kwargs.pop("extra_stop_points", []))
         return simgr.step(stash=stash, extra_stop_points=base_extra_stop_points | self._extra_stop_points, **kwargs)
 
     def _classify(self, addr, findable, avoidable):


### PR DESCRIPTION
one line fix. easy to understand.