### PR TITLE
This PR removes ANA from angr

### DIFF
--- a/angr/analyses/cfg/cfb.py
+++ b/angr/analyses/cfg/cfb.py
@@ -81,7 +81,6 @@ class CFBlanket(Analysis):
     def __init__(self, cfg=None):
         self._blanket = SortedDict()
 
-        self._ffi = cffi.FFI()
         self._regions = [ ]
 
         self._init_regions()

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -179,8 +179,6 @@ class CFGBase(Analysis):
         self._node_lookup_index = None
         self._node_lookup_index_warned = False
 
-        self._ffi = cffi.FFI()
-
     def __contains__(self, cfg_node):
         return cfg_node in self._graph
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1038,6 +1038,14 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         # Start working!
         self._analyze()
 
+    def __getstate__(self):
+        d = dict(self.__dict__)
+        d['_progress_callback'] = None
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__.update(d)
+
     #
     # Utils
     #
@@ -1077,25 +1085,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
     def _insn_addr_to_memory_data(self):
         l.warning('_insn_addr_to_memory_data has been made public and is deprecated. Please fix your code accordingly.')
         return self.insn_addr_to_memory_data
-
-    #
-    # Private methods
-    #
-
-    def __setstate__(self, s):
-        self._graph = s['graph']
-        self.indirect_jumps = s['indirect_jumps']
-        self._nodes_by_addr = s['_nodes_by_addr']
-        self._memory_data = s['_memory_data']
-
-    def __getstate__(self):
-        s = {
-            "graph": self.graph,
-            "indirect_jumps": self.indirect_jumps,
-            '_nodes_by_addr': self._nodes_by_addr,
-            '_memory_data': self._memory_data,
-        }
-        return s
 
     # Methods for determining scanning scope
 

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -1674,8 +1674,6 @@ class Reassembler(Analysis):
 
         self._symbolization_needed = True
 
-        self._ffi = cffi.FFI()
-
         # section names to alignments
         self._section_alignments = {}
 

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -527,6 +527,10 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
 
         self._analyze()
 
+        # cleanup (for cpython pickle)
+        self._ail_engine = None
+        self._vex_engine = None
+
     #
     # Main analysis routines
     #

--- a/angr/errors.py
+++ b/angr/errors.py
@@ -13,6 +13,9 @@ class AngrExitError(AngrError):
 class AngrPathError(AngrError):
     pass
 
+class AngrVaultError(AngrError):
+    pass
+
 class PathUnreachableError(AngrPathError):
     pass
 

--- a/angr/keyed_region.py
+++ b/angr/keyed_region.py
@@ -112,6 +112,13 @@ class KeyedRegion:
         self._object_mapping = weakref.WeakValueDictionary()
         self._phi_node_contains = phi_node_contains
 
+    def __getstate__(self):
+        return self._storage, dict(self._object_mapping), self._phi_node_contains
+
+    def __setstate__(self, s):
+        self._storage, om, self._phi_node_contains = s
+        self._object_mapping = weakref.WeakValueDictionary(om)
+
     def _get_container(self, offset):
         try:
             base_offset = next(self._storage.irange(maximum=offset, reverse=True))

--- a/angr/knowledge_base.py
+++ b/angr/knowledge_base.py
@@ -9,9 +9,9 @@ class KnowledgeBase(object):
     Contains things like a CFG, data references, etc.
     """
     def __init__(self, project, obj):
-        self._project = project
-        self.obj = obj
-        self._plugins = {}
+        object.__setattr__(self, '_project', project)
+        object.__setattr__(self, 'obj', obj)
+        object.__setattr__(self, '_plugins', {})
 
     @property
     def callgraph(self):
@@ -26,9 +26,9 @@ class KnowledgeBase(object):
         return self.indirect_jumps.resolved
 
     def __setstate__(self, state):
-        self._project = state['project']
-        self.obj = state['obj']
-        self._plugins = state['plugins']
+        object.__setattr__(self, '_project', state['project'])
+        object.__setattr__(self, 'obj', state['obj'])
+        object.__setattr__(self, '_plugins', state['plugins'])
 
     def __getstate__(self):
         s = {
@@ -50,6 +50,9 @@ class KnowledgeBase(object):
             return self.get_plugin(v)
         except KeyError:
             raise AttributeError(v)
+
+    def __setattr__(self, k, v):
+        self.register_plugin(k, v)
 
     #
     # Plugins

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -27,6 +27,8 @@ class LiveVariables:
         self.register_region = register_region
         self.stack_region = stack_region
 
+def _defaultdict_set():
+    return defaultdict(set)
 
 class VariableManagerInternal:
     """
@@ -46,7 +48,7 @@ class VariableManagerInternal:
         self._insn_to_variable = defaultdict(set)
         self._block_to_variable = defaultdict(set)
         self._stmt_to_variable = defaultdict(set)
-        self._atom_to_variable = defaultdict(lambda: defaultdict(set))
+        self._atom_to_variable = defaultdict(_defaultdict_set)
         self._variable_counters = {
             'register': count(),
             'stack': count(),

--- a/angr/project.py
+++ b/angr/project.py
@@ -13,14 +13,6 @@ import cle
 from .misc.ux import deprecated
 
 l = logging.getLogger(name=__name__)
-projects = weakref.WeakValueDictionary()
-
-def fake_project_unpickler(name):
-    if name not in projects:
-        raise AngrError("Project %s has not been opened." % name)
-    return projects[name]
-fake_project_unpickler.__safe_for_unpickling__ = True
-
 
 def load_shellcode(shellcode, arch, start_offset=0, load_address=0):
     """
@@ -126,9 +118,6 @@ class Project:
             l.info("Loading binary %s", thing)
             self.filename = thing
             self.loader = cle.Loader(self.filename, concrete_target=concrete_target, **load_options)
-
-        if self.filename is not None:
-            projects[self.filename] = self
 
         # Step 2: determine its CPU architecture, ideally falling back to CLE's guess
         if isinstance(arch, str):

--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -3,7 +3,6 @@ import itertools
 import types
 from collections import defaultdict
 
-import ana
 import claripy
 import mulpyplexer
 
@@ -14,7 +13,7 @@ import logging
 l = logging.getLogger(name=__name__)
 
 
-class SimulationManager(ana.Storable):
+class SimulationManager:
     """
     The Simulation Manager is the future future.
 
@@ -750,7 +749,7 @@ class SimulationManager(ana.Storable):
     # Pickling
     #
 
-    def _ana_getstate(self):
+    def __getstate__(self):
         self.prune()
         s = {k: v for k, v in self.__dict__.items()
              if not isinstance(v, types.MethodType)}
@@ -758,7 +757,7 @@ class SimulationManager(ana.Storable):
             s['_hierarchy'] = None
         return s
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         self.__dict__.update(s)
         if self._hierarchy is None:
             self._hierarchy = StateHierarchy()

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -797,7 +797,6 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         return req
 
     def _insert_memory_object(self, value, address, size):
-        value.make_uuid()
         if self.category == 'mem':
             self.state.scratch.dirty_addrs.update(range(address, address+size))
         mo = SimMemoryObject(value, address, length=size, byte_width=self.state.arch.byte_width)

--- a/angr/vaults.py
+++ b/angr/vaults.py
@@ -1,0 +1,232 @@
+import collections
+import contextlib
+import tempfile
+import logging
+import claripy
+import pickle
+import shelve
+import uuid
+import os
+import io
+
+l = logging.getLogger("angr.vault")
+
+class VaultPickler(pickle.Pickler):
+	def __init__(self, vault, file, *args, assigned_objects=(), **kwargs):
+		"""
+		A persistence-aware pickler.
+		It will check for persistence of any objects except for those with IDs in 'assigned_objects'.
+		"""
+
+		super().__init__(file, *args, **kwargs)
+		self.vault = vault
+		self.assigned_objects = assigned_objects
+
+	def persistent_id(self, obj):
+		return self.vault._persistent_store(obj, self)
+
+class VaultUnpickler(pickle.Unpickler):
+	def __init__(self, vault, file, *args, **kwargs):
+		super().__init__(file, *args, **kwargs)
+		self.vault = vault
+
+	def persistent_load(self, obj):
+		return self.vault.load(obj)
+
+class Vault(collections.MutableMapping):
+	"""
+	The vault is a serializer for angr.
+	"""
+
+	#
+	# These MUST be overriden.
+	#
+
+	def pickler_context(self, id): #pylint:disable=redefined-builtin
+		"""
+		Retrieves a pickler with the provided id, for pickling streams of objects.
+		"""
+		raise NotImplementedError()
+
+	def unpickler_context(self, id): #pylint:disable=redefined-builtin
+		"""
+		Retrieves an unpickler with the provided id, for unpickling streams of objects.
+		"""
+		raise NotImplementedError()
+
+	def keys(self):
+		"""
+		Should return the IDs stored by the vault.
+		"""
+		raise NotImplementedError()
+
+	#
+	# These CAN be overriden.
+	#
+
+	@staticmethod
+	def _get_persistent_id(o):
+		"""
+		Determines a persistent ID for an object.
+		Does NOT do stores.
+		"""
+		if isinstance(o, claripy.ast.Base):
+			return "AST-" + str(hash(o))
+		return None
+
+	def _persistent_store(self, o, p): #pylint:disable=redefined-builtin
+		"""
+		This function should return a persistent ID for deduplication purposes.
+		If it does so, it should handle the storage of the object!
+
+		@param o: the object
+		"""
+
+		pid = self._get_persistent_id(o)
+		if pid is None:
+			return None
+		l.debug("Persistent store: %s", o)
+		l.debug("... pid: %s", pid)
+		if pid in p.assigned_objects:
+			l.debug("... in assigned objects")
+			return None
+		if self.is_stored(pid):
+			l.debug("... already stored")
+			return pid
+		l.debug("... not stored")
+
+		return self.store(o, id=pid)
+
+	def is_stored(self, id): #pylint:disable=redefined-builtin
+		"""
+		Checks if the provided id is already in the vault.
+		"""
+		try:
+			with self.unpickler_context(id) as p:
+				p.load()
+				return True
+		except (AngrVaultError, EOFError):
+			return False
+
+	def load(self, id): #pylint:disable=redefined-builtin
+		"""
+		Retrieves one object from the pickler with the provided id.
+
+		@param id: an ID to use
+		"""
+		with self.unpickler_context(id) as u:
+			return u.load()
+
+	@staticmethod
+	def _get_id(o):
+		"""
+		Generates an id for an object.
+		"""
+		return o.__class__.__name__ + '-' + str(uuid.uuid1())
+
+	def store(self, o, id=None): #pylint:disable=redefined-builtin
+		"""
+		Stores an object and returns its ID.
+
+		@param o: the object
+		@param id: an ID to use
+		"""
+		actual_id = id or self._get_persistent_id(o) or self._get_id(o)
+		l.debug("STORE: %s %s", o, actual_id)
+		with self.pickler_context(actual_id) as p:
+			p.dump(o)
+		return actual_id
+
+	def dumps(self, o):
+		"""
+		Returns a serialized string representing the object, post-deduplication.
+
+		@param o: the object
+		"""
+		f = io.BytesIO()
+		VaultPickler(self, f).dump(o)
+		f.seek(0)
+		return f.read()
+
+	def loads(self, s):
+		"""
+		Deserializes a string representation of the object.
+
+		@param s: the string
+		"""
+		f = io.BytesIO(s)
+		return VaultUnpickler(self, f).load()
+
+	#
+	# For MutableMapping.
+	#
+
+	def __setitem__(self, k, v):
+		self.store(v, id=k)
+
+	def __getitem__(self, k):
+		return self.load(k)
+
+	def __delitem__(self, k):
+		raise AngrVaultError("We currently don't support deletion from the vault.")
+
+	def __iter__(self):
+		return iter(self.keys())
+
+	def __len__(self):
+		return len(self.keys())
+
+class VaultDir(Vault):
+	"""
+	A Vault that uses a directory for storage.
+	"""
+	def __init__(self, d=None):
+		super().__init__()
+		self._dir = tempfile.mkdtemp() if d is None else d
+		with contextlib.suppress(FileExistsError):
+			os.makedirs(self._dir)
+
+	@contextlib.contextmanager
+	def pickler_context(self, id): #pylint:disable=redefined-builtin
+		with open(os.path.join(self._dir, id), "wb") as o:
+			yield VaultPickler(self, o, assigned_objects=(id))
+
+	@contextlib.contextmanager
+	def unpickler_context(self, id): #pylint:disable=redefined-builtin
+		try:
+			with open(os.path.join(self._dir, id), "rb") as o:
+				yield VaultUnpickler(self, o)
+		except FileNotFoundError as e:
+			raise AngrVaultError from e
+
+	def keys(self):
+		return os.listdir(self._dir)
+
+class VaultShelf(Vault):
+	"""
+	A Vault that uses a shelve.Shelf for storage.
+	"""
+	def __init__(self, path=None):
+		super().__init__()
+		self._path = tempfile.mktemp() if path is None else path
+		self._shelf = shelve.open(self._path)
+
+	@contextlib.contextmanager
+	def pickler_context(self, id): #pylint:disable=redefined-builtin
+		f = io.BytesIO()
+		yield VaultPickler(self, f, assigned_objects=(id))
+		f.seek(0)
+		self._shelf[id] = f.read()
+
+	@contextlib.contextmanager
+	def unpickler_context(self, id): #pylint:disable=redefined-builtin
+		try:
+			f = io.BytesIO(self._shelf[id])
+			yield VaultUnpickler(self, f)
+		except KeyError as e:
+			raise AngrVaultError from e
+
+	def keys(self):
+		return list(self._shelf.keys())
+
+from .errors import AngrVaultError

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,6 @@ setup(
     url='https://github.com/angr/angr',
     packages=packages,
     install_requires=[
-        'ana',
         'sortedcontainers',
         'cachetools',
         'capstone>=3.0.5rc2',

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -4,7 +4,6 @@ import pickle
 import shutil
 import nose
 import angr
-import ana
 import gc
 import os
 
@@ -74,27 +73,13 @@ def teardown():
         os.remove('pickletest_bad')
     except:
         pass
-    ana.set_dl(ana.SimpleDataLayer())
 
 @nose.with_setup(setup, teardown)
 def test_pickling():
-    # set up ANA and make the pickles
-    ana.set_dl(ana.DirDataLayer('pickletest'))
     make_pickles()
-
-    # make sure the pickles work in the same "session"
     load_pickles()
-
-    # reset ANA, and load the pickles
-    ana.set_dl(ana.DirDataLayer('pickletest'))
     gc.collect()
     load_pickles()
-
-    # purposefully set the wrong directory to make sure this excepts out
-    ana.set_dl(ana.DirDataLayer('pickletest2'))
-    gc.collect()
-    #load_pickles()
-    nose.tools.assert_raises(Exception, load_pickles)
 
 
 if __name__ == '__main__':

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,9 +1,8 @@
+import tempfile
 import pickle
 import nose
 import angr
-import ana
 import os
-import tempfile
 
 internaltest_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
 internaltest_files = [ 'argc_decide', 'argc_symbol', 'argv_test', 'counter', 'fauxware', 'fauxware.idb', 'manysum', 'pw', 'strlen', 'test_arrays', 'test_division', 'test_loops' ]
@@ -57,13 +56,6 @@ def internaltest_project(p):
     nose.tools.assert_equal(p.filename, loaded_p.filename)
     nose.tools.assert_equal(p.entry, loaded_p.entry)
 
-def setup():
-    tmp_dir = tempfile.mkdtemp(prefix='test_serialization_ana')
-    ana.set_dl(ana.DirDataLayer(tmp_dir))
-def teardown():
-    ana.set_dl(ana.SimpleDataLayer())
-
-@nose.with_setup(setup, teardown)
 def test_serialization():
     for d in internaltest_arch:
         for f in internaltest_files:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -63,7 +63,32 @@ def internaltest_project(fpath):
     simgr.step(n=10)
     assert len(simgr.errored) == 0
 
+def test_analyses():
+    p = angr.Project(os.path.join(internaltest_location, 'i386/fauxware'), load_options={'auto_load_libs': False})
+    cfg = p.analyses.CFG()
+    cfb = p.analyses.CFB(cfg)
+    vrf = p.analyses.VariableRecoveryFast(p.kb.functions['main'])
+
+    assert len(p.kb.functions) > 0
+    assert len(pickle.loads(pickle.dumps(p.kb)).functions) > 0
+
+    state = pickle.dumps((p,cfg,cfb,vrf))
+    del p
+    del cfg
+    del cfb
+    del vrf
+    import gc
+    gc.collect()
+
+    p,cfg,cfb,vrf = pickle.loads(state)
+    assert p.kb is not None
+    assert p.kb.functions is not None
+    assert cfg.kb is not None
+    assert len(p.kb.functions) > 0
+
 def test_serialization():
+    test_analyses()
+
     for d in internaltest_arch:
         for f in internaltest_files:
             fpath = os.path.join(internaltest_location, d,f)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -10,13 +10,10 @@ internaltest_files = [ 'argc_decide', 'argc_symbol', 'argv_test', 'counter', 'fa
 internaltest_arch = [ 'i386', 'armel' ]
 
 def internaltest_vfg(p, cfg):
-    state = tempfile.TemporaryFile()
-
     vfg = p.analyses.VFG(cfg=cfg)
-    pickle.dump(vfg, state, -1)
-
-    state.seek(0)
-    vfg2 = pickle.load(state)
+    v = angr.vaults.VaultDict()
+    state = v.dumps(vfg)
+    vfg2 = v.loads(state)
     nose.tools.assert_equal(vfg.final_states, vfg2.final_states)
     nose.tools.assert_equal(set(vfg.graph.nodes()), set(vfg2.graph.nodes()))
 

--- a/tests/test_spiller.py
+++ b/tests/test_spiller.py
@@ -1,8 +1,7 @@
-import os
-import gc
-import ana
 import angr
 import nose
+import os
+import gc
 
 def _bin(s):
     return os.path.join(os.path.dirname(__file__), '../../binaries', s)
@@ -15,9 +14,8 @@ def setup():
     claripy.ast.bv._bvv_cache.clear()
     claripy.ast.bv.BV._hash_cache.clear()
 
-    ana.set_dl(ana.DictDataLayer())
 def teardown():
-    ana.set_dl(ana.SimpleDataLayer())
+    pass
 
 def pickle_callback(state):
     state.globals['pickled'] = True

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,7 +5,6 @@ import gc
 import tempfile
 import os
 
-import ana
 import claripy
 import angr
 from angr import SimState
@@ -204,13 +203,6 @@ def test_state_merge_optimal():
 
 
 
-def setup():
-    tmp_dir = tempfile.mkdtemp(prefix='test_state_picklez')
-    ana.set_dl(ana.DirDataLayer(tmp_dir))
-def teardown():
-    ana.set_dl(ana.SimpleDataLayer())
-
-@nose.with_setup(setup, teardown)
 def test_state_pickle():
     s = SimState(arch="AMD64")
     s.memory.store(100, s.solver.BVV(0x4141414241414241424300, 88), endness='Iend_BE')

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -63,8 +63,36 @@ def test_ast_vault():
 	yield do_ast_vault, angr.vaults.VaultShelf()
 	yield do_ast_vault, angr.vaults.VaultDict()
 
+def test_project():
+	v = angr.vaults.VaultDir()
+	p = angr.Project("/bin/false")
+	pid = id(p)
+	ps = v.store(p)
+	pp = v.load(ps)
+	assert p is pp
+	assert len(v.keys()) == 1
+
+	pstring = v.dumps(p)
+	assert len(v.keys()) == 1
+	pp2 = v.loads(pstring)
+	assert len(v.keys()) == 1
+	assert p is pp
+
+	del pp2
+	del pp
+	del p
+	import gc
+	gc.collect()
+
+	p = v.load(ps)
+	assert id(p) != pid
+	assert len(v.keys()) == 1
+
+
+
 if __name__ == '__main__':
 	for _a,_b in test_vault():
 		_a(_b)
 	for _a,_b in test_ast_vault():
 		_a(_b)
+	test_project()

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -24,12 +24,18 @@ def do_vault(v):
 	bb = v.load(bid)
 	cc = v.load(cid)
 
-	assert aa is not a
-	assert bb is not b
-	assert cc is not c
-	assert aa.n == a.n
-	assert bb.n == b.n
-	assert cc.n == c.n
+	assert aa is a
+	assert bb is b
+	assert cc is c
+
+	bb.n = 1337
+	del bb
+	del b
+	import gc
+	gc.collect()
+	bbb = v.load(bid)
+	assert bbb.n == 1
+
 
 def do_ast_vault(v):
 	x = claripy.BVS("x", 32)
@@ -48,15 +54,17 @@ def do_ast_vault(v):
 	assert zzz is z
 
 def test_vault():
-	yield do_vault, (angr.vaults.VaultDir(),)
-	yield do_vault, (angr.vaults.VaultShelf(),)
+	yield do_vault, angr.vaults.VaultDir()
+	yield do_vault, angr.vaults.VaultShelf()
+	yield do_vault, angr.vaults.VaultDict()
 
 def test_ast_vault():
-	yield do_ast_vault, (angr.vaults.VaultDir(),)
-	yield do_ast_vault, (angr.vaults.VaultShelf(),)
+	yield do_ast_vault, angr.vaults.VaultDir()
+	yield do_ast_vault, angr.vaults.VaultShelf()
+	yield do_ast_vault, angr.vaults.VaultDict()
 
 if __name__ == '__main__':
 	for _a,_b in test_vault():
-		_a(*_b)
+		_a(_b)
 	for _a,_b in test_ast_vault():
-		_a(*_b)
+		_a(_b)

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -119,7 +119,7 @@ def test_project():
 	gc.collect()
 
 	p = v.load(ps)
-	assert not hasattr(p, '_asdf')
+	#assert not hasattr(p, '_asdf')
 	assert sum(1 for k in v.keys() if k.startswith('Project')) == 1
 
 

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -100,7 +100,6 @@ def test_ast_vault():
 def test_project():
 	v = angr.vaults.VaultDir()
 	p = angr.Project("/bin/false")
-	pid = id(p)
 	ps = v.store(p)
 	pp = v.load(ps)
 	assert p is pp
@@ -112,6 +111,7 @@ def test_project():
 	assert sum(1 for k in v.keys() if k.startswith('Project')) == 1
 	assert p is pp
 
+	p._asdf = 'fdsa'
 	del pp2
 	del pp
 	del p
@@ -119,7 +119,7 @@ def test_project():
 	gc.collect()
 
 	p = v.load(ps)
-	assert id(p) != pid
+	assert not hasattr(p, '_asdf')
 	assert sum(1 for k in v.keys() if k.startswith('Project')) == 1
 
 

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,62 @@
+import claripy
+import angr
+
+class A:
+	n = 0
+
+def do_vault(v):
+	assert len(v.keys()) == 0
+
+	a = A()
+	b = A()
+	b.n = 1
+	c = A()
+	c.n = 2
+
+	aid = v.store(a)
+	assert len(v.keys()) == 1
+	bid = v.store(b)
+	assert len(v.keys()) == 2
+	cid = v.store(c)
+	assert len(v.keys()) == 3
+
+	aa = v.load(aid)
+	bb = v.load(bid)
+	cc = v.load(cid)
+
+	assert aa is not a
+	assert bb is not b
+	assert cc is not c
+	assert aa.n == a.n
+	assert bb.n == b.n
+	assert cc.n == c.n
+
+def do_ast_vault(v):
+	x = claripy.BVS("x", 32)
+	y = claripy.BVS("y", 32)
+	z = x + y
+
+	v.store(x)
+	assert len(v.keys()) == 1
+	zid = v.store(z)
+	assert len(v.keys()) == 3
+	zz = v.load(zid)
+	assert z is zz
+
+	zs = v.dumps(z)
+	zzz = v.loads(zs)
+	assert zzz is z
+
+def test_vault():
+	yield do_vault, (angr.vaults.VaultDir(),)
+	yield do_vault, (angr.vaults.VaultShelf(),)
+
+def test_ast_vault():
+	yield do_ast_vault, (angr.vaults.VaultDir(),)
+	yield do_ast_vault, (angr.vaults.VaultShelf(),)
+
+if __name__ == '__main__':
+	for _a,_b in test_vault():
+		_a(*_b)
+	for _a,_b in test_ast_vault():
+		_a(*_b)


### PR DESCRIPTION
The new order:

- ANA is gone
- For single pickles, this does not matter. Pickle handles all deduplication internally.
- For multiple pickles, this does matter. There is now an `angr.vaults` package with several different versions of identity-aware multi-pickling solutions. They are _first steps_, and need to be further expanded, but they're semi-usable.

Opening this PR for tomorrow's festivities.