### PR TITLE
Make Parameter hashable in ReachingDefinitions

### DIFF
--- a/angr/analyses/reaching_definitions/atoms.py
+++ b/angr/analyses/reaching_definitions/atoms.py
@@ -95,3 +95,6 @@ class Parameter(Atom):
                self.value == other.value and \
                self.type_ == other.type_ and \
                self.meta == other.meta
+
+    def __hash__(self):
+        return hash(('par', self.value, self.type_, self.meta))


### PR DESCRIPTION
In foreign code, I would like to append `Parameter` instances to [`DataSet`](https://github.com/angr/angr/blob/master/angr/analyses/reaching_definitions/dataset.py)s, which requires `Parameter` to be hashable.

Made this dummy implementation, unsure of all its implications though...