### PR TITLE
remove null bytes from path

### DIFF
--- a/angr/procedures/posix/open.py
+++ b/angr/procedures/posix/open.py
@@ -19,7 +19,7 @@ class open(angr.SimProcedure): #pylint:disable=W0622
         p_expr = self.state.memory.load(p_addr, p_strlen.max_null_index, endness='Iend_BE')
         path = self.state.solver.eval(p_expr, cast_to=bytes)
 
-        fd = self.state.posix.open(path, flags)
+        fd = self.state.posix.open(path.strip(bytes('\x00', 'UTF-8')), flags)
         if fd is None:
             return -1
         return fd


### PR DESCRIPTION
By default, angr reads 24 bytes of path name. If the name is not 24 bytes long, there were null bytes appended to the name. So, when angr searches if the file(simfile) is present in memory, it does not find it. (Eg: angr searches for `test\x00\x00\x00` when the file name is `test`).