### PR TITLE
CFGFast: Make pending jobs LIFO

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -912,7 +912,7 @@ class CFGBase(Analysis):
     # Analyze function features
     #
 
-    def _analyze_function_features(self):
+    def _analyze_function_features(self, all_funcs_completed=False):
         """
         For each function in the function_manager, try to determine if it returns or not. A function does not return if
         it calls another function that is known to be not returning, and this function does not have other exits.
@@ -926,6 +926,10 @@ class CFGBase(Analysis):
            be added to it), and it does not have a ret or any equivalent instruction.
 
         A function returns if any of its block contains a ret instruction or any equivalence.
+
+        :param bool all_funcs_completed:    Ignore _completed_functions set and treat all functions as completed. This
+                                            can be set to True after the entire CFG is built and _post_analysis() is
+                                            called (at which point analysis on all functions must be completed).
         """
 
         changes = {
@@ -994,7 +998,7 @@ class CFGBase(Analysis):
                 continue
 
             # did we finish analyzing this function?
-            if func.addr not in self._completed_functions:
+            if not all_funcs_completed and func.addr not in self._completed_functions:
                 continue
 
             if not func.block_addrs_set:
@@ -1068,7 +1072,7 @@ class CFGBase(Analysis):
 
         return changes
 
-    def _iteratively_analyze_function_features(self):
+    def _iteratively_analyze_function_features(self, all_funcs_completed=False):
         """
         Iteratively analyze function features until a fixed point is reached.
 
@@ -1082,7 +1086,7 @@ class CFGBase(Analysis):
         }
 
         while True:
-            new_changes = self._analyze_function_features()
+            new_changes = self._analyze_function_features(all_funcs_completed=all_funcs_completed)
 
             changes['functions_do_not_return'] |= set(new_changes['functions_do_not_return'])
             changes['functions_return'] |= set(new_changes['functions_return'])

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1549,7 +1549,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         # Revisit all edges and rebuild all functions to correctly handle returning/non-returning functions.
         self.make_functions()
 
-        self._analyze_all_function_features()
+        self._analyze_all_function_features(all_funcs_completed=True)
 
         # Scan all functions, and make sure all fake ret edges are either confirmed or removed
         for f in self.functions.values():
@@ -3054,7 +3054,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         #if node.addr in self.kb.functions.callgraph:
         #    self.kb.functions.callgraph.remove_node(node.addr)
 
-    def _analyze_all_function_features(self):
+    def _analyze_all_function_features(self, all_funcs_completed=False):
         """
         Iteratively analyze all changed functions, update their returning attribute, until a fix-point is reached (i.e.
         no new returning/not-returning functions are found).
@@ -3063,7 +3063,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         """
 
         while True:
-            new_changes = self._iteratively_analyze_function_features()
+            new_changes = self._iteratively_analyze_function_features(all_funcs_completed=all_funcs_completed)
             new_returning_functions = new_changes['functions_return']
             new_not_returning_functions = new_changes['functions_do_not_return']
 

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -530,8 +530,8 @@ def test_tail_call_optimization_detection_armel():
     nose.tools.assert_not_in(0x8008419, all_func_addrs, "0x8008419 is inside __mulsf3().")
 
     # Functions that are jumped to from tail-calls
-    tail_call_funcs = [ 0x8002bc1, 0x80046c1, 0x8000281, 0x8000c0f, 0x8000be3, 0x8001bdb, 0x8002839, 0x80037ad,
-                        0x8002c09, 0x8004165, 0x8004be1, 0x8002eb1 ]
+    tail_call_funcs = [ 0x8002bc1, 0x80046c1, 0x8000281, 0x8001bdb, 0x8002839, 0x80037ad, 0x8002c09, 0x8004165,
+                        0x8004be1, 0x8002eb1 ]
     for member in tail_call_funcs:
         nose.tools.assert_in(member, all_func_addrs)
 


### PR DESCRIPTION
Now we first pop the jobs that are added last. This way we prioritize popping jobs from "inner functions" -- functions that are scanned later during CFG recovery.

Without this fix, we incorrectly mark `__wrap_main()` (0x8000bd5) as returning in binary `Nucleo_read_hyperterminal-stripped.elf` on Python 3.6+ (because `dict`s are ordered starting from Python 3.6). This issue is exposed on Travis CI and cause the test case `test_tail_call_optimization_detection_armel()` to fail since our test VM image on Travis CI was still using Python 3.5.