### PR TITLE
Implement necessary helpers and information storage for call pretty printing

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -907,6 +907,19 @@ class SimCC:
         return None
 
 
+    def get_arg_info(self, state, is_fp=None, sizes=None):
+        """
+        This is just a simple wrapper that collects the information from various locations
+        is_fp and sizes are passed to self.arg_locs and self.get_args
+        :param angr.SimState state: The state to evaluate and extract the values from
+        :return:    A list of tuples, where the nth tuple is (type, name, location, value) of the nth argument
+        """
+        argument_types = self.func_ty.args
+        argument_names = self.arg_names if self.arg_names else ['unknown'] * self.num_args
+        argument_locations = self.arg_locs(is_fp=is_fp, sizes=sizes)
+        argument_values = self.get_args(state, is_fp=is_fp, sizes=sizes)
+        return list(zip(argument_types, argument_names, argument_locations, argument_values))
+
 class SimLyingRegArg(SimRegArg):
     """
     A register that LIES about the types it holds

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -120,7 +120,14 @@ class Function:
         self.sp_delta = 0
 
         # Calling convention
-        self.calling_convention = None
+        # If it is a SimProcedure it might have a CC already defined which can be used
+        if self.is_simprocedure and self.addr in self._project._sim_procedures:
+            self.calling_convention = self._project._sim_procedures[self.addr].cc
+        else:
+            self.calling_convention = None
+
+
+
 
         # Function prototype
         self.prototype = None

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -126,9 +126,6 @@ class Function:
         else:
             self.calling_convention = None
 
-
-
-
         # Function prototype
         self.prototype = None
 

--- a/angr/procedures/definitions/__init__.py
+++ b/angr/procedures/definitions/__init__.py
@@ -3,6 +3,7 @@ import os
 import archinfo
 from collections import defaultdict
 import logging
+import inspect
 
 from ...calling_conventions import DEFAULT_CC
 from ...misc import autoimport
@@ -168,10 +169,14 @@ class SimLibrary(object):
     def _apply_metadata(self, proc, arch):
         if proc.cc is None and arch.name in self.default_ccs:
             proc.cc = self.default_ccs[arch.name](arch)
+            # Use inspect to extract the parameters from the run python function
+            proc.cc.arg_names = inspect.getfullargspec(proc.run).args[1:]
         if proc.display_name in self.prototypes:
             if proc.cc is None:
                 proc.cc = self.fallback_cc[arch.name](arch)
             proc.cc.func_ty = self.prototypes[proc.display_name].with_arch(arch)
+            # Use inspect to extract the parameters from the run python function
+            proc.cc.arg_names = inspect.getfullargspec(proc.run).args[1:]
             if not proc.ARGS_MISMATCH:
                 proc.cc.num_args = len(proc.cc.func_ty.args)
                 proc.num_args = len(proc.cc.func_ty.args)

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -614,7 +614,7 @@ class SimTypeFunction(SimType):
     _fields = ('args', 'returnty')
     base = False
 
-    def __init__(self, args, returnty, label=None, arg_names=[]):
+    def __init__(self, args, returnty, label=None, arg_names=None):
         """
         :param label:    The type label
         :param args:     A tuple of types representing the arguments to the function
@@ -623,7 +623,7 @@ class SimTypeFunction(SimType):
         super(SimTypeFunction, self).__init__(label=label)
         self.args = args
         self.returnty = returnty
-        self.arg_names = arg_names
+        self.arg_names = arg_names if arg_names else []
 
     def __repr__(self):
         return '({}) -> {}'.format(', '.join(str(a) for a in self.args), self.returnty)

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -614,7 +614,7 @@ class SimTypeFunction(SimType):
     _fields = ('args', 'returnty')
     base = False
 
-    def __init__(self, args, returnty, label=None):
+    def __init__(self, args, returnty, label=None, arg_names=[]):
         """
         :param label:    The type label
         :param args:     A tuple of types representing the arguments to the function
@@ -623,6 +623,7 @@ class SimTypeFunction(SimType):
         super(SimTypeFunction, self).__init__(label=label)
         self.args = args
         self.returnty = returnty
+        self.arg_names = arg_names
 
     def __repr__(self):
         return '({}) -> {}'.format(', '.join(str(a) for a in self.args), self.returnty)


### PR DESCRIPTION
This PR does two things:

The first commits adds the instance attribute `arg_name` to CCs, populates this with the argument names from the SimProc `run` method and makes sure that the Function Object for the SimProc in the KB is initialized with the CC of the SimProc.

The second commit implements a simple helper that collects this information so it is possible to just pass a state to CC method and get the list of (type, name, location, value) tuples for each argument. This can then be either used for quick checking/debugging or properly formatted in some user interface.

The formatting can get more complicated so I think this is out of scope to implement in angr itself. So this sufficiently addresses https://github.com/angr/angr/issues/1496, at least for my use case.