### PR TITLE
replace deprecated inspect.getargspec by getfullargspec

### DIFF
--- a/angr/exploration_techniques/__init__.py
+++ b/angr/exploration_techniques/__init__.py
@@ -5,11 +5,11 @@ class ExplorationTechniqueMeta(type):
     def __new__(cls, name, bases, attrs):
         import inspect
         if name != 'ExplorationTechniqueCompat':
-            if 'step' in attrs and not inspect.getargspec(attrs['step']).defaults:
+            if 'step' in attrs and not inspect.getfullargspec(attrs['step']).defaults:
                 attrs['step'] = cls._step_factory(attrs['step'])
-            if 'filter' in attrs and inspect.getargspec(attrs['filter']).args[1] != 'simgr':
+            if 'filter' in attrs and inspect.getfullargspec(attrs['filter']).args[1] != 'simgr':
                 attrs['filter'] = cls._filter_factory(attrs['filter'])
-            if 'step_state' in attrs and inspect.getargspec(attrs['step_state']).args[1] != 'simgr':
+            if 'step_state' in attrs and inspect.getfullargspec(attrs['step_state']).args[1] != 'simgr':
                 attrs['step_state'] = cls._step_state_factory(attrs['step_state'])
         return type.__new__(cls, name, bases, attrs)
 

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -67,7 +67,7 @@ class SimProcedure:
 
         # Get the concrete number of arguments that should be passed to this procedure
         if num_args is None:
-            run_spec = inspect.getargspec(self.run)
+            run_spec = inspect.getfullargspec(self.run)
             self.num_args = len(run_spec.args) - (len(run_spec.defaults) if run_spec.defaults is not None else 0) - 1
         else:
             self.num_args = num_args


### PR DESCRIPTION
this useful if external modules make use of type annotations