### PR TITLE
Decompilation support.

### DIFF
--- a/angr/analyses/__init__.py
+++ b/angr/analyses/__init__.py
@@ -28,3 +28,4 @@ from .calling_convention import CallingConventionAnalysis
 from .code_tagging import CodeTagging
 from .stack_pointer_tracker import StackPointerTracker
 from .dominance_frontier import DominanceFrontier
+from .decompiler import Decompiler

--- a/angr/analyses/code_location.py
+++ b/angr/analyses/code_location.py
@@ -1,9 +1,11 @@
 
-class CodeLocation(object):
+class CodeLocation:
     """
     Stands for a specific program point by specifying basic block address and statement ID (for IRSBs), or SimProcedure
     name (for SimProcedures).
     """
+
+    __slots__ = ('block_addr', 'stmt_idx', 'sim_procedure', 'ins_addr', 'info', )
 
     def __init__(self, block_addr, stmt_idx, sim_procedure=None, ins_addr=None, **kwargs):
         """

--- a/angr/analyses/decompiler/__init__.py
+++ b/angr/analyses/decompiler/__init__.py
@@ -3,3 +3,4 @@ from .structurer import Structurer
 from .structured_codegen import StructuredCodeGenerator
 from .clinic import Clinic
 from .region_simplifier import RegionSimplifier
+from .decompiler import Decompiler

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -20,7 +20,7 @@ class Clinic(Analysis):
     def __init__(self, func):
 
         # Delayed import
-        import ailment.analyses
+        import ailment.analyses  # pylint:disable=redefined-outer-name,unused-import
 
         self.function = func
 
@@ -148,7 +148,7 @@ class Clinic(Analysis):
 
         # First of all, let's simplify blocks one by one
 
-        for key in self._blocks.keys():
+        for key in self._blocks:
             ail_block = self._blocks[key]
             simplified = self._simplify_block(ail_block, stack_pointer_tracker=stack_pointer_tracker)
             self._blocks[key] = simplified
@@ -266,26 +266,26 @@ class Clinic(Analysis):
 
         elif type(expr) is ailment.Expr.Load:
             # import ipdb; ipdb.set_trace()
-            vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
-            if len(vars) == 1:
-                var = next(iter(vars))[0]
+            variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(variables) == 1:
+                var = next(iter(variables))[0]
                 expr.variable = var
             else:
                 self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.addr)
 
         elif type(expr) is ailment.Expr.BinaryOp:
-            vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
-            if len(vars) == 1:
-                var = next(iter(vars))[0]
+            variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(variables) == 1:
+                var = next(iter(variables))[0]
                 expr.referenced_variable = var
             else:
                 self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands[0])
                 self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands[1])
 
         elif type(expr) is ailment.Expr.UnaryOp:
-            vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
-            if len(vars) == 1:
-                var = next(iter(vars))[0]
+            variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(variables) == 1:
+                var = next(iter(variables))[0]
                 expr.referenced_variable = var
             else:
                 self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands)
@@ -294,9 +294,9 @@ class Clinic(Analysis):
             self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operand)
 
         elif isinstance(expr, ailment.Expr.BasePointerOffset):
-            vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
-            if len(vars) == 1:
-                var = next(iter(vars))[0]
+            variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(variables) == 1:
+                var = next(iter(variables))[0]
                 expr.referenced_variable = var
 
     def _update_graph(self):

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -8,7 +8,6 @@ from ...codenode import BlockNode
 from ..calling_convention import CallingConventionAnalysis
 
 import ailment
-import ailment.analyses
 
 
 l = logging.getLogger(name=__name__)
@@ -19,9 +18,13 @@ class Clinic(Analysis):
     A Clinic deals with AILments.
     """
     def __init__(self, func):
+
+        # Delayed import
+        import ailment.analyses
+
         self.function = func
 
-        self.graph = networkx.DiGraph()
+        self.graph = None
 
         self._ail_manager = None
         self._blocks = { }
@@ -74,11 +77,19 @@ class Clinic(Analysis):
         # initialize the AIL conversion manager
         self._ail_manager = ailment.Manager(arch=self.project.arch)
 
+        spt = self._track_stack_pointers()
+
         self._convert_all()
+
+        self._simplify_blocks(stack_pointer_tracker=spt)
 
         self._recover_and_link_variables()
 
-        self._simplify_all()
+        # Make call-sites
+        self._make_callsites()
+
+        # Simplify the entire function
+        self._simplify_function()
 
         self._update_graph()
 
@@ -86,6 +97,17 @@ class Clinic(Analysis):
 
         # print ri.region.dbg_print()
 
+    def _track_stack_pointers(self):
+        """
+        For each instruction, track its stack pointer offset and stack base pointer offset.
+
+        :return: None
+        """
+
+        spt = self.project.analyses.StackPointerTracker(self.function)
+        if spt.sp_inconsistent:
+            l.warning("Inconsistency found during stack pointer tracking. Decompilation results might be incorrect.")
+        return spt
 
     def _convert_all(self):
         """
@@ -101,9 +123,11 @@ class Clinic(Analysis):
 
     def _convert(self, block_node):
         """
+        Convert a VEX block to an AIL block.
 
-        :param block_node:
-        :return:
+        :param block_node:  A BlockNode instance.
+        :return:            An converted AIL block.
+        :rtype:             ailment.Block
         """
 
         if not type(block_node) is BlockNode:
@@ -114,27 +138,74 @@ class Clinic(Analysis):
         ail_block = ailment.IRSBConverter.convert(block.vex, self._ail_manager)
         return ail_block
 
-    def _simplify_all(self):
+    def _simplify_blocks(self, stack_pointer_tracker=None):
+        """
+        Simplify all blocks in self._blocks.
+
+        :param stack_pointer_tracker:   The StackPointerTracker analysis instance.
+        :return:                        None
         """
 
-        :return:
-        """
+        # First of all, let's simplify blocks one by one
 
         for key in self._blocks.keys():
             ail_block = self._blocks[key]
-            simplified = self._simplify(ail_block)
+            simplified = self._simplify_block(ail_block, stack_pointer_tracker=stack_pointer_tracker)
             self._blocks[key] = simplified
 
-    def _simplify(self, ail_block):
+        # Update the function graph so that we can use reaching definitions
+        self._update_graph()
 
-        simp = self.project.analyses.AILSimplifier(ail_block)
+    def _simplify_block(self, ail_block, stack_pointer_tracker=None):
+        """
+        Simplify a single AIL block.
 
-        csm = self.project.analyses.AILCallSiteMaker(simp.result_block)
-        if csm.result_block:
-            ail_block = csm.result_block
-            simp = self.project.analyses.AILSimplifier(ail_block)
+        :param ailment.Block ail_block: The AIL block to simplify.
+        :param stack_pointer_tracker:   The StackPointerTracker analysis instance.
+        :return:                        A simplified AIL block.
+        """
 
+        simp = self.project.analyses.AILBlockSimplifier(ail_block, stack_pointer_tracker=stack_pointer_tracker)
         return simp.result_block
+
+    def _simplify_function(self):
+        """
+        Simplify the entire function.
+
+        :return:    None
+        """
+
+        # Computing reaching definitions
+        rd = self.project.analyses.ReachingDefinitions(func=self.function, func_graph=self.graph, observe_all=True)
+
+        simp = self.project.analyses.AILSimplifier(self.function, func_graph=self.graph, reaching_definitions=rd)
+
+        for key in list(self._blocks.keys()):
+            old_block = self._blocks[key]
+            if old_block in simp.blocks:
+                self._blocks[key] = simp.blocks[old_block]
+
+        self._update_graph()
+
+    def _make_callsites(self):
+        """
+        Simplify all function call statements.
+
+        :return:    None
+        """
+
+        # Computing reaching definitions
+        rd = self.project.analyses.ReachingDefinitions(func=self.function, func_graph=self.graph, observe_all=True)
+
+        for key in self._blocks:
+            block = self._blocks[key]
+            csm = self.project.analyses.AILCallSiteMaker(block, reaching_definitions=rd)
+            if csm.result_block:
+                ail_block = csm.result_block
+                simp = self.project.analyses.AILBlockSimplifier(ail_block)
+                self._blocks[key] = simp.result_block
+
+        self._update_graph()
 
     def _recover_and_link_variables(self):
 
@@ -148,51 +219,90 @@ class Clinic(Analysis):
 
     def _link_variables_on_block(self, block):
         """
+        Link atoms (AIL expressions) in the given block to corresponding variables identified previously.
 
-        :param block:
-        :return:
+        :param ailment.Block block: The AIL block to work on.
+        :return:                    None
         """
 
-        var_man = self.kb.variables[self.function.addr]
+        variable_manager = self.kb.variables[self.function.addr]
 
         for stmt_idx, stmt in enumerate(block.statements):
             # I wish I could do functional programming in this method...
             stmt_type = type(stmt)
             if stmt_type is ailment.Stmt.Store:
                 # find a memory variable
-                mem_vars = var_man.find_variables_by_stmt(block.addr, stmt_idx, 'memory')
+                mem_vars = variable_manager.find_variables_by_stmt(block.addr, stmt_idx, 'memory')
                 if len(mem_vars) == 1:
                     stmt.variable = mem_vars[0][0]
-                self._link_variables_on_expr(var_man, block, stmt_idx, stmt, stmt.data)
+                self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, stmt.data)
 
             elif stmt_type is ailment.Stmt.Assignment:
-                self._link_variables_on_expr(var_man, block, stmt_idx, stmt, stmt.dst)
-                self._link_variables_on_expr(var_man, block, stmt_idx, stmt, stmt.src)
+                self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, stmt.dst)
+                self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, stmt.src)
+
+            elif stmt_type is ailment.Stmt.ConditionalJump:
+                self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, stmt.condition)
 
     def _link_variables_on_expr(self, variable_manager, block, stmt_idx, stmt, expr):
+        """
+        Link atoms (AIL expressions) in the given expression to corresponding variables identified previously.
 
-        # TODO: Make it recursive
+        :param variable_manager:    Variable manager of the function.
+        :param ailment.Block block: AIL block.
+        :param int stmt_idx:        ID of the statement.
+        :param stmt:                The AIL statement that `expr` belongs to.
+        :param expr:                The AIl expression to work on.
+        :return:                    None
+        """
 
         if type(expr) is ailment.Expr.Register:
             # find a register variable
-            reg_vars = variable_manager.find_variables_by_stmt(block.addr, stmt_idx, 'register')
+            reg_vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
             # TODO: make sure it is the correct register we are looking for
             if len(reg_vars) == 1:
-                reg_var = reg_vars[0][0]
+                reg_var = next(iter(reg_vars))[0]
                 expr.variable = reg_var
 
         elif type(expr) is ailment.Expr.Load:
-            # self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.addr)
-            pass
+            # import ipdb; ipdb.set_trace()
+            vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(vars) == 1:
+                var = next(iter(vars))[0]
+                expr.variable = var
+            else:
+                self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.addr)
 
         elif type(expr) is ailment.Expr.BinaryOp:
+            vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(vars) == 1:
+                var = next(iter(vars))[0]
+                expr.referenced_variable = var
+            else:
+                self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands[0])
+                self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands[1])
 
-            self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands[0])
-            self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands[1])
+        elif type(expr) is ailment.Expr.UnaryOp:
+            vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(vars) == 1:
+                var = next(iter(vars))[0]
+                expr.referenced_variable = var
+            else:
+                self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands)
+
+        elif type(expr) is ailment.Expr.Convert:
+            self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operand)
+
+        elif isinstance(expr, ailment.Expr.BasePointerOffset):
+            vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(vars) == 1:
+                var = next(iter(vars))[0]
+                expr.referenced_variable = var
 
     def _update_graph(self):
 
         node_to_block_mapping = {}
+        self.graph = networkx.DiGraph()
 
         for node in self.function.transition_graph.nodes():
             ail_block = self._blocks.get((node.addr, node.size), node)

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -115,7 +115,7 @@ class Clinic(Analysis):
         :return:
         """
 
-        for block_node in self.function.transition_graph.nodes():
+        for block_node in self.function.graph.nodes():
             ail_block = self._convert(block_node)
 
             if type(ail_block) is ailment.Block:
@@ -304,13 +304,13 @@ class Clinic(Analysis):
         node_to_block_mapping = {}
         self.graph = networkx.DiGraph()
 
-        for node in self.function.transition_graph.nodes():
+        for node in self.function.graph.nodes():
             ail_block = self._blocks.get((node.addr, node.size), node)
             node_to_block_mapping[node] = ail_block
 
             self.graph.add_node(ail_block)
 
-        for src_node, dst_node, data in self.function.transition_graph.edges(data=True):
+        for src_node, dst_node, data in self.function.graph.edges(data=True):
             src = node_to_block_mapping[src_node]
             dst = node_to_block_mapping[dst_node]
 

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -1,0 +1,32 @@
+
+from .. import Analysis, AnalysesHub
+
+
+class Decompiler(Analysis):
+    def __init__(self, func, cfg=None):
+        self.func = func
+        self._cfg = cfg
+
+        self.codegen = None
+
+        self._decompile()
+
+    def _decompile(self):
+        # convert function blocks to AIL blocks
+        clinic = self.project.analyses.Clinic(self.func)
+
+        # recover regions
+        ri = self.project.analyses.RegionIdentifier(self.func, graph=clinic.graph)
+
+        # structure it
+        rs = self.project.analyses.RecursiveStructurer(ri.region)
+
+        # simplify it
+        s = self.project.analyses.RegionSimplifier(rs.result)
+
+        codegen = self.project.analyses.StructuredCodeGenerator(self.func, s.result, cfg=self._cfg)
+
+        self.codegen = codegen
+
+
+AnalysesHub.register_default('Decompiler', Decompiler)

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -12,6 +12,10 @@ class Decompiler(Analysis):
         self._decompile()
 
     def _decompile(self):
+
+        if self.func.is_simprocedure:
+            return
+
         # convert function blocks to AIL blocks
         clinic = self.project.analyses.Clinic(self.func)
 

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -249,6 +249,7 @@ class RegionIdentifier(Analysis):
         loop_subgraph = self.slice_graph(graph, head, latching_nodes, include_frontier=True)
         nodes = set(loop_subgraph.nodes())
         return nodes
+
     @staticmethod
     def _dominates(idom, dominator_node, node):
         n = node
@@ -357,7 +358,8 @@ class RegionIdentifier(Analysis):
 
                     l.debug("Initial exit nodes %s", self._dbg_block_list(initial_exit_nodes))
 
-                    refined_loop_nodes, refined_exit_nodes = self._refine_loop(graph, node, initial_loop_nodes, initial_exit_nodes)
+                    refined_loop_nodes, refined_exit_nodes = self._refine_loop(graph, node, initial_loop_nodes,
+                                                                               initial_exit_nodes)
                     l.debug("Refined loop nodes %s", self._dbg_block_list(refined_loop_nodes))
                     l.debug("Refined exit nodes %s", self._dbg_block_list(refined_exit_nodes))
 
@@ -371,7 +373,8 @@ class RegionIdentifier(Analysis):
                         normal_exit_node = next(iter(refined_exit_nodes)) if len(refined_exit_nodes) > 0 else None
                         abnormal_exit_nodes = set()
 
-                    self._abstract_cyclic_region(graph, refined_loop_nodes, node, normal_entries, abnormal_entries, normal_exit_node, abnormal_exit_nodes)
+                    self._abstract_cyclic_region(graph, refined_loop_nodes, node, normal_entries, abnormal_entries,
+                                                 normal_exit_node, abnormal_exit_nodes)
                     break
                 # acyclic region
                 else:

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -197,7 +197,9 @@ class RegionIdentifier(Analysis):
 
         self._make_regions(graph)
 
-        assert len(graph.nodes()) == 1
+        if len(graph.nodes()) > 1:
+            l.warning("RegionIdentifier is unable to make one region out of the function graph of %s.",
+                      repr(self.function))
 
         self.region = next(iter(graph.nodes()))
 

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -324,15 +324,15 @@ class RegionIdentifier(Analysis):
             self._update_start_node(graph)
 
             for node in networkx.dfs_postorder_nodes(graph, source=self._start_node):
-                succs = graph.successors(node)
-                if not succs:
+                out_degree = graph.out_degree[node]
+                if out_degree == 0:
                     # the root element of the region hierarchy should always be a GraphRegion,
                     # so we transform it into one, if necessary
-                    if not graph.predecessors(node) and not isinstance(node, GraphRegion):
+                    if graph.in_degree(node) == 0 and not isinstance(node, GraphRegion):
                         subgraph = networkx.DiGraph()
                         subgraph.add_node(node)
                         self._abstract_acyclic_region(graph, GraphRegion(node, subgraph), [])
-                    break
+                    continue
 
                 # cyclic region
                 # TODO optimize

--- a/angr/analyses/decompiler/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifier.py
@@ -127,7 +127,8 @@ class RegionSimplifier(Analysis):
 
         if block.statements and isinstance(block.statements[-1], ailment.Stmt.Jump):
             goto_stmt = block.statements[-1]  # ailment.Stmt.Jump
-            if successor and goto_stmt.target.value == successor.addr:
+            if successor and isinstance(goto_stmt.target, ailment.Expr.Const) \
+                    and goto_stmt.target.value == successor.addr:
                 # we can remove this statement
                 block.statements = block.statements[:-1]
 

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -581,7 +581,7 @@ class StructuredCodeGenerator(Analysis):
     def _handle_Loop(self, loop_node):
 
         if loop_node.sort == 'while':
-            return CWhileLoop(self._handle(loop_node.condition),
+            return CWhileLoop(None if loop_node.condition is None else self._handle(loop_node.condition),
                               self._handle(loop_node.sequence_node)
                               )
         elif loop_node.sort == 'do-while':

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -510,6 +510,7 @@ class StructuredCodeGenerator(Analysis):
             Expr.BinaryOp: self._handle_Expr_BinaryOp,
             Expr.Convert: self._handle_Expr_Convert,
             Expr.StackBaseOffset: self._handle_Expr_StackBaseOffset,
+            Expr.DirtyExpression: self._handle_Expr_Dirty,
         }
 
         self._analyze()
@@ -744,6 +745,9 @@ class StructuredCodeGenerator(Analysis):
             raise UnsupportedNodeTypeError("Unsupported conversion bits %s." % expr.to_bits)
 
         return CTypeCast(None, dst_type, self._handle(expr.operand))
+
+    def _handle_Expr_Dirty(self, expr):
+        return expr
 
     def _handle_Expr_StackBaseOffset(self, expr):  # pylint:disable=no-self-use
 

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -743,6 +743,8 @@ class StructuredCodeGenerator(Analysis):
             dst_type = SimTypeShort()
         elif expr.to_bits == 8:
             dst_type = SimTypeChar()
+        elif expr.to_bits == 1:
+            dst_type = SimTypeChar()  # FIXME: Add a SimTypeBit?
         else:
             raise UnsupportedNodeTypeError("Unsupported conversion bits %s." % expr.to_bits)
 

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -84,8 +84,8 @@ class CAILBlock(CStatement):
         r = str(self.block)
 
         indent_str = self.indent_str(indent=indent)
-        for l in r.split("\n"):
-            lines.append(indent_str + l)
+        for line in r.split("\n"):
+            lines.append(indent_str + line)
 
         return "\n".join(lines)
 
@@ -94,7 +94,6 @@ class CLoop(CStatement):  # pylint:disable=abstract-method
     """
     Represents a loop in C.
     """
-    pass
 
 
 class CWhileLoop(CLoop):
@@ -327,7 +326,8 @@ class CExpression:
     def c_repr(self):
         raise NotImplementedError()
 
-    def _try_c_repr(self, expr):
+    @staticmethod
+    def _try_c_repr(expr):
         if hasattr(expr, 'c_repr'):
             return expr.c_repr()
         else:
@@ -569,8 +569,6 @@ class StructuredCodeGenerator(Analysis):
 
     def _handle_Loop(self, loop_node):
 
-        lines = [ ]
-
         if loop_node.sort == 'while':
             return CWhileLoop(self._handle(loop_node.condition),
                               self._handle(loop_node.sequence_node)
@@ -685,7 +683,7 @@ class StructuredCodeGenerator(Analysis):
     # AIL expression handlers
     #
 
-    def _handle_Expr_Register(self, expr):
+    def _handle_Expr_Register(self, expr):  # pylint:disable=no-self-use
 
         return expr
 
@@ -698,12 +696,12 @@ class StructuredCodeGenerator(Analysis):
 
         return CVariable(variable, offset=offset)
 
-    def _handle_Expr_Tmp(self, expr):
+    def _handle_Expr_Tmp(self, expr):  # pylint:disable=no-self-use
 
         l.warning("FIXME: Leftover Tmp expressions are found.")
         return CVariable(SimTemporaryVariable(expr.tmp_idx))
 
-    def _handle_Expr_Const(self, expr):
+    def _handle_Expr_Const(self, expr):  # pylint:disable=no-self-use
 
         return expr.value
 
@@ -734,7 +732,7 @@ class StructuredCodeGenerator(Analysis):
 
         return CTypeCast(None, dst_type, self._handle(expr.operand))
 
-    def _handle_Expr_StackBaseOffset(self, expr):
+    def _handle_Expr_StackBaseOffset(self, expr):  # pylint:disable=no-self-use
 
         if hasattr(expr, 'referenced_variable') and expr.referenced_variable is not None:
             return CUnaryOp('Reference', expr, referenced_variable=expr.referenced_variable)

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -1,11 +1,22 @@
 
-from ailment import Block
+import logging
 
+from ailment import Block, Expr, Stmt
+
+from ...sim_type import SimTypeLongLong, SimTypeInt, SimTypeShort, SimTypeChar, SimTypePointer
+from ...sim_variable import SimVariable, SimTemporaryVariable
 from .. import Analysis, register_analysis
 from .region_identifier import MultiNode
 from .structurer import SequenceNode, CodeNode, ConditionNode, ConditionalBreakNode, LoopNode
 
+
+l = logging.getLogger(name=__name__)
+
 INDENT_DELTA = 4
+
+
+class UnsupportedNodeTypeError(NotImplementedError):
+    pass
 
 
 class CConstruct:
@@ -107,14 +118,47 @@ class CWhileLoop(CLoop):
             # while(true)
             lines.append(indent_str + 'while(true)')
             lines.append(indent_str + '{')
-            lines.append(indent_str + self.body.c_repr(indent=indent + INDENT_DELTA))
+            lines.append(self.body.c_repr(indent=indent + INDENT_DELTA))
             lines.append(indent_str + '}')
         else:
             # while(cond)
-            lines.append(indent_str + 'while(%s)' % repr(self.condition))
+            lines.append(indent_str + 'while(%s)' % self.condition.c_repr())
             lines.append(indent_str + '{')
-            lines.append(indent_str + self.body.c_repr(indent=indent + INDENT_DELTA))
+            lines.append(self.body.c_repr(indent=indent + INDENT_DELTA))
             lines.append(indent_str + '}')
+
+        return "\n".join(lines)
+
+
+class CDoWhileLoop(CLoop):
+    """
+    Represents a do-while loop in C.
+    """
+    def __init__(self, condition, body):
+
+        super().__init__()
+
+        self.condition = condition
+        self.body = body
+
+    def c_repr(self, indent=0):
+
+        indent_str = self.indent_str(indent=indent)
+
+        lines = [ ]
+
+        if self.condition is None:
+            # do-while true
+            lines.append(indent_str + 'do')
+            lines.append(indent_str + '{')
+            lines.append(self.body.c_repr(indent=indent + INDENT_DELTA))
+            lines.append(indent_str + '} while(true);')
+        else:
+            # do-while(cond)
+            lines.append(indent_str + 'do')
+            lines.append(indent_str + '{')
+            lines.append(self.body.c_repr(indent=indent + INDENT_DELTA))
+            lines.append(indent_str + '} while(%s);' % (self.condition.c_repr()))
 
         return "\n".join(lines)
 
@@ -139,7 +183,7 @@ class CIfElse(CStatement):
         indent_str = self.indent_str(indent=indent)
 
         lines = [
-            indent_str + "if (%s)" % self.condition,
+            indent_str + "if (%s)" % self.condition.c_repr(),
             indent_str + "{",
         ]
 
@@ -196,23 +240,308 @@ class CAssignment(CStatement):
 
         indent_str = self.indent_str(indent=indent)
 
-        return indent_str + "%s = %s;" % (self.lhs, self.rhs)
+        lhs_str = str(self.lhs)
+        if isinstance(self.lhs, SimVariable):
+            lhs_str = self.lhs.name
+
+        rhs_str = str(self.rhs)
+        if hasattr(self.rhs, 'c_repr'):
+            rhs_str = self.rhs.c_repr()
+
+        return indent_str + "%s = %s;" % (lhs_str, rhs_str)
+
+
+class CFunctionCall(CStatement):
+    """
+    func(arg0, arg1)
+
+    :ivar Function callee_func:  The function getting called.
+    """
+    def __init__(self, callee_target, callee_func, args, returning=True):
+        super().__init__()
+
+        self.callee_target = callee_target
+        self.callee_func = callee_func
+        self.args = args if args is not None else [ ]
+        self.returning = returning
+
+    def c_repr(self, indent=0):
+
+        indent_str = self.indent_str(indent=indent)
+
+        if self.callee_func is not None:
+            func_name = self.callee_func.name
+        else:
+            func_name = str(self.callee_target)
+
+        args_list = [ ]
+        for arg in self.args:
+            if isinstance(arg, SimVariable):
+                arg_str = arg.name
+            elif isinstance(arg, CExpression):
+                arg_str = arg.c_repr()
+            else:
+                arg_str = str(arg)
+            args_list.append(arg_str)
+        args_str = ", ".join(args_list)
+
+        return indent_str + "%s(%s);%s" % (func_name, args_str, " /* do not return */" if not self.returning else "")
+
+
+class CReturn(CStatement):
+    def __init__(self, retval):
+        super().__init__()
+
+        self.retval = retval
+
+    def c_repr(self, indent=0):
+
+        indent_str = self.indent_str(indent=indent)
+
+        if self.retval is None:
+            return indent_str + "return;"
+        else:
+            return indent_str + "return %s;" % (self.retval.c_repr())
+
+
+class CUnsupportedStatement(CStatement):
+    """
+    A wrapper for unsupported AIL statement.
+    """
+    def __init__(self, stmt):
+        super().__init__()
+
+        self.stmt = stmt
+
+    def c_repr(self, indent=0):
+
+        indent_str = self.indent_str(indent=indent)
+
+        return indent_str + str(self.stmt)
+
+
+class CExpression:
+    """
+    Base class for C expressions.
+    """
+    def c_repr(self):
+        raise NotImplementedError()
+
+    def _try_c_repr(self, expr):
+        if hasattr(expr, 'c_repr'):
+            return expr.c_repr()
+        else:
+            return str(expr)
+
+
+class CVariable(CExpression):
+    """
+    Read value from a variable.
+    """
+    def __init__(self, variable, offset=None):
+        self.variable = variable
+        self.offset = offset
+
+    def c_repr(self):
+        if self.offset is None:
+            if isinstance(self.variable, SimVariable):
+                return self.variable.name
+            else:
+                return str(self.variable)
+        else:
+            if isinstance(self.variable, SimVariable):
+                return "*(%s[%d])" % (self.variable.name, self.offset)
+            elif isinstance(self.variable, CExpression):
+                return "*(%s:%d)" % (self.variable.c_repr(), self.offset)
+            elif isinstance(self.variable, Expr.Register):
+                return "%s:%x" % (self.variable.reg_name if hasattr(self.variable, 'reg_name') else self.variable,
+                                   self.offset)
+            else:
+                return "*(%s:%d)" % (self.variable, self.offset)
+
+
+class CUnaryOp(CExpression):
+    """
+    Unary operations.
+    """
+    def __init__(self, op, operand, referenced_variable):
+
+        self.op = op
+        self.operand = operand
+        self.referenced_variable = referenced_variable
+
+    def c_repr(self):
+        if self.referenced_variable is not None:
+            return "&%s" % self.referenced_variable.name
+
+        OP_MAP = {
+            'Not': self._c_repr_not,
+        }
+
+        handler = OP_MAP.get(self.op, None)
+        if handler is not None:
+            return handler()
+        return "UnaryOp %s" % (self.op)
+
+    #
+    # Handlers
+    #
+
+    def _c_repr_not(self):
+        return "!(%s)" % (self.operand.c_repr())
+
+
+class CBinaryOp(CExpression):
+    """
+    Binary operations.
+    """
+    def __init__(self, op, lhs, rhs, referenced_variable):
+
+        self.op = op
+        self.lhs = lhs
+        self.rhs = rhs
+        self.referenced_variable = referenced_variable
+
+    def c_repr(self):
+
+        if self.referenced_variable is not None:
+            return "&%s" % self.referenced_variable.name
+
+        OP_MAP = {
+            'Add': self._c_repr_add,
+            'Sub': self._c_repr_sub,
+            'Xor': self._c_repr_xor,
+            'CmpLE': self._c_repr_cmple,
+            'CmpEQ': self._c_repr_cmpeq,
+        }
+
+        handler = OP_MAP.get(self.op, None)
+        if handler is not None:
+            return handler()
+        return "BinaryOp %s" % (self.op)
+
+    #
+    # Handlers
+    #
+
+    def _c_repr_add(self):
+        return "%s + %s" % (self._try_c_repr(self.lhs), self._try_c_repr(self.rhs))
+
+    def _c_repr_sub(self):
+        return "%s - %s" % (self._try_c_repr(self.lhs), self._try_c_repr(self.rhs))
+
+    def _c_repr_xor(self):
+        return "%s ^ %s" % (self._try_c_repr(self.lhs), self._try_c_repr(self.rhs))
+
+    def _c_repr_cmple(self):
+        return "%s <= %s" % (self._try_c_repr(self.lhs), self._try_c_repr(self.rhs))
+
+    def _c_repr_cmpeq(self):
+        return "%s == %s" % (self._try_c_repr(self.lhs), self._try_c_repr(self.rhs))
+
+
+class CTypeCast(CExpression):
+    def __init__(self, src_type, dst_type, expr):
+        self.src_type = src_type
+        self.dst_type = dst_type
+        self.expr = expr
+
+    def c_repr(self):
+        expr_str = str(self.expr) if not isinstance(self.expr, CExpression) else self.expr.c_repr()
+        return "(%s)%s" % (self.dst_type, expr_str)
+
+
+class CConstant(CExpression):
+    def __init__(self, value, type_, reference_values=None):
+        self.value = value
+        self.type = type_
+        self.reference_values = reference_values
+
+    def c_repr(self):
+        if self.reference_values is not None and self.type is not None:
+            if self.type in self.reference_values:
+                if isinstance(self.type, SimTypeInt):
+                    return hex(self.reference_values[self.type])
+                elif isinstance(self.type, SimTypePointer) and isinstance(self.type.pts_to, SimTypeChar):
+                    refval = self.reference_values[self.type]  # angr.analyses.cfg.MemoryData
+                    return '"' + refval.content.decode('utf-8') + '"'
+                else:
+                    return self.reference_values[self.type]
+
+        return str(self.value)
 
 
 class StructuredCodeGenerator(Analysis):
-    def __init__(self, sequence):
+    def __init__(self, func, sequence, indent=0, cfg=None):
+        self._func = func
         self._sequence = sequence
+        self._cfg = cfg
 
         self.text = None
+        self._indent = indent
+
+        self._handlers = {
+            SequenceNode: self._handle_Sequence,
+            CodeNode: self._handle_Code,
+            LoopNode: self._handle_Loop,
+            ConditionNode: self._handle_Condition,
+            ConditionalBreakNode: self._handle_ConditionalBreak,
+            MultiNode: self._handle_MultiNode,
+            Block: self._handle_AILBlock,
+            # AIL statements
+            Stmt.Store: self._handle_Stmt_Store,
+            Stmt.Assignment: self._handle_Stmt_Assignment,
+            Stmt.Call: self._handle_Stmt_Call,
+            # AIL expressions
+            Expr.Register: self._handle_Expr_Register,
+            Expr.Load: self._handle_Expr_Load,
+            Expr.Tmp: self._handle_Expr_Tmp,
+            Expr.Const: self._handle_Expr_Const,
+            Expr.UnaryOp: self._handle_Expr_UnaryOp,
+            Expr.BinaryOp: self._handle_Expr_BinaryOp,
+            Expr.Convert: self._handle_Expr_Convert,
+            Expr.StackBaseOffset: self._handle_Expr_StackBaseOffset,
+        }
 
         self._analyze()
 
     def _analyze(self):
 
         obj = self._handle(self._sequence)
-        text = obj.c_repr()
+        func_header = self._function_header_repr()
+        func_body = obj.c_repr(indent=self._indent + INDENT_DELTA)
 
-        self.text = text
+        self.text = func_header + "\n{\n" + func_body + "\n}\n"
+
+    def _function_header_repr(self):
+        """
+        Generate text for function header.
+
+        :return:    Text for the function header.
+        :rtype:     str
+        """
+
+        return "void %s()" % (self._func.name)
+
+    #
+    # Util methods
+    #
+
+    def _parse_load_addr(self, addr):
+        expr = self._handle(addr)
+
+        if isinstance(expr, CBinaryOp):
+            if expr.op in ("Add", "Sub"):
+                lhs, rhs = expr.lhs, expr.rhs
+                if isinstance(expr.lhs, int) and not isinstance(expr.rhs, int):
+                    # swap lhs and rhs
+                    lhs, rhs = rhs, lhs
+                if expr.op == "Sub":
+                    return lhs, -rhs
+                return lhs, rhs
+
+
+        raise NotImplementedError("Unsupported address %s." % addr)
 
     #
     # Handlers
@@ -220,22 +549,10 @@ class StructuredCodeGenerator(Analysis):
 
     def _handle(self, node):
 
-        if type(node) is SequenceNode:
-            return self._handle_Sequence(node)
-        elif type(node) is CodeNode:
-            return self._handle_Code(node)
-        elif type(node) is LoopNode:
-            return self._handle_Loop(node)
-        elif type(node) is ConditionNode:
-            return self._handle_Condition(node)
-        elif type(node) is ConditionalBreakNode:
-            return self._handle_ConditionalBreak(node)
-        elif type(node) is MultiNode:
-            return self._handle_MultiNode(node)
-        elif type(node) is Block:
-            return self._handle_AILBlock(node)
-        else:
-            raise Exception("Node type %s is not supported yet." % type(node))
+        handler = self._handlers.get(node.__class__, None)
+        if handler is not None:
+            return handler(node)
+        raise UnsupportedNodeTypeError("Node type %s is not supported yet." % type(node))
 
     def _handle_Code(self, code):
 
@@ -255,28 +572,20 @@ class StructuredCodeGenerator(Analysis):
         lines = [ ]
 
         if loop_node.sort == 'while':
-            return CWhileLoop(loop_node.condition,
+            return CWhileLoop(self._handle(loop_node.condition),
                               self._handle(loop_node.sequence_node)
                               )
         elif loop_node.sort == 'do-while':
-            # TODO: FIXME
-
-            if loop_node.condition is None:
-                raise NotImplementedError()
-            else:
-                lines.append('do')
-                lines.append('{')
-                lines.extend(self._handle(loop_node.sequence_node))
-                lines.append('} while(%s);' % repr(loop_node.condition))
-
-            return lines
+            return CDoWhileLoop(self._handle(loop_node.condition),
+                                self._handle(loop_node.sequence_node)
+                                )
 
         else:
             raise NotImplementedError()
 
     def _handle_Condition(self, condition_node):
 
-        code = CIfElse(condition_node.condition,
+        code = CIfElse(self._handle(condition_node.condition),
                        true_node=self._handle(condition_node.true_node) if condition_node.true_node else None,
                        false_node=self._handle(condition_node.false_node) if condition_node.false_node else None,
                        )
@@ -296,8 +605,141 @@ class StructuredCodeGenerator(Analysis):
 
         return CStatements(lines) if len(lines) > 1 else lines[0]
 
-    def _handle_AILBlock(self, node):  # pylint:disable=no-self-use
+    def _handle_AILBlock(self, node):
+        """
 
-        return CStatements([ CAILBlock(node) ])
+        :param Block node:
+        :return:
+        """
+
+        # return CStatements([ CAILBlock(node) ])
+        cstmts = [ ]
+        for stmt in node.statements:
+            try:
+                cstmt = self._handle(stmt)
+            except UnsupportedNodeTypeError:
+                l.warning("Unsupported AIL statement or expression %s.", type(stmt), exc_info=True)
+                cstmt = CUnsupportedStatement(stmt)
+            cstmts.append(cstmt)
+
+        return CStatements(cstmts)
+
+    #
+    # AIL statement handlers
+    #
+
+    def _handle_Stmt_Store(self, stmt):
+
+        # cvariable = self._handle(stmt.variable)
+        cvariable = stmt.variable
+        cdata = self._handle(stmt.data)
+
+        return CAssignment(cvariable, cdata)
+
+    def _handle_Stmt_Assignment(self, stmt):
+
+        cdst = stmt.dst
+        csrc = self._handle(stmt.src)
+
+        return CAssignment(cdst, csrc)
+
+    def _handle_Stmt_Call(self, stmt):
+
+        try:
+            # Try to handle it as a normal function call
+            target = self._handle(stmt.target)
+        except UnsupportedNodeTypeError:
+            target = stmt.target
+
+        if isinstance(target, int):
+            target_func = self.kb.functions.function(addr=target)
+        else:
+            target_func = None
+
+        args = [ ]
+        if target_func.prototype is not None:
+            for i, arg in enumerate(stmt.args):
+                if i < len(target_func.prototype.args):
+                    type_ = target_func.prototype.args[i].with_arch(self.project.arch)
+                else:
+                    type_ = None
+                reference_values = { }
+                if isinstance(arg, Expr.Const):
+                    if isinstance(type_, SimTypePointer) and isinstance(type_.pts_to, SimTypeChar):
+                        # char*
+                        # Try to get a string
+                        if self._cfg is not None:
+                            if arg.value in self._cfg.memory_data and self._cfg.memory_data[arg.value].sort == 'string':
+                                reference_values[type_] = self._cfg.memory_data[arg.value]
+                    elif isinstance(type_, SimTypeInt):
+                        # int
+                        reference_values[type_] = arg.value
+                    new_arg = CConstant(arg, type_, reference_values if reference_values else None)
+                else:
+                    new_arg = arg
+                args.append(new_arg)
+
+        return CFunctionCall(target, target_func, args, returning=target_func.returning)
+
+    #
+    # AIL expression handlers
+    #
+
+    def _handle_Expr_Register(self, expr):
+
+        return expr
+
+    def _handle_Expr_Load(self, expr):
+
+        if hasattr(expr, 'variable') and expr.variable is not None:
+            return CVariable(expr.variable)
+
+        variable, offset = self._parse_load_addr(expr.addr)
+
+        return CVariable(variable, offset=offset)
+
+    def _handle_Expr_Tmp(self, expr):
+
+        l.warning("FIXME: Leftover Tmp expressions are found.")
+        return CVariable(SimTemporaryVariable(expr.tmp_idx))
+
+    def _handle_Expr_Const(self, expr):
+
+        return expr.value
+
+    def _handle_Expr_UnaryOp(self, expr):
+
+        return CUnaryOp(expr.op, self._handle(expr.operand),
+                        referenced_variable=expr.referenced_variable if hasattr(expr, 'referenced_variable') else None
+                        )
+
+    def _handle_Expr_BinaryOp(self, expr):
+
+        return CBinaryOp(expr.op, self._handle(expr.operands[0]), self._handle(expr.operands[1]),
+                         referenced_variable=expr.referenced_variable if hasattr(expr, 'referenced_variable') else None
+                         )
+
+    def _handle_Expr_Convert(self, expr):
+
+        if expr.to_bits == 64:
+            dst_type = SimTypeLongLong()
+        elif expr.to_bits == 32:
+            dst_type = SimTypeInt()
+        elif expr.to_bits == 16:
+            dst_type = SimTypeShort()
+        elif expr.to_bits == 8:
+            dst_type = SimTypeChar()
+        else:
+            raise UnsupportedNodeTypeError("Unsupported conversion bits %s." % expr.to_bits)
+
+        return CTypeCast(None, dst_type, self._handle(expr.operand))
+
+    def _handle_Expr_StackBaseOffset(self, expr):
+
+        if hasattr(expr, 'referenced_variable') and expr.referenced_variable is not None:
+            return CUnaryOp('Reference', expr, referenced_variable=expr.referenced_variable)
+
+        return expr
+
 
 register_analysis(StructuredCodeGenerator, 'StructuredCodeGenerator')

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -666,7 +666,7 @@ class StructuredCodeGenerator(Analysis):
             target_func = None
 
         args = [ ]
-        if target_func.prototype is not None:
+        if target_func is not None and target_func.prototype is not None:
             for i, arg in enumerate(stmt.args):
                 if i < len(target_func.prototype.args):
                     type_ = target_func.prototype.args[i].with_arch(self.project.arch)
@@ -688,7 +688,9 @@ class StructuredCodeGenerator(Analysis):
                     new_arg = arg
                 args.append(new_arg)
 
-        return CFunctionCall(target, target_func, args, returning=target_func.returning)
+        return CFunctionCall(target, target_func, args,
+                             returning=target_func.returning if target_func is not None else True
+                             )
 
     #
     # AIL expression handlers

--- a/angr/analyses/decompiler/structurer.py
+++ b/angr/analyses/decompiler/structurer.py
@@ -346,7 +346,7 @@ class Structurer(Analysis):
             # it's an endless loop
             first_node = loop_node.sequence_node.nodes[0]
             if type(first_node) is ConditionalBreakNode:
-                while_cond = ailment.Expr.UnaryOp(0, 'Not', first_node.condition)
+                while_cond = Structurer._negate_cond(first_node.condition)
                 new_seq = loop_node.sequence_node.copy()
                 new_seq.nodes = new_seq.nodes[1:]
                 new_loop_node = LoopNode('while', while_cond, new_seq, addr=loop_node.addr)
@@ -362,7 +362,7 @@ class Structurer(Analysis):
             # it's an endless loop
             last_node = loop_node.sequence_node.nodes[-1]
             if type(last_node) is ConditionalBreakNode:
-                while_cond = ailment.Expr.UnaryOp(0, 'Not', last_node.condition)
+                while_cond = Structurer._negate_cond(last_node.condition)
                 new_seq = loop_node.sequence_node.copy()
                 new_seq.nodes = new_seq.nodes[:-1]
                 new_loop_node = LoopNode('do-while', while_cond, new_seq)
@@ -635,6 +635,13 @@ class Structurer(Analysis):
         var = claripy.BoolS('structurer-cond_%#x_%s' % (block.addr, repr(condition)), explicit_name=True)
         self._condition_mapping[var] = condition
         return var
+
+    @staticmethod
+    def _negate_cond(cond):
+        if isinstance(cond, ailment.Expr.UnaryOp) and cond.op == 'Not':
+            # Unpacck it
+            return cond.operand
+        return ailment.Expr.UnaryOp(0, 'Not', cond)
 
 
 register_analysis(RecursiveStructurer, 'RecursiveStructurer')

--- a/angr/analyses/decompiler/structurer.py
+++ b/angr/analyses/decompiler/structurer.py
@@ -610,7 +610,8 @@ class Structurer(Analysis):
         else:
             raise NotImplementedError()
 
-    def _extract_jump_targets(self, stmt):
+    @staticmethod
+    def _extract_jump_targets(stmt):
         """
         Extract goto targets from a Jump or a ConditionalJump statement.
 

--- a/angr/analyses/decompiler/structurer.py
+++ b/angr/analyses/decompiler/structurer.py
@@ -122,14 +122,18 @@ class ConditionNode:
 
 
 class LoopNode:
-    def __init__(self, sort, condition, sequence_node):
+    def __init__(self, sort, condition, sequence_node, addr=None):
         self.sort = sort
         self.condition = condition
         self.sequence_node = sequence_node
+        self._addr = addr
 
     @property
     def addr(self):
-        return self.sequence_node.addr
+        if self._addr is None:
+            return self.sequence_node.addr
+        else:
+            return self._addr
 
 
 class BreakNode:
@@ -314,7 +318,7 @@ class Structurer(Analysis):
         loop_body = self._to_loop_body_sequence(loop_head, loop_subgraph, loop_successors)
 
         # create a while(true) loop with sequence node being the loop body
-        loop_node = LoopNode('while', None, loop_body)
+        loop_node = LoopNode('while', None, loop_body, addr=loop_head.addr)
 
         return loop_node
 
@@ -344,7 +348,7 @@ class Structurer(Analysis):
                 while_cond = ailment.Expr.UnaryOp(0, 'Not', first_node.condition)
                 new_seq = loop_node.sequence_node.copy()
                 new_seq.nodes = new_seq.nodes[1:]
-                new_loop_node = LoopNode('while', while_cond, new_seq)
+                new_loop_node = LoopNode('while', while_cond, new_seq, addr=loop_node.addr)
 
                 return True, new_loop_node
 

--- a/angr/analyses/forward_analysis.py
+++ b/angr/analyses/forward_analysis.py
@@ -292,7 +292,7 @@ class SingleNodeGraphVisitor(GraphVisitor):
 #
 
 
-class JobInfo(object):
+class JobInfo:
     """
     Stores information of each job.
     """
@@ -352,7 +352,7 @@ class JobInfo(object):
         self.jobs.append((job, job_type))
 
 
-class ForwardAnalysis(object):
+class ForwardAnalysis:
     """
     This is my very first attempt to build a static forward analysis framework that can serve as the base of multiple
     static analyses in angr, including CFG analysis, VFG analysis, DDG, etc.

--- a/angr/analyses/reaching_definitions/atoms.py
+++ b/angr/analyses/reaching_definitions/atoms.py
@@ -55,7 +55,7 @@ class MemoryLocation(Atom):
         self.size = size
 
     def __repr__(self):
-        return "<Mem %#x<%d>>" % (self.addr, self.size)
+        return "<Mem %s<%d>>" % (hex(self.addr) if type(self.addr) is int else self.addr, self.size)
 
     @property
     def bits(self):

--- a/angr/analyses/reaching_definitions/dataset.py
+++ b/angr/analyses/reaching_definitions/dataset.py
@@ -64,7 +64,7 @@ class DataSet(object):
 
         for s in self:
             if type(s) is Undefined:
-                res.add(Undefined())
+                res.add(Undefined(s.bits))
             else:
                 try:
                     tmp = op(s)
@@ -72,7 +72,7 @@ class DataSet(object):
                         tmp &= self._mask
                     res.add(tmp)
                 except TypeError as e:
-                    res.add(Undefined())
+                    res.add(Undefined(self._bits))
                     l.warning(e)
 
         return DataSet(res, self._bits)
@@ -88,7 +88,7 @@ class DataSet(object):
         for o in other:
             for s in self:
                 if type(o) is Undefined or type(s) is Undefined:
-                    res.add(Undefined())
+                    res.add(Undefined(s.bits))
                 else:
                     try:
                         tmp = op(s, o)
@@ -96,7 +96,7 @@ class DataSet(object):
                             tmp &= self._mask
                         res.add(tmp)
                     except TypeError as e:
-                        res.add(Undefined())
+                        res.add(Undefined(self._bits))
                         l.warning(e)
 
         return DataSet(res, self._bits)

--- a/angr/analyses/reaching_definitions/definition.py
+++ b/angr/analyses/reaching_definitions/definition.py
@@ -16,7 +16,7 @@ class Definition:
 
     __slots__ = ('atom', 'codeloc', 'data', 'dummy')
 
-    def __init__(self, atom, codeloc, data, dummy):
+    def __init__(self, atom, codeloc, data, dummy=False):
 
         self.atom = atom
         self.codeloc = codeloc

--- a/angr/analyses/reaching_definitions/definition.py
+++ b/angr/analyses/reaching_definitions/definition.py
@@ -3,12 +3,24 @@ from .atoms import MemoryLocation, Register
 from .dataset import DataSet
 
 
-class Definition(object):
-    def __init__(self, atom, codeloc, data):
+class Definition:
+    """
+    An atom definition.
+
+    :ivar Atom atom:            The atom being defined.
+    :ivar CodeLocation codeloc: Where this definition is created.
+    :ivar data:                 A concrete value (or many concrete values) that the atom holds when the definition is
+                                created.
+    """
+
+    __slots__ = ('atom', 'codeloc', 'data', 'dummy')
+
+    def __init__(self, atom, codeloc, data, dummy):
 
         self.atom = atom
         self.codeloc = codeloc
         self.data = data
+        self.dummy = dummy
 
         # convert everything into a DataSet
         if not isinstance(self.data, DataSet):

--- a/angr/analyses/reaching_definitions/definition.py
+++ b/angr/analyses/reaching_definitions/definition.py
@@ -1,5 +1,6 @@
 
 from .atoms import MemoryLocation, Register
+from .undefined import Undefined
 from .dataset import DataSet
 
 
@@ -23,14 +24,15 @@ class Definition:
         self.dummy = dummy
 
         # convert everything into a DataSet
-        if not isinstance(self.data, DataSet):
+        if not isinstance(self.data, (DataSet, Undefined)):
             self.data = DataSet(self.data, self.data.bits)
 
     def __eq__(self, other):
         return self.atom == other.atom and self.codeloc == other.codeloc and self.data == other.data
 
     def __repr__(self):
-        return 'Definition %#x {Atom: %s, Codeloc: %s, Data: %s}' % (id(self), self.atom, self.codeloc, self.data)
+        return '<Definition {Atom:%s, Codeloc:%s, Data:%s%s}>' % (self.atom, self.codeloc, self.data,
+                                                                  "" if not self.dummy else " dummy")
 
     def __hash__(self):
         return hash((self.atom, self.codeloc, self.data))

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -211,6 +211,9 @@ class SimEngineRDAIL(SimEngineLightAIL):  # pylint:disable=abstract-method
     def _ail_handle_Const(self, expr):
         return DataSet(expr, expr.bits)
 
+    def _ail_handle_StackBaseOffset(self, expr):
+        return SpOffset(self.arch.bits, expr.offset, is_base=False)
+
     #
     # User defined high level statement handlers
     #

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -214,7 +214,7 @@ class SimEngineRDAIL(SimEngineLightAIL):  # pylint:disable=abstract-method
     def _ail_handle_StackBaseOffset(self, expr):
         return SpOffset(self.arch.bits, expr.offset, is_base=False)
 
-    def _ail_handle_DirtyExpression(self, expr):
+    def _ail_handle_DirtyExpression(self, expr):  # pylint:disable=no-self-use
         return expr
 
     #

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -214,6 +214,9 @@ class SimEngineRDAIL(SimEngineLightAIL):  # pylint:disable=abstract-method
     def _ail_handle_StackBaseOffset(self, expr):
         return SpOffset(self.arch.bits, expr.offset, is_base=False)
 
+    def _ail_handle_DirtyExpression(self, expr):
+        return expr
+
     #
     # User defined high level statement handlers
     #

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -45,12 +45,12 @@ class SimEngineRDAIL(SimEngineLightAIL):  # pylint:disable=abstract-method
     def _ail_handle_Stmt(self, stmt):
 
         if self.state.analysis:
-            self.state.analysis.observe(self.ins_addr, stmt, self.block, self.state, OP_BEFORE)
+            self.state.analysis.insn_observe(self.ins_addr, stmt, self.block, self.state, OP_BEFORE)
 
         super(SimEngineRDAIL, self)._ail_handle_Stmt(stmt)
 
         if self.state.analysis:
-            self.state.analysis.observe(self.ins_addr, stmt, self.block, self.state, OP_AFTER)
+            self.state.analysis.insn_observe(self.ins_addr, stmt, self.block, self.state, OP_AFTER)
 
     def _ail_handle_Assignment(self, stmt):
         """

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -72,7 +72,7 @@ class SimEngineRDAIL(SimEngineLightAIL):  # pylint:disable=abstract-method
         dst = stmt.dst
 
         if src is None:
-            src = DataSet(Undefined(), dst.bits)
+            src = DataSet(Undefined(dst.bits), dst.bits)
 
         if type(dst) is ailment.Tmp:
             self.state.kill_and_add_definition(Tmp(dst.tmp_idx), self._codeloc(), src)

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -38,6 +38,15 @@ class SimEngineRDAIL(SimEngineLightAIL):  # pylint:disable=abstract-method
     def _external_codeloc():
         return ExternalCodeLocation()
 
+    @staticmethod
+    def _dataset_unpack(d):
+        if type(d) is DataSet and len(d) == 1:
+            return next(iter(d.data))
+        return d
+
+    def _expr(self, expr):
+        return self._dataset_unpack(super()._expr(expr))
+
     #
     # AIL statement handlers
     #

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -49,12 +49,12 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
     def _handle_Stmt(self, stmt):
 
         if self.state.analysis:
-            self.state.analysis.observe(self.ins_addr, stmt, self.block, self.state, OP_BEFORE)
+            self.state.analysis.insn_observe(self.ins_addr, stmt, self.block, self.state, OP_BEFORE)
 
         super(SimEngineRDVEX, self)._handle_Stmt(stmt)
 
         if self.state.analysis:
-            self.state.analysis.observe(self.ins_addr, stmt, self.block, self.state, OP_AFTER)
+            self.state.analysis.insn_observe(self.ins_addr, stmt, self.block, self.state, OP_AFTER)
 
     # e.g. PUT(rsp) = t2, t2 might include multiple values
     def _handle_Put(self, stmt):

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -165,13 +165,15 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
 
         if tmp in self.tmps:
             return self.tmps[tmp]
-        return DataSet(Undefined(), expr.result_size(self.tyenv))
+        bits = expr.result_size(self.tyenv)
+        return DataSet(Undefined(bits), bits)
 
     # e.g. t0 = GET:I64(rsp), rsp might be defined multiple times
     def _handle_Get(self, expr):
 
         reg_offset = expr.offset
-        size = expr.result_size(self.tyenv)
+        bits = expr.result_size(self.tyenv)
+        size = bits // self.arch.byte_width
 
         # FIXME: size, overlapping
         data = set()
@@ -179,7 +181,7 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
         for current_def in current_defs:
             data.update(current_def.data)
         if len(data) == 0:
-            data.add(Undefined())
+            data.add(Undefined(bits))
         if any(type(d) is Undefined for d in data):
             l.info('Data in register <%s> with offset %d undefined, ins_addr = %#x.',
                    self.arch.register_names[reg_offset], reg_offset, self.ins_addr)
@@ -192,7 +194,8 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
     # caution: Is also called from StoreG
     def _handle_Load(self, expr):
         addr = self._expr(expr.addr)
-        size = expr.result_size(self.tyenv) // 8
+        bits = expr.result_size(self.tyenv)
+        size = bits // self.arch.byte_width
 
         data = set()
         for a in addr:
@@ -215,9 +218,9 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
                 l.info('Memory address undefined, ins_addr = %#x.', self.ins_addr)
 
         if len(data) == 0:
-            data.add(Undefined())
+            data.add(Undefined(bits))
 
-        return DataSet(data, expr.result_size(self.tyenv))
+        return DataSet(data, bits)
 
     # CAUTION: experimental
     def _handle_ITE(self, expr):
@@ -301,18 +304,18 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
         expr_0 = self._expr(arg0)
         expr_1 = self._expr(arg1)
 
-        size = expr.result_size(self.tyenv)
+        bits = expr.result_size(self.tyenv)
         data = set()
         for e0 in expr_0:
             for e1 in expr_1:
                 try:
-                    if e0 >> (size - 1) == 0:
+                    if e0 >> (bits - 1) == 0:
                         head = 0
                     else:
-                        head = ((1 << e1) - 1) << (size - e1)
+                        head = ((1 << e1) - 1) << (bits - e1)
                     data.add(head | (e0 >> e1))
                 except (ValueError, TypeError) as e:
-                    data.add(Undefined())
+                    data.add(Undefined(bits))
                     l.warning(e)
 
         return DataSet(data, expr.result_size(self.tyenv))
@@ -380,7 +383,8 @@ class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
         return DataSet({True, False}, expr.result_size(self.tyenv))
 
     def _handle_CCall(self, expr):
-        return DataSet(Undefined(), expr.result_size(self.tyenv))
+        bits = expr.result_size(self.tyenv)
+        return DataSet(Undefined(bits), bits)
 
     #
     # User defined high level statement handlers

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -8,7 +8,7 @@ from ...calling_conventions import SimRegArg, SimStackArg
 from ...engines.light import SpOffset
 from ...keyed_region import KeyedRegion
 from ...block import Block
-from ...codenode import CodeNode, BlockNode, HookNode
+from ...codenode import CodeNode
 from ...misc.ux import deprecated
 from .. import register_analysis
 from ..analysis import Analysis

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -22,7 +22,7 @@ from ...keyed_region import KeyedRegion
 l = logging.getLogger(name=__name__)
 
 
-class LiveDefinitions(object):
+class LiveDefinitions:
     def __init__(self, arch, loader, track_tmps=False, analysis=None, init_func=False, cc=None, func_addr=None):
 
         # handy short-hands
@@ -346,9 +346,6 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
     #
 
     def _pre_analysis(self):
-        pass
-
-    def _pre_job_handling(self, job):
         pass
 
     def _initial_abstract_state(self, node):

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -4,6 +4,16 @@ from collections import defaultdict
 import ailment
 import pyvex
 
+from ...calling_conventions import SimRegArg, SimStackArg
+from ...engines.light import SpOffset
+from ...keyed_region import KeyedRegion
+from ...block import Block
+from ...codenode import CodeNode
+from ...misc.ux import deprecated
+from .. import register_analysis
+from ..analysis import Analysis
+from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor, SingleNodeGraphVisitor
+from ..code_location import CodeLocation
 from .atoms import Register, MemoryLocation, Tmp, Parameter
 from .constants import OP_BEFORE, OP_AFTER
 from .dataset import DataSet
@@ -12,12 +22,7 @@ from .engine_ail import SimEngineRDAIL
 from .engine_vex import SimEngineRDVEX
 from .undefined import Undefined
 from .uses import Uses
-from .. import register_analysis
-from ..analysis import Analysis
-from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor, SingleNodeGraphVisitor
-from ...calling_conventions import SimRegArg, SimStackArg
-from ...engines.light import SpOffset
-from ...keyed_region import KeyedRegion
+
 
 l = logging.getLogger(name=__name__)
 
@@ -231,7 +236,7 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
 
     def __init__(self, func=None, block=None, func_graph=None, max_iterations=3, track_tmps=False,
                  observation_points=None, init_state=None, init_func=False, cc=None, function_handler=None,
-                 current_local_call_depth=1, maximum_local_call_depth=5):
+                 current_local_call_depth=1, maximum_local_call_depth=5, observe_all=False):
         """
 
         :param angr.knowledge.Function func:    The function to run reaching definition analysis on.
@@ -252,6 +257,7 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
                                                 <ReachingDefinitions>, <Codeloc>, <IP address>).
         :param int current_local_call_depth:    Current local function recursion depth.
         :param int maximum_local_call_depth:    Maximum local function recursion depth.
+        :param bool observa_all:                Observe every statement, both before and after.
         """
 
         if func is not None:
@@ -292,11 +298,13 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
             self._cc = None
             self._func_addr = None
 
+        self._observe_all = observe_all
+
         # sanity check
         if self._observation_points and any(not type(op) is tuple for op in self._observation_points):
             raise ValueError('"observation_points" must be tuples.')
 
-        if type(self) is ReachingDefinitionAnalysis and not self._observation_points:
+        if type(self) is ReachingDefinitionAnalysis and not self._observe_all and not self._observation_points:
             l.warning('No observation point is specified. '
                       'You cannot get any analysis result from performing the analysis.'
                       )
@@ -323,23 +331,53 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
 
         return next(iter(self.observed_results.values()))
 
-    def observe(self, ins_addr, stmt, block, state, ob_type):
-        if self._observation_points is not None and (ins_addr, ob_type) in self._observation_points:
+    @deprecated(replacement="get_reaching_definitions_by_insn")
+    def get_reaching_definitions(self, ins_addr, ob_type):
+        return self.get_reaching_definitions_by_insn(ins_addr, ob_type)
+
+    def get_reaching_definitions_by_insn(self, ins_addr, ob_type):
+
+        key = 'insn', ins_addr, ob_type
+        if key not in self.observed_results:
+            raise KeyError(("Reaching definitions are not available at observation point %s. "
+                            "Did you specify that observation point?") % key)
+
+        return self.observed_results[key]
+
+    def get_reaching_definitions_by_node(self, node_addr, ob_type):
+
+        key = 'node', node_addr, ob_type
+        if key not in self.observed_results:
+            raise KeyError(("Reaching definitions are not available at observation point %s. "
+                            "Did you specify that observation point?") % key)
+
+        return self.observed_results[key]
+
+    def node_observe(self, node_addr, state, ob_type):
+        key = 'node', node_addr, ob_type
+        if self._observe_all or \
+                self._observation_points is not None and key in self._observation_points:
+            self.observed_results[key] = state
+
+    def insn_observe(self, ins_addr, stmt, block, state, ob_type):
+        key = 'insn', ins_addr, ob_type
+        if self._observe_all or \
+                self._observation_points is not None and key in self._observation_points:
             if isinstance(stmt, pyvex.IRStmt.IRStmt):
                 # it's an angr block
                 vex_block = block.vex
                 # OP_BEFORE: stmt has to be IMark
                 if ob_type == OP_BEFORE and type(stmt) is pyvex.IRStmt.IMark:
-                    self.observed_results[(ins_addr, ob_type)] = state.copy()
+                    self.observed_results[key] = state.copy()
                 # OP_AFTER: stmt has to be last stmt of block or next stmt has to be IMark
                 elif ob_type == OP_AFTER:
                     idx = vex_block.statements.index(stmt)
                     if idx == len(vex_block.statements) - 1 or type(
                             vex_block.statements[idx + 1]) is pyvex.IRStmt.IMark:
-                        self.observed_results[(ins_addr, ob_type)] = state.copy()
+                        self.observed_results[key] = state.copy()
             elif isinstance(stmt, ailment.Stmt.Statement):
                 # it's an AIL block
-                self.observed_results[(ins_addr, ob_type)] = state.copy()
+                self.observed_results[key] = state.copy()
 
     #
     # Main analysis routines
@@ -364,12 +402,17 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
             block = node
             block_key = node.addr
             engine = self._engine_ail
-        else:
+        elif isinstance(node, (Block, CodeNode)):
             block = self.project.factory.block(node.addr, node.size, opt_level=0)
             block_key = node.addr
             engine = self._engine_vex
+        else:
+            l.warning("Unsupported node type %s.", node.__class__)
+            return False, state.copy()
 
-        state = state.copy()
+        self.node_observe(node.addr, state, OP_BEFORE)
+
+        state = state.copy()  # type: LiveDefinitions
         state = engine.process(state, block=block, fail_fast=self._fail_fast)
 
         # clear the tmp store
@@ -377,6 +420,15 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
         # state.tmp_definitions.clear()
 
         self._node_iterations[block_key] += 1
+
+        if not self._graph_visitor.successors(node):
+            # no more successors. kill definitions of certain registers
+            codeloc = CodeLocation(node.addr, len(node.statements))
+            state.kill_definitions(Register(self.project.arch.sp_offset, self.project.arch.bytes),
+                                   codeloc)
+            state.kill_definitions(Register(self.project.arch.ip_offset, self.project.arch.bytes),
+                                   codeloc)
+        self.node_observe(node.addr, state, OP_AFTER)
 
         if self._node_iterations[block_key] < self._max_iterations:
             return True, state

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -145,13 +145,13 @@ class LiveDefinitions:
         if data is None:
             data = DataSet(Undefined(), 8)
 
-        self.kill_and_add_definition(atom, code_loc, data)
+        self.kill_and_add_definition(atom, code_loc, data, dummy=True)
 
-    def kill_and_add_definition(self, atom, code_loc, data):
+    def kill_and_add_definition(self, atom, code_loc, data, dummy=False):
         if type(atom) is Register:
-            self._kill_and_add_register_definition(atom, code_loc, data)
+            self._kill_and_add_register_definition(atom, code_loc, data, dummy=dummy)
         elif type(atom) is MemoryLocation:
-            self._kill_and_add_memory_definition(atom, code_loc, data)
+            self._kill_and_add_memory_definition(atom, code_loc, data, dummy=dummy)
         elif type(atom) is Tmp:
             self._add_tmp_definition(atom, code_loc)
         else:
@@ -169,7 +169,7 @@ class LiveDefinitions:
     # Private methods
     #
 
-    def _kill_and_add_register_definition(self, atom, code_loc, data):
+    def _kill_and_add_register_definition(self, atom, code_loc, data, dummy=False):
 
         # FIXME: check correctness
         current_defs = self.register_definitions.get_objects_by_offset(atom.reg_offset)
@@ -180,12 +180,12 @@ class LiveDefinitions:
             if not uses:
                 self._dead_virgin_definitions |= current_defs
 
-        definition = Definition(atom, code_loc, data)
+        definition = Definition(atom, code_loc, data, dummy=dummy)
         # set_object() replaces kill (not implemented) and add (add) in one step
         self.register_definitions.set_object(atom.reg_offset, definition, atom.size)
 
-    def _kill_and_add_memory_definition(self, atom, code_loc, data):
-        definition = Definition(atom, code_loc, data)
+    def _kill_and_add_memory_definition(self, atom, code_loc, data, dummy=False):
+        definition = Definition(atom, code_loc, data, dummy=dummy)
         # set_object() replaces kill (not implemented) and add (add) in one step
         self.memory_definitions.set_object(atom.addr, definition, atom.size)
 

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -148,7 +148,7 @@ class LiveDefinitions:
         """
 
         if data is None:
-            data = DataSet(Undefined(), 8)
+            data = DataSet(Undefined(atom.size), atom.size)
 
         self.kill_and_add_definition(atom, code_loc, data, dummy=True)
 

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -8,7 +8,7 @@ from ...calling_conventions import SimRegArg, SimStackArg
 from ...engines.light import SpOffset
 from ...keyed_region import KeyedRegion
 from ...block import Block
-from ...codenode import CodeNode
+from ...codenode import CodeNode, BlockNode, HookNode
 from ...misc.ux import deprecated
 from .. import register_analysis
 from ..analysis import Analysis
@@ -423,7 +423,12 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
 
         if not self._graph_visitor.successors(node):
             # no more successors. kill definitions of certain registers
-            codeloc = CodeLocation(node.addr, len(node.statements))
+            if isinstance(node, ailment.Block):
+                codeloc = CodeLocation(node.addr, len(node.statements))
+            elif isinstance(node, Block):
+                codeloc = CodeLocation(node.addr, len(node.vex.statements))
+            else: #if isinstance(node, CodeNode):
+                codeloc = CodeLocation(node.addr, 0)
             state.kill_definitions(Register(self.project.arch.sp_offset, self.project.arch.bytes),
                                    codeloc)
             state.kill_definitions(Register(self.project.arch.ip_offset, self.project.arch.bytes),

--- a/angr/analyses/reaching_definitions/undefined.py
+++ b/angr/analyses/reaching_definitions/undefined.py
@@ -1,8 +1,9 @@
 class Undefined:
 
-    __slots__ = ('_type', '_meta')
+    __slots__ = ('bits', '_type', '_meta')
 
-    def __init__(self, type_=None, meta=None):
+    def __init__(self, bits, type_=None, meta=None):
+        self.bits = bits
         self._type = type_
         self._meta = meta
 
@@ -61,11 +62,12 @@ class Undefined:
 
     def __eq__(self, other):
         return type(other) is Undefined and \
+               self.bits == other.bits and \
                self._type == other.type_ and \
                self._meta == other.meta
 
     def __hash__(self):
-        return hash((self._type, self._meta))
+        return hash(('undefined', self.bits, self._type, self._meta))
 
     def __str__(self):
         type_ = (', type=%s' % self._type) if self._type is not None else ''

--- a/angr/analyses/reaching_definitions/undefined.py
+++ b/angr/analyses/reaching_definitions/undefined.py
@@ -1,11 +1,14 @@
-class Undefined(object):
+class Undefined:
+
+    __slots__ = ('_type', '_meta')
+
     def __init__(self, type_=None, meta=None):
-        self._type_ = type_
+        self._type = type_
         self._meta = meta
 
     @property
     def type_(self):
-        return self._type_
+        return self._type
 
     @property
     def meta(self):
@@ -58,13 +61,16 @@ class Undefined(object):
 
     def __eq__(self, other):
         return type(other) is Undefined and \
-               self._type_ == other.type_ and \
+               self._type == other.type_ and \
                self._meta == other.meta
 
     def __hash__(self):
-        return hash((self._type_, self._meta))
+        return hash((self._type, self._meta))
 
     def __str__(self):
-        type_ = (', type=%s' % self._type_) if self._type_ is not None else ''
+        type_ = (', type=%s' % self._type) if self._type is not None else ''
         meta = ', meta=%s' % self._meta if self._meta is not None else ''
         return '<Undef%s%s>' % (type_, meta)
+
+    def __repr__(self):
+        return "<Undefined>"

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -1,6 +1,7 @@
 
 # pylint:disable=abstract-method
 
+from collections import defaultdict
 import logging
 
 import pyvex
@@ -14,23 +15,33 @@ from .forward_analysis import ForwardAnalysis, FunctionGraphVisitor
 _l = logging.getLogger(name=__name__)
 
 
+LOC_BEFORE = 0
+LOC_AFTER = 1
+
+
 class StackPointerState:
 
-    __slots__ = ['block_addr', 'sp_offset_in', 'sp_offset_out']
+    __slots__ = ('block_addr', 'sp_offset_in', 'sp_offset_out', 'bp_offset_in', 'bp_offset_out', )
 
-    def __init__(self, block_addr : int, sp_offset_in : int=0, sp_offset_out : int=0):
+    def __init__(self, block_addr : int, sp_offset_in : int=0, sp_offset_out : int=0, bp_offset_in : int=None,
+                 bp_offset_out : int=None):
         self.block_addr = block_addr
         self.sp_offset_in = sp_offset_in
         self.sp_offset_out = sp_offset_out
+        self.bp_offset_in = bp_offset_in
+        self.bp_offset_out = bp_offset_out
 
     def __eq__(self, other):
         return isinstance(other, StackPointerState) and \
             self.block_addr == other.block_addr and \
             self.sp_offset_in == other.sp_offset_in and \
-            self.sp_offset_out == other.sp_offset_out
+            self.sp_offset_out == other.sp_offset_out and \
+            self.bp_offset_in == other.bp_offset_in and \
+            self.bp_offset_out == other.bp_offset_out
 
     def copy(self):
-        return StackPointerState(self.block_addr, self.sp_offset_in, self.sp_offset_out)
+        return StackPointerState(self.block_addr, sp_offset_in=self.sp_offset_in, sp_offset_out=self.sp_offset_out,
+                                 bp_offset_in=self.bp_offset_in, bp_offset_out=self.bp_offset_out)
 
 
 class StackPointerTracker(Analysis, ForwardAnalysis):
@@ -54,7 +65,9 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
 
         self._func = func
         self._states = { }
-        self._insn_to_sp_offset = { }
+        self._insn_to_sp_offset = defaultdict(dict)
+        self._insn_to_bp_offset = defaultdict(dict)
+        self.sp_inconsistent = False
 
         self._analyze()
 
@@ -68,10 +81,43 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
             return None
         return self._states[block_addr].sp_offset_in
 
+    def bp_offset_out(self, block_addr):
+        if block_addr not in self._states:
+            return None
+        return self._states[block_addr].bp_offset_out
+
+    def bp_offset_in(self, block_addr):
+        if block_addr not in self._states:
+            return None
+        return self._states[block_addr].bp_offset_in
+
+    def insn_sp_offset_in(self, insn_addr):
+        if insn_addr not in self._insn_to_sp_offset:
+            return None
+        if LOC_BEFORE not in self._insn_to_sp_offset[insn_addr]:
+            return None
+        return self._insn_to_sp_offset[insn_addr][LOC_BEFORE]
+
     def insn_sp_offset_out(self, insn_addr):
         if insn_addr not in self._insn_to_sp_offset:
             return None
-        return self._insn_to_sp_offset[insn_addr]
+        if LOC_AFTER not in self._insn_to_sp_offset[insn_addr]:
+            return None
+        return self._insn_to_sp_offset[insn_addr][LOC_AFTER]
+
+    def insn_bp_offset_in(self, insn_addr):
+        if insn_addr not in self._insn_to_bp_offset:
+            return None
+        if LOC_BEFORE not in self._insn_to_bp_offset[insn_addr]:
+            return None
+        return self._insn_to_bp_offset[insn_addr][LOC_BEFORE]
+
+    def insn_bp_offset_out(self, insn_addr):
+        if insn_addr not in self._insn_to_bp_offset:
+            return None
+        if LOC_AFTER not in self._insn_to_bp_offset[insn_addr]:
+            return None
+        return self._insn_to_bp_offset[insn_addr][LOC_AFTER]
 
     #
     # Overridable methods
@@ -94,19 +140,33 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
         block = self.project.factory.block(node.addr, size=node.size)
 
         sp_offset = self.project.arch.get_register_offset('sp')
-        state = StackPointerState(node.addr, sp_offset_in=state.sp_offset_out, sp_offset_out=0)
+        bp_offset = self.project.arch.get_register_offset('bp')
+        state = StackPointerState(node.addr, sp_offset_in=state.sp_offset_out, sp_offset_out=0,
+                                  bp_offset_in=state.bp_offset_out, bp_offset_out=0)
 
         tmps = { }
         sp = state.sp_offset_in
+        bp = state.bp_offset_in
         ins_addr = None
 
         for stmt in block.vex.statements:
             if type(stmt) is pyvex.IRStmt.IMark:
+                if ins_addr is not None:
+                    self._insn_to_sp_offset[ins_addr][LOC_AFTER] = sp
+                    self._insn_to_bp_offset[ins_addr][LOC_AFTER] = bp
                 ins_addr = stmt.addr + stmt.delta
+                self._insn_to_sp_offset[ins_addr][LOC_BEFORE] = sp
+                self._insn_to_bp_offset[ins_addr][LOC_BEFORE] = bp
+
             elif type(stmt) is pyvex.IRStmt.WrTmp:
-                if type(stmt.data) is pyvex.IRExpr.Get and stmt.data.offset == sp_offset:
-                    # writing to tmp
-                    tmps[stmt.tmp] = sp
+                if type(stmt.data) is pyvex.IRExpr.Get:
+                    if stmt.data.offset == sp_offset:
+                        # writing SP to tmp
+                        tmps[stmt.tmp] = sp
+                    elif stmt.data.offset == bp_offset:
+                        # writing BP to tmp
+                        tmps[stmt.tmp] = bp
+
                 elif type(stmt.data) is pyvex.IRExpr.Binop:
                     arg0, arg1 = stmt.data.args
                     if type(arg0) is pyvex.IRExpr.RdTmp and arg0.tmp in tmps and \
@@ -115,21 +175,51 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
                             tmps[stmt.tmp] = tmps[arg0.tmp] + arg1.con.value
                         elif stmt.data.op.startswith('Iop_Sub'):
                             tmps[stmt.tmp] = tmps[arg0.tmp] - arg1.con.value
-            elif type(stmt) is pyvex.IRStmt.Put and stmt.offset == sp_offset:
-                if type(stmt.data) is pyvex.IRExpr.RdTmp and stmt.data.tmp in tmps:
-                    sp = tmps[stmt.data.tmp]
-                    if ins_addr not in self._insn_to_sp_offset:
-                        self._insn_to_sp_offset[ins_addr] = sp
-                    elif sp != self._insn_to_sp_offset[ins_addr]:
-                        _l.warning("Inconsistent stack pointers (original=%#x, new%#x) at instruction %#x.",
-                                   self._insn_to_sp_offset[ins_addr],
-                                   sp,
-                                   ins_addr
-                                   )
-                        # do not update it. instead, abort
-                        self.abort()
+
+            elif type(stmt) is pyvex.IRStmt.Put:
+                if stmt.offset == sp_offset:
+                    if type(stmt.data) is pyvex.IRExpr.RdTmp and stmt.data.tmp in tmps:
+                        sp = tmps[stmt.data.tmp]
+                        # if ins_addr not in self._insn_to_sp_offset:
+                        #    self._insn_to_sp_offset[ins_addr] = sp
+                        if ins_addr in self._insn_to_sp_offset and \
+                                LOC_AFTER in self._insn_to_sp_offset and \
+                                sp != self._insn_to_sp_offset[ins_addr][LOC_AFTER]:
+                            _l.warning("Inconsistent stack pointers (original=%#x, new%#x) at instruction %#x.",
+                                       self._insn_to_sp_offset[ins_addr],
+                                       sp,
+                                       ins_addr
+                                       )
+                            # do not update it. instead, abort
+                            self.sp_inconsistent = True
+                            self.abort()
+                elif stmt.offset == bp_offset:
+                    if type(stmt.data) is pyvex.IRExpr.RdTmp and stmt.data.tmp in tmps:
+                        bp = tmps[stmt.data.tmp]
+                        # if ins_addr not in self._insn_to_sp_offset:
+                        #    self._insn_to_sp_offset[ins_addr] = sp
+                        if ins_addr in self._insn_to_bp_offset and \
+                                LOC_AFTER in self._insn_to_bp_offset and \
+                                bp != self._insn_to_bp_offset[ins_addr][LOC_AFTER]:
+                            _l.warning("Inconsistent stack base pointers (original=%#x, new%#x) at instruction %#x.",
+                                       self._insn_to_bp_offset[ins_addr],
+                                       bp,
+                                       ins_addr
+                                       )
+                            # do not update it. instead, abort
+                            self.sp_inconsistent = True
+                            self.abort()
+
+        # stack pointer adjustment
+        if block.vex.jumpkind == 'Ijk_Call' and self.project.arch.call_pushes_ret:
+            sp += self.project.arch.bytes
+
+        if ins_addr is not None:
+            self._insn_to_sp_offset[ins_addr][LOC_AFTER] = sp
+            self._insn_to_bp_offset[ins_addr][LOC_AFTER] = bp
 
         state.sp_offset_out = sp
+        state.bp_offset_out = bp
 
         if node.addr not in self._states:
             self._states[node.addr] = state

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -174,7 +174,7 @@ def get_engine(base_engine):
             pass
 
         def _ail_handle_ConditionalJump(self, stmt):
-            pass
+            self._expr(stmt.condition)
 
         def _ail_handle_Call(self, stmt):
             pass
@@ -192,6 +192,20 @@ def get_engine(base_engine):
             size = expr.size
 
             return self._load(addr, size)
+
+        def _ail_handle_BinaryOp(self, expr):
+            r = super()._ail_handle_BinaryOp(expr)
+            if r is None:
+                # Treat it as a normal binaryop expression
+                self._expr(expr.operands[0])
+                self._expr(expr.operands[1])
+            return r
+
+        def _ail_handle_Convert(self, expr):
+            return self._expr(expr.operand)
+
+        def _ail_handle_StackBaseOffset(self, expr):
+            return SpOffset(self.arch.bits, expr.offset, is_base=False)
 
         #
         # Logic

--- a/angr/codenode.py
+++ b/angr/codenode.py
@@ -2,7 +2,7 @@ import logging
 l = logging.getLogger(name=__name__)
 
 
-class CodeNode(object):
+class CodeNode:
 
     __slots__ = ['addr', 'size', '_graph', 'thumb', '_hash']
 

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -1,0 +1,23 @@
+
+import os
+
+import angr
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+
+
+def test_decompiling_all_x86_64():
+    bin_path = os.path.join(test_location, "x86_64", "all")
+    p = angr.Project(bin_path, auto_load_libs=False)
+
+    cfg = p.analyses.CFG(collect_data_references=True)
+    for f in cfg.functions.values():
+        dec = p.analyses.Decompiler(f, cfg=cfg)
+        if dec.codegen is not None:
+            print(dec.codegen.text)
+        else:
+            print("Failed to decompile function %s." % repr(f))
+
+
+if __name__ == "__main__":
+    test_decompiling_all_x86_64()

--- a/tests/test_structurer.py
+++ b/tests/test_structurer.py
@@ -11,7 +11,7 @@ test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '.
 def test_smoketest():
 
     p = angr.Project(os.path.join(test_location, 'x86_64', 'all'), auto_load_libs=False)
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
 
     main_func = cfg.kb.functions['main']
 
@@ -49,7 +49,7 @@ def test_smoketest_cm3_firmware():
 def test_simple():
 
     p = angr.Project(os.path.join(test_location, 'x86_64', 'all'), auto_load_libs=False)
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
 
     main_func = cfg.kb.functions['main']
 
@@ -65,14 +65,14 @@ def test_simple():
     # simplify it
     s = p.analyses.RegionSimplifier(rs.result)
 
-    codegen = p.analyses.StructuredCodeGenerator(s.result)
+    codegen = p.analyses.StructuredCodeGenerator(main_func, s.result, cfg=cfg)
     print(codegen.text)
 
 
 def test_simple_loop():
 
     p = angr.Project(os.path.join(test_location, 'x86_64', 'cfg_loop_unrolling'), auto_load_libs=False)
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
 
     test_func = cfg.kb.functions['test_func']
 
@@ -88,14 +88,14 @@ def test_simple_loop():
     # simplify it
     s = p.analyses.RegionSimplifier(rs.result)
 
-    codegen = p.analyses.StructuredCodeGenerator(s.result)
+    codegen = p.analyses.StructuredCodeGenerator(test_func, s.result, cfg=cfg)
     print(codegen.text)
 
 
 def test_recursive_structuring():
     p = angr.Project(os.path.join(test_location, 'x86_64', 'cfg_loop_unrolling'),
                      auto_load_libs=False)
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
 
     test_func = cfg.kb.functions['test_func']
 
@@ -111,14 +111,14 @@ def test_recursive_structuring():
     # simplify it
     s = p.analyses.RegionSimplifier(rs.result)
 
-    codegen = p.analyses.StructuredCodeGenerator(s.result)
+    codegen = p.analyses.StructuredCodeGenerator(test_func, s.result, cfg=cfg)
     print(codegen.text)
 
 
 def test_while_true_break():
     p = angr.Project(os.path.join(test_location, 'x86_64', 'test_decompiler_loops_O0'),
                      auto_load_libs=False)
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
 
     test_func = cfg.kb.functions['_while_true_break']
 
@@ -134,14 +134,15 @@ def test_while_true_break():
     # simplify it
     s = p.analyses.RegionSimplifier(rs.result)
 
-    codegen = p.analyses.StructuredCodeGenerator(s.result)
+    codegen = p.analyses.StructuredCodeGenerator(test_func, s.result, cfg=cfg)
 
     print(codegen.text)
+
 
 def test_while():
     p = angr.Project(os.path.join(test_location, 'x86_64', 'test_decompiler_loops_O0'),
                      auto_load_libs=False)
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
 
     test_func = cfg.kb.functions['_while']
 
@@ -157,7 +158,7 @@ def test_while():
     # simplify it
     s = p.analyses.RegionSimplifier(rs.result)
 
-    codegen = p.analyses.StructuredCodeGenerator(s.result)
+    codegen = p.analyses.StructuredCodeGenerator(test_func, s.result, cfg=cfg)
 
     print(codegen.text)
 


### PR DESCRIPTION
A somewhat working pseudocode generator! YAY!

![image](https://user-images.githubusercontent.com/5071575/50813672-5df1b880-12d4-11e9-8e11-6ee794e22684.png)

Caveats:
- No type inference is performed. High-quality variable types will greatly improve the quality of decompilation.
- Function arguments are totally ignored. Should consider integrating CallingConventionAnalysis into decompiler.
- No inference of pointer types. `p->foo()` is not a thing right now.
- The structural analysis does not correctly structure `for(i = x; i < y; i += z)` type of loops. They are currently displayed as `while(true) { ... if(i < y) {goto ...} ... i +=z; }`.
- The structural analysis does not correctly structure irreducible code regions into a goto-free region.
- Does not detect stack pointer differences for callee cleanup functions (e.g., `stdcall`). So it currently does not really work for most Windows binaries.
- Variable names can be made more meaningful by finding loop counters.
- Variable names can be made more meaningful by using library function argument hints.
- Many types of comparisons implemented in VEX ccalls are not correctly mapped to AIL expressions.
- Redundant stack base pointer saving statements are not removed.
- Redundant stack canary comparison statements are not eliminated.

I do not plan to address any of the above issues within the next few weeks (since I have other things to work on). Feel free to grab any of them and make your contribution!