### PR TITLE
Fix %% register prefix

### DIFF
--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -268,10 +268,6 @@ class Instruction(DisassemblyPiece):
                 else:
                     in_word = True
                     pieces.append(c)
-            elif c == '%':
-                in_word = False
-                pieces.append('%%')
-
             else:
                 in_word = False
                 pieces.append(c)


### PR DESCRIPTION
When register names start with %, split_op_string() replaces it with %%,
which then leaks into the UI.  This change makes the register prefix
detection logic account for that.