### PR TITLE
Add Exit support to slicer

### DIFF
--- a/angr/slicer.py
+++ b/angr/slicer.py
@@ -201,6 +201,14 @@ class SimSlicer(object):
 
         return in_slice
 
+    def _backward_handler_stmt_Exit(self, stmt, state):
+        # HACK: TODO: WARNING: This might not be what we want.
+        # You may end up with bigger slices than you expect
+        # However, since a conditional exit reflects your ability to continue
+        # to follow the slice, all conditional exits must be included
+        # (until we find a more clever way to exclude them)
+        self._backward_handler_expr(stmt.guard, state)
+        return True
     def _backward_handler_stmt_WrTmp(self, stmt, state):
         tmp = stmt.tmp
 


### PR DESCRIPTION
Ensures that, if you are backward-slicing through an Exit statement, that your slice depends on it and its guard.

Improves jumptable resolution on ARM/GCC where Exits usually precede indirect jumps