### PR TITLE
Handle self-referential unions and structs, and add test to struct and unions referencing each other

### DIFF
--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -1187,8 +1187,7 @@ def _decl_to_type(decl, extra_types=None):
             if key in extra_types:
                 struct = extra_types[key]
             elif key in ALL_TYPES:
-                stored_struct = ALL_TYPES[key]
-                struct = SimStruct(stored_struct.fields, stored_struct.name)
+                struct = ALL_TYPES[key]
             else:
                 extra_types[key] = struct
 
@@ -1205,8 +1204,7 @@ def _decl_to_type(decl, extra_types=None):
             if key in extra_types:
                 union = extra_types[key]
             elif key in ALL_TYPES:
-                stored_union = ALL_TYPES[key]
-                union = SimUnion(stored_union.members, stored_union.name)
+                union = ALL_TYPES[key]
             else:
                 extra_types[key] = union
 

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -1187,7 +1187,8 @@ def _decl_to_type(decl, extra_types=None):
             if key in extra_types:
                 struct = extra_types[key]
             elif key in ALL_TYPES:
-                struct = ALL_TYPES[key]
+                stored_struct = ALL_TYPES[key]
+                struct = SimStruct(stored_struct.fields, stored_struct.name)
             else:
                 extra_types[key] = struct
 
@@ -1204,7 +1205,8 @@ def _decl_to_type(decl, extra_types=None):
             if key in extra_types:
                 union = extra_types[key]
             elif key in ALL_TYPES:
-                union = ALL_TYPES[key]
+                stored_union = ALL_TYPES[key]
+                union = SimUnion(stored_union.members, stored_union.name)
             else:
                 extra_types[key] = union
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -119,6 +119,18 @@ def test_self_referential_struct_or_union():
     nose.tools.assert_is_instance(forward_union_heap.members['data'], SimTypeInt)
     nose.tools.assert_is_instance(forward_union_heap.members['forward'], SimTypePointer)
 
+def test_avoid_modify_stored_union_struct_while_parsing():
+    union_a = angr.types.parse_type('union a')
+    angr.types.register_types(union_a)
+    angr.types.parse_type('union a { int x; }')
+    nose.tools.assert_true(len(union_a.members) == 0)
+
+def test_avoid_return_stored_union_struct_while_parsing():
+    union_a = angr.types.parse_type('union a { int x; }')
+    angr.types.register_types(union_a)
+    parsed_union_a = angr.types.parse_type('union a')
+    nose.tools.assert_false(union_a is parsed_union_a)
+
 if __name__ == '__main__':
     test_type_annotation()
     test_cproto_conversion()
@@ -126,3 +138,5 @@ if __name__ == '__main__':
     test_parse_type()
     test_parse_type_no_basic_types()
     test_self_referential_struct_or_union()
+    test_avoid_modify_stored_union_struct_while_parsing()
+    test_avoid_return_stored_union_struct_while_parsing()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -106,6 +106,18 @@ def test_parse_type_no_basic_types():
     nose.tools.assert_true(byte.size, 8)
     nose.tools.assert_false(byte.signed)
 
+def test_self_referential_struct_or_union():
+    struct_llist = angr.types.parse_type('struct llist { int data; struct llist *next; }')
+    next_struct_llist = struct_llist.fields['next'].pts_to
+    nose.tools.assert_true(len(next_struct_llist.fields) == 2)
+    nose.tools.assert_is_instance(next_struct_llist.fields['data'], SimTypeInt)
+    nose.tools.assert_is_instance(next_struct_llist.fields['next'], SimTypePointer)
+
+    union_heap = angr.types.parse_type('union heap { int data; union heap *forward; }')
+    forward_union_heap = union_heap.members['forward'].pts_to
+    nose.tools.assert_true(len(forward_union_heap.members) == 2)
+    nose.tools.assert_is_instance(forward_union_heap.members['data'], SimTypeInt)
+    nose.tools.assert_is_instance(forward_union_heap.members['forward'], SimTypePointer)
 
 if __name__ == '__main__':
     test_type_annotation()
@@ -113,3 +125,4 @@ if __name__ == '__main__':
     test_struct_deduplication()
     test_parse_type()
     test_parse_type_no_basic_types()
+    test_self_referential_struct_or_union()


### PR DESCRIPTION
* Modify SimUnion __repr__ method (to avoid exceed maximum recursive depth while representing self-referential unions).
* Add tests for both cases (unions and structs).
* Modify _decl_to_type.