### PR TITLE
Fix a panic in libvex caused by passing wrong values to typeOfPrimop().

### DIFF
--- a/angr/engines/vex/expressions/op.py
+++ b/angr/engines/vex/expressions/op.py
@@ -28,7 +28,7 @@ def SimIRExpr_Op(engine, state, expr):
     except UnsupportedIROpError:
         if o.BYPASS_UNSUPPORTED_IROP in state.options:
             state.history.add_event('resilience', resilience_type='irop', op=expr.op, message='unsupported IROp')
-            res_type = get_op_retty(expr.tag)
+            res_type = get_op_retty(expr.op)
             res_size = get_type_size(res_type)
             if o.UNSUPPORTED_BYPASS_ZERO_DEFAULT in state.options:
                 result = state.solver.BVV(0, res_size)


### PR DESCRIPTION
We should pass enums_to_ints[expr.op] to typeOfPrimop() instead of
enums_to_ints[expr.tag].

This bug was causing a vpanic in libvex whenever angr saw an unsupported VEX operation.