### PR TITLE
setup.py: angr needs at least sortedcontainers > 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
     packages=packages,
     install_requires=[
         'ana',
-        'sortedcontainers',
+        'sortedcontainers>2.0',
         'cachetools',
         'capstone>=3.0.5rc2',
         'cooldict',


### PR DESCRIPTION
It makes use of `SortedKeyList` which was introduced in that version:

https://github.com/grantjenks/python-sortedcontainers/blob/64dfae3e1481736ed63a7bad11cbdbc02c90268f/HISTORY.rst#200-2018-05-18