### PR TITLE
JumpTableResolver: Resolve load-signext-addbase jump tables.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -721,19 +721,20 @@ class CFGBase(Analysis):
 
         return False
 
-    def _executable_memory_regions(self, binary=None, force_segment=False):
+    def _executable_memory_regions(self, objects=None, force_segment=False):
         """
         Get all executable memory regions from the binaries
 
-        :param binary: Binary object to collect regions from. If None, regions from all project binary objects are used.
+        :param objects: A collection of binary objects to collect regions from. If None, regions from all project
+                        binary objects are used.
         :param bool force_segment: Rely on binary segments instead of sections.
         :return: A sorted list of tuples (beginning_address, end_address)
         """
 
-        if binary is None:
+        if objects is None:
             binaries = self.project.loader.all_objects
         else:
-            binaries = [ binary ]
+            binaries = objects
 
         memory_regions = [ ]
 

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -875,17 +875,18 @@ class CFGBase(Analysis):
         except KeyError:
             return None
 
-    def _fast_memory_load_pointer(self, addr):
+    def _fast_memory_load_pointer(self, addr, size=None):
         """
         Perform a fast memory loading of a pointer.
 
         :param int addr: Address to read from.
+        :param int size: Size of the pointer. Default to machine-word size.
         :return:         A pointer or None if the address does not exist.
         :rtype:          int
         """
 
         try:
-            return self.project.loader.memory.unpack_word(addr)
+            return self.project.loader.memory.unpack_word(addr, size=size)
         except KeyError:
             return None
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -920,8 +920,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         )
 
         # necessary warnings
+        regions_not_specified = regions is None and binary is None and not objects
         if self.project.loader._auto_load_libs is True and end is None and len(self.project.loader.all_objects) > 3 \
-                and regions is None and binary is None and not objects:
+                and regions_not_specified:
             l.warning('"auto_load_libs" is enabled. With libraries loaded in project, CFGFast will cover libraries, '
                       'which may take significantly more time than expected. You may reload the binary with '
                       '"auto_load_libs" disabled, or specify "regions" to limit the scope of CFG recovery.'
@@ -2821,7 +2822,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         a = None  # it always hold the very recent non-removed node
 
-        for i in range(len(sorted_nodes)):
+        for i in range(len(sorted_nodes)):  # pylint:disable=consider-using-enumerate
 
             if a is None:
                 a = sorted_nodes[0]
@@ -3533,7 +3534,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
                 return addr, current_function_addr, cfg_node, irsb
 
-            is_arm_arch = True if self.project.arch.name in ('ARMHF', 'ARMEL') else False
+            is_arm_arch = self.project.arch.name in ('ARMHF', 'ARMEL')
 
             if is_arm_arch:
                 real_addr = addr & (~1)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -828,6 +828,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
     def __init__(self,
                  binary=None,
+                 objects=None,
                  regions=None,
                  pickle_intermediate_results=False,
                  symbols=True,
@@ -856,6 +857,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                  ):
         """
         :param binary:                  The binary to recover CFG on. By default the main binary is used.
+        :param objects:                 A list of objects to recover the CFG on. By default it will recover the CFG of
+                                        all loaded objects.
         :param iterable regions:        A list of tuples in the form of (start address, end address) describing memory
                                         regions that the CFG should cover.
         :param bool pickle_intermediate_results: If we want to store the intermediate results or not.
@@ -918,7 +921,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         # necessary warnings
         if self.project.loader._auto_load_libs is True and end is None and len(self.project.loader.all_objects) > 3 \
-                and regions is None:
+                and regions is None and binary is None and not objects:
             l.warning('"auto_load_libs" is enabled. With libraries loaded in project, CFGFast will cover libraries, '
                       'which may take significantly more time than expected. You may reload the binary with '
                       '"auto_load_libs" disabled, or specify "regions" to limit the scope of CFG recovery.'
@@ -933,7 +936,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             else:
                 l.warning('"regions", "start", and "end" are all specified. Ignoring "start" and "end".')
 
-        regions = regions if regions is not None else self._executable_memory_regions(binary=None,
+        if binary is not None and not objects:
+            objects = [ binary ]
+        regions = regions if regions is not None else self._executable_memory_regions(objects=objects,
                                                                                       force_segment=force_segment
                                                                                       )
         if exclude_sparse_regions:

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -191,7 +191,7 @@ class JumpTableResolver(IndirectJumpResolver):
                 # this is how an ARM jump table is translated to VEX
                 # > t16 = if (t43) ILGop_Ident32(LDle(t29)) else 0x0000c844
                 load_stmt, load_stmt_loc, load_size = stmt, stmt_loc, \
-                                                      block.tyenv.sizeof(stmt.tmp) // self.project.arch.byte_width
+                                                      block.tyenv.sizeof(stmt.dst) // self.project.arch.byte_width
                 stmts_to_remove.append(stmt_loc)
 
             break

--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -53,7 +53,7 @@ class LoopSeer(ExplorationTechnique):
             cfg_kb = KnowledgeBase(self.project, self.project.loader.main_object)
             self.cfg = self.project.analyses.CFGFast(kb=cfg_kb, normalize=True)
         elif not self.cfg.normalized:
-            l.warning("LoopSeer uses normalized CFG. Recomputing the CFG...")
+            l.warning("LoopSeer must use a normalized CFG. Normalizing the provided CFG...")
             self.cfg.normalize()
 
         funcs = None

--- a/tests/test_str_funcs.py
+++ b/tests/test_str_funcs.py
@@ -18,7 +18,8 @@ def test_strncpy():
 def test_strncpy_size():
     strncpy_size_amd64 = angr.Project(test_location + "/x86_64/strncpy-size", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])
     explorer = strncpy_size_amd64.factory.simulation_manager()
-    explorer.use_technique(angr.exploration_techniques.LoopSeer(bound=50))
+    cfg = strncpy_size_amd64.analyses.CFG(objects=[strncpy_size_amd64.loader.main_object], normalize=True)
+    explorer.use_technique(angr.exploration_techniques.LoopSeer(cfg=cfg, bound=50))
     explorer.explore(find=[0x40064C])
     s = explorer.found[0]
     result = s.solver.eval(s.memory.load(s.registers.load(16), 40), cast_to=bytes)
@@ -27,7 +28,8 @@ def test_strncpy_size():
 def test_strncpy_verify_null():
     strncpy_verify_null_amd64 = angr.Project(test_location + "/x86_64/strncpy-verify-null", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])
     explorer = strncpy_verify_null_amd64.factory.simulation_manager()
-    explorer.use_technique(angr.exploration_techniques.LoopSeer(bound=50))
+    cfg = strncpy_verify_null_amd64.analyses.CFG(objects=[strncpy_verify_null_amd64.loader.main_object], normalize=True)
+    explorer.use_technique(angr.exploration_techniques.LoopSeer(cfg=cfg, bound=50))
     explorer.explore(find=[0x40064C])
     s = explorer.found[0]
     result = s.solver.eval(s.memory.load(s.registers.load(16), 40), cast_to=bytes)
@@ -36,7 +38,8 @@ def test_strncpy_verify_null():
 def test_strstr_and_strncpy():
     strstr_and_strncpy_amd64 = angr.Project(test_location + "/x86_64/strstr_and_strncpy", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strstr'])
     explorer = strstr_and_strncpy_amd64.factory.simulation_manager()
-    explorer.use_technique(angr.exploration_techniques.LoopSeer(bound=50))
+    cfg = strstr_and_strncpy_amd64.analyses.CFG(objects=[strstr_and_strncpy_amd64.loader.main_object], normalize=True)
+    explorer.use_technique(angr.exploration_techniques.LoopSeer(cfg=cfg, bound=50))
     explorer.explore(find=[0x400657])
     s = explorer.found[0]
     result = s.solver.eval(s.memory.load(s.registers.load(16), 15), cast_to=bytes)


### PR DESCRIPTION
Add support for jump tables of the following type:

```
lea     eax, [r11-21h]
cmp     eax, 3Bh
ja      def_4C64D2
lea     rdx, jpt_4C64D2
movsxd  rax, ds:(jpt_4C64D2 - 571DF0h)[rdx+rax*4]
add     rdx, rax
jmp     rdx
```