### PR TITLE
CFGFast: SimProcedure.returning was ignored before creating the function.

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1756,9 +1756,9 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         callee_function = None
 
         if new_function_addr is not None:
-            if is_syscall:
-                # we can create the syscall function if it does not exist yet. it has to be handled as a SimProcedure
-                # anyway
+            if is_syscall or self.project.is_hooked(new_function_addr):
+                # we can create the function if it is a syscall or a SimProcedure and it does not exist yet. Note that
+                # syscalls are handled as SimProcedures anyway.
                 callee_function = self.kb.functions.function(addr=new_function_addr, syscall=is_syscall, create=True)
             else:
                 callee_function = self.kb.functions.function(addr=new_function_addr, syscall=is_syscall)


### PR DESCRIPTION
Thanks @gynophage for reporting another issue that leads to the finding of
this bug.