### PR TITLE
Adding incrementing ID to SimAction

### DIFF
--- a/angr/state_plugins/sim_action.py
+++ b/angr/state_plugins/sim_action.py
@@ -17,7 +17,7 @@ class SimAction(SimEvent):
     TMP = 'tmp'
     REG = 'reg'
     MEM = 'mem'
-    _MAX_ACTION_ID = 0
+    _MAX_ACTION_ID = -1
 
     def __init__(self, state, region_type):
         """

--- a/angr/state_plugins/sim_action.py
+++ b/angr/state_plugins/sim_action.py
@@ -17,6 +17,7 @@ class SimAction(SimEvent):
     TMP = 'tmp'
     REG = 'reg'
     MEM = 'mem'
+    _MAX_ACTION_ID = 0
 
     def __init__(self, state, region_type):
         """
@@ -26,6 +27,8 @@ class SimAction(SimEvent):
         """
         SimEvent.__init__(self, state, 'action')
         self.type = region_type
+        SimAction._MAX_ACTION_ID += 1
+        self._action_id = SimAction._MAX_ACTION_ID
 
     def __repr__(self):
         if self.sim_procedure is not None:


### PR DESCRIPTION
In looking through the history class and specifically at the actions list, i realized that angr is currently implicitly handling the question of 'actions happened in what order'. This is fine, however I would like to be able to merge different filters together. In doing so, it would be very beneficial to have an `action_id` associated with each action to make the order explicit.

This PR suggests placing a global MAX_ACTION_ID var into the class itself, and referencing it on class instantiation time to transparently add an ID to each SimAction class instantiated.