### PR TITLE
Add more info for statement inspect points

### DIFF
--- a/angr/engines/soot/engine.py
+++ b/angr/engines/soot/engine.py
@@ -122,9 +122,9 @@ class SimEngineSoot(SimEngine):
     def _handle_block(self, state, successors, block, starting_stmt_idx, method=None):
         for tindex, stmt in enumerate(block.statements[starting_stmt_idx:]):
             stmt_idx = starting_stmt_idx + tindex
-            state._inspect('statement', BP_BEFORE, statement=stmt_idx)
+            state._inspect('statement', BP_BEFORE, statement=stmt, stmt_idx=stmt_idx)
             terminate = self._handle_statement(state, successors, stmt_idx, stmt)
-            state._inspect('statement', BP_AFTER)
+            state._inspect('statement', BP_AFTER, statement=stmt, stmt_idx=stmt_idx)
             if terminate:
                 break
         else:

--- a/angr/engines/vex/engine.py
+++ b/angr/engines/vex/engine.py
@@ -272,9 +272,9 @@ class SimEngineVEX(SimEngine):
 
             try:
                 state.scratch.stmt_idx = stmt_idx
-                state._inspect('statement', BP_BEFORE, statement=stmt_idx)
+                state._inspect('statement', BP_BEFORE, statement=stmt, stmt_idx=stmt_idx)
                 cont = self._handle_statement(state, successors, stmt)
-                state._inspect('statement', BP_AFTER)
+                state._inspect('statement', BP_AFTER, statement=stmt, stmt_idx=stmt_idx)
                 if not cont:
                     return
             except UnsupportedDirtyError:

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -68,6 +68,7 @@ inspect_attributes = {
 
     # statement
     'statement',
+    'stmt_idx',
 
     # instruction
     'instruction',


### PR DESCRIPTION
I'm wondering if you would be willing to take a PR along these lines, to expose more information for consumers of `statement` inspect points.  I'm not sure how breaking this change is for angr users, what tests might need to be adjusted, etc; I'm happy to help with any additional required changes.

If this does get merged I can submit another PR to `angr-doc` accordingly (but actually, the current docs on the `statement` inspect point are incorrect anyway as they claim that the `statement` attribute is available both `BP_BEFORE` and `BP_AFTER` whereas in the code it's currently only passed `BP_BEFORE`).