### PR TITLE
Concrete memory backing, unicorn page caching fix

### DIFF
--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -897,8 +897,11 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
 
         return stored_values
 
-    def flush_pages(self,whitelist):
-        self.mem.flush_pages(whitelist)
+    def flush_pages(self, whitelist):
+        flushed_regions = self.mem.flush_pages(whitelist)
+        if self.state.has_plugin('unicorn'):
+            for addr, length in flushed_regions:
+                self.unicorn.uncache_region(addr, length)
 
     @staticmethod
     def _create_segment(addr, size, s_options, idx, segments):
@@ -1248,7 +1251,8 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         # if unicorn is in play and we've marked a page writable, it must be uncached
         if permissions is not None and self.state.solver.is_true(permissions & 2 == 2):
             if self.state.has_plugin('unicorn'):
-                self.state.unicorn.uncache_page(addr)
+                p = self.mem._get_page(self.mem._page_id(addr))
+                self.state.unicorn.uncache_region(p._page_addr, p._page_size)
         return out
 
     def map_region(self, addr, length, permissions, init_zero=False):
@@ -1268,6 +1272,9 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         :param addr: address to unmap the pages at
         :param length: length in bytes of region to map, will be rounded upwards to the page size
         """
+        if self.state.has_plugin('unicorn'):
+            self.state.unicorn.uncache_region(addr, length)
+
         return self.mem.unmap_region(addr, length)
 
 

--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -901,7 +901,7 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         flushed_regions = self.mem.flush_pages(whitelist)
         if self.state.has_plugin('unicorn'):
             for addr, length in flushed_regions:
-                self.unicorn.uncache_region(addr, length)
+                self.state.unicorn.uncache_region(addr, length)
 
     @staticmethod
     def _create_segment(addr, size, s_options, idx, segments):

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -220,7 +220,8 @@ def _load_native():
         _setup_prototype(h, 'activate', None, state_t, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_char_p)
         _setup_prototype(h, 'set_stops', None, state_t, ctypes.c_uint64, ctypes.POINTER(ctypes.c_uint64))
         _setup_prototype(h, 'cache_page', ctypes.c_bool, state_t, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_char_p, ctypes.c_uint64)
-        _setup_prototype(h, 'uncache_page', None, state_t, ctypes.c_uint64)
+        _setup_prototype(h, 'uncache_pages_touching_region', None, state_t, ctypes.c_uint64, ctypes.c_uint64)
+        _setup_prototype(h, 'clear_page_cache', None, state_t)
         _setup_prototype(h, 'enable_symbolic_reg_tracking', None, state_t, VexArch, _VexArchInfo)
         _setup_prototype(h, 'disable_symbolic_reg_tracking', None, state_t)
         _setup_prototype(h, 'symbolic_register_data', None, state_t, ctypes.c_uint64, ctypes.POINTER(ctypes.c_uint64))
@@ -308,7 +309,7 @@ class Unicorn(SimStatePlugin):
 
         self.steps = 0
         self._mapped = 0
-        self._uncache_pages = []
+        self._uncache_regions = []
         self.gdt = None
 
         # following variables are used in python level hook
@@ -377,7 +378,7 @@ class Unicorn(SimStatePlugin):
         u.countdown_symbolic_memory = self.countdown_symbolic_memory
         u.countdown_stop_point = self.countdown_stop_point
         u.transmit_addr = self.transmit_addr
-        u._uncache_pages = list(self._uncache_pages)
+        u._uncache_regions = list(self._uncache_regions)
         u.gdt = self.gdt
         return u
 
@@ -836,14 +837,17 @@ class Unicorn(SimStatePlugin):
 
             # investigate the chunk, taint if symbolic
             chunk_size = last_missing - mo_addr + 1
-            chunk = mo.bytes_at(mo_addr, chunk_size)
-            d = self._process_value(chunk, 'mem')
-            if d is None:
-                #print "TAINT: %x, %d" % (mo_addr, chunk_size)
-                _taint(mo_addr, chunk_size)
+            chunk = mo.bytes_at(mo_addr, chunk_size, allow_concrete=True)
+            if mo.is_bytes:
+                data[mo_addr - start : mo_addr - start + chunk_size] = chunk
             else:
-                s = self.state.solver.eval(d, cast_to=bytes)
-                data[mo_addr-start:mo_addr-start+chunk_size] = s
+                d = self._process_value(chunk, 'mem')
+                if d is None:
+                    #print "TAINT: %x, %d" % (mo_addr, chunk_size)
+                    _taint(mo_addr, chunk_size)
+                else:
+                    s = self.state.solver.eval(d, cast_to=bytes)
+                    data[mo_addr-start:mo_addr-start+chunk_size] = s
             last_missing = mo_addr - 1
 
         # handle missing bytes at the beginning
@@ -867,8 +871,12 @@ class Unicorn(SimStatePlugin):
             _UC_NATIVE.activate(self._uc_state, start, length, taint[0] if taint else None)
             return True
 
-    def uncache_page(self, addr):
-        self._uncache_pages.append(addr & ~0xfff)
+    def uncache_region(self, addr, length):
+        self._uncache_regions.append((addr, length))
+
+    def clear_page_cache(self):
+        self._uncache_regions = [] # this is no longer needed, everything has been uncached
+        _UC_NATIVE.clear_page_cache()
 
     @property
     def _is_mips32(self):
@@ -913,10 +921,10 @@ class Unicorn(SimStatePlugin):
         self.jumpkind = 'Ijk_Boring'
         self.countdown_nonunicorn_blocks = self.cooldown_nonunicorn_blocks
 
-        for addr in self._uncache_pages:
-            l.info("Un-caching writable page %#x", addr)
-            _UC_NATIVE.uncache_page(self._uc_state, addr)
-        self._uncache_pages = []
+        for addr, length in self._uncache_regions:
+            l.debug("Un-caching writable page region @ %#x of length %x", addr, length)
+            _UC_NATIVE.uncache_pages_touching_region(self._uc_state, addr, length)
+        self._uncache_regions = []
 
         # should this be in setup?
         if options.UNICORN_SYM_REGS_SUPPORT in self.state.options and \

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1246,13 +1246,14 @@ class Unicorn(SimStatePlugin):
         ''' loading registers from unicorn '''
 
         # first, get the ignore list (in case of symbolic registers)
+        saved_registers = []
         if options.UNICORN_SYM_REGS_SUPPORT in self.state.options:
             highest_reg_offset, reg_size = max(self.state.arch.registers.values())
             symbolic_list = (ctypes.c_uint64*(highest_reg_offset + reg_size))()
             num_regs = _UC_NATIVE.get_symbolic_registers(self._uc_state, symbolic_list)
 
             # we take the approach of saving off the symbolic regs and then writing them back
-            saved_registers = [ ]
+
             cur_group = None
             last = None
             for i in sorted(symbolic_list[:num_regs]):
@@ -1342,7 +1343,7 @@ class Unicorn(SimStatePlugin):
 
         # now, we restore the symbolic registers
         if options.UNICORN_SYM_REGS_SUPPORT in self.state.options:
-            for o,r in saved_registers:
+            for o, r in saved_registers:
                 self.state.registers.store(o, r)
 
     def _check_registers(self, report=True):

--- a/angr/storage/memory_object.py
+++ b/angr/storage/memory_object.py
@@ -1,6 +1,10 @@
 import claripy
 from ..errors import SimMemoryError
 
+def obj_bit_size(o):
+    if type(o) == bytes:
+        return len(o) * 8
+    return o.size()
 
 class SimMemoryObject(object):
     """
@@ -9,12 +13,16 @@ class SimMemoryObject(object):
     SimSymbolicMemory class.
     """
     def __init__(self, obj, base, length=None, byte_width=8):
-        if not isinstance(obj, claripy.ast.Base):
+        if type(obj) == bytes:
+            assert byte_width == 8
+
+        elif not isinstance(obj, claripy.ast.Base):
             raise SimMemoryError('memory can only store claripy Expression')
+        self.is_bytes = type(obj) == bytes
         self._byte_width = byte_width
         self.base = base
         self.object = obj
-        self.length = obj.size()//self._byte_width if length is None else length
+        self.length = obj_bit_size(obj) // self._byte_width if length is None else length
 
     def size(self):
         return self.length * self._byte_width
@@ -29,27 +37,49 @@ class SimMemoryObject(object):
     def includes(self, x):
         return 0 <= x - self.base < self.length
 
-    def bytes_at(self, addr, length):
+    def bytes_at(self, addr, length, allow_concrete=False):
         if addr == self.base and length == self.length:
-            return self.object
+            return claripy.BVV(self.object) if not allow_concrete and self.is_bytes else self.object
 
+        if self.is_bytes:
+            start = addr - self.base
+            end = start + length
+            o = self.object[start:end]
+            return o if allow_concrete else claripy.BVV(o)
         obj_size = self.size()
         left = obj_size - (addr-self.base)*self._byte_width - 1
         right = left - length*self._byte_width + 1
         return self.object[left:right]
 
+    def _object_equals(self, other):
+        if self.is_bytes != other.is_bytes:
+            return False
+
+        if self.is_bytes:
+            return self.object == other.object
+        else:
+            return self.object.cache_key == other.object.cache_key
+
+    def _length_equals(self, other):
+        if type(self.length) != other.length:
+            return False
+
+        if type(self.length) is int:
+            return self.length == other.length
+        else:
+            return self.length.cache_key == other.length.cache_key
+
     def __eq__(self, other):
         if type(other) is not SimMemoryObject:
             return NotImplemented
 
-        return self.object.cache_key == other.object.cache_key and \
-               self.base == other.base and \
-               (self.length == other.length if type(self.length) is int
-                else False if type(other.length) != int
-                else self.length.cache_key == other.length.cache_key)
+        return  self.base == other.base and \
+                self._object_equals(other) and \
+                self._length_equals(other)
 
     def __hash__(self):
-        return hash((self.object.cache_key, self.base, hash(self.length)))
+        obj_hash = hash(self.object) if self.is_bytes else self.object.cache_key
+        return hash((obj_hash, self.base, hash(self.length)))
 
     def __ne__(self, other):
         return not self == other

--- a/angr/storage/memory_object.py
+++ b/angr/storage/memory_object.py
@@ -1,10 +1,12 @@
 import claripy
 from ..errors import SimMemoryError
 
+
 def obj_bit_size(o):
-    if type(o) == bytes:
+    if type(o) is bytes:
         return len(o) * 8
     return o.size()
+
 
 class SimMemoryObject(object):
     """
@@ -13,11 +15,12 @@ class SimMemoryObject(object):
     SimSymbolicMemory class.
     """
     def __init__(self, obj, base, length=None, byte_width=8):
-        if type(obj) == bytes:
+        if type(obj) is bytes:
             assert byte_width == 8
 
         elif not isinstance(obj, claripy.ast.Base):
             raise SimMemoryError('memory can only store claripy Expression')
+
         self.is_bytes = type(obj) == bytes
         self._byte_width = byte_width
         self.base = base
@@ -61,7 +64,7 @@ class SimMemoryObject(object):
             return self.object.cache_key == other.object.cache_key
 
     def _length_equals(self, other):
-        if type(self.length) != other.length:
+        if type(self.length) != type(other.length):
             return False
 
         if type(self.length) is int:

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -352,7 +352,7 @@ class SimPagedMemory:
     def _page_align_up(self, x):
         return self._page_align_down(x + self._page_size - 1)
 
-    def __is_page_aligned(self, x):
+    def _is_page_aligned(self, x):
         return x % self._page_size == 0
 
     def _num_pages(self, start, end):
@@ -584,7 +584,7 @@ class SimPagedMemory:
                     if not isinstance(self._memory_backer[i], (claripy.ast.Base, bytes)):
                         backer = claripy.BVV(self._memory_backer[i], self.byte_width)
 
-                    if type(backer) == bytes and self.byte_width != 8:
+                    if type(backer) is bytes and self.byte_width != 8:
                         backer = claripy.BVV(backer)
 
                     mo = SimMemoryObject(backer, new_page_addr+i, byte_width=self.byte_width)

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -350,7 +350,7 @@ class SimPagedMemory:
         return x - (x % self._page_size)
 
     def _page_align_up(self, x):
-        return (x + self._page_size - 1) % self._page_size
+        return self._page_align_down(x + self._page_size - 1)
 
     def __is_page_aligned(self, x):
         return x % self._page_size == 0

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -1116,7 +1116,7 @@ class SimPagedMemory:
 
         for addr in white_list:
             for page_addr in range(addr[0], addr[1], self._page_size):
-                white_list_page_number.append(page_addr // self._page_size)
+                white_list_page_number.append(self._page_id(page_addr))
 
         new_page_dict = {}
 
@@ -1127,7 +1127,8 @@ class SimPagedMemory:
                 # l.debug("Page " + str(page) + " not flushed!")
                 new_page_dict[page] = self._pages[page]
             else:
-                flushed.append((page._page_addr, page._page_size))
+                p = self._pages[page]
+                flushed.append((p._page_addr, p._page_size))
 
         self._pages = new_page_dict
         self._initialized = set()

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -346,6 +346,31 @@ class SimPagedMemory:
         self._hash_mapping = cooldict.BranchingDict() if hash_mapping is None else hash_mapping
         self._updated_mappings = set()
 
+    def _page_align_down(self, x):
+        return x - (x % self._page_size)
+
+    def _page_align_up(self, x):
+        return (x + self._page_size - 1) % self._page_size
+
+    def __is_page_aligned(self, x):
+        return x % self._page_size == 0
+
+    def _num_pages(self, start, end):
+        return self._page_align_up(end - self._page_align_down(start)) // self._page_size
+
+    def _page_id(self, addr):
+        return addr // self._page_size
+
+    def _page_addr(self, page_id):
+        return page_id * self._page_size
+
+    def _page_base_addrs(self, addr, length):
+        addr = self._page_align_down(addr)
+        return range(addr, length, self._page_size)
+
+    #def _page_ids(self, addr, length):
+    #    return (a // self._page_size for a in range(start, start + num))
+
     def __getstate__(self):
         return {
             '_memory_backer': self._memory_backer,
@@ -487,7 +512,10 @@ class SimPagedMemory:
         elif isinstance(self._memory_backer, cle.Clemory) and self._memory_backer.is_concrete_target_set():
             try:
                 concrete_memory = self._memory_backer.load(new_page_addr, self._page_size)
-                backer = claripy.BVV(concrete_memory)
+                if self.byte_width == 8:
+                    backer = concrete_memory
+                else:
+                    backer = claripy.BVV(concrete_memory)
                 mo = SimMemoryObject(backer, new_page_addr, byte_width=self.byte_width)
                 self._apply_object_to_page(n * self._page_size, mo, page=new_page)
                 initialized = True
@@ -520,7 +548,7 @@ class SimPagedMemory:
                 if self.byte_width == 8:
                     relevant_data = bytes(memoryview(backer)[slice_start:slice_end])
                     mo = SimMemoryObject(
-                            claripy.BVV(relevant_data),
+                            relevant_data,
                             relevant_region_start,
                             byte_width=self.byte_width)
                     self._apply_object_to_page(new_page_addr, mo, page=new_page)
@@ -539,7 +567,9 @@ class SimPagedMemory:
                     if isinstance(self._memory_backer[i], claripy.ast.Base):
                         backer = self._memory_backer[i]
                     elif isinstance(self._memory_backer[i], bytes):
-                        backer = claripy.BVV(self._memory_backer[i])
+                        backer = self._memory_backer[i]
+                        if self.byte_width != 8: # if we have direct bytes we can store it directly
+                            backer = claripy.BVV(backer)
                     else:
                         backer = claripy.BVV(self._memory_backer[i], self.byte_width)
                     mo = SimMemoryObject(backer, i, byte_width=self.byte_width)
@@ -549,12 +579,14 @@ class SimPagedMemory:
         elif len(self._memory_backer) > self._page_size:
             for i in range(self._page_size):
                 try:
-                    if isinstance(self._memory_backer[i], claripy.ast.Base):
-                        backer = self._memory_backer[i]
-                    elif isinstance(self._memory_backer[i], bytes):
-                        backer = claripy.BVV(self._memory_backer[i])
-                    else:
+                    backer = self._memory_backer[i]
+
+                    if not isinstance(self._memory_backer[i], (claripy.ast.Base, bytes)):
                         backer = claripy.BVV(self._memory_backer[i], self.byte_width)
+
+                    if type(backer) == bytes and self.byte_width != 8:
+                        backer = claripy.BVV(backer)
+
                     mo = SimMemoryObject(backer, new_page_addr+i, byte_width=self.byte_width)
                     self._apply_object_to_page(n*self._page_size, mo, page=new_page)
                     initialized = True
@@ -726,9 +758,7 @@ class SimPagedMemory:
         return True
 
     def _containing_pages(self, mo_start, mo_end):
-        page_start = mo_start - mo_start%self._page_size
-        page_end = mo_end + (self._page_size - mo_end%self._page_size) if mo_end % self._page_size else mo_end
-        return [ b for b in range(page_start, page_end, self._page_size) ]
+        return [a for a in self._page_base_addrs(mo_start, mo_end)]
 
     def _containing_pages_mo(self, mo):
         mo_start = mo.base
@@ -1018,18 +1048,14 @@ class SimPagedMemory:
         if isinstance(addr, claripy.ast.bv.BV):
             addr = self.state.solver.max_int(addr)
 
-        base_page_num = addr // self._page_size
-
-        # round length
-        pages = length // self._page_size
-        if length % self._page_size > 0:
-            pages += 1
+        base_page_num = self._page_id(addr)
+        pages = self._num_pages(addr, addr + length)
 
         # this check should not be performed when constructing a CFG
         if self.state.mode != 'fastpath':
-            for page in range(pages):
-                page_id = base_page_num + page
-                if page_id * self._page_size in self:
+            for p_num in range(pages):
+                page_id = base_page_num + p_num
+                if self._page_addr(page_id) in self:
                     err = "map_page received address and length combination which contained mapped page"
                     l.warning(err)
                     raise SimMemoryError(err)
@@ -1044,8 +1070,15 @@ class SimPagedMemory:
             if init_zero:
                 if self.state is not None:
                     self.state.scratch.push_priv(True)
-                mo = SimMemoryObject(claripy.BVV(0, self._page_size * self.byte_width), page_id*self._page_size, byte_width=self.byte_width)
-                self._apply_object_to_page(page_id*self._page_size, mo, page=self._pages[page_id])
+                page_addr = self._page_addr(page_id)
+
+                if self.byte_width == 8:
+                    content = b'\0' * self._page_size
+                else:
+                    content = claripy.BVV(0, self._page_size * self.byte_width)
+
+                mo = SimMemoryObject(content, page_addr, byte_width=self.byte_width)
+                self._apply_object_to_page(page_addr, mo, page=self._pages[page_id])
                 if self.state is not None:
                     self.state.scratch.pop_priv()
 
@@ -1059,26 +1092,25 @@ class SimPagedMemory:
         if isinstance(addr, claripy.ast.bv.BV):
             addr = self.state.solver.max_int(addr)
 
-        base_page_num = addr // self._page_size
-
-        pages = length // self._page_size
-        if length % self._page_size > 0:
-            pages += 1
+        base_page_num = self._page_id(addr)
+        pages = self._num_pages(addr, addr + length)
 
         # this check should not be performed when constructing a CFG
         if self.state.mode != 'fastpath':
             for page in range(pages):
+                # TODO: Why is this different from the check in map_region? what if we unmap _backer backed pages?
                 if base_page_num + page not in self._pages:
                     l.warning("unmap_region received address and length combination is not mapped")
                     return
 
-        for page in range(pages):
-            del self._pages[base_page_num + page]
-            del self._symbolic_addrs[base_page_num + page]
+        for page_id in range(base_page_num, base_page_num + pages):
+            del self._pages[page_id]
+            del self._symbolic_addrs[page_id]
 
     def flush_pages(self, white_list):
         """
             :param white_list: white list of page number to exclude from the flush
+            :returns : a list of memory page ranges that were flushed
         """
         white_list_page_number = []
 
@@ -1088,14 +1120,18 @@ class SimPagedMemory:
 
         new_page_dict = {}
 
+        flushed = []
         # cycle over all the keys ( the page number )
         for page in self._pages:
             if page in white_list_page_number:
                 # l.debug("Page " + str(page) + " not flushed!")
                 new_page_dict[page] = self._pages[page]
+            else:
+                flushed.append((page._page_addr, page._page_size))
 
         self._pages = new_page_dict
         self._initialized = set()
+        return flushed
 
 
 from .. import sim_options as o

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -770,7 +770,7 @@ class SimPagedMemory:
         This function optimizes a large store by storing a single reference to the :class:`SimMemoryObject` instead of
         one for each byte.
 
-        :param memory_object: the memory object to store
+        :param mo: the memory object to store
         """
 
         for p in self._containing_pages_mo(mo):
@@ -1109,8 +1109,13 @@ class SimPagedMemory:
 
     def flush_pages(self, white_list):
         """
-            :param white_list: white list of page number to exclude from the flush
-            :returns : a list of memory page ranges that were flushed
+        Flush all pages not included in the `white_list` by removing their pages. Note, this will not wipe them
+        from memory if they were backed by a memory_backer, it will simply reset them to their initial state.
+        Returns the list of pages that were cleared consisting of `(addr, length)` tuples.
+
+        :param white_list: white list of regions in the form of (start, end) to exclude from the flush
+        :return: a list of memory page ranges that were flushed
+        :rtype: list
         """
         white_list_page_number = []
 

--- a/tests/test_strtol.py
+++ b/tests/test_strtol.py
@@ -58,7 +58,7 @@ def test_strtol_long_string():
 
     state.libc.max_strtol_len = 11
 
-    strtol = angr.SIM_LIBRARIES['libc.so.6'].procedures['strtol']
+    strtol = angr.SIM_LIBRARIES['libc.so.6'].get('strtol', arch=b.arch)
     strtol.state = state.copy()
     ret = strtol.run(0x500000, 0, 0)
 


### PR DESCRIPTION
Implemented support for storing bytes in the memory model directly to speed up memory syncing between unicorn and angr directly. 

Reimplemented page cache syncing interface between angr and angr-native so that pages get accurately mapped into the unicorn cache. this fixes a bug where pages were in the cache that were not updated correctly.