### PR TITLE
remove annoying #import ipdb;ipdb.set_trace() pattern

### DIFF
--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -850,11 +850,6 @@ class DDG(Analysis):
                 else:
                     l.debug("Skip an unsupported action %s.", a)
 
-        #import pprint
-        #pprint.pprint(self._data_graph.edges())
-        #pprint.pprint(self.simplified_data_graph.edges())
-        # import ipdb; ipdb.set_trace()
-
         return self._live_defs
 
     def _def_lookup(self, variable):  # pylint:disable=no-self-use

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -570,16 +570,6 @@ class VariableRecoveryFast(ForwardAnalysis, Analysis):  #pylint:disable=abstract
 
         if node.addr in self._node_to_input_state:
             prev_state = self._node_to_input_state[node.addr]
-            #if node.addr == 0x804824f:
-            #    print "###\n### STACK\n###"
-            #    print input_state.stack_region.dbg_repr()
-            #    print ""
-            #    print prev_state.stack_region.dbg_repr()
-            #    print "###\nREGISTER\n###"
-            #    print input_state.register_region.dbg_repr()
-            #    print ""
-            #    print prev_state.register_region.dbg_repr()
-            #    # import ipdb; ipdb.set_trace()
             if input_state == prev_state:
                 l.debug('Skip node %#x as we have reached a fixed-point', node.addr)
                 return False, input_state

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -1040,8 +1040,6 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
         # print "job_0.state.eax =", job_0.state.regs.eax._model_vsa, "job_1.state.eax =", job_1.state.regs.eax._model_vsa
         # print "new_job.state.eax =", new_state.regs.eax._model_vsa
 
-        # import ipdb; ipdb.set_trace()
-
         new_job = VFGJob(jobs[0].addr, new_state, self._context_sensitivity_level, jumpkind=jobs[0].jumpkind,
                          block_id=jobs[0].block_id, call_stack=jobs[0].call_stack, src_block_id=jobs[0].src_block_id,
                          src_exit_stmt_idx=jobs[0].src_exit_stmt_idx, src_ins_addr=jobs[0].src_ins_addr,

--- a/angr/engines/vex/ccall.py
+++ b/angr/engines/vex/ccall.py
@@ -586,7 +586,6 @@ def pc_calculate_condition(state, cond, cc_op, cc_dep1, cc_dep2, cc_ndep, platfo
         if v == 0xe:
             # jle
             pass
-            # import ipdb; ipdb.set_trace()    l.debug("cond value: 0x%x", v)
         if v in [data[platform]['CondTypes']['CondO'], data[platform]['CondTypes']['CondNO']]:
             l.debug("CondO")
             of = state.se.LShR(rdata, data[platform]['CondBitOffsets']['G_CC_SHIFT_O'])

--- a/angr/exploration_techniques/director.py
+++ b/angr/exploration_techniques/director.py
@@ -73,9 +73,6 @@ class BaseGoal(object):
 
         block_id = cfg._generate_block_id(call_stack_suffix, state.addr, is_syscall)
 
-        #if cfg.get_node(block_id) is None:
-        #    import ipdb; ipdb.set_trace()
-
         return cfg.get_node(block_id)
 
     @staticmethod

--- a/angr/procedures/linux_kernel/getrlimit.py
+++ b/angr/procedures/linux_kernel/getrlimit.py
@@ -12,7 +12,6 @@ class getrlimit(angr.SimProcedure):
     IS_SYSCALL = True
 
     def run(self, resource, rlim):
-        #import ipdb; ipdb.set_trace()
 
         if self.state.se.eval(resource) == 3:  # RLIMIT_STACK
             l.debug('running getrlimit(RLIMIT_STACK)')

--- a/angr/storage/pcap.py
+++ b/angr/storage/pcap.py
@@ -18,7 +18,6 @@ class PCAP(object):
             self.initialize(self.path)
 
     def initialize(self,path):
-        #import ipdb;ipdb.set_trace()
         f = open(path)
         pcap = dpkt.pcap.Reader(f)
         for _,buf in pcap:
@@ -33,9 +32,7 @@ class PCAP(object):
         f.close()
 
     def recv(self, length):
-        #import ipdb;ipdb.set_trace()
         temp = 0
-        #import ipdb;ipdb.set_trace()
         #pcap = self.pcap
         initial_packet = self.packet_num
         plength, pdata = self.in_streams[self.packet_num]

--- a/angr/type_backend.py
+++ b/angr/type_backend.py
@@ -138,10 +138,6 @@ class TypeBackend(claripy.Backend):
     def default_op(expr):
         return TypedValue(Top(label=[]), expr)
 
-    #def convert(self, *args, **kwargs):
-    #    import ipdb; ipdb.set_trace()
-    #    return super(TypeBackend, self).convert(*args, **kwargs)
-
 class TypeAnnotation(claripy.Annotation):
     def __init__(self, ty):
         self.ty = ty

--- a/tests/broken_pickle.py
+++ b/tests/broken_pickle.py
@@ -15,7 +15,6 @@ def test_pickle_state():
     del p
     del s2
 
-    #import ipdb; ipdb.set_trace()
     import gc; gc.collect()
 
     s2 = pickle.loads(s_str)

--- a/tests/test_prototypes.py
+++ b/tests/test_prototypes.py
@@ -20,8 +20,6 @@ def test_function_prototype():
         func_ty=func.prototype,
     )
 
-    # import ipdb; ipdb.set_trace()
-
 
 def test_find_prototype():
     proj = angr.Project(os.path.join(test_location, 'x86_64', 'all'), auto_load_libs=False)

--- a/tests/test_simulation_manager.py
+++ b/tests/test_simulation_manager.py
@@ -66,9 +66,6 @@ def run_fauxware(arch, threads):
     nose.tools.assert_equal(len(pg7.backdoor), 0)
     nose.tools.assert_equal(len(pg7.auth), 0)
 
-    #import ipdb; ipdb.set_trace()
-    #print pg2.mp_active.addr.mp_map(hex).mp_items
-
     # test selecting paths to step
     pg_a = p.factory.simgr(immutable=True)
     pg_b = pg_a.step(until=lambda lpg: len(lpg.active) > 1, step_func=lambda lpg: lpg.prune().drop(stash='pruned'))

--- a/tests/test_syscall_override.py
+++ b/tests/test_syscall_override.py
@@ -38,7 +38,7 @@ def run_fauxware_override(arch):
     def overwrite_str(state):
         state.posix.get_fd(1).write_data("HAHA\0")
 
-    #s.posix.queued_syscall_returns = [ ] #[ lambda s,run: __import__('ipdb').set_trace() ] * 1000
+    #s.posix.queued_syscall_returns = [ ]
     s.posix.queued_syscall_returns.append(None) # let the mmap run
     s.posix.queued_syscall_returns.append(overwrite_str) # prompt for username
     s.posix.queued_syscall_returns.append(0) # username read


### PR DESCRIPTION
there are lots of `import ipdb; ipdb.set_trace()` pattern in the code. I don't know exactly what they are used for. So I suggest deleting the commented ones.

They were definitely used for debugging. For example, you can see something like this: `#if node.addr == 0x804824f`.