### PR TITLE
strtol: Correctly convert 11-digit numbers.

### DIFF
--- a/angr/procedures/libc/strtol.py
+++ b/angr/procedures/libc/strtol.py
@@ -81,8 +81,7 @@ class strtol(angr.SimProcedure):
         """
 
         # if length wasn't provided, read the maximum bytes
-        cutoff = (read_length == None)
-        length = state.libc.max_strtol_len if cutoff else read_length
+        length = state.libc.max_strtol_len if read_length is None else read_length
 
         # expression whether or not it was valid at all
         expression, _ = strtol._char_to_val(region.load(s, 1), base)
@@ -96,6 +95,7 @@ class strtol(angr.SimProcedure):
         constraints_num_bytes = []
         conditions = []
 
+        cutoff = False
         # we need all the conditions to hold except the last one to have found a value
         for i in range(length):
             char = region.load(s + i, 1)

--- a/tests/test_strtol.py
+++ b/tests/test_strtol.py
@@ -41,9 +41,32 @@ def run_strtol(threads):
     # check that all of the outputs were seen
     nose.tools.assert_equal(len(expected_outputs), 0)
 
+
 def test_strtol():
     yield run_strtol, None
     # yield run_strtol, 8
 
+
+def test_strtol_long_string():
+
+    # convert a 11-digit long string to a number.
+    # there was an off-by-one error before.
+
+    b = angr.load_shellcode(b"\x90\x90", "AMD64")
+    state = b.factory.blank_state()
+    state.memory.store(0x500000, b"98831114236\x00")
+
+    state.libc.max_strtol_len = 11
+
+    strtol = angr.SIM_LIBRARIES['libc.so.6'].procedures['strtol']
+    strtol.state = state.copy()
+    ret = strtol.run(0x500000, 0, 0)
+
+    nose.tools.assert_true(strtol.state.satisfiable())
+    nose.tools.assert_equal(len(strtol.state.solver.eval_upto(ret, 2)), 1)
+    nose.tools.assert_equal(strtol.state.solver.eval_one(ret), 98831114236)
+
+
 if __name__ == "__main__":
+    test_strtol_long_string()
     run_strtol(None)


### PR DESCRIPTION
_string_to_int() did not trigger the cutoff handling logic if the length
of the string equals to state.libc.max_strtol_len, which was causing
issues when converting strings that were exactly 11 bytes long.