### PR TITLE
When the tracer finds a crash it does not change the predecessors whi…

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -105,6 +105,8 @@ class Tracer(ExplorationTechnique):
             if self._crash_addr is not None:
                 self.last_state, crash_state = self.crash_windup(state, self._crash_addr)
                 simgr.populate('crashed', [crash_state])
+                self.predecessors.append(state)
+                self.predecessors.pop(0)
 
             return 'traced'
 


### PR DESCRIPTION
…ch causes the state to be two states ahead of the previous state. The fix we decided on is to tick the state when we detect a crash.