### PR TITLE
Distinguish syscall and hooked sim_procedure

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2,7 +2,6 @@
 import logging
 from collections import defaultdict
 
-import cffi
 import networkx
 
 import pyvex

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1918,7 +1918,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                 # TODO: Is it really OK?
                 func_addr = self._block_id_addr(node_key)
 
-            is_syscall = node_key.jump_type == 'syscall'
             is_thumb = isinstance(self.project.arch, ArchARM) and addr % 2 == 1
 
             pt = CFGENode(self._block_id_addr(node_key),
@@ -1929,7 +1928,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                           simprocedure_name="PathTerminator",
                           function_address=func_addr,
                           callstack_key=self._block_id_callstack_key(node_key),
-                          is_syscall=is_syscall,
                           thumb=is_thumb
                           )
             if self._keep_state:
@@ -3035,7 +3033,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         # Determine if this is a SimProcedure, and further, if this is a syscall
         syscall = None
-        is_syscall = False
         if sim_successors.sort == 'SimProcedure':
             is_simprocedure = True
             if sa['is_syscall'] is True:
@@ -3061,7 +3058,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                                 simprocedure_name=simproc_name,
                                 syscall_name=syscall,
                                 no_ret=no_ret,
-                                is_syscall=is_syscall,
                                 syscall=syscall,
                                 function_address=sim_successors.addr,
                                 block_id=block_id,
@@ -3076,7 +3072,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                                 self,
                                 callstack=call_stack,
                                 input_state=None,
-                                is_syscall=is_syscall,
                                 syscall=syscall,
                                 function_address=func_addr,
                                 block_id=block_id,

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -174,7 +174,9 @@ class CFGNode:
         return self._hash
 
     def to_codenode(self):
-        if self.is_syscall:
+        #TODO: after we add a new attribute to indicate whether this node is a syscall,
+        # we should change the next line to `if self.{attribute}:`
+        if self._cfg.project.simos.is_syscall_addr(self.addr):
             return SyscallNode(self.addr, self.size, self.simprocedure_name)
         if self.is_simprocedure:
             return HookNode(self.addr, self.size, self.simprocedure_name)

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -46,7 +46,6 @@ class CFGNode:
                  size,
                  cfg,
                  simprocedure_name=None,
-                 is_syscall=False,
                  no_ret=False,
                  function_address=None,
                  block_id=None,
@@ -63,7 +62,6 @@ class CFGNode:
         self.simprocedure_name = simprocedure_name
         self.size = size
         self.no_ret = no_ret
-        self.is_syscall = is_syscall
         self._cfg = cfg
         self.function_address = function_address
         self.block_id = block_id
@@ -73,6 +71,7 @@ class CFGNode:
         self._name = simprocedure_name
         self.instruction_addrs = instruction_addrs if instruction_addrs is not None else tuple()
 
+        self.is_syscall = True if self.simprocedure_name and self._cfg.project.simos.is_syscall_addr(addr) else False
         if not instruction_addrs and not self.is_simprocedure:
             # We have to collect instruction addresses by ourselves
             if irsb is not None:
@@ -174,9 +173,7 @@ class CFGNode:
         return self._hash
 
     def to_codenode(self):
-        #TODO: after we add a new attribute to indicate whether this node is a syscall,
-        # we should change the next line to `if self.{attribute}:`
-        if self._cfg.project.simos.is_syscall_addr(self.addr):
+        if self.is_syscall:
             return SyscallNode(self.addr, self.size, self.simprocedure_name)
         if self.is_simprocedure:
             return HookNode(self.addr, self.size, self.simprocedure_name)

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -3,7 +3,7 @@ import logging
 
 import archinfo
 
-from ...codenode import BlockNode, HookNode
+from ...codenode import BlockNode, HookNode, SyscallNode
 from ...engines.successors import SimSuccessors
 
 _l = logging.getLogger(__name__)
@@ -174,6 +174,8 @@ class CFGNode:
         return self._hash
 
     def to_codenode(self):
+        if self.is_syscall:
+            return SyscallNode(self.addr, self.size, self.simprocedure_name)
         if self.is_simprocedure:
             return HookNode(self.addr, self.size, self.simprocedure_name)
         return BlockNode(self.addr, self.size, thumb=self.thumb)

--- a/angr/analyses/cfg/cfg_node.py
+++ b/angr/analyses/cfg/cfg_node.py
@@ -215,7 +215,6 @@ class CFGENode(CFGNode):
                  final_states=None,
                  syscall_name=None,
                  looping_times=0,
-                 is_syscall=False,
                  syscall=None,
                  depth=None,
                  callstack_key=None,
@@ -224,7 +223,6 @@ class CFGENode(CFGNode):
 
         super(CFGENode, self).__init__(addr, size, cfg,
                                        simprocedure_name=simprocedure_name,
-                                       is_syscall=is_syscall,
                                        no_ret=no_ret,
                                        function_address=function_address,
                                        block_id=block_id,
@@ -317,7 +315,6 @@ class CFGENode(CFGNode):
             input_state=self.input_state,
             syscall_name=self.syscall_name,
             looping_times=self.looping_times,
-            is_syscall=self.is_syscall,
             syscall=self.syscall,
             depth=self.depth,
             final_states=self.final_states[::],

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -69,7 +69,9 @@ class FunctionStart(DisassemblyPiece):
         self.name = func.name
         self.is_simprocedure = func.is_simprocedure
         self.sim_procedure = None
-        if self.is_simprocedure:
+        if func.is_syscall:
+            self.sim_procedure = func._project.simos.syscall_from_addr(self.addr)
+        elif func.is_simprocedure:
             self.sim_procedure = func._project.hooked_by(self.addr)
 
     def _render(self, formatting):

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -406,7 +406,7 @@ class MemoryOperand(Operand):
         if self.children[0] != '[':
             try:
                 square_bracket_pos = self.children.index('[')
-            except ValueError:
+            except ValueError:#pylint: disable=try-except-raise
                 raise
 
             self.prefix = self.children[ : square_bracket_pos]
@@ -433,7 +433,7 @@ class MemoryOperand(Operand):
         if self.children[0] != '(':
             try:
                 paren_pos = self.children.index('(')
-            except ValueError:
+            except ValueError:#pylint: disable=try-except-raise
                 raise
 
             self.prefix = self.children[ : paren_pos]

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -408,7 +408,7 @@ class MemoryOperand(Operand):
         if self.children[0] != '[':
             try:
                 square_bracket_pos = self.children.index('[')
-            except ValueError:#pylint: disable=try-except-raise
+            except ValueError:  #pylint: disable=try-except-raise
                 raise
 
             self.prefix = self.children[ : square_bracket_pos]
@@ -435,7 +435,7 @@ class MemoryOperand(Operand):
         if self.children[0] != '(':
             try:
                 paren_pos = self.children.index('(')
-            except ValueError:#pylint: disable=try-except-raise
+            except ValueError:  #pylint: disable=try-except-raise
                 raise
 
             self.prefix = self.children[ : paren_pos]

--- a/angr/codenode.py
+++ b/angr/codenode.py
@@ -103,4 +103,9 @@ class HookNode(CodeNode):
     def __setstate__(self, dat):
         self.__init__(*dat)
 
+class SyscallNode(HookNode):
+    is_hook = False
+    def __repr__(self):
+        return '<SyscallNode %r at %#x (size %s)>' % (self.sim_procedure, self.addr, self.size)
+
 from .block import Block

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -1,4 +1,3 @@
-import angr
 from typing import List
 import logging
 

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -30,6 +30,10 @@ class AngrObjectFactory(object):
             hook = self.project._sim_procedures[addr]
             size = hook.kwargs.get('length', 0)
             return HookNode(addr, size, self.project.hooked_by(addr))
+        elif self.project.simos.is_syscall_addr(addr):
+            syscall = self.project.simos.syscall_from_addr(addr)
+            size = syscall.kwargs.get('length', 0)
+            return SyscallNode(addr, size, syscall)
         else:
             return self.block(addr, **block_opts).codenode # pylint: disable=no-member
 
@@ -305,5 +309,5 @@ class AngrObjectFactory(object):
 
 from .errors import AngrError
 from .sim_manager import SimulationManager
-from .codenode import HookNode
+from .codenode import HookNode, SyscallNode
 from .block import Block

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1072,8 +1072,9 @@ class Function:
             # PLT entries must have the same declaration as their jump targets
             # Try to determine which library this PLT entry will jump to
             edges = self.transition_graph.edges()
-            if len(edges) == 1 and isinstance(next(iter(edges))[1], HookNode):
-                target = next(iter(edges))[1].addr
+            node = next(iter(edges))[1]
+            if len(edges) == 1 and (type(node) is HookNode or type(node) is SyscallNode):
+                target = node.addr
                 if target in self._function_manager:
                     target_func = self._function_manager[target]
                     binary_name = target_func.binary_name
@@ -1137,5 +1138,5 @@ class Function:
         return func
 
 
-from ...codenode import BlockNode, HookNode
+from ...codenode import BlockNode, HookNode, SyscallNode
 from ...errors import AngrValueError

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -67,7 +67,8 @@ class Function:
             # Determine whether this function is a syscall or not
             self.is_syscall = self._project.simos.is_syscall_addr(addr)
 
-        if project.is_hooked(addr):
+        # Determine whether this function is a simprocedure
+        if self.is_syscall or project.is_hooked(addr):
             self.is_simprocedure = True
 
         if project.loader.find_plt_stub_name(addr) is not None:
@@ -1075,7 +1076,7 @@ class Function:
             # PLT entries must have the same declaration as their jump targets
             # Try to determine which library this PLT entry will jump to
             edges = self.transition_graph.edges()
-            if len(edges) == 1 and type(next(iter(edges))[1]) is HookNode:
+            if len(edges) == 1 and isinstance(next(iter(edges))[1], HookNode):
                 target = next(iter(edges))[1].addr
                 if target in self._function_manager:
                     target_func = self._function_manager[target]

--- a/angr/project.py
+++ b/angr/project.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import types
-import weakref
 from io import BytesIO, IOBase
 import pickle
 import string
@@ -683,7 +682,7 @@ class Project:
         return self.simos
 
 
-from .errors import AngrError, AngrNoPluginError
+from .errors import AngrNoPluginError
 from .factory import AngrObjectFactory
 from angr.simos import SimOS, os_mapping
 from .analyses.analysis import AnalysesHub

--- a/tests/test_ddg.py
+++ b/tests/test_ddg.py
@@ -75,13 +75,13 @@ def test_ddg_0():
 
 def run_all():
     functions = globals()
-    all_functions = dict(filter((lambda kv: kv[0].startswith('test_') and hasattr(v, '__call__')), functions.items()))
+    all_functions = dict(filter((lambda kv: kv[0].startswith('test_') and hasattr(kv[1], '__call__')), functions.items()))
     for f in sorted(all_functions.keys()):
         all_functions[f]()
 
 if __name__ == "__main__":
-    #logging.getLogger("angr.analyses.cfg").setLevel(logging.DEBUG)
-    #logging.getLogger("angr.analyses.ddg").setLevel(logging.DEBUG)
+    logging.getLogger("angr.analyses.cfg").setLevel(logging.DEBUG)
+    logging.getLogger("angr.analyses.ddg").setLevel(logging.DEBUG)
 
     if len(sys.argv) > 1:
         globals()['test_' + sys.argv[1]]()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -60,7 +60,7 @@ def internaltest_project(fpath):
     assert p.entry == loaded_p.entry
 
     simgr = loaded_p.factory.simulation_manager()
-    simgr.step(n=10)
+    simgr.run(n=10)
     assert len(simgr.errored) == 0
 
 def test_analyses():

--- a/tests/test_sim_procedure.py
+++ b/tests/test_sim_procedure.py
@@ -38,7 +38,7 @@ def test_syscall_and_simprocedure():
     func = proj.kb.functions[node.addr]
     
     nose.tools.assert_true(node.is_simprocedure)
-    #nose.tools.assert_true(node.is_syscall)
+    nose.tools.assert_true(node.is_syscall)
     nose.tools.assert_false(node.to_codenode().is_hook)
     nose.tools.assert_false(proj.is_hooked(node.addr))
     nose.tools.assert_true(func.is_syscall)

--- a/tests/test_sim_procedure.py
+++ b/tests/test_sim_procedure.py
@@ -3,7 +3,9 @@ import angr
 import claripy
 import nose
 from angr.codenode import BlockNode, HookNode, SyscallNode
+
 BIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries')
+
 def test_ret_float():
     p = angr.load_shellcode(b'X', arch='i386')
 
@@ -68,7 +70,6 @@ def test_syscall_and_simprocedure():
     nose.tools.assert_false(func.is_syscall)
     nose.tools.assert_true(func.is_simprocedure)
     nose.tools.assert_equal(type(proj.factory.snippet(node.addr)), HookNode)
-
 
 
 if __name__ == '__main__':

--- a/tests/test_sim_procedure.py
+++ b/tests/test_sim_procedure.py
@@ -1,6 +1,8 @@
+import os
 import angr
 import claripy
 import nose
+from angr.codenode import BlockNode, HookNode, SyscallNode
 
 def test_ret_float():
     p = angr.load_shellcode(b'X', arch='i386')
@@ -26,5 +28,49 @@ def test_ret_float():
     nose.tools.assert_false(s2.regs.st0.symbolic)
     nose.tools.assert_equal(s2.solver.eval(s2.regs.st0.raw_to_fp()), 12.5)
 
+def test_syscall_and_simprocedure():
+    bin_path = os.path.join('..', '..', 'binaries', 'tests', 'cgc', 'CADET_00002')
+    proj = angr.Project(bin_path)
+    cfg = proj.analyses.CFGFast(normalize=True)
+    
+    # check syscall
+    node = cfg.get_any_node(0xa000001)
+    func = proj.kb.functions[node.addr]
+    
+    nose.tools.assert_true(node.is_simprocedure)
+    #nose.tools.assert_true(node.is_syscall)
+    nose.tools.assert_false(node.to_codenode().is_hook)
+    nose.tools.assert_false(proj.is_hooked(node.addr))
+    nose.tools.assert_true(func.is_syscall)
+    nose.tools.assert_true(func.is_simprocedure)
+    nose.tools.assert_equal(type(proj.factory.snippet(node.addr)), SyscallNode)
+    
+    # check normal functions
+    node = cfg.get_any_node(0x80480a0)
+    func = proj.kb.functions[node.addr]
+    
+    nose.tools.assert_false(node.is_simprocedure)
+    nose.tools.assert_false(node.is_syscall)
+    nose.tools.assert_false(proj.is_hooked(node.addr))
+    nose.tools.assert_false(func.is_syscall)
+    nose.tools.assert_false(func.is_simprocedure)
+    nose.tools.assert_equal(type(proj.factory.snippet(node.addr)), BlockNode)
+    
+    # check hooked functions
+    proj.hook(0x80480a0, angr.SIM_PROCEDURES['libc']['puts']())
+    cfg = proj.analyses.CFGFast(normalize=True)# rebuild cfg to updated nodes
+    node = cfg.get_any_node(0x80480a0)
+    func = proj.kb.functions[node.addr]
+    
+    nose.tools.assert_true(node.is_simprocedure)
+    nose.tools.assert_false(node.is_syscall)
+    nose.tools.assert_true(proj.is_hooked(node.addr))
+    nose.tools.assert_false(func.is_syscall)
+    nose.tools.assert_true(func.is_simprocedure)
+    nose.tools.assert_equal(type(proj.factory.snippet(node.addr)), HookNode)
+
+
+
 if __name__ == '__main__':
     test_ret_float()
+    test_syscall_and_simprocedure()

--- a/tests/test_sim_procedure.py
+++ b/tests/test_sim_procedure.py
@@ -3,7 +3,7 @@ import angr
 import claripy
 import nose
 from angr.codenode import BlockNode, HookNode, SyscallNode
-
+BIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries')
 def test_ret_float():
     p = angr.load_shellcode(b'X', arch='i386')
 
@@ -29,7 +29,7 @@ def test_ret_float():
     nose.tools.assert_equal(s2.solver.eval(s2.regs.st0.raw_to_fp()), 12.5)
 
 def test_syscall_and_simprocedure():
-    bin_path = os.path.join('..', '..', 'binaries', 'tests', 'cgc', 'CADET_00002')
+    bin_path = os.path.join(BIN_PATH, 'tests', 'cgc', 'CADET_00002')
     proj = angr.Project(bin_path)
     cfg = proj.analyses.CFGFast(normalize=True)
     


### PR DESCRIPTION
Here is what this pull request does:
1. introduce `SyscallNode` to CFG which is kind of like `HookNode` but it is not hooked. Because syscall is processed in simos instead of hook mechanism.
2. many fixes to distinguish these two. Before this fix, some codes make an assumption that a `sim_procedure` is always hooked which is not true. `syscall` is also a `sim_procedure` but not hooked.
3. add a test case to make sure everything is OK.

Something needs discussion:
There is a terribly confusing attribute `is_syscall` in `CFGNode`. Intuitively, it tells whether this node is the start of a syscall. However, in the world of CFG, its definition is like this:
~~~
is_syscall = jumpkind.startswith("Ijk_Sys")
~~~
It's more like a `end_with_syscall`.
And in other parts of `angr`, for example, `Function`. `Function.is_syscall` tells whether a function object is a syscall or not. In `SimProcedure`, `is_syscall` indicates whether a `sim_procedure` is a syscall or not.
This inconsistency is very confusing.
