### PR TITLE
Prevent tests from segfaulting

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -374,6 +374,9 @@ public:
 		for (auto it = mem_writes.begin(); it != mem_writes.end(); it++) {
 			if (it->clean == -1) {
 				taint_t *bitmap = page_lookup(it->address);
+				if (bitmap == NULL) {
+					continue;
+				}
 				memset(&bitmap[it->address & 0xFFFULL], TAINT_DIRTY, sizeof(taint_t) * it->size);
 				it->clean = (1 << it->size) - 1;
 				//LOG_D("commit: lazy initialize mem_write [%#lx, %#lx]", it->address, it->address + it->size);


### PR DESCRIPTION
Running the tests as prescribed in the tests readme caused the tests to segfualt. Running the whole thing through GDB pointed to the memset on line 377, which would segfault when page_lookup returns NULL. I don't know if this is the correct fix, however it, at a minimum, causes all the tests to be able to run.