### PR TITLE
CFG.normalize(): Do not crash on completely overlapping nodes.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1178,6 +1178,13 @@ class CFGBase(Analysis):
                             # umm, those nodes are overlapping, but they must have different end addresses
                             nodekey_a = node.addr + node.size, callstack_key
                             nodekey_b = next_node.addr + next_node.size, callstack_key
+                            if nodekey_a == nodekey_b:
+                                # error handling: this will only happen if we have completely overlapping nodes
+                                # caused by different jumps (one of the jumps is probably incorrect), which usually
+                                # indicates an error in CFG recovery. we print a warning and skip this node
+                                l.warning("Found completely overlapping nodes %s. It usually indicates an error in CFG "
+                                          "recovery. Skip.", node)
+                                continue
 
                             if nodekey_a in smallest_nodes and nodekey_b in smallest_nodes:
                                 # misuse end_addresses_to_nodes


### PR DESCRIPTION
Overlapping nodes might happen due to bugs or errors in CFG recovery. One
such example can be found in Nucleo_read_hyperterminal-stripped.elf (with
force_complete_scan=True), caused by incorrectly performing ARM block
creation from 0x8002bb4 (that is, if we do not force the entire binary to
be lifted as THUMB mode). This commit prevents normalize() from crashing
on such overlapping nodes.