### PR TITLE
Fix accidental use of arg_names in the cc object instead of the func_ty object

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -915,7 +915,7 @@ class SimCC:
         :return:    A list of tuples, where the nth tuple is (type, name, location, value) of the nth argument
         """
         argument_types = self.func_ty.args
-        argument_names = self.arg_names if self.arg_names else ['unknown'] * self.num_args
+        argument_names = self.func_ty.arg_names if self.func_ty.arg_names else ['unknown'] * len(self.func_ty.args)
         argument_locations = self.arg_locs(is_fp=is_fp, sizes=sizes)
         argument_values = self.get_args(state, is_fp=is_fp, sizes=sizes)
         return list(zip(argument_types, argument_names, argument_locations, argument_values))

--- a/angr/procedures/definitions/__init__.py
+++ b/angr/procedures/definitions/__init__.py
@@ -170,13 +170,13 @@ class SimLibrary(object):
         if proc.cc is None and arch.name in self.default_ccs:
             proc.cc = self.default_ccs[arch.name](arch)
             # Use inspect to extract the parameters from the run python function
-            proc.cc.arg_names = inspect.getfullargspec(proc.run).args[1:]
+            proc.cc.func_ty.arg_names = inspect.getfullargspec(proc.run).args[1:]
         if proc.display_name in self.prototypes:
             if proc.cc is None:
                 proc.cc = self.fallback_cc[arch.name](arch)
             proc.cc.func_ty = self.prototypes[proc.display_name].with_arch(arch)
             # Use inspect to extract the parameters from the run python function
-            proc.cc.arg_names = inspect.getfullargspec(proc.run).args[1:]
+            proc.cc.func_ty.arg_names = inspect.getfullargspec(proc.run).args[1:]
             if not proc.ARGS_MISMATCH:
                 proc.cc.num_args = len(proc.cc.func_ty.args)
                 proc.num_args = len(proc.cc.func_ty.args)


### PR DESCRIPTION
I messed up in my last PR and partly added arg_names to the cc and partly to the func_ty object.

It should all be in the func_ty object because it is static information.

Also fixes a bug that num_args doesn't exist for variadic functions so the number of arguments is just `len(self.func_ty.args)` 