### PR TITLE
Fix a bug in CFG/Function normalization.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1181,6 +1181,9 @@ class CFGBase(Analysis):
                 continue
 
             for _, d, data in original_successors:
+                ins_addr = data['ins_addr']
+                if ins_addr < smallest_node.addr:
+                    continue
                 if d not in graph[smallest_node]:
                     if d is n:
                         graph.add_edge(smallest_node, new_node, **data)
@@ -1212,7 +1215,7 @@ class CFGBase(Analysis):
                               if i.addr == smallest_node.addr]
             if new_successors:
                 new_successor = new_successors[0]
-                graph.add_edge(new_node, new_successor, jumpkind='Ijk_Boring')
+                graph.add_edge(new_node, new_successor, jumpkind='Ijk_Boring', ins_addr=new_node.instruction_addrs[-1])
             else:
                 # We gotta create a new one
                 l.error('normalize(): Please report it to Fish.')

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1180,9 +1180,15 @@ class CFGBase(Analysis):
             if smallest_node not in graph:
                 continue
 
-            for _, d, data in original_successors:
-                ins_addr = data['ins_addr']
-                if ins_addr < smallest_node.addr:
+            for _s, d, data in original_successors:
+                ins_addr = data.get('ins_addr', None)  # ins_addr might be None for FakeRet edges
+                if ins_addr is None and data.get('jumpkind', None) != "Ijk_FakeRet":
+                    l.warning("Unexpected edge with ins_addr being None: %s -> %s, data = %s.",
+                              _s,
+                              d,
+                              str(data),
+                              )
+                if ins_addr is not None and ins_addr < smallest_node.addr:
                     continue
                 if d not in graph[smallest_node]:
                     if d is n:


### PR DESCRIPTION
I was assuming that a block can be split into at most two different
blocks, and the first half only has a boring jump targeting the second
half. Unfortunately, this is not the case in ARM. This bug is triggered
when normalizing CFG for ARM binary "a_thingy-stripped.elf" (see angr
issue #1286), function 0x8002b71. The block 0x8002b70 can be split into
four small blocks.