### PR TITLE
Various improvements to CFG {de}serialization

### DIFF
--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -161,7 +161,7 @@ class CFGModel(Serializable):
             model.graph.add_node(node)
             if len(model._nodes_by_addr[node.block_id]) > 1:
                 if once("cfg_model_parse_from_cmessage many nodes at addr"):
-                    l.warning("Importing a CFG with more than one node for a given address is currently unsupported. " +
+                    l.warning("Importing a CFG with more than one node for a given address is currently unsupported. "
                               "The resulting graph may be broken.")
 
         # edges

--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -101,8 +101,7 @@ class CFGModel(Serializable):
 
     def serialize_to_cmessage(self):
         if "Emulated" in self.ident:
-            l.error("Serializing a CFGEmulated instance is currently not supported.")
-            return None
+            raise NotImplementedError("Serializing a CFGEmulated instance is currently not supported.")
 
         cmsg = self._get_cmsg()
         cmsg.ident = self.ident
@@ -110,10 +109,7 @@ class CFGModel(Serializable):
         # nodes
         nodes = [ ]
         for n in self.graph.nodes():
-            n_cmsg = n.serialize_to_cmessage()
-            if n_cmsg is None:
-                continue
-            nodes.append(n_cmsg)
+            nodes.append(n.serialize_to_cmessage())
         cmsg.nodes.extend(nodes)
 
         # edges

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -70,7 +70,7 @@ class CFGNode(Serializable):
         self.no_ret = no_ret
         self._cfg_model = cfg
         self.function_address = function_address
-        self.block_id = block_id  # type: int or tuple
+        self.block_id = block_id  # type: int or BlockID
         self.thumb = thumb
         self.byte_string = byte_string  # type: None or bytes
 
@@ -158,25 +158,26 @@ class CFGNode(Serializable):
         return cfg_pb2.CFGNode()
 
     def serialize_to_cmessage(self):
+        if isinstance(self, CFGENode):
+            _l.error("CFGEmulated instances are not currently serializable")
+            return None
         obj = self._get_cmsg()
         obj.ea = self.addr
         obj.size = self.size
         if self.block_id is not None:
             if type(self.block_id) is int:
                 obj.block_id.append(self.block_id)  # pylint:disable=no-member
-            else:  # should be a tuple
-                obj.block_id.extend(self.block_id)  # pylint:disable=no-member
+            else:  # should be a BlockID
+                _l.error("CFGEmulated instances are not currently serializable")
+                return None
         return obj
 
     @classmethod
     def parse_from_cmessage(cls, cmsg, cfg=None):  # pylint:disable=arguments-differ
-
         if len(cmsg.block_id) == 0:
             block_id = None
-        elif len(cmsg.block_id) == 1:
-            block_id = cmsg.block_id[0]
         else:
-            block_id = tuple(cmsg.block_id)
+            block_id = cmsg.block_id[0]
 
         obj = cls(cmsg.ea,
                   cmsg.size,

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -159,8 +159,8 @@ class CFGNode(Serializable):
 
     def serialize_to_cmessage(self):
         if isinstance(self, CFGENode):
-            _l.error("CFGEmulated instances are not currently serializable")
-            return None
+            raise NotImplementedError("CFGEmulated instances are not currently serializable")
+
         obj = self._get_cmsg()
         obj.ea = self.addr
         obj.size = self.size
@@ -168,8 +168,7 @@ class CFGNode(Serializable):
             if type(self.block_id) is int:
                 obj.block_id.append(self.block_id)  # pylint:disable=no-member
             else:  # should be a BlockID
-                _l.error("CFGEmulated instances are not currently serializable")
-                return None
+                raise NotImplementedError("CFGEmulated instances are not currently serializable")
         return obj
 
     @classmethod

--- a/angr/serializable.py
+++ b/angr/serializable.py
@@ -31,13 +31,10 @@ class Serializable:
         Serialize the class object and returns a bytes object.
 
         :return:    A bytes object.
-        :rtype:     bytes or None
+        :rtype:     bytes
         """
 
-        cmsg = self.serialize_to_cmessage()
-        if cmsg is None:
-            return None
-        return cmsg.SerializeToString()
+        return self.serialize_to_cmessage().SerializeToString()
 
     @classmethod
     def parse_from_cmessage(cls, cmsg, **kwargs):

--- a/angr/serializable.py
+++ b/angr/serializable.py
@@ -31,10 +31,13 @@ class Serializable:
         Serialize the class object and returns a bytes object.
 
         :return:    A bytes object.
-        :rtype:     bytes
+        :rtype:     bytes or None
         """
 
-        return self.serialize_to_cmessage().SerializeToString()
+        cmsg = self.serialize_to_cmessage()
+        if cmsg is None:
+            return None
+        return cmsg.SerializeToString()
 
     @classmethod
     def parse_from_cmessage(cls, cmsg, **kwargs):

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -484,14 +484,24 @@ def test_serialization_cfgnode():
 
 def test_serialization_cfgfast():
     path = os.path.join(test_location, "x86_64", "fauxware")
-    proj = angr.Project(path, auto_load_libs=False)
+    proj1 = angr.Project(path, auto_load_libs=False)
+    proj2 = angr.Project(path, auto_load_libs=False)
 
-    cfg = proj.analyses.CFGFast()
+    cfg = proj1.analyses.CFGFast()
     # parse the entire graph
     b = cfg.model.serialize()
     nose.tools.assert_greater(len(b), 0)
-    cfg_model = CFGModel.parse(b)
-    nose.tools.assert_equal(len(cfg_model.graph), len(cfg.graph))
+
+    # simulate importing a cfg from another tool
+    cfg_model = CFGModel.parse(b, cfg_manager=proj2.kb.cfgs)
+
+    nose.tools.assert_equal(len(cfg_model.graph.nodes), len(cfg.graph.nodes))
+    nose.tools.assert_equal(len(cfg_model.graph.edges), len(cfg.graph.edges))
+
+    n1 = cfg.model.get_any_node(proj1.entry)
+    n2 = cfg_model.get_any_node(proj1.entry)
+    nose.tools.assert_equal(n1, n2)
+
 
 #
 # CFG instance copy


### PR DESCRIPTION
* Fix discrepancy in handling node.block_id (type is either int or BlockID, not tuple)
* Try to disallow CFGEmulated instances from being serialized since BlockIDs are not serializable
* Associate the resulting cfg with the project when cfg_manager is provided