### PR TITLE
Implement tail-call optimization detection. Closes #1286.

### DIFF
--- a/angr/analyses/__init__.py
+++ b/angr/analyses/__init__.py
@@ -26,3 +26,4 @@ from .callee_cleanup_finder import CalleeCleanupFinder
 from .reaching_definitions import ReachingDefinitionAnalysis
 from .calling_convention import CallingConventionAnalysis
 from .code_tagging import CodeTagging
+from .stack_pointer_tracker import StackPointerTracker

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -849,6 +849,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                  exclude_sparse_regions=True,
                  skip_specific_regions=True,
                  heuristic_plt_resolving=None,
+                 detect_tail_calls=False,
                  start=None,  # deprecated
                  end=None,  # deprecated
                  **extra_arch_options
@@ -884,6 +885,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                                              default indirect jump resolvers specific to this architecture and binary
                                              types will be loaded.
         :param base_state:              A state to use as a backer for all memory loads
+        :param bool detect_tail_calls:  Enable aggressive tail-call optimization detection.
         :param int start:               (Deprecated) The beginning address of CFG recovery.
         :param int end:                 (Deprecated) The end address of CFG recovery.
         :param CFGArchOptions arch_options: Architecture-specific options.
@@ -911,6 +913,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             resolve_indirect_jumps=resolve_indirect_jumps,
             indirect_jump_resolvers=indirect_jump_resolvers,
             indirect_jump_target_limit=indirect_jump_target_limit,
+            detect_tail_calls=detect_tail_calls,
         )
 
         # necessary warnings

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -1,0 +1,159 @@
+
+import logging
+
+import pyvex
+
+from ..knowledge_plugins import Function
+from ..block import BlockNode
+from .analysis import Analysis
+from .forward_analysis import ForwardAnalysis, FunctionGraphVisitor
+
+
+_l = logging.getLogger(name=__name__)
+
+
+class StackPointerState:
+
+    __slots__ = ['block_addr', 'sp_offset_in', 'sp_offset_out']
+
+    def __init__(self, block_addr : int, sp_offset_in : int=0, sp_offset_out : int=0):
+        self.block_addr = block_addr
+        self.sp_offset_in = sp_offset_in
+        self.sp_offset_out = sp_offset_out
+
+    def __eq__(self, other):
+        return isinstance(other, StackPointerState) and \
+            self.block_addr == other.block_addr and \
+            self.sp_offset_in == other.sp_offset_in and \
+            self.sp_offset_out == other.sp_offset_out
+
+    def copy(self):
+        return StackPointerState(self.block_addr, self.sp_offset_in, self.sp_offset_out)
+
+
+class StackPointerTracker(Analysis, ForwardAnalysis):
+    """
+    Track the offset of stack pointer at the end of each basic block of a function.
+    """
+
+    def __init__(self, func : Function):
+
+        super(StackPointerTracker, self).__init__(
+            order_jobs=False,
+            allow_merging=True,
+            allow_widening=False,
+            graph_visitor=FunctionGraphVisitor(func)
+        )
+
+        if not func.normalized:
+            _l.warning("The provided function is not normalized. It will be normalized now.")
+            func = func.copy()
+            func.normalize()
+
+        self._func = func
+        self._states = { }
+        self._insn_to_sp_offset = { }
+
+        self._analyze()
+
+    def sp_offset_out(self, block_addr):
+        if block_addr not in self._states:
+            return None
+        return self._states[block_addr].sp_offset_out
+
+    def sp_offset_in(self, block_addr):
+        if block_addr not in self._states:
+            return None
+        return self._states[block_addr].sp_offset_in
+
+    def insn_sp_offset_out(self, insn_addr):
+        if insn_addr not in self._insn_to_sp_offset:
+            return None
+        return self._insn_to_sp_offset[insn_addr]
+
+    #
+    # Overridable methods
+    #
+
+    def _pre_analysis(self):
+        pass
+
+    def _intra_analysis(self):
+        pass
+
+    def _post_analysis(self):
+        pass
+
+    def _initial_abstract_state(self, node : BlockNode):
+        return StackPointerState(node.addr)
+
+    def _run_on_node(self, node : BlockNode, state : StackPointerState):
+
+        block = self.project.factory.block(node.addr, size=node.size)
+
+        sp_offset = self.project.arch.get_register_offset('sp')
+        state = StackPointerState(node.addr, sp_offset_in=state.sp_offset_out, sp_offset_out=0)
+
+        tmps = { }
+        sp = state.sp_offset_in
+        ins_addr = None
+
+        for stmt in block.vex.statements:
+            if type(stmt) is pyvex.IRStmt.IMark:
+                ins_addr = stmt.addr + stmt.delta
+            elif type(stmt) is pyvex.IRStmt.WrTmp:
+                if type(stmt.data) is pyvex.IRExpr.Get and stmt.data.offset == sp_offset:
+                    # writing to tmp
+                    tmps[stmt.tmp] = sp
+                elif type(stmt.data) is pyvex.IRExpr.Binop:
+                    arg0, arg1 = stmt.data.args
+                    if type(arg0) is pyvex.IRExpr.RdTmp and arg0.tmp in tmps and \
+                            type(arg1) is pyvex.IRExpr.Const:
+                        if stmt.data.op.startswith('Iop_Add'):
+                            tmps[stmt.tmp] = tmps[arg0.tmp] + arg1.con.value
+                        elif stmt.data.op.startswith('Iop_Sub'):
+                            tmps[stmt.tmp] = tmps[arg0.tmp] - arg1.con.value
+            elif type(stmt) is pyvex.IRStmt.Put and stmt.offset == sp_offset:
+                if type(stmt.data) is pyvex.IRExpr.RdTmp and stmt.data.tmp in tmps:
+                    sp = tmps[stmt.data.tmp]
+                    if ins_addr not in self._insn_to_sp_offset:
+                        self._insn_to_sp_offset[ins_addr] = sp
+                    elif sp != self._insn_to_sp_offset[ins_addr]:
+                        _l.warning("Inconsistent stack pointers (original=%#x, new%#x) at instruction %#x.",
+                                   self._insn_to_sp_offset[ins_addr],
+                                   sp,
+                                   ins_addr
+                                   )
+                        # do not update it. instead, abort
+                        self.abort()
+
+        state.sp_offset_out = sp
+
+        if node.addr not in self._states:
+            self._states[node.addr] = state
+            return True, state
+        else:
+            return state != self._states[node.addr], state
+
+    def _merge_states(self, node, *states):
+
+        assert len(states) == 2
+
+        if states[0].sp_offset_out == states[1].sp_offset_out:
+            return states[0].copy()
+
+        # umm... this is pretty bad, but this should be rare, too
+        _l.warning("Inconsistent stack pointers (%#x, %#x) at block %#x.",
+                   states[0].sp_offset_out,
+                   states[1].sp_offset_out,
+                   node.addr
+                   )
+
+        # We... abort
+        self.abort()
+        # return the first one. It's aborting anyway.
+        return states[0].copy()
+
+
+from ..analyses import AnalysesHub
+AnalysesHub.register_default('StackPointerTracker', StackPointerTracker)

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -1,4 +1,6 @@
 
+# pylint:disable=abstract-method
+
 import logging
 
 import pyvex
@@ -46,7 +48,7 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
         )
 
         if not func.normalized:
-            _l.warning("The provided function is not normalized. It will be normalized now.")
+            # Make a copy before normalizing the function
             func = func.copy()
             func.normalize()
 

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1103,6 +1103,36 @@ class Function(object):
                 return ast.__str__()
         return self.name
 
+    def copy(self):
+        func = Function(self._function_manager, self.addr, name=self.name, syscall=self.is_syscall)
+        func.transition_graph = networkx.DiGraph(self.transition_graph)
+        func.normalized = self.normalized
+        func._ret_sites = self._ret_sites.copy()
+        func._jumpout_sites = self._jumpout_sites.copy()
+        func._retout_sites = self._retout_sites.copy()
+        func._endpoints = self._endpoints.copy()
+        func._call_sites = self._call_sites.copy()
+        func._project = self._project
+        func.is_plt = self.is_plt
+        func.is_simprocedure = self.is_simprocedure
+        func.binary_name = self.binary_name
+        func.bp_on_stack = self.bp_on_stack
+        func.retaddr_on_stack = self.retaddr_on_stack
+        func.sp_delta = self.sp_delta
+        func.calling_convention = self.calling_convention
+        func.prototype = self.prototype
+        func._returning = self._returning
+        func.startpoint = self.startpoint
+        func._addr_to_block_node = self._addr_to_block_node.copy()
+        func._block_sizes = self._block_sizes.copy()
+        func._block_cache = self._block_cache.copy()
+        func._local_blocks = self._local_blocks.copy()
+        func._local_block_addrs = self._local_block_addrs.copy()
+        func.info = self.info.copy()
+        func.tags = self.tags
+
+        return func
+
 
 from ...codenode import BlockNode, HookNode
 from ...errors import AngrValueError


### PR DESCRIPTION
- Implemented a StackPointerTracker analysis.
- Tail-call optimization detection is controlled by option
  "detect_tail_calls" in CFGFast. It is disabled by default (since tail
  call optimization detection is usually not important, and tracking stack
  pointer offets can be very costly sometimes).