### PR TITLE
requirements.txt: use dependencies from setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,2 @@
-ailment==8.18.10.5
-ana
-archinfo==8.18.10.5
-sortedcontainers
-cachetools
-capstone>=3.0.5.rc2
-claripy==8.18.10.5
-cle==8.18.10.5
-cooldict
-dpkt
-futures
-mulpyplexer
-networkx>=2.0
-progressbar
-pyvex==8.18.10.5
-rpyc
-unicorn
-GitPython
-pycparser>=2.18
+# backwards compatibility
+-e .


### PR DESCRIPTION
This will install angr in editable mode (i.e. setuptools "develop mode").
The advantage is that both files no longer need to be kept in sync.

Follow up to: https://github.com/angr/angr/pull/1239
