### PR TITLE
Fix several bugs in Reassembler

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2510,6 +2510,13 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 # IRSB is owned by plt!
                 return "GOT PLT Entry", pointer_size
 
+        # is it in a section with zero bytes, like .bss?
+        obj = self.project.loader.find_object_containing(data_addr)
+        section = obj.find_section_containing(data_addr)
+        if section is not None and section.only_contains_uninitialized_data:
+            # Nothing much you can do
+            return None, None
+
         pointers_count = 0
 
         max_pointer_array_size = min(512 * pointer_size, max_size)

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -307,6 +307,20 @@ class SymbolManager(object):
         self.cfg = cfg
 
         self.addr_to_label = defaultdict(list)
+        self.symbol_names = set()  # deduplicate symbol names
+
+    def get_unique_symbol_name(self, symbol_name):
+        if symbol_name not in self.symbol_names:
+            self.symbol_names.add(symbol_name)
+            return symbol_name
+
+        i = 0
+        while True:
+            name = "%s_%d" % (symbol_name, i)
+            if name not in self.symbol_names:
+                self.symbol_names.add(name)
+                return name
+            i += 1
 
     def new_label(self, addr, name=None, is_function=None, force=False):
 
@@ -338,13 +352,16 @@ class SymbolManager(object):
                 # check the type...
                 if symbol.type == cle.Symbol.TYPE_FUNCTION:
                     # it's a function!
-                    label = FunctionLabel(self.binary, symbol_name, addr)
+                    unique_symbol_name = self.get_unique_symbol_name(symbol_name)
+                    label = FunctionLabel(self.binary, unique_symbol_name, addr)
                 elif symbol.type == cle.Symbol.TYPE_OBJECT:
                     # it's an object
-                    label = ObjectLabel(self.binary, symbol_name, addr)
+                    unique_symbol_name = self.get_unique_symbol_name(symbol_name)
+                    label = ObjectLabel(self.binary, unique_symbol_name, addr)
                 elif symbol.type == cle.Symbol.TYPE_NONE:
                     # notype
-                    label = NotypeLabel(self.binary, symbol_name, addr)
+                    unique_symbol_name = self.get_unique_symbol_name(symbol_name)
+                    label = NotypeLabel(self.binary, unique_symbol_name, addr)
                 elif symbol.type == cle.Symbol.TYPE_SECTION:
                     # section label
                     # use a normal label instead

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -2284,7 +2284,6 @@ class Reassembler(Analysis):
             '__progname_full',
             '_IO_stdin_used',
             'obstack_alloc_failed_hand',
-            'program_invocation_short_',
             'optind',
             'optarg',
             '__progname',

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -1213,7 +1213,7 @@ class Data(object):
                 # it's not aligned?
                 raise BinaryError('Fails at Data.shrink()')
 
-            pointers = self.size / pointer_size
+            pointers = self.size // pointer_size
             self._content = self._content[ : pointers]
 
         else:

--- a/tests/test_reassembler.py
+++ b/tests/test_reassembler.py
@@ -1,0 +1,101 @@
+
+import sys
+import platform
+import os
+import tempfile
+import subprocess
+
+import angr
+
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+
+# Note: Reassembler is intensively tested by Patcherex test cases on CGC binaries.
+
+
+def is_linux_x64():
+    return sys.platform.startswith("linux") and platform.machine().endswith("64")
+
+
+def test_ln_gcc_O2():
+
+    # Issue reported and test binary provided by Antonio F. Montoya
+
+    p = angr.Project(os.path.join(test_location, "x86_64", "ln_gcc_-O2"), auto_load_libs=False)
+    r = p.analyses.Reassembler()
+    r.remove_unnecessary_stuff()
+    assembly = r.assembly(comments=True, symbolized=True)
+
+    # There should be two symbols with the same name: file_name. Reassembler renames the second one to file_name_0.
+    # Test their existence.
+    assert "\nfile_name:" in assembly and "\nfile_name_0:" in assembly
+
+    if is_linux_x64():
+        # we should be able to compile it and run it ... if we are running on x64 Linux
+        tempdir = tempfile.mkdtemp(prefix="angr_test_reassembler_")
+        asm_filename = "ln_gcc-O2.s"
+        bin_filename = "ln_gcc-O2"
+        asm_filepath = os.path.join(tempdir, asm_filename)
+        bin_filepath = os.path.join(tempdir, bin_filename)
+        with open(asm_filepath, "w") as f:
+            f.write(assembly)
+        # Call out to GCC, and it should return 0. Otherwise check_call() will raise an exception.
+        subprocess.check_call(["gcc", "-no-pie", asm_filepath, "-o", bin_filepath])
+        # Run the generated binary file, and it should not crash (which is a pretty basic requirement, I know)
+        subprocess.check_call([bin_filepath, "-h"])
+
+
+def test_chmod_gcc_O1():
+
+    # Issue reported and test binary provided by Antonio F. Montoya
+
+    p = angr.Project(os.path.join(test_location, "x86_64", "chmod_gcc_-O1"), auto_load_libs=False)
+    r = p.analyses.Reassembler()
+    r.remove_unnecessary_stuff()
+    assembly = r.assembly(comments=True, symbolized=True)
+
+
+    if is_linux_x64():
+        # we should be able to compile it and run it ... if we are running on x64 Linux
+        tempdir = tempfile.mkdtemp(prefix="angr_test_reassembler_")
+        asm_filename = "chmod_gcc-O1.s"
+        bin_filename = "chmod_gcc-O1"
+        asm_filepath = os.path.join(tempdir, asm_filename)
+        bin_filepath = os.path.join(tempdir, bin_filename)
+        with open(asm_filepath, "w") as f:
+            f.write(assembly)
+        # Call out to GCC, and it should return 0. Otherwise check_call() will raise an exception.
+        subprocess.check_call(["gcc", "-no-pie", asm_filepath, "-o", bin_filepath])
+        # Run the generated binary file, and it should not crash (which is a pretty basic requirement, I know)
+        subprocess.check_call([bin_filepath, "-h"])
+
+
+def test_ex_gpp():
+
+    # Issue reported and test binary provided by Antonio F. Montoya
+
+    p = angr.Project(os.path.join(test_location, "x86_64", "chmod_gcc_-O1"), auto_load_libs=False)
+    r = p.analyses.Reassembler()
+    r.remove_unnecessary_stuff()
+    assembly = r.assembly(comments=True, symbolized=True)
+
+    if is_linux_x64():
+        # we should be able to compile it and run it ... if we are running on x64 Linux
+        tempdir = tempfile.mkdtemp(prefix="angr_test_reassembler_")
+        asm_filename = "ex_g++.s"
+        bin_filename = "ex_g++"
+        asm_filepath = os.path.join(tempdir, asm_filename)
+        bin_filepath = os.path.join(tempdir, bin_filename)
+        with open(asm_filepath, "w") as f:
+            f.write(assembly)
+        # Call out to GCC, and it should return 0. Otherwise check_call() will raise an exception.
+        subprocess.check_call(["g++", "-no-pie", asm_filepath, "-o", bin_filepath])
+        # Run the generated binary file and check the output
+        output = subprocess.check_output([bin_filepath])
+        assert output == "A1\nA2\n"
+
+
+if __name__ == "__main__":
+    test_ln_gcc_O2()
+    test_chmod_gcc_O1()
+    test_ex_gpp()


### PR DESCRIPTION
Make it work on Linux x64 binaries. Thanks Antonio F. Montoya from GrammaTech for reporting these issues.

The following PRs must be merged first:
- https://github.com/angr/pyvex/pull/176
- https://github.com/angr/cle/pull/165