### PR TITLE
make it possible to copy cfg correctly

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -233,7 +233,8 @@ class CFGBase(Analysis):
         :return: None
         """
 
-        copy_to._normalized = self._normalized
+        for attr, value in self.__dict__.items():
+            setattr(copy_to, attr, value)
 
     # pylint: disable=no-self-use
     def copy(self):

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -234,6 +234,8 @@ class CFGBase(Analysis):
         """
 
         for attr, value in self.__dict__.items():
+            if attr.startswith('__') and attr.endswith('__'):
+                continue
             setattr(copy_to, attr, value)
 
     # pylint: disable=no-self-use

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3767,32 +3767,16 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
     def copy(self):
         n = CFGFast.__new__(CFGFast)
-        super(CFGFast, self).make_copy(n)
 
-        n._binary = self._binary
-        n._regions = self._regions
-        n._pickle_intermediate_results = self._pickle_intermediate_results
-        n._indirect_jump_target_limit = self._indirect_jump_target_limit
-        n._collect_data_ref = self._collect_data_ref
-        n._use_symbols = self._use_symbols
-        n._use_function_prologues = self._use_function_prologues
-        n._resolve_indirect_jumps = self._resolve_indirect_jumps
-        n._force_segment = self._force_segment
-        n._force_complete_scan = self._force_complete_scan
-
-        n._progress_callback = self._progress_callback
-        n._show_progressbar = self._show_progressbar
+        for attr, value in self.__dict__.items():
+            setattr(n, attr, value)
 
         n._exec_mem_regions = self._exec_mem_regions[::]
-        n._exec_mem_region_size = self._exec_mem_region_size
-
         n._memory_data = self._memory_data.copy()
-
         n._seg_list = self._seg_list.copy()
-
         n._function_addresses_from_symbols = self._function_addresses_from_symbols.copy()
 
-        n._graph = self._graph
+        n._graph = self._graph.copy()
 
         return n
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -450,6 +450,7 @@ class SegmentList:
 
         n._list = [ a.copy() for a in self._list ]
         n._bytes_occupied = self._bytes_occupied
+        return n
 
     #
     # Properties
@@ -3769,6 +3770,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         n = CFGFast.__new__(CFGFast)
 
         for attr, value in self.__dict__.items():
+            if attr.startswith('__') and attr.endswith('__'):
+                continue
             setattr(n, attr, value)
 
         n._exec_mem_regions = self._exec_mem_regions[::]

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -418,6 +418,24 @@ def test_segment_list_6():
     nose.tools.assert_equal(seg_list._list[1].sort, 'code')
 
 #
+# CFG instance copy
+#
+
+def test_cfg_copy():
+    path = os.path.join(test_location, "cgc/CADET_00002")
+    proj = angr.Project(path)
+
+    cfg = proj.analyses.CFGFast()
+    cfg_copy = cfg.copy()
+    for attr, value in cfg_copy.__dict__.items():
+        if attr in ['_graph', '_seg_list']:
+            continue
+        nose.tools.assert_equal(getattr(cfg, attr), getattr(cfg_copy, attr))
+
+    nose.tools.assert_not_equal(id(cfg._graph), id(cfg_copy._graph))
+    nose.tools.assert_not_equal(id(cfg._seg_list), id(cfg_copy._seg_list))
+
+#
 # Indirect jump resolvers
 #
 

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -422,12 +422,12 @@ def test_segment_list_6():
 #
 
 def test_cfg_copy():
-    path = os.path.join(test_location, "cgc/CADET_00002")
+    path = os.path.join(test_location, "cgc", "CADET_00002")
     proj = angr.Project(path)
 
     cfg = proj.analyses.CFGFast()
     cfg_copy = cfg.copy()
-    for attr, value in cfg_copy.__dict__.items():
+    for attr in cfg_copy.__dict__:
         if attr in ['_graph', '_seg_list']:
             continue
         nose.tools.assert_equal(getattr(cfg, attr), getattr(cfg_copy, attr))


### PR DESCRIPTION
This commit is aiming at resolving issue #1316 .

I know it may be not right to copy attributes in such a lazy way, but I could not find a reason not to.
So if you think there is something wrong with this implementation, please tell me. And I will fix it ASAP.
 