### PR TITLE
Fix more test join paths

### DIFF
--- a/tests/broken_find_avoid_conflict.py
+++ b/tests/broken_find_avoid_conflict.py
@@ -1,7 +1,7 @@
 import angr
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 # While exploring, if the 'find' and 'avoid' addresses occur in the same run
 # the path is added to find_stash even if the avoid address occurs first.
@@ -11,7 +11,7 @@ test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '.
 # rejected by angr because there is no control flow instruction at the assembly
 # level between the start of the else branch and the target address.
 def test_FindAvoidConflict():
-    proj = angr.Project(test_location+'/i386/ite_FindAvoidConflict-O3')
+    proj = angr.Project(os.path.join(test_location, 'i386', 'ite_FindAvoidConflict-O3'))
     initial_state = proj.factory.blank_state()
     sm = proj.factory.simulation_manager(initial_state)
 

--- a/tests/broken_find_avoid_conflict.py
+++ b/tests/broken_find_avoid_conflict.py
@@ -1,7 +1,7 @@
 import angr
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 # While exploring, if the 'find' and 'avoid' addresses occur in the same run
 # the path is added to find_stash even if the avoid address occurs first.

--- a/tests/broken_loop.py
+++ b/tests/broken_loop.py
@@ -8,12 +8,12 @@ import angr
 
 # load the tests
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 loop_nolibs = None
 
 def setup_module():
     global loop_nolibs
-    loop_nolibs = angr.Project(test_location + "/blob/x86_64/loop",  default_analysis_mode='symbolic')
+    loop_nolibs = angr.Project(os.path.join(test_location, 'x86_64', 'loop'),  default_analysis_mode='symbolic')
 
 def test_loop_entry():
     s = loop_nolibs.sim_run(loop_nolibs.exit_to(0x4004f4))

--- a/tests/broken_loop.py
+++ b/tests/broken_loop.py
@@ -8,7 +8,7 @@ import angr
 
 # load the tests
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 loop_nolibs = None
 
 def setup_module():

--- a/tests/broken_never.py
+++ b/tests/broken_never.py
@@ -9,7 +9,7 @@ import angr
 
 # load the tests
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 never_nolibs = None
 
 

--- a/tests/broken_never.py
+++ b/tests/broken_never.py
@@ -9,13 +9,13 @@ import angr
 
 # load the tests
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 never_nolibs = None
 
 
 def setup_module():
     global never_nolibs
-    never_nolibs = angr.Project( test_location + "/blob/x86_64/never")
+    never_nolibs = angr.Project( os.path.join(test_location, 'x86_64', 'never') )
 
 # def test_slicing():
 # addresses = [ 0x40050C, 0x40050D, 0x400514, 0x40051B, 0x400521, 0x400534 ]

--- a/tests/broken_orwc.py
+++ b/tests/broken_orwc.py
@@ -12,17 +12,17 @@ import nose
 
 # load the tests
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 p_rw = None
 p = None
 
 def setup_rw():
     global p_rw
-    p_rw = angr.Project(test_location + "/blob/x86_64/rw",  use_sim_procedures=False)
+    p_rw = angr.Project(os.path.join(test_location, 'x86_64', 'rw'),  use_sim_procedures=False)
 
 def setup_orwc():
     global p
-    p = angr.Project(test_location + "/blob/x86_64/orwc",  use_sim_procedures=False)
+    p = angr.Project(os.path.join(test_location, 'x86_64', 'orwc'),  use_sim_procedures=False)
 
 def setup_module():
     setup_rw()

--- a/tests/broken_simcc.py
+++ b/tests/broken_simcc.py
@@ -6,10 +6,10 @@ import logging
 l = logging.getLogger("angr.tests.test_simcc")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_simcc_x86_64():
-    binary_path = test_location + "/x86_64/simcc"
+    binary_path = os.path.join(test_location, 'x86_64', 'simcc')
 
     p = angr.Project(binary_path)
     p.analyses.CFGEmulated()
@@ -34,7 +34,7 @@ def test_simcc_x86_64():
 
 def run_all():
     functions = globals()
-    all_functions = dict(filter((lambda kv: kv[0].startswith('test_') and hasattr(v, '__call__')), functions.items()))
+    all_functions = dict(filter((lambda kv: kv[0].startswith('test_') and hasattr(kv[0], '__call__')), functions.items()))
     for f in sorted(all_functions.keys()):
         all_functions[f]()
 

--- a/tests/broken_simcc.py
+++ b/tests/broken_simcc.py
@@ -6,7 +6,7 @@ import logging
 l = logging.getLogger("angr.tests.test_simcc")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_simcc_x86_64():
     binary_path = os.path.join(test_location, 'x86_64', 'simcc')

--- a/tests/broken_sleak.py
+++ b/tests/broken_sleak.py
@@ -9,9 +9,9 @@ p64 = None
 
 def setup_module():
     global p32, p64
-    test_location = str(os.path.dirname(os.path.realpath(__file__)))
-    bin64 = os.path.join(test_location, "blob/x86_64/all")
-    bin32 = os.path.join(test_location, "blob/i386/all")
+    test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
+    bin64 = os.path.join(test_location, 'x86_64', 'all')
+    bin32 = os.path.join(test_location, 'i386', 'all')
 
     p32 = angr.Project(bin64)
     p64 = angr.Project(bin32)

--- a/tests/broken_switch.py
+++ b/tests/broken_switch.py
@@ -8,14 +8,13 @@ import angr
 
 # load the tests
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 switch_nolibs = None
 
 def setup_module():
     global switch_nolibs
     switch_nolibs = angr.Project(
-        test_location +
-        "/blob/x86_64/switch",
+        os.path.join(test_location, 'x86_64', 'switch'),
         default_analysis_mode='symbolic')
 
 

--- a/tests/broken_variableseekr.py
+++ b/tests/broken_variableseekr.py
@@ -10,7 +10,7 @@ from angr import AngrError
 
 # load the tests
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.dirname(os.path.realpath(__file__))
 projects = {}
 projects['fauxwares'] = {}
 projects['cfg_1'] = {}

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     tracer = None
 
-bin_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries'))
+bin_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries')
 if not os.path.isdir(bin_location):
     raise Exception("Can't find the angr/binaries repo for holding testcases. It should be cloned into the same folder as the rest of your angr modules.")
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     tracer = None
 
-bin_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries'))
+bin_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries'))
 if not os.path.isdir(bin_location):
     raise Exception("Can't find the angr/binaries repo for holding testcases. It should be cloned into the same folder as the rest of your angr modules.")
 

--- a/tests/manual_explosion.py
+++ b/tests/manual_explosion.py
@@ -7,7 +7,7 @@ import os
 
 b = angr.Project(os.path.join(
     os.path.dirname(__file__),
-    "../../binaries-private/cgc_scored_event_2/cgc/0b32aa01_01"
+    '..', '..', 'binaries-private', 'cgc_scored_event_2', 'cgc', '0b32aa01_01'
 ))
 
 start = time.time()

--- a/tests/manual_performance.py
+++ b/tests/manual_performance.py
@@ -16,7 +16,7 @@ from os.path import join, dirname, realpath
 
 from progressbar import ProgressBar, Percentage, Bar
 
-test_location = str(join(dirname(realpath(__file__)), '../../binaries/tests'))
+test_location = str(join(dirname(realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 
 class Timer(object):

--- a/tests/perf_concrete_execution.py
+++ b/tests/perf_concrete_execution.py
@@ -12,7 +12,7 @@ import claripy
 if hasattr(claripy, "set_debug"):
     claripy.set_debug(False)
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_tight_loop(arch):

--- a/tests/perf_unicorn.py
+++ b/tests/perf_unicorn.py
@@ -6,7 +6,7 @@ import time
 import angr
 from angr import options as so
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
 
 def perf_unicorn_0():
     p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'x86_64', 'perf_unicorn_0'))

--- a/tests/perf_unicorn.py
+++ b/tests/perf_unicorn.py
@@ -6,7 +6,7 @@ import time
 import angr
 from angr import options as so
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
 
 def perf_unicorn_0():
     p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'x86_64', 'perf_unicorn_0'))

--- a/tests/test_0div.py
+++ b/tests/test_0div.py
@@ -2,7 +2,7 @@ import angr
 import nose
 import os
 
-test_location = os.path.join(os.path.dirname(__file__), '../../binaries/tests')
+test_location = os.path.join(os.path.dirname(__file__), '..', '..', 'binaries', 'tests')
 
 def run_0div(arch):
     # check that we run in unicorn up to the zero-div site, fall back, try again in angr, and error correctly.

--- a/tests/test_adc.py
+++ b/tests/test_adc.py
@@ -2,7 +2,7 @@ import angr
 import nose
 import os
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_adc_i386():
     proj = angr.Project(os.path.join(test_location, 'i386', 'test_adc'), load_options={'auto_load_libs':False})

--- a/tests/test_adc.py
+++ b/tests/test_adc.py
@@ -2,10 +2,10 @@ import angr
 import nose
 import os
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_adc_i386():
-    proj = angr.Project(test_location + "/i386/test_adc", load_options={'auto_load_libs':False})
+    proj = angr.Project(os.path.join(test_location, 'i386', 'test_adc'), load_options={'auto_load_libs':False})
 
     start = 0x804840b
     end = 0x804842e

--- a/tests/test_argc.py
+++ b/tests/test_argc.py
@@ -5,10 +5,10 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_mips():
-    proj = angr.Project(test_location + "/mips/argc_decide")
+    proj = angr.Project(os.path.join(test_location, 'mips', 'argc_decide'))
     r_addr = 0x4006f4
 
     s = proj.factory.entry_state(args = ['aaa'], env = {"HOME": "/home/angr"})
@@ -22,7 +22,7 @@ def test_mips():
     nose.tools.assert_equal(len(xpl.found), 0)
 
 def test_mipsel():
-    proj = angr.Project(test_location + "/mipsel/argc_decide")
+    proj = angr.Project(os.path.join(test_location, 'mipsel', 'argc_decide'))
     r_addr = 0x400708
     s = proj.factory.entry_state(args = ['aaa', 'bbb'], env ={"HOME": "/home/angr"})
     xpl = proj.factory.simulation_manager(s).explore(find=r_addr)
@@ -35,7 +35,7 @@ def test_mipsel():
     nose.tools.assert_equal(len(xpl.found), 0)
 
 def test_i386():
-    proj = angr.Project(test_location + "/i386/argc_decide")
+    proj = angr.Project(os.path.join(test_location, 'i386', 'argc_decide'))
     r_addr = 0x80483d4
     s = proj.factory.entry_state(args = ['aaa'], env ={"HOME": "/home/angr"})
     xpl = proj.factory.simulation_manager(s).explore(find=r_addr)
@@ -48,7 +48,7 @@ def test_i386():
     nose.tools.assert_equal(len(xpl.found), 0)
 
 def test_amd64():
-    proj = angr.Project(test_location + "/x86_64/argc_decide")
+    proj = angr.Project(os.path.join(test_location, 'x86_64', 'argc_decide'))
     r_addr = 0x4004c7
     s = proj.factory.entry_state(args = ['aaa'], env ={"HOME": "/home/angr"})
     xpl = proj.factory.simulation_manager(s).explore(find=r_addr)
@@ -61,7 +61,7 @@ def test_amd64():
     nose.tools.assert_equal(len(xpl.found), 0)
 
 def test_arm():
-    proj = angr.Project(test_location + "/armel/argc_decide")
+    proj = angr.Project(os.path.join(test_location, 'armel', 'argc_decide'))
     r_addr = 0x1040c
 
     s = proj.factory.entry_state(args = ['aaa'], env ={"HOME": "/home/angr"})
@@ -75,7 +75,7 @@ def test_arm():
     nose.tools.assert_equal(len(xpl.found), 0)
 
 def test_ppc32():
-    proj = angr.Project(test_location + "/ppc/argc_decide")
+    proj = angr.Project(os.path.join(test_location, 'ppc', 'argc_decide'))
     r_addr = 0x10000404
 
     s = proj.factory.entry_state(args = ['aaa'], env ={"HOME": "/home/angr"})

--- a/tests/test_argc.py
+++ b/tests/test_argc.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_mips():
     proj = angr.Project(os.path.join(test_location, 'mips', 'argc_decide'))

--- a/tests/test_argc_sym.py
+++ b/tests/test_argc_sym.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def _verify_results(pg, sargc, length=400):
     argcs = pg.mp_found.solver.eval(sargc)
@@ -16,7 +16,7 @@ def _verify_results(pg, sargc, length=400):
         assert b"Good man" in s if a == 1 else b"Very Good man" if a == 2 else True
 
 def test_mips():
-    arger_mips = angr.Project(test_location + "/mips/argc_symbol")
+    arger_mips = angr.Project(os.path.join(test_location, 'mips', 'argc_symbol'))
     r_addr = [0x400720, 0x40076c, 0x4007bc]
 
     sargc = claripy.BVS('argc', 32)
@@ -25,7 +25,7 @@ def test_mips():
     _verify_results(pg, sargc)
 
 def test_mipsel():
-    arger_mipsel = angr.Project(test_location + "/mipsel/argc_symbol")
+    arger_mipsel = angr.Project(os.path.join(test_location, 'mipsel', 'argc_symbol'))
     r_addr = [0x400720, 0x40076c, 0x4007bc]
 
     sargc = claripy.BVS('argc', 32)
@@ -34,7 +34,7 @@ def test_mipsel():
     _verify_results(pg, sargc)
 
 def test_i386():
-    arger_i386 = angr.Project(test_location + "/i386/argc_symbol")
+    arger_i386 = angr.Project(os.path.join(test_location, 'i386', 'argc_symbol'))
     r_addr = [0x08048411, 0x08048437, 0x08048460]
 
     sargc = claripy.BVS('argc', 32)
@@ -43,7 +43,7 @@ def test_i386():
     _verify_results(pg, sargc)
 
 def test_amd64():
-    arger_amd64 = angr.Project(test_location + "/x86_64/argc_symbol", load_options={'auto_load_libs': False})
+    arger_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'argc_symbol'), load_options={'auto_load_libs': False})
     r_addr = [0x40051B, 0x400540, 0x400569]
 
     sargc = claripy.BVS('argc', 64)
@@ -52,7 +52,7 @@ def test_amd64():
     _verify_results(pg, sargc, length=800)
 
 def test_arm():
-    arger_arm = angr.Project(test_location + "/armel/argc_symbol")
+    arger_arm = angr.Project(os.path.join(test_location, 'armel', 'argc_symbol'))
     r_addr = [0x00010444, 0x00010478, 0x000104B0]
 
     sargc = claripy.BVS('argc', 32)
@@ -61,7 +61,7 @@ def test_arm():
     _verify_results(pg, sargc)
 
 def test_ppc32():
-    arger_ppc32 = angr.Project(test_location + "/ppc/argc_symbol")
+    arger_ppc32 = angr.Project(os.path.join(test_location, 'ppc', 'argc_symbol'))
     r_addr = [0x1000043C, 0x10000474, 0x100004B0]
 
     sargc = claripy.BVS('argc', 32)

--- a/tests/test_argc_sym.py
+++ b/tests/test_argc_sym.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def _verify_results(pg, sargc, length=400):
     argcs = pg.mp_found.solver.eval(sargc)

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -5,10 +5,10 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_mips():
-    proj = angr.Project(test_location + "/mips/argv_test")
+    proj = angr.Project(os.path.join(test_location, 'mips', 'argv_test'))
     r_addr = 0x400768
 
     s = proj.factory.entry_state(args = ['aaa', "Yan is a noob"], env ={"HOME": "/home/angr"})
@@ -32,7 +32,7 @@ def test_mips():
     nose.tools.assert_equal(b"Yan is a noob" in conc, True)
 
 def test_mipsel():
-    proj = angr.Project(test_location + "/mipsel/argv_test")
+    proj = angr.Project(os.path.join(test_location, 'mipsel', 'argv_test'))
     r_addr = 0x400768
     s = proj.factory.entry_state(args = ['aaa', 'Yan is a noob'], env ={"HOME": "/home/angr"})
     xpl = proj.factory.simulation_manager(s).explore(find=r_addr)
@@ -54,7 +54,7 @@ def test_mipsel():
     nose.tools.assert_equal(b"Yan is a noob" in conc, True)
 
 def test_i386():
-    proj = angr.Project(test_location + "/i386/argv_test")
+    proj = angr.Project(os.path.join(test_location, 'i386', 'argv_test'))
     r_addr = 0x804845B
     s = proj.factory.entry_state(args = ['aaa', 'Yan is a noob'], env ={"HOME": "/home/angr"})
     xpl = proj.factory.simulation_manager(s).explore(find=r_addr)
@@ -76,7 +76,7 @@ def test_i386():
     nose.tools.assert_equal(b"Yan is a noob" in conc, True)
 
 def test_amd64():
-    proj = angr.Project(test_location + "/x86_64/argv_test")
+    proj = angr.Project(os.path.join(test_location, 'x86_64', 'argv_test'))
     r_addr = 0x400571
     s = proj.factory.entry_state(args = ['aaa', 'Yan is a noob'], env ={"HOME": "/home/angr"})
     xpl = proj.factory.simulation_manager(s).explore(find=r_addr)
@@ -98,7 +98,7 @@ def test_amd64():
     nose.tools.assert_equal(b"Yan is a noob" in conc, True)
 
 def test_arm():
-    proj = angr.Project(test_location + "/armel/argv_test")
+    proj = angr.Project(os.path.join(test_location, 'armel', 'argv_test'))
     r_addr = 0x1048c
 
     s = proj.factory.entry_state(args = ['aaa', 'Yan is a noob'], env ={"HOME": "/home/angr"})
@@ -121,7 +121,7 @@ def test_arm():
     nose.tools.assert_equal(b"Yan is a noob" in conc, True)
 
 def test_ppc32():
-    proj = angr.Project(test_location + "/ppc/argv_test")
+    proj = angr.Project(os.path.join(test_location, 'ppc', 'argv_test'))
     r_addr = 0x10000498
 
     s = proj.factory.entry_state(args = ['aaa', 'Yan is a noob'], env ={"HOME": "/home/angr"})

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_mips():
     proj = angr.Project(os.path.join(test_location, 'mips', 'argv_test'))

--- a/tests/test_bindiff.py
+++ b/tests/test_bindiff.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr.tests.test_bindiff")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 # todo make a better test
 def test_bindiff_x86_64():

--- a/tests/test_bindiff.py
+++ b/tests/test_bindiff.py
@@ -5,12 +5,12 @@ import logging
 l = logging.getLogger("angr.tests.test_bindiff")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 # todo make a better test
 def test_bindiff_x86_64():
-    binary_path_1 = test_location + "/x86_64/bindiff_a"
-    binary_path_2 = test_location + "/x86_64/bindiff_b"
+    binary_path_1 = os.path.join(test_location, 'x86_64', 'bindiff_a')
+    binary_path_2 = os.path.join(test_location, 'x86_64', 'bindiff_b')
     b = angr.Project(binary_path_1, load_options={"auto_load_libs": False})
     b2 = angr.Project(binary_path_2, load_options={"auto_load_libs": False})
     bindiff = b.analyses.BinDiff(b2)

--- a/tests/test_block_cache.py
+++ b/tests/test_block_cache.py
@@ -4,7 +4,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_block_cache():
     p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), translation_cache=True)

--- a/tests/test_block_cache.py
+++ b/tests/test_block_cache.py
@@ -4,7 +4,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_block_cache():
     p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), translation_cache=True)

--- a/tests/test_boyscout.py
+++ b/tests/test_boyscout.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 import logging
 l = logging.getLogger('angr.test_boyscout')

--- a/tests/test_boyscout.py
+++ b/tests/test_boyscout.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 import logging
 l = logging.getLogger('angr.test_boyscout')

--- a/tests/test_bp_save_optimization.py
+++ b/tests/test_bp_save_optimization.py
@@ -6,7 +6,7 @@ import ailment
 
 test_location = str(
     os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+        os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 
 def check_bp_save_fauxware(arch):

--- a/tests/test_cacher.py
+++ b/tests/test_cacher.py
@@ -9,7 +9,7 @@ import angr
 
 l = logging.getLogger("angr_tests.managers")
 
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def broken_cacher():
     p = angr.Project(os.path.join(location, 'x86_64', 'fauxware'), load_options={'auto_load_libs': False})

--- a/tests/test_callable.py
+++ b/tests/test_callable.py
@@ -9,7 +9,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 addresses_fauxware = {
     'armel': 0x8524,
@@ -35,7 +35,7 @@ addresses_manysum = {
 
 def run_fauxware(arch):
     addr = addresses_fauxware[arch]
-    p = angr.Project(location + '/' + arch + '/fauxware')
+    p = angr.Project(os.path.join(location, arch, 'fauxware'))
     charstar = SimTypePointer(SimTypeChar())
     prototype = SimTypeFunction((charstar, charstar), SimTypeInt(False))
     cc = p.factory.cc(func_ty=prototype)
@@ -82,7 +82,7 @@ def run_manyfloatsum(arch):
     if type_cache is None:
         type_cache = parse_defns(open(os.path.join(location, '..', 'tests_src', 'manyfloatsum.c')).read())
 
-    p = angr.Project(location + '/' + arch + '/manyfloatsum')
+    p = angr.Project(os.path.join(location, arch, 'manyfloatsum'))
     for function in ('sum_floats', 'sum_combo', 'sum_segregated', 'sum_doubles', 'sum_combo_doubles', 'sum_segregated_doubles'):
         cc = p.factory.cc(func_ty=type_cache[function])
         args = list(range(len(cc.func_ty.args)))
@@ -99,7 +99,7 @@ def run_manyfloatsum_symbolic(arch):
     if type_cache is None:
         type_cache = parse_defns(open(os.path.join(location, '..', 'tests_src', 'manyfloatsum.c')).read())
 
-    p = angr.Project(location + '/' + arch + '/manyfloatsum')
+    p = angr.Project(os.path.join(location, arch, 'manyfloatsum'))
     function = 'sum_doubles'
     cc = p.factory.cc(func_ty=type_cache[function])
     args = [claripy.FPS('arg_%d' % i, claripy.FSORT_DOUBLE) for i in range(len(type_cache[function].args))]

--- a/tests/test_callable.py
+++ b/tests/test_callable.py
@@ -9,7 +9,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 addresses_fauxware = {
     'armel': 0x8524,

--- a/tests/test_cdg.py
+++ b/tests/test_cdg.py
@@ -8,7 +8,7 @@ import nose.tools
 import angr
 from angr.analyses.cdg import TemporaryNode
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests"))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
 
 
 def test_graph_0():

--- a/tests/test_cdg.py
+++ b/tests/test_cdg.py
@@ -17,7 +17,7 @@ def test_graph_0():
     # etc.
 
     # Create a project with a random binary - it will not be used anyways
-    p = angr.Project(test_location + "/x86_64/datadep_test",
+    p = angr.Project(os.path.join(test_location, 'x86_64', 'datadep_test'),
                      load_options={'auto_load_libs': False},
                      use_sim_procedures=True)
 

--- a/tests/test_cfg_clflush.py
+++ b/tests/test_cfg_clflush.py
@@ -6,7 +6,7 @@ import nose
 import angr
 
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_cfgfast_clflush():

--- a/tests/test_cfg_thumb_firmware.py
+++ b/tests/test_cfg_thumb_firmware.py
@@ -4,7 +4,7 @@ import os
 import angr
 from nose.tools import assert_true
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_thumb_firmware_cfg():

--- a/tests/test_cfg_vex_postprocessor.py
+++ b/tests/test_cfg_vex_postprocessor.py
@@ -3,7 +3,7 @@ import os
 
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_issue_1172():

--- a/tests/test_cfgemulated.py
+++ b/tests/test_cfgemulated.py
@@ -7,7 +7,7 @@ import logging
 l = logging.getLogger("angr.tests.test_cfgemulated")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 import angr
 from angr import options as o
@@ -106,34 +106,34 @@ def perform_single(binary_path, cfg_path=None):
         l.warning("No standard CFG specified.")
 
 def disabled_cfg_0():
-    binary_path = test_location + "/x86_64/cfg_0"
+    binary_path = os.path.join(test_location, 'x86_64', 'cfg_0')
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
 
 def disabled_cfg_1():
-    binary_path = test_location + "/x86_64/cfg_1"
+    binary_path = os.path.join(test_location, 'x86_64', 'cfg_1')
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
 
 def disabled_cfg_2():
-    binary_path = test_location + "/armel/test_division"
+    binary_path = os.path.join(test_location, 'armel', 'test_division')
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
 
 def disabled_cfg_3():
-    binary_path = test_location + "/mips/test_arrays"
+    binary_path = os.path.join(test_location, 'mips', 'test_arrays')
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
 
 def disabled_cfg_4():
-    binary_path = test_location + "/mipsel/darpa_ping"
+    binary_path = os.path.join(test_location, 'mipsel', 'darpa_ping')
     cfg_path = binary_path + ".cfg"
     perform_single(binary_path, cfg_path)
 
 def test_additional_edges():
     # Test the `additional_edges` parameter for CFG generation
 
-    binary_path = test_location + "/x86_64/switch"
+    binary_path = os.path.join(test_location, 'x86_64', 'switch')
     proj = angr.Project(binary_path,
                         use_sim_procedures=True,
                         default_analysis_mode='symbolic',
@@ -155,7 +155,7 @@ def test_additional_edges():
 def test_not_returning():
     # Make sure we are properly labeling functions that do not return in function manager
 
-    binary_path = test_location + "/x86_64/not_returning"
+    binary_path = os.path.join(test_location, 'x86_64', 'not_returning')
     proj = angr.Project(binary_path,
                         use_sim_procedures=True,
                         load_options={'auto_load_libs': False}
@@ -182,7 +182,7 @@ def test_not_returning():
     nose.tools.assert_equal(proj.kb.functions.function(name='function_d'), None)
 
 def disabled_cfg_5():
-    binary_path = test_location + "/mipsel/busybox"
+    binary_path = os.path.join(test_location, 'mipsel', 'busybox')
     cfg_path = binary_path + ".cfg"
 
     perform_single(binary_path, cfg_path)
@@ -205,13 +205,13 @@ def test_cfg_6():
     o.modes['fastpath'] ^= {o.DO_CCALLS}
 
 def test_fauxware():
-    binary_path = test_location + "/x86_64/fauxware"
+    binary_path = os.path.join(test_location, 'x86_64', 'fauxware')
     cfg_path = binary_path + ".cfg"
 
     perform_single(binary_path, cfg_path)
 
 def disabled_loop_unrolling():
-    binary_path = test_location + "/x86_64/cfg_loop_unrolling"
+    binary_path = os.path.join(test_location, 'x86_64', 'cfg_loop_unrolling')
 
     p = angr.Project(binary_path)
     cfg = p.analyses.CFGEmulated(fail_fast=True)
@@ -225,7 +225,7 @@ def test_thumb_mode():
     # In thumb mode, all addresses of instructions and in function manager should be odd numbers, which loyally
     # reflect VEX's trick to encode the THUMB state in the address.
 
-    binary_path = test_location + "/armhf/test_arrays"
+    binary_path = os.path.join(test_location, 'armhf', 'test_arrays')
     p = angr.Project(binary_path)
     cfg = p.analyses.CFGEmulated(fail_fast=True)
 

--- a/tests/test_cfgemulated.py
+++ b/tests/test_cfgemulated.py
@@ -7,7 +7,7 @@ import logging
 l = logging.getLogger("angr.tests.test_cfgemulated")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 import angr
 from angr import options as o

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -12,7 +12,7 @@ from angr.knowledge_plugins.cfg import CFGNode, CFGModel, MemoryDataSort
 
 l = logging.getLogger("angr.tests.test_cfgfast")
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def cfg_fast_functions_check(arch, binary_path, func_addrs, func_features):
     """

--- a/tests/test_cfgfast_soot.py
+++ b/tests/test_cfgfast_soot.py
@@ -1,7 +1,7 @@
 import os
 import angr
 
-test_location = os.path.join(os.path.dirname(os.path.realpath(str(__file__))), '../../binaries/tests/')
+test_location = os.path.join(os.path.dirname(os.path.realpath(str(__file__))), '..', '..', 'binaries', 'tests')
 
 def test_simple1():
     binary_path = os.path.join(test_location, "java", "simple1.jar")

--- a/tests/test_checkbyte.py
+++ b/tests/test_checkbyte.py
@@ -4,7 +4,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 arches = ( "armel", "i386", "mips", "mipsel", "ppc64", "ppc", "x86_64" )
 # TODO: arches += ( "armhf", )

--- a/tests/test_checkbyte.py
+++ b/tests/test_checkbyte.py
@@ -4,7 +4,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 arches = ( "armel", "i386", "mips", "mipsel", "ppc64", "ppc", "x86_64" )
 # TODO: arches += ( "armhf", )

--- a/tests/test_ctype_locale.py
+++ b/tests/test_ctype_locale.py
@@ -32,7 +32,7 @@ def test_ctype_b_loc():
 
     # Just load a binary so that we can do the initialization steps from
     # libc_start_main
-    bin_path = os.path.join(test_location, '../../binaries/tests/x86_64/ctype_b_loc')
+    bin_path = os.path.join(test_location, '..', '..', 'binaries', 'tests', 'x86_64', 'ctype_b_loc')
 
     ctype_b_loc = lambda state, arguments: angr.SIM_PROCEDURES['glibc']['__ctype_b_loc']().execute(state, arguments=arguments)
 
@@ -82,7 +82,7 @@ def test_ctype_tolower_loc():
 
     # Just load a binary so that we can do the initialization steps from
     # libc_start_main
-    bin_path = os.path.join(test_location, '../../binaries/tests/x86_64/ctype_tolower_loc')
+    bin_path = os.path.join(test_location, '..', '..', 'binaries', 'tests', 'x86_64', 'ctype_tolower_loc')
 
     ctype_tolower_loc = lambda state, arguments: angr.SIM_PROCEDURES['glibc']['__ctype_tolower_loc']().execute(state, arguments=arguments)
 
@@ -132,7 +132,7 @@ def test_ctype_toupper_loc():
 
     # Just load a binary so that we can do the initialization steps from
     # libc_start_main
-    bin_path = os.path.join(test_location, '../../binaries/tests/x86_64/ctype_toupper_loc')
+    bin_path = os.path.join(test_location, '..', '..', 'binaries', 'tests', 'x86_64', 'ctype_toupper_loc')
 
     ctype_toupper_loc = lambda state, arguments: angr.SIM_PROCEDURES['glibc']['__ctype_toupper_loc']().execute(state, arguments=arguments)
 

--- a/tests/test_ddg.py
+++ b/tests/test_ddg.py
@@ -11,7 +11,7 @@ import nose
 import angr
 
 # Load the tests
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def perform_one(binary_path):
     proj = angr.Project(binary_path,

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -2,7 +2,7 @@
 import os
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_decompiling_all_x86_64():

--- a/tests/test_director.py
+++ b/tests/test_director.py
@@ -8,7 +8,7 @@ import nose.tools
 import angr
 from angr.sim_type import SimTypePointer, SimTypeChar
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_execute_address_brancher():
 

--- a/tests/test_driller_core.py
+++ b/tests/test_driller_core.py
@@ -9,7 +9,7 @@ from common import bin_location
 from test_tracer import tracer_cgc
 
 def test_cgc():
-    binary = os.path.join(bin_location, "tests/cgc/sc1_0b32aa01_01")
+    binary = os.path.join(bin_location, 'tests', 'cgc', 'sc1_0b32aa01_01')
     simgr, tracer = tracer_cgc(binary, 'driller_core_cgc', b'AAAA', copy_states=True)
     simgr.use_technique(angr.exploration_techniques.DrillerCore(tracer._trace))
     simgr.run()
@@ -18,7 +18,7 @@ def test_cgc():
     nose.tools.assert_equal(len(simgr.diverted), 3)
 
 def test_simprocs():
-    binary = os.path.join(bin_location, "tests/i386/driller_simproc")
+    binary = os.path.join(bin_location, 'tests', 'i386', 'driller_simproc')
     memcmp = angr.SIM_PROCEDURES['libc']['memcmp']()
 
     simgr, tracer = tracer_cgc(binary, 'driller_core_simprocs', b'A'*128, copy_states=True)

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -4,7 +4,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 target_arches = {
     #'i386',

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -4,7 +4,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 target_arches = {
     #'i386',

--- a/tests/test_fauxware.py
+++ b/tests/test_fauxware.py
@@ -10,7 +10,7 @@ from nose.plugins.attrib import attr
 from angr.state_plugins.history import HistoryIter
 
 l = logging.getLogger("angr.tests")
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 target_addrs = {
     'i386': [ 0x080485C9 ],

--- a/tests/test_fauxware.py
+++ b/tests/test_fauxware.py
@@ -10,7 +10,7 @@ from nose.plugins.attrib import attr
 from angr.state_plugins.history import HistoryIter
 
 l = logging.getLogger("angr.tests")
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 target_addrs = {
     'i386': [ 0x080485C9 ],

--- a/tests/test_file_struct_funcs.py
+++ b/tests/test_file_struct_funcs.py
@@ -31,7 +31,7 @@ def check_state_3(state):
 
 
 def test_file_struct_funcs():
-    test_bin = os.path.join(test_location, "../../binaries/tests/x86_64/file_func_test")
+    test_bin = os.path.join(test_location, '..', '..', 'binaries', 'tests', 'x86_64', 'file_func_test')
     b = angr.Project(test_bin)
 
     pg = b.factory.simulation_manager()

--- a/tests/test_file_struct_funcs.py
+++ b/tests/test_file_struct_funcs.py
@@ -6,7 +6,7 @@ import logging
 
 l = logging.getLogger('angr.tests.test_file_struct_funcs')
 
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.dirname(os.path.realpath(__file__))
 
 
 def check_state_1(state):

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -5,7 +5,7 @@ import nose.tools
 
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_function_serialization():

--- a/tests/test_function_manager.py
+++ b/tests/test_function_manager.py
@@ -72,7 +72,7 @@ def test_amd64():
     #l.info("PNG files generated.")
 
 def test_call_to():
-    project = angr.Project(test_location + "/x86_64/fauxware")
+    project = angr.Project(os.path.join(test_location, 'x86_64', 'fauxware'))
     project.arch = ArchAMD64()
 
     project.kb.functions._add_call_to(0x400000, 0x400410, 0x400420, 0x400414)

--- a/tests/test_function_manager.py
+++ b/tests/test_function_manager.py
@@ -7,7 +7,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_amd64():

--- a/tests/test_gdb_plugin.py
+++ b/tests/test_gdb_plugin.py
@@ -6,11 +6,11 @@ import angr
 l = logging.getLogger("angr_tests")
 
 this_file = str(os.path.dirname(os.path.realpath(__file__)))
-test_location = os.path.join(this_file, '../../binaries/tests')
-data_location = os.path.join(this_file, "../../binaries/tests_data/test_gdb_plugin")
+test_location = os.path.join(this_file, '..', '..', 'binaries', 'tests')
+data_location = os.path.join(this_file, '..', '..', 'binaries', 'tests_data', 'test_gdb_plugin')
 
 def test_gdb():
-    p = angr.Project(os.path.join(test_location, "x86_64/test_gdb_plugin"))
+    p = angr.Project(os.path.join(test_location, 'x86_64', 'test_gdb_plugin'))
     st = p.factory.blank_state()
 
     st.gdb.set_stack(os.path.join(data_location, "stack"), stack_top=0x7ffffffff000)

--- a/tests/test_gdb_plugin.py
+++ b/tests/test_gdb_plugin.py
@@ -5,7 +5,7 @@ import angr
 
 l = logging.getLogger("angr_tests")
 
-this_file = str(os.path.dirname(os.path.realpath(__file__)))
+this_file = os.path.dirname(os.path.realpath(__file__))
 test_location = os.path.join(this_file, '..', '..', 'binaries', 'tests')
 data_location = os.path.join(this_file, '..', '..', 'binaries', 'tests_data', 'test_gdb_plugin')
 

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -3,7 +3,7 @@ import angr
 
 import os
 
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_mips():

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -3,7 +3,7 @@ import angr
 
 import os
 
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 
 def test_mips():
@@ -11,7 +11,7 @@ def test_mips():
     INNER_LOOP = 0x40069C
     OUTER_LOOP = 0x40076C
 
-    p = angr.Project(location + '/mips/test_loops')
+    p = angr.Project(os.path.join(location, 'mips', 'test_loops'))
     output = []
 
     # hooking by a function decorator

--- a/tests/test_iat_resolver.py
+++ b/tests/test_iat_resolver.py
@@ -3,7 +3,7 @@ import os
 
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_iat():
     p = angr.Project(os.path.join(test_location, 'i386', 'simple_windows.exe'), auto_load_libs=False)

--- a/tests/test_iat_resolver.py
+++ b/tests/test_iat_resolver.py
@@ -3,10 +3,10 @@ import os
 
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_iat():
-    p = angr.Project(test_location + '/i386/simple_windows.exe', auto_load_libs=False)
+    p = angr.Project(os.path.join(test_location, 'i386', 'simple_windows.exe'), auto_load_libs=False)
     cfg = p.analyses.CFGFast()
 
     strcmp_caller_bb = cfg.get_any_node(0x401010)

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -2,7 +2,7 @@ import angr
 import nose
 
 import os
-bin_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries'))
+bin_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries')
 
 import logging
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -240,7 +240,7 @@ def test_inspect_concretization():
 
 
 def test_inspect_engine_process():
-    p = angr.Project(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests/x86_64/fauxware'))
+    p = angr.Project(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests', 'x86_64', 'fauxware'))
     constraints = []
     def check_first_symbolic_fork(state):
         succs = state.inspect.sim_successors.successors

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -11,7 +11,7 @@ from archinfo.arch_soot import (ArchSoot, SootAddressDescriptor, SootMethodDescr
                                 SootArgument, SootAddressTerminator)
 
 file_dir = os.path.dirname(os.path.realpath(__file__))
-test_location = str(os.path.join(file_dir, "..", "..", "binaries", "tests", "java"))
+test_location = os.path.join(file_dir, "..", "..", "binaries", "tests", "java")
 
 
 

--- a/tests/test_jumptables.py
+++ b/tests/test_jumptables.py
@@ -9,7 +9,7 @@ import nose.tools
 import angr
 
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 l = logging.getLogger("angr.tests.test_jumptables")
 
 

--- a/tests/test_kb_plugins.py
+++ b/tests/test_kb_plugins.py
@@ -3,7 +3,7 @@ import angr
 import networkx
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_kb_plugins():

--- a/tests/test_kb_plugins.py
+++ b/tests/test_kb_plugins.py
@@ -3,11 +3,11 @@ import angr
 import networkx
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 
 def test_kb_plugins():
-    p = angr.Project(location + "/x86_64/fauxware")
+    p = angr.Project(os.path.join(location, 'x86_64', 'fauxware'))
 
     nose.tools.assert_is_instance(p.kb.data, angr.knowledge_plugins.Data)
     nose.tools.assert_is_instance(p.kb.functions, angr.knowledge_plugins.FunctionManager)

--- a/tests/test_keystone.py
+++ b/tests/test_keystone.py
@@ -7,7 +7,7 @@ import nose
 import angr
 
 l = logging.getLogger("angr.tests")
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 insn_texts = {
     'i386': b"add eax, 15",

--- a/tests/test_keystone.py
+++ b/tests/test_keystone.py
@@ -7,7 +7,7 @@ import nose
 import angr
 
 l = logging.getLogger("angr.tests")
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 insn_texts = {
     'i386': b"add eax, 15",

--- a/tests/test_loop_seer.py
+++ b/tests/test_loop_seer.py
@@ -4,7 +4,7 @@ import sys
 import angr
 import nose.tools
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_various_loops():

--- a/tests/test_mem_funcs.py
+++ b/tests/test_mem_funcs.py
@@ -5,24 +5,24 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_memmove():
-    proj = angr.Project(test_location + "/x86_64/memmove", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['memmove'])
+    proj = angr.Project(os.path.join(test_location, 'x86_64', 'memmove'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['memmove'])
     explorer = proj.factory.simulation_manager().explore(find=[0x4005D7])
     s = explorer.found[0]
     result = s.solver.eval(s.memory.load(s.registers.load(16), 13), cast_to=bytes)
     nose.tools.assert_equal(result, b'very useful.\x00')
 
 def test_memcpy():
-    proj = angr.Project(test_location + "/x86_64/memcpy", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['memcpy'])
+    proj = angr.Project(os.path.join(test_location, 'x86_64', 'memcpy'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['memcpy'])
     explorer = proj.factory.simulation_manager().explore(find=[0x40065A])
     s = explorer.found[0]
     result = s.solver.eval(s.memory.load(s.registers.load(16), 19), cast_to=bytes)
     nose.tools.assert_equal(result, b"let's test memcpy!\x00")
 
 def test_memset():
-    proj = angr.Project(test_location + "/x86_64/memset", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['memset'])
+    proj = angr.Project(os.path.join(test_location, 'x86_64', 'memset'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['memset'])
     explorer = proj.factory.simulation_manager().explore(find=[0x400608])
     s = explorer.found[0]
     result = s.solver.eval(s.memory.load(s.registers.load(16), 50), cast_to=bytes)

--- a/tests/test_mem_funcs.py
+++ b/tests/test_mem_funcs.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_memmove():
     proj = angr.Project(os.path.join(test_location, 'x86_64', 'memmove'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['memmove'])

--- a/tests/test_memory_watcher.py
+++ b/tests/test_memory_watcher.py
@@ -9,10 +9,10 @@ import psutil
 from common import bin_location
 
 def test_memory_watcher():
-    binary = os.path.join(bin_location, "tests/x86_64/veritesting_a")
+    binary = os.path.join(bin_location, 'tests', 'x86_64', 'veritesting_a')
     proj = angr.Project(binary)
     simgr = proj.factory.simulation_manager()
-    
+
     memory_watcher = angr.exploration_techniques.MemoryWatcher()
     simgr.use_technique(memory_watcher)
 

--- a/tests/test_multi_open_file.py
+++ b/tests/test_multi_open_file.py
@@ -8,7 +8,7 @@ l = logging.getLogger('angr.tests.test_multi_open_file')
 test_location = str(os.path.dirname(os.path.realpath(__file__)))
 
 def test_multi_open_file():
-    test_bin = os.path.join(test_location, "../../binaries/tests/x86_64/test_multi_open_file")
+    test_bin = os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "test_multi_open_file")
     b = angr.Project(test_bin)
 
     pg = b.factory.simulation_manager()

--- a/tests/test_multi_open_file.py
+++ b/tests/test_multi_open_file.py
@@ -5,7 +5,7 @@ import os
 import logging
 l = logging.getLogger('angr.tests.test_multi_open_file')
 
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.dirname(os.path.realpath(__file__))
 
 def test_multi_open_file():
     test_bin = os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "test_multi_open_file")

--- a/tests/test_oppologist.py
+++ b/tests/test_oppologist.py
@@ -2,7 +2,7 @@ import os
 
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
 
 def _ultra_oppologist(p, s):
     old_ops = dict(angr.engines.vex.irop.operations)

--- a/tests/test_oppologist.py
+++ b/tests/test_oppologist.py
@@ -2,7 +2,7 @@ import os
 
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
 
 def _ultra_oppologist(p, s):
     old_ops = dict(angr.engines.vex.irop.operations)
@@ -19,7 +19,7 @@ def _ultra_oppologist(p, s):
         angr.engines.vex.irop.operations.update(old_ops)
 
 def test_fauxware_oppologist():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/fauxware'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'fauxware'))
     s = p.factory.full_init_state(
         remove_options={ angr.options.LAZY_SOLVES, angr.options.EXTENDED_IROP_SUPPORT }
     )
@@ -30,7 +30,7 @@ def test_fauxware_oppologist():
     assert pg.deadended[0].posix.dumps(1).count(b"\n") == 3
 
 def test_cromu_70():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/cgc/CROMU_00070'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'cgc', 'CROMU_00070'))
     inp = bytes.fromhex("030e000001000001001200010000586d616ce000000600030000040dd0000000000600000606000006030e000001000001003200010000586d616ce0030000000000030e000001000001003200010000586d616ce003000000000006000006030e000001000001003200010000586d616ce0030000df020000")
     s = p.factory.full_init_state(
         add_options={ angr.options.UNICORN },

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_nx():
     nx_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'memmove'))

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -5,10 +5,10 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_nx():
-    nx_amd64 = angr.Project(test_location + "/x86_64/memmove")
+    nx_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'memmove'))
     es = nx_amd64.factory.entry_state()
 
     # .text should be PROT_READ|PROT_EXEC

--- a/tests/test_project_resolve_simproc.py
+++ b/tests/test_project_resolve_simproc.py
@@ -2,7 +2,7 @@ import nose
 import angr
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 bina = os.path.join(test_location, "x86_64", "test_project_resolve_simproc")
 
 """

--- a/tests/test_project_resolve_simproc.py
+++ b/tests/test_project_resolve_simproc.py
@@ -2,8 +2,8 @@ import nose
 import angr
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
-bina = os.path.join(test_location, "x86_64/test_project_resolve_simproc")
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+bina = os.path.join(test_location, "x86_64", "test_project_resolve_simproc")
 
 """
 We voluntarily don't use SimProcedures for 'rand' and 'sleep' because we want

--- a/tests/test_prototypes.py
+++ b/tests/test_prototypes.py
@@ -6,7 +6,7 @@ import nose.tools
 import angr
 import angr.calling_conventions
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_function_prototype():

--- a/tests/test_rcr.py
+++ b/tests/test_rcr.py
@@ -4,7 +4,7 @@ import claripy
 import angr
 
 def test_rcr():
-    p = angr.Project(os.path.join(os.path.dirname(__file__), '../../binaries/tests/i386/rcr_test'))
+    p = angr.Project(os.path.join(os.path.dirname(__file__), '..', '..', 'binaries', 'tests', 'i386', 'rcr_test'))
     result = p.factory.successors(p.factory.entry_state()).successors[0]
     nose.tools.assert_true(claripy.is_true(result.regs.cl == 8))
 

--- a/tests/test_reachingdefinitions.py
+++ b/tests/test_reachingdefinitions.py
@@ -10,10 +10,10 @@ import angr
 l = logging.getLogger('test_reachingdefinitions')
 
 
-TESTS_LOCATION = str(os.path.join(
+TESTS_LOCATION = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     '..', '..', 'binaries', 'tests'
-))
+)
 
 
 def run_reaching_definition_analysis(project, func, result_path):

--- a/tests/test_reassembler.py
+++ b/tests/test_reassembler.py
@@ -9,7 +9,7 @@ import shutil
 import angr
 
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 # Note: Reassembler is intensively tested by Patcherex test cases on CGC binaries.
 

--- a/tests/test_regionidentifier.py
+++ b/tests/test_regionidentifier.py
@@ -4,7 +4,7 @@ import os
 import angr
 import angr.analyses.decompiler
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_smoketest():

--- a/tests/test_regression_memcmp_definite_size.py
+++ b/tests/test_regression_memcmp_definite_size.py
@@ -5,7 +5,7 @@ import nose.tools
 import angr
 import claripy as cp
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def regression_test_memcmp_strlen_simprocedure_interaction():

--- a/tests/test_rol.py
+++ b/tests/test_rol.py
@@ -6,10 +6,10 @@ import logging
 l = logging.getLogger("angr.tests.test_rol")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_rol_x86_64():
-    binary_path = test_location + "/x86_64/test_rol.exe"
+    binary_path = os.path.join(test_location, 'x86_64', 'test_rol.exe')
 
     proj = angr.Project(binary_path)
 
@@ -25,7 +25,7 @@ def test_rol_x86_64():
     nose.tools.assert_equal(result, 0x37B7AB70)
 
 def test_rol_i386():
-    binary_path = test_location + "/i386/test_rol.exe"
+    binary_path = os.path.join(test_location, 'i386', 'test_rol.exe')
 
     proj = angr.Project(binary_path)
 
@@ -38,7 +38,7 @@ def test_rol_i386():
     found_state = pg.found[0]
 
     result = found_state.solver.eval(r_eax)
-    nose.tools.assert_equal(result, 0x37B7AB70) 
+    nose.tools.assert_equal(result, 0x37B7AB70)
 
 def test_all():
     test_rol_x86_64()
@@ -46,4 +46,3 @@ def test_all():
 
 if __name__ == "__main__":
     test_all()
-    

--- a/tests/test_rol.py
+++ b/tests/test_rol.py
@@ -6,7 +6,7 @@ import logging
 l = logging.getLogger("angr.tests.test_rol")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_rol_x86_64():
     binary_path = os.path.join(test_location, 'x86_64', 'test_rol.exe')

--- a/tests/test_scanf.py
+++ b/tests/test_scanf.py
@@ -60,7 +60,7 @@ class Checker(object):
         return check_passes
 
 def test_scanf():
-    test_bin = os.path.join(test_location, "../../binaries/tests/x86_64/scanf_test")
+    test_bin = os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "scanf_test")
     b = angr.Project(test_bin)
 
     pg = b.factory.simulation_manager()

--- a/tests/test_scanf.py
+++ b/tests/test_scanf.py
@@ -5,7 +5,7 @@ import angr
 import logging
 
 l = logging.getLogger('angr.tests.scanf')
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.dirname(os.path.realpath(__file__))
 
 class Checker(object):
     def __init__(self, check_func, length=None, base=10, dummy=False):

--- a/tests/test_self_modifying_code.py
+++ b/tests/test_self_modifying_code.py
@@ -6,7 +6,7 @@ import os
 from nose.plugins.attrib import attr
 from angr import options as o
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 @attr(speed='slow')
 def test_self_modifying_code():

--- a/tests/test_self_modifying_code.py
+++ b/tests/test_self_modifying_code.py
@@ -6,11 +6,11 @@ import os
 from nose.plugins.attrib import attr
 from angr import options as o
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 @attr(speed='slow')
 def test_self_modifying_code():
-    p = angr.Project(os.path.join(test_location, 'cgc/stuff'))
+    p = angr.Project(os.path.join(test_location, 'cgc', 'stuff'))
     pg = p.factory.simulation_manager(p.factory.entry_state(add_options={o.STRICT_PAGE_ACCESS}))
     pg.step(until=lambda lpg: len(lpg.active) != 1)
     retval = pg.one_deadended.regs.ebx

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,7 +5,7 @@ import nose
 import angr
 import os
 
-internaltest_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+internaltest_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 internaltest_files = [ 'argc_decide', 'argc_symbol', 'argv_test', 'counter', 'fauxware', 'fauxware.idb', 'manysum', 'pw', 'strlen', 'test_arrays', 'test_division', 'test_loops' ]
 internaltest_arch = [ 'i386', 'armel' ]
 
@@ -65,7 +65,7 @@ def internaltest_project(fpath):
 
 
 def test_analyses():
-    p = angr.Project(os.path.join(internaltest_location, 'i386/fauxware'), load_options={'auto_load_libs': False})
+    p = angr.Project(os.path.join(internaltest_location, 'i386', 'fauxware'), load_options={'auto_load_libs': False})
     cfg = p.analyses.CFG()
     cfb = p.analyses.CFB(cfg)
     vrf = p.analyses.VariableRecoveryFast(p.kb.functions['main'])
@@ -95,7 +95,7 @@ def test_serialization():
             if os.path.isfile(fpath) and os.access(fpath, os.X_OK):
                 internaltest_project(fpath)
 
-    p = angr.Project(os.path.join(internaltest_location, 'i386/fauxware'), load_options={'auto_load_libs': False})
+    p = angr.Project(os.path.join(internaltest_location, 'i386', 'fauxware'), load_options={'auto_load_libs': False})
     internaltest_cfgfast(p)
 
     cfg = internaltest_cfg(p)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,7 +5,7 @@ import nose
 import angr
 import os
 
-internaltest_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+internaltest_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 internaltest_files = [ 'argc_decide', 'argc_symbol', 'argv_test', 'counter', 'fauxware', 'fauxware.idb', 'manysum', 'pw', 'strlen', 'test_arrays', 'test_division', 'test_loops' ]
 internaltest_arch = [ 'i386', 'armel' ]
 

--- a/tests/test_signed_div.py
+++ b/tests/test_signed_div.py
@@ -13,7 +13,7 @@ test_location = str(os.path.dirname(os.path.realpath(__file__)))
 def test_signed_div():
     if not sys.platform.startswith('linux'):
         raise nose.SkipTest()   # this is not technically required, the run result could just be inlined
-    test_bin = os.path.join(test_location, "../../binaries/tests/x86_64/test_signed_div")
+    test_bin = os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "test_signed_div")
     b = angr.Project(test_bin)
 
     pg = b.factory.simulation_manager()

--- a/tests/test_signed_div.py
+++ b/tests/test_signed_div.py
@@ -7,7 +7,7 @@ import logging
 l = logging.getLogger('angr.tests.test_signed_div')
 
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.dirname(os.path.realpath(__file__))
 
 
 def test_signed_div():

--- a/tests/test_sim_procedure.py
+++ b/tests/test_sim_procedure.py
@@ -34,11 +34,11 @@ def test_syscall_and_simprocedure():
     bin_path = os.path.join(BIN_PATH, 'tests', 'cgc', 'CADET_00002')
     proj = angr.Project(bin_path)
     cfg = proj.analyses.CFGFast(normalize=True)
-    
+
     # check syscall
     node = cfg.get_any_node(0xa000001)
     func = proj.kb.functions[node.addr]
-    
+
     nose.tools.assert_true(node.is_simprocedure)
     nose.tools.assert_true(node.is_syscall)
     nose.tools.assert_false(node.to_codenode().is_hook)
@@ -46,24 +46,24 @@ def test_syscall_and_simprocedure():
     nose.tools.assert_true(func.is_syscall)
     nose.tools.assert_true(func.is_simprocedure)
     nose.tools.assert_equal(type(proj.factory.snippet(node.addr)), SyscallNode)
-    
+
     # check normal functions
     node = cfg.get_any_node(0x80480a0)
     func = proj.kb.functions[node.addr]
-    
+
     nose.tools.assert_false(node.is_simprocedure)
     nose.tools.assert_false(node.is_syscall)
     nose.tools.assert_false(proj.is_hooked(node.addr))
     nose.tools.assert_false(func.is_syscall)
     nose.tools.assert_false(func.is_simprocedure)
     nose.tools.assert_equal(type(proj.factory.snippet(node.addr)), BlockNode)
-    
+
     # check hooked functions
     proj.hook(0x80480a0, angr.SIM_PROCEDURES['libc']['puts']())
     cfg = proj.analyses.CFGFast(normalize=True)# rebuild cfg to updated nodes
     node = cfg.get_any_node(0x80480a0)
     func = proj.kb.functions[node.addr]
-    
+
     nose.tools.assert_true(node.is_simprocedure)
     nose.tools.assert_false(node.is_syscall)
     nose.tools.assert_true(proj.is_hooked(node.addr))

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -1,11 +1,11 @@
 import os
 import angr
 
-def _bin(s):
-    return os.path.join(os.path.dirname(__file__), "../../binaries/tests", s)
+def _bin(*s):
+    return os.path.join(os.path.dirname(__file__), "..", "..", "binaries", "tests", *s)
 
 def test_fauxware():
-    project = angr.Project(_bin("i386/fauxware"))
+    project = angr.Project(_bin("i386", "fauxware"))
 
     result = [ 0, 0]
 

--- a/tests/test_simulation_manager.py
+++ b/tests/test_simulation_manager.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests.managers")
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 addresses_fauxware = {
     'armel': 0x8524,

--- a/tests/test_simulation_manager.py
+++ b/tests/test_simulation_manager.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests.managers")
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 addresses_fauxware = {
     'armel': 0x8524,

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -10,11 +10,11 @@ from angr.utils.constants import DEFAULT_STATEMENT
 
 # Load the tests
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests"))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests"))
 
 
 def test_find_exits():
-    slicing_test = angr.Project(test_location + "/x86_64/cfg_1",
+    slicing_test = angr.Project(os.path.join(test_location, 'x86_64', 'cfg_1'),
                                 use_sim_procedures=True,
                                 default_analysis_mode='symbolic')
 
@@ -47,7 +47,7 @@ def test_find_exits():
 
 
 def test_control_flow_slicing():
-    slicing_test = angr.Project(test_location + "/x86_64/cfg_1",
+    slicing_test = angr.Project(os.path.join(test_location, 'x86_64', 'cfg_1'),
                                 use_sim_procedures=True,
                                 default_analysis_mode='symbolic')
     l.info("Control Flow Slicing")
@@ -103,7 +103,7 @@ def broken_backward_slice():
 
 
 def test_last_branching_statement():
-    slicing_test = angr.Project(test_location + '/armel/fauxware',
+    slicing_test = angr.Project(os.path.join(test_location, 'armel', 'fauxware'),
                                 use_sim_procedures=True)
     l.info('Testing _search_for_last_branching_statement.')
 

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -10,7 +10,7 @@ from angr.utils.constants import DEFAULT_STATEMENT
 
 # Load the tests
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests"))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
 
 
 def test_find_exits():

--- a/tests/test_spiller.py
+++ b/tests/test_spiller.py
@@ -3,8 +3,8 @@ import nose
 import os
 import gc
 
-def _bin(s):
-    return os.path.join(os.path.dirname(__file__), '../../binaries', s)
+def _bin(*s):
+    return os.path.join(os.path.dirname(__file__), '..', '..', 'binaries', *s)
 
 def setup():
 
@@ -26,7 +26,7 @@ def priority_key(state):
 
 @nose.with_setup(setup, teardown)
 def test_basic():
-    project = angr.Project(_bin('tests/cgc/sc2_0b32aa01_01'))
+    project = angr.Project(_bin('tests', 'cgc', 'sc2_0b32aa01_01'))
     state = project.factory.entry_state()
     spiller = angr.exploration_techniques.Spiller(pickle_callback=pickle_callback, unpickle_callback=unpickle_callback)
     spiller._pickle([state])
@@ -40,7 +40,7 @@ def test_basic():
 
 @nose.with_setup(setup, teardown)
 def test_palindrome2():
-    project = angr.Project(_bin('tests/cgc/sc2_0b32aa01_01'))
+    project = angr.Project(_bin('tests', 'cgc', 'sc2_0b32aa01_01'))
     pg = project.factory.simulation_manager()
     limiter = angr.exploration_techniques.LengthLimiter(max_length=250)
     pg.use_technique(limiter)

--- a/tests/test_sprintf.py
+++ b/tests/test_sprintf.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger('angr_tests.dataflowgraph')
 
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.dirname(os.path.realpath(__file__))
 
 def test_sprintf():
     p = angr.Project(os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "sprintf_test"))

--- a/tests/test_sprintf.py
+++ b/tests/test_sprintf.py
@@ -8,7 +8,7 @@ import os
 test_location = str(os.path.dirname(os.path.realpath(__file__)))
 
 def test_sprintf():
-    p = angr.Project(os.path.join(test_location, "../../binaries/tests/x86_64/sprintf_test"))
+    p = angr.Project(os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "sprintf_test"))
     a = p.factory.simulation_manager().explore(find=0x4005c0)
     state = a.found[0]
 

--- a/tests/test_sscanf.py
+++ b/tests/test_sscanf.py
@@ -14,7 +14,7 @@ def test_sscanf():
     if not sys.platform.startswith('linux'):
         raise nose.SkipTest()
 
-    test_bin = os.path.join(test_location, "../../binaries/tests/x86_64/sscanf_test")
+    test_bin = os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "sscanf_test")
     b = angr.Project(test_bin)
 
     pg = b.factory.simulation_manager()

--- a/tests/test_sscanf.py
+++ b/tests/test_sscanf.py
@@ -7,7 +7,7 @@ import logging
 l = logging.getLogger('angr.tests.sscanf')
 
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.dirname(os.path.realpath(__file__))
 
 
 def test_sscanf():

--- a/tests/test_stack_pointer_tracker.py
+++ b/tests/test_stack_pointer_tracker.py
@@ -5,10 +5,10 @@ import nose
 
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def run_tracker(track_mem, use_bp):
-    p = angr.Project(test_location + '/x86_64/fauxware', auto_load_libs=False)
+    p = angr.Project(os.path.join(test_location, 'x86_64', 'fauxware'), auto_load_libs=False)
     p.analyses.CFGFast()
     main = p.kb.functions['main']
     sp = p.arch.sp_offset

--- a/tests/test_stack_pointer_tracker.py
+++ b/tests/test_stack_pointer_tracker.py
@@ -5,7 +5,7 @@ import nose
 
 import angr
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def run_tracker(track_mem, use_bp):
     p = angr.Project(os.path.join(test_location, 'x86_64', 'fauxware'), auto_load_libs=False)

--- a/tests/test_state_customization.py
+++ b/tests/test_state_customization.py
@@ -2,7 +2,7 @@ import angr
 import glob
 import os
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_stack_end():
     for fn in glob.glob(os.path.join(test_location, "*", "fauxware")):

--- a/tests/test_state_customization.py
+++ b/tests/test_state_customization.py
@@ -2,34 +2,34 @@ import angr
 import glob
 import os
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_stack_end():
-	for fn in glob.glob(os.path.join(test_location, "*", "fauxware")):
-		p = angr.Project(fn, auto_load_libs=False)
+    for fn in glob.glob(os.path.join(test_location, "*", "fauxware")):
+        p = angr.Project(fn, auto_load_libs=False)
 
-		# normal state
-		s = p.factory.full_init_state()
-		offset = s.solver.eval(p.arch.initial_sp - s.regs.sp)
+        # normal state
+        s = p.factory.full_init_state()
+        offset = s.solver.eval(p.arch.initial_sp - s.regs.sp)
 
-		# different stack ends
-		for n in [ 0x1337000, 0xbaaaaa00, 0x100, 0xffffff00, 0x13371337000, 0xbaaaaaaa0000, 0xffffffffffffff00 ]:
-			if n.bit_length() > p.arch.bits:
-				continue
-			s = p.factory.full_init_state(stack_end=n)
-			assert s.solver.eval_one(s.regs.sp + offset == n)
+        # different stack ends
+        for n in [ 0x1337000, 0xbaaaaa00, 0x100, 0xffffff00, 0x13371337000, 0xbaaaaaaa0000, 0xffffffffffffff00 ]:
+            if n.bit_length() > p.arch.bits:
+                continue
+            s = p.factory.full_init_state(stack_end=n)
+            assert s.solver.eval_one(s.regs.sp + offset == n)
 
 def test_brk():
-	for fn in glob.glob(os.path.join(test_location, "*", "fauxware")):
-		p = angr.Project(fn, auto_load_libs=False)
+    for fn in glob.glob(os.path.join(test_location, "*", "fauxware")):
+        p = angr.Project(fn, auto_load_libs=False)
 
-		# different stack ends
-		for n in [ 0x1337000, 0xbaaaaa00, 0x100, 0xffffff00, 0x13371337000, 0xbaaaaaaa0000, 0xffffffffffffff00 ]:
-			if n.bit_length() > p.arch.bits:
-				continue
-			s = p.factory.full_init_state(brk=n)
-			assert s.solver.eval_one(s.posix.brk == n)
+        # different stack ends
+        for n in [ 0x1337000, 0xbaaaaa00, 0x100, 0xffffff00, 0x13371337000, 0xbaaaaaaa0000, 0xffffffffffffff00 ]:
+            if n.bit_length() > p.arch.bits:
+                continue
+            s = p.factory.full_init_state(brk=n)
+            assert s.solver.eval_one(s.posix.brk == n)
 
 if __name__ == '__main__':
-	test_stack_end()
-	test_brk()
+    test_stack_end()
+    test_brk()

--- a/tests/test_static_hooker.py
+++ b/tests/test_static_hooker.py
@@ -2,10 +2,10 @@ import angr
 import os
 import nose
 
-test_location = os.path.join(os.path.dirname(os.path.realpath(str(__file__))), '../../binaries/tests/')
+test_location = os.path.join(os.path.dirname(os.path.realpath(str(__file__))), '..', '..', 'binaries', 'tests', '')
 
 def test_static_hooker():
-    test_file = os.path.join(test_location, 'x86_64/static')
+    test_file = os.path.join(test_location, 'x86_64', 'static')
     p = angr.Project(test_file)
     sh = p.analyses.StaticHooker('libc.so.6')
 

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -15,7 +15,7 @@ criteria = {
 }
 
 def run_stochastic(binary, arch):
-    proj = angr.Project(os.path.join(os.path.join(location, arch), binary),
+    proj = angr.Project(os.path.join(location, arch, binary),
                         auto_load_libs=False)
     simgr = proj.factory.simulation_manager()
     start_state = simgr.active[0]

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -2,7 +2,7 @@ import os
 import nose
 import angr
 
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 find = {
     'veritesting_a': {

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -2,7 +2,7 @@ import os
 import nose
 import angr
 
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 find = {
     'veritesting_a': {

--- a/tests/test_str_funcs.py
+++ b/tests/test_str_funcs.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_strncpy():
     strncpy_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'strncpy'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])

--- a/tests/test_str_funcs.py
+++ b/tests/test_str_funcs.py
@@ -5,10 +5,10 @@ import logging
 l = logging.getLogger("angr_tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_strncpy():
-    strncpy_amd64 = angr.Project(test_location + "/x86_64/strncpy", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])
+    strncpy_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'strncpy'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])
     explorer = strncpy_amd64.factory.simulation_manager()
     explorer.explore(find=[0x4005FF])
     s = explorer.found[0]
@@ -16,7 +16,7 @@ def test_strncpy():
     nose.tools.assert_equal(result, b'why hello there\x00')
 
 def test_strncpy_size():
-    strncpy_size_amd64 = angr.Project(test_location + "/x86_64/strncpy-size", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])
+    strncpy_size_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'strncpy-size'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])
     explorer = strncpy_size_amd64.factory.simulation_manager()
     cfg = strncpy_size_amd64.analyses.CFG(objects=[strncpy_size_amd64.loader.main_object], normalize=True)
     explorer.use_technique(angr.exploration_techniques.LoopSeer(cfg=cfg, bound=50))
@@ -26,7 +26,7 @@ def test_strncpy_size():
     nose.tools.assert_equal(result, b'just testing things\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 
 def test_strncpy_verify_null():
-    strncpy_verify_null_amd64 = angr.Project(test_location + "/x86_64/strncpy-verify-null", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])
+    strncpy_verify_null_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'strncpy-verify-null'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strncpy'])
     explorer = strncpy_verify_null_amd64.factory.simulation_manager()
     cfg = strncpy_verify_null_amd64.analyses.CFG(objects=[strncpy_verify_null_amd64.loader.main_object], normalize=True)
     explorer.use_technique(angr.exploration_techniques.LoopSeer(cfg=cfg, bound=50))
@@ -36,7 +36,7 @@ def test_strncpy_verify_null():
     nose.tools.assert_equal(result, b'just testing things\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00AAAAAA\x00')
 
 def test_strstr_and_strncpy():
-    strstr_and_strncpy_amd64 = angr.Project(test_location + "/x86_64/strstr_and_strncpy", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strstr'])
+    strstr_and_strncpy_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'strstr_and_strncpy'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strstr'])
     explorer = strstr_and_strncpy_amd64.factory.simulation_manager()
     cfg = strstr_and_strncpy_amd64.analyses.CFG(objects=[strstr_and_strncpy_amd64.loader.main_object], normalize=True)
     explorer.use_technique(angr.exploration_techniques.LoopSeer(cfg=cfg, bound=50))
@@ -46,7 +46,7 @@ def test_strstr_and_strncpy():
     nose.tools.assert_equal(result, b'hi th hi there\x00')
 
 def test_strstr():
-    strstr_amd64 = angr.Project(test_location + "/x86_64/strstr", load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strstr'])
+    strstr_amd64 = angr.Project(os.path.join(test_location, 'x86_64', 'strstr'), load_options={'auto_load_libs': True}, exclude_sim_procedures_list=['strstr'])
     explorer = strstr_amd64.factory.simulation_manager()
     explorer.explore(find=[0x4005FB])
     s = explorer.found[0]

--- a/tests/test_strcasecmp.py
+++ b/tests/test_strcasecmp.py
@@ -4,10 +4,10 @@ import claripy
 
 import os
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 def test_i386():
-    p = angr.Project(test_location + "/i386/test_strcasecmp", auto_load_libs=False)
+    p = angr.Project(os.path.join(test_location, 'i386', 'test_strcasecmp'), auto_load_libs=False)
     arg1 = claripy.BVS('arg1', 20*8)
     s = p.factory.entry_state(args=("test_strcasecmp", arg1))
     sm = p.factory.simulation_manager(s)

--- a/tests/test_strcasecmp.py
+++ b/tests/test_strcasecmp.py
@@ -4,7 +4,7 @@ import claripy
 
 import os
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 def test_i386():
     p = angr.Project(os.path.join(test_location, 'i386', 'test_strcasecmp'), auto_load_libs=False)

--- a/tests/test_strtol.py
+++ b/tests/test_strtol.py
@@ -14,7 +14,7 @@ def run_strtol(threads):
     if not sys.platform.startswith('linux'):
         raise nose.SkipTest()
 
-    test_bin = os.path.join(test_location, "../../binaries/tests/x86_64/strtol_test")
+    test_bin = os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "strtol_test")
     b = angr.Project(test_bin)
 
     initial_state = b.factory.entry_state(remove_options={angr.options.LAZY_SOLVES})

--- a/tests/test_strtol.py
+++ b/tests/test_strtol.py
@@ -7,7 +7,7 @@ import logging
 l = logging.getLogger('angr.tests.strtol')
 
 import os
-test_location = str(os.path.dirname(os.path.realpath(__file__)))
+test_location = os.path.dirname(os.path.realpath(__file__))
 
 
 def run_strtol(threads):

--- a/tests/test_structurer.py
+++ b/tests/test_structurer.py
@@ -6,7 +6,7 @@ import nose.tools
 import angr
 import angr.analyses.decompiler
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_smoketest():

--- a/tests/test_syscall_override.py
+++ b/tests/test_syscall_override.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 target_addrs = {
     'i386': [ 0x080485C9 ],

--- a/tests/test_syscall_override.py
+++ b/tests/test_syscall_override.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr.tests")
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 target_addrs = {
     'i386': [ 0x080485C9 ],

--- a/tests/test_tech_builder.py
+++ b/tests/test_tech_builder.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests.test_proxy")
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 
 def test_tech_builder():

--- a/tests/test_tech_builder.py
+++ b/tests/test_tech_builder.py
@@ -5,7 +5,7 @@ import logging
 l = logging.getLogger("angr_tests.test_proxy")
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 def test_tech_builder():

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -39,7 +39,7 @@ def tracer_linux(filename, test_name, stdin):
 
 def test_recursion():
     blob = bytes.fromhex("00aadd114000000000000000200000001d0000000005000000aadd2a1100001d0000000001e8030000aadd21118611b3b3b3b3b3e3b1b1b1adb1b1b1b1b1b1118611981d8611")
-    fname = os.path.join(os.path.dirname(__file__), "../../binaries/tests/cgc/NRFIN_00075")
+    fname = os.path.join(os.path.dirname(__file__), "..", "..", "binaries", "tests", "cgc", "NRFIN_00075")
 
     simgr, _ = tracer_cgc(fname, 'tracer_recursion', blob)
     simgr.run()
@@ -51,7 +51,7 @@ def test_recursion():
 @slow_test
 def broken_cache_stall():
     # test a valid palindrome
-    b = os.path.join(bin_location, "tests/cgc/CROMU_00071")
+    b = os.path.join(bin_location, "tests", "cgc", "CROMU_00071")
     blob = bytes.fromhex("0c0c492a53acacacacacacacacacacacacac000100800a0b690e0aef6503697d660a0059e20afc0a0a332f7d66660a0059e20afc0a0a332f7fffffff16fb1616162516161616161616166a7dffffff7b0e0a0a6603697d660a0059e21c")
 
     simgr, tracer = tracer_cgc(b, 'tracer_cache_stall', blob)
@@ -79,8 +79,8 @@ def test_manual_recursion():
     if not sys.platform.startswith('linux'):
         raise nose.SkipTest()
 
-    b = os.path.join(bin_location, "tests/cgc", "CROMU_00071")
-    blob = open(os.path.join(bin_location, 'tests_data/', 'crash2731'), 'rb').read()
+    b = os.path.join(bin_location, "tests", "cgc", "CROMU_00071")
+    blob = open(os.path.join(bin_location, 'tests_data', 'crash2731'), 'rb').read()
 
     simgr, tracer = tracer_cgc(b, 'tracer_manual_recursion', blob)
     simgr.run()
@@ -93,7 +93,7 @@ def test_manual_recursion():
 
 
 def test_cgc_se1_palindrome_raw():
-    b = os.path.join(bin_location, "tests/cgc/sc1_0b32aa01_01")
+    b = os.path.join(bin_location, "tests", "cgc", "sc1_0b32aa01_01")
     # test a valid palindrome
 
     simgr, _ = tracer_cgc(b, 'tracer_cgc_se1_palindrome_raw_nocrash', b'racecar\n')
@@ -123,7 +123,7 @@ def test_cgc_se1_palindrome_raw():
 
 
 def test_symbolic_sized_receives():
-    b = os.path.join(bin_location, "tests/cgc/CROMU_00070")
+    b = os.path.join(bin_location, "tests", "cgc", "CROMU_00070")
 
     simgr, _ = tracer_cgc(b, 'tracer_symbolic_sized_receives', b'hello')
     simgr.run()
@@ -141,7 +141,7 @@ def test_symbolic_sized_receives():
 def test_allocation_base_continuity():
     correct_out = b'prepare for a challenge\nb7fff000\nb7ffe000\nb7ffd000\nb7ffc000\nb7ffb000\nb7ffa000\nb7ff9000\nb7ff8000\nb7ff7000\nb7ff6000\nb7ff5000\nb7ff4000\nb7ff3000\nb7ff2000\nb7ff1000\nb7ff0000\nb7fef000\nb7fee000\nb7fed000\nb7fec000\ndeallocating b7ffa000\na: b7ffb000\nb: b7fff000\nc: b7ff5000\nd: b7feb000\ne: b7fe8000\ne: b7fa8000\na: b7ffe000\nb: b7ffd000\nc: b7ff7000\nd: b7ff6000\ne: b7ff3000\ne: b7f68000\nallocate: 3\na: b7fef000\n'
 
-    b = os.path.join(bin_location, "tests/i386/cgc_allocations")
+    b = os.path.join(bin_location, "tests", "i386", "cgc_allocations")
 
     simgr, _ = tracer_cgc(b, 'tracer_allocation_base_continuity', b'')
     simgr.run()
@@ -150,7 +150,7 @@ def test_allocation_base_continuity():
 
 
 def test_crash_addr_detection():
-    b = os.path.join(bin_location, "tests/i386/call_symbolic")
+    b = os.path.join(bin_location, "tests", "i386", "call_symbolic")
 
     simgr, _ = tracer_cgc(b, 'tracer_crash_addr_detection', b'A'*700)
     simgr.run()
@@ -163,7 +163,7 @@ def test_fauxware():
     if not sys.platform.startswith('linux'):
         raise nose.SkipTest()
 
-    b = os.path.join(bin_location, "tests/x86_64/fauxware")
+    b = os.path.join(bin_location, "tests", "x86_64", "fauxware")
     simgr, _ = tracer_linux(b, 'tracer_fauxware', b'A'*18)
     simgr.run()
 

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -6,7 +6,7 @@ from angr import options as so
 from nose.plugins.attrib import attr
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
 
 
 

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -6,7 +6,7 @@ from angr import options as so
 from nose.plugins.attrib import attr
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
 
 
 
@@ -30,7 +30,7 @@ def _compare_trace(trace, expected):
         nose.tools.assert_equal(trace_item_str, expected_str)
 
 def test_stops():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'uc_stop'))
 
     # test STOP_NORMAL, STOP_STOPPOINT
     s_normal = p.factory.entry_state(args=['a'], add_options=so.unicorn)
@@ -86,7 +86,7 @@ def test_stops():
     nose.tools.assert_equal(pg_segfault_angr.errored[0].error.addr, pg_segfault.errored[0].error.addr)
 
 def run_longinit(arch):
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/' + arch + '/longinit'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', arch, 'longinit'))
     s_unicorn = p.factory.entry_state(add_options=so.unicorn, remove_options={so.SHORT_READS})
     pg = p.factory.simulation_manager(s_unicorn, save_unconstrained=True, save_unsat=True)
     pg.explore()
@@ -102,7 +102,7 @@ def test_longinit_x86_64():
     run_longinit('x86_64')
 
 def test_fauxware():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/fauxware'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'fauxware'))
     s_unicorn = p.factory.entry_state(add_options=so.unicorn) # unicorn
     pg = p.factory.simulation_manager(s_unicorn)
     pg.explore()
@@ -115,7 +115,7 @@ def test_fauxware():
     )))
 
 def test_fauxware_aggressive():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/fauxware'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'fauxware'))
     s_unicorn = p.factory.entry_state(
         add_options=so.unicorn | { so.UNICORN_AGGRESSIVE_CONCRETIZATION },
         remove_options={ so.LAZY_SOLVES }
@@ -148,11 +148,11 @@ def test_similarity_fauxware():
         # gotta skip the initializers because of cpuid and RDTSC
         pg.one_left.unicorn.countdown_nonunicorn_blocks = 39
         return pg
-    run_similarity("binaries/tests/i386/fauxware", 1000, prehook=cooldown)
+    run_similarity(os.path.join("binaries", "tests", "i386", "fauxware"), 1000, prehook=cooldown)
 
 def test_fp():
-    type_cache = angr.sim_type.parse_defns(open(os.path.join(test_location, 'binaries/tests_src/manyfloatsum.c')).read())
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/manyfloatsum'))
+    type_cache = angr.sim_type.parse_defns(open(os.path.join(test_location, 'binaries', 'tests_src', 'manyfloatsum.c')).read())
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'manyfloatsum'))
 
     for function in ('sum_floats', 'sum_combo', 'sum_segregated', 'sum_doubles', 'sum_combo_doubles', 'sum_segregated_doubles'):
         cc = p.factory.cc(func_ty=type_cache[function])
@@ -167,7 +167,7 @@ def test_fp():
         nose.tools.assert_equal(answer, result_concrete)
 
 def test_unicorn_pickle():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/fauxware'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'fauxware'))
 
     def _uni_state():
         # try pickling out paths that went through unicorn
@@ -197,7 +197,7 @@ def test_unicorn_pickle():
     )))
 
     # test the pickling of SimUnicorn itself
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/fauxware'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'fauxware'))
     pg = p.factory.simulation_manager(_uni_state())
     pg.run(n=2)
     assert p.factory.successors(pg.one_active).sort == 'Unicorn'
@@ -215,7 +215,7 @@ def test_unicorn_pickle():
     )))
 
 def test_concrete_transmits():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/cgc/PIZZA_00001'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'cgc', 'PIZZA_00001'))
     inp = bytes.fromhex("320a310a0100000005000000330a330a340a")
 
     s_unicorn = p.factory.entry_state(add_options=so.unicorn | {so.CGC_NO_SYMBOLIC_RECEIVE_LENGTH}, stdin=inp, flag_page=b'\0'*4096)
@@ -225,7 +225,7 @@ def test_concrete_transmits():
     nose.tools.assert_equal(pg_unicorn.one_active.posix.dumps(1), b'1) Add number to the array\n2) Add random number to the array\n3) Sum numbers\n4) Exit\nRandomness added\n1) Add number to the array\n2) Add random number to the array\n3) Sum numbers\n4) Exit\n  Index: \n1) Add number to the array\n2) Add random number to the array\n3) Sum numbers\n4) Exit\n')
 
 def test_inspect():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'uc_stop'))
 
     def main_state(argc, add_options=None):
         add_options = add_options or so.unicorn
@@ -269,7 +269,7 @@ def test_inspect():
     nose.tools.assert_equal(collect_trace(so.unicorn), collect_trace(set()))
 
 def test_explore():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'uc_stop'))
 
     def main_state(argc, add_options=None):
         add_options = add_options or so.unicorn
@@ -290,7 +290,7 @@ def test_explore():
 
 
 def test_single_step():
-    p = angr.Project(os.path.join(test_location, 'binaries/tests/i386/uc_stop'))
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'uc_stop'))
 
 
     def main_state(argc, add_options=None):

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -4,7 +4,7 @@ import nose
 
 import angr
 
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 find = {
     'veritesting_a': {
@@ -17,7 +17,7 @@ criteria = {
 }
 
 def run_unique(binary, arch):
-    proj = angr.Project(os.path.join(os.path.join(location, arch), binary),
+    proj = angr.Project(os.path.join(location, arch, binary),
                         auto_load_libs=False)
     simgr = proj.factory.simulation_manager()
     technique = angr.exploration_techniques.UniqueSearch()

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -4,7 +4,7 @@ import nose
 
 import angr
 
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 find = {
     'veritesting_a': {

--- a/tests/test_variablerecovery.py
+++ b/tests/test_variablerecovery.py
@@ -13,10 +13,9 @@ from angr.knowledge_plugins.variables import VariableType
 l = logging.getLogger('test_variablerecovery')
 
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  '..', '..', 'binaries', 'tests'
                                  )
-                    )
 
 
 #

--- a/tests/test_veritesting.py
+++ b/tests/test_veritesting.py
@@ -7,7 +7,7 @@ import logging
 l = logging.getLogger('angr_tests.veritesting')
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 addresses_veritesting_a = {
     'x86_64': 0x400674
@@ -22,7 +22,7 @@ def run_veritesting_a(arch):
 
     #logging.getLogger('angr.analyses.sse').setLevel(logging.DEBUG)
 
-    proj = angr.Project(os.path.join(os.path.join(location, arch), "veritesting_a"),
+    proj = angr.Project(os.path.join(location, arch, "veritesting_a"),
                         load_options={'auto_load_libs': False},
                         use_sim_procedures=True
                         )
@@ -37,7 +37,7 @@ def run_veritesting_a(arch):
 def run_veritesting_b(arch):
     #logging.getLogger('angr.analyses.sse').setLevel(logging.DEBUG)
 
-    proj = angr.Project(os.path.join(os.path.join(location, arch), "veritesting_b"),
+    proj = angr.Project(os.path.join(location, arch, "veritesting_b"),
                         load_options={'auto_load_libs': False},
                         use_sim_procedures=True
                         )

--- a/tests/test_veritesting.py
+++ b/tests/test_veritesting.py
@@ -7,7 +7,7 @@ import logging
 l = logging.getLogger('angr_tests.veritesting')
 
 import os
-location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 addresses_veritesting_a = {
     'x86_64': 0x400674

--- a/tests/test_vfg.py
+++ b/tests/test_vfg.py
@@ -10,7 +10,7 @@ import claripy
 
 l = logging.getLogger("angr_tests")
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 vfg_buffer_overflow_addresses = {
     'x86_64': 0x40055c

--- a/tests/test_vfg.py
+++ b/tests/test_vfg.py
@@ -10,14 +10,14 @@ import claripy
 
 l = logging.getLogger("angr_tests")
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 vfg_buffer_overflow_addresses = {
     'x86_64': 0x40055c
 }
 
 def run_vfg_buffer_overflow(arch):
-    proj = angr.Project(os.path.join(os.path.join(test_location, arch), "basic_buffer_overflows"),
+    proj = angr.Project(os.path.join(test_location, arch, "basic_buffer_overflows"),
                  use_sim_procedures=True,
                  default_analysis_mode='symbolic')
 
@@ -125,7 +125,7 @@ vfg_1_addresses = {
 
 def run_vfg_1(arch):
     proj = angr.Project(
-        os.path.join(os.path.join(test_location, arch), "fauxware"),
+        os.path.join(test_location, arch, "fauxware"),
         use_sim_procedures=True,
     )
 

--- a/tests/test_windows_args.py
+++ b/tests/test_windows_args.py
@@ -4,7 +4,7 @@ from archinfo import ArchX86
 
 import os
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
 class StdcallStub1Arg(angr.SimProcedure):


### PR DESCRIPTION
Uses os.path.join to build file paths in order to make tests work on Windows too.