### PR TITLE
Fix tab complete on knowledge base

### DIFF
--- a/angr/knowledge_base.py
+++ b/angr/knowledge_base.py
@@ -38,6 +38,11 @@ class KnowledgeBase(object):
         }
         return s
 
+    def __dir__(self):
+        x = super(KnowledgeBase, self).__dir__()
+        x.extend(default_plugins.keys())
+        return x
+
     #
     # Plugin accessor
     #

--- a/tests/test_kb_plugins.py
+++ b/tests/test_kb_plugins.py
@@ -19,6 +19,10 @@ def test_kb_plugins():
     nose.tools.assert_is_instance(p.kb.resolved_indirect_jumps, set)
     nose.tools.assert_is_instance(p.kb.unresolved_indirect_jumps, set)
 
+    nose.tools.assert_is_not_none(dir(p.kb))
+    for plugin in ['data', 'functions', 'variables', 'labels', 'comments', 'callgraph', 'resolved_indirect_jumps', 'unresolved_indirect_jumps']:
+        nose.tools.assert_in(plugin, dir(p.kb))
+
 
 if __name__ == '__main__':
     test_kb_plugins()


### PR DESCRIPTION
Couldn't tab complete `proj.kb.f<TAB>` got annoyed and fixed it.


For some reason
```python
return super(KnowledgeBase, self).__dir__().extend(self._plugins.keys())
```
makes ` proj.kb.__dir__()` return `None` and I have no idea why.

Introducing a temp variable makes it work.
