### PR TITLE
Fix a dictionary modification error in discard_plugin_preset.

### DIFF
--- a/angr/misc/plugins.py
+++ b/angr/misc/plugins.py
@@ -133,7 +133,7 @@ class PluginHub(object):
         Discard the current active preset. Will release any active plugins that could have come from the old preset.
         """
         if self.has_plugin_preset:
-            for name, plugin in self._active_plugins.items():
+            for name, plugin in set(self._active_plugins.items()):
                 if id(plugin) in self._provided_by_preset:
                     self.release_plugin(name)
             self._active_preset.deactivate(self)

--- a/angr/misc/plugins.py
+++ b/angr/misc/plugins.py
@@ -133,7 +133,7 @@ class PluginHub(object):
         Discard the current active preset. Will release any active plugins that could have come from the old preset.
         """
         if self.has_plugin_preset:
-            for name, plugin in set(self._active_plugins.items()):
+            for name, plugin in list(self._active_plugins.items()):
                 if id(plugin) in self._provided_by_preset:
                     self.release_plugin(name)
             self._active_preset.deactivate(self)


### PR DESCRIPTION
PluginHub.discard_plugin_preset iterates over
PluginHub._active_plugins.items() to identify loaded plugins to remove.
If it actually tries to remove one, this causes a modification to
_active_plugins, which results in an error.

Copying _active_plugins.items() before iterating prevents this error.

Fixes bug 1464