### PR TITLE
Add heap infrastructure and simple ptmalloc model

### DIFF
--- a/angr/__init__.py
+++ b/angr/__init__.py
@@ -58,6 +58,7 @@ from .engines import SimEngineVEX, SimEngine
 from .calling_conventions import DEFAULT_CC, SYSCALL_CC, PointerWrapper, SimCC
 from .storage.file import SimFileBase, SimFile, SimPackets, SimFileStream, SimPacketsStream, SimFileDescriptor, SimFileDescriptorDuplex
 from .state_plugins.filesystem import SimMount, SimHostFilesystem
+from .state_plugins.heap import SimHeapBrk, SimHeapPTMalloc, PTChunk
 
 # for compatibility reasons
 from . import sim_manager as manager

--- a/angr/errors.py
+++ b/angr/errors.py
@@ -209,6 +209,9 @@ class SimSymbolicFilesystemError(SimFilesystemError):
 class SimFileError(SimMemoryError, SimFilesystemError):
     pass
 
+class SimHeapError(SimStateError):
+    pass
+
 #
 # Error class during VEX parsing
 #

--- a/angr/procedures/libc/calloc.py
+++ b/angr/procedures/libc/calloc.py
@@ -7,33 +7,8 @@ from angr.sim_type import SimTypeLength, SimTypeArray, SimTypeTop
 
 class calloc(angr.SimProcedure):
     #pylint:disable=arguments-differ
-
     def run(self, sim_nmemb, sim_size):
         self.argument_types = { 0: SimTypeLength(self.state.arch),
                                 1: SimTypeLength(self.state.arch)}
-        plugin = self.state.get_plugin('libc')
-
         self.return_type = self.ty_ptr(SimTypeArray(SimTypeTop(sim_size), sim_nmemb))
-
-        if self.state.solver.symbolic(sim_nmemb):
-            # TODO: find a better way
-            nmemb = self.state.solver.max_int(sim_nmemb)
-        else:
-            nmemb = self.state.solver.eval(sim_nmemb)
-
-        if self.state.solver.symbolic(sim_size):
-            # TODO: find a better way
-            size = self.state.solver.max_int(sim_size)
-        else:
-            size = self.state.solver.eval(sim_size)
-
-        final_size = size * nmemb
-        if final_size > plugin.max_variable_size:
-            final_size = plugin.max_variable_size
-
-        addr = plugin.heap_location
-        plugin.heap_location += final_size
-        v = self.state.solver.BVV(0, final_size * 8)
-        self.state.memory.store(addr, v)
-
-        return addr
+        return self.state.heap._calloc(sim_nmemb, sim_size)

--- a/angr/procedures/libc/free.py
+++ b/angr/procedures/libc/free.py
@@ -7,6 +7,6 @@ from angr.sim_type import SimTypeTop
 class free(angr.SimProcedure):
     #pylint:disable=arguments-differ
 
-    def run(self, ptr): #pylint:disable=unused-argument
+    def run(self, ptr):
         self.argument_types = {0: self.ty_ptr(SimTypeTop())}
-        return self.state.solver.Unconstrained('free', self.state.arch.bits)
+        return self.state.heap._free(ptr)

--- a/angr/procedures/libc/malloc.py
+++ b/angr/procedures/libc/malloc.py
@@ -14,14 +14,4 @@ class malloc(angr.SimProcedure):
     def run(self, sim_size):
         self.argument_types = {0: SimTypeLength(self.state.arch)}
         self.return_type = self.ty_ptr(SimTypeTop(sim_size))
-
-        if self.state.solver.symbolic(sim_size):
-            size = self.state.solver.max_int(sim_size)
-            if size > self.state.libc.max_variable_size:
-                size = self.state.libc.max_variable_size
-        else:
-            size = self.state.solver.eval(sim_size)
-
-        addr = self.state.libc.heap_location
-        self.state.libc.heap_location += size
-        return addr
+        return self.state.heap._malloc(sim_size)

--- a/angr/procedures/libc/realloc.py
+++ b/angr/procedures/libc/realloc.py
@@ -1,32 +1,14 @@
 import angr
 from angr.sim_type import SimTypeLength, SimTypeTop
 
-import logging
-l = logging.getLogger(name=__name__)
-
 ######################################
 # realloc
 ######################################
 
 class realloc(angr.SimProcedure):
     #pylint:disable=arguments-differ
-
     def run(self, ptr, size):
-        if size.symbolic:
-            try:
-                size_int = self.state.solver.max(size, extra_constraints=(size < self.state.libc.max_variable_size,))
-            except angr.errors.SimSolverError:
-                size_int = self.state.solver.min(size)
-            self.state.add_constraints(size_int == size)
-        else:
-            size_int = self.state.solver.eval(size)
-
-        addr = self.state.libc.heap_location
-
-        if self.state.solver.eval(ptr) != 0:
-            v = self.state.memory.load(ptr, size_int)
-            self.state.memory.store(addr, v)
-            
-        self.state.libc.heap_location += size_int
-
-        return addr
+        self.argument_types = { 0: self.ty_ptr(SimTypeTop()),
+                                1: SimTypeLength(self.state.arch) }
+        self.return_type = self.ty_ptr(SimTypeTop(size))
+        return self.state.heap._realloc(ptr, size)

--- a/angr/procedures/posix/mmap.py
+++ b/angr/procedures/posix/mmap.py
@@ -91,13 +91,13 @@ class mmap(angr.SimProcedure):
 
     def allocate_memory(self,size):
 
-        addr = self.state.libc.mmap_base
+        addr = self.state.heap.mmap_base
         new_base = addr + size
 
         if new_base & 0xfff:
             new_base = (new_base & ~0xfff) + 0x1000
 
-        self.state.libc.mmap_base = new_base
+        self.state.heap.mmap_base = new_base
 
         return addr
 

--- a/angr/procedures/win32/VirtualAlloc.py
+++ b/angr/procedures/win32/VirtualAlloc.py
@@ -96,12 +96,12 @@ class VirtualAlloc(angr.SimProcedure):
         return addr
 
     def allocate_memory(self,size):
-        addr = self.state.libc.mmap_base
+        addr = self.state.heap.mmap_base
         new_base = addr + size
 
         if new_base & 0xfff:
             new_base = (new_base & ~0xfff) + 0x1000
 
-        self.state.libc.mmap_base = new_base
+        self.state.heap.mmap_base = new_base
         return addr
 

--- a/angr/procedures/win32/heap.py
+++ b/angr/procedures/win32/heap.py
@@ -10,16 +10,7 @@ class HeapCreate(angr.SimProcedure):
 
 class HeapAlloc(angr.SimProcedure):
     def run(self, HeapHandle, Flags, Size):
-        if self.state.solver.symbolic(Size):
-            size = self.state.solver.max_int(Size)
-            if size > self.state.libc.max_variable_size:
-                size = self.state.libc.max_variable_size
-        else:
-            size = self.state.solver.eval(Size)
-
-        addr = self.state.libc.heap_location
-        self.state.libc.heap_location += size
-        return addr
+        return self.state.heap._malloc(Size)
 
 class GlobalAlloc(HeapAlloc):
     def run(self, Flags, Size):

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -52,8 +52,9 @@ class SimState(PluginHub):
     :ivar str unicorn:      Control of the Unicorn Engine
     """
 
-    def __init__(self, project=None, arch=None, plugins=None, memory_backer=None, permissions_backer=None, mode=None, options=None,
-                 add_options=None, remove_options=None, special_memory_filler=None, os_name=None, plugin_preset='default', **kwargs):
+    def __init__(self, project=None, arch=None, plugins=None, memory_backer=None, permissions_backer=None, mode=None,
+                 options=None, add_options=None, remove_options=None, special_memory_filler=None, os_name=None,
+                 heap=None, plugin_preset='default', **kwargs):
         if kwargs:
             l.warning("Unused keyword arguments passed to SimState: %s", " ".join(kwargs))
         super(SimState, self).__init__()
@@ -145,6 +146,9 @@ class SimState(PluginHub):
         # this is a global condition, applied to all added constraints, memory reads, etc
         self._global_condition = None
         self.ip_constraints = []
+
+        if heap is not None:
+            self.register_plugin('heap', heap)
 
     def __getstate__(self):
         s = { k:v for k,v in self.__dict__.items() if k not in ('inspect', 'regs', 'mem')}

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -179,7 +179,7 @@ class SimWindows(SimOS):
         state = super(SimWindows, self).state_blank(**kwargs)
 
         # yikes!!!
-        fun_stuff_addr = state.libc.mmap_base
+        fun_stuff_addr = state.heap.mmap_base
         if fun_stuff_addr & 0xffff != 0:
             fun_stuff_addr += 0x10000 - (fun_stuff_addr & 0xffff)
         state.memory.map_region(fun_stuff_addr, 0x2000, claripy.BVV(3, 3))
@@ -222,7 +222,7 @@ class SimWindows(SimOS):
             if total_alloc_size & 0xfff != 0:
                 total_alloc_size += 0x1000 - (total_alloc_size & 0xfff)
             state.memory.map_region(LDR_addr, total_alloc_size, claripy.BVV(3, 3))
-            state.libc.mmap_base = LDR_addr + total_alloc_size
+            state.heap.mmap_base = LDR_addr + total_alloc_size
 
             string_area = LDR_addr + thunk_alloc_size
             for i, obj in enumerate(self.project.loader.all_pe_objects):

--- a/angr/state_plugins/__init__.py
+++ b/angr/state_plugins/__init__.py
@@ -23,4 +23,5 @@ from .preconstrainer import *
 from .loop_data import *
 from .view import *
 from .filesystem import *
+from .heap import *
 from .concrete import *

--- a/angr/state_plugins/gdb.py
+++ b/angr/state_plugins/gdb.py
@@ -60,7 +60,7 @@ class GDB(SimStatePlugin):
         """
         # We set the heap at the same addresses as the gdb session to avoid pointer corruption.
         data = self._read_data(heap_dump)
-        self.state.libc.heap_location = heap_base + len(data)
+        self.state.heap.heap_location = heap_base + len(data)
         addr = heap_base
         l.info("Set heap from 0x%x to %#x", addr, addr+len(data))
         #FIXME: we should probably make we don't overwrite other stuff loaded there

--- a/angr/state_plugins/heap/__init__.py
+++ b/angr/state_plugins/heap/__init__.py
@@ -1,0 +1,5 @@
+#pylint:disable=wildcard-import
+from .heap_base import *
+from .heap_brk import *
+from .heap_libc import *
+from .heap_ptmalloc import *

--- a/angr/state_plugins/heap/heap_base.py
+++ b/angr/state_plugins/heap/heap_base.py
@@ -1,0 +1,118 @@
+from ..plugin import SimStatePlugin
+
+from ...errors import SimMemoryError
+from .. import sim_options as opts
+
+import logging
+
+l = logging.getLogger("angr.state_plugins.heap.heap_base")
+
+# TODO: derive heap location from SimOS and binary info for something more realistic (and safe?)
+DEFAULT_HEAP_LOCATION = 0xc0000000
+DEFAULT_HEAP_SIZE = 64 * 4096
+
+class SimHeapBase(SimStatePlugin):
+    """
+    This is the base heap class that all heap implementations should subclass. It defines a few handlers for common
+    heap functions (the libc memory management functions). Heap implementations are expected to override these
+    functions regardless of whether they implement the SimHeapLibc interface. For an example, see the SimHeapBrk
+    implementation, which is based on the original libc SimProcedure implementations.
+
+    :ivar heap_base: the address of the base of the heap in memory
+    :ivar heap_size: the total size of the main memory region managed by the heap in memory
+    :ivar mmap_base: the address of the region from which large mmap allocations will be made
+    """
+
+    def __init__(self, heap_base=None, heap_size=None):
+        SimStatePlugin.__init__(self)
+
+        self.heap_base = heap_base if heap_base is not None else DEFAULT_HEAP_LOCATION
+        self.heap_size = heap_size if heap_size is not None else DEFAULT_HEAP_SIZE
+        self.mmap_base = DEFAULT_HEAP_LOCATION + DEFAULT_HEAP_SIZE * 2
+
+    def _conc_alloc_size(self, sim_size):
+        """
+        Concretizes a size argument, if necessary, to something that makes sense when allocating space. Here we just
+        maximize its potential size up to the maximum variable size specified in the libc plugin.
+
+        TODO:
+        Further consideration of the tradeoffs of this approach is probably warranted. SimHeapPTMalloc especially makes
+        a lot of different concretization strategy assumptions, but this function handles one of the more important
+        problems that any heap implementation will face: how to decide the amount of space to allocate upon request for
+        a symbolic size. Either we do as we do here and silently constrain the amount returned to a default max value,
+        or we could add a path constraint to the state to prevent exploration of any paths that would have legitimately
+        occurred given a larger allocation size.
+
+        The first approach (the silent maximum) has its benefit in that the explored state space will not be
+        constrained. Sometimes this could work out, as when an allocation is returned that is smaller than requested but
+        which the program doesn't end up making full use of anyways. Alternatively, this lack of fidelity could cause
+        the program to overwrite other allocations made, since it should be able to assume the allocation is as large as
+        it requested it be.
+
+        The second approach (the path constraint) has its benefit in that no paths will be explored that *could* fail
+        when an allocation is made too small. On the other hand, as stated above, some of these paths might not have
+        failed anyways, and doing this causes us to lose the opportunity to explore those paths.
+
+        Perhaps these behaviors could be parameterized in the future?
+        """
+        if self.state.solver.symbolic(sim_size):
+            size = self.state.solver.max_int(sim_size)
+            if size > self.state.libc.max_variable_size:
+                l.warning("Allocation request of %d bytes exceeded maximum of %d bytes; allocating %d bytes",
+                          size, self.state.libc.max_variable_size, size)
+                size = self.state.libc.max_variable_size
+        else:
+            size = self.state.solver.eval(sim_size)
+        return size
+
+    def _malloc(self, sim_size):
+        """
+        Handler for any libc `malloc` SimProcedure call. If the heap has faithful support for `malloc`, it ought to be
+        implemented in a `malloc` function (as opposed to the `_malloc` function).
+
+        :param sim_size: the amount of memory (in bytes) to be allocated
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self._malloc.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def _free(self, ptr):
+        """
+        Handler for any libc `free` SimProcedure call. If the heap has faithful support for `free`, it ought to be
+        implemented in a `free` function (as opposed to the `_free` function).
+
+        :param ptr: the location in memory to be freed
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self._free.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def _calloc(self, sim_nmemb, sim_size):
+        """
+        Handler for any libc `calloc` SimProcedure call. If the heap has faithful support for `calloc`, it ought to be
+        implemented in a `calloc` function (as opposed to the `_calloc` function).
+
+        :param sim_nmemb: the number of elements to allocated
+        :param sim_size: the size of each element (in bytes)
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self._calloc.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def _realloc(self, ptr, size):
+        """
+        Handler for any libc `realloc` SimProcedure call. If the heap has faithful support for `realloc`, it ought to be
+        implemented in a `realloc` function (as opposed to the `_realloc` function).
+
+        :param ptr: the location in memory to be reallocated
+        :param size: the new size desired for the allocation
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self._realloc.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def init_state(self):
+        if opts.ABSTRACT_MEMORY in self.state.options:
+            return
+
+        try:
+            self.state.memory.permissions(self.heap_base)
+        except SimMemoryError:
+            l.debug("Mapping base heap region")
+            self.state.memory.map_region(self.heap_base, self.heap_size, 3)

--- a/angr/state_plugins/heap/heap_base.py
+++ b/angr/state_plugins/heap/heap_base.py
@@ -28,7 +28,7 @@ class SimHeapBase(SimStatePlugin):
 
         self.heap_base = heap_base if heap_base is not None else DEFAULT_HEAP_LOCATION
         self.heap_size = heap_size if heap_size is not None else DEFAULT_HEAP_SIZE
-        self.mmap_base = DEFAULT_HEAP_LOCATION + DEFAULT_HEAP_SIZE * 2
+        self.mmap_base = self.heap_base + self.heap_size * 2
 
     def _conc_alloc_size(self, sim_size):
         """

--- a/angr/state_plugins/heap/heap_brk.py
+++ b/angr/state_plugins/heap/heap_brk.py
@@ -1,0 +1,128 @@
+from angr.errors import SimSolverError
+from ..plugin import SimStatePlugin
+from . import SimHeapBase
+
+import logging
+
+l = logging.getLogger("angr.state_plugins.heap.heap_brk")
+
+class SimHeapBrk(SimHeapBase):
+    """
+    SimHeapBrk represents a trivial heap implementation based on the Unix `brk` system call. This type of heap stores
+    virtually no metadata, so it is up to the user to determine when it is safe to release memory. This also means that
+    it does not properly support standard heap operations like `realloc`.
+
+    This heap implementation is a holdover from before any more proper implementations were modelled. At the time,
+    various libc (or win32) SimProcedures handled the heap in the same way that this plugin does now. To make future
+    heap implementations plug-and-playable, they should implement the necessary logic themselves, and dependent
+    SimProcedures should invoke a method by the same name as theirs (prepended with an underscore) upon the heap plugin.
+    Depending on the heap implementation, if the method is not supported, an error should be raised.
+
+    Out of consideration for the original way the heap was handled, this plugin implements functionality for all
+    relevant SimProcedures (even those that would not normally be supported together in a single heap implementation).
+
+    :ivar heap_location: the address of the top of the heap, bounding the allocations made starting from `heap_base`
+    """
+
+    def __init__(self, heap_base=None, heap_size=None):
+        super(SimHeapBrk, self).__init__(heap_base, heap_size)
+        self.heap_location = self.heap_base
+
+    def allocate(self, sim_size):
+        """
+        The actual allocation primitive for this heap implementation. Increases the position of the break to allocate
+        space. Has no guards against the heap growing too large.
+
+        :param sim_size: a size specifying how much to increase the break pointer by
+        :returns: a pointer to the previous break position, above which there is now allocated space
+        """
+        size = self._conc_alloc_size(sim_size)
+        addr = self.state.heap.heap_location
+        self.state.heap.heap_location += size
+        l.debug("Allocating %d bytes at address %#08x", size, addr)
+        return addr
+
+    def release(self, sim_size):
+        """
+        The memory release primitive for this heap implementation. Decreases the position of the break to deallocate
+        space. Guards against releasing beyond the initial heap base.
+
+        :param sim_size: a size specifying how much to decrease the break pointer by (may be symbolic or not)
+        """
+        requested = self._conc_alloc_size(sim_size)
+        used = self.heap_location - self.heap_base
+        released = requested if requested <= used else used
+        self.heap_location -= released
+        l.debug("Releasing %d bytes from the heap (%d bytes were requested to be released)", released, requested)
+
+    def _malloc(self, sim_size):
+        return self.allocate(sim_size)
+
+    def _free(self, ptr):  #pylint:disable=unused-argument
+        return self.state.solver.Unconstrained('free', self.state.arch.bits)
+
+    def _calloc(self, sim_nmemb, sim_size):
+        plugin = self.state.get_plugin('libc')
+
+        if self.state.solver.symbolic(sim_nmemb):
+            # TODO: find a better way
+            nmemb = self.state.solver.max_int(sim_nmemb)
+        else:
+            nmemb = self.state.solver.eval(sim_nmemb)
+
+        if self.state.solver.symbolic(sim_size):
+            # TODO: find a better way
+            size = self.state.solver.max_int(sim_size)
+        else:
+            size = self.state.solver.eval(sim_size)
+
+        final_size = size * nmemb
+        if final_size > plugin.max_variable_size:
+            final_size = plugin.max_variable_size
+
+        addr = self.state.heap.allocate(final_size)
+        v = self.state.solver.BVV(0, final_size * 8)
+        self.state.memory.store(addr, v)
+        return addr
+
+    def _realloc(self, ptr, size):
+        if size.symbolic:
+            try:
+                size_int = self.state.solver.max(size, extra_constraints=(size < self.state.libc.max_variable_size,))
+            except SimSolverError:
+                size_int = self.state.solver.min(size)
+            self.state.add_constraints(size_int == size)
+        else:
+            size_int = self.state.solver.eval(size)
+
+        addr = self.state.heap.allocate(size_int)
+
+        if self.state.solver.eval(ptr) != 0:
+            v = self.state.memory.load(ptr, size_int)
+            self.state.memory.store(addr, v)
+
+        return addr
+
+    @SimStatePlugin.memo
+    def copy(self, memo):# pylint: disable=unused-argument
+        c = SimHeapBrk()
+        c.heap_location = self.heap_location
+        c.mmap_base = self.mmap_base
+        return c
+
+    def _combine(self, others):
+        new_heap_location = max(o.heap_location for o in others)
+        if self.heap_location != new_heap_location:
+            self.heap_location = new_heap_location
+            return True
+        else:
+            return False
+
+    def merge(self, others, merge_conditions, common_ancestor=None):  #pylint:disable=unused-argument
+        return self._combine(others)
+
+    def widen(self, others):
+        return self._combine(others)
+
+from angr.sim_state import SimState
+SimState.register_default('heap', SimHeapBrk)

--- a/angr/state_plugins/heap/heap_brk.py
+++ b/angr/state_plugins/heap/heap_brk.py
@@ -105,7 +105,7 @@ class SimHeapBrk(SimHeapBase):
 
     @SimStatePlugin.memo
     def copy(self, memo):# pylint: disable=unused-argument
-        c = SimHeapBrk()
+        c = SimHeapBrk(heap_base=self.heap_base, heap_size=self.heap_size)
         c.heap_location = self.heap_location
         c.mmap_base = self.mmap_base
         return c

--- a/angr/state_plugins/heap/heap_freelist.py
+++ b/angr/state_plugins/heap/heap_freelist.py
@@ -1,0 +1,208 @@
+from . import SimHeapLibc
+from .utils import concretize
+from ...errors import SimHeapError
+
+import logging
+
+l = logging.getLogger("angr.state_plugins.heap.heap_freelist")
+
+class Chunk:
+    """
+    The sort of chunk as would typically be found in a freelist-style heap implementation. Provides a representation of
+    a chunk via a view into the memory plugin. Chunks may be adjacent, in different senses, to as many as four other
+    chunks. For any given chunk, two of these chunks are adjacent to it in memory, and are referred to as the "previous"
+    and "next" chunks throughout this implementation. For any given free chunk, there may also be two significant chunks
+    that are adjacent to it in some linked list of free chunks. These chunks are referred to the "backward" and "foward"
+    chunks relative to the chunk in question.
+
+    :ivar base: the location of the base of the chunk in memory
+    :ivar state: the program state that the chunk is resident in
+    """
+
+    def __init__(self, base, sim_state):
+        self.state = sim_state
+
+        def sym_chunk_handler(chunk):
+            l.warning("A pointer to a chunk is symbolic; maximizing it")
+            return self.state.solver.max_int(chunk)
+
+        self.base = concretize(base, self.state.solver, sym_chunk_handler)
+
+    def get_size(self):
+        """
+        Returns the actual size of a chunk (as opposed to the entire size field, which may include some flags).
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.get_size.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def set_size(self, size):
+        """
+        Sets the size of the chunk, preserving any flags.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.set_size.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def data_ptr(self):
+        """
+        Returns the address of the payload of the chunk.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.data_ptr.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def is_free(self):
+        """
+        Returns a concrete determination as to whether the chunk is free.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.is_free.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def next_chunk(self):
+        """
+        Returns the chunk immediately following (and adjacent to) this one.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.next_chunk.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def prev_chunk(self):
+        """
+        Returns the chunk immediately prior (and adjacent) to this one.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.prev_chunk.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def fwd_chunk(self):
+        """
+        Returns the chunk following this chunk in the list of free chunks.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.fwd_chunk.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def set_fwd_chunk(self, fwd):
+        """
+        Sets the chunk following this chunk in the list of free chunks.
+
+        :param fwd: the chunk to follow this chunk in the list of free chunks
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.set_fwd_chunk.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def bck_chunk(self):
+        """
+        Returns the chunk backward from this chunk in the list of free chunks.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.bck_chunk.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def set_bck_chunk(self, bck):
+        """
+        Sets the chunk backward from this chunk in the list of free chunks.
+
+        :param bck: the chunk to precede this chunk in the list of free chunks
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.set_bck_chunk.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def _compare(self, other, comparison):
+        if self.state is other.state:
+            return comparison
+        else:
+            raise SimHeapError("Chunks must originate from the same simulation state to be compared!")
+
+    def __lt__(self, other):
+        """
+        Compares the base of this chunk with another chunk.
+        """
+        return self._compare(other, self.base < other.base)
+
+    def __le__(self, other):
+        """
+        Compares the base of this chunk with another chunk.
+        """
+        return self._compare(other, self.base <= other.base)
+
+    def __eq__(self, other):
+        """
+        Compares the base of this chunk with another chunk.
+        """
+        return self._compare(other, self.base == other.base)
+
+    def __ne__(self, other):
+        """
+        Compares the base of this chunk with another chunk.
+        """
+        return self._compare(other, self.base != other.base)
+
+    def __gt__(self, other):
+        """
+        Compares the base of this chunk with another chunk.
+        """
+        return self._compare(other, self.base > other.base)
+
+    def __ge__(self, other):
+        """
+        Compares the base of this chunk with another chunk.
+        """
+        return self._compare(other, self.base >= other.base)
+
+    def __repr__(self):
+        return "<%s (%s @ 0x%x)>" % (self.__class__.__name__, "free" if self.is_free() else "used", self.base)
+
+class SimHeapFreelist(SimHeapLibc):
+    """
+    A freelist-style heap implementation. Distinguishing features of such heaps include chunks containing heap
+    metadata in addition to user data and at least (but often more than) one linked list of free chunks.
+    """
+
+    def __iter__(self):
+        return self.chunks()
+
+    def chunks(self):
+        """
+        Returns an iterator over all the chunks in the heap.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.chunks.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def allocated_chunks(self):
+        """
+        Returns an iterator over all the allocated chunks in the heap.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.allocated_chunks.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def free_chunks(self):
+        """
+        Returns an iterator over all the free chunks in the heap.
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.free_chunks.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def chunk_from_mem(self, ptr):
+        """
+        Given a pointer to a user payload, return the chunk associated with that payload.
+
+        :param ptr: a pointer to the base of a user payload in the heap
+        :returns: the associated heap chunk
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.chunk_from_mem.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def print_heap_state(self):
+        print("┌───────────────────────────────┐")
+        print("├───────── HEAP CHUNKS ─────────┤")
+        for ck in self.chunks():
+            print("│ " + str(ck) + " │")
+        print("├───────── USED CHUNKS ─────────┤")
+        for ck in self.allocated_chunks():
+            print("│ " + str(ck) + " │")
+        print("├───────── FREE CHUNKS ─────────┤")
+        for ck in self.free_chunks():
+            print("│ " + str(ck) + " │")
+        print("└───────────────────────────────┘")
+
+    def print_all_chunks(self):
+        print("┌───────────────────────────────┐")
+        print("├───────── HEAP CHUNKS ─────────┤")
+        for ck in self.chunks():
+            print("│ " + str(ck) + " │")
+        print("└───────────────────────────────┘")

--- a/angr/state_plugins/heap/heap_libc.py
+++ b/angr/state_plugins/heap/heap_libc.py
@@ -1,0 +1,48 @@
+from . import SimHeapBase
+
+class SimHeapLibc(SimHeapBase):
+    """
+    A class of heap that implements the major libc heap management functions.
+    """
+
+    def malloc(self, sim_size):
+        """
+        A somewhat faithful implementation of libc `malloc`.
+
+        :param sim_size: the amount of memory (in bytes) to be allocated
+        :returns: the address of the allocation, or a NULL pointer if the allocation failed
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.malloc.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def free(self, ptr):  #pylint:disable=unused-argument
+        """
+        A somewhat faithful implementation of libc `free`.
+
+        :param ptr: the location in memory to be freed
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.free.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def calloc(self, sim_nmemb, sim_size):
+        """
+        A somewhat faithful implementation of libc `calloc`.
+
+        :param sim_nmemb: the number of elements to allocated
+        :param sim_size: the size of each element (in bytes)
+        :returns: the address of the allocation, or a NULL pointer if the allocation failed
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.calloc.__func__.__name__,
+                                                                 self.__class__.__name__))
+
+    def realloc(self, ptr, size):
+        """
+        A somewhat faithful implementation of libc `realloc`.
+
+        :param ptr: the location in memory to be reallocated
+        :param size: the new size desired for the allocation
+        :returns: the address of the allocation, or a NULL pointer if the allocation was freed or if no new allocation
+        was made
+        """
+        raise NotImplementedError("%s not implemented for %s" % (self.realloc.__func__.__name__,
+                                                                 self.__class__.__name__))

--- a/angr/state_plugins/heap/heap_ptmalloc.py
+++ b/angr/state_plugins/heap/heap_ptmalloc.py
@@ -540,9 +540,7 @@ class SimHeapPTMalloc(SimHeapFreelist):
 
     @SimStatePlugin.memo
     def copy(self, memo):# pylint: disable=unused-argument
-        c = SimHeapPTMalloc()
-        c.heap_base = self.heap_base
-        c.heap_size = self.heap_size
+        c = SimHeapPTMalloc(heap_base=self.heap_base, heap_size=self.heap_size)
         c.mmap_base = self.mmap_base
         c._free_head_chunk_exists = True if self.free_head_chunk is not None else False
         c._free_head_chunk_init_base = self.free_head_chunk.base if self.free_head_chunk is not None else None

--- a/angr/state_plugins/heap/heap_ptmalloc.py
+++ b/angr/state_plugins/heap/heap_ptmalloc.py
@@ -1,0 +1,613 @@
+from ..plugin import SimStatePlugin
+from .heap_freelist import SimHeapFreelist, Chunk
+from .utils import concretize
+
+from ...errors import SimHeapError, SimMergeError
+
+import logging
+
+l = logging.getLogger("angr.state_plugins.heap.heap_ptmalloc")
+sml = logging.getLogger('angr.state_plugins.symbolic_memory')
+
+CHUNK_FLAGS_MASK = 0x07
+CHUNK_P_MASK = 0x01
+
+# These are included as sometimes the heap will touch uninitialized locations, which normally causes a warning
+def silence_logger():
+    level = sml.getEffectiveLevel()
+    sml.setLevel('ERROR')
+    return level
+
+def unsilence_logger(level):
+    sml.setLevel(level)
+
+class PTChunk(Chunk):
+    """
+    A chunk, inspired by the implementation of chunks in ptmalloc. Provides a representation of a chunk via a view into
+    the memory plugin. For the chunk definitions and docs that this was loosely based off of, see glibc malloc/malloc.c,
+    line 1033, as of commit 5a580643111ef6081be7b4c7bd1997a5447c903f. Alternatively, take the following link.
+    https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=67cdfd0ad2f003964cd0f7dfe3bcd85ca98528a7;hb=5a580643111ef6081be7b4c7bd1997a5447c903f#l1033
+
+    :ivar base: the location of the base of the chunk in memory
+    :ivar state: the program state that the chunk is resident in
+    :ivar heap: the heap plugin that the chunk is managed by
+    """
+
+    def __init__(self, base, sim_state, heap=None):
+        super(PTChunk, self).__init__(base, sim_state)
+
+        # This is necessary since the heap can't always be referenced through the state, e.g. during heap initialization
+        self.heap = self.state.heap if heap is None else heap
+
+        # Size in bytes of the type used to store a piece of metadata
+        self._chunk_size_t_size = self.heap._chunk_size_t_size
+        self._chunk_min_size = self.heap._chunk_min_size
+        self._chunk_align_mask = self.heap._chunk_align_mask
+
+    def get_size(self):
+        return self.state.memory.load(self.base + self._chunk_size_t_size, self._chunk_size_t_size) & ~CHUNK_FLAGS_MASK
+
+    def _set_leading_size(self, size):
+        level = silence_logger()
+        chunk_flags = self.state.memory.load(self.base + self._chunk_size_t_size, self._chunk_size_t_size) \
+                      & CHUNK_FLAGS_MASK
+        unsilence_logger(level)
+        self.state.memory.store(self.base + self._chunk_size_t_size, size | chunk_flags)
+
+    def _set_trailing_size(self, size):
+        if self.is_free():
+            next_chunk = self.next_chunk()
+            if next_chunk is not None:
+                self.state.memory.store(next_chunk.base, size)
+
+    def set_size(self, size, is_free=None):  #pylint:disable=arguments-differ
+        """
+        Use this to set the size on a chunk. When the chunk is new (such as when a free chunk is shrunk to form an
+        allocated chunk and a remainder free chunk) it is recommended that the is_free hint be used since setting the
+        size depends on the chunk's freeness, and vice versa.
+
+        :param size: size of the chunk
+        :param is_free: boolean indicating the chunk's freeness
+        """
+        self._set_leading_size(size)
+        next_chunk = self.next_chunk()
+        if is_free is not None:
+            if next_chunk is not None:
+                next_chunk.set_prev_freeness(is_free)
+            else:
+                self.heap._set_final_freeness(is_free)
+        if is_free is not None and is_free or self.is_free():
+            if next_chunk is not None:
+                self.state.memory.store(next_chunk.base, size)
+
+    def set_prev_freeness(self, is_free):
+        """
+        Sets (or unsets) the flag controlling whether the previous chunk is free.
+
+        :param is_free: if True, sets the previous chunk to be free; if False, sets it to be allocated
+        """
+        level = silence_logger()
+        size_field = self.state.memory.load(self.base + self._chunk_size_t_size, self._chunk_size_t_size)
+        unsilence_logger(level)
+        if is_free:
+            self.state.memory.store(self.base + self._chunk_size_t_size, size_field & ~CHUNK_P_MASK)
+        else:
+            self.state.memory.store(self.base + self._chunk_size_t_size, size_field | CHUNK_P_MASK)
+
+    def is_prev_free(self):
+        """
+        Returns a concrete state of the flag indicating whether the previous chunk is free or not. Issues a warning if
+        that flag is symbolic and has multiple solutions, and then assumes that the previous chunk is free.
+
+        :returns: True if the previous chunk is free; False otherwise
+        """
+        flag = self.state.memory.load(self.base + self._chunk_size_t_size, self._chunk_size_t_size) & CHUNK_P_MASK
+
+        def sym_flag_handler(flag):
+            l.warning("A chunk's P flag is symbolic; assuming it is not set")
+            return self.state.solver.min_int(flag)
+
+        flag = concretize(flag, self.state.solver, sym_flag_handler)
+        return False if flag else True
+
+    def prev_size(self):
+        """
+        Returns the size of the previous chunk, masking off what would be the flag bits if it were in the actual size
+        field. Performs NO CHECKING to determine whether the previous chunk size is valid (for example, when the
+        previous chunk is not free, its size cannot be determined).
+        """
+        return self.state.memory.load(self.base, self._chunk_size_t_size) & ~CHUNK_FLAGS_MASK
+
+    def is_free(self):
+        next_chunk = self.next_chunk()
+        if next_chunk is not None:
+            return next_chunk.is_prev_free()
+        else:
+            flag = self.state.memory.load(self.heap.heap_base
+                                          + self.heap.heap_size
+                                          - self._chunk_size_t_size
+                                          , self._chunk_size_t_size) \
+                   & CHUNK_P_MASK
+
+            def sym_flag_handler(flag):
+                l.warning("The final P flag is symbolic; assuming it is not set")
+                return self.state.solver.min_int(flag)
+
+            flag = concretize(flag, self.state.solver, sym_flag_handler)
+            return False if flag else True
+
+    def data_ptr(self):
+        return self.base + (2 * self._chunk_size_t_size)
+
+    def next_chunk(self):
+        """
+        Returns the chunk immediately following (and adjacent to) this one, if it exists.
+
+        :returns: The following chunk, or None if applicable
+        """
+
+        def sym_base_handler(base):
+            l.warning("A computed chunk base is symbolic; maximizing it")
+            return self.state.solver.max_int(base)
+
+        base = concretize(self.base + self.get_size(), self.state.solver, sym_base_handler)
+        if base >= self.heap.heap_base + self.heap.heap_size - 2 * self._chunk_size_t_size:
+            return None
+        else:
+            return PTChunk(base, self.state)
+
+    def prev_chunk(self):
+        """
+        Returns the chunk immediately prior (and adjacent) to this one, if that chunk is free. If the prior chunk is not
+        free, then its base cannot be located and this method raises an error.
+
+        :returns: If possible, the previous chunk; otherwise, raises an error
+        """
+        if self.is_prev_free():
+            return PTChunk(self.base - self.prev_size(), self.state)
+        else:
+            raise SimHeapError("Attempted to access the previous chunk, but it was not free")
+
+    def fwd_chunk(self):
+        """
+        Returns the chunk following this chunk in the list of free chunks. If this chunk is not free, then it resides in
+        no such list and this method raises an error.
+
+        :returns: If possible, the forward chunk; otherwise, raises an error
+        """
+        if self.is_free():
+            base = self.state.memory.load(self.base + 2 * self._chunk_size_t_size, self._chunk_size_t_size)
+            return PTChunk(base, self.state)
+        else:
+            raise SimHeapError("Attempted to access the forward chunk of an allocated chunk")
+
+    def set_fwd_chunk(self, fwd):
+        self.state.memory.store(self.base + 2 * self._chunk_size_t_size, fwd.base)
+
+    def bck_chunk(self):
+        """
+        Returns the chunk backward from this chunk in the list of free chunks. If this chunk is not free, then it
+        resides in no such list and this method raises an error.
+
+        :returns: If possible, the backward chunk; otherwise, raises an error
+        """
+        if self.is_free():
+            base = self.state.memory.load(self.base + 3 * self._chunk_size_t_size, self._chunk_size_t_size)
+            return PTChunk(base, self.state)
+        else:
+            raise SimHeapError("Attempted to access the backward chunk of an allocated chunk")
+
+    def set_bck_chunk(self, bck):
+        self.state.memory.store(self.base + 3 * self._chunk_size_t_size, bck.base)
+
+class PTChunkIterator:
+    def __init__(self, chunk, cond=lambda chunk: True):
+        self.chunk = chunk
+        self.cond = cond
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.chunk is None:
+            raise StopIteration
+
+        if self.cond(self.chunk):
+            ret = self.chunk
+            self.chunk = self.chunk.next_chunk()
+        else:
+            while self.chunk is not None and not self.cond(self.chunk):
+                self.chunk = self.chunk.next_chunk()
+            if self.chunk is None:
+                raise StopIteration
+            else:
+                ret = self.chunk
+                self.chunk = self.chunk.next_chunk()
+
+        return ret
+
+class SimHeapPTMalloc(SimHeapFreelist):
+    """
+    A freelist-style heap implementation inspired by ptmalloc. The chunks used by this heap contain heap metadata in
+    addition to user data. While the real-world ptmalloc is implemented using multiple lists of free chunks
+    (corresponding to their different sizes), this more basic model uses a single list of chunks and searches for free
+    chunks using a first-fit algorithm.
+
+    :ivar heap_base: the address of the base of the heap in memory
+    :ivar heap_size: the total size of the main memory region managed by the heap in memory
+    :ivar mmap_base: the address of the region from which large mmap allocations will be made
+    :ivar free_head_chunk: the head of the linked list of free chunks in the heap
+    """
+
+    def __init__(self, heap_base=None, heap_size=None):
+        super(SimHeapPTMalloc, self).__init__(heap_base, heap_size)
+
+        # All of these depend on the state and so are initialized in init_state
+        self._free_head_chunk_exists = True  # Only used during plugin copy due to the dependency on the memory plugin
+        self._free_head_chunk_init_base = None  # Same as above
+        self._chunk_size_t_size = None  # Size (bytes) of the type used to store a piece of metadata
+        self._chunk_min_size = None  # Based on needed fields for any chunk
+        self.free_head_chunk = None
+
+    def chunks(self):
+        return PTChunkIterator(PTChunk(self.heap_base, self.state))
+
+    def allocated_chunks(self):
+        return PTChunkIterator(PTChunk(self.heap_base, self.state), lambda chunk: not chunk.is_free())
+
+    def free_chunks(self):
+        return PTChunkIterator(PTChunk(self.heap_base, self.state), lambda chunk: chunk.is_free())
+
+    def chunk_from_mem(self, ptr):
+        """
+        Given a pointer to a user payload, return the base of the chunk associated with that payload (i.e. the chunk
+        pointer). Returns None if ptr is null.
+
+        :param ptr: a pointer to the base of a user payload in the heap
+        :returns: a pointer to the base of the associated heap chunk, or None if ptr is null
+        """
+        if self.state.solver.symbolic(ptr):
+            sols = self.state.solver.eval_upto(ptr, 2)
+            if len(sols) > 1:
+                l.warning("A pointer to a chunk is symbolic; maximizing it")
+                ptr = self.state.solver.max_int(ptr)
+            else:
+                ptr = sols[0]
+        else:
+            ptr = self.state.solver.eval(ptr)
+        return PTChunk(ptr - (2 * self._chunk_size_t_size), self.state) if ptr != 0 else None
+
+    def _find_bck(self, chunk):
+        """
+        Simply finds the free chunk that would be the backwards chunk relative to the chunk at ptr. Hence, the free head
+        and all other metadata are unaltered by this function.
+        """
+        cur = self.free_head_chunk
+        if cur is None:
+            return None
+        fwd = cur.fwd_chunk()
+        if cur == fwd:
+            return cur
+        # At this point there should be at least two free chunks in the heap
+        if cur < chunk:
+            while cur < fwd < chunk:
+                cur = fwd
+                fwd = cur.fwd_chunk()
+            return cur
+        else:
+            while fwd != self.free_head_chunk:
+                cur = fwd
+                fwd = cur.fwd_chunk()
+            return cur
+
+    def _set_final_freeness(self, flag):
+        """
+        Sets the freedom of the final chunk. Since no proper chunk follows the final chunk, the heap itself manages
+        this. Nonetheless, for now it is implemented as if an additional chunk followed the final chunk.
+        """
+        if flag:
+            self.state.memory.store(self.heap_base + self.heap_size - self._chunk_size_t_size, ~CHUNK_P_MASK)
+        else:
+            self.state.memory.store(self.heap_base + self.heap_size - self._chunk_size_t_size, CHUNK_P_MASK)
+
+    def _make_chunk_size(self, req_size):
+        """
+        Takes an allocation size as requested by the user and modifies it to be a suitable chunk size.
+        """
+        size = req_size
+        size += 2 * self._chunk_size_t_size  # Two size fields
+        size = self._chunk_min_size if size < self._chunk_min_size else size
+        if size & self._chunk_align_mask:                                         # If the chunk would not be aligned
+            size = (size & ~self._chunk_align_mask) + self._chunk_align_mask + 1  # Fix it
+        return size
+
+    def malloc(self, sim_size):
+        size = self._conc_alloc_size(sim_size)
+        req_size = size
+        size = self._make_chunk_size(size)
+
+        chunk = None  # This will be the resulting allocation
+        free_chunk = self.free_head_chunk
+        if free_chunk is None:
+            l.warning("No free chunks available; heap space exhausted")
+            return 0  # No free chunks available
+
+        # This handler will be necessary as we'll be checking the size fields of many free chunks
+        def sym_free_size_handler(size):
+            l.warning("A free chunk's size field is symbolic; maximizing it")
+            return self.state.solver.max_int(size)
+
+        while chunk is None:
+            free_size = free_chunk.get_size()
+            free_size = concretize(free_size, self.state.solver, sym_free_size_handler)
+            if free_size < size:
+                # Chunk is too small to be used; move to the next or fail
+                fwd = free_chunk.fwd_chunk()
+                if fwd <= free_chunk:
+                    l.debug("No free chunks of sufficient size available")
+                    return 0
+                else:
+                    free_chunk = fwd
+            elif free_size > size and free_size - size >= self._chunk_min_size:
+                # Chunk may be too large but we'll use it anyway
+                chunk = free_chunk
+                bck = free_chunk.bck_chunk()  # Store these now as we'll have to remove this chunk from the list
+                fwd = free_chunk.fwd_chunk()
+
+                rem_chunk = PTChunk(chunk.base + size, chunk.state)  # The "remainder" chunk is the unused portion after
+                rem_chunk.set_size(free_size - size, True)           # the allocation is made. Since it follows the used
+                rem_chunk.set_prev_freeness(False)                   # portion, we can set the used chunk as not free.
+                if free_chunk == self.free_head_chunk:
+                    self.free_head_chunk = rem_chunk  # If the used chunk had been the head, now the remainder is
+                chunk.set_size(size)
+                if free_chunk == bck and free_chunk == fwd:  # If the free chunk had been the only free chunk, then the
+                    rem_chunk.set_bck_chunk(rem_chunk)       # remainder chunk is now the only free chunk
+                    rem_chunk.set_fwd_chunk(rem_chunk)
+                else:
+                    rem_chunk.set_bck_chunk(bck)             # Otherwise there was at least one other chunk, and the
+                    rem_chunk.set_fwd_chunk(fwd)             # remainder chunk may safely replace the original in the
+                    bck.set_fwd_chunk(rem_chunk)             # list
+                    fwd.set_bck_chunk(rem_chunk)
+            else:
+                # Chunk is a perfect fit, or the remainder would be too small to split off as a free chunk
+                chunk = free_chunk
+                fwd = free_chunk.fwd_chunk()  # Once again we store these in advance
+                bck = free_chunk.bck_chunk()
+                if bck == fwd and free_chunk == fwd:  # Last chunk being used up
+                    self.free_head_chunk = None
+                else:
+                    if free_chunk == self.free_head_chunk:
+                        self.free_head_chunk = fwd
+                    bck.set_fwd_chunk(fwd)  # We can safely remove the chunk from the list
+                    fwd.set_bck_chunk(bck)
+                next_chunk = chunk.next_chunk()          # Now we set the new chunk to be allocated, using a different
+                if next_chunk is not None:               # approach depending on whether the chunk was the last in the
+                    next_chunk.set_prev_freeness(False)  # heap or not
+                else:
+                    self._set_final_freeness(False)
+
+        addr = chunk.data_ptr()
+        l.debug("Requested: %4d; Allocated: %4d; Returned: %#08x; Chunk: %#08x", req_size, size, addr, chunk.base)
+        return addr
+
+    def free(self, ptr):
+        # In the following, "next" and "previous" (and their abbreviations) refer to the adjacent chunks in memory,
+        # while forward and backward (and their abbreviations) refer to the adjacent chunks in the list of free chunks
+        req = ptr
+        chunk = self.chunk_from_mem(ptr)
+        if chunk is None:
+            return
+        size = chunk.get_size()
+
+        p_in_use = False if chunk.is_prev_free() else True
+        n_ptr = chunk.next_chunk()
+        n_in_use = False if n_ptr is not None and n_ptr.is_free() else True  # Next is taken to be in use if it doesn't
+        if p_in_use and n_in_use:                                            # exist
+            # When both adjacent chunks are in use, no merging will be
+            # necessary between the freed chunk and another free chunk
+            if n_ptr is not None:
+                n_ptr.set_prev_freeness(True)  # Set the chunk to be free
+            else:
+                self._set_final_freeness(True)
+            chunk.set_size(size)           # Reset the chunk's size to account for the trailing size field
+            bck = self._find_bck(chunk)    # Scan the free list to determine where to insert the newly freed chunk
+            if bck is None:
+                # There was no other chunk in the free list
+                self.free_head_chunk = chunk
+                bck = chunk
+                fwd = chunk
+            else:
+                # Insert the chunk after the bck chunk that was found
+                fwd = bck.fwd_chunk()
+                bck.set_fwd_chunk(chunk)
+                fwd.set_bck_chunk(chunk)
+            chunk.set_bck_chunk(bck)
+            chunk.set_fwd_chunk(fwd)
+            if chunk < self.free_head_chunk:
+                self.free_head_chunk = chunk
+        elif not p_in_use and not n_in_use:
+            # If both the adjacent chunks are free, merging between all three will be needed
+            p_ptr = chunk.prev_chunk()  # The previous chunk will be the base of the overall new chunk
+            p_ptr.set_size(p_ptr.get_size() + size + n_ptr.get_size())
+            n_fwd = n_ptr.fwd_chunk()   # The chunk forward from the chunk that's next after the freed chunk, which is
+            p_ptr.set_fwd_chunk(n_fwd)  # needed since we're removing a free chunk (chunk.next_chunk()) from the linked
+            n_fwd.set_bck_chunk(p_ptr)  # list
+        else:
+            # There are two remaining cases, but we handle them generically below by deciding on a base for a new chunk,
+            # determining its size, and updating all metadata around it (even though sometimes it isn't necessary).
+            if not p_in_use:
+                base = chunk.prev_chunk()
+                new_size = size + base.get_size()
+                bck = base.bck_chunk()
+                fwd = base.fwd_chunk()
+            else:
+                n_size = n_ptr.get_size()
+                base = chunk
+                new_size = size + n_size
+                bck = n_ptr.bck_chunk()
+                fwd = n_ptr.fwd_chunk()
+
+                # In case the freed chunk preceded the free head
+                if base < self.free_head_chunk:
+                    self.free_head_chunk = base
+
+                # In case the following chunk was the last free chunk, we can't use its links due to the merge
+                if bck == fwd and bck == n_ptr:
+                    bck = base
+                    fwd = base
+            base.set_size(new_size)
+            base.set_bck_chunk(bck)
+            base.set_fwd_chunk(fwd)
+            bck.set_fwd_chunk(base)
+            fwd.set_bck_chunk(base)
+            new_next = base.next_chunk()
+            if new_next is not None:
+                new_next.set_prev_freeness(True)
+            else:
+                self._set_final_freeness(True)
+            # FIXME: must set size twice so that once free, the trailing size field is updated; more elegant way?
+            base.set_size(new_size)
+
+        l.debug("Free request: %#08x; Freed chunk: %#08x", self.state.solver.eval(req),
+                self.state.solver.eval(chunk.base))
+
+    def calloc(self, sim_nmemb, sim_size):
+        size = self._conc_alloc_size(sim_nmemb * sim_size)
+        addr = self.malloc(size)
+        if addr == 0:
+            return 0
+        if size != 0:
+            z = self.state.solver.BVV(0, size * 8)
+            self.state.memory.store(addr, z)
+        return addr
+
+    def realloc(self, ptr, size):
+        chunk = self.chunk_from_mem(ptr)
+        if chunk is None:  # ptr is null
+            return self.malloc(size)
+        size = self._conc_alloc_size(size)
+        if size == 0:
+            # assumes that REALLOC_ZERO_BYTES_FREES is set for ptmalloc
+            self.free(ptr)
+            return 0
+        old_size = chunk.get_size()
+
+        def sym_size_handler(sym_size):
+            l.warning("An allocated chunk's size field is symbolic; maximizing it")
+            return self.state.solver.max_int(sym_size)
+
+        old_size = concretize(old_size, self.state.solver, sym_size_handler)
+        new_size = self._make_chunk_size(size)
+
+        if new_size > old_size:
+            # If more space is needed, will have to reallocate
+            # TODO: this could be made more complex to make better usage of remaining heap space when it runs out by
+            # TODO: checking for smaller adjacent free chunks that could be amalgamated (rather than malloc, copy, free)
+            new_data_ptr = self.malloc(size)  # Make the new allocation
+            if new_data_ptr == 0:  # Check for failure
+                return 0
+            # Copy the old data over
+            old_data_ptr = chunk.data_ptr()
+            level = silence_logger()
+            old_data = self.state.memory.load(old_data_ptr, size=old_size - 2 * self._chunk_size_t_size)
+            unsilence_logger(level)
+            self.state.memory.store(new_data_ptr, old_data)
+            self.free(old_data_ptr)  # Free the old chunk
+            return new_data_ptr
+        elif new_size < old_size and old_size - new_size >= self._chunk_min_size:
+            # Less space is needed, so just shrink the chunk and create a new free chunk from the freed space
+            chunk.set_size(new_size, False)
+            new_next_chunk = chunk.next_chunk()
+            new_next_chunk.set_size(old_size - new_size, False)
+            new_next_chunk.set_prev_freeness(False)
+            self.free(new_next_chunk.data_ptr())
+            return chunk.data_ptr()
+        else:
+            # No changes needed; we're already the right size
+            return chunk.data_ptr()
+
+    def _malloc(self, sim_size):
+        return self.malloc(sim_size)
+
+    def _free(self, ptr):
+        return self.free(ptr)
+
+    def _calloc(self, sim_nmemb, sim_size):
+        return self.calloc(sim_nmemb, sim_size)
+
+    def _realloc(self, ptr, size):
+        return self.realloc(ptr, size)
+
+    @SimStatePlugin.memo
+    def copy(self, memo):# pylint: disable=unused-argument
+        c = SimHeapPTMalloc()
+        c.heap_base = self.heap_base
+        c.heap_size = self.heap_size
+        c.mmap_base = self.mmap_base
+        c._free_head_chunk_exists = True if self.free_head_chunk is not None else False
+        c._free_head_chunk_init_base = self.free_head_chunk.base if self.free_head_chunk is not None else None
+        return c
+
+    def _combine(self, others):
+        if any(o.heap_base != self.heap_base for o in others):
+            raise SimMergeError("Cannot merge heaps with different bases")
+        # When heaps become more dynamic, this next one can probably change
+        if any(o.heap_size != self.heap_size for o in others):
+            raise SimMergeError("Cannot merge heaps with different sizes")
+        if any(o.free_head_chunk != self.free_head_chunk for o in others):
+            raise SimMergeError("Cannot merge heaps with different freelist head chunks")
+        if any(o.mmap_base != self.mmap_base for o in others):
+            raise SimMergeError("Cannot merge heaps with different mmap bases")
+
+        # These are definitely sanity checks
+        if any(o._chunk_size_t_size != self._chunk_size_t_size for o in others):
+            raise SimMergeError("Cannot merge heaps with different chunk size_t sizes")
+        if any(o._chunk_min_size != self._chunk_min_size for o in others):
+            raise SimMergeError("Cannot merge heaps with different minimum chunk sizes")
+        if any(o._chunk_align_mask != self._chunk_align_mask for o in others):
+            raise SimMergeError("Cannot merge heaps with different chunk alignments")
+
+        return False
+
+    def merge(self, others, merge_conditions, common_ancestor=None):  #pylint:disable=unused-argument
+        return self._combine(others)
+
+    def widen(self, others):
+        return self._combine(others)
+
+    def init_state(self):
+        super(SimHeapPTMalloc, self).init_state()
+
+        self._chunk_size_t_size = self.state.arch.bits // 8
+        self._chunk_min_size = 4 * self._chunk_size_t_size
+        self._chunk_align_mask = 2 * self._chunk_size_t_size - 1  #pylint:disable=attribute-defined-outside-init
+
+        # TODO: where are bin metadata stored in reality?
+        if self._free_head_chunk_exists and self._free_head_chunk_init_base is None:
+            free_base = self.heap_base
+            if self.heap_base & self._chunk_align_mask:
+                free_base = (self.heap_base & ~self._chunk_align_mask) + self._chunk_align_mask + 1
+            self.free_head_chunk = PTChunk(free_base, self.state, self)
+        elif not self._free_head_chunk_exists:
+            self.free_head_chunk = None
+        else:
+            self.free_head_chunk = PTChunk(self._free_head_chunk_init_base, self.state)
+
+        # We reserve enough space at the top of the heap to simulate the presence of another chunk, for the purpose of
+        # storing the usage information of the real final chunk
+        try:
+            self.state.memory.store(self.free_head_chunk.base + self._chunk_size_t_size
+                                    , ((self.heap_size - 2 * self._chunk_size_t_size) & ~self._chunk_align_mask)
+                                    | CHUNK_P_MASK)
+            self._set_final_freeness(True)
+            self.free_head_chunk.set_fwd_chunk(self.free_head_chunk)
+            self.free_head_chunk.set_bck_chunk(self.free_head_chunk)
+        except AttributeError:
+            # TODO: probably shouldn't ignore this error (find a better way to do this only for the factory state such
+            # TODO: that the memory plugin is already attached to the state)
+
+            # To elaborate on the above, this error is raised (apparently) by the first line in the try block above when
+            # the plugin is copied during state copies, but not when the initial state and plugin are created. As a
+            # result, the try block above is used to initialize the heap when it is first created, but it doesn't need
+            # to be run thereafter and is preempted by the raised error.
+            pass

--- a/angr/state_plugins/heap/utils.py
+++ b/angr/state_plugins/heap/utils.py
@@ -1,3 +1,5 @@
+from ...errors import SimSolverError
+
 def concretize(x, solver, sym_handler):
     """
     For now a lot of naive concretization is done when handling heap metadata to keep things manageable. This idiom
@@ -10,10 +12,9 @@ def concretize(x, solver, sym_handler):
     :returns: a concrete value for the item
     """
     if solver.symbolic(x):
-        sols = solver.eval_upto(x, 2)
-        if len(sols) > 1:
+        try:
+            return solver.eval_one(x)
+        except SimSolverError:
             return sym_handler(x)
-        else:
-            return sols[0]
     else:
         return solver.eval(x)

--- a/angr/state_plugins/heap/utils.py
+++ b/angr/state_plugins/heap/utils.py
@@ -1,0 +1,19 @@
+def concretize(x, solver, sym_handler):
+    """
+    For now a lot of naive concretization is done when handling heap metadata to keep things manageable. This idiom
+    showed up a lot as a result, so to reduce code repetition this function uses a callback to handle the one or two
+    operations that varied across invocations.
+
+    :param x: the item to be concretized
+    :param solver: the solver to evaluate the item with
+    :param sym_handler: the handler to be used when the item may take on more than one value
+    :returns: a concrete value for the item
+    """
+    if solver.symbolic(x):
+        sols = solver.eval_upto(x, 2)
+        if len(sols) > 1:
+            return sym_handler(x)
+        else:
+            return sols[0]
+    else:
+        return solver.eval(x)

--- a/tests/test_mmap.py
+++ b/tests/test_mmap.py
@@ -12,14 +12,14 @@ def test_mmap_base_copy():
 
     mmap_base = 0x12345678
 
-    state.libc.mmap_base = mmap_base
+    state.heap.mmap_base = mmap_base
 
     # Sanity check
-    nose.tools.assert_equal(state.libc.mmap_base, mmap_base)
+    nose.tools.assert_equal(state.heap.mmap_base, mmap_base)
 
     state_copy = state.copy()
 
-    nose.tools.assert_equal(state_copy.libc.mmap_base, mmap_base)
+    nose.tools.assert_equal(state_copy.heap.mmap_base, mmap_base)
 
 
 if __name__ == '__main__':

--- a/tests/test_ptmalloc.py
+++ b/tests/test_ptmalloc.py
@@ -239,20 +239,6 @@ def test_skips_chunks_too_small():
         yield run_skips_chunks_too_small, arch
 
 
-def run_skips_chunks_too_small(arch):
-    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
-    s.heap.malloc(30)
-    p = s.heap.malloc(50)
-    s.heap.malloc(40)
-    s.heap.free(p)
-    p2 = s.heap.calloc(20, 5)
-    nose.tools.assert_less(p, p2)
-
-def test_skips_chunks_too_small():
-    for arch in ('X86', 'AMD64'):
-        yield run_skips_chunks_too_small, arch
-
-
 def run_calloc_multiplies(arch):
     s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
     s.heap.malloc(30)

--- a/tests/test_ptmalloc.py
+++ b/tests/test_ptmalloc.py
@@ -266,3 +266,11 @@ def run_calloc_clears(arch):
 def test_calloc_clears():
     for arch in ('X86', 'AMD64'):
         yield run_calloc_clears, arch
+
+
+if __name__ == "__main__":
+    g = globals().copy()
+    for func_name, func in g.items():
+        if func_name.startswith("test_") and hasattr(func, '__call__'):
+            for r, a in func():
+                r(a)

--- a/tests/test_ptmalloc.py
+++ b/tests/test_ptmalloc.py
@@ -1,0 +1,282 @@
+import nose.tools
+from angr import SimState, SimHeapPTMalloc
+
+# TODO: Make these tests more architecture-independent (note dependencies of some behavior on chunk metadata size)
+
+def chunk_iterators_are_same(iterator1, iterator2):
+    for ck in iterator1:
+        ck2 = next(iterator2)
+        if ck.base != ck2.base:
+            return False
+        if ck.is_free() != ck2.is_free():
+            return False
+    try:
+        next(iterator2)
+    except StopIteration:
+        return True
+    return False
+
+def same_heap_states(state1, state2):
+    return chunk_iterators_are_same(state1.heap.chunks(), state2.heap.chunks())
+
+
+def max_sym_var_val(state):
+    return state.libc.max_variable_size
+
+
+def run_malloc_maximizes_sym_arg(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    sc = s.copy()
+    x = s.solver.BVS("x", 32)
+    s.solver.add(x.UGE(0))
+    s.solver.add(x.ULE(max_sym_var_val(s)))
+    s.heap.malloc(x)
+    sc.heap.malloc(max_sym_var_val(sc))
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_malloc_maximizes_sym_arg():
+    for arch in ('X86', 'AMD64'):
+        yield run_malloc_maximizes_sym_arg, arch
+
+
+def run_free_maximizes_sym_arg(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    p = s.heap.malloc(50)
+    sc = s.copy()
+    x = s.solver.BVS("x", 32)
+    s.solver.add(x.UGE(0))
+    s.solver.add(x.ULE(p))
+    s.heap.free(x)
+    sc.heap.free(p)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_free_maximizes_sym_arg():
+    for arch in ('X86', 'AMD64'):
+        yield run_free_maximizes_sym_arg, arch
+
+
+def run_calloc_maximizes_sym_arg(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    sc = s.copy()
+    x = s.solver.BVS("x", 32)
+    s.solver.add(x.UGE(0))
+    s.solver.add(x.ULE(20))
+    y = s.solver.BVS("y", 32)
+    s.solver.add(y.UGE(0))
+    s.solver.add(y.ULE(6))
+    s.heap.calloc(x, y)
+    sc.heap.calloc(20, 6)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_calloc_maximizes_sym_arg():
+    for arch in ('X86', 'AMD64'):
+        yield run_calloc_maximizes_sym_arg, arch
+
+
+def run_realloc_maximizes_sym_arg(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    p = s.heap.malloc(50)
+    sc = s.copy()
+    x = s.solver.BVS("x", 32)
+    s.solver.add(x.UGE(0))
+    s.solver.add(x.ULE(p))
+    y = s.solver.BVS("y", 32)
+    s.solver.add(y.UGE(0))
+    s.solver.add(y.ULE(max_sym_var_val(s)))
+    s.heap.realloc(x, y)
+    sc.heap.realloc(p, max_sym_var_val(sc))
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_realloc_maximizes_sym_arg():
+    for arch in ('X86', 'AMD64'):
+        yield run_realloc_maximizes_sym_arg, arch
+
+
+def run_malloc_no_space_returns_null(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    sc = s.copy()
+    p1 = s.heap.malloc(0x2000)
+    nose.tools.assert_equals(p1, 0)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_malloc_no_space_returns_null():
+    for arch in ('X86', 'AMD64'):
+        yield run_malloc_no_space_returns_null, arch
+
+
+def run_calloc_no_space_returns_null(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    sc = s.copy()
+    p1 = s.heap.calloc(0x500, 4)
+    nose.tools.assert_equals(p1, 0)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_calloc_no_space_returns_null():
+    for arch in ('X86', 'AMD64'):
+        yield run_calloc_no_space_returns_null, arch
+
+
+def run_realloc_no_space_returns_null(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    p1 = s.heap.malloc(20)
+    sc = s.copy()
+    p2 = s.heap.realloc(p1, 0x2000)
+    nose.tools.assert_equals(p2, 0)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_realloc_no_space_returns_null():
+    for arch in ('X86', 'AMD64'):
+        yield run_realloc_no_space_returns_null, arch
+
+
+def run_first_fit_and_free_malloced_makes_available(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.malloc(20)
+    p1 = s.heap.malloc(50)
+    s.heap.free(p1)
+    p2 = s.heap.malloc(30)
+    nose.tools.assert_equals(p1, p2)
+
+def test_first_fit_and_free_malloced_makes_available():
+    for arch in ('X86', 'AMD64'):
+        yield run_first_fit_and_free_malloced_makes_available, arch
+
+
+def run_free_calloced_makes_available(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.calloc(20, 5)
+    p1 = s.heap.calloc(30, 4)
+    s.heap.free(p1)
+    p2 = s.heap.calloc(15, 8)
+    nose.tools.assert_equals(p1, p2)
+
+def test_free_calloced_makes_available():
+    for arch in ('X86', 'AMD64'):
+        yield run_free_calloced_makes_available, arch
+
+
+def run_realloc_moves_and_frees(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.malloc(20)
+    p1 = s.heap.malloc(60)
+    s.heap.malloc(200)
+    p2 = s.heap.realloc(p1, 300)
+    p3 = s.heap.malloc(30)
+    nose.tools.assert_equals(p1, p3)
+    nose.tools.assert_less(p1, p2)
+
+def test_realloc_moves_and_frees():
+    for arch in ('X86', 'AMD64'):
+        yield run_realloc_moves_and_frees, arch
+
+
+def run_realloc_near_same_size(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.malloc(20)
+    p1 = s.heap.malloc(61)
+    s.heap.malloc(80)
+    sc = s.copy()
+    p2 = s.heap.realloc(p1, 62)
+    nose.tools.assert_equals(p1, p2)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_realloc_near_same_size():
+    for arch in ('X86', 'AMD64'):
+        yield run_realloc_near_same_size, arch
+
+
+def run_needs_space_for_metadata(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    sc = s.copy()
+    p1 = s.heap.malloc(0x1000)
+    nose.tools.assert_equals(p1, 0)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_needs_space_for_metadata():
+    for arch in ('X86', 'AMD64'):
+        yield run_needs_space_for_metadata, arch
+
+
+def run_unusable_amount_returns_null(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.malloc(0x1000 - 4 * s.heap._chunk_size_t_size)
+    sc = s.copy()
+    p = s.heap.malloc(1)
+    nose.tools.assert_equals(p, 0)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_unusable_amount_returns_null():
+    for arch in ('X86', 'AMD64'):
+        yield run_unusable_amount_returns_null, arch
+
+
+def run_free_null_preserves_state(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.malloc(30)
+    p = s.heap.malloc(40)
+    s.heap.malloc(50)
+    s.heap.free(p)
+    s2 = s.copy()
+    s2.heap.free(0)
+    nose.tools.assert_true(same_heap_states(s, s2))
+
+def test_free_null_preserves_state():
+    for arch in ('X86', 'AMD64'):
+        yield run_free_null_preserves_state, arch
+
+
+def run_skips_chunks_too_small(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.malloc(30)
+    p = s.heap.malloc(50)
+    s.heap.malloc(40)
+    s.heap.free(p)
+    p2 = s.heap.calloc(20, 5)
+    nose.tools.assert_less(p, p2)
+
+def test_skips_chunks_too_small():
+    for arch in ('X86', 'AMD64'):
+        yield run_skips_chunks_too_small, arch
+
+
+def run_skips_chunks_too_small(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.malloc(30)
+    p = s.heap.malloc(50)
+    s.heap.malloc(40)
+    s.heap.free(p)
+    p2 = s.heap.calloc(20, 5)
+    nose.tools.assert_less(p, p2)
+
+def test_skips_chunks_too_small():
+    for arch in ('X86', 'AMD64'):
+        yield run_skips_chunks_too_small, arch
+
+
+def run_calloc_multiplies(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.heap.malloc(30)
+    sc = s.copy()
+    s.heap.malloc(100)
+    sc.heap.calloc(4, 25)
+    nose.tools.assert_true(same_heap_states(s, sc))
+
+def test_calloc_multiplies():
+    for arch in ('X86', 'AMD64'):
+        yield run_calloc_multiplies, arch
+
+
+def run_calloc_clears(arch):
+    s = SimState(arch=arch, heap=SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))
+    s.memory.store(0xd0000000 + 2 * s.heap._chunk_size_t_size, s.solver.BVV(-1, 100 * 8))
+    sc = s.copy()
+    p1 = s.heap.calloc(6, 5)
+    p2 = sc.heap.malloc(30)
+    v1 = s.memory.load(p1, 30)
+    v2 = sc.memory.load(p2, 30)
+    nose.tools.assert_true(s.solver.is_true(v1 == 0))
+    nose.tools.assert_true(sc.solver.is_true(v2 == -1))
+
+def test_calloc_clears():
+    for arch in ('X86', 'AMD64'):
+        yield run_calloc_clears, arch


### PR DESCRIPTION
# Overview

I took a shot at improving the heap situation in angr. This pull request does not change any of angr's default behavior, so if you merge this you should see no change in the behavior of the current heap model. The changes do introduce more infrastructure around the heap, making it more accessible to users and introducing the ability to switch heap models. As an example, I've implemented a very very *very* simple model of ptmalloc (although due to its limitations it's much more like dlmalloc right now). A `heap` state plugin has been added, and users can modify the state while performing dynamic memory management with functions like `state.heap.malloc()` and `state.heap.free()`.

This attempts to address #762.

# Interfacing with angr

angr has `SimProcedure`s for libc's `malloc`, `free`, `calloc`, and `realloc`. Under different heap implementations, these should affect the program state differently. To this end, these `SimProcedure`s are no longer directly responsible for this functionality. They now defer requests made of them to a heap plugin, which may be one of many implementations.

To be faithful to angr's current expectations of the `SimProcedure`s listed above, all heaps are expected to implement some kind of behavior for these libc functions via `_malloc`, `_free`, `_calloc`, and `_realloc` heap methods. Heaps that actually support (near-)standard libc functionality should alias these to a public method as well. As an example, the `SimHeapPTMalloc` class makes these functions public since it approximates the expected behavior of these functions. For the current angr model (which I've moved to `SimHeapBrk`), these are not made public. Instead, it offers `allocate()` and `release()` as a sort of "push" and "pop" model (although it's important to note that, in the interest in preserving the old functionality, the `free` `SimProcedure` does NOT end up using the `release()` functionality in any way).

# Important Files

Most of the relevant code can be found in the `angr.state_plugins.heap` module. A potential class hierarchy might be envisioned to look something like the diagram seen below. BiBOP heaps are "big bags of pages". They differ from the classic freelist-style heap in that they allocate entire pages that are used to store objects of the same size. From what I've read, jemalloc and the Windows 10 heap are implemented in this fashion. On the other hand, ptmalloc (derived from dlmalloc, and used in glibc) and the classic Windows heaps are freelist heap implementations. I call angr's current heap implementation a brk heap since it just moves the brk up and up forever. Real heaps do manipulate the brk obviously but it is not the basis for the heap management, hence the earlier relation to a stack.

```plain
                   ___BaseHeap___
                  /      |       \
         BiBOPHeap    brkHeap     FreeListHeap
        /       |                 |          \
jemalloc      W10Heap           ptmalloc      NTHeap
```

In the aforementioned module you will find a few files corresponding to the different kinds of heaps considered right now (not all of the above heaps and heap types are implemented right now).
* `SimHeapBase`: The basic interface for all heaps. Specifies basic heap properties and expected functionality.
* `SimHeapBrk`: This is where the old angr heap functionality now lives. Whenever a `SimState` is created without an explicit heap specified, this is the default heap plugin that gets attached.
* `SimHeapFreeList`: The basic interface for all freelist heaps. It also defines the notion of a chunk in such a heap. It may be a bit biased towards the dlmalloc style.
* `SimHeapLibc`: This is meant to be a superclass of any heap implementing (near-)standard libc functionality. It just specifies that the libc functions should be publicly exposed for ease-of-use. It sits in the class hierarchy just below `SimHeapBase` at the moment and is subclassed by `SimHeapFreeList`, but should probably be a mixin or whatever if someone wants to investigate that further.
* `SimHeapPTMalloc`: This is a very basic interpretation of ptmalloc that looks a lot more like a very basic interpretation of dlmalloc. It's more efficient than the old angr functionality for memory management purposes and may offer greater fidelity if you're looking for basic heap bugs, but it's not *that* sophisticated.

# Considerations for `SimHeapPTMalloc`

This heap makes all sorts of concretization assumptions because the path explosion would be quite substantial if certain pieces of metadata became symbolic. Whenever such a concretization is made, a warning is issued. As an example, if the metadata for a chunk's size is overwritten with symbolic data, a whole bunch of new paths are possible for symbolic execution, many of which become chaotic quickly since a user assigning an arbitrary size to a chunk can have all sorts of effects on the rest of the heap state after the fact. Having the bit controlling a chunk's allocation or freedom become symbolic has similar implications since that one bit governs the presence or absence of other fields, which can impact the legality of other heap operations, cause other symbolic data to become relevant metadata, and so on.

A special case of such a concretization strategy can be seen [here](https://github.com/tgduckworth/angr/blob/feat/heap/master/angr/state_plugins/heap/heap_base.py#L33) with some more in-depth discussion. Other instances of concretization assumptions could probably be pursued after a satisfactory solution to this one is found, but for now they just issue warnings when a decision must be made, and then they concretize in a manner I assumed would be sane to start with. In the future there could probably be better user control over these decisions.

`SimHeapPTMalloc` is not capable of requesting additional memory from the system at the moment, so it simply manages the memory that was given to it to start with.

# Example Usage

```python
import angr
import logging

p = angr.Project('/bin/true', auto_load_libs=False)

# To create a state with a `SimHeapBrk` heap, with the old angr behavior
s = p.factory.entry_state()

# Or explicitly
s = p.factory.entry_state(heap=angr.SimHeapBrk())

# Or explicitly with params (note: `SimHeapBrk` does not respect its size)
s = p.factory.entry_state(heap=angr.SimHeapBrk(heap_base=0xd0000000, heap_size=32 * 4096))

# To create a state with a `SimHeapPTMalloc` heap, with optional params
s = p.factory.entry_state(heap=angr.SimHeapPTMalloc(heap_base=0xd0000000, heap_size=32 * 4096))

# As usual, you can do plugin registration manually
s.register_plugin('heap', angr.SimHeapPTMalloc(heap_base=0xd0000000, heap_size=0x1000))

s.heap.print_all_chunks()
# Freelist heaps support the above, which produces:
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (free @ 0xd0000000)> │
# └───────────────────────────────┘

# Interspersing the following statements with prints and the heap's debug statements, you'd get this trace on amd64
logging.getLogger('angr.state_plugins.heap').setLevel('DEBUG')

s.heap.malloc(100)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:44,955 | angr.state_plugins.heap.heap_ptmalloc | Requested:  100; Allocated:  128; Returned: 0xd0000010; Chunk: 0xd0000000
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (free @ 0xd0000080)> │
# └───────────────────────────────┘

a1 = s.heap.calloc(7, 32)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,022 | angr.state_plugins.heap.heap_ptmalloc | Requested:  224; Allocated:  240; Returned: 0xd0000090; Chunk: 0xd0000080
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (free @ 0xd0000170)> │
# └───────────────────────────────┘

s.heap.malloc(5)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,139 | angr.state_plugins.heap.heap_ptmalloc | Requested:    5; Allocated:   32; Returned: 0xd0000180; Chunk: 0xd0000170
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (free @ 0xd0000190)> │
# └───────────────────────────────┘

a2 = s.heap.malloc(0)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,265 | angr.state_plugins.heap.heap_ptmalloc | Requested:    0; Allocated:   32; Returned: 0xd00001a0; Chunk: 0xd0000190
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (used @ 0xd0000190)> │
# │ <PTChunk (free @ 0xd00001b0)> │
# └───────────────────────────────┘

a3 = s.heap.malloc(643)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,363 | angr.state_plugins.heap.heap_ptmalloc | Requested:  643; Allocated:  672; Returned: 0xd00001c0; Chunk: 0xd00001b0
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (used @ 0xd0000190)> │
# │ <PTChunk (used @ 0xd00001b0)> │
# │ <PTChunk (free @ 0xd0000450)> │
# └───────────────────────────────┘

a4 = s.heap.malloc(25)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,476 | angr.state_plugins.heap.heap_ptmalloc | Requested:   25; Allocated:   48; Returned: 0xd0000460; Chunk: 0xd0000450
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (used @ 0xd0000190)> │
# │ <PTChunk (used @ 0xd00001b0)> │
# │ <PTChunk (used @ 0xd0000450)> │
# │ <PTChunk (free @ 0xd0000480)> │
# └───────────────────────────────┘

s.heap.free(a1)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,548 | angr.state_plugins.heap.heap_ptmalloc | Free request: 0xd0000090; Freed chunk: 0xd0000080
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (free @ 0xd0000080)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (used @ 0xd0000190)> │
# │ <PTChunk (used @ 0xd00001b0)> │
# │ <PTChunk (used @ 0xd0000450)> │
# │ <PTChunk (free @ 0xd0000480)> │
# └───────────────────────────────┘

a5 = s.heap.malloc(20)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,680 | angr.state_plugins.heap.heap_ptmalloc | Requested:   20; Allocated:   48; Returned: 0xd0000090; Chunk: 0xd0000080
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (free @ 0xd00000b0)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (used @ 0xd0000190)> │
# │ <PTChunk (used @ 0xd00001b0)> │
# │ <PTChunk (used @ 0xd0000450)> │
# │ <PTChunk (free @ 0xd0000480)> │
# └───────────────────────────────┘

s.heap.free(a2)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,774 | angr.state_plugins.heap.heap_ptmalloc | Free request: 0xd00001a0; Freed chunk: 0xd0000190
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (free @ 0xd00000b0)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (free @ 0xd0000190)> │
# │ <PTChunk (used @ 0xd00001b0)> │
# │ <PTChunk (used @ 0xd0000450)> │
# │ <PTChunk (free @ 0xd0000480)> │
# └───────────────────────────────┘

s.heap.free(a4)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,856 | angr.state_plugins.heap.heap_ptmalloc | Free request: 0xd0000460; Freed chunk: 0xd0000450
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (free @ 0xd00000b0)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (free @ 0xd0000190)> │
# │ <PTChunk (used @ 0xd00001b0)> │
# │ <PTChunk (free @ 0xd0000450)> │
# └───────────────────────────────┘

s.heap.free(a3)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,923 | angr.state_plugins.heap.heap_ptmalloc | Free request: 0xd00001c0; Freed chunk: 0xd00001b0
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (used @ 0xd0000080)> │
# │ <PTChunk (free @ 0xd00000b0)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (free @ 0xd0000190)> │
# └───────────────────────────────┘

s.heap.realloc(a5, 200)
s.heap.print_all_chunks()

# DEBUG   | 2019-02-04 12:36:45,999 | angr.state_plugins.heap.heap_ptmalloc | Requested:  200; Allocated:  224; Returned: 0xd00001a0; Chunk: 0xd0000190
# DEBUG   | 2019-02-04 12:36:46,039 | angr.state_plugins.heap.heap_ptmalloc | Free request: 0xd0000090; Freed chunk: 0xd0000080
# ┌───────────────────────────────┐
# ├───────── HEAP CHUNKS ─────────┤
# │ <PTChunk (used @ 0xd0000000)> │
# │ <PTChunk (free @ 0xd0000080)> │
# │ <PTChunk (used @ 0xd0000170)> │
# │ <PTChunk (used @ 0xd0000190)> │
# │ <PTChunk (free @ 0xd0000270)> │
# └───────────────────────────────┘
```
