### PR TITLE
some small changes

### DIFF
--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -520,6 +520,9 @@ class SimTypeString(SimTypeArray):
         if self.length is None:
             out = None
             last_byte = state.memory.load(addr, 1)
+            # if we try to extract a symbolic string, it's likely that we are going to be trapped in a very large loop.
+            if state.solver.symbolic(last_byte):
+                raise ValueError("Trying to extract a symbolic string at %#x" % state.solver.eval(addr))
             addr += 1
             while not claripy.is_true(last_byte == 0):
                 out = last_byte if out is None else out.concat(last_byte)
@@ -568,6 +571,9 @@ class SimTypeWString(SimTypeArray):
         if self.length is None:
             out = None
             last_byte = state.memory.load(addr, 2)
+            # if we try to extract a symbolic string, it's likely that we are going to be trapped in a very large loop.
+            if state.solver.symbolic(last_byte):
+                raise ValueError("Trying to extract a symbolic string at %#x" % state.solver.eval(addr))
             addr += 2
             while not claripy.is_true(last_byte == 0):
                 out = last_byte if out is None else out.concat(last_byte)

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -699,7 +699,7 @@ class SimTypeFloat(SimTypeReg):
         return itype
 
     def store(self, state, addr, value):
-        if type(value) in (int, float, long):
+        if type(value) in (int, float):
             value = claripy.FPV(float(value), self.sort)
         return super(SimTypeFloat, self).store(state, addr, value)
 

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -193,8 +193,9 @@ class SimLinux(SimUserland):
         state = super(SimLinux, self).state_entry(**kwargs)
 
         # Handle default values
+        filename = self.project.filename or 'dummy_filename'
         if args is None:
-            args = [self.project.filename]
+            args = [filename]
 
         if env is None:
             env = {}

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -194,7 +194,7 @@ class SimLinux(SimUserland):
 
         # Handle default values
         if args is None:
-            args = []
+            args = [self.project.filename]
 
         if env is None:
             env = {}

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -59,7 +59,7 @@ class SimWindows(SimOS):
     def state_entry(self, args=None, env=None, argc=None, **kwargs):
         state = super(SimWindows, self).state_entry(**kwargs)
 
-        if args is None: args = []
+        if args is None: args = [self.project.filename]
         if env is None: env = {}
 
         # Prepare argc

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -59,8 +59,13 @@ class SimWindows(SimOS):
     def state_entry(self, args=None, env=None, argc=None, **kwargs):
         state = super(SimWindows, self).state_entry(**kwargs)
 
-        if args is None: args = [self.project.filename]
-        if env is None: env = {}
+        # Handle default values
+        filename = self.project.filename or 'dummy_filename'
+        if args is None:
+            args = [filename]
+
+        if env is None:
+            env = {}
 
         # Prepare argc
         if argc is None:


### PR DESCRIPTION
1. provide a default `argv` when initializing the memory. In this case, default behavior can be consistent with the case where `args` argument is provided when initializing state.

2. raise when trying to extract a symbolic string. I encountered this when trying to access `argv` and 
 found nothing there. And I was trapped in a very large loop trying to find a concrete zero.
I think give out a warning about this may be an alternative.