### PR TITLE
Correct strchr behaviour when c==0x00

### DIFF
--- a/angr/procedures/libc/strchr.py
+++ b/angr/procedures/libc/strchr.py
@@ -25,11 +25,11 @@ class strchr(angr.SimProcedure):
         if self.state.solver.symbolic(s_strlen.ret_expr):
             l.debug("symbolic strlen")
             # TODO: more constraints here to make sure we don't search too little
-            max_sym = min(self.state.solver.max_int(s_strlen.ret_expr), self.state.libc.max_symbolic_strchr)
+            max_sym = min(self.state.solver.max_int(s_strlen.ret_expr)+1, self.state.libc.max_symbolic_strchr)
             a, c, i = self.state.memory.find(s_addr, c, s_strlen.max_null_index, max_symbolic_bytes=max_sym, default=0)
         else:
             l.debug("concrete strlen")
-            max_search = self.state.solver.eval(s_strlen.ret_expr)
+            max_search = self.state.solver.eval(s_strlen.ret_expr)+1
             a, c, i = self.state.memory.find(s_addr, c, max_search, default=0, chunk_size=chunk_size)
 
         if len(i) > 1:

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -708,7 +708,7 @@ def test_strchr():
 
     ss_res = strchr(s, arguments=[addr_haystack, str_needle])
     nose.tools.assert_false(s.solver.unique(ss_res))
-    nose.tools.assert_equal(len(s.solver.eval_upto(ss_res, 10)), 4)
+    nose.tools.assert_equal(len(s.solver.eval_upto(ss_res, 10)), 5)
 
     s_match = s.copy()
     s_nomatch = s.copy()
@@ -717,15 +717,16 @@ def test_strchr():
 
     nose.tools.assert_true(s_match.satisfiable())
     nose.tools.assert_true(s_nomatch.satisfiable())
-    nose.tools.assert_equal(len(s_match.solver.eval_upto(chr_needle, 300)), 3)
-    nose.tools.assert_equal(len(s_nomatch.solver.eval_upto(chr_needle, 300)), 253)
-    nose.tools.assert_sequence_equal(sorted(s_match.solver.eval_upto(ss_res, 300)), [ 0x10, 0x11, 0x12 ])
-    nose.tools.assert_sequence_equal(sorted(s_match.solver.eval_upto(chr_needle, 300)), [ 0x41, 0x42, 0x43 ])
+    nose.tools.assert_equal(len(s_match.solver.eval_upto(chr_needle, 300)), 4)
+    nose.tools.assert_equal(len(s_nomatch.solver.eval_upto(chr_needle, 300)), 252)
+    nose.tools.assert_sequence_equal(sorted(s_match.solver.eval_upto(ss_res, 300)), [ 0x10, 0x11, 0x12, 0x13 ])
+    nose.tools.assert_sequence_equal(sorted(s_match.solver.eval_upto(chr_needle, 300)), [ 0x00, 0x41, 0x42, 0x43 ])
 
     s_match.memory.store(ss_res, s_match.solver.BVV(0x44, 8))
     nose.tools.assert_sequence_equal(sorted(s_match.solver.eval_upto(s_match.memory.load(0x10, 1), 300)), [ 0x41, 0x44 ])
     nose.tools.assert_sequence_equal(sorted(s_match.solver.eval_upto(s_match.memory.load(0x11, 1), 300)), [ 0x42, 0x44 ])
     nose.tools.assert_sequence_equal(sorted(s_match.solver.eval_upto(s_match.memory.load(0x12, 1), 300)), [ 0x43, 0x44 ])
+    nose.tools.assert_sequence_equal(sorted(s_match.solver.eval_upto(s_match.memory.load(0x13, 1), 300)), [ 0x00, 0x44 ])
 
     return
 


### PR DESCRIPTION
From man 3 strchr:
> ... The terminating null byte is considered part of the string, so that if c is specified as '\0', these functions return a pointer to the terminator.


Could also optimize to always return s_addr+strlen when c == 0x00, but that would be a premature optimization from my part.