### PR TITLE
Rename CFGAccurate to CFGEmulated (Do not lie to the users) + bonus

### DIFF
--- a/angr/analyses/__init__.py
+++ b/angr/analyses/__init__.py
@@ -4,7 +4,7 @@ from ..misc.ux import deprecated
 def register_analysis(cls, name):
     AnalysesHub.register_default(name, cls)
 
-from .cfg import CFGFast, CFGAccurate, CFG, CFGArchOptions
+from .cfg import CFGFast, CFGEmulated, CFG, CFGArchOptions
 from .cdg import CDG
 from .ddg import DDG
 from .vfg import VFG

--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -176,7 +176,7 @@ class BinaryOptimizer(Analysis):
         #    14 | PUT(eip) = 0x0804828b
         # there is no write to or read from eax
 
-        cfg = self.project.analyses.CFGAccurate(kb=func_kb,
+        cfg = self.project.analyses.CFGEmulated(kb=func_kb,
                                                 call_depth=1,
                                                 base_graph=function.graph,
                                                 keep_state=True,

--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -848,12 +848,12 @@ class BinDiff(Analysis):
         if cfg_a is None:
             #self.cfg_a = self.project.analyses.CFG(resolve_indirect_jumps=True)
             #self.cfg_b = other_project.analyses.CFG(resolve_indirect_jumps=True)
-            self.cfg_a = self.project.analyses.CFGAccurate(context_sensitivity_level=1,
+            self.cfg_a = self.project.analyses.CFGEmulated(context_sensitivity_level=1,
                                                             keep_state = True,
                                                             enable_symbolic_back_traversal = back_traversal,
                                                             enable_advanced_backward_slicing = enable_advanced_backward_slicing)
 
-            self.cfg_b = other_project.analyses.CFGAccurate(context_sensitivity_level=1,
+            self.cfg_b = other_project.analyses.CFGEmulated(context_sensitivity_level=1,
                                                             keep_state = True,
                                                             enable_symbolic_back_traversal = back_traversal,
                                                             enable_advanced_backward_slicing = enable_advanced_backward_slicing)

--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -34,7 +34,7 @@ class CDG(Analysis):
 
         if not no_construct:
             if self._cfg is None:
-                self._cfg = self.project.analyses.CFGAccurate()
+                self._cfg = self.project.analyses.CFGEmulated()
 
             # FIXME: We should not use get_any_irsb in such a real setting...
             self._entry = self._cfg.get_any_node(self._start)

--- a/angr/analyses/cfg/__init__.py
+++ b/angr/analyses/cfg/__init__.py
@@ -1,7 +1,7 @@
 
 # analyses
 from .cfg_fast import CFGFast
-from .cfg_accurate import CFGAccurate
+from .cfg_emulated import CFGEmulated
 from .cfg import CFG
 from .cfb import CFBlanket
 

--- a/angr/analyses/cfg/cfg.py
+++ b/angr/analyses/cfg/cfg.py
@@ -9,36 +9,36 @@ class OutdatedError(Exception):
 class CFG(CFGFast):     # pylint: disable=abstract-method
     """
     tl;dr: CFG is just a wrapper around CFGFast for compatibility issues. It will be fully replaced by CFGFast in future
-    releases. Feel free to use CFG if you intend to use CFGFast. Please use CFGAccurate if you *have to* use the old,
-    slow, but more accurate version of CFG.
+    releases. Feel free to use CFG if you intend to use CFGFast. Please use CFGEmulated if you *have to* use the old,
+    slow, dynamically-generated version of CFG.
 
     For multiple historical reasons, angr's CFG is accurate but slow, which does not meet what most people expect. We
-    developed CFGFast for light-speed CFG recovery, and renamed the old CFG class to CFGAccurate. For compability
-    concerns, CFG was kept as an alias to CFGAccurate.
+    developed CFGFast for light-speed CFG recovery, and renamed the old CFG class to CFGEmulated. For compability
+    concerns, CFG was kept as an alias to CFGEmulated.
 
     However, so many new users of angr would load up a binary and generate a CFG immediately after running
     "pip install angr", and draw the conclusion that "angr's CFG is so slow - angr must be unusable!" Therefore, we made
-    the hard decision: CFG will be an alias to CFGFast, instead of CFGAccurate.
+    the hard decision: CFG will be an alias to CFGFast, instead of CFGEmulated.
 
     To ease the transition of your existing code and script, the following changes are made:
 
     - A CFG class, which is a sub class of CFGFast, is created.
     - You will see both a warning message printed out to stderr and an exception raised by angr if you are passing CFG
-      any parameter that only CFGAccurate supports. This exception is not a sub class of AngrError, so you wouldn't
+      any parameter that only CFGEmulated supports. This exception is not a sub class of AngrError, so you wouldn't
       capture it with your old code by mistake.
     - In the near future, this wrapper class will be removed completely, and CFG will be a simple alias to CFGFast.
 
-    We expect most interfaces are the same between CFGFast and CFGAccurate. Apparently some functionalities (like
-    context-sensitivity, and state keeping) only exist in CFGAccurate, which is when you want to use CFGAccurate
+    We expect most interfaces are the same between CFGFast and CFGEmulated. Apparently some functionalities (like
+    context-sensitivity, and state keeping) only exist in CFGEmulated, which is when you want to use CFGEmulated
     instead.
     """
     def __init__(self, **kwargs):
         outdated_exception = "CFG is now an alias to CFGFast."
-        outdated_message = "CFG is now an alias to CFGFast. Please switch to CFGAccurate if you need functionalities " \
+        outdated_message = "CFG is now an alias to CFGFast. Please switch to CFGEmulated if you need functionalities " \
                            "that only exist there. For most cases, your code should be fine by changing \"CFG(...)\" " \
-                           "to \"CFGAccurate(...)\". Sorry for breaking your code with this giant change."
+                           "to \"CFGEmulated(...)\". Sorry for breaking your code with this giant change."
 
-        cfgaccurate_params = {'context_sensitivity_level', 'avoid_runs', 'enable_function_hints', 'call_depth',
+        cfgemulated_params = {'context_sensitivity_level', 'avoid_runs', 'enable_function_hints', 'call_depth',
                               'call_tracing_filter', 'initial_state', 'starts', 'keep_state',
                               'enable_advanced_backward_slicing', 'enable_symbolic_back_traversal', 'additional_edges',
                               'no_construct'
@@ -46,7 +46,7 @@ class CFG(CFGFast):     # pylint: disable=abstract-method
 
         # Sanity check to make sure the user only wants to use CFGFast
 
-        for p in cfgaccurate_params:
+        for p in cfgemulated_params:
             if kwargs.get(p, None) is not None:
                 sys.stderr.write(outdated_message + "\n")
                 raise OutdatedError(outdated_exception)

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -65,7 +65,7 @@ class CFGBase(Analysis):
     def __init__(self, sort, context_sensitivity_level, normalize=False, binary=None, force_segment=False, iropt_level=None, base_state=None,
                  resolve_indirect_jumps=True, indirect_jump_resolvers=None, indirect_jump_target_limit=100000):
         """
-        :param str sort:                            'fast' or 'accurate'.
+        :param str sort:                            'fast' or 'emulated'.
         :param int context_sensitivity_level:       The level of context-sensitivity of this CFG (see documentation for
                                                     further details). It ranges from 0 to infinity.
         :param bool normalize:                      Whether the CFG as well as all Function graphs should be normalized.
@@ -387,7 +387,7 @@ class CFGBase(Analysis):
         #    self._node_lookup_index_warned = True
 
         for n in self.graph.nodes():
-            if self.tag == "CFGAccurate":
+            if self.tag == "CFGEmulated":
                 cond = n.looping_times == 0
             else:
                 cond = True
@@ -1151,7 +1151,7 @@ class CFGBase(Analysis):
                                                           ]),
                                        thumb=n.thumb
                                        )
-                elif self.tag == "CFGAccurate":
+                elif self.tag == "CFGEmulated":
                     new_node = CFGNodeA(n.addr, new_size, self, callstack_key=callstack_key,
                                         function_address=n.function_address, block_id=n.block_id,
                                         instruction_addrs=tuple([i for i in n.instruction_addrs

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -24,7 +24,7 @@ from ...sim_state import SimState
 from ...state_plugins.callstack import CallStack
 from ...state_plugins.sim_action import SimActionData
 
-l = logging.getLogger("angr.analyses.cfg.cfg_accurate")
+l = logging.getLogger("angr.analyses.cfg.cfg_emulated")
 
 
 class CFGJob(CFGJobBase):
@@ -54,7 +54,7 @@ class CFGJob(CFGJobBase):
     def block_id(self):
         if self._block_id is None:
             # generate a new block ID
-            self._block_id = CFGAccurate._generate_block_id(
+            self._block_id = CFGEmulated._generate_block_id(
                 self.call_stack.stack_suffix(self._context_sensitivity_level), self.addr, self.is_syscall)
         return self._block_id
 
@@ -114,12 +114,12 @@ class PendingJob(object):
                self.src_exit_ins_addr == other.src_exit_ins_addr
 
 
-class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
+class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
     """
     This class represents a control-flow graph.
     """
 
-    tag = "CFGAccurate"
+    tag = "CFGEmulated"
 
     def __init__(self,
                  context_sensitivity_level=1,
@@ -186,7 +186,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                                                     will strictly follow nodes and edges shown in the graph, and discard
                                                     any contorl flow that does not follow an existing edge in the base
                                                     graph. For example, you can pass in a Function local transition
-                                                    graph as the base graph, and CFGAccurate will traverse nodes and
+                                                    graph as the base graph, and CFGEmulated will traverse nodes and
                                                     edges and extract useful information.
         :param int iropt_level:                     The optimization level of VEX IR (0, 1, 2). The default level will
                                                     be used if `iropt_level` is None.
@@ -196,7 +196,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         :param state_remove_options:                State options that will be removed from the initial state.
         """
         ForwardAnalysis.__init__(self, order_jobs=True if base_graph is not None else False)
-        CFGBase.__init__(self, 'accurate', context_sensitivity_level, normalize=normalize, iropt_level=iropt_level,
+        CFGBase.__init__(self, 'emulated', context_sensitivity_level, normalize=normalize, iropt_level=iropt_level,
                          resolve_indirect_jumps=resolve_indirect_jumps,
                          indirect_jump_resolvers=indirect_jump_resolvers,
                          indirect_jump_target_limit=indirect_jump_target_limit,
@@ -307,8 +307,8 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         :return: A copy of the CFG instance.
         :rtype: angr.analyses.CFG
         """
-        new_cfg = CFGAccurate.__new__(CFGAccurate)
-        super(CFGAccurate, self).make_copy(new_cfg)
+        new_cfg = CFGEmulated.__new__(CFGEmulated)
+        super(CFGEmulated, self).make_copy(new_cfg)
 
         new_cfg._indirect_jump_target_limit = self._indirect_jump_target_limit
         new_cfg.named_errors = dict(self.named_errors)
@@ -614,7 +614,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                                         there is a path between `starting_node` and a CFGNode with the specified
                                         address, and all nodes on the path should also be included in the subgraph.
         :return: A new CFG that only contain the specific subgraph.
-        :rtype: CFGAccurate
+        :rtype: CFGEmulated
         """
 
         graph = networkx.DiGraph()
@@ -1341,7 +1341,7 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                     successors.append(successor_state)
             else:
                 if extra_successor_addrs:
-                    l.error('CFGAccurate terminates at %#x although base graph provided more exits.', addr)
+                    l.error('CFGEmulated terminates at %#x although base graph provided more exits.', addr)
 
         if not successors:
             # There is no way out :-(
@@ -3438,4 +3438,4 @@ class CFGAccurate(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         state.options = state.options.difference(self._state_remove_options)
 
 from angr.analyses import AnalysesHub
-AnalysesHub.register_default('CFGAccurate', CFGAccurate)
+AnalysesHub.register_default('CFGEmulated', CFGEmulated)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -806,7 +806,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
     and then re-recover the CFG.
     """
 
-    # TODO: Move arch_options to CFGBase, and add those logic to CFGAccurate as well.
+    # TODO: Move arch_options to CFGBase, and add those logic to CFGEmulated as well.
     # TODO: Identify tail call optimization, and correctly mark the target as a new function
 
     PRINTABLES = string.printable.replace("\x0b", "").replace("\x0c", "").encode()

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -181,7 +181,7 @@ class CFGNode(object):
 
 class CFGNodeA(CFGNode):
     """
-    The CFGNode that is used in CFGAccurate.
+    The CFGNode that is used in CFGEmulated.
     """
 
     __slots__ = [ 'input_state', 'looping_times', 'callstack', 'depth', 'final_states', 'creation_failure_info',

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -2744,7 +2744,7 @@ class Reassembler(Analysis):
                 continue
             base_graph.add_node(candidate_node)
             tmp_kb = KnowledgeBase(self.project, self.project.loader.main_object)
-            cfg = self.project.analyses.CFGAccurate(kb=tmp_kb,
+            cfg = self.project.analyses.CFGEmulated(kb=tmp_kb,
                                                     starts=(candidate.irsb_addr,),
                                                     keep_state=True,
                                                     base_graph=base_graph

--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -108,7 +108,7 @@ class CallTracingFilter(object):
             new_blacklist = self.blacklist[ :: ]
             new_blacklist.append(addr)
             tracing_filter = CallTracingFilter(self.project, depth=self.depth + 1, blacklist=new_blacklist)
-            cfg = self.project.analyses.CFGAccurate(starts=((addr, jumpkind),),
+            cfg = self.project.analyses.CFGEmulated(starts=((addr, jumpkind),),
                                                     initial_state=call_target_state,
                                                     context_sensitivity_level=0,
                                                     call_depth=1,
@@ -522,7 +522,7 @@ class Veritesting(Analysis):
         Builds a CFG from the current function.
         Saved in cfg_cache.
 
-        returns (CFGAccurate, networkx.DiGraph): Tuple of the CFG and networkx representation of it
+        returns (CFGEmulated, networkx.DiGraph): Tuple of the CFG and networkx representation of it
         """
 
         state = self._input_state
@@ -550,7 +550,7 @@ class Veritesting(Analysis):
                 if not state.solver.symbolic(state.regs.rax):
                     cfg_initial_state.regs.rax = state.regs.rax
 
-            cfg = self.project.analyses.CFGAccurate(
+            cfg = self.project.analyses.CFGEmulated(
                 starts=((ip_int, state.history.jumpkind),),
                 context_sensitivity_level=0,
                 call_depth=1,
@@ -583,7 +583,7 @@ class Veritesting(Analysis):
         """
         Return all possible merge points in this CFG.
 
-        :param CFGAccurate cfg: The control flow graph, which must be acyclic.
+        :param CFGEmulated cfg: The control flow graph, which must be acyclic.
         :returns [(int, int)]:  A list of merge points (address and number of times looped).
         """
 

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -273,7 +273,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
                  ):
         """
         :param cfg: The control-flow graph to base this analysis on. If none is provided, we will
-                    construct a CFGAccurate.
+                    construct a CFGEmulated.
         :param context_sensitivity_level: The level of context-sensitivity of this VFG.
                                         It ranges from 0 to infinity. Default 2.
         :param function_start: The address of the function to analyze.
@@ -462,7 +462,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
             l.debug("Generating a CFG, since none was given...")
             # TODO: can we use a fast CFG instead? note that fast CFG does not care of context sensitivity at all, but
             # TODO: for state merging, we also don't really care about context sensitivity.
-            self._cfg = self.project.analyses.CFGAccurate(context_sensitivity_level=self._context_sensitivity_level,
+            self._cfg = self.project.analyses.CFGEmulated(context_sensitivity_level=self._context_sensitivity_level,
                 starts=(self._start,)
             )
 

--- a/angr/blade.py
+++ b/angr/blade.py
@@ -14,7 +14,7 @@ class Blade(object):
                  ignore_bp=False, ignored_regs=None, max_level=3, base_state=None):
         """
         :param networkx.DiGraph graph:  A graph representing the control flow graph. Note that it does not take
-                                        angr.analyses.CFGAccurate or angr.analyses.CFGFast.
+                                        angr.analyses.CFGEmulated or angr.analyses.CFGFast.
         :param int dst_run:             An address specifying the target SimRun.
         :param int dst_stmt_idx:        The target statement index. -1 means executing until the last statement.
         :param str direction:           'backward' or 'forward' slicing. Forward slicing is not yet supported.

--- a/angr/exploration_techniques/director.py
+++ b/angr/exploration_techniques/director.py
@@ -32,7 +32,7 @@ class BaseGoal(object):
     def check(self, cfg, state, peek_blocks):
         """
 
-        :param angr.analyses.CFGAccurate cfg:   An instance of CFGAccurate.
+        :param angr.analyses.CFGEmulated cfg:   An instance of CFGEmulated.
         :param angr.SimState state:             The state to check.
         :param int peek_blocks:                 Number of blocks to peek ahead from the current point.
         :return: True if we can determine that this condition is definitely satisfiable if the path is taken, False
@@ -62,7 +62,7 @@ class BaseGoal(object):
         """
         Get the CFGNode object on the control flow graph given an angr state.
 
-        :param angr.analyses.CFGAccurate cfg:   An instance of CFGAccurate.
+        :param angr.analyses.CFGEmulated cfg:   An instance of CFGEmulated.
         :param angr.SimState state:             The current state.
         :return: A CFGNode instance if the node exists, or None if the node cannot be found.
         :rtype: CFGNode or None
@@ -173,7 +173,7 @@ class CallFunctionGoal(BaseGoal):
     A goal that prioritizes states reaching certain function, and optionally with specific arguments.
     Note that constraints on arguments (and on function address as well) have to be identifiable on an accurate CFG.
     For example, you may have a CallFunctionGoal saying "call printf with the first argument being 'Hello, world'", and
-    CFGAccurate must be able to figure our the first argument to printf is in fact "Hello, world", not some symbolic
+    CFGEmulated must be able to figure our the first argument to printf is in fact "Hello, world", not some symbolic
     strings that will be constrained to "Hello, world" during symbolic execution (or simulation, however you put it).
     """
 
@@ -362,7 +362,7 @@ class Director(ExplorationTechnique):
     """
     An exploration technique for directed symbolic execution.
 
-    A control flow graph (using CFGAccurate) is built and refined during symbolic execution. Each time the execution
+    A control flow graph (using CFGEmulated) is built and refined during symbolic execution. Each time the execution
     reaches a block that is outside of the CFG, the CFG recovery will be triggered with that state, with a maximum
     recovery depth (100 by default). If we see a basic block during state stepping that is not yet in the control flow
     graph, we go back to control flow graph recovery and "peek" more blocks forward.
@@ -448,7 +448,7 @@ class Director(ExplorationTechnique):
             starts = list(simgr.active)
             self._cfg_kb = KnowledgeBase(self.project, self.project.loader.main_object)
 
-            self._cfg = self.project.analyses.CFGAccurate(kb=self._cfg_kb, starts=starts, max_steps=self._peek_blocks,
+            self._cfg = self.project.analyses.CFGEmulated(kb=self._cfg_kb, starts=starts, max_steps=self._peek_blocks,
                                                           keep_state=self._cfg_keep_states
                                                           )
 

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -930,7 +930,7 @@ class Function(object):
         Make sure all basic blocks in the transition graph of this function do not overlap. You will end up with a CFG
         that IDA Pro generates.
 
-        This method does not touch the CFG result. You may call CFG{Accurate, Fast}.normalize() for that matter.
+        This method does not touch the CFG result. You may call CFG{Emulated, Fast}.normalize() for that matter.
 
         :return: None
         """

--- a/angr/project.py
+++ b/angr/project.py
@@ -225,6 +225,13 @@ class Project:
                 missing_libs.append(SIM_LIBRARIES[lib_name])
             except KeyError:
                 l.info("There are no simprocedures for missing library %s :(", lib_name)
+        # additionally provide libraries we _have_ loaded as a fallback fallback
+        # this helps in the case that e.g. CLE picked up a linux arm libc to satisfy an android arm binary
+        for lib in self.loader.all_objects:
+            if lib.provides in SIM_LIBRARIES:
+                simlib = SIM_LIBRARIES[lib.provides]
+                if simlib not in missing_libs:
+                    missing_libs.append(simlib)
 
         # Step 2: Categorize every "import" symbol in each object.
         # If it's IGNORED, mark it for stubbing

--- a/tests/broken_simcc.py
+++ b/tests/broken_simcc.py
@@ -12,7 +12,7 @@ def test_simcc_x86_64():
     binary_path = test_location + "/x86_64/simcc"
 
     p = angr.Project(binary_path)
-    p.analyses.CFGAccurate()
+    p.analyses.CFGEmulated()
 
     f_arg1 = p.kb.functions['arg1']
     nose.tools.assert_not_equal(f_arg1, None)

--- a/tests/broken_slicing.py
+++ b/tests/broken_slicing.py
@@ -17,7 +17,7 @@ def test_find_exits():
                                 default_analysis_mode='symbolic')
 
     l.info("Unit test for BackwardSlice._find_exits()")
-    cfg = slicing_test.analyses.CFGAccurate(context_sensitivity_level=2, keep_state=True)
+    cfg = slicing_test.analyses.CFGEmulated(context_sensitivity_level=2, keep_state=True)
     cdg = slicing_test.analyses.CDG(cfg)
     ddg = slicing_test.analyses.DDG(cfg)
 
@@ -49,7 +49,7 @@ def test_control_flow_slicing():
                                 default_analysis_mode='symbolic')
     l.info("Control Flow Slicing")
     start = time.time()
-    cfg = slicing_test.analyses.CFGAccurate(context_sensitivity_level=2)
+    cfg = slicing_test.analyses.CFGEmulated(context_sensitivity_level=2)
     end = time.time()
     duration = end - start
     l.info("CFG generation is done in %f seconds.", duration)
@@ -70,7 +70,7 @@ def broken_backward_slice():
 
     l.info("Control Flow Slicing")
 
-    cfg = slicing_test.analyses.CFGAccurate(context_sensitivity_level=2, keep_state=True)
+    cfg = slicing_test.analyses.CFGEmulated(context_sensitivity_level=2, keep_state=True)
     cdg = slicing_test.analyses.CDG(cfg=cfg)
     ddg = slicing_test.analyses.DDG(cfg=cfg)
 

--- a/tests/manual_performance.py
+++ b/tests/manual_performance.py
@@ -68,7 +68,7 @@ def run_cfg_analysis(path):
                      load_options=load_options,
                      translation_cache=True
                      )
-    p.analyses.CFGAccurate()
+    p.analyses.CFGEmulated()
 
 
 def time_one(args, test, queue):

--- a/tests/test_cdg.py
+++ b/tests/test_cdg.py
@@ -22,7 +22,7 @@ def test_graph_0():
                      use_sim_procedures=True)
 
     # Create the CDG analysis
-    cfg = p.analyses.CFGAccurate(no_construct=True)
+    cfg = p.analyses.CFGEmulated(no_construct=True)
 
     # Create our mock control flow graph
     g = networkx.DiGraph()

--- a/tests/test_cfgaccurate.py
+++ b/tests/test_cfgaccurate.py
@@ -86,7 +86,7 @@ def perform_single(binary_path, cfg_path=None):
                         default_analysis_mode='symbolic',
                         load_options={'auto_load_libs': False})
     start = time.time()
-    cfg = proj.analyses.CFGAccurate(context_sensitivity_level=1, fail_fast=True)
+    cfg = proj.analyses.CFGEmulated(context_sensitivity_level=1, fail_fast=True)
     end = time.time()
     duration = end - start
     bbl_dict = cfg.nodes()
@@ -141,9 +141,9 @@ def test_additional_edges():
     additional_edges = {
         0x400573 : [ 0x400580, 0x40058f, 0x40059e ]
     }
-    cfg = proj.analyses.CFGAccurate(context_sensitivity_level=0, additional_edges=additional_edges, fail_fast=True,
+    cfg = proj.analyses.CFGEmulated(context_sensitivity_level=0, additional_edges=additional_edges, fail_fast=True,
                                     resolve_indirect_jumps=False,  # For this test case, we need to disable the
-                                                                   # jump table resolving, otherwise CFGAccurate
+                                                                   # jump table resolving, otherwise CFGEmulated
                                                                    # can automatically find the node 0x4005ad.
                                     )
 
@@ -160,7 +160,7 @@ def test_not_returning():
                         use_sim_procedures=True,
                         load_options={'auto_load_libs': False}
                         )
-    cfg = proj.analyses.CFGAccurate(context_sensitivity_level=0, fail_fast=True)  # pylint:disable=unused-variable
+    cfg = proj.analyses.CFGEmulated(context_sensitivity_level=0, fail_fast=True)  # pylint:disable=unused-variable
 
     # function_a returns
     nose.tools.assert_not_equal(proj.kb.functions.function(name='function_a'), None)
@@ -200,7 +200,7 @@ def test_cfg_6():
     proj = angr.Project(binary_path,
                         use_sim_procedures=True,
                         page_size=1)
-    cfg = proj.analyses.CFGAccurate(context_sensitivity_level=1, fail_fast=True)  # pylint:disable=unused-variable
+    cfg = proj.analyses.CFGEmulated(context_sensitivity_level=1, fail_fast=True)  # pylint:disable=unused-variable
     nose.tools.assert_greater_equal(set(f for f in proj.kb.functions), set(function_addresses))
     o.modes['fastpath'] ^= {o.DO_CCALLS}
 
@@ -214,7 +214,7 @@ def disabled_loop_unrolling():
     binary_path = test_location + "/x86_64/cfg_loop_unrolling"
 
     p = angr.Project(binary_path)
-    cfg = p.analyses.CFGAccurate(fail_fast=True)
+    cfg = p.analyses.CFGEmulated(fail_fast=True)
 
     cfg.normalize()
     cfg.unroll_loops(5)
@@ -227,7 +227,7 @@ def test_thumb_mode():
 
     binary_path = test_location + "/armhf/test_arrays"
     p = angr.Project(binary_path)
-    cfg = p.analyses.CFGAccurate(fail_fast=True)
+    cfg = p.analyses.CFGEmulated(fail_fast=True)
 
     def check_addr(a):
         if a % 2 == 1:
@@ -257,7 +257,7 @@ def test_fakeret_edges_0():
     binary_path = os.path.join(test_location, "x86_64", "cfg_3")
 
     p = angr.Project(binary_path)
-    cfg = p.analyses.CFGAccurate(context_sensitivity_level=3, fail_fast=True)
+    cfg = p.analyses.CFGEmulated(context_sensitivity_level=3, fail_fast=True)
 
     putchar_plt = cfg.functions.function(name="putchar", plt=True)
     nose.tools.assert_true(putchar_plt.returning)
@@ -304,7 +304,7 @@ def test_string_references():
 
     binary_path = os.path.join(test_location, "i386", "ctf_nuclear")
     b = angr.Project(binary_path, load_options={'auto_load_libs': False})
-    cfg = b.analyses.CFGAccurate(keep_state=True, fail_fast=True)
+    cfg = b.analyses.CFGEmulated(keep_state=True, fail_fast=True)
 
     string_references = []
     for f in cfg.functions.values():
@@ -316,7 +316,7 @@ def test_arrays():
 
     binary_path = os.path.join(test_location, "armhf", "test_arrays")
     b = angr.Project(binary_path, load_options={'auto_load_libs': False})
-    cfg = b.analyses.CFGAccurate(fail_fast=True)
+    cfg = b.analyses.CFGEmulated(fail_fast=True)
 
     node = cfg.get_any_node(0x10415)
     nose.tools.assert_is_not_none(node)
@@ -328,7 +328,7 @@ def test_max_steps():
 
     binary_path = os.path.join(test_location, "x86_64", "fauxware")
     b = angr.Project(binary_path, load_options={'auto_load_libs': False})
-    cfg = b.analyses.CFGAccurate(max_steps=5, fail_fast=True)
+    cfg = b.analyses.CFGEmulated(max_steps=5, fail_fast=True)
 
     dfs_edges = networkx.dfs_edges(cfg.graph)
 
@@ -345,13 +345,13 @@ def test_max_steps():
 
 def test_armel_final_missing_block():
 
-    # Due to a stupid bug in CFGAccurate, the last block of a function might go missing in the function graph if the
+    # Due to a stupid bug in CFGEmulated, the last block of a function might go missing in the function graph if the
     # only entry edge to that block is an Ijk_Ret edge. See #475 on GitHub.
     # Thank @gergo for reporting and providing this test binary.
 
     binary_path = os.path.join(test_location, 'armel', 'last_block')
     b = angr.Project(binary_path, auto_load_libs=False)
-    cfg = b.analyses.CFGAccurate(fail_fast=True)
+    cfg = b.analyses.CFGEmulated(fail_fast=True)
 
     blocks = list(cfg.kb.functions[0x8000].blocks)
 
@@ -379,7 +379,7 @@ def test_armel_final_missing_block_b():
     b = angr.Project(binary_path, auto_load_libs=False)
 
     function = b.loader.main_object.get_symbol('main').rebased_addr
-    cfg = b.analyses.CFGAccurate(starts=[function],
+    cfg = b.analyses.CFGEmulated(starts=[function],
                                  context_sensitivity_level=0,
                                  normalize=True,
                                  fail_fast=True,
@@ -397,7 +397,7 @@ def test_armel_incorrect_function_detection_caused_by_branch():
     binary_path = os.path.join(test_location, "armel", "RTOSDemo.axf.issue_685")
     b = angr.Project(binary_path, auto_load_libs=False)
 
-    cfg = b.analyses.CFGAccurate()
+    cfg = b.analyses.CFGEmulated()
 
     # The Main function should be identified as a single function
     nose.tools.assert_in(0x80a1, cfg.functions)
@@ -470,7 +470,7 @@ def test_cfg_switches():
         path = os.path.join(test_location, arch, filename)
         proj = angr.Project(path, load_options={'auto_load_libs': False})
 
-        cfg = proj.analyses.CFGAccurate()
+        cfg = proj.analyses.CFGEmulated()
 
         for src, dst in edges[arch]:
             src_node = cfg.get_any_node(src)
@@ -492,7 +492,7 @@ if __name__ == "__main__":
     logging.getLogger("angr.state_plugins.abstract_memory").setLevel(logging.DEBUG)
     logging.getLogger("angr.surveyors.Explorer").setLevel(logging.DEBUG)
     # logging.getLogger("angr.state_plugins.symbolic_memory").setLevel(logging.DEBUG)
-    # logging.getLogger("angr.analyses.cfg.cfg_accurate").setLevel(logging.DEBUG)
+    # logging.getLogger("angr.analyses.cfg.cfg_emulated").setLevel(logging.DEBUG)
     # logging.getLogger("s_irsb").setLevel(logging.DEBUG)
     # Temporarily disable the warnings of claripy backend
     #logging.getLogger("claripy.backends.backend").setLevel(logging.ERROR)

--- a/tests/test_ddg.py
+++ b/tests/test_ddg.py
@@ -19,7 +19,7 @@ def perform_one(binary_path):
                         use_sim_procedures=True,
                         default_analysis_mode='symbolic')
     start = time.time()
-    cfg = proj.analyses.CFGAccurate(context_sensitivity_level=2, keep_state=True,
+    cfg = proj.analyses.CFGEmulated(context_sensitivity_level=2, keep_state=True,
                                     state_add_options=angr.sim_options.refs  # refs are necessary for DDG to work
                                     )
     end = time.time()

--- a/tests/test_function_manager.py
+++ b/tests/test_function_manager.py
@@ -21,7 +21,7 @@ def test_amd64():
     EXPECTED_CALLSITE_RETURNS = { 0x40073e, 0x400754, 0x40076a, 0x400774, 0x40078a, 0x4007a0, 0x4007b3, 0x4007c7,
                                   None }
 
-    cfg = fauxware_amd64.analyses.CFGAccurate()  # pylint:disable=unused-variable
+    cfg = fauxware_amd64.analyses.CFGEmulated()  # pylint:disable=unused-variable
     nose.tools.assert_equal(set([ k for k in fauxware_amd64.kb.functions.keys() if k < 0x500000 ]), EXPECTED_FUNCTIONS)
 
     main = fauxware_amd64.kb.functions.function(name='main')

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -23,7 +23,7 @@ def internaltest_vfg(p, cfg):
 def internaltest_cfg(p):
     state = tempfile.TemporaryFile()
 
-    cfg = p.analyses.CFGAccurate()
+    cfg = p.analyses.CFGEmulated()
     pickle.dump(cfg, state, -1)
 
     state.seek(0)

--- a/tests/test_simulation_manager.py
+++ b/tests/test_simulation_manager.py
@@ -110,7 +110,7 @@ def test_find_to_middle():
 def test_explore_with_cfg():
     p = angr.Project(os.path.join(location, 'x86_64', 'fauxware'), load_options={'auto_load_libs': False})
 
-    cfg = p.analyses.CFGAccurate()
+    cfg = p.analyses.CFGEmulated()
 
     pg = p.factory.simulation_manager()
     pg.use_technique(angr.exploration_techniques.Explorer(find=0x4006ED, cfg=cfg, num_find=3))

--- a/tests/test_vfg.py
+++ b/tests/test_vfg.py
@@ -21,7 +21,7 @@ def run_vfg_buffer_overflow(arch):
                  use_sim_procedures=True,
                  default_analysis_mode='symbolic')
 
-    cfg = proj.analyses.CFGAccurate(context_sensitivity_level=1)
+    cfg = proj.analyses.CFGEmulated(context_sensitivity_level=1)
 
     # For this test case, OPTIMIZE_IR does not work due to the way we are widening the states: an index variable
     # directly goes to 0xffffffff, and when OPTIMIZE_IR is used, it does a signed comparison with 0x27, which
@@ -129,7 +129,7 @@ def run_vfg_1(arch):
         use_sim_procedures=True,
     )
 
-    cfg = proj.analyses.CFGAccurate()
+    cfg = proj.analyses.CFGEmulated()
     vfg = proj.analyses.VFG(cfg, start=0x40071d, context_sensitivity_level=10, interfunction_level=10,
                             record_function_final_states=True
                             )


### PR DESCRIPTION
Does what it says on the tin.
See the angr-doc version for fancy new docs 

Includes a bonus fix for cases where a library may have the same name, but not provide the same symbols on a given host, causing angr to mis-hook some simprocedures.
(e.g., I have a pile of ARM libs, but none are Android's libc, therefore i miss a few symbols, and our android tests fail)