### PR TITLE
Initialize _security_cookie in SimWindows

### DIFF
--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -464,7 +464,7 @@ class SimWindows(SimOS):
 
     def _init_object_pe_security_cookie(self, pe_object, state, state_kwargs):
         sc_init = state_kwargs.pop('security_cookie_init', SecurityCookieInit.STATIC)
-        if sc_init is SecurityCookieInit.NONE:
+        if sc_init is SecurityCookieInit.NONE or sc_init is None:
             return
         pe = getattr(pe_object, '_pe', None)
         if pe is None:
@@ -477,7 +477,7 @@ class SimWindows(SimOS):
             return
         vs_cookie = VS_SECURITY_COOKIES.get(self.project.arch.name)
         if vs_cookie is None:
-            _l.warning('Unsupported architecture: ' + self.project.arch + ' for /GS, leaving _security_cookie uninitialized')
+            _l.warning('Unsupported architecture: %s for /GS, leaving _security_cookie uninitialized', self.project.arch.name)
             return
         if sc_init is SecurityCookieInit.RANDOM:
             sc_value = random.randint(1, (2 ** vs_cookie.width - 1))

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -24,8 +24,8 @@ _l = logging.getLogger('angr.simos.windows')
 _VS_Security_Cookie = collections.namedtuple('_VS_Security_Cookie', ('default', 'width'))
 # security cookie details from visual studio, keyed by architecture name
 VS_SECURITY_COOKIES = {
-	'AMD64': _VS_Security_Cookie(0x2b992ddfa232, 48),
-	'X86': _VS_Security_Cookie(0xbb40e64e, 32)
+    'AMD64': _VS_Security_Cookie(0x2b992ddfa232, 48),
+    'X86': _VS_Security_Cookie(0xbb40e64e, 32)
 }
 
 
@@ -458,7 +458,7 @@ class SimWindows(SimOS):
         pe = getattr(pe_object, '_pe', None)
         if pe is None:
             # this is a code compatibility issue because we're using the private member
-            raise errors.AngrSimOSError('cle backened pe_object has no _pe attribute')
+            raise errors.AngrSimOSError('cle backend object has no _pe attribute')
         if hasattr(pe, 'DIRECTORY_ENTRY_LOAD_CONFIG'):
             config = pe.DIRECTORY_ENTRY_LOAD_CONFIG.struct
             if config.SecurityCookie:

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -57,7 +57,7 @@ def test_emulation():
         yield emulate, p, steps, hit_addrs, finished
 
 def test_windows():
-    yield emulate, angr.Project(test_location + 'i386/test_arrays.exe'), 49, [], False # blocked on GetLastError or possibly dynamic loading
+    yield emulate, angr.Project(test_location + 'i386/test_arrays.exe'), 41, [], False # blocked on GetLastError or possibly dynamic loading
 
 def test_locale():
     p = angr.Project(test_location + 'i386/isalnum', use_sim_procedures=False)

--- a/tests/test_windows_stack_cookie.py
+++ b/tests/test_windows_stack_cookie.py
@@ -1,0 +1,55 @@
+import os
+import struct
+
+import nose
+import angr
+import angr.simos.windows
+
+
+test_location = os.path.join(os.path.dirname(os.path.realpath(str(__file__))), '../../binaries/tests/')
+
+
+def compare_none(state, test_value):
+    test_value = test_value.concrete
+    correct_value = angr.simos.windows.VS_SECURITY_COOKIES[state.arch.name].default
+    nose.tools.assert_equal(test_value, correct_value)
+
+
+def compare_random(state, test_value):
+    test_value = test_value.concrete
+    incorrect_value = angr.simos.windows.VS_SECURITY_COOKIES[state.arch.name].default
+    nose.tools.assert_not_equal(test_value, incorrect_value)
+
+
+def compare_static(state, test_value):
+    test_value = test_value.concrete
+    correct_value = struct.unpack('>I', b'cook')[0]
+    nose.tools.assert_equal(test_value, correct_value)
+
+
+def compare_symbolic(state, test_value):
+    nose.tools.assert_true(test_value.resolved.symbolic)
+
+
+def check_value(project, init_type, comparison):
+    main_object = project.loader.main_object
+    main_pe = main_object._pe
+    load_config = main_pe.DIRECTORY_ENTRY_LOAD_CONFIG.struct
+
+    state = project.factory.blank_state(security_cookie_init=init_type)
+    value = getattr(state.mem[load_config.SecurityCookie], "uint{0}_t".format(state.arch.bits))
+    comparison(state, value)
+
+
+def test_security_cookie_init():
+    project = angr.Project(test_location + 'i386/test_arrays.exe')
+    check_value(project, angr.simos.windows.SecurityCookieInit.NONE, compare_none)
+    check_value(project, angr.simos.windows.SecurityCookieInit.RANDOM, compare_random)
+    check_value(project, angr.simos.windows.SecurityCookieInit.STATIC, compare_static)
+    check_value(project, angr.simos.windows.SecurityCookieInit.SYMBOLIC, compare_symbolic)
+
+    nose.tools.assert_raises(TypeError, project.factory.blank_state, security_cookie_init=1)
+
+
+if __name__ == '__main__':
+    test_security_cookie_init()


### PR DESCRIPTION
This PR adds support to `SimWindows` to automatically initialize the `_security_cookie` value as determined from the [Load Configuration](https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#load-configuration-directory). This enables users to analyze PE images without requiring that they somehow initialize the cookie themselves, execute, etc.

The default behavior of `_init_security_cookie` is to check if the value has already been initialized and return if it has been. Some PE images (such as drivers) require that the OS loader handle the initialization.

## Testing Steps
The following script can be used to test the behavior of this. Executing it repeatedly should return randomized, non-zero, non-default values for PE images which specify a `LoadConfig->SecurityCookie`.

```
import sys

import angr

def main():
	if len(sys.argv) < 2:
		print("usage: {0} [pe file]".format(sys.argv[0]))
		return
	project = angr.Project(sys.argv[1])
	main_object = project.loader.main_object
	main_pe = main_object._pe
	load_config = main_pe.DIRECTORY_ENTRY_LOAD_CONFIG.struct
	value = main_object.memory.unpack_word(load_config.SecurityCookie - main_pe.NT_HEADERS.OPTIONAL_HEADER.ImageBase)
	print("value: 0x{0:x}".format(value))

if __name__ == '__main__':
	main()
```