### PR TITLE
Fix SimSymbolicMemory._find() in tracing mode.

### DIFF
--- a/angr/sim_options.py
+++ b/angr/sim_options.py
@@ -284,6 +284,10 @@ HYBRID_SOLVER = 'HYBRID_SOLVER'
 # Note, that this option will only take effect if a hybrid solver used.
 APPROXIMATE_FIRST = 'APPROXIMATE_FIRST'
 
+# Disable optimizations based on symbolic memory bytes being single-valued in SimSymbolicMemory. This is useful in
+# tracing mode since such optimizations are unreliable since preconstraints will be removed after tracing is done.
+SYMBOLIC_MEMORY_NO_SINGLEVALUE_OPTIMIZATIONS = 'SYMBOLIC_MEMORY_NO_SINGLEVALUE_OPTIMIZATIONS'
+
 #
 # CGC specific state options
 #
@@ -331,5 +335,5 @@ modes = {
     'symbolic_approximating': common_options | symbolic | approximation | { TRACK_CONSTRAINT_ACTIONS },
     'static': (common_options - simplification) | { REGION_MAPPING, BEST_EFFORT_MEMORY_STORING, SYMBOLIC_INITIAL_VALUES, DO_CCALLS, DO_RET_EMULATION, TRUE_RET_EMULATION_GUARD, BLOCK_SCOPE_CONSTRAINTS, TRACK_CONSTRAINTS, ABSTRACT_MEMORY, ABSTRACT_SOLVER, USE_SIMPLIFIED_CCALLS, REVERSE_MEMORY_NAME_MAP },
     'fastpath': (common_options - simplification ) | (symbolic - { SYMBOLIC, DO_CCALLS }) | resilience | { TRACK_OP_ACTIONS, BEST_EFFORT_MEMORY_STORING, AVOID_MULTIVALUED_READS, AVOID_MULTIVALUED_WRITES, SYMBOLIC_INITIAL_VALUES, DO_RET_EMULATION, NO_SYMBOLIC_JUMP_RESOLUTION, NO_SYMBOLIC_SYSCALL_RESOLUTION, FAST_REGISTERS },
-    'tracing': (common_options - simplification - {SUPPORT_FLOATING_POINT, ALL_FILES_EXIST}) | symbolic | resilience | (unicorn - { UNICORN_TRACK_STACK_POINTERS }) | { CGC_NO_SYMBOLIC_RECEIVE_LENGTH, REPLACEMENT_SOLVER, EXCEPTION_HANDLING, ZERO_FILL_UNCONSTRAINED_MEMORY, PRODUCE_ZERODIV_SUCCESSORS, ALLOW_SEND_FAILURES },
+    'tracing': (common_options - simplification - {SUPPORT_FLOATING_POINT, ALL_FILES_EXIST}) | symbolic | resilience | (unicorn - { UNICORN_TRACK_STACK_POINTERS }) | { CGC_NO_SYMBOLIC_RECEIVE_LENGTH, REPLACEMENT_SOLVER, EXCEPTION_HANDLING, ZERO_FILL_UNCONSTRAINED_MEMORY, PRODUCE_ZERODIV_SUCCESSORS, ALLOW_SEND_FAILURES, SYMBOLIC_MEMORY_NO_SINGLEVALUE_OPTIMIZATIONS },
 }

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -595,7 +595,8 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         match_indices = [ ]
         offsets_matched = [ ] # Only used in static mode
         byte_width = self.state.arch.byte_width
-        cond_prefix = None
+        no_singlevalue_opt = options.SYMBOLIC_MEMORY_NO_SINGLEVALUE_OPTIMIZATIONS in self.state.options
+        cond_prefix = [ ]
 
         for i in itertools.count(step=step):
             l.debug("... checking offset %d", i)
@@ -616,17 +617,14 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
             b = chunk[chunk_size*byte_width - chunk_off*byte_width - 1 : chunk_size*byte_width - chunk_off*byte_width - seek_size*byte_width]
             condition = b == what
             if not self.state.solver.is_false(condition):
-                if self.state.mode == 'tracing' and cond_prefix is not None:
-                    condition = claripy.And(cond_prefix, condition)
+                if no_singlevalue_opt and cond_prefix:
+                    condition = claripy.And(*(cond_prefix + [condition]))
                 cases.append([condition, claripy.BVV(i, len(start))])
                 match_indices.append(i)
 
-            if self.state.mode == 'tracing' and b.symbolic:
+            if b.symbolic and no_singlevalue_opt:
                 # in tracing mode, we need to make sure that all previous bytes are not equal to what
-                if cond_prefix is None:
-                    cond_prefix = b != what
-                else:
-                    cond_prefix = claripy.And(cond_prefix, cond_prefix)
+                cond_prefix.append(b != what)
 
             if self.state.mode == 'static':
                 si = b._model_vsa


### PR DESCRIPTION
_find() wasn't adding constraints for preconstrained input bytes if
those bytes are not equal to the byte we are looking for. However,
preconstraints will get removed after tracing is over. As a result, we
might generate input data that do not satisfy _find() anymore.