### PR TITLE
Add KeyError to except in handle_Load

### DIFF
--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -206,7 +206,7 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
                 else:
                     try:
                         data.add(self.state.loader.memory.unpack_word(a, size=size))
-                    except struct.error:
+                    except (struct.error, KeyError):
                         pass
 
                 # FIXME: _add_memory_use() iterates over the same loop

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -206,7 +206,7 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
                 else:
                     try:
                         data.add(self.state.loader.memory.unpack_word(a, size=size))
-                    except (struct.error, KeyError):
+                    except KeyError:
                         pass
 
                 # FIXME: _add_memory_use() iterates over the same loop


### PR DESCRIPTION
The address from which we read ("a" var) could point to an invalid memory location, causing a KeyError unhandled exception when trying to read from there.