### PR TITLE
Fix bug in pysoot delayed import in CFGFastSoot

### DIFF
--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -12,20 +12,23 @@ from ...codenode import HookNode, SootBlockNode
 from .cfg_fast import CFGFast, CFGJob, PendingJobs, FunctionTransitionEdge
 from .cfg_node import CFGNode
 
-l = logging.getLogger('angr.analyses.cfg_fast_soot')
+l = logging.getLogger(name=__name__)
+
+try:
+    from pysoot.sootir.soot_statement import IfStmt, InvokeStmt, GotoStmt, AssignStmt
+    from pysoot.sootir.soot_expr import SootInterfaceInvokeExpr, SootSpecialInvokeExpr, SootStaticInvokeExpr, \
+        SootVirtualInvokeExpr, SootInvokeExpr, SootDynamicInvokeExpr
+    PYSOOT_INSTALLED = True
+except ImportError:
+    PYSOOT_INSTALLED = False
 
 
 class CFGFastSoot(CFGFast):
+
     def __init__(self, **kwargs):
 
-        # Delayed import
-        try:
-            from pysoot.sootir.soot_statement import IfStmt, InvokeStmt, GotoStmt, AssignStmt
-            from pysoot.sootir.soot_expr import SootInterfaceInvokeExpr, SootSpecialInvokeExpr, SootStaticInvokeExpr, \
-                SootVirtualInvokeExpr, SootInvokeExpr, SootDynamicInvokeExpr
-        except ImportError:
-            l.error("Please install PySoot before analyzing Java byte code.")
-            raise
+        if not PYSOOT_INSTALLED:
+            raise ImportError("Please install PySoot before analyzing Java byte code.")
 
         if self.project.arch.name != 'Soot':
             raise AngrCFGError('CFGFastSoot only supports analyzing Soot programs.')


### PR DESCRIPTION
* CfgFstSoot was broken due to an incorrect delayed import of pysoot.

~* A critical deprecation warning was triggered because of an incorrect use of `state.se` instead of  `state.solver`.~