### PR TITLE
Allow user to hook an address (or entire memory range) with a custom SimEngine

### DIFF
--- a/angr/engines/__init__.py
+++ b/angr/engines/__init__.py
@@ -8,7 +8,7 @@ from .failure import SimEngineFailure
 from .syscall import SimEngineSyscall
 from .hook import SimEngineHook
 
-from .hub import EngineHub, EnginePreset
+from .selector import EngineSelector, EnginePreset
 
 
 # This is a basic preset of essential engines.
@@ -24,7 +24,7 @@ basic_preset.procedure_engine = 'procedure'
 # This is a VEX engine preset.
 # It will be used as a default preset for engine hub.
 vex_preset = basic_preset.copy()
-EngineHub.register_preset('default', vex_preset)
+EngineSelector.register_preset('default', vex_preset)
 
 vex_preset.add_default_plugin('unicorn', SimEngineUnicorn)
 vex_preset.add_default_plugin('vex', SimEngineVEX)

--- a/angr/engines/__init__.py
+++ b/angr/engines/__init__.py
@@ -13,7 +13,7 @@ from .selector import EngineSelector, EnginePreset
 
 # This is a basic preset of essential engines.
 # It is meant to serve as the boilerplate for other presets.
-basic_preset = EnginePreset(['failure', 'syscall', 'hook'])
+basic_preset = EnginePreset(['failure', 'syscall'])
 basic_preset.add_default_plugin('failure', SimEngineFailure)
 basic_preset.add_default_plugin('syscall', SimEngineSyscall)
 basic_preset.add_default_plugin('hook', SimEngineHook)
@@ -29,5 +29,5 @@ EngineSelector.register_preset('default', vex_preset)
 vex_preset.add_default_plugin('unicorn', SimEngineUnicorn)
 vex_preset.add_default_plugin('vex', SimEngineVEX)
 
-vex_preset.order = 'unicorn', 'vex'
+vex_preset.regular_engines = 'unicorn', 'vex'
 vex_preset.default_engine = 'vex'

--- a/angr/engines/hook.py
+++ b/angr/engines/hook.py
@@ -2,12 +2,22 @@ import logging
 
 from .engine import SimEngine
 from .successors import SimSuccessors
+from ..misc.ux import once
 
 l = logging.getLogger(name=__name__)
 
 
 # pylint: disable=abstract-method,unused-argument,arguments-differ
 class SimEngineHook(SimEngine):
+
+    def __init__(self, *args, **kwargs):
+        super(SimEngineHook, self).__init__(*args, **kwargs)
+
+        if once('sim_engine_hook'):
+            print("\x1b[31;1mDeprecation warning: SimProcedures are now engines on their own."
+                  "Consider using EngineSelector.insert_engine() to mark an address (or a memory range)"
+                  "to be executed with a particular SimProcedure.\x1b[0m")
+
     def _check(self, state, procedure=None, **kwargs):
         # we have not yet entered the next step - we should check the "current" jumpkind
         if state.history.jumpkind == 'Ijk_NoHook':

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -10,6 +10,8 @@ from ...analyses.code_location import CodeLocation
 
 
 class SimEngineLight(SimEngine):
+    requires_project = False
+
     def __init__(self, engine_type='vex'):
         super(SimEngineLight, self).__init__()
 

--- a/angr/engines/procedure.py
+++ b/angr/engines/procedure.py
@@ -2,6 +2,7 @@ import logging
 l = logging.getLogger(name=__name__)
 
 from .engine import SimEngine
+from ..misc.ux import once
 
 #pylint: disable=arguments-differ
 
@@ -10,6 +11,13 @@ class SimEngineProcedure(SimEngine):
     An engine for running SimProcedures
     """
     requires_project = False
+
+    def __init__(self, *args, **kwargs):
+        super(SimEngineProcedure, self).__init__(*args, **kwargs)
+
+        if once('sim_engine_hook'):
+            print("\x1b[31;1mDeprecation warning: SimProcedures are now engines on their own."
+                  "You can run them directly using the instance process() method.\x1b[0m")
 
     def process(self, state, procedure=None, ret_to=None, **kwargs):
         """

--- a/angr/engines/procedure.py
+++ b/angr/engines/procedure.py
@@ -9,81 +9,20 @@ class SimEngineProcedure(SimEngine):
     """
     An engine for running SimProcedures
     """
+    requires_project = False
 
-    def process(self, state, procedure,
-            ret_to=None,
-            inline=None,
-            force_addr=None,
-            **kwargs):
+    def process(self, state, procedure=None, ret_to=None, **kwargs):
         """
         Perform execution with a state.
 
         :param state:       The state with which to execute
-        :param procedure:   An instance of a SimProcedure to run
+        :param procedure:   An instance of a SimProcedure to run.
         :param ret_to:      The address to return to when this procedure is finished
         :param inline:      This is an inline execution. Do not bother copying the state.
         :param force_addr:  Force execution to pretend that we're working at this concrete address
         :returns:           A SimSuccessors object categorizing the execution's successor states
         """
-        return super(SimEngineProcedure, self).process(state, procedure,
-                ret_to=ret_to,
-                inline=inline,
-                force_addr=force_addr)
+        return procedure.process(state, ret_to=ret_to, **kwargs)
 
     def _check(self, state, *args, **kwargs):
         return True
-
-    def _process(self, state, successors, procedure, ret_to=None):
-        successors.sort = 'SimProcedure'
-
-        # fill in artifacts
-        successors.artifacts['is_syscall'] = procedure.is_syscall
-        successors.artifacts['name'] = procedure.display_name
-        successors.artifacts['no_ret'] = procedure.NO_RET
-        successors.artifacts['adds_exits'] = procedure.ADDS_EXITS
-
-        # Update state.scratch
-        state.scratch.sim_procedure = procedure
-        state.history.recent_block_count = 1
-
-        # prepare and run!
-        state._inspect('simprocedure',
-                       BP_BEFORE,
-                       simprocedure_name=procedure.display_name,
-                       simprocedure_addr=successors.addr,
-                       simprocedure=procedure
-                       )
-        if procedure.is_syscall:
-            state._inspect('syscall', BP_BEFORE, syscall_name=procedure.display_name)
-
-        cleanup_options = o.AUTO_REFS not in state.options
-        if cleanup_options:
-            state.options.add(o.AST_DEPS)
-            state.options.add(o.AUTO_REFS)
-
-        # do it
-        inst = procedure.execute(state, successors, ret_to=ret_to)
-        successors.artifacts['procedure'] = inst
-
-        if cleanup_options:
-            state.options.discard(o.AST_DEPS)
-            state.options.discard(o.AUTO_REFS)
-
-        if procedure.is_syscall:
-            state._inspect('syscall', BP_AFTER, syscall_name=procedure.display_name)
-        state._inspect('simprocedure',
-                       BP_AFTER,
-                       simprocedure_name=procedure.display_name,
-                       simprocedure_addr=successors.addr,
-                       simprocedure=inst
-                       )
-
-        successors.description = 'SimProcedure ' + procedure.display_name
-        if procedure.is_syscall:
-            successors.description += ' (syscall)'
-        if procedure.is_stub:
-            successors.description += ' (stub)'
-        successors.processed = True
-
-from .. import sim_options as o
-from ..state_plugins.inspect import BP_BEFORE, BP_AFTER

--- a/angr/engines/selector.py
+++ b/angr/engines/selector.py
@@ -1,3 +1,10 @@
+from sys import maxsize
+from itertools import chain, zip_longest, tee
+from collections import defaultdict
+
+from rdict import RangeDict, MeldDict
+
+from ..misc.ux import deprecated
 from ..misc.plugins import PluginHub, PluginPreset
 from ..errors import AngrExitError
 
@@ -5,23 +12,94 @@ import logging
 l = logging.getLogger(name=__name__)
 
 
+class EngineRanges(MeldDict):
+
+    def __init__(self):
+        super(EngineRanges, self).__init__()
+
+        # A set of all stop points that are introduced by the ranges.
+        self._stop_points = set()
+
+        # A mapping that stores engines along with a sets of stop points, that
+        # should not affect those engines.
+        self._amend_engines = defaultdict(set)
+
+        # The reversed version of of self._amend_engines.
+        self._reverse_amend = defaultdict(set)
+
+    def list_stop_points(self, engine):
+        """
+        Return a set of all stop points at which the given engine should stop execution.
+
+        :param engine:
+        :return:
+        """
+        return self._stop_points - self._amend_engines.get(engine, set())
+
+    def occupy(self, start, end, value, **meld_opts):
+        return super(EngineRanges, self).occupy(start, end, value, **meld_opts)
+
+    def _replace(self, left_idx, right_idx, items):
+        # Normalize indexes.
+        left_idx = max(left_idx, 0)
+        right_idx = min(right_idx, len(self._list))
+
+        # Remove old stop points that were created by those ranges.
+        for item in self._list[left_idx:right_idx]:
+            self._stop_points.discard(item.start)
+            for engine in self._reverse_amend[item.start]:
+                self._amend_engines[engine].discard(item.start)
+            self._reverse_amend.pop(item.start)
+
+        # Replace ranges.
+        self._list[left_idx:right_idx] = items
+
+        # Add new stop points per range.
+        for item in items:
+            self._stop_points.add(item.start)
+
+            if item.value:
+                engine = item.value[0]
+                self._amend_engines[engine].add(item.start)
+                self._reverse_amend[item.start].add(engine)
+
+    def _meld(self, old_val, new_val, operation=None, **kwargs):
+        if operation == 'insert':
+            return new_val + old_val
+        elif operation == 'append':
+            return old_val + new_val
+        elif operation == 'assign':
+            return new_val
+        else:
+            raise ValueError(operation)
+
+
 class EngineSelector(PluginHub):
 
-    def __init__(self, project):
+    def __init__(self, project=None):
         super(EngineSelector, self).__init__()
         self.project = project
 
-        self._order = None
+        self._eager_engines = []
+        self._regular_engines = []
+        self._fallback_engines = []
+
         self._default_engine = None
         self._procedure_engine = None
 
+        self._assigned_engines = EngineRanges()
+
     def __getstate__(self):
         s = super(EngineSelector, self).__getstate__()
-        return s, self._order, self._default_engine, self._procedure_engine, self.project
+        return s, self._default_engine, self._procedure_engine, self.project, \
+            self._eager_engines, self._regular_engines, self._fallback_engines, \
+            self._assigned_engines
 
     def __setstate__(self, s):
         super(EngineSelector, self).__setstate__(s[0])
-        self._order, self._default_engine, self._procedure_engine, self.project = s[1:]
+        self._default_engine, self._procedure_engine, self.project, \
+            self._eager_engines, self._regular_engines, self._fallback_engines, \
+            self._assigned_engines = s[1:]
 
     #
     #   ...
@@ -30,34 +108,83 @@ class EngineSelector(PluginHub):
     def _init_plugin(self, plugin_cls):
         return plugin_cls(self.project)
 
-    def use_plugin_preset(self, preset, adjust_order=True):  # pylint:disable=arguments-differ
+    def use_plugin_preset(self, preset, adjust_order=True, assign_engines=True):  # pylint:disable=arguments-differ
         super(EngineSelector, self).use_plugin_preset(preset)
 
         if adjust_order and self.plugin_preset.has_order():
-            self.order = self.plugin_preset.order
+            self._eager_engines = self.plugin_preset.eager_engines
+            self._regular_engines = self.plugin_preset.regular_engines
+            self._fallback_engines = self.plugin_preset.fallback_engines
+
+        if assign_engines:
+            self.assign_engines((0, maxsize), self._regular_engines)
 
         if self.plugin_preset.has_default_engine():
-            self.default_engine = self.plugin_preset.default_engine
+            self._default_engine = self.plugin_preset.default_engine
 
         if self.plugin_preset.has_procedure_engine():
-            self.procedure_engine = self.plugin_preset.procedure_engine
+            self._procedure_engine = self.plugin_preset.procedure_engine
 
     #
     #   ...
     #
 
     @property
+    def eager_engines(self):
+        """
+        A list of engines that will be executed first for _any_ address,
+        regardless of the current assignments.
+
+        :return:
+        """
+        return self._eager_engines
+
+    @eager_engines.setter
+    def eager_engines(self, value):
+        self._eager_engines = list(value)
+
+    @property
+    def fallback_engines(self):
+        """
+        A list of engines that will be executed last for _any_ address,
+        regardless of the current assignments.
+
+        :return:
+        """
+        return self._fallback_engines
+
+    @fallback_engines.setter
+    def fallback_engines(self, value):
+        self._fallback_engines = list(value)
+
+    @property
+    def regular_engines(self):
+        """
+        A list of engines that will be executed after the ``eager_engines``,
+        but before the ``fallback_engines``, if no assignments were made for
+        the execution address.
+
+        """
+        return self._regular_engines
+
+    @regular_engines.setter
+    def regular_engines(self, value):
+        self._regular_engines = list(value)
+
+    @property
     def order(self):
-        if self._order is None:
-            if self.has_plugin_preset:
-                self._order = self.plugin_preset.list_default_plugins()
-            else:
-                self._order = self._active_plugins.keys()
-        return self._order
+        """
+        A list of engines that will be executed in case no engines were assigned
+        for execution.
+
+        :return:
+        """
+        return self._eager_engines + self._regular_engines + self._fallback_engines
 
     @order.setter
+    @deprecated('regular_engines')
     def order(self, value):
-        self._order = list(value)
+        self._regular_engines = list(value)
 
     @property
     def default_engine(self):
@@ -89,6 +216,80 @@ class EngineSelector(PluginHub):
     #   ...
     #
 
+    def assign_engines(self, addr, engines):
+        """
+        Assign engines to be executed for the specified address (or memory range).
+        This will replace any previously assigned engines with the new ones.
+
+        :param addr:    An integer specifying the address or a tuple of (min_addr, max_addr)
+                        specifying a memory range.
+        :param engines: A list of engines to assign to the address.
+        """
+        engines = self._normalize_engines(engines)
+        min_addr, max_addr = self._addr_to_range(addr)
+        self._assigned_engines.occupy(min_addr, max_addr, engines, operation='assign')
+
+    def insert_engine(self, addr, engine):
+        """
+        Assign the given engine to be executed first for the specified address.
+
+        :param addr:    An integer specifying the address or a tuple of (min_addr, max_addr)
+                        specifying a memory range.
+        :param engine:  The engine to be inserted.
+        :return:
+        """
+        engines = self._normalize_engines([engine])
+        min_addr, max_addr = self._addr_to_range(addr)
+        self._assigned_engines.occupy(min_addr, max_addr, engines, operation='insert')
+
+    def append_engine(self, addr, engine):
+        """
+        Assign an engine to be executed last for the specified address.
+
+        :param addr:    An integer specifying the address or a tuple of (min_addr, max_addr)
+                        specifying a memory range.
+        :param engine:  The engine to be appended.
+        :return:
+        """
+        engines = self._normalize_engines([engine])
+        min_addr, max_addr = self._addr_to_range(addr)
+        self._assigned_engines.occupy(min_addr, max_addr, engines, operation='append')
+
+    def remove_engine(self, addr, engine):
+        """
+        Remove the engine from the list of engines that are assigned to the given
+        address (or memory range).
+
+        :param addr:    An integer specifying the address or a tuple of (min_addr, max_addr)
+                        specifying a memory range.
+        :param engine:  The engine to be removed.
+        :return:
+        """
+        min_addr, max_addr = self._addr_to_range(addr)
+        for _range in self._assigned_engines.irange(min_addr, max_addr):
+            del self._assigned_engines[_range.start:_range.end]
+
+            new_engines = [e for e in _range.value if e is not engine]
+            not new_engines or self._assigned_engines.occupy(_range.start, _range.end, new_engines)
+
+    def list_engines(self, addr):
+        """
+        List all engines that are assigned to the given address.
+
+        :param addr:    An integer specifying the address.
+        :return:
+        """
+        return self._normalize_engines(self._assigned_engines.get(addr, []))
+
+    def list_stop_points(self, engine):
+        """
+        Return a set of all stop points at which the given engine should stop execution.
+
+        :param engine:  The engine for which to return a set of stop points.
+        :return:
+        """
+        return self._assigned_engines.list_stop_points(engine)
+
     def successors(self, state, addr=None, jumpkind=None, default_engine=False, procedure_engine=False,
                    engines=None, **kwargs):
         """
@@ -116,20 +317,41 @@ class EngineSelector(PluginHub):
 
         if default_engine and self.has_default_engine():
             engines = [self.default_engine]
+
         elif procedure_engine and self.has_procedure_engine():
             engines = [self.procedure_engine]
-        elif engines is None:
-            engines = (self.get_plugin(name) for name in self.order)
-        else:
-            engines = (self.get_plugin(e) if isinstance(e, str) else e for e in engines)
+
+        elif engines is not None:
+            engines = self._normalize_engines(engines)
+
+        elif state._ip.concrete:
+            regular_engines = self._assigned_engines.get(state.addr, self._regular_engines)
+            engines = self._normalize_engines(self._eager_engines + regular_engines + self._fallback_engines)
+
+        if not engines:
+            engines = self._normalize_engines(self.order)
 
         for engine in engines:
             if engine.check(state, **kwargs):
-                r = engine.process(state, **kwargs)
-                if r.processed:
-                    return r
+                base_stop_points = self.list_stop_points(engine)
+                base_stop_points -= {state.addr} if state._ip.concrete else set()
+                successors = engine.process(state, base_stop_points=base_stop_points, **kwargs)
+                if successors.processed:
+                    return successors
 
         raise AngrExitError("All engines failed to execute!")
+
+    def _addr_to_range(self, addr):
+        if isinstance(addr, int):
+            min_addr, max_addr = addr, addr + 1
+        elif isinstance(addr, tuple):
+            min_addr, max_addr = addr
+        else:
+            raise TypeError
+        return min_addr, max_addr
+
+    def _normalize_engines(self, engines):
+        return [self.get_plugin(e) if isinstance(e, str) else e for e in engines]
 
 
 class EnginePreset(PluginPreset):
@@ -137,47 +359,87 @@ class EnginePreset(PluginPreset):
     This represents a preset of engines for an engine hub.
 
     As was pointed out by @rhelmot (see https://github.com/angr/angr/pull/897), there's a lot of
-    behavior in angr which very very specifically assumes that failure/syscall/hook will happen
-    exactly the way we want them to.  This plugin preset addresses the issue by allowing a user to
-    specify a list of plugins that should be executed first using the ``predefined_order``
-    parameter. In that case, any other adjustment to order will be made with respect to the
-    specified predefined order.
+    behavior in angr which very very specifically assumes that the first engines to be executed
+    are the ``failure`` and the ``syscall`` engines. This plugin preset addresses the issue by
+    allowing a user to specify a list of plugins that should be executed first using the
+    ``eager_engines`` parameter. "Eager" engines will be checked first for _any_ address,
+    regardless of the current assignments.
 
     If you want to use your custom preset with the angr's original analyses, you should
-    specify the following predefined order: ``failure``, ``syscall``, and then ``hook``.
+    specify the following eager engines: ``failure``, ``syscall``.
     """
 
-    def __init__(self, predefined_order=None):
+    def __init__(self, eager_engines=None, fallback_engines=None):
         super(EnginePreset, self).__init__()
 
-        self._order = predefined_order
-        self._predefined_order = predefined_order or []
+        self._eager_engines = eager_engines or []
+        self._fallback_engines = fallback_engines or []
+        self._regular_engines = []
 
         self._default_engine = None
         self._procedure_engine = None
 
     def activate(self, hub):
-        for plugin_name in self._order:
+        for plugin_name in self.order:
             if plugin_name not in self._default_plugins:
-                l.warn("%s doesn't provide a plugin for %s. Expect execution to fail.",
-                       self, plugin_name)
+                l.warning("%s doesn't provide a plugin for %s. Expect execution to fail.", self, plugin_name)
 
     #
     #   ...
     #
 
     @property
+    def eager_engines(self):
+        """
+        A list of engines that will be executed first for _any_ address,
+        regardless of the current assignments.
+
+        This list should start with ``failure`` and ``syscall``, if you want to
+        use this preset with the angr's original analyses.
+
+        :return:
+        """
+        return self._eager_engines
+
+    @property
+    def fallback_engines(self):
+        """
+        A list of engines that will be executed last for _any_ address,
+        regardless of the current assignments.
+
+        :return:
+        """
+        return self._fallback_engines
+
+    @property
+    def regular_engines(self):
+        """
+        A list of engines that will be executed after the ``eager_engines``,
+        but before the ``fallback_engines``, if no assignments were made for
+        the execution address.
+
+        VEX and Unicorn engines are common examples of a "regular" engine.
+
+        :return:
+        """
+        return self._regular_engines
+
+    @regular_engines.setter
+    def regular_engines(self, value):
+        self._regular_engines = list(value)
+
+    @property
     def order(self):
-        if self._order is None:
-            return self.list_default_plugins()
-        return self._order
+        order = self._eager_engines + self._regular_engines + self._fallback_engines
+        return order if order else self.list_default_plugins()
 
     @order.setter
+    @deprecated('regular_engines')
     def order(self, value):
-        self._order = self._predefined_order + list(value)
+        self._regular_engines = list(value)
 
     def has_order(self):
-        return self._order is not None
+        return any((self._eager_engines, self._regular_engines, self._fallback_engines))
 
     @property
     def default_engine(self):
@@ -207,8 +469,16 @@ class EnginePreset(PluginPreset):
 
     def copy(self):
         result = super(EnginePreset, self).copy()
-        result._predefined_order = list(self._predefined_order)  # pylint:disable=protected-access
-        result._order = list(self._order)  # pylint:disable=protected-access
+        result._eager_engines = list(self._eager_engines)  # pylint:disable=protected-access
+        result._fallback_engines = list(self._fallback_engines)  # pylint:disable=protected-access
+        result._regular_engines = list(self._regular_engines)  # pylint:disable=protected-access
         result._default_engine = self._default_engine  # pylint:disable=protected-access
         result._procedure_engine = self._procedure_engine  # pylint:disable=protected-access
         return result
+
+
+def pairwise(iterable):
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)

--- a/angr/engines/selector.py
+++ b/angr/engines/selector.py
@@ -5,10 +5,10 @@ import logging
 l = logging.getLogger(name=__name__)
 
 
-class EngineHub(PluginHub):
+class EngineSelector(PluginHub):
 
     def __init__(self, project):
-        super(EngineHub, self).__init__()
+        super(EngineSelector, self).__init__()
         self.project = project
 
         self._order = None
@@ -16,11 +16,11 @@ class EngineHub(PluginHub):
         self._procedure_engine = None
 
     def __getstate__(self):
-        s = super(EngineHub, self).__getstate__()
+        s = super(EngineSelector, self).__getstate__()
         return s, self._order, self._default_engine, self._procedure_engine, self.project
 
     def __setstate__(self, s):
-        super(EngineHub, self).__setstate__(s[0])
+        super(EngineSelector, self).__setstate__(s[0])
         self._order, self._default_engine, self._procedure_engine, self.project = s[1:]
 
     #
@@ -31,7 +31,7 @@ class EngineHub(PluginHub):
         return plugin_cls(self.project)
 
     def use_plugin_preset(self, preset, adjust_order=True):  # pylint:disable=arguments-differ
-        super(EngineHub, self).use_plugin_preset(preset)
+        super(EngineSelector, self).use_plugin_preset(preset)
 
         if adjust_order and self.plugin_preset.has_order():
             self.order = self.plugin_preset.order

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -27,6 +27,7 @@ class SimEngineVEX(SimEngine):
     """
     Execution engine based on VEX, Valgrind's IR.
     """
+    requires_project = False
 
     def __init__(self, project=None,
             stop_points=None,

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -66,13 +66,6 @@ class SimEngineVEX(SimEngine):
 
         self._initialize_block_cache()
 
-    def is_stop_point(self, addr):
-        if self.project is not None and addr in self.project._sim_procedures:
-            return True
-        elif self._stop_points is not None and addr in self._stop_points:
-            return True
-        return False
-
     def _initialize_block_cache(self):
         self._block_cache = LRUCache(maxsize=self._cache_size)
         self._block_cache_hits = 0
@@ -122,6 +115,10 @@ class SimEngineVEX(SimEngine):
                 raise AngrAssemblyError("Assembling failed. Please make sure keystone is installed, and the assembly"
                                         " string is correct.")
 
+        base_stop_points = None
+        if 'base_stop_points' in kwargs:
+            base_stop_points = kwargs['base_stop_points']
+
         return super(SimEngineVEX, self).process(state, irsb,
                 skip_stmts=skip_stmts,
                 last_stmt=last_stmt,
@@ -133,12 +130,13 @@ class SimEngineVEX(SimEngine):
                 num_inst=num_inst,
                 traceflags=traceflags,
                 thumb=thumb,
-                opt_level=opt_level)
+                opt_level=opt_level,
+                base_stop_points=base_stop_points)
 
     def _check(self, state, *args, **kwargs):
         return True
 
-    def _process(self, state, successors, irsb=None, skip_stmts=0, last_stmt=None, whitelist=None, insn_bytes=None, size=None, num_inst=None, traceflags=0, thumb=False, opt_level=None):
+    def _process(self, state, successors, irsb=None, skip_stmts=0, last_stmt=None, whitelist=None, insn_bytes=None, size=None, num_inst=None, traceflags=0, thumb=False, opt_level=None, base_stop_points=None):
         successors.sort = 'IRSB'
         successors.description = 'IRSB'
         state.history.recent_block_count = 1
@@ -157,7 +155,8 @@ class SimEngineVEX(SimEngine):
                     num_inst=num_inst,
                     traceflags=traceflags,
                     thumb=thumb,
-                    opt_level=opt_level)
+                    opt_level=opt_level,
+                    base_stop_points=base_stop_points)
 
             if irsb.size == 0:
                 if irsb.jumpkind == 'Ijk_NoDecode' and not state.project.is_hooked(irsb.addr):
@@ -432,7 +431,8 @@ class SimEngineVEX(SimEngine):
              opt_level=None,
              strict_block_end=None,
              skip_stmts=False,
-             collect_data_refs=False):
+             collect_data_refs=False,
+             **kwargs):
 
         """
         Lift an IRSB.
@@ -527,7 +527,14 @@ class SimEngineVEX(SimEngine):
             if cache_key in self._block_cache:
                 self._block_cache_hits += 1
                 irsb = self._block_cache[cache_key]
-                stop_point = self._first_stoppoint(irsb)
+
+                base_stop_points = None
+                if 'base_stop_points' in kwargs:
+                    base_stop_points = kwargs['base_stop_points']
+                elif self.project is not None:
+                    base_stop_points = self.project.engines.list_stop_points(self)
+
+                stop_point = self._first_stoppoint(irsb, base_stop_points)
                 if stop_point is None:
                     return irsb
                 else:
@@ -576,7 +583,12 @@ class SimEngineVEX(SimEngine):
 
                 if subphase == 0 and irsb.statements is not None:
                     # check for possible stop points
-                    stop_point = self._first_stoppoint(irsb)
+                    base_stop_points = None
+                    if 'base_stop_points' in kwargs:
+                        base_stop_points = kwargs['base_stop_points']
+                    elif self.project is not None:
+                        base_stop_points = self.project.engines.list_stop_points(self)
+                    stop_point = self._first_stoppoint(irsb, base_stop_points)
                     if stop_point is not None:
                         size = stop_point - addr
                         continue
@@ -663,12 +675,15 @@ class SimEngineVEX(SimEngine):
         size = min(max_size, size)
         return buff, size
 
-    def _first_stoppoint(self, irsb):
+    def _first_stoppoint(self, irsb, base_stop_points=None):
         """
         Enumerate the imarks in the block. If any of them (after the first one) are at a stop point, returns the address
         of the stop point. None is returned otherwise.
         """
-        if self._stop_points is None and self.project is None:
+        if self._stop_points is not None:
+            base_stop_points |= set(self._stop_points)
+
+        if not base_stop_points:
             return None
 
         first_imark = True
@@ -676,10 +691,10 @@ class SimEngineVEX(SimEngine):
             if type(stmt) is pyvex.stmt.IMark:  # pylint: disable=unidiomatic-typecheck
                 addr = stmt.addr + stmt.delta
                 if not first_imark:
-                    if self.is_stop_point(addr):
+                    if addr in base_stop_points:
                         # could this part be moved by pyvex?
                         return addr
-                    if stmt.delta != 0 and self.is_stop_point(stmt.addr):
+                    if stmt.delta != 0 and stmt.addr in base_stop_points:
                         return addr
 
                 first_imark = False

--- a/angr/misc/immutability.py
+++ b/angr/misc/immutability.py
@@ -1,0 +1,44 @@
+import abc
+import contextlib
+import functools
+
+
+class ImmutabilityMixin(object):
+
+    def __init__(self, immutable=False):
+        super(ImmutabilityMixin, self).__init__()
+        self._immutable = immutable
+
+    @abc.abstractmethod
+    def copy(self):
+        raise NotImplementedError
+
+    @classmethod
+    def immutable(cls, method):
+        """
+
+        :param method:
+        :return:
+        """
+        @functools.wraps(method)
+        def _wrapper(self, *args, **kwargs):
+            with cls.context(self) as self:  # pylint:disable=redefined-argument-from-local
+                return method(self, *args, **kwargs)
+        return _wrapper
+
+    @classmethod
+    @contextlib.contextmanager
+    def context(cls, obj):
+        was_immutable = obj._immutable
+        if was_immutable:
+            obj = obj.copy()
+            obj._immutable = False
+        yield obj
+        obj._immutable = was_immutable
+
+
+class ImmutabilityMixinMisused(Exception):
+
+    def __init__(self):
+        super(ImmutabilityMixinMisused, self).\
+            __init__('Immutable methods are expected to return the new self object')

--- a/angr/project.py
+++ b/angr/project.py
@@ -70,7 +70,7 @@ class Project:
     :param load_function:               A function that defines how the Project should be loaded. Default to unpickling.
     :param analyses_preset:             The plugin preset for the analyses provider (i.e. Analyses instance).
     :type analyses_preset:              angr.misc.PluginPreset
-    :param engines_preset:              The plugin preset for the engines provider (i.e. EngineHub instance).
+    :param engines_preset:              The plugin preset for the engines provider (i.e. EngineSelector instance).
     :type engines_preset:               angr.misc.PluginPreset
 
     Any additional keyword arguments passed will be passed onto ``cle.Loader``.
@@ -168,7 +168,7 @@ class Project:
 
         # Step 4: Set up the project's plugin hubs
         # Step 4.1: Engines. Get the preset from the loader, from the arch, or use the default.
-        engines = EngineHub(self)
+        engines = EngineSelector(self)
         if engines_preset is not None:
             engines.use_plugin_preset(engines_preset)
         elif self.loader.main_object.engine_preset is not None:
@@ -663,5 +663,5 @@ from .factory import AngrObjectFactory
 from angr.simos import SimOS, os_mapping
 from .analyses.analysis import AnalysesHub
 from .knowledge_base import KnowledgeBase
-from .engines import EngineHub
+from .engines import EngineSelector
 from .procedures import SIM_PROCEDURES, SIM_LIBRARIES

--- a/angr/project.py
+++ b/angr/project.py
@@ -402,6 +402,7 @@ class Project:
                 return
             else:
                 l.warning("Address is already hooked, during hook(%#x, %s). Re-hooking.", addr, hook)
+            self.engines.remove_engine(addr, self._sim_procedures[addr])
 
         if isinstance(hook, type):
             raise TypeError("Please instanciate your SimProcedure before hooking with it")
@@ -410,6 +411,7 @@ class Project:
             hook = SIM_PROCEDURES['stubs']['UserHook'](user_func=hook, length=length, **kwargs)
 
         self._sim_procedures[addr] = hook
+        self.engines.insert_engine(addr, hook)
 
     def is_hooked(self, addr):
         """

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ setup(
         'GitPython',
         'pycparser>=2.18',
         'itanium_demangler',
+        'yardict',
     ],
     setup_requires=['unicorn', 'pyvex'],
     cmdclass=cmdclass,

--- a/tests/test_engine_selector.py
+++ b/tests/test_engine_selector.py
@@ -1,0 +1,51 @@
+import nose
+import angr
+
+import os
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+
+
+def test_engine_selector():
+    p = angr.Project(location + '/x86_64/fauxware')
+    s = p.factory.blank_state(addr=p.entry)
+
+    # test if it works at all
+    ss = p.factory.successors(s)
+    nose.tools.assert_true(ss.processed)
+
+    simproc_cls = angr.procedures.SIM_PROCEDURES["stubs"]["PathTerminator"]
+    simproc = simproc_cls(p)
+
+    # test insertion/removal
+    p.engines.insert_engine(p.entry, simproc)
+    nose.tools.assert_in(simproc, p.engines.list_engines(p.entry))
+
+    ss = p.factory.successors(s)
+    nose.tools.assert_true(ss.is_empty)
+
+    p.engines.remove_engine(p.entry, simproc)
+    nose.tools.assert_not_in(simproc, p.engines.list_engines(p.entry))
+
+    ss = p.factory.successors(s)
+    nose.tools.assert_true(ss.processed)
+
+    # test stop points
+    p.engines.insert_engine(0x400582, simproc)
+    ss = p.factory.successors(s)
+    nose.tools.assert_equal(ss[0].addr, 0x400582)
+
+    p.engines.remove_engine(0x400582, simproc)
+
+    ss = p.factory.successors(s)
+    nose.tools.assert_true(ss.processed)
+
+    # test amend
+    p.engines.insert_engine(0x400580, p.engines.vex)
+    ss = p.factory.successors(s)
+    nose.tools.assert_equal(ss[0].addr, 0x400540)
+
+    return
+
+
+if __name__ == '__main__':
+    test_engine_selector()


### PR DESCRIPTION
The idea here is to allow the user to specify one or more engines to be called for any address within a specified memory range. This would allow for more fine-grained control over which engines should handle execution of certain parts of the binary, see original discussion here: https://github.com/angr/angr/issues/695.

The most important change here is that the SimProcedure was made to be a subclass of SimEngine. That means the SimProcedure is now a *class which understands how to perform execution on a state*, and that it has the same abilities and API, as any other engine. The latter results in two interesting advantages:

- The SimProcedure is now capable of producing a complete SimSuccessors object on its own, just like any other engine, thus eliminating the need in dedicated SimEngineProcedure.

- The SimProcedure can now be assigned to be called for any address (or even a memory range!), just like any other engine, thus eliminating the need in dedicated SimEngineHook and designated "hooking" functionality. It also means that the SimProcedure could now be executed *after* the regular engines (like VEX), which was rather difficult to acheive before.

As an idea for future improvement, I suggest to completely remove the `_sim_procedures` dictionary from the Project class and establish the following statement:

> The address (or a memory range) is "hooked" with a SimProcedure, if that particular SimProcedure is scheduled to be executed first for the given address.

The order in which the engines are executed for any address is defined by both the active preset and the active assignments, and goes as follows:

- First, we try to perform execution using the engines specified in the `eager_engines` property of the currently active preset. These engines will be executed first for any address, regardless of the current assignments

- Second, we look if there are any engines that was explicitly assigned to the given address. If there are any, we execute them in order they're assigned. By default, the whole address space is assigned to be executed by the engines that are provided by the `regular_engines` property of the currently active preset.

- Third, we try to perform execution using the engines specified in the `fallback_engines` property of the preset. If they also fail, we raise an AngrExitError.

This also brings the changes to the "stop points" mechanism that is used by SimEngineVEX and SimEngineUnicorn. Now, we treat an address to be a "stop point" for a particular engine, if there are any other engines, that are scheduled to be executed first before that particular engine.

For example, suppose we have the following map of assignments:

```
0x400000               0x401000               0x402000
+-----------------------+-----------------------+-----------------------+
|           VEX         |      Unicorn, VEX     |           VEX         |
+-----------------------+-----------------------+-----------------------+
```

That would mean that the VEX engine will have its stop point at 0x401000, while the Unicorn will have its stop point at 0x402000. Note, that the VEX engine will not have a stop point at 0x402000, since it has the highest execution priority on that range.