### PR TITLE
CFGFast: support thunks

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1116,7 +1116,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             return address
 
         try:
-            return next(self._regions.irange(minimum=address, reverse=True))
+            return next(self._regions.irange(minimum=address, reverse=False))
         except StopIteration:
             return None
 
@@ -1488,6 +1488,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         if self._force_complete_scan:
             addr = self._next_code_addr()
+            if addr is None:
+                l.debug("Force-scan jumping failed")
+            else:
+                l.debug("Force-scanning to %#x", addr)
 
             if addr is not None:
                 job = CFGJob(addr, addr, "Ijk_Boring", last_addr=None, job_type=CFGJob.JOB_TYPE_COMPLETE_SCANNING)

--- a/angr/block.py
+++ b/angr/block.py
@@ -16,7 +16,7 @@ class Block(object):
                  ]
 
     def __init__(self, addr, project=None, arch=None, size=None, byte_string=None, vex=None, thumb=False, backup_state=None,
-                 opt_level=None, num_inst=None, traceflags=0, strict_block_end=None, collect_data_refs=False):
+                 extra_stop_points=None, opt_level=None, num_inst=None, traceflags=0, strict_block_end=None, collect_data_refs=False):
 
         # set up arch
         if project is not None:
@@ -55,6 +55,7 @@ class Block(object):
                         insn_bytes=byte_string,
                         addr=addr,
                         thumb=thumb,
+                        extra_stop_points=extra_stop_points,
                         opt_level=opt_level,
                         num_inst=num_inst,
                         traceflags=traceflags,

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -266,7 +266,7 @@ class AngrObjectFactory(object):
                 func_ty=func_ty)
 
     def block(self, addr, size=None, max_size=None, byte_string=None, vex=None, thumb=False, backup_state=None,
-              opt_level=None, num_inst=None, traceflags=0,
+              extra_stop_points=None, opt_level=None, num_inst=None, traceflags=0,
               insn_bytes=None, insn_text=None,  # backward compatibility
               strict_block_end=None, collect_data_refs=False,
               ):
@@ -287,10 +287,11 @@ class AngrObjectFactory(object):
         if max_size is not None:
             l.warning('Keyword argument "max_size" has been deprecated for block(). Please use "size" instead.')
             size = max_size
-        return Block(addr, project=self.project, size=size, byte_string=byte_string, vex=vex, thumb=thumb,
-                     backup_state=backup_state, opt_level=opt_level, num_inst=num_inst, traceflags=traceflags,
+        return Block(addr, project=self.project, size=size, byte_string=byte_string, vex=vex,
+                     extra_stop_points=extra_stop_points, thumb=thumb, backup_state=backup_state,
+                     opt_level=opt_level, num_inst=num_inst, traceflags=traceflags,
                      strict_block_end=strict_block_end, collect_data_refs=collect_data_refs,
-                     )
+         )
 
     def fresh_block(self, addr, size, backup_state=None):
         return Block(addr, project=self.project, size=size, backup_state=backup_state)


### PR DESCRIPTION
Fixes a bunch of things.

- a shitty bug in cfgfast that made force_complete_scan not deal with holes correctly
- add knowledge of "thunks" to cfgfast which should be handled specially, currently just the batshit insane `__x86_return_thunk` nonsense. `__x86_indirect_thunk_rax` is also detected, but nothing is done about it since that's going to require a refactor for the indirect jump resolvers I believe...
- SimEngineVEX (and consequencially factory.block() etc) now support `extra_stop_points`
- as a cute bonus, this allows the Explorer otiegnqwvk to be simplified ruthlessly, eliminating literally all the windup stuff.

Closes #1296 