### PR TITLE
Fix for incorrect condition to filter out ARM plt entries

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1518,7 +1518,7 @@ class CFGBase(Analysis):
         to_remove = set()
 
         # Remove all stubs after PLT entries
-        if is_arm_arch(self.project.arch):
+        if not is_arm_arch(self.project.arch):
             for fn in self.kb.functions.values():
                 addr = fn.addr - (fn.addr % 16)
                 if addr != fn.addr and addr in self.kb.functions and self.kb.functions[addr].is_plt:


### PR DESCRIPTION
Hi Guys!

It seems that commit 

https://github.com/angr/angr/commit/1095ed18cc97e50e8c420b4b3c33b0250a427609#diff-3e214ce41c00cfb8a1b7298cd8b39453

inverted condition for removing PLT entries check. For ARM, PLT entries not aligned at 16 bytes should **NOT** be removed.