### PR TITLE
Skip tests when avatar2 or angr_targets modules are not available

### DIFF
--- a/tests/test_concrete_not_packed_elf32.py
+++ b/tests/test_concrete_not_packed_elf32.py
@@ -1,11 +1,14 @@
 import angr
-import avatar2
 import claripy
 import nose
 import os
 import subprocess
 
-from angr_targets import AvatarGDBConcreteTarget
+try:
+    import avatar2
+    from angr_targets import AvatarGDBConcreteTarget
+except ImportError:
+    raise nose.SkipTest()
 
 GDB_SERVER_IP = '127.0.0.1'
 GDB_SERVER_PORT = 9999

--- a/tests/test_concrete_not_packed_elf64.py
+++ b/tests/test_concrete_not_packed_elf64.py
@@ -1,12 +1,15 @@
 import angr
-import avatar2
 import claripy
 import nose
 import os
 import subprocess
 import logging
 
-from angr_targets import AvatarGDBConcreteTarget
+try:
+    import avatar2
+    from angr_targets import AvatarGDBConcreteTarget
+except ImportError:
+    raise nose.SkipTest()
 
 
 binary_x64 = os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/tests/test_concrete_packed_elf32.py
+++ b/tests/test_concrete_packed_elf32.py
@@ -1,11 +1,14 @@
 import angr
-import avatar2
 import claripy
 import nose
 import os
 import subprocess
 
-from angr_targets import AvatarGDBConcreteTarget
+try:
+    import avatar2
+    from angr_targets import AvatarGDBConcreteTarget
+except ImportError:
+    raise nose.SkipTest()
 
 
 binary_x86 = os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/tests/test_concrete_packed_elf64.py
+++ b/tests/test_concrete_packed_elf64.py
@@ -1,11 +1,14 @@
 import angr
-import avatar2
 import claripy
 import nose
 import os
 import subprocess
 
-from angr_targets import AvatarGDBConcreteTarget
+try:
+    import avatar2
+    from angr_targets import AvatarGDBConcreteTarget
+except ImportError:
+    raise nose.SkipTest()
 
 binary_x64 = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                           os.path.join('..', '..', 'binaries', 'tests', 'x86_64', 'packed_elf64'))


### PR DESCRIPTION
Makes avatar2 and angr_targets imports optional. (angr/angr-dev#80)