### PR TITLE
fix get_all_successors/get_all_predecessors in cfg

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -342,11 +342,18 @@ class CFGBase(Analysis):
         :return: A list of predecessors in the CFG
         :rtype: list
         """
+        s = set()
+        for child, parent in networkx.dfs_predecessors(self._graph, cfgnode).items():
+            s.add(child)
+            s.add(parent)
+        return list(s)
 
-        return list(networkx.dfs_predecessors(self._graph, cfgnode))
-
-    def get_all_successors(self, basic_block):
-        return list(networkx.dfs_successors(self._graph, basic_block))
+    def get_all_successors(self, cfgnode):
+        s = set()
+        for parent, children in networkx.dfs_successors(self._graph, cfgnode).items():
+            s.add(parent)
+            s = s.union(children)
+        return list(s)
 
     def get_node(self, block_id):
         """


### PR DESCRIPTION
according to [here](https://networkx.github.io/documentation/networkx-1.10/_modules/networkx/algorithms/traversal/depth_first_search.html#dfs_successors).

The return value of `dfs_successors` is a dict instead of a set or list.
This PR is an attempt to resolve #1420 