### PR TITLE
Support running CPU-bound analyses without pegging the Python interpreter.

### DIFF
--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -3,6 +3,7 @@ import contextlib
 from collections import defaultdict
 import progressbar
 import logging
+import time
 
 from ..misc.plugins import PluginVendor, VendorPreset
 from ..misc.ux import deprecated
@@ -167,12 +168,13 @@ class Analysis(object):
 
         self._progressbar = progressbar.ProgressBar(widgets=Analysis._PROGRESS_WIDGETS, maxval=10000 * 100).start()
 
-    def _update_progress(self, percentage):
+    def _update_progress(self, percentage, **kwargs):
         """
         Update the progress with a percentage, including updating the progressbar as well as calling the progress
         callback.
 
-        :param float percentage: Percentage of the progressbar. from 0.0 to 100.0.
+        :param float percentage:    Percentage of the progressbar. from 0.0 to 100.0.
+        :param kwargs:              Other parameters that will be passed to the progress_callback handler.
         :return: None
         """
 
@@ -183,7 +185,7 @@ class Analysis(object):
             self._progressbar.update(percentage * 10000)
 
         if self._progress_callback is not None:
-            self._progress_callback(percentage)  # pylint:disable=not-callable
+            self._progress_callback(percentage, **kwargs)  # pylint:disable=not-callable
 
     def _finish_progress(self):
         """
@@ -199,6 +201,22 @@ class Analysis(object):
 
         if self._progress_callback is not None:
             self._progress_callback(100.0)  # pylint:disable=not-callable
+
+    def _release_gil(self, ctr, freq, sleep_time=0.001):
+        """
+        Periodically calls time.sleep() and releases the GIL so other threads (like, GUI threads) have a much better
+        chance to be scheduled, and other critical components (like the GUI) can be kept responsiveness.
+
+        This is, of course, a hack before we move all computational intensive tasks to pure C++ implementations.
+
+        :param int ctr:     A number provided by the caller.
+        :param int freq:    How frequently time.sleep() should be called. time.sleep() is called when ctr % freq == 0.
+        :param sleep_time:  Number (or fraction) of seconds to sleep.
+        :return:            None
+        """
+
+        if ctr % freq == 0:
+            time.sleep(sleep_time)
 
     def __repr__(self):
         return '<%s Analysis Result at %#x>' % (self._name, id(self))

--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -12,7 +12,7 @@ from ..errors import AngrAnalysisError
 l = logging.getLogger(name=__name__)
 
 
-class AnalysisLogEntry(object):
+class AnalysisLogEntry:
     def __init__(self, message, exc_info=False):
         if exc_info:
             (e_type, value, traceback) = sys.exc_info()
@@ -76,7 +76,7 @@ class AnalysesHub(PluginVendor):
         super(AnalysesHub, self).__setstate__(s)
 
 
-class AnalysisFactory(object):
+class AnalysisFactory:
     def __init__(self, project, analysis_cls):
         self._project = project
         self._analysis_cls = analysis_cls
@@ -110,7 +110,7 @@ class AnalysisFactory(object):
         return oself
 
 
-class Analysis(object):
+class Analysis:
     """
     This class represents an analysis on the program.
 
@@ -202,7 +202,8 @@ class Analysis(object):
         if self._progress_callback is not None:
             self._progress_callback(100.0)  # pylint:disable=not-callable
 
-    def _release_gil(self, ctr, freq, sleep_time=0.001):
+    @staticmethod
+    def _release_gil(ctr, freq, sleep_time=0.001):
         """
         Periodically calls time.sleep() and releases the GIL so other threads (like, GUI threads) have a much better
         chance to be scheduled, and other critical components (like the GUI) can be kept responsiveness.

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -408,7 +408,7 @@ class CFGBase(Analysis):
             else:
                 cond = True
             if anyaddr and n.size is not None:
-                cond = cond and (addr >= n.addr and addr < n.addr + n.size)
+                cond = cond and n.addr <= addr < n.addr + n.size
             else:
                 cond = cond and (addr == n.addr)
             if cond:
@@ -1439,7 +1439,7 @@ class CFGBase(Analysis):
 
         # aggressively remove and merge functions
         # For any function, if there is a call to it, it won't be removed
-        called_function_addrs = set([n.addr for n in function_nodes])
+        called_function_addrs = { n.addr for n in function_nodes }
 
         removed_functions_a = self._process_irrational_functions(tmp_functions,
                                                                  called_function_addrs,
@@ -2326,9 +2326,9 @@ class CFGBase(Analysis):
         l.info("%d indirect jumps to resolve.", len(self._indirect_jumps_to_resolve))
 
         all_targets = set()
-        for idx, jump in enumerate(self._indirect_jumps_to_resolve):  # type: IndirectJump
+        for idx, jump in enumerate(self._indirect_jumps_to_resolve):  # type:int,IndirectJump
             if self._low_priority:
-                self._release_gil(len(self._nodes), 20, 0.0001)
+                self._release_gil(idx, 20, 0.0001)
             all_targets |= self._process_one_indirect_jump(jump)
 
         self._indirect_jumps_to_resolve.clear()

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -918,7 +918,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             indirect_jump_resolvers=indirect_jump_resolvers,
             indirect_jump_target_limit=indirect_jump_target_limit,
             detect_tail_calls=detect_tail_calls,
-            low_priority = low_priority,
+            low_priority=low_priority,
         )
 
         # necessary warnings

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -851,6 +851,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                  skip_specific_regions=True,
                  heuristic_plt_resolving=None,
                  detect_tail_calls=False,
+                 low_priority=False,
                  start=None,  # deprecated
                  end=None,  # deprecated
                  **extra_arch_options
@@ -917,6 +918,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             indirect_jump_resolvers=indirect_jump_resolvers,
             indirect_jump_target_limit=indirect_jump_target_limit,
             detect_tail_calls=detect_tail_calls,
+            low_priority = low_priority,
         )
 
         # necessary warnings
@@ -1395,6 +1397,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :return: None
         """
 
+        if self._low_priority:
+            self._release_gil(len(self._nodes), 20, 0.0001)
+
         # a new entry is picked. Deregister it
         self._deregister_analysis_job(job.func_addr, job)
 
@@ -1413,7 +1418,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             if percentage > max_percentage_stage_1:
                 percentage = max_percentage_stage_1
 
-            self._update_progress(percentage)
+            self._update_progress(percentage, cfg=self)
 
     def _intra_analysis(self):
         pass


### PR DESCRIPTION
You may now call `self._release_gil()` in your analysis to release GIL periodically inside tight IO-free loops.