### PR TITLE
Remove the redundant Reverse() operation in uninitialized ASTs read from files.

### DIFF
--- a/angr/state_plugins/preconstrainer.py
+++ b/angr/state_plugins/preconstrainer.py
@@ -55,6 +55,11 @@ class SimStatePreconstrainer(SimStatePlugin):
         elif value.op != 'BVV':
             raise ValueError("Passed a value to preconstrain that was not a BVV or a string")
 
+        if variable.op not in claripy.operations.leaf_operations:
+            l.warning("The variable %s to preconstrain is not a leaf AST. This may cause replacement failures in the "
+                      "claripy replacement backend.", variable)
+            l.warning("Please use a leaf AST as the preconstraining variable instead.")
+
         constraint = variable == value
         l.debug("Preconstraint: %s", constraint)
 

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -488,9 +488,15 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
                     reg_str = self.state.arch.translate_register_name(addr, size=num_bytes)
                     l.warning("Filling register %s with %d unconstrained bytes referenced from %#x (%s)", reg_str, num_bytes, refplace_int, refplace_str)
 
+        # this is an optimization to ensure most operations in the future will deal with leaf ASTs (instead of reversed
+        # ASTs)
         if self.category == 'reg' and self.state.arch.register_endness == 'Iend_LE':
             all_missing = [ a.reversed for a in all_missing ]
+        elif self.category == 'file':
+            # file data has to be big-endian
+            pass
         elif self.category != 'reg' and self.state.arch.memory_endness == 'Iend_LE':
+            # endianness of memory data
             all_missing = [ a.reversed for a in all_missing ]
         b = self.state.solver.Concat(*all_missing) if len(all_missing) > 1 else all_missing[0]
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,4 +1,9 @@
+
+import nose.tools
+
 import angr
+from angr.state_plugins.posix import Flags
+
 
 def test_files():
     s = angr.SimState(arch='AMD64')
@@ -11,5 +16,22 @@ def test_files():
     s.posix.get_fd(1).write_data(b"A"*0x1000, 0x800)
     assert s.posix.dumps(1) == b"A"*0x800
 
+
+def test_file_read_missing_content():
+
+    # test in tracing mode since the Reverse operator will not be optimized away
+    s = angr.SimState(arch='AMD64', mode="tracing")
+    fd = s.posix.open(b"/tmp/oops", Flags.O_RDWR)
+    length = s.posix.get_fd(fd).read(0xc00000, 100)
+
+    data = s.memory.load(0xc00000, length, endness="Iend_BE")
+    nose.tools.assert_not_equal(data.op, 'Reverse', "Byte strings read directly out of a file should not have Reverse "
+                                                    "operators.")
+    nose.tools.assert_equal(data.op, "BVS")
+    nose.tools.assert_equal(len(data.variables), 1)
+    nose.tools.assert_in("oops", next(iter(data.variables)))  # file name should be part of the variable name
+
+
 if __name__ == '__main__':
     test_files()
+    test_file_read_missing_content()


### PR DESCRIPTION
This bug was also preventing preconstrainer from working in some cases.