### PR TITLE
add complete_hook function to exploration techniques

### DIFF
--- a/angr/exploration_techniques/__init__.py
+++ b/angr/exploration_techniques/__init__.py
@@ -145,6 +145,18 @@ class ExplorationTechnique:
         """
         return False
 
+    def complete_hook(self, simgr):
+        """
+        Perform post completed procedure if manager has reached a "completed" state, i.e. ``SimulationManager.run()`` halt at a
+        ``complete`` function provided by any exploration technique this manager adoptes.
+
+        User can override this function to execute a function after the manager halts.
+
+        ..note:: This function may be invoked when ``self.complete(simgr)`` does not return True. This is because manager
+        might reach a "completed" state due to other exploration techniques adopted by the same manager.
+        """
+        pass
+
 
 from .cacher import Cacher
 from .driller_core import DrillerCore

--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -255,12 +255,17 @@ class SimulationManager(ana.Storable):
         :return:            The simulation manager, for chaining.
         :rtype:             SimulationManager
         """
+        completed = False
         for _ in (itertools.count() if n is None else range(0, n)):
-            if not self.complete() and self._stashes[stash]:
+            completed = self.complete()
+            if not completed and self._stashes[stash]:
                 self.step(stash=stash, **kwargs)
                 if not (until and until(self)):
                     continue
             break
+        if completed:
+            for tech in self._techniques:
+                tech.complete_hook(self)
         return self
 
     def complete(self):


### PR DESCRIPTION
It will allow user to execute a function after `simgr.run()` stops.
I may be useful to carry out some cleanup actions or some analysis after exploration stops.