### PR TITLE
CFGFast: Avoid generating blocks that go across function boundaries.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -553,11 +553,12 @@ class CFGBase(Analysis):
     def is_thumb_addr(self, addr):
         return addr in self._thumb_addrs
 
-    def _arm_thumb_filter_jump_successors(self, addr, successors, get_ins_addr, get_exit_stmt_idx):
+    def _arm_thumb_filter_jump_successors(self, addr, size, successors, get_ins_addr, get_exit_stmt_idx):
         """
         Filter successors for THUMB mode basic blocks, and remove those successors that won't be taken normally.
 
         :param int addr: Address of the basic block / SimIRSB.
+        :param int size: Size of the basic block.
         :param list successors: A list of successors.
         :param func get_ins_addr: A callable that returns the source instruction address for a successor.
         :param func get_exit_stmt_idx: A callable that returns the source statement ID for a successor.
@@ -571,7 +572,7 @@ class CFGBase(Analysis):
         it_counter = 0
         conc_temps = {}
         can_produce_exits = set()
-        bb = self._lift(addr, thumb=True, opt_level=0)
+        bb = self._lift(addr, size=size, thumb=True, opt_level=0)
 
         for stmt in bb.vex.statements:
             if stmt.tag == 'Ist_IMark':

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1449,6 +1449,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         if sim_successors.sort == 'IRSB' and input_state.thumb:
             successors = self._arm_thumb_filter_jump_successors(sim_successors.addr,
+                                                                sim_successors.artifacts['irsb'].size,
                                                                 successors,
                                                                 lambda state: state.scratch.ins_addr,
                                                                 lambda state: state.scratch.exit_stmt_idx


### PR DESCRIPTION
Now blocks will always be cut at function boundaries. Both blocks and
function boundaries will be refined during Stage 2 in
_process_irrational_function_starts(). This commit fixes issue #1312.