### PR TITLE
Adds all active successors to _hierarchy in simgr

### DIFF
--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -364,6 +364,10 @@ class SimulationManager:
 
             for to_stash, successor_states in successors.items():
                 bucket[to_stash or stash].extend(successor_states)
+                if to_stash == 'active' or (to_stash is None and stash == 'active'):
+                    for state in successor_states:
+                        self._hierarchy.add_state(state)
+                    self._hierarchy.simplify()
 
         self._clear_states(stash=stash)
         for to_stash, states in bucket.items():


### PR DESCRIPTION
Previously we would never record active successors post-step() to
self._hierarchy; so, merges would never find a common ancestor to merge.