### PR TITLE
Fix for incorrect block.size during CFG normalilzation for ARM arch

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1206,7 +1206,7 @@ class CFGBase(Analysis):
 
         # Break other nodes
         for n in other_nodes:
-            new_size = smallest_node.addr - n.addr
+            new_size = smallest_node.addr - self._real_address(self.project.arch, n.addr)
             if new_size == 0:
                 # This node has the same size as the smallest one. Don't touch it.
                 continue

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -8,7 +8,7 @@ import pyvex
 from claripy.utils.orderedset import OrderedSet
 from cle import ELF, PE, Blob, TLSObject, MachO, ExternObject, KernelObject
 from archinfo.arch_soot import SootAddressDescriptor
-from archinfo.arch_arm import is_arm_arch
+from archinfo.arch_arm import is_arm_arch, get_real_address_if_arm
 
 from ...misc.ux import deprecated
 from ... import SIM_PROCEDURES
@@ -1099,18 +1099,6 @@ class CFGBase(Analysis):
 
         return changes
 
-    def _real_address(self, arch, addr):
-        """
-        Obtain the real address of an instruction. ARM architectures are supported.
-
-        :param Arch arch:   The Arch object.
-        :param int addr:    The instruction address.
-        :return:            The real address of an instruction.
-        :rtype:             int
-        """
-
-        return ((addr >> 1) << 1) if is_arm_arch(arch) else addr
-
     def normalize(self):
         """
         Normalize the CFG, making sure that there are no overlapping basic blocks.
@@ -1206,7 +1194,7 @@ class CFGBase(Analysis):
 
         # Break other nodes
         for n in other_nodes:
-            new_size = smallest_node.addr - self._real_address(self.project.arch, n.addr)
+            new_size = get_real_address_if_arm(self.project.arch, smallest_node.addr) - get_real_address_if_arm(self.project.arch, n.addr)
             if new_size == 0:
                 # This node has the same size as the smallest one. Don't touch it.
                 continue

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -12,7 +12,7 @@ import cle
 import pyvex
 from cle.address_translator import AT
 from archinfo.arch_soot import SootAddressDescriptor
-from archinfo.arch_arm import is_arm_arch
+from archinfo.arch_arm import is_arm_arch, get_real_address_if_arm
 
 from ...misc.ux import deprecated
 from .memory_data import MemoryData
@@ -1864,7 +1864,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             self._updated_nonreturning_functions.add(function_addr)
 
         # If we have traced it before, don't trace it anymore
-        real_addr = self._real_address(self.project.arch, addr)
+        real_addr = get_real_address_if_arm(self.project.arch, addr)
         if real_addr in self._traced_addresses:
             # the address has been traced before
             return [ ]
@@ -2069,7 +2069,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 else:
                     # it might be a jumpout
                     target_func_addr = None
-                    real_target_addr = self._real_address(self.project.arch, target_addr)
+                    real_target_addr = get_real_address_if_arm(self.project.arch, target_addr)
                     if real_target_addr in self._traced_addresses:
                         node = self.get_any_node(target_addr)
                         if node is not None:

--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from sortedcontainers import  SortedDict
 
 from archinfo.arch_soot import SootMethodDescriptor, SootAddressDescriptor
-from archinfo.arch_arm import get_real_address_if_arm
 
 from .. import register_analysis
 from ...errors import AngrCFGError, SimMemoryError, SimEngineError
@@ -347,13 +346,12 @@ class CFGFastSoot(CFGFast):
         self._function_add_node(cfg_node, function_addr)
 
         # If we have traced it before, don't trace it anymore
-        real_addr = get_real_address_if_arm(self.project.arch, addr)
-        if real_addr in self._traced_addresses:
+        if addr in self._traced_addresses:
             # the address has been traced before
             return [ ]
         else:
             # Mark the address as traced
-            self._traced_addresses.add(real_addr)
+            self._traced_addresses.add(addr)
 
         # soot_block is only used once per CFGNode. We should be able to clean up the CFGNode here in order to save memory
         cfg_node.soot_block = None
@@ -413,8 +411,7 @@ class CFGFastSoot(CFGFast):
             if jumpkind in ('Ijk_Boring', 'Ijk_InvalICache'):
                 # it might be a jumpout
                 target_func_addr = None
-                real_target_addr = get_real_address_if_arm(self.project.arch, target_addr)
-                if real_target_addr in self._traced_addresses:
+                if target_addr in self._traced_addresses:
                     node = self.get_any_node(target_addr)
                     if node is not None:
                         target_func_addr = node.function_address

--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from sortedcontainers import  SortedDict
 
 from archinfo.arch_soot import SootMethodDescriptor, SootAddressDescriptor
+from archinfo.arch_arm import get_real_address_if_arm
 
 from .. import register_analysis
 from ...errors import AngrCFGError, SimMemoryError, SimEngineError

--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -346,7 +346,7 @@ class CFGFastSoot(CFGFast):
         self._function_add_node(cfg_node, function_addr)
 
         # If we have traced it before, don't trace it anymore
-        real_addr = self._real_address(self.project.arch, addr)
+        real_addr = get_real_address_if_arm(self.project.arch, addr)
         if real_addr in self._traced_addresses:
             # the address has been traced before
             return [ ]
@@ -412,7 +412,7 @@ class CFGFastSoot(CFGFast):
             if jumpkind in ('Ijk_Boring', 'Ijk_InvalICache'):
                 # it might be a jumpout
                 target_func_addr = None
-                real_target_addr = self._real_address(self.project.arch, target_addr)
+                real_target_addr = get_real_address_if_arm(self.project.arch, target_addr)
                 if real_target_addr in self._traced_addresses:
                     node = self.get_any_node(target_addr)
                     if node is not None:

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -969,7 +969,7 @@ class Function:
 
             # Break other nodes
             for n in other_nodes:
-                new_size = self.get_real_address_if_arm(self._project.arch, smallest_node.addr) - self.get_real_address_if_arm(self._project.arch, n.addr)
+                new_size = get_real_address_if_arm(self._project.arch, smallest_node.addr) - get_real_address_if_arm(self._project.arch, n.addr)
                 if new_size == 0:
                     # This is the node that has the same size as the smallest one
                     continue

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -7,6 +7,7 @@ import itertools
 from collections import defaultdict
 from itanium_demangler import parse
 
+from archinfo.arch_arm import get_real_address_if_arm
 import claripy
 from ...errors import SimEngineError, SimMemoryError
 from ...procedures import SIM_LIBRARIES
@@ -968,7 +969,7 @@ class Function:
 
             # Break other nodes
             for n in other_nodes:
-                new_size = smallest_node.addr - n.addr
+                new_size = self.get_real_address_if_arm(self._project.arch, smallest_node.addr) - self.get_real_address_if_arm(self._project.arch, n.addr)
                 if new_size == 0:
                     # This is the node that has the same size as the smallest one
                     continue


### PR DESCRIPTION
Block size will be calculated incorrectly if block "n" is in thumb mode and "smallest_node" is in arm mode. It will lack 1 byte.