### PR TITLE
increase max_symbolic_strstr

### DIFF
--- a/angr/state_plugins/libc.py
+++ b/angr/state_plugins/libc.py
@@ -187,7 +187,7 @@ class SimStateLibc(SimStatePlugin):
         self.heap_location = HEAP_LOCATION
         self.mmap_base = HEAP_LOCATION + HEAP_SIZE * 2
         self.buf_symbolic_bytes = 60
-        self.max_symbolic_strstr = 1
+        self.max_symbolic_strstr = 16
         self.max_symbolic_strchr = 16
         self.max_variable_size = 128
         self.max_str_len = 128


### PR DESCRIPTION
Hi,

I'm not quite sure if that's right, but angr(version 8.19.2.4 installed using pip) doesn't return any qualified result until I increase `max_symbolic_strstr` for the following PoC:

```c
#include <stdio.h>
#include <string.h>

int main(int argc, char *argv[]) {
    char buf[8];
    fgets(buf, 7, stdin);
    if(strstr(buf, "12") && strstr(buf, "34"))
        puts("good");
    else
        puts("bad");
    return 0;
}
```

Here's the Python code that I use to find a "good" input
```python
proj=angr.Project('test')
simgr=proj.factory.simgr(proj.factory.entry_state())
simgr.explore(find=0x40127e)
```

I've just started learning angr, and my workaround might not be the right one to make it work. Could you please show me if I missed anything? Thanks!
