### PR TITLE
JumpTableResolver: Support one more jump table for x86_64 binaries.

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -24,6 +24,8 @@ class UninitReadMeta:
 class AddressTransferringTypes:
     Assignment = 0
     SignedExtension32to64 = 1
+    UnsignedExtension32to64 = 2
+    Truncation64to32 = 3
 
 
 class JumpTargetBaseAddr:
@@ -142,6 +144,20 @@ class JumpTableResolver(IndirectJumpResolver):
                         stmts_to_remove.append(stmt_loc)
                         if isinstance(stmt, pyvex.IRStmt.WrTmp):
                             all_addr_holders[(stmt_loc[0], stmt.tmp)] = AddressTransferringTypes.SignedExtension32to64
+                        continue
+                    elif stmt.data.op == 'Iop_64to32':
+                        # data transferring with conversion
+                        # t24 = 64to32(t21)
+                        stmts_to_remove.append(stmt_loc)
+                        if isinstance(stmt, pyvex.IRStmt.WrTmp):
+                            all_addr_holders[(stmt_loc[0], stmt.tmp)] = AddressTransferringTypes.Truncation64to32
+                        continue
+                    elif stmt.data.op == 'Iop_32Uto64':
+                        # data transferring with conversion
+                        # t21 = 32Uto64(t22)
+                        stmts_to_remove.append(stmt_loc)
+                        if isinstance(stmt, pyvex.IRStmt.WrTmp):
+                            all_addr_holders[(stmt_loc[0], stmt.tmp)] = AddressTransferringTypes.UnsignedExtension32to64
                         continue
                 elif isinstance(stmt.data, pyvex.IRExpr.Binop) and stmt.data.op.startswith('Iop_Add'):
                     # GitHub issue #1289, a S390X binary
@@ -385,6 +401,10 @@ class JumpTableResolver(IndirectJumpResolver):
                         for conversion_op in conversion_ops:
                             if conversion_op is AddressTransferringTypes.SignedExtension32to64:
                                 lam = lambda a: (a | 0xffffffff00000000) if a >= 0x80000000 else a
+                            elif conversion_op is AddressTransferringTypes.UnsignedExtension32to64:
+                                lam = lambda a: a
+                            elif conversion_op is AddressTransferringTypes.Truncation64to32:
+                                lam = lambda a: a & 0xffffffff
                             else:
                                 raise NotImplementedError("Unsupported conversion operation.")
                             invert_conversion_ops.append(lam)


### PR DESCRIPTION
Thanks @ling on Slack for reporting this issue and providing a test case.

Disassembly:
```
.text:00000000000006AB mov     eax, [rbp+var_8]
.text:00000000000006AE lea     rdx, ds:0[rax*4]
.text:00000000000006B6 lea     rax, jpt_6CD
.text:00000000000006BD mov     eax, ds:(jpt_6CD - 80Ch)[rdx+rax]
.text:00000000000006C0 movsxd  rdx, eax
.text:00000000000006C3 lea     rax, jpt_6CD
.text:00000000000006CA add     rax, rdx
.text:00000000000006CD jmp     rax             ; switch jump
```
VEX Slice:
```
       IRSB 0x400697
   00 | ------ IMark(0x400697, 3, 0) ------
 + 01 | t7 = GET:I64(rbp)
 + 02 | t6 = Add64(t7,0xfffffffffffffff8)
 + 03 | t9 = GET:I64(rax)
 + 04 | t23 = 64to32(t9)
 + 05 | t8 = t23
 + 06 | STle(t6) = t8
   07 | PUT(rip) = 0x000000000040069a
   08 | ------ IMark(0x40069a, 7, 0) ------
   09 | t10 = Add64(t7,0xfffffffffffffffc)
   10 | STle(t10) = 0x00000000
   11 | PUT(rip) = 0x00000000004006a1
   12 | ------ IMark(0x4006a1, 4, 0) ------
 + 13 | t12 = Add64(t7,0xfffffffffffffff8)
 + 14 | t4 = LDle:I32(t12)
   15 | PUT(cc_op) = 0x0000000000000007
 + 16 | t24 = 32Uto64(t4)
 + 17 | t14 = t24
   18 | PUT(cc_dep1) = t14
   19 | PUT(cc_dep2) = 0x0000000000000005
   20 | PUT(rip) = 0x00000000004006a5
   21 | ------ IMark(0x4006a5, 6, 0) ------
 + 22 | t27 = 64to32(0x0000000000000005)
 + 23 | t28 = 64to32(t14)
 + 24 | t26 = CmpLE32U(t28,t27)
 + 25 | t25 = 1Uto64(t26)
 + 26 | t21 = t25
 + 27 | t29 = 64to1(t21)
 + 28 | t16 = t29
 + 29 | if (t16) { PUT(offset=184) = 0x4006ab; Ijk_Boring }
   Next: 0x400742

       IRSB 0x4006ab
   00 | ------ IMark(0x4006ab, 3, 0) ------
 + 01 | t11 = GET:I64(rbp)
 + 02 | t10 = Add64(t11,0xfffffffffffffff8)
 + 03 | t13 = LDle:I32(t10)
 + 04 | t12 = 32Uto64(t13)
   05 | ------ IMark(0x4006ae, 8, 0) ------
 + 06 | t15 = Shl64(t12,0x02)
   07 | ------ IMark(0x4006b6, 7, 0) ------
   08 | PUT(rip) = 0x00000000004006bd
   09 | ------ IMark(0x4006bd, 3, 0) ------
 + 10 | t17 = Add64(t15,0x000000000040080c)
 + 11 | t22 = LDle:I32(t17)
 + 12 | t21 = 32Uto64(t22)
   13 | ------ IMark(0x4006c0, 3, 0) ------
 + 14 | t24 = 64to32(t21)
 + 15 | t23 = 32Sto64(t24)
   16 | PUT(rdx) = t23
   17 | ------ IMark(0x4006c3, 7, 0) ------
   18 | ------ IMark(0x4006ca, 3, 0) ------
 + 19 | t5 = Add64(0x000000000040080c,t23)
   20 | PUT(cc_op) = 0x0000000000000004
   21 | PUT(cc_dep1) = 0x000000000040080c
   22 | PUT(cc_dep2) = t23
   23 | PUT(rax) = t5
   24 | ------ IMark(0x4006cd, 2, 0) ------
 + Next: t5
```
Added support of `64to32` and `32Uto64` to support this jump table.