### PR TITLE
veritesting_options kwarg not being pop'd

### DIFF
--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -98,6 +98,7 @@ class SimulationManager:
 
         if kwargs.pop('veritesting', False):
             self.use_technique(Veritesting(**kwargs.get('veritesting_options', {})))
+        kwargs.pop('veritesting_options', {})
 
         threads = kwargs.pop('threads', None)
         if threads is not None:

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -560,7 +560,7 @@ class SimState(PluginHub):
             if id(p) in memo:
                 out[n] = memo[id(p)]
             else:
-                out[n] = p.copy(memo)
+                out[n] = p.copy()
                 memo[id(p)] = out[n]
 
         return out

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -560,7 +560,7 @@ class SimState(PluginHub):
             if id(p) in memo:
                 out[n] = memo[id(p)]
             else:
-                out[n] = p.copy()
+                out[n] = p.copy(memo)
                 memo[id(p)] = out[n]
 
         return out


### PR DESCRIPTION
veritesting_options wasn't pop'd in sim_manager constructor, so you could never pass it in
