### PR TITLE
Adding more debug info to symbolic memory message

### DIFF
--- a/angr/engines/concrete.py
+++ b/angr/engines/concrete.py
@@ -72,6 +72,7 @@ class SimEngineConcrete(SimEngine):
 
         state.timeout = False
         state.errored = False
+        extra_stop_points = [] if extra_stop_points is None else extra_stop_points
 
         l.debug("Entering in SimEngineConcrete: simulated address %#x concrete address %#x stop points %s",
                 state.addr, self.target.read_register("pc"), map(hex, extra_stop_points))

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -471,7 +471,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
                     l.warning("Filling memory at %#x with %d unconstrained bytes referenced from %#x (%s)", addr, num_bytes, self.state.solver.eval(self.state.ip), self.state.project.loader.describe_addr(self.state.solver.eval(self.state.ip)))
                 else:
                     reg_str = self.state.arch.translate_register_name(addr, size=num_bytes)
-                    l.warning("Filling register %s with %d unconstrained bytes", reg_str, num_bytes)
+                    l.warning("Filling register %s with %d unconstrained bytes referenced from %#x (%s)", reg_str, num_bytes, self.state.solver.eval(self.state.ip), self.state.project.loader.describe_addr(self.state.solver.eval(self.state.ip)))
 
         if self.category == 'reg' and self.state.arch.register_endness == 'Iend_LE':
             all_missing = [ a.reversed for a in all_missing ]

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -468,7 +468,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
                     l.warning("3) adding the state option SYMBOL_FILL_UNCONSTRAINED_{MEMORY_REGISTERS}, "
                         "to suppress these messages.")
                 if is_mem:
-                    l.warning("Filling memory at %#x with %d unconstrained bytes", addr, num_bytes)
+                    l.warning("Filling memory at %#x with %d unconstrained bytes referenced from %#x (%s)", addr, num_bytes, self.state.solver.eval(self.state.ip), self.state.project.loader.describe_addr(self.state.solver.eval(self.state.ip)))
                 else:
                     reg_str = self.state.arch.translate_register_name(addr, size=num_bytes)
                     l.warning("Filling register %s with %d unconstrained bytes", reg_str, num_bytes)


### PR DESCRIPTION
Adding some more output to the symbolic memory message that helps the user see where that symbolic memory is coming from.

Also, small bugfix in concrete engine where it assumes that variable is a list, but sometimes it's None and would error.