### PR TITLE
Correctly reason about where phi variables are.

### DIFF
--- a/angr/analyses/__init__.py
+++ b/angr/analyses/__init__.py
@@ -27,3 +27,4 @@ from .reaching_definitions import ReachingDefinitionAnalysis
 from .calling_convention import CallingConventionAnalysis
 from .code_tagging import CodeTagging
 from .stack_pointer_tracker import StackPointerTracker
+from .dominance_frontier import DominanceFrontier

--- a/angr/analyses/dominance_frontier.py
+++ b/angr/analyses/dominance_frontier.py
@@ -1,0 +1,40 @@
+
+import networkx
+
+from ..utils.graph import compute_dominance_frontier, Dominators
+from .analysis import Analysis
+from . import register_analysis
+
+
+class DominanceFrontier(Analysis):
+    """
+    Computes the dominance frontier of all nodes in a function graph, and provides an easy-to-use interface for
+    querying the frontier information.
+    """
+
+    def __init__(self, func):
+        self.function = func
+
+        self.frontiers = None
+
+        self._compute()
+
+    def _get_graph(self):
+
+        g = networkx.DiGraph(self.function.graph)
+        return g
+
+    def _compute(self):
+
+        g = self._get_graph()
+
+        # Compute the dominator tree
+        doms = Dominators(g, self.function.startpoint)
+
+        # Compute the dominance frontier
+        dom_frontiers = compute_dominance_frontier(g, doms.dom)
+
+        self.frontiers = dom_frontiers
+
+
+register_analysis(DominanceFrontier, "DominanceFrontier")

--- a/angr/analyses/variable_recovery/variable_recovery.py
+++ b/angr/analyses/variable_recovery/variable_recovery.py
@@ -6,39 +6,28 @@ import angr # type annotations; pylint: disable=unused-import
 
 from .. import Analysis
 
-from .annotations import StackLocationAnnotation
+from ... import BP, BP_AFTER
+from ...sim_variable import SimRegisterVariable, SimStackVariable
 from ..code_location import CodeLocation
 from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor
-from ... import BP, BP_AFTER
-from ...keyed_region import KeyedRegion
-from ...sim_variable import SimRegisterVariable, SimStackVariable, SimStackVariablePhi
+from .variable_recovery_base import VariableRecoveryBase, VariableRecoveryStateBase
+from .annotations import StackLocationAnnotation
 
 l = logging.getLogger(name=__name__)
 
 
-class VariableRecoveryState:
+class VariableRecoveryState(VariableRecoveryStateBase):
     """
     The abstract state of variable recovery analysis.
 
     :ivar angr.knowledge.variable_manager.VariableManager variable_manager: The variable manager.
     """
 
-    def __init__(self, variable_manager, arch, func_addr, concrete_states, stack_region=None, register_region=None):
-        self.variable_manager = variable_manager  # type: angr.knowledge_plugins.variables.variable_manager.VariableManager
-        self.arch = arch
-        self.func_addr = func_addr
+    def __init__(self, block_addr, analysis, arch, func, concrete_states, stack_region=None, register_region=None):
+
+        super().__init__(block_addr, analysis, arch, func, stack_region=stack_region, register_region=register_region)
+
         self._concrete_states = concrete_states
-
-        # self._state_per_instruction = { }
-        if stack_region is not None:
-            self.stack_region = stack_region
-        else:
-            self.stack_region = KeyedRegion()
-        if register_region is not None:
-            self.register_region = register_region
-        else:
-            self.register_region = KeyedRegion()
-
         # register callbacks
         self.register_callbacks(self.concrete_states)
 
@@ -68,9 +57,10 @@ class VariableRecoveryState:
 
     def copy(self):
 
-        state = VariableRecoveryState(self.variable_manager,
+        state = VariableRecoveryState(self.block_addr,
+                                      self._analysis,
                                       self.arch,
-                                      self.func_addr,
+                                      self.function,
                                       self._concrete_states,
                                       stack_region=self.stack_region.copy(),
                                       register_region=self.register_region.copy(),
@@ -102,7 +92,7 @@ class VariableRecoveryState:
                                                   )
             concrete_state.inspect.add_breakpoint('mem_write', BP(enabled=True, action=self._hook_memory_write))
 
-    def merge(self, other):
+    def merge(self, other, successor=None):
         """
         Merge two abstract states.
 
@@ -111,17 +101,19 @@ class VariableRecoveryState:
         :rtype:                             VariableRecoveryState
         """
 
-        # TODO: finish it
+        replacements = {}
+        if successor in self.dominance_frontiers:
+            replacements = self._make_phi_variables(successor, self, other)
 
         merged_concrete_states =  [ self._concrete_states[0] ] # self._merge_concrete_states(other)
 
-        new_stack_region = self.stack_region.copy()
-        new_stack_region.merge(other.stack_region)
+        new_stack_region = self.stack_region.copy().replace(replacements)
+        new_stack_region.merge(other.stack_region, replacements=replacements)
 
-        new_register_region = self.register_region.copy()
-        new_register_region.merge(other.register_region)
+        new_register_region = self.register_region.copy().replace(replacements)
+        new_register_region.merge(other.register_region, replacements=replacements)
 
-        return VariableRecoveryState(self.variable_manager, self.arch, self.func_addr, merged_concrete_states,
+        return VariableRecoveryState(successor, self._analysis, self.arch, self.function, merged_concrete_states,
                                      stack_region=new_stack_region,
                                      register_region=new_register_region
                                      )
@@ -254,18 +246,13 @@ class VariableRecoveryState:
 
             if len(existing_variables) > 1:
                 # create a phi node for all other variables
-                ident_sort = 'argument' if stack_offset > 0 else 'stack'
-                variable = SimStackVariablePhi(
-                    ident=self.variable_manager[self.func_addr].next_variable_ident(ident_sort),
-                    region=self.func_addr,
-                    variables=existing_variables,
-                )
-                self.stack_region.set_variable(stack_offset, variable)
+                l.warning("Reading memory with overlapping variables: %s. Ignoring all but the first one.",
+                          existing_variables)
 
-                self.variable_manager[self.func_addr].add_variable('stack', stack_offset, variable)
-
-            for variable in self.stack_region.get_variables_by_offset(stack_offset):
-                self.variable_manager[self.func_addr].read_from(variable, stack_offset - base_offset, self._codeloc_from_state(state))
+            if existing_variables:
+                variable = next(iter(existing_variables))
+                self.variable_manager[self.func_addr].read_from(variable, stack_offset - base_offset,
+                                                                self._codeloc_from_state(state))
 
     def _hook_memory_write(self, state):
 
@@ -368,7 +355,7 @@ class VariableRecoveryState:
         return self._to_signed(offset)
 
 
-class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-method
+class VariableRecovery(ForwardAnalysis, VariableRecoveryBase):  #pylint:disable=abstract-method
     """
     Recover "variables" from a function using forced execution.
 
@@ -381,8 +368,8 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
     This analysis uses heuristics to identify and recovers the following types of variables:
     - Register variables.
     - Stack variables.
-    - Heap variables.
-    - Global variables.
+    - Heap variables.  (not implemented yet)
+    - Global variables.  (not implemented yet)
 
     This analysis takes a function as input, and performs a data-flow analysis on nodes. It runs concrete execution on
     every statement and hooks all register/memory accesses to discover all places that are accessing variables. It is
@@ -404,15 +391,10 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
 
         function_graph_visitor = FunctionGraphVisitor(func)
 
+        VariableRecoveryBase.__init__(self, func, max_iterations)
         ForwardAnalysis.__init__(self, order_jobs=True, allow_merging=True, allow_widening=False,
                                  graph_visitor=function_graph_visitor)
 
-        self.function = func
-        self._node_to_state = { }
-
-        self.variable_manager = self.kb.variables
-
-        self._max_iterations = max_iterations
         self._node_iterations = defaultdict(int)
 
         self._analyze()
@@ -422,7 +404,7 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
     #
 
     def _pre_analysis(self):
-        pass
+        self.initialize_dominance_frontiers()
 
     def _pre_job_handling(self, job):
         pass
@@ -440,7 +422,7 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
         # give it enough stack space
         concrete_state.regs.bp = concrete_state.regs.sp + 0x100000
 
-        return VariableRecoveryState(self.variable_manager, self.project.arch, self.function.addr, [ concrete_state ])
+        return VariableRecoveryState(node.addr, self, self.project.arch, self.function, [ concrete_state ])
 
     def _merge_states(self, node, *states):
 
@@ -451,11 +433,12 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
 
     def _run_on_node(self, node, state):
         """
+        Take an input abstract state, execute the node, and derive an output state.
 
-
-        :param angr.Block node:
-        :param VariableRecoveryState state:
-        :return:
+        :param angr.Block node:             The node to work on.
+        :param VariableRecoveryState state: The input state.
+        :return:                            A tuple of (changed, new output state).
+        :rtype:                             tuple
         """
 
         l.debug('Analyzing block %#x, iteration %d.', node.addr, self._node_iterations[node])
@@ -468,6 +451,7 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
             return False, state
 
         state = state.copy()
+        self._instates[node.addr] = state
 
         if self._node_iterations[node] >= self._max_iterations:
             l.debug('Skip node %s as we have iterated %d times on it.', node, self._node_iterations[node])
@@ -485,7 +469,7 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
 
         state.concrete_states = [ state for state in output_states if not state.ip.symbolic ]
 
-        self._node_to_state[node.addr] = state
+        self._outstates[node.addr] = state
 
         self._node_iterations[node] += 1
 
@@ -498,7 +482,7 @@ class VariableRecovery(ForwardAnalysis, Analysis):  #pylint:disable=abstract-met
         # TODO: only re-assign variable names to those that are newly changed
         self.variable_manager.initialize_variable_names()
 
-        for addr, state in self._node_to_state.items():
+        for addr, state in self._outstates.items():
             self.variable_manager[self.function.addr].set_live_variables(addr,
                                                                          state.register_region,
                                                                          state.stack_region

--- a/angr/analyses/variable_recovery/variable_recovery.py
+++ b/angr/analyses/variable_recovery/variable_recovery.py
@@ -4,8 +4,6 @@ from functools import reduce
 
 import angr # type annotations; pylint: disable=unused-import
 
-from .. import Analysis
-
 from ... import BP, BP_AFTER
 from ...sim_variable import SimRegisterVariable, SimStackVariable
 from ..code_location import CodeLocation

--- a/angr/analyses/variable_recovery/variable_recovery_base.py
+++ b/angr/analyses/variable_recovery/variable_recovery_base.py
@@ -1,9 +1,12 @@
 
+import logging
 from collections import defaultdict
 
 from ...keyed_region import KeyedRegion
 from ...sim_variable import SimStackVariable, SimRegisterVariable
 from ..analysis import Analysis
+
+l = logging.getLogger(name=__name__)
 
 
 class VariableRecoveryBase(Analysis):

--- a/angr/analyses/variable_recovery/variable_recovery_base.py
+++ b/angr/analyses/variable_recovery/variable_recovery_base.py
@@ -1,0 +1,165 @@
+
+from collections import defaultdict
+
+from ...keyed_region import KeyedRegion
+from ...sim_variable import SimStackVariable, SimRegisterVariable
+from ..analysis import Analysis
+
+
+class VariableRecoveryBase(Analysis):
+    """
+    The base class for VariableRecovery and VariableRecoveryFast.
+    """
+
+    def __init__(self, func, max_iterations):
+
+        self.function = func
+        self.variable_manager = self.kb.variables
+
+        self._max_iterations = max_iterations
+
+        self._outstates = {}
+        self._instates = {}
+        self._dominance_frontiers = None
+
+    #
+    # Public methods
+    #
+
+    def get_variable_definitions(self, block_addr):
+        """
+        Get variables that are defined at the specified block.
+
+        :param int block_addr:  Address of the block.
+        :return:                A set of variables.
+        """
+
+        if block_addr in self._outstates:
+            return self._outstates[block_addr].variables
+        return set()
+
+    #
+    # Private methods
+    #
+
+    def initialize_dominance_frontiers(self):
+        # Computer the dominance frontier for each node in the graph
+        df = self.project.analyses.DominanceFrontier(self.function)
+        self._dominance_frontiers = defaultdict(set)
+        for b0, domfront in df.frontiers.items():
+            for d in domfront:
+                self._dominance_frontiers[d.addr].add(b0.addr)
+
+
+class VariableRecoveryStateBase:
+    """
+    The base abstract state for variable recovery analysis.
+    """
+
+    def __init__(self, block_addr, analysis, arch, func, stack_region=None, register_region=None):
+
+        self.block_addr = block_addr
+        self._analysis = analysis
+        self.arch = arch
+        self.function = func
+
+        if stack_region is not None:
+            self.stack_region = stack_region
+        else:
+            self.stack_region = KeyedRegion(phi_node_contains=self._phi_node_contains)
+        if register_region is not None:
+            self.register_region = register_region
+        else:
+            self.register_region = KeyedRegion(phi_node_contains=self._phi_node_contains)
+
+    @property
+    def func_addr(self):
+        return self.function.addr
+
+    @property
+    def dominance_frontiers(self):
+        return self._analysis._dominance_frontiers
+
+    @property
+    def variable_manager(self):
+        return self._analysis.variable_manager
+
+    @property
+    def variables(self):
+        for ro in self.stack_region:
+            for var in ro.internal_objects:
+                yield var
+        for ro in self.register_region:
+            for var in ro.internal_objects:
+                yield var
+
+    def get_variable_definitions(self, block_addr):
+        """
+        Get variables that are defined at the specified block.
+
+        :param int block_addr:  Address of the block.
+        :return:                A set of variables.
+        """
+
+        return self._analysis.get_variable_definitions(block_addr)
+
+    #
+    # Private methods
+    #
+
+    def _make_phi_variables(self, successor, state0, state1):
+
+        stack_variables = defaultdict(set)
+        register_variables = defaultdict(set)
+
+        for dominatee in self.dominance_frontiers[successor]:
+            vardefs = self._analysis.get_variable_definitions(dominatee)
+            for var in vardefs:
+                if isinstance(var, SimStackVariable):
+                    stack_variables[(var.offset, var.size)].add(var)
+                    if dominatee != state0.block_addr:
+                        v0s = state0.stack_region.get_variables_by_offset(var.offset)
+                        for v0 in v0s:
+                            stack_variables[(v0.offset, v0.size)].add(v0)
+                    if dominatee != state1.block_addr:
+                        v1s = state1.stack_region.get_variables_by_offset(var.offset)
+                        for v1 in v1s:
+                            stack_variables[(v1.offset, v1.size)].add(v1)
+                elif isinstance(var, SimRegisterVariable):
+                    register_variables[(var.reg, var.size)].add(var)
+                    if dominatee != state0.block_addr:
+                        v0s = state0.register_region.get_variables_by_offset(var.reg)
+                        for v0 in v0s:
+                            register_variables[(v0.reg, v0.size)].add(v0)
+                    if dominatee != state1.block_addr:
+                        v1s = state1.register_region.get_variables_by_offset(var.reg)
+                        for v1 in v1s:
+                            register_variables[(v1.reg, v1.size)].add(v1)
+                else:
+                    l.warning("Unsupported variable type %s.", type(var))
+
+        replacements = {}
+
+        for variable_dict in [stack_variables, register_variables]:
+            for _, variables in variable_dict.items():
+                if len(variables) > 1:
+                    # Create a new phi variable
+                    phi_node = self.variable_manager[self.function.addr].make_phi_node(successor, *variables)
+                    # Fill the replacements dict
+                    for var in variables:
+                        replacements[var] = phi_node
+
+        return replacements
+
+    def _phi_node_contains(self, phi_variable, variable):
+        """
+        Checks if `phi_variable` is a phi variable, and if it contains `variable` as a sub-variable.
+
+        :param phi_variable:
+        :param variable:
+        :return:
+        """
+
+        if self.variable_manager[self.function.addr].is_phi_variable(phi_variable):
+            return variable in self.variable_manager[self.function.addr].get_phi_subvariables(phi_variable)
+        return False

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -6,10 +6,8 @@ import ailment
 
 from ...engines.light import SpOffset, SimEngineLightVEX, SimEngineLightAIL
 from ...errors import SimEngineError
-from ...keyed_region import KeyedRegion
 from ...knowledge_plugins import Function
 from ...sim_variable import SimStackVariable, SimRegisterVariable
-from .. import Analysis
 from ..calling_convention import CallingConventionAnalysis
 from ..code_location import CodeLocation
 from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -238,8 +238,8 @@ def get_engine(base_engine):
                     # TODO: how to determine the size for a lea?
                     existing_vars = self.state.stack_region.get_variables_by_offset(stack_offset)
                     if not existing_vars:
-                        size = 1
-                        variable = SimStackVariable(stack_offset, size, base='bp',
+                        lea_size = 1
+                        variable = SimStackVariable(stack_offset, lea_size, base='bp',
                                                     ident=self.variable_manager[self.func_addr].next_variable_ident(
                                                         'stack'),
                                                     region=self.func_addr,

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -1,6 +1,5 @@
 
 import logging
-import itertools
 from collections import defaultdict
 
 import ailment
@@ -10,7 +9,6 @@ from ...errors import SimEngineError
 from ...keyed_region import KeyedRegion
 from ...knowledge_plugins import Function
 from ...sim_variable import SimStackVariable, SimRegisterVariable
-from ...utils.graph import PostDominators, compute_dominance_frontier
 from .. import Analysis
 from ..calling_convention import CallingConventionAnalysis
 from ..code_location import CodeLocation
@@ -706,10 +704,6 @@ class VariableRecoveryFast(ForwardAnalysis, Analysis):  #pylint:disable=abstract
             else:
                 l.debug('Merging input state of node %#x with the previous state.', node.addr)
                 input_state = prev_state.merge(input_state, successor=node.addr)
-
-        # Copy variable definitions from the previous block to this block
-        #if input_state.block_addr in self._variable_definitions:
-        #    self._variable_definitions[node.addr] = self._variable_definitions[input_state.block_addr].copy()
 
         state = input_state.copy()
         state.block_addr = node.addr

--- a/angr/keyed_region.py
+++ b/angr/keyed_region.py
@@ -1,11 +1,15 @@
 import logging
+import weakref
 from sortedcontainers import SortedDict
 
 
 l = logging.getLogger(name=__name__)
 
 
-class StoredObject(object):
+class StoredObject:
+
+    __slots__ = ('__weakref__', 'start', 'obj', 'size')
+
     def __init__(self, start, obj, size):
         self.start = start
         self.obj = obj
@@ -17,13 +21,23 @@ class StoredObject(object):
         return self.obj == other.obj and self.start == other.start and self.size == other.size
 
     def __hash__(self):
-        return hash((self.start, self.size))
+        return hash((self.start, self.size, self.obj))
+
+    def __repr__(self):
+        return "<SO %s@%#x, %d bytes>" % (repr(self.obj), self.start, self.size)
+
+    @property
+    def obj_id(self):
+        return id(self.obj)
 
 
-class RegionObject(object):
+class RegionObject:
     """
     Represents one or more objects occupying one or more bytes in KeyedRegion.
     """
+
+    __slots__ = ('start', 'size', 'stored_objects', '_internal_objects')
+
     def __init__(self, start, size, objects=None):
         self.start = start
         self.size = size
@@ -35,7 +49,8 @@ class RegionObject(object):
                 self._internal_objects.add(obj.obj)
 
     def __eq__(self, other):
-        return self.start == other.start and self.size == other.size and self.stored_objects == other.stored_objects
+        return type(other) is RegionObject and self.start == other.start and self.size == other.size and \
+               self.stored_objects == other.stored_objects
 
     def __ne__(self, other):
         return not self == other
@@ -77,15 +92,19 @@ class RegionObject(object):
         return ro
 
 
-class KeyedRegion(object):
+class KeyedRegion:
     """
     KeyedRegion keeps a mapping between stack offsets and all objects covering that offset. It assumes no variable in
     this region overlap with another variable in this region.
 
     Registers and function frames can all be viewed as a keyed region.
     """
+
+    __slots__ = ('_storage', '_object_mapping', )
+
     def __init__(self, tree=None):
         self._storage = SortedDict() if tree is None else tree
+        self._object_mapping = weakref.WeakValueDictionary()
 
     def _get_container(self, offset):
         try:
@@ -131,9 +150,10 @@ class KeyedRegion(object):
         kr = KeyedRegion()
         for key, ro in self._storage.items():
             kr._storage[key] = ro.copy()
+        kr._object_mapping = self._object_mapping.copy()
         return kr
 
-    def merge(self, other, make_phi_func=None):
+    def merge(self, other, replacements=None):
         """
         Merge another KeyedRegion into this KeyedRegion.
 
@@ -143,8 +163,28 @@ class KeyedRegion(object):
 
         # TODO: is the current solution not optimal enough?
         for _, item in other._storage.items():  # type: RegionObject
-            for loc_and_var in item.stored_objects:
-                self.__store(loc_and_var, overwrite=False, make_phi_func=make_phi_func)
+            for so in item.stored_objects:  # type: StoredObject
+                if replacements and so.obj in replacements:
+                    so = StoredObject(so.start, replacements[so.obj], so.size)
+                self._object_mapping[so.obj_id] = so
+                self.__store(so, overwrite=False)
+
+        return self
+
+    def replace(self, replacements):
+        """
+        Replace variables with other variables.
+
+        :param dict replacements:   A dict of variable replacements.
+        :return:                    self
+        """
+
+        for old_var, new_var in replacements.items():
+            old_var_id = id(old_var)
+            if old_var_id in self._object_mapping:
+                # FIXME: we need to check if old_var still exists in the storage
+                old_so = self._object_mapping[old_var_id]  # type: StoredObject
+                self._store(old_so.start, new_var, old_so.size, overwrite=True)
 
         return self
 
@@ -278,14 +318,16 @@ class KeyedRegion(object):
         """
 
         stored_object = StoredObject(start, obj, size)
+        self._object_mapping[stored_object.obj_id] = stored_object
         self.__store(stored_object, overwrite=overwrite)
 
-    def __store(self, stored_object, overwrite=False, make_phi_func=None):
+    def __store(self, stored_object, overwrite=False):
         """
         Store a variable into the storage.
 
         :param StoredObject stored_object: The descriptor describing start address and the variable.
-        :param bool overwrite: Whether existing objects should be overwritten or not.
+        :param bool overwrite:  Whether existing objects should be overwritten or not. True to make a strong update,
+                                False to make a weak update.
         :return: None
         """
 
@@ -299,8 +341,8 @@ class KeyedRegion(object):
         # is there a region item that begins before the start and overlaps with this variable?
         floor_key, floor_item = self._get_container(start)
         if floor_item is not None and floor_key not in overlapping_items:
-                # insert it into the beginning
-                overlapping_items.insert(0, floor_key)
+            # insert it into the beginning
+            overlapping_items.insert(0, floor_key)
 
         # scan through the entire list of region items, split existing regions and insert new regions as needed
         to_update = {start: RegionObject(start, object_size, {stored_object})}
@@ -314,7 +356,7 @@ class KeyedRegion(object):
                 if overwrite:
                     b.set_object(stored_object)
                 else:
-                    self._add_object_or_make_phi(b, stored_object, make_phi_func=make_phi_func)
+                    self._add_object_with_check(b, stored_object)
                 to_update[a.start] = a
                 to_update[b.start] = b
                 last_end = b.end
@@ -330,7 +372,7 @@ class KeyedRegion(object):
                 if overwrite:
                     a.set_object(stored_object)
                 else:
-                    self._add_object_or_make_phi(a, stored_object, make_phi_func=make_phi_func)
+                    self._add_object_with_check(a, stored_object)
                 to_update[a.start] = a
                 to_update[b.start] = b
                 last_end = b.end
@@ -338,7 +380,7 @@ class KeyedRegion(object):
                 if overwrite:
                     item.set_object(stored_object)
                 else:
-                    self._add_object_or_make_phi(item, stored_object, make_phi_func=make_phi_func)
+                    self._add_object_with_check(item, stored_object)
                 to_update[item.start] = item
 
         self._storage.update(to_update)
@@ -374,13 +416,8 @@ class KeyedRegion(object):
 
         return False
 
-    def _add_object_or_make_phi(self, item, stored_object, make_phi_func=None):  #pylint:disable=no-self-use
-        if not make_phi_func or len({stored_object.obj} | item.internal_objects) == 1:
-            item.add_object(stored_object)
-        else:
-            # make a phi node
-            item.set_object(StoredObject(stored_object.start,
-                                         make_phi_func(stored_object.obj, *item.internal_objects),
-                                         stored_object.size,
-                                         )
-                            )
+    @staticmethod
+    def _add_object_with_check(item, stored_object):
+        if len({stored_object.obj} | item.internal_objects) > 1:
+            l.warning("Overlapping objects %s.", str({stored_object.obj} | item.internal_objects))
+        item.add_object(stored_object)

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -14,7 +14,7 @@ from ...procedures import SIM_LIBRARIES
 l = logging.getLogger(name=__name__)
 
 
-class Function(object):
+class Function:
     """
     A representation of a function and various information about it.
     """

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -4,8 +4,7 @@ from collections import defaultdict
 from itertools import count
 
 from claripy.utils.orderedset import OrderedSet
-from ...sim_variable import SimStackVariable, SimMemoryVariable, SimRegisterVariable, SimMemoryVariablePhi, \
-    SimStackVariablePhi, SimRegisterVariablePhi
+from ...sim_variable import SimStackVariable, SimMemoryVariable, SimRegisterVariable
 
 from ...keyed_region import KeyedRegion
 from .variable_access import VariableAccess
@@ -15,12 +14,12 @@ from ..plugin import KnowledgeBasePlugin
 l = logging.getLogger(name=__name__)
 
 
-class VariableType(object):
+class VariableType:
     REGISTER = 0
     MEMORY = 1
 
 
-class LiveVariables(object):
+class LiveVariables:
     """
     A collection of live variables at a program point.
     """
@@ -29,7 +28,7 @@ class LiveVariables(object):
         self.stack_region = stack_region
 
 
-class VariableManagerInternal(object):
+class VariableManagerInternal:
     """
     Manage variables for a function. It is meant to be used internally by VariableManager.
     """
@@ -168,10 +167,10 @@ class VariableManagerInternal(object):
         if ins_addr not in self._insn_to_variable:
             return None
 
-        if sort == VariableType.MEMORY or sort == 'memory':
+        if sort in (VariableType.MEMORY, 'memory'):
             vars_and_offset = [(var, offset) for var, offset in self._insn_to_variable[ins_addr]
                         if isinstance(var, (SimStackVariable, SimMemoryVariable))]
-        elif sort == VariableType.REGISTER or sort == 'register':
+        elif sort in (VariableType.REGISTER, 'register'):
             vars_and_offset = [(var, offset) for var, offset in self._insn_to_variable[ins_addr]
                         if isinstance(var, SimRegisterVariable)]
         else:

--- a/angr/sim_variable.py
+++ b/angr/sim_variable.py
@@ -106,7 +106,6 @@ class SimRegisterVariable(SimVariable):
     def __eq__(self, other):
         if isinstance(other, SimRegisterVariable):
             return self.ident == other.ident and \
-                   self.name == other.name and \
                    self.reg == other.reg and \
                    self.size == other.size and \
                    self.region == other.region and \
@@ -131,7 +130,7 @@ class SimRegisterVariablePhi(SimRegisterVariable):
 
     def __hash__(self):
         if self._hash is None:
-            self._hash = hash((self.name, self.region, self.size, self.ident, tuple(self.variables)))
+            self._hash = hash((self.region, self.size, self.ident, tuple(self.variables)))
         return self._hash
 
     def __eq__(self, other):
@@ -140,7 +139,6 @@ class SimRegisterVariablePhi(SimRegisterVariable):
 
         return self.ident == other.ident and \
                self.variables == other.variables and \
-               self.name == other.name and \
                self.region == other.region and \
                self.size == other.size
 
@@ -202,7 +200,6 @@ class SimMemoryVariable(SimVariable):
         if isinstance(other, SimMemoryVariable):
             return self.ident == other.ident and \
                    self.addr == other.addr and \
-                   self.name == other.name and \
                    self.size == other.size and \
                    self.phi == other.phi
 
@@ -235,7 +232,6 @@ class SimMemoryVariablePhi(SimMemoryVariable):
         return self.ident == other.ident and \
                self.variables == other.variables and \
                self.addr == other.addr and \
-               self.name == other.name and \
                self.region == other.region and \
                self.size == other.size
 
@@ -296,14 +292,13 @@ class SimStackVariable(SimMemoryVariable):
             return False
 
         return self.ident == other.ident and \
-               self.name == other.name and \
                self.base == other.base and \
                self.offset == other.offset and \
                self.size == other.size and \
                self.phi == other.phi
 
     def __hash__(self):
-        return hash((self.ident, self.name, self.base, self.offset, self.size, self.phi))
+        return hash((self.ident, self.base, self.offset, self.size, self.phi))
 
 
 class SimStackVariablePhi(SimStackVariable):
@@ -332,7 +327,6 @@ class SimStackVariablePhi(SimStackVariable):
         return self.ident == other.ident and \
                self.variables == other.variables and \
                self.addr == other.addr and \
-               self.name == other.name and \
                self.region == other.region and \
                self.size == other.size
 

--- a/angr/sim_variable.py
+++ b/angr/sim_variable.py
@@ -1,7 +1,7 @@
 import collections
 import claripy
 
-class SimVariable(object):
+class SimVariable:
 
     __slots__ = ['ident', 'name', 'region', 'category']
 
@@ -245,7 +245,7 @@ class SimVariableSet(collections.MutableSet):
         # For the sake of performance, we have another set that stores memory addresses of memory_variables
         self.memory_variable_addresses = set()
 
-    def add(self, item):
+    def add(self, item):  # pylint:disable=arguments-differ
         if type(item) is SimRegisterVariable:
             if not self.contains_register_variable(item):
                 self.add_register_variable(item)
@@ -266,7 +266,7 @@ class SimVariableSet(collections.MutableSet):
         for i in range(mem_var.size):
             self.memory_variable_addresses.add(base_address + i)
 
-    def discard(self, item):
+    def discard(self, item):  # pylint:disable=arguments-differ
         if type(item) is SimRegisterVariable:
             if self.contains_register_variable(item):
                 self.discard_register_variable(item)

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -60,7 +60,7 @@ def dfs_back_edges(graph, start_node):
 # Dominance frontier
 #
 
-def compute_dominance_frontier(graph, postdom):
+def compute_dominance_frontier(graph, domtree):
     """
     Compute a dominance frontier based on the given post-dominator tree.
 
@@ -68,43 +68,48 @@ def compute_dominance_frontier(graph, postdom):
     Form by Ron Cytron, etc.
 
     :param graph:   The graph where we want to compute the dominance frontier.
-    :param postdom: The post-dominator tree
+    :param domtree: The dominator tree
     :returns:       A dict of dominance frontier
     """
 
     df = {}
 
-    # Perform a post-order search on the post-dom tree
-    for x in networkx.dfs_postorder_nodes(postdom):
+    # Perform a post-order search on the dominator tree
+    for x in networkx.dfs_postorder_nodes(domtree):
+
+        if x not in graph:
+            # Skip nodes that are not in the graph
+            continue
+
         df[x] = set()
 
         # local set
         for y in graph.successors(x):
-            if x not in postdom.predecessors(y):
+            if x not in domtree.predecessors(y):
                 df[x].add(y)
 
         # up set
         if x is None:
             continue
 
-        for z in postdom.successors(x):
+        for z in domtree.successors(x):
             if z is x:
                 continue
             if z not in df:
                 continue
             for y in df[z]:
-                if x not in list(postdom.predecessors(y)):
+                if x not in list(domtree.predecessors(y)):
                     df[x].add(y)
 
     return df
 
 
 #
-# Post dominators
+# Dominators and post-dominators
 #
 
 
-class TemporaryNode(object):
+class TemporaryNode:
     """
     A temporary node.
 
@@ -117,7 +122,7 @@ class TemporaryNode(object):
         self._label = label
 
     def __repr__(self):
-        return 'TemporaryNode[%s]' % self._label
+        return 'TN[%s]' % self._label
 
     def __eq__(self, other):
         if isinstance(other, TemporaryNode) and other._label == self._label:
@@ -125,14 +130,14 @@ class TemporaryNode(object):
         return False
 
     def __hash__(self):
-        return hash('%s' % self._label)
+        return hash(('TemporaryNode', self._label))
 
 
-class ContainerNode(object):
+class ContainerNode:
     """
     A container node.
 
-    Only used in post-dominator tree generation. We did this so we can set the index property without modifying the
+    Only used in dominator tree generation. We did this so we can set the index property without modifying the
     original object.
     """
 
@@ -154,13 +159,18 @@ class ContainerNode(object):
     def __hash__(self):
         return 1  # I have genuinely no idea why defining a normal hash function makes everything break but it does
 
+    def __repr__(self):
+        return "CN[%s]" % repr(self._obj)
 
-class PostDominators(object):
 
-    def __init__(self, graph, entry_node, successors_func=None):
+class Dominators:
 
-        self._l = logging.getLogger("utils.graph.post_dominators")
+    def __init__(self, graph, entry_node, successors_func=None, reverse=False):
+
+        self._l = logging.getLogger("utils.graph.dominators")
         self._graph_successors_func = successors_func
+
+        self._reverse = reverse  # Set it to True to generate a post-dominator tree.
 
         # Temporary variables
         self._ancestor = None
@@ -168,7 +178,7 @@ class PostDominators(object):
         self._label = None
 
         # Output
-        self.post_dom = None
+        self.dom = None
         self.prepared_graph = None
 
         self._construct(graph, entry_node)
@@ -245,10 +255,10 @@ class PostDominators(object):
             if dom[w.index].index != vertices[self._semi[w.index].index].index:
                 dom[w.index] = dom[dom[w.index].index]
 
-        self.post_dom = networkx.DiGraph()  # The post-dom tree described in a directional graph
+        self.dom = networkx.DiGraph()  # The post-dom tree described in a directional graph
         for i in range(1, len(vertices)):
             if dom[i] is not None and vertices[i] is not None:
-                self.post_dom.add_edge(dom[i].obj, vertices[i].obj)
+                self.dom.add_edge(dom[i].obj, vertices[i].obj)
 
         # Output
         self.prepared_graph = _prepared_graph
@@ -264,6 +274,8 @@ class PostDominators(object):
         start_node = TemporaryNode("start_node")
         # Put the start_node into a Container as well
         start_node = ContainerNode(start_node)
+        # Create the end_node, too
+        end_node = ContainerNode(TemporaryNode("end_node"))
 
         container_nodes = {}
 
@@ -283,8 +295,13 @@ class PostDominators(object):
             traversed_nodes.add(container_node)
 
             if len(successors) == 0:
-                # Add an edge between this node and our start node
-                new_graph.add_edge(start_node, container_node)
+                if self._reverse:
+                    # Add an edge between the start node and this node
+                    new_graph.add_edge(start_node, container_node)
+                else:
+                    # Add an edge between our this node and end node
+                    new_graph.add_edge(container_node, end_node)
+
 
             for s in successors:
                 if s in container_nodes:
@@ -292,12 +309,19 @@ class PostDominators(object):
                 else:
                     container_s = ContainerNode(s)
                     container_nodes[s] = container_s
-                new_graph.add_edge(container_s, container_node)  # Reversed
+                if self._reverse:
+                    new_graph.add_edge(container_s, container_node)  # Reversed
+                else:
+                    new_graph.add_edge(container_node, container_s)  # Reversed
                 if container_s not in traversed_nodes:
                     queue.append(s)
 
-        # Add a start node and an end node
-        new_graph.add_edge(container_nodes[n], ContainerNode(TemporaryNode("end_node")))
+        if self._reverse:
+            # Add the end node
+            new_graph.add_edge(container_nodes[n], end_node)
+        else:
+            # Add the start node
+            new_graph.add_edge(start_node, container_nodes[n])
 
         all_nodes_count = len(traversed_nodes) + 2  # A start node and an end node
         self._l.debug("There should be %d nodes in all", all_nodes_count)
@@ -366,3 +390,12 @@ class PostDominators(object):
                     self._semi[self._label[v.index].index].index:
                 self._label[v.index] = self._label[self._ancestor[v.index].index]
             self._ancestor[v.index] = self._ancestor[self._ancestor[v.index].index]
+
+
+class PostDominators(Dominators):
+    def __init__(self, graph, entry_node, successors_func=None):
+        super().__init__(graph, entry_node, successors_func=successors_func, reverse=True)
+
+    @property
+    def post_dom(self):
+        return self.dom

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -295,13 +295,14 @@ class Dominators:
             traversed_nodes.add(container_node)
 
             if len(successors) == 0:
+                # Note that this condition may never be satisfied if there is no real "end node" in the graph: the graph
+                # may end with a loop.
                 if self._reverse:
                     # Add an edge between the start node and this node
                     new_graph.add_edge(start_node, container_node)
                 else:
                     # Add an edge between our this node and end node
                     new_graph.add_edge(container_node, end_node)
-
 
             for s in successors:
                 if s in container_nodes:
@@ -323,7 +324,7 @@ class Dominators:
             # Add the start node
             new_graph.add_edge(start_node, container_nodes[n])
 
-        all_nodes_count = len(traversed_nodes) + 2  # A start node and an end node
+        all_nodes_count = new_graph.number_of_nodes()
         self._l.debug("There should be %d nodes in all", all_nodes_count)
         counter = 0
         vertices = [ContainerNode("placeholder")]

--- a/tests/test_variablerecovery.py
+++ b/tests/test_variablerecovery.py
@@ -169,5 +169,6 @@ if __name__ == '__main__':
 
     l.setLevel(logging.DEBUG)
     logging.getLogger('angr.analyses.variable_recovery_fast').setLevel(logging.DEBUG)
+    logging.getLogger('angr.analyses.variable_recovery').setLevel(logging.DEBUG)
 
     main()

--- a/tests/test_variablerecovery.py
+++ b/tests/test_variablerecovery.py
@@ -5,7 +5,7 @@ import logging
 import nose
 
 import angr
-from angr.sim_variable import SimStackVariable
+from angr.sim_variable import SimStackVariable, SimRegisterVariable
 from angr.knowledge_plugins.variables import VariableType
 
 
@@ -58,7 +58,20 @@ def _compare_memory_variable(variable, variable_info):
 
 def _compare_register_variable(variable, variable_info):  # pylint:disable=unused-argument
 
-    raise NotImplementedError()
+    if not isinstance(variable, SimRegisterVariable):
+        return False
+
+    if 'reg' in variable_info:
+        reg = variable_info['reg']
+        if variable.reg != reg:
+            return False
+
+    if 'size' in variable_info:
+        size = variable_info['size']
+        if variable.size != size:
+            return False
+
+    return True
 
 
 def run_variable_recovery_analysis(project, func, groundtruth, is_fast):
@@ -75,7 +88,7 @@ def run_variable_recovery_analysis(project, func, groundtruth, is_fast):
 
     variable_manager = vr.variable_manager[func.addr]
 
-    for insn_addr, variables in groundtruth.items():
+    for insn_addr, variables in groundtruth['variables_by_instruction'].items():
         for var_info in variables:
             var_sort = var_info['sort']
             vars_and_offset = variable_manager.find_variables_by_insn(insn_addr, var_sort)
@@ -94,8 +107,27 @@ def run_variable_recovery_analysis(project, func, groundtruth, is_fast):
                                           )
             l.debug("Found variable %s at %#x.", the_var, insn_addr)
 
+    for block_addr, variables in groundtruth['phi_variables_by_block'].items():
+        phi_variables = variable_manager.get_phi_variables(block_addr)
+        for var_info in variables:
+            var_sort = var_info['sort']
 
-def test_variable_analysis_fast():
+            # enumerate vars and find the variable that we want
+            if var_sort == VariableType.MEMORY:
+                the_var = next((var for var in phi_variables if _compare_memory_variable(var, var_info)), None)
+            elif var_sort == VariableType.REGISTER:
+                the_var = next((var for var in phi_variables if _compare_register_variable(var, var_info)), None)
+            else:
+                l.error('Unsupported variable sort %s.', var_sort)
+                assert False
+
+            nose.tools.assert_is_not_none(the_var, msg="The phi variable %s in groundtruth at block %#x cannot be "
+                                                       "found in variable manager." % (var_info, block_addr)
+                                          )
+            l.debug("Found phi variable %s at %#x.", the_var, block_addr)
+
+
+def test_variable_analysis():
 
     binary_path = os.path.join(test_location, 'x86_64', 'fauxware')
     project = angr.Project(binary_path, load_options={'auto_load_libs': False})
@@ -103,55 +135,71 @@ def test_variable_analysis_fast():
 
     groundtruth = {
         'authenticate': {
-            0x40066c: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x18, 'size': 8},
-            ],
-            0x400670: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x20, 'size': 8},
-            ],
-            0x400674: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x8, 'size': 1},
-            ],
-            0x40067f: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x20, 'size': 8},
-            ],
-            0x400699: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x18, 'size': 8},
-            ],
-            0x4006af: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x4, 'size': 4},
-            ],
-            0x4006b2: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x10, 'size': 1},
-            ]
+            'variables_by_instruction': {
+                0x40066c: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x18, 'size': 8},
+                ],
+                0x400670: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x20, 'size': 8},
+                ],
+                0x400674: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x8, 'size': 1},
+                ],
+                0x40067f: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x20, 'size': 8},
+                ],
+                0x400699: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x18, 'size': 8},
+                ],
+                0x4006af: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x4, 'size': 4},
+                ],
+                0x4006b2: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x10, 'size': 1},
+                ]
+            },
+            'phi_variables_by_block': {
+                0x4006eb: [
+                    {'sort': VariableType.REGISTER, 'reg': 16, 'size': 8},
+                    {'sort': VariableType.REGISTER, 'reg': 32, 'size': 8},
+                    {'sort': VariableType.REGISTER, 'reg': 64, 'size': 8},
+                    {'sort': VariableType.REGISTER, 'reg': 72, 'size': 8},
+                ]
+            },
         },
         'main': {
-            0x400725: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x34, 'size': 4},
-            ],
-            0x400728: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x40, 'size': 8},
-            ],
-            0x40072c: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x8, 'size': 1},
-            ],
-            0x400730: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x18, 'size': 1},
-            ],
-            0x40073e: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x10, 'size': 1},
-            ],
-            0x400754: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x24, 'size': 1},
-            ],
-            0x400774: [
-                {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x20, 'size': 1},
-            ],
+            'variables_by_instruction': {
+                0x400725: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x34, 'size': 4},
+                ],
+                0x400728: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x40, 'size': 8},
+                ],
+                0x40072c: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x8, 'size': 1},
+                ],
+                0x400730: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x18, 'size': 1},
+                ],
+                0x40073e: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x10, 'size': 1},
+                ],
+                0x400754: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x24, 'size': 1},
+                ],
+                0x400774: [
+                    {'sort': VariableType.MEMORY, 'location': 'stack', 'base': 'bp', 'offset': -0x20, 'size': 1},
+                ],
+            },
+            'phi_variables_by_block': {
+
+            },
         }
     }
 
     for func_name, truth in groundtruth.items():
         yield run_variable_recovery_analysis, project, cfg.kb.functions[func_name], truth, True
+        yield run_variable_recovery_analysis, project, cfg.kb.functions[func_name], truth, False
 
 
 def main():


### PR DESCRIPTION
Eventually we can correctly determine where phi variables should locate. One step closer to function-level SSA.

- Add a `DominanceFrontier` analysis to compute the dominance frontier of each block in a function.
- Refactor the `PostDominator` class into ` Dominator` class and a `PostDominator` class. Now we can easily calculate dominators and post-dominators by switching between the two classes.
- Fix the dominance frontier computation. It should use a dominator tree, not a post-dominator tree.
- Add `VariableManagerInternal.get_phi_variables(block_addr)`.

TODOs:
- [x] Get rid of `SimXXXVariablePhi` classes.
- [x] Update `VariableRecovery`.
- [x] Add test cases for determining the locations of phi variables.
- [x] Test angr Management on more binaries to make sure the performance is acceptable.