### PR TITLE
ARM CFG party favor: Cortex-M support and CFG fixes

### DIFF
--- a/angr/analyses/boyscout.py
+++ b/angr/analyses/boyscout.py
@@ -29,6 +29,10 @@ class BoyScout(Analysis):
 
         for arch in all_arches:
             regexes = set()
+            if not arch.function_prologs:
+                continue
+            # TODO: BoyScout does not support Thumb-only / Cortex-M binaries yet.
+
             for ins_regex in set(arch.function_prologs).union(arch.function_epilogs):
                 r = re.compile(ins_regex)
                 regexes.add(r)

--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -145,7 +145,7 @@ class CallingConventionAnalysis(Analysis):
                     64 <= variable.reg < 104 or  # rsi, rdi, r8, r9, r10
                     224 <= variable.reg < 480)  # xmm0-xmm7
 
-        elif arch.name == 'ARMEL' or arch.name == 'ARMHF':
+        elif arch.name == 'ARMEL' or arch.name == 'ARMHF' or arch.name == "ARMCortexM":
             return 8 <= variable.reg < 24  # r0-r3
 
         elif arch.name == 'MIPS32':

--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -3,6 +3,7 @@ import logging
 from ..calling_conventions import SimRegArg, SimStackArg, SimCC
 from ..sim_variable import SimStackVariable, SimRegisterVariable
 from . import Analysis, register_analysis
+from archinfo.arch_arm import is_arm_arch
 
 l = logging.getLogger(name=__name__)
 
@@ -145,7 +146,7 @@ class CallingConventionAnalysis(Analysis):
                     64 <= variable.reg < 104 or  # rsi, rdi, r8, r9, r10
                     224 <= variable.reg < 480)  # xmm0-xmm7
 
-        elif arch.name == 'ARMEL' or arch.name == 'ARMHF' or arch.name == "ARMCortexM":
+        elif is_arm_arch(arch):
             return 8 <= variable.reg < 24  # r0-r3
 
         elif arch.name == 'MIPS32':

--- a/angr/analyses/cfg/cfg_arch_options.py
+++ b/angr/analyses/cfg/cfg_arch_options.py
@@ -26,6 +26,10 @@ class CFGArchOptions(object):
             'ret_jumpkind_heuristics': (bool, True),
             'switch_mode_on_nodecode': (bool, False),
         },
+        'ARMCortexM': {
+            'ret_jumpkind_heuristics': (bool, True),
+            'switch_mode_on_nodecode': (bool, False),
+        },
     }
 
     arch = None

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1108,7 +1108,7 @@ class CFGBase(Analysis):
         :rtype:             int
         """
 
-        return ((addr >> 1) << 1) if arch.name in ('ARMEL', 'ARMHF') else addr
+        return ((addr >> 1) << 1) if arch.name in ('ARMEL', 'ARMHF', 'ARMCortexM') else addr
 
     def normalize(self):
         """
@@ -1529,7 +1529,7 @@ class CFGBase(Analysis):
         to_remove = set()
 
         # Remove all stubs after PLT entries
-        if self.project.arch.name not in {'ARMEL', 'ARMHF'}:
+        if self.project.arch.name not in {'ARMEL', 'ARMHF', 'ARMCortexM'}:
             for fn in self.kb.functions.values():
                 addr = fn.addr - (fn.addr % 16)
                 if addr != fn.addr and addr in self.kb.functions and self.kb.functions[addr].is_plt:

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -8,6 +8,7 @@ import pyvex
 from claripy.utils.orderedset import OrderedSet
 from cle import ELF, PE, Blob, TLSObject, MachO, ExternObject, KernelObject
 from archinfo.arch_soot import SootAddressDescriptor
+from archinfo.arch_arm import is_arm_arch
 
 from ...misc.ux import deprecated
 from ... import SIM_PROCEDURES
@@ -1108,7 +1109,7 @@ class CFGBase(Analysis):
         :rtype:             int
         """
 
-        return ((addr >> 1) << 1) if arch.name in ('ARMEL', 'ARMHF', 'ARMCortexM') else addr
+        return ((addr >> 1) << 1) if is_arm_arch(arch) else addr
 
     def normalize(self):
         """
@@ -1529,7 +1530,7 @@ class CFGBase(Analysis):
         to_remove = set()
 
         # Remove all stubs after PLT entries
-        if self.project.arch.name not in {'ARMEL', 'ARMHF', 'ARMCortexM'}:
+        if is_arm_arch(self.project.arch):
             for fn in self.kb.functions.values():
                 addr = fn.addr - (fn.addr % 16)
                 if addr != fn.addr and addr in self.kb.functions and self.kb.functions[addr].is_plt:

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1730,7 +1730,6 @@ class CFGBase(Analysis):
         adjusted_cfgnodes = set()
 
         for addr_0, addr_1 in zip(addrs[:-1], addrs[1:]):
-
             if addr_1 in predetermined_function_addrs:
                 continue
 
@@ -1745,9 +1744,10 @@ class CFGBase(Analysis):
                     continue
 
                 target = block.vex.next
-                if type(target) is pyvex.IRExpr.Const:  # pylint: disable=unidiomatic-typecheck
+                # TODO: FIXME: EDG says: WHY???
+                if isinstance(target, pyvex.IRExpr.Const):  # pylint: disable=unidiomatic-typecheck
                     target_addr = target.con.value
-                elif type(target) in (pyvex.IRConst.U32, pyvex.IRConst.U64):  # pylint: disable=unidiomatic-typecheck
+                elif isinstance(target, pyvex.IRConst.IRConst):  # pylint: disable=unidiomatic-typecheck
                     target_addr = target.value
                 elif type(target) is int:  # pylint: disable=unidiomatic-typecheck
                     target_addr = target

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1744,10 +1744,9 @@ class CFGBase(Analysis):
                     continue
 
                 target = block.vex.next
-                # TODO: FIXME: EDG says: WHY???
                 if isinstance(target, pyvex.IRExpr.Const):  # pylint: disable=unidiomatic-typecheck
                     target_addr = target.con.value
-                elif isinstance(target, pyvex.IRConst.IRConst):  # pylint: disable=unidiomatic-typecheck
+                elif type(target) in (pyvex.IRConst.U16, pyvex.IRConst.U32, pyvex.IRConst.U64):  # pylint: disable=unidiomatic-typecheck
                     target_addr = target.value
                 elif type(target) is int:  # pylint: disable=unidiomatic-typecheck
                     target_addr = target

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1840,7 +1840,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :rtype: list
         """
         addr, function_addr, cfg_node, irsb = self._generate_cfgnode(cfg_job, current_func_addr)
-
+        if addr == 0x4484:
+            import ipdb; ipdb.set_trace()
         # Add edges going to this node in function graphs
         cfg_job.apply_function_edges(self, clear=True)
 
@@ -1944,7 +1945,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         if type(target) is pyvex.IRExpr.Const:  # pylint: disable=unidiomatic-typecheck
             target_addr = target.con.value
-        elif type(target) in (pyvex.IRConst.U32, pyvex.IRConst.U64):  # pylint: disable=unidiomatic-typecheck
+        elif type(target) in (pyvex.IRConst.U8, pyvex.IRConst.U16, pyvex.IRConst.U32, pyvex.IRConst.U64):  # pylint: disable=unidiomatic-typecheck
             target_addr = target.value
         elif type(target) is int:  # pylint: disable=unidiomatic-typecheck
             target_addr = target

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3641,10 +3641,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
             # also check the distance between `addr` and the closest function.
             # we don't want to have a basic block that spans across function boundaries
-            next_func = self.functions.ceiling_func(addr)
-            if next_func is not None and next_func.addr == current_function_addr:
-                # The current block is the first in a function. We want the next one after that
-                next_func = self.functions.ceiling_func(addr + 1)
+            next_func = self.functions.ceiling_func(addr + 1)
             if next_func is not None:
                 distance_to_func = (next_func.addr & (~1) if is_arm_arch else next_func.addr) - real_addr
                 if distance_to_func != 0:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1676,7 +1676,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         for ins_regex in self.project.arch.function_prologs:
             r = re.compile(ins_regex)
             regexes.append(r)
-        # FIXME: HACK: Oh my god i'm sorry
+        # EDG says: I challenge anyone bothering to read this to come up with a better
+        # way to handle CPU modes that affect instruction decoding.
+        # Since the only one we care about is ARM/Thumb right now
+        # we have this gross hack. Sorry about that.
         thumb_regexes = list()
         if hasattr(self.project.arch, 'thumb_prologs'):
             for ins_regex in self.project.arch.thumb_prologs:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1482,7 +1482,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
     def _post_process_successors(self, addr, size, successors):
 
-        if self.project.arch.name in ('ARMEL', 'ARMHF') and addr % 2 == 1:
+        if self.project.arch.name in ('ARMEL', 'ARMHF', 'ARMCortexM') and addr % 2 == 1:
             # we are in thumb mode. filter successors
             successors = self._arm_thumb_filter_jump_successors(addr,
                                                                 size,
@@ -3771,7 +3771,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :param func_addr: function address
         :return: None
         """
-        if self.project.arch.name in ('ARMEL', 'ARMHF'):
+        if self.project.arch.name in ('ARMEL', 'ARMHF', 'ARMCortexM'):
             if self._arch_options.ret_jumpkind_heuristics:
                 if addr == func_addr:
                     self._arm_track_lr_on_stack(addr, irsb, self.functions[func_addr])
@@ -3793,6 +3793,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
                 if not irsb.statements:
                     # Get an IRSB with statements
+
                     irsb = self.project.factory.block(irsb.addr, size=irsb.size).vex
 
                 for stmt in irsb.statements:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3642,6 +3642,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             # also check the distance between `addr` and the closest function.
             # we don't want to have a basic block that spans across function boundaries
             next_func = self.functions.ceiling_func(addr)
+            if next_func is not None and next_func.addr == current_function_addr:
+                # The current block is the first in a function. We want the next one after that
+                next_func = self.functions.ceiling_func(addr + 1)
             if next_func is not None:
                 distance_to_func = (next_func.addr & (~1) if is_arm_arch else next_func.addr) - real_addr
                 if distance_to_func != 0:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2841,7 +2841,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         if insns:
                             nop_length = self._get_nop_length(insns)
 
-                    if nop_length <= 0:
+                    if nop_length is None or nop_length <= 0:
                         continue
 
                     # leading nop for alignment.

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1844,6 +1844,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :rtype: list
         """
         addr, function_addr, cfg_node, irsb = self._generate_cfgnode(cfg_job, current_func_addr)
+        
         # Add edges going to this node in function graphs
         cfg_job.apply_function_edges(self, clear=True)
 

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -87,7 +87,7 @@ class JumpTableResolver(IndirectJumpResolver):
         """
         project = self.project  # short-hand
         self._max_targets = cfg._indirect_jump_target_limit
-        
+
         # Perform a backward slicing from the jump target
         b = Blade(cfg.graph, addr, -1,
             cfg=cfg, project=project,
@@ -265,7 +265,7 @@ class JumpTableResolver(IndirectJumpResolver):
                 if jump_target is None:
                     l.info("Constant indirect jump at %#08x points outside of loaded memory to %#08x", addr, jump_target_addr)
                     return False, None
-                l.info("Resolved constant indirect jump from %#08x to %#08x" % (addr, jump_target_addr))
+                l.info("Resolved constant indirect jump from %#08x to %#08x", addr, jump_target_addr)
                 ij = cfg.indirect_jumps[addr]
                 ij.jumptable = False
                 ij.resolved_targets = set([jump_target])
@@ -284,7 +284,7 @@ class JumpTableResolver(IndirectJumpResolver):
                 # value of R3 is. Some intensive data-flow analysis is required in this case.
                 jump_target_addr = load_stmt.addr.con.value
                 jump_target = cfg._fast_memory_load_pointer(jump_target_addr)
-                l.info("Resolved constant indirect jump from %#08x to %#08x" % (addr, jump_target_addr))
+                l.info("Resolved constant indirect jump from %#08x to %#08x", addr, jump_target_addr)
                 ij = cfg.indirect_jumps[addr]
                 ij.jumptable = False
                 ij.resolved_targets = set([jump_target])
@@ -717,7 +717,7 @@ class JumpTableResolver(IndirectJumpResolver):
             guard = state.scratch.temps[guard_tmp] != 0
             try:
                 jump_addr = state.memory._apply_condition_to_symbolic_addr(jump_addr, guard)
-            except Exception: # pylint: disable=bare-except
+            except Exception: # pylint: disable=broad-except
                 l.exception("Error computing jump table address!")
                 return None
         return jump_addr

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -296,6 +296,10 @@ class JumpTableResolver(IndirectJumpResolver):
                 # It's not a jump table, but we resolve it anyway
                 jump_target_addr = load_stmt.data.addr.con.value
                 jump_target = cfg._fast_memory_load_pointer(jump_target_addr)
+                if not jump_target:
+                    #...except this constant looks like a jumpout!
+                    l.info("Constant indirect jump directed out of the binary at #%08x" % addr)
+                    return False, []
                 l.info("Resolved constant indirect jump from %#08x to %#08x" % (addr, jump_target_addr))
                 ij = cfg.indirect_jumps[addr]
                 ij.jumptable = False

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -706,8 +706,11 @@ class JumpTableResolver(IndirectJumpResolver):
             # LoadG comes with a guard. We should apply this guard to the load expression
             guard_tmp = load_stmt.guard.tmp
             guard = state.scratch.temps[guard_tmp] != 0
-            jump_addr = state.memory._apply_condition_to_symbolic_addr(jump_addr, guard)
-
+            try:
+                jump_addr = state.memory._apply_condition_to_symbolic_addr(jump_addr, guard)
+            except:
+                l.exception("Error computing jump table address!")
+                return None
         return jump_addr
 
     def _is_jumptarget_legal(self, target):

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -87,6 +87,7 @@ class JumpTableResolver(IndirectJumpResolver):
         """
         project = self.project  # short-hand
         self._max_targets = cfg._indirect_jump_target_limit
+        
         # Perform a backward slicing from the jump target
         b = Blade(cfg.graph, addr, -1,
             cfg=cfg, project=project,

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -456,10 +456,10 @@ class JumpTableResolver(IndirectJumpResolver):
 
                 # Both the min jump target and the max jump target should be within a mapped memory region
                 # i.e., we shouldn't be jumping to the stack or somewhere unmapped
-                if (not project.loader.find_segment_containing(min_jump_target) or \
-                        not project.loader.find_segment_containing(max_jump_target)):
-                    if (not project.loader.find_section_containing(min_jump_target) or \
-                            not project.loader.find_section_containing(max_jump_target)):
+                if (not project.loader.find_segment_containing(min_jumptable_addr) or
+                        not project.loader.find_segment_containing(max_jumptable_addr)):
+                    if (not project.loader.find_section_containing(min_jumptable_addr) or
+                            not project.loader.find_section_containing(max_jumptable_addr)):
 
                         l.debug("Jump table %#x might have jump targets outside mapped memory regions. "
                                 "Continue to resolve it from the next data source.", addr)

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -262,6 +262,9 @@ class JumpTableResolver(IndirectJumpResolver):
                 # It's not a jump table, but we resolve it anyway
                 jump_target_addr = load_stmt.data.addr.con.value
                 jump_target = cfg._fast_memory_load_pointer(jump_target_addr)
+                if jump_target is None:
+                    l.info("Constant indirect jump at %#08x points outside of loaded memory to %#08x", addr, jump_target_addr)
+                    return False, None
                 l.info("Resolved constant indirect jump from %#08x to %#08x" % (addr, jump_target_addr))
                 ij = cfg.indirect_jumps[addr]
                 ij.jumptable = False

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -68,10 +68,11 @@ class JumpTableResolver(IndirectJumpResolver):
     def filter(self, cfg, addr, func_addr, block, jumpkind):
         # TODO:
 
-        if jumpkind == "Ijk_Boring" or jumpkind == 'Ijk_Call':
-            # Currently we only support boring jumps and calls
-            return True
-        return False
+        if jumpkind not in ('Ijk_Boring', 'Ijk_Call'):
+            # Currently we only support boring and call ones
+            return False
+
+        return True
 
     def resolve(self, cfg, addr, func_addr, block, jumpkind):
         """
@@ -298,9 +299,9 @@ class JumpTableResolver(IndirectJumpResolver):
                 jump_target = cfg._fast_memory_load_pointer(jump_target_addr)
                 if not jump_target:
                     #...except this constant looks like a jumpout!
-                    l.info("Constant indirect jump directed out of the binary at #%08x" % addr)
+                    l.info("Constant indirect jump directed out of the binary at #%08x", addr)
                     return False, []
-                l.info("Resolved constant indirect jump from %#08x to %#08x" % (addr, jump_target_addr))
+                l.info("Resolved constant indirect jump from %#08x to %#08x", addr, jump_target_addr)
                 ij = cfg.indirect_jumps[addr]
                 ij.jumptable = False
                 ij.resolved_targets = set([jump_target])
@@ -319,7 +320,7 @@ class JumpTableResolver(IndirectJumpResolver):
                 # value of R3 is. Some intensive data-flow analysis is required in this case.
                 jump_target_addr = load_stmt.addr.con.value
                 jump_target = cfg._fast_memory_load_pointer(jump_target_addr)
-                l.info("Resolved constant indirect jump from %#08x to %#08x" % (addr, jump_target_addr))
+                l.info("Resolved constant indirect jump from %#08x to %#08x", addr, jump_target_addr)
                 ij = cfg.indirect_jumps[addr]
                 ij.jumptable = False
                 ij.resolved_targets = set([jump_target])
@@ -712,7 +713,7 @@ class JumpTableResolver(IndirectJumpResolver):
             guard = state.scratch.temps[guard_tmp] != 0
             try:
                 jump_addr = state.memory._apply_condition_to_symbolic_addr(jump_addr, guard)
-            except:
+            except Exception: # pylint: disable=bare-except
                 l.exception("Error computing jump table address!")
                 return None
         return jump_addr

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -273,6 +273,8 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
             regval = dict(self._state_for(addr, pre_or_post).regs)[reg]
         except KeyError:
             return TOP
+        except AttributeError:
+            return TOP
         if regval is TOP or type(regval) is Constant:
             return TOP
         else:

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -273,8 +273,6 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
             regval = dict(self._state_for(addr, pre_or_post).regs)[reg]
         except KeyError:
             return TOP
-        except AttributeError:
-            return TOP
         if regval is TOP or type(regval) is Constant:
             return TOP
         else:

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -1200,7 +1200,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
 
         if self.project.arch.name in ('X86', 'AMD64'):
             state.stack_push(ret_bvv)
-        elif self.project.arch.name in ('ARMEL', 'ARMHF', 'AARCH64'):
+        elif self.project.arch.name in ('ARMEL', 'ARMHF', 'AARCH64', 'ARMCortexM'):
             state.regs.lr = ret_bvv
         elif self.project.arch.name in ('MIPS32', 'MIPS64'):
             state.regs.ra = ret_bvv

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 import angr
 import archinfo
+from archinfo.arch_arm import is_arm_arch
 import claripy
 import networkx
 from . import Analysis
@@ -1200,7 +1201,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
 
         if self.project.arch.name in ('X86', 'AMD64'):
             state.stack_push(ret_bvv)
-        elif self.project.arch.name in ('ARMEL', 'ARMHF', 'AARCH64', 'ARMCortexM'):
+        elif is_arm_arch(self.project.arch):
             state.regs.lr = ret_bvv
         elif self.project.arch.name in ('MIPS32', 'MIPS64'):
             state.regs.ra = ret_bvv

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1266,6 +1266,9 @@ CC = {
     'ARMHF': [
         SimCCARM,
     ],
+    'ARMCortexM': [
+        SimCCARM,
+    ],
     'MIPS32': [
         SimCCO32,
     ],
@@ -1292,6 +1295,7 @@ DEFAULT_CC = {
     'X86': SimCCCdecl,
     'ARMEL': SimCCARM,
     'ARMHF': SimCCARM,
+    'ARMCortexM': SimCCARM,
     'MIPS32': SimCCO32,
     'MIPS64': SimCCO64,
     'PPC32': SimCCPowerPC,
@@ -1322,6 +1326,10 @@ SYSCALL_CC = {
     'ARMEL': {
         'default': SimCCARMLinuxSyscall,
         'Linux': SimCCARMLinuxSyscall,
+    },
+    'ARMCortexM': {
+        # FIXME: TODO: This is wrong.  Fill in with a real CC when we support CM syscalls
+        'default': SimCCARMLinuxSyscall,
     },
     'ARMHF': {
         'default': SimCCARMLinuxSyscall,

--- a/angr/engines/vex/ccall.py
+++ b/angr/engines/vex/ccall.py
@@ -1705,7 +1705,7 @@ def _get_flags(state):
         return x86g_calculate_eflags_all(state, state.regs.cc_op, state.regs.cc_dep1, state.regs.cc_dep2, state.regs.cc_ndep)
     elif state.arch.name == 'AMD64':
         return amd64g_calculate_rflags_all(state, state.regs.cc_op, state.regs.cc_dep1, state.regs.cc_dep2, state.regs.cc_ndep)
-    elif state.arch.name in ('ARMEL', 'ARMHF', 'ARM'):
+    elif state.arch.name in ('ARMEL', 'ARMHF', 'ARM', 'ARMCortexM'):
         return armg_calculate_flags_nzcv(state, state.regs.cc_op, state.regs.cc_dep1, state.regs.cc_dep2, state.regs.cc_ndep)
     elif state.arch.name == 'AARCH64':
         return arm64g_calculate_data_nzcv(state, state.regs.cc_op, state.regs.cc_dep1, state.regs.cc_dep2, state.regs.cc_ndep)

--- a/angr/engines/vex/ccall.py
+++ b/angr/engines/vex/ccall.py
@@ -1,5 +1,7 @@
 import claripy
 import logging
+from archinfo.arch_arm import is_arm_arch
+
 l = logging.getLogger(name=__name__)
 #l.setLevel(logging.DEBUG)
 
@@ -1705,7 +1707,7 @@ def _get_flags(state):
         return x86g_calculate_eflags_all(state, state.regs.cc_op, state.regs.cc_dep1, state.regs.cc_dep2, state.regs.cc_ndep)
     elif state.arch.name == 'AMD64':
         return amd64g_calculate_rflags_all(state, state.regs.cc_op, state.regs.cc_dep1, state.regs.cc_dep2, state.regs.cc_ndep)
-    elif state.arch.name in ('ARMEL', 'ARMHF', 'ARM', 'ARMCortexM'):
+    elif is_arm_arch(state.arch):
         return armg_calculate_flags_nzcv(state, state.regs.cc_op, state.regs.cc_dep1, state.regs.cc_dep2, state.regs.cc_ndep)
     elif state.arch.name == 'AARCH64':
         return arm64g_calculate_data_nzcv(state, state.regs.cc_op, state.regs.cc_dep1, state.regs.cc_dep2, state.regs.cc_ndep)

--- a/angr/project.py
+++ b/angr/project.py
@@ -101,7 +101,8 @@ class Project:
         if load_options is None: load_options = {}
 
         load_options.update(kwargs)
-
+        if arch is not None: 
+            load_options.update({'arch': arch})
         if isinstance(thing, cle.Loader):
             if load_options:
                 l.warning("You provided CLE options to angr but you also provided a completed cle.Loader object!")

--- a/angr/project.py
+++ b/angr/project.py
@@ -101,7 +101,7 @@ class Project:
         if load_options is None: load_options = {}
 
         load_options.update(kwargs)
-        if arch is not None: 
+        if arch is not None:
             load_options.update({'arch': arch})
         if isinstance(thing, cle.Loader):
             if load_options:

--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -2,7 +2,7 @@ import logging
 
 import claripy
 from archinfo.arch_soot import ArchSoot, SootAddressDescriptor
-
+from archinfo.arch_arm import is_arm_arch
 from .plugin import SimStatePlugin
 
 
@@ -79,7 +79,7 @@ class SimRegNameView(SimStatePlugin):
     def __dir__(self):
         if self.state.arch.name in ('X86', 'AMD64'):
             return list(self.state.arch.registers.keys()) + ['st%d' % n for n in range(8)] + ['tag%d' % n for n in range(8)] + ['flags', 'eflags', 'rflags']
-        elif self.state.arch.name in ('ARMEL', 'ARMHF', 'ARM', 'AARCH64', 'ARMCortexM'):
+        elif is_arm_arch(self.state.arch):
             return self.state.arch.registers.keys() + ['flags']
         return self.state.arch.registers.keys()
 

--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -79,7 +79,7 @@ class SimRegNameView(SimStatePlugin):
     def __dir__(self):
         if self.state.arch.name in ('X86', 'AMD64'):
             return list(self.state.arch.registers.keys()) + ['st%d' % n for n in range(8)] + ['tag%d' % n for n in range(8)] + ['flags', 'eflags', 'rflags']
-        elif self.state.arch.name in ('ARMEL', 'ARMHF', 'ARM', 'AARCH64'):
+        elif self.state.arch.name in ('ARMEL', 'ARMHF', 'ARM', 'AARCH64', 'ARMCortexM'):
             return self.state.arch.registers.keys() + ['flags']
         return self.state.arch.registers.keys()
 

--- a/angr/storage/memory.py
+++ b/angr/storage/memory.py
@@ -381,7 +381,7 @@ class SimMemory(SimStatePlugin):
                         self.store('cc_dep1', _get_flags(self.state)[0]) # TODO: can constraints be added by this?
                     self.store('cc_op', 0) # OP_COPY
                     return self.state.arch.registers['cc_dep1'][0], self.state.arch.bytes
-            if self.state.arch.name in ('ARMEL', 'ARMHF', 'ARM', 'AARCH64'):
+            if self.state.arch.name in ('ARMEL', 'ARMHF', 'ARM', 'AARCH64', 'ARMCortexM'):
                 if name == 'flags':
                     if not is_write:
                         self.store('cc_dep1', _get_flags(self.state)[0])

--- a/angr/storage/memory.py
+++ b/angr/storage/memory.py
@@ -1,7 +1,7 @@
 import logging
 import claripy
 from sortedcontainers import SortedDict
-
+from archinfo.arch_arm import is_arm_arch
 from ..state_plugins.plugin import SimStatePlugin
 
 
@@ -381,7 +381,7 @@ class SimMemory(SimStatePlugin):
                         self.store('cc_dep1', _get_flags(self.state)[0]) # TODO: can constraints be added by this?
                     self.store('cc_op', 0) # OP_COPY
                     return self.state.arch.registers['cc_dep1'][0], self.state.arch.bytes
-            if self.state.arch.name in ('ARMEL', 'ARMHF', 'ARM', 'AARCH64', 'ARMCortexM'):
+            if is_arm_arch(self.state.arch):
                 if name == 'flags':
                     if not is_write:
                         self.store('cc_dep1', _get_flags(self.state)[0])

--- a/tests/test_cfg_thumb_firmware.py
+++ b/tests/test_cfg_thumb_firmware.py
@@ -1,0 +1,40 @@
+
+import os
+
+import angr
+from nose.tools import assert_equal, assert_true
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+
+
+def test_thumb_firmware_cfg():
+    """
+    Test an ARM firmware sample.
+
+    This tests CFG, but also the Gym (the ThumbSpotter, etc)
+    Also requires proper relocs support, or You're Gonna Have a Bad Time(tm)
+    In short, a very comprehensive high level test
+    :return:
+    """
+    path = os.path.join(test_location, "armel", "i2c_master_read-nucleol152re.elf")
+    p = angr.Project(path, auto_load_libs=False)
+
+    # This is the canonical way to carve up a nasty firmware thing.
+    cfg = p.analyses.CFGFast(resolve_indirect_jumps=True, force_complete_scan=False, normalize=True)
+
+    # vfprintf should return; this function has a weird C++ thing that gets compiled as a tail-call.
+    # The function itself must return, and _NOT_ contain its callee.
+    vfprintf = p.kb.functions[p.loader.find_symbol('vfprintf').rebased_addr]
+    assert_true(vfprintf.returning)
+    assert_true(len(list(vfprintf.blocks)) == 1)
+    # The function should have one "transition"
+    block = list(vfprintf.endpoints_with_type['transition'])[0]
+    assert_true(len(block.successors()) == 1)
+    succ = list(block.successors())[0]
+    assert_true(succ.addr == 0x080081dd)
+    f2 = p.kb.functions[succ.addr]
+    assert_true(f2.name == '_vfprintf_r')
+    assert_true(f2.returning)
+
+if __name__ == "__main__":
+    test_thumb_firmware_cfg()

--- a/tests/test_cfg_thumb_firmware.py
+++ b/tests/test_cfg_thumb_firmware.py
@@ -2,7 +2,7 @@
 import os
 
 import angr
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_true
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
@@ -20,11 +20,12 @@ def test_thumb_firmware_cfg():
     p = angr.Project(path, auto_load_libs=False)
 
     # This is the canonical way to carve up a nasty firmware thing.
+
     cfg = p.analyses.CFGFast(resolve_indirect_jumps=True, force_complete_scan=False, normalize=True)
 
     # vfprintf should return; this function has a weird C++ thing that gets compiled as a tail-call.
     # The function itself must return, and _NOT_ contain its callee.
-    vfprintf = p.kb.functions[p.loader.find_symbol('vfprintf').rebased_addr]
+    vfprintf = cfg.kb.functions[p.loader.find_symbol('vfprintf').rebased_addr]
     assert_true(vfprintf.returning)
     assert_true(len(list(vfprintf.blocks)) == 1)
     # The function should have one "transition"

--- a/tests/test_cfgemulated.py
+++ b/tests/test_cfgemulated.py
@@ -374,9 +374,14 @@ def test_armel_final_missing_block_b():
     # Fixing either bug will resolve the issue that the final block does not show up in the function graph of main. To
     # stay on the safe side, both of them are fixed. Thanks @tyb0807 for reporting this issue and providing a test
     # binary.
-
+    # EDG says: This binary is compiled incorrectly.
+    # The binary's app code was compiled as CortexM, but linked against ARM libraries.
+    # This is illegal, and does not actually execute on a real CortexM.
+    # Somebody should recompile it....
+    raise nose.SkipTest()
+    """
     binary_path = os.path.join(test_location, 'armel', 'aes')
-    b = angr.Project(binary_path, auto_load_libs=False)
+    b = angr.Project(binary_path, arch="ARMEL", auto_load_libs=False)
 
     function = b.loader.main_object.get_symbol('main').rebased_addr
     cfg = b.analyses.CFGEmulated(starts=[function],
@@ -389,7 +394,7 @@ def test_armel_final_missing_block_b():
 
     nose.tools.assert_equal(len(blocks), 2)
     nose.tools.assert_set_equal(set(block.addr for block in blocks), { 0x10b79, 0x10bbf })
-
+    """
 
 def test_armel_incorrect_function_detection_caused_by_branch():
 

--- a/tests/test_cfgemulated.py
+++ b/tests/test_cfgemulated.py
@@ -378,8 +378,6 @@ def test_armel_final_missing_block_b():
     # The binary's app code was compiled as CortexM, but linked against ARM libraries.
     # This is illegal, and does not actually execute on a real CortexM.
     # Somebody should recompile it....
-    raise nose.SkipTest()
-    """
     binary_path = os.path.join(test_location, 'armel', 'aes')
     b = angr.Project(binary_path, arch="ARMEL", auto_load_libs=False)
 
@@ -394,7 +392,6 @@ def test_armel_final_missing_block_b():
 
     nose.tools.assert_equal(len(blocks), 2)
     nose.tools.assert_set_equal(set(block.addr for block in blocks), { 0x10b79, 0x10bbf })
-    """
 
 def test_armel_incorrect_function_detection_caused_by_branch():
 

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -556,7 +556,7 @@ def test_function_leading_blocks_merging():
                                 )
 
     nose.tools.assert_in(0x8000799, cfg.kb.functions, "Function 0x8000799 does not exist.")
-    nose.tools.assert_not_in(0x800079b, cfg.kb.functions, "Function 0x8000799 does not exist.")
+    nose.tools.assert_not_in(0x800079b, cfg.kb.functions, "Function 0x800079b does not exist.")
     nose.tools.assert_not_in(0x800079b, cfg.kb.functions[0x8000799].block_addrs_set,
                              "Block 0x800079b is found, but it should not exist.")
     nose.tools.assert_in(0x8000799, cfg.kb.functions[0x8000799].block_addrs_set,

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -556,6 +556,7 @@ def test_function_leading_blocks_merging():
                                 )
 
     nose.tools.assert_in(0x8000799, cfg.kb.functions, "Function 0x8000799 does not exist.")
+    nose.tools.assert_not_in(0x800079b, cfg.kb.functions, "Function 0x8000799 does not exist.")
     nose.tools.assert_not_in(0x800079b, cfg.kb.functions[0x8000799].block_addrs_set,
                              "Block 0x800079b is found, but it should not exist.")
     nose.tools.assert_in(0x8000799, cfg.kb.functions[0x8000799].block_addrs_set,

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -610,6 +610,7 @@ def test_collect_data_references():
     nose.tools.assert_equal(sneaky_str.sort, "string")
     nose.tools.assert_equal(sneaky_str.content, b"SOSNEAKY")
 
+
 def test_unresolvable_targets():
 
     path = os.path.join(test_location, 'cgc', 'CADET_00002')

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -4,6 +4,7 @@ import sys
 
 import nose.tools
 
+import archinfo
 import angr
 
 from angr.analyses.cfg.cfg_fast import SegmentList
@@ -535,6 +536,34 @@ def test_tail_call_optimization_detection_armel():
     for member in tail_call_funcs:
         nose.tools.assert_in(member, all_func_addrs)
 
+
+#
+# Incorrect function-leading blocks merging
+#
+
+def test_function_leading_blocks_merging():
+
+    # GitHub issue #1312
+
+    path = os.path.join(test_location, 'armel', 'Nucleo_read_hyperterminal-stripped.elf')
+    proj = angr.Project(path, arch=archinfo.ArchARMCortexM(), auto_load_libs=False)
+
+    cfg = proj.analyses.CFGFast(resolve_indirect_jumps=True,
+                                force_complete_scan=True,
+                                normalize=True,
+                                symbols=False,
+                                detect_tail_calls=True
+                                )
+
+    nose.tools.assert_in(0x8000799, cfg.kb.functions, "Function 0x8000799 does not exist.")
+    nose.tools.assert_not_in(0x800079b, cfg.kb.functions[0x8000799].block_addrs_set,
+                             "Block 0x800079b is found, but it should not exist.")
+    nose.tools.assert_in(0x8000799, cfg.kb.functions[0x8000799].block_addrs_set,
+                         "Block 0x8000799 is not found inside function 0x8000799.")
+    nose.tools.assert_equal(next(iter(b for b in cfg.kb.functions[0x8000799].blocks if b.addr == 0x8000799)).size, 6,
+                            "Block 0x800079b has an incorrect size.")
+
+
 #
 # Blanket
 #
@@ -626,6 +655,7 @@ def run_all():
     test_tail_call_optimization_detection_armel()
     test_blanket_fauxware()
     test_collect_data_references()
+    test_function_leading_blocks_merging()
 
 
 def main():

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -1,6 +1,6 @@
 
 import os
-
+import nose
 import angr
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
@@ -68,6 +68,9 @@ def test_decompiling_all_i386():
 
 
 def test_decompiling_aes_armel():
+    # EDG Says: This binary is invalid.
+    # Consider replacing with some real firmware
+    raise nose.SkipTest()
     bin_path = os.path.join(test_location, "armel", "aes")
     p = angr.Project(bin_path, auto_load_libs=False)
 

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -70,9 +70,10 @@ def test_decompiling_all_i386():
 def test_decompiling_aes_armel():
     # EDG Says: This binary is invalid.
     # Consider replacing with some real firmware
-    raise nose.SkipTest()
     bin_path = os.path.join(test_location, "armel", "aes")
-    p = angr.Project(bin_path, auto_load_libs=False)
+    # TODO: FIXME: EDG says: This binary is actually CortexM
+    # It is incorrectly linked. We override this here
+    p = angr.Project(bin_path, arch='ARMEL', auto_load_libs=False)
 
     cfg = p.analyses.CFG(collect_data_references=True)
 

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -1,6 +1,5 @@
 
 import os
-import nose
 import angr
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))


### PR DESCRIPTION
Remaining fixes not already merged:
- Implement a Cortex-M sub-architecture in Archinfo, and associated hacks throughout to make it work
- Improvements to static indirect call resolution for code generated by GCC6 for Cortex-M
- Support for thumb-specific prologs, in which the prolog's address has the thumb bit set to avoid weirdness.
- Tests based on real ARM firmware for most (all?) of the above
- Fix Project so you can override the arch of an elf (needed to pass tests w/ some invalid CM binary we had around)
- Fix Boyscout so it doesn't try to find all possible bytes as prologues on CortexM
- Fix a nasty bug with CFG where we'd ask for the next function after an address, and get the current function back instead

Sync https://github.com/angr/archinfo/pull/59, https://github.com/angr/cle/pull/154, and https://github.com/angr/pyvex/pull/166.