### PR TITLE
Address issue #1541

### DIFF
--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -35,6 +35,7 @@ inspect_attributes = {
     'mem_read_expr',
     'mem_read_length',
     'mem_read_condition',
+    'mem_read_fallback',
 
     # mem_write
     'mem_write_address',
@@ -47,6 +48,7 @@ inspect_attributes = {
     'reg_read_expr',
     'reg_read_length',
     'reg_read_condition',
+    'reg_read_fallback',
 
     # reg_write
     'reg_write_offset',

--- a/angr/storage/memory.py
+++ b/angr/storage/memory.py
@@ -750,19 +750,23 @@ class SimMemory(SimStatePlugin):
         if _inspect:
             if self.category == 'reg':
                 self.state._inspect('reg_read', BP_BEFORE, reg_read_offset=addr_e, reg_read_length=size_e,
-                                    reg_read_condition=condition_e
+                                    reg_read_condition=condition_e,
+                                    reg_read_fallback=fallback_e
                                     )
                 addr_e = self.state._inspect_getattr("reg_read_offset", addr_e)
                 size_e = self.state._inspect_getattr("reg_read_length", size_e)
                 condition_e = self.state._inspect_getattr("reg_read_condition", condition_e)
+                fallback_e = self.state._inspect_getattr("reg_read_fallback", fallback_e)
 
             elif self.category == 'mem':
                 self.state._inspect('mem_read', BP_BEFORE, mem_read_address=addr_e, mem_read_length=size_e,
-                                    mem_read_condition=condition_e
+                                    mem_read_condition=condition_e,
+                                    mem_read_fallback=fallback_e
                                     )
                 addr_e = self.state._inspect_getattr("mem_read_address", addr_e)
                 size_e = self.state._inspect_getattr("mem_read_length", size_e)
                 condition_e = self.state._inspect_getattr("mem_read_condition", condition_e)
+                fallback_e = self.state._inspect_getattr("mem_read_fallback", fallback_e)
 
         if (
             o.UNDER_CONSTRAINED_SYMEXEC in self.state.options and


### PR DESCRIPTION
Exposes fallback expressions passed into a call to SimMemory.load()
to the inspect events "reg_read" and "mem_read".
This allows breakpoint routines to modify or even create new
conditional memory behaviors.

I'm not 100% sure what conditional memory expressions were originally intended to do,
so I'm not sure if this is an abuse of the API or if the feature is still supported.  
Please let me know if this was a bad idea :)