### PR TITLE
Convert VEX light engine and AIL light engine to mixins.

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -6,7 +6,7 @@ import pyvex
 from archinfo.arch_arm import is_arm_arch
 
 from ....engines.vex import ccall
-from ....engines.light import SimEngineLightVEX, SpOffset, RegisterOffset
+from ....engines.light import SimEngineLightVEXMixin, SimEngineLight, SpOffset, RegisterOffset
 from ....errors import AngrError, SimError
 from ....blade import Blade
 from ....annocfg import AnnotatedCFG
@@ -111,7 +111,10 @@ class JumpTableProcessorState:
         self.regs_to_initialize = [ ]  # registers that we should initialize
 
 
-class JumpTableProcessor(SimEngineLightVEX):  # pylint:disable=abstract-method
+class JumpTableProcessor(
+    SimEngineLightVEXMixin,
+    SimEngineLight,
+):  # pylint:disable=abstract-method
     """
     Implements a simple and stupid data dependency tracking for stack and register variables.
 

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -7,13 +7,16 @@ from .constants import OP_BEFORE, OP_AFTER
 from .dataset import DataSet
 from .external_codeloc import ExternalCodeLocation
 from .undefined import Undefined
-from ...engines.light import SimEngineLightAIL, RegisterOffset, SpOffset
+from ...engines.light import SimEngineLight, SimEngineLightAILMixin, RegisterOffset, SpOffset
 from ...errors import SimEngineError
 
 l = logging.getLogger(name=__name__)
 
 
-class SimEngineRDAIL(SimEngineLightAIL):  # pylint:disable=abstract-method
+class SimEngineRDAIL(
+    SimEngineLightAILMixin,
+    SimEngineLight,
+):  # pylint:disable=abstract-method
     def __init__(self, project, current_local_call_depth, maximum_local_call_depth, function_handler=None):
         super(SimEngineRDAIL, self).__init__()
         self.project = project

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -8,14 +8,17 @@ from .constants import OP_BEFORE, OP_AFTER
 from .dataset import DataSet
 from .external_codeloc import ExternalCodeLocation
 from .undefined import Undefined
-from ...engines.light import SimEngineLightVEX, SpOffset
+from ...engines.light import SimEngineLight, SimEngineLightVEXMixin, SpOffset
 from ...engines.vex.irop import operations as vex_operations
 from ...errors import SimEngineError
 
 l = logging.getLogger(name=__name__)
 
 
-class SimEngineRDVEX(SimEngineLightVEX):  # pylint:disable=abstract-method
+class SimEngineRDVEX(
+    SimEngineLightVEXMixin,
+    SimEngineLight,
+):  # pylint:disable=abstract-method
     def __init__(self, project, current_local_call_depth, maximum_local_call_depth, function_handler=None):
         super(SimEngineRDVEX, self).__init__()
         self.project = project

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -103,7 +103,7 @@ class SimEngineVRBase(SimEngineLight):
             if kwargs.pop('fail_fast', False) is True:
                 raise e
 
-    def _process(self, state, successors, block=None, func_addr=None):  # pylint:disable=unused-argument
+    def _process(self, state, successors, block=None, func_addr=None):  # pylint:disable=unused-argument,arguments-differ
         super()._process(state, successors, block=block)
 
     #
@@ -316,6 +316,8 @@ class SimEngineVRBase(SimEngineLight):
                                                             )
             return var
 
+        return None
+
     def _read_from_register(self, offset, size, expr=None):
         """
 
@@ -478,12 +480,12 @@ class SimEngineVRAIL(
     def _ail_handle_StackBaseOffset(self, expr):
         return SpOffset(self.arch.bits, expr.offset, is_base=False)
 
-    def _ail_handle_CmpEQ(self, expr):
+    def _ail_handle_CmpEQ(self, expr):  # pylint:disable=useless-return
         self._expr(expr.operands[0])
         self._expr(expr.operands[1])
         return None
 
-    def _ail_handle_CmpLE(self, expr):
+    def _ail_handle_CmpLE(self, expr):  # pylint:disable=useless-return
         self._expr(expr.operands[0])
         self._expr(expr.operands[1])
         return None

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 import ailment
 
-from ...engines.light import SpOffset, ArithmeticExpression, SimEngineLightVEX, SimEngineLightAIL
+from ...engines.light import SpOffset, ArithmeticExpression, SimEngineLight, SimEngineLightVEXMixin, SimEngineLightAILMixin
 from ...errors import SimEngineError, AngrVariableRecoveryError
 from ...knowledge_plugins import Function
 from ...sim_variable import SimStackVariable, SimRegisterVariable
@@ -74,415 +74,419 @@ class ProcessorState:
             " adjusted" if self.sp_adjusted else "", self.bp_as_base)
 
 
-def get_engine(base_engine):
-    class SimEngineVR(base_engine):
-        def __init__(self, project):
-            super(SimEngineVR, self).__init__()
+#
+# The base engine
+#
 
-            self.project = project
-            self.processor_state = None
-            self.variable_manager = None
+class SimEngineVRBase(SimEngineLight):
+    def __init__(self, project):
+        super().__init__()
 
-        @property
-        def func_addr(self):
-            if self.state is None:
-                return None
-            return self.state.function.addr
+        self.project = project
+        self.processor_state = None
+        self.variable_manager = None
 
-        def process(self, state, *args, **kwargs):  # pylint:disable=unused-argument
-            # we are using a completely different state. Therefore, we directly call our _process() method before
-            # SimEngine becomes flexible enough.
-            try:
-                self._process(state, None, block=kwargs.pop('block', None))
-            except SimEngineError as e:
-                if kwargs.pop('fail_fast', False) is True:
-                    raise e
-
-        def _process(self, state, successors, block=None, func_addr=None):  # pylint:disable=unused-argument
-
-            self.processor_state = state.processor_state
-            self.variable_manager = state.variable_manager
-
-            super(SimEngineVR, self)._process(state, successors, block=block)
-
-        #
-        # VEX
-        #
-
-        # Statement handlers
-
-        def _handle_Put(self, stmt):
-            offset = stmt.offset
-            data = self._expr(stmt.data)
-            size = stmt.data.result_size(self.tyenv) // 8
-
-            if offset == self.arch.ip_offset:
-                return
-            self._assign_to_register(offset, data, size)
-
-        def _handle_Store(self, stmt):
-            addr = self._expr(stmt.addr)
-            size = stmt.data.result_size(self.tyenv) // 8
-            data = self._expr(stmt.data)
-
-            self._store(addr, data, size, stmt=stmt)
-
-
-        # Expression handlers
-
-        def _handle_Get(self, expr):
-            reg_offset = expr.offset
-            reg_size = expr.result_size(self.tyenv) // 8
-
-            return self._read_from_register(reg_offset, reg_size, expr=expr)
-
-
-        def _handle_Load(self, expr):
-            addr = self._expr(expr.addr)
-            size = expr.result_size(self.tyenv) // 8
-
-            return self._load(addr, size)
-
-        #
-        # AIL
-        #
-
-        # Statement handlers
-
-        def _ail_handle_Assignment(self, stmt):
-            dst_type = type(stmt.dst)
-
-            if dst_type is ailment.Expr.Register:
-                offset = stmt.dst.reg_offset
-                data = self._expr(stmt.src)
-                size = stmt.src.bits // 8
-
-                self._assign_to_register(offset, data, size, src=stmt.src, dst=stmt.dst)
-
-            elif dst_type is ailment.Expr.Tmp:
-                # simply write to self.tmps
-                data = self._expr(stmt.src)
-                if data is None:
-                    return
-
-                self.tmps[stmt.dst.tmp_idx] = data
-
-            else:
-                l.warning('Unsupported dst type %s.', dst_type)
-
-        def _ail_handle_Store(self, stmt):
-            addr = self._expr(stmt.addr)
-            data = self._expr(stmt.data)
-            size = stmt.data.bits // 8
-
-            self._store(addr, data, size, stmt=stmt)
-
-        def _ail_handle_Jump(self, stmt):
-            pass
-
-        def _ail_handle_ConditionalJump(self, stmt):
-            self._expr(stmt.condition)
-
-        def _ail_handle_Call(self, stmt):
-            target = stmt.target
-            if stmt.args:
-                for arg in stmt.args:
-                    self._expr(arg)
-
-            ret_expr = stmt.ret_expr
-            if ret_expr is None:
-                if stmt.calling_convention is not None:
-                    # return value
-                    ret_expr = stmt.calling_convention.RETURN_VAL
-                else:
-                    l.debug("Unknown calling convention for function %s. Fall back to default calling convention.", target)
-                    ret_expr = self.project.factory.cc().RETURN_VAL
-
-            if ret_expr is not None:
-                self._assign_to_register(
-                    ret_expr.reg_offset,
-                    None,
-                    self.state.arch.bytes,
-                    dst=ret_expr,
-                )
-
-        # Expression handlers
-
-        def _ail_handle_Register(self, expr):
-            offset = expr.reg_offset
-            size = expr.bits // 8
-
-            return self._read_from_register(offset, size, expr=expr)
-
-        def _ail_handle_Load(self, expr):
-            addr = self._expr(expr.addr)
-            size = expr.size
-
-            return self._load(addr, size, expr=expr)
-
-        def _ail_handle_BinaryOp(self, expr):
-            r = super()._ail_handle_BinaryOp(expr)
-            if r is None:
-                # Treat it as a normal binaryop expression
-                self._expr(expr.operands[0])
-                self._expr(expr.operands[1])
-            return r
-
-        def _ail_handle_Convert(self, expr):
-            return self._expr(expr.operand)
-
-        def _ail_handle_StackBaseOffset(self, expr):
-            return SpOffset(self.arch.bits, expr.offset, is_base=False)
-
-        def _ail_handle_CmpEQ(self, expr):
-            self._expr(expr.operands[0])
-            self._expr(expr.operands[1])
+    @property
+    def func_addr(self):
+        if self.state is None:
             return None
+        return self.state.function.addr
 
-        def _ail_handle_CmpLE(self, expr):
-            self._expr(expr.operands[0])
-            self._expr(expr.operands[1])
-            return None
+    def process(self, state, *args, **kwargs):  # pylint:disable=unused-argument
 
-        #
-        # Logic
-        #
+        self.processor_state = state.processor_state
+        self.variable_manager = state.variable_manager
 
-        def _assign_to_register(self, offset, data, size, src=None, dst=None):
-            """
+        try:
+            self._process(state, None, block=kwargs.pop('block', None))
+        except SimEngineError as e:
+            if kwargs.pop('fail_fast', False) is True:
+                raise e
 
-            :param int offset:
-            :param data:
-            :param int size:
-            :return:
-            """
+    def _process(self, state, successors, block=None, func_addr=None):  # pylint:disable=unused-argument
+        super()._process(state, successors, block=block)
 
-            codeloc = self._codeloc()  # type: CodeLocation
+    #
+    # Logic
+    #
 
-            if offset == self.arch.sp_offset:
-                if type(data) is SpOffset:
-                    sp_offset = data.offset
-                    self.processor_state.sp_adjusted = True
-                    self.processor_state.sp_adjustment = sp_offset
-                    l.debug('Adjusting stack pointer at %#x with offset %+#x.', self.ins_addr, sp_offset)
-                return
+    def _assign_to_register(self, offset, data, size, src=None, dst=None):
+        """
 
-            if offset == self.arch.bp_offset:
-                if data is not None:
-                    self.processor_state.bp = data
-                else:
-                    self.processor_state.bp = None
-                return
+        :param int offset:
+        :param data:
+        :param int size:
+        :return:
+        """
 
-            # handle register writes
+        codeloc = self._codeloc()  # type: CodeLocation
+
+        if offset == self.arch.sp_offset:
             if type(data) is SpOffset:
-                # lea
-                stack_offset = data.offset
-                existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(self.block.addr,
-                                                                                             self.stmt_idx,
-                                                                                             'memory')
+                sp_offset = data.offset
+                self.processor_state.sp_adjusted = True
+                self.processor_state.sp_adjustment = sp_offset
+                l.debug('Adjusting stack pointer at %#x with offset %+#x.', self.ins_addr, sp_offset)
+            return
 
-                if not existing_vars:
-                    # TODO: how to determine the size for a lea?
-                    existing_vars = self.state.stack_region.get_variables_by_offset(stack_offset)
-                    if not existing_vars:
-                        lea_size = 1
-                        variable = SimStackVariable(stack_offset, lea_size, base='bp',
-                                                    ident=self.variable_manager[self.func_addr].next_variable_ident(
-                                                        'stack'),
-                                                    region=self.func_addr,
-                                                    )
-
-                        self.variable_manager[self.func_addr].add_variable('stack', stack_offset, variable)
-                        l.debug('Identified a new stack variable %s at %#x.', variable, self.ins_addr)
-                    else:
-                        variable = next(iter(existing_vars))
-
-                else:
-                    variable, _ = existing_vars[0]
-
-                self.state.stack_region.add_variable(stack_offset, variable)
-                base_offset = self.state.stack_region.get_base_addr(stack_offset)
-                for var in self.state.stack_region.get_variables_by_offset(base_offset):
-                    offset_into_var = stack_offset - base_offset
-                    if offset_into_var == 0: offset_into_var = None
-                    self.variable_manager[self.func_addr].reference_at(var, offset_into_var, codeloc,
-                                                                       atom=src)
-
+        if offset == self.arch.bp_offset:
+            if data is not None:
+                self.processor_state.bp = data
             else:
-                pass
+                self.processor_state.bp = None
+            return
 
-            # register writes
+        # handle register writes
+        if type(data) is SpOffset:
+            # lea
+            stack_offset = data.offset
+            existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(self.block.addr,
+                                                                                         self.stmt_idx,
+                                                                                         'memory')
 
-            existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(self.block.addr, self.stmt_idx,
-                                                                                         'register'
-                                                                                         )
             if not existing_vars:
-                variable = SimRegisterVariable(offset, size,
-                                               ident=self.variable_manager[self.func_addr].next_variable_ident(
-                                                   'register'),
-                                               region=self.func_addr
-                                               )
-                self.variable_manager[self.func_addr].set_variable('register', offset, variable)
+                # TODO: how to determine the size for a lea?
+                existing_vars = self.state.stack_region.get_variables_by_offset(stack_offset)
+                if not existing_vars:
+                    lea_size = 1
+                    variable = SimStackVariable(stack_offset, lea_size, base='bp',
+                                                ident=self.variable_manager[self.func_addr].next_variable_ident(
+                                                    'stack'),
+                                                region=self.func_addr,
+                                                )
+
+                    self.variable_manager[self.func_addr].add_variable('stack', stack_offset, variable)
+                    l.debug('Identified a new stack variable %s at %#x.', variable, self.ins_addr)
+                else:
+                    variable = next(iter(existing_vars))
+
             else:
                 variable, _ = existing_vars[0]
 
-            self.state.register_region.set_variable(offset, variable)
-            self.variable_manager[self.func_addr].write_to(variable, None, codeloc, atom=dst)
+            self.state.stack_region.add_variable(stack_offset, variable)
+            base_offset = self.state.stack_region.get_base_addr(stack_offset)
+            for var in self.state.stack_region.get_variables_by_offset(base_offset):
+                offset_into_var = stack_offset - base_offset
+                if offset_into_var == 0: offset_into_var = None
+                self.variable_manager[self.func_addr].reference_at(var, offset_into_var, codeloc,
+                                                                   atom=src)
 
-        def _store(self, addr, data, size, stmt=None):  # pylint:disable=unused-argument
-            """
+        else:
+            pass
 
-            :param addr:
-            :param data:
-            :param int size:
-            :return:
-            """
+        # register writes
 
-            if type(addr) is SpOffset:
-                # Storing data to stack
-                stack_offset = addr.offset
+        existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(self.block.addr, self.stmt_idx,
+                                                                                     'register'
+                                                                                     )
+        if not existing_vars:
+            variable = SimRegisterVariable(offset, size,
+                                           ident=self.variable_manager[self.func_addr].next_variable_ident(
+                                               'register'),
+                                           region=self.func_addr
+                                           )
+            self.variable_manager[self.func_addr].set_variable('register', offset, variable)
+        else:
+            variable, _ = existing_vars[0]
 
-                if stmt is None:
-                    existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(self.block.addr,
-                                                                                                 self.stmt_idx,
-                                                                                                 'memory'
-                                                                                                 )
-                else:
-                    existing_vars = self.variable_manager[self.func_addr].find_variables_by_atom(self.block.addr,
-                                                                                                 self.stmt_idx,
-                                                                                                 stmt
-                                                                                                 )
-                if not existing_vars:
-                    variable = SimStackVariable(stack_offset, size, base='bp',
-                                                ident=self.variable_manager[self.func_addr].next_variable_ident('stack'),
-                                                region=self.func_addr,
-                                                )
-                    if isinstance(stack_offset, int):
-                        self.variable_manager[self.func_addr].set_variable('stack', stack_offset, variable)
-                        l.debug('Identified a new stack variable %s at %#x.', variable, self.ins_addr)
+        self.state.register_region.set_variable(offset, variable)
+        self.variable_manager[self.func_addr].write_to(variable, None, codeloc, atom=dst)
 
-                else:
-                    variable, _ = next(iter(existing_vars))
+    def _store(self, addr, data, size, stmt=None):  # pylint:disable=unused-argument
+        """
 
+        :param addr:
+        :param data:
+        :param int size:
+        :return:
+        """
+
+        if type(addr) is SpOffset:
+            # Storing data to stack
+            stack_offset = addr.offset
+
+            if stmt is None:
+                existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(self.block.addr,
+                                                                                             self.stmt_idx,
+                                                                                             'memory'
+                                                                                             )
+            else:
+                existing_vars = self.variable_manager[self.func_addr].find_variables_by_atom(self.block.addr,
+                                                                                             self.stmt_idx,
+                                                                                             stmt
+                                                                                             )
+            if not existing_vars:
+                variable = SimStackVariable(stack_offset, size, base='bp',
+                                            ident=self.variable_manager[self.func_addr].next_variable_ident(
+                                                'stack'),
+                                            region=self.func_addr,
+                                            )
                 if isinstance(stack_offset, int):
-                    self.state.stack_region.set_variable(stack_offset, variable)
-                    base_offset = self.state.stack_region.get_base_addr(stack_offset)
-                    codeloc = CodeLocation(self.block.addr, self.stmt_idx, ins_addr=self.ins_addr)
-                    for var in self.state.stack_region.get_variables_by_offset(stack_offset):
-                        offset_into_var = stack_offset - base_offset
-                        if offset_into_var == 0:
-                            offset_into_var = None
-                        self.variable_manager[self.func_addr].write_to(var,
-                                                                       offset_into_var,
-                                                                       codeloc,
-                                                                       atom=stmt,
-                                                                       )
-
-        def _load(self, addr, size, expr=None):
-            """
-
-            :param addr:
-            :param size:
-            :return:
-            """
-
-            if type(addr) is SpOffset:
-                # Loading data from stack
-                stack_offset = addr.offset
-
-                # split the offset into a concrete offset and a dynamic offset
-                # the stack offset may not be a concrete offset
-                # for example, SP-0xe0+var_1
-                if type(stack_offset) is ArithmeticExpression:
-                    if type(stack_offset.operands[0]) is int:
-                        concrete_offset = stack_offset.operands[0]
-                        dynamic_offset = stack_offset.operands[1]
-                    elif type(stack_offset.operands[1]) is int:
-                        concrete_offset = stack_offset.operands[1]
-                        dynamic_offset = stack_offset.operands[0]
-                    else:
-                        # cannot determine the concrete offset. give up
-                        concrete_offset = None
-                        dynamic_offset = stack_offset
-                else:
-                    # type(stack_offset) is int
-                    concrete_offset = stack_offset
-                    dynamic_offset = None
-
-                # decide which base variable is being accessed using the concrete offset
-                if concrete_offset is not None and concrete_offset not in self.state.stack_region:
-                    variable = SimStackVariable(concrete_offset, size, base='bp',
-                                                ident=self.variable_manager[self.func_addr].next_variable_ident('stack'),
-                                                region=self.func_addr,
-                                                )
-                    self.state.stack_region.add_variable(concrete_offset, variable)
-
-                    self.variable_manager[self.func_addr].add_variable('stack', concrete_offset, variable)
-
+                    self.variable_manager[self.func_addr].set_variable('stack', stack_offset, variable)
                     l.debug('Identified a new stack variable %s at %#x.', variable, self.ins_addr)
 
-                base_offset = self.state.stack_region.get_base_addr(concrete_offset)
+            else:
+                variable, _ = next(iter(existing_vars))
+
+            if isinstance(stack_offset, int):
+                self.state.stack_region.set_variable(stack_offset, variable)
+                base_offset = self.state.stack_region.get_base_addr(stack_offset)
                 codeloc = CodeLocation(self.block.addr, self.stmt_idx, ins_addr=self.ins_addr)
+                for var in self.state.stack_region.get_variables_by_offset(stack_offset):
+                    offset_into_var = stack_offset - base_offset
+                    if offset_into_var == 0:
+                        offset_into_var = None
+                    self.variable_manager[self.func_addr].write_to(var,
+                                                                   offset_into_var,
+                                                                   codeloc,
+                                                                   atom=stmt,
+                                                                   )
 
-                all_vars = self.state.stack_region.get_variables_by_offset(base_offset)
-                if len(all_vars) > 1:
-                    # overlapping variables
-                    l.warning("Reading memory with overlapping variables: %s. Ignoring all but the first one.",
-                              all_vars)
+    def _load(self, addr, size, expr=None):
+        """
 
-                var = next(iter(all_vars))
-                # calculate variable_offset
-                if dynamic_offset is None:
-                    offset_into_variable = concrete_offset - base_offset
-                    if offset_into_variable == 0:
-                        offset_into_variable = None
+        :param addr:
+        :param size:
+        :return:
+        """
+
+        if type(addr) is SpOffset:
+            # Loading data from stack
+            stack_offset = addr.offset
+
+            # split the offset into a concrete offset and a dynamic offset
+            # the stack offset may not be a concrete offset
+            # for example, SP-0xe0+var_1
+            if type(stack_offset) is ArithmeticExpression:
+                if type(stack_offset.operands[0]) is int:
+                    concrete_offset = stack_offset.operands[0]
+                    dynamic_offset = stack_offset.operands[1]
+                elif type(stack_offset.operands[1]) is int:
+                    concrete_offset = stack_offset.operands[1]
+                    dynamic_offset = stack_offset.operands[0]
                 else:
-                    if concrete_offset == base_offset:
-                        offset_into_variable = dynamic_offset
-                    else:
-                        offset_into_variable = ArithmeticExpression(ArithmeticExpression.Add,
-                                                                    (dynamic_offset, concrete_offset - base_offset, )
-                                                                    )
-                self.variable_manager[self.func_addr].read_from(var,
-                                                                offset_into_variable,
-                                                                codeloc,
-                                                                atom=expr,
-                                                                # overwrite=True
+                    # cannot determine the concrete offset. give up
+                    concrete_offset = None
+                    dynamic_offset = stack_offset
+            else:
+                # type(stack_offset) is int
+                concrete_offset = stack_offset
+                dynamic_offset = None
+
+            # decide which base variable is being accessed using the concrete offset
+            if concrete_offset is not None and concrete_offset not in self.state.stack_region:
+                variable = SimStackVariable(concrete_offset, size, base='bp',
+                                            ident=self.variable_manager[self.func_addr].next_variable_ident(
+                                                'stack'),
+                                            region=self.func_addr,
+                                            )
+                self.state.stack_region.add_variable(concrete_offset, variable)
+
+                self.variable_manager[self.func_addr].add_variable('stack', concrete_offset, variable)
+
+                l.debug('Identified a new stack variable %s at %#x.', variable, self.ins_addr)
+
+            base_offset = self.state.stack_region.get_base_addr(concrete_offset)
+            codeloc = CodeLocation(self.block.addr, self.stmt_idx, ins_addr=self.ins_addr)
+
+            all_vars = self.state.stack_region.get_variables_by_offset(base_offset)
+            if len(all_vars) > 1:
+                # overlapping variables
+                l.warning("Reading memory with overlapping variables: %s. Ignoring all but the first one.",
+                          all_vars)
+
+            var = next(iter(all_vars))
+            # calculate variable_offset
+            if dynamic_offset is None:
+                offset_into_variable = concrete_offset - base_offset
+                if offset_into_variable == 0:
+                    offset_into_variable = None
+            else:
+                if concrete_offset == base_offset:
+                    offset_into_variable = dynamic_offset
+                else:
+                    offset_into_variable = ArithmeticExpression(ArithmeticExpression.Add,
+                                                                (dynamic_offset, concrete_offset - base_offset,)
                                                                 )
-                return var
+            self.variable_manager[self.func_addr].read_from(var,
+                                                            offset_into_variable,
+                                                            codeloc,
+                                                            atom=expr,
+                                                            # overwrite=True
+                                                            )
+            return var
 
-        def _read_from_register(self, offset, size, expr=None):
-            """
+    def _read_from_register(self, offset, size, expr=None):
+        """
 
-            :param offset:
-            :param size:
-            :return:
-            """
+        :param offset:
+        :param size:
+        :return:
+        """
 
-            codeloc = self._codeloc()
+        codeloc = self._codeloc()
 
-            if offset == self.arch.sp_offset:
-                # loading from stack pointer
-                return SpOffset(self.arch.bits, self.processor_state.sp_adjustment, is_base=False)
-            elif offset == self.arch.bp_offset:
-                return self.processor_state.bp
+        if offset == self.arch.sp_offset:
+            # loading from stack pointer
+            return SpOffset(self.arch.bits, self.processor_state.sp_adjustment, is_base=False)
+        elif offset == self.arch.bp_offset:
+            return self.processor_state.bp
 
-            if offset not in self.state.register_region:
-                variable = SimRegisterVariable(offset, size,
-                                               ident=self.variable_manager[self.func_addr].next_variable_ident('register'),
-                                               region=self.func_addr,
-                                               )
-                self.state.register_region.add_variable(offset, variable)
-                self.variable_manager[self.func_addr].add_variable('register', offset, variable)
+        if offset not in self.state.register_region:
+            variable = SimRegisterVariable(offset, size,
+                                           ident=self.variable_manager[self.func_addr].next_variable_ident(
+                                               'register'),
+                                           region=self.func_addr,
+                                           )
+            self.state.register_region.add_variable(offset, variable)
+            self.variable_manager[self.func_addr].add_variable('register', offset, variable)
 
-            for var in self.state.register_region.get_variables_by_offset(offset):
-                self.variable_manager[self.func_addr].read_from(var, None, codeloc, atom=expr)
+        for var in self.state.register_region.get_variables_by_offset(offset):
+            self.variable_manager[self.func_addr].read_from(var, None, codeloc, atom=expr)
 
-            return None
+        return None
 
 
-    return SimEngineVR
+class SimEngineVRVEX(
+    SimEngineLightVEXMixin,
+    SimEngineVRBase,
+):
+
+    # Statement handlers
+
+    def _handle_Put(self, stmt):
+        offset = stmt.offset
+        data = self._expr(stmt.data)
+        size = stmt.data.result_size(self.tyenv) // 8
+
+        if offset == self.arch.ip_offset:
+            return
+        self._assign_to_register(offset, data, size)
+
+    def _handle_Store(self, stmt):
+        addr = self._expr(stmt.addr)
+        size = stmt.data.result_size(self.tyenv) // 8
+        data = self._expr(stmt.data)
+
+        self._store(addr, data, size, stmt=stmt)
+
+    # Expression handlers
+
+    def _handle_Get(self, expr):
+        reg_offset = expr.offset
+        reg_size = expr.result_size(self.tyenv) // 8
+
+        return self._read_from_register(reg_offset, reg_size, expr=expr)
+
+
+    def _handle_Load(self, expr):
+        addr = self._expr(expr.addr)
+        size = expr.result_size(self.tyenv) // 8
+
+        return self._load(addr, size)
+
+
+class SimEngineVRAIL(
+    SimEngineLightAILMixin,
+    SimEngineVRBase,
+):
+
+    # Statement handlers
+
+    def _ail_handle_Assignment(self, stmt):
+        dst_type = type(stmt.dst)
+
+        if dst_type is ailment.Expr.Register:
+            offset = stmt.dst.reg_offset
+            data = self._expr(stmt.src)
+            size = stmt.src.bits // 8
+
+            self._assign_to_register(offset, data, size, src=stmt.src, dst=stmt.dst)
+
+        elif dst_type is ailment.Expr.Tmp:
+            # simply write to self.tmps
+            data = self._expr(stmt.src)
+            if data is None:
+                return
+
+            self.tmps[stmt.dst.tmp_idx] = data
+
+        else:
+            l.warning('Unsupported dst type %s.', dst_type)
+
+    def _ail_handle_Store(self, stmt):
+        addr = self._expr(stmt.addr)
+        data = self._expr(stmt.data)
+        size = stmt.data.bits // 8
+
+        self._store(addr, data, size, stmt=stmt)
+
+    def _ail_handle_Jump(self, stmt):
+        pass
+
+    def _ail_handle_ConditionalJump(self, stmt):
+        self._expr(stmt.condition)
+
+    def _ail_handle_Call(self, stmt):
+        target = stmt.target
+        if stmt.args:
+            for arg in stmt.args:
+               self._expr(arg)
+
+        ret_expr = stmt.ret_expr
+        if ret_expr is None:
+            if stmt.calling_convention is not None:
+                # return value
+                ret_expr = stmt.calling_convention.RETURN_VAL
+            else:
+                l.debug("Unknown calling convention for function %s. Fall back to default calling convention.", target)
+                ret_expr = self.project.factory.cc().RETURN_VAL
+
+        if ret_expr is not None:
+            self._assign_to_register(
+                ret_expr.reg_offset,
+                None,
+                self.state.arch.bytes,
+                dst=ret_expr,
+            )
+
+    # Expression handlers
+
+    def _ail_handle_Register(self, expr):
+        offset = expr.reg_offset
+        size = expr.bits // 8
+
+        return self._read_from_register(offset, size, expr=expr)
+
+    def _ail_handle_Load(self, expr):
+        addr = self._expr(expr.addr)
+        size = expr.size
+
+        return self._load(addr, size, expr=expr)
+
+    def _ail_handle_BinaryOp(self, expr):
+        r = super()._ail_handle_BinaryOp(expr)
+        if r is None:
+            # Treat it as a normal binaryop expression
+            self._expr(expr.operands[0])
+            self._expr(expr.operands[1])
+        return r
+
+    def _ail_handle_Convert(self, expr):
+        return self._expr(expr.operand)
+
+    def _ail_handle_StackBaseOffset(self, expr):
+        return SpOffset(self.arch.bits, expr.offset, is_base=False)
+
+    def _ail_handle_CmpEQ(self, expr):
+        self._expr(expr.operands[0])
+        self._expr(expr.operands[1])
+        return None
+
+    def _ail_handle_CmpLE(self, expr):
+        self._expr(expr.operands[0])
+        self._expr(expr.operands[1])
+        return None
 
 
 class VariableRecoveryFastState(VariableRecoveryStateBase):
@@ -600,8 +604,8 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
 
         self._clinic = clinic
 
-        self._ail_engine = get_engine(SimEngineLightAIL)(self.project)
-        self._vex_engine = get_engine(SimEngineLightVEX)(self.project)
+        self._ail_engine = SimEngineVRAIL(self.project)
+        self._vex_engine = SimEngineVRVEX(self.project)
 
         self._node_iterations = defaultdict(int)
 

--- a/angr/engines/light/__init__.py
+++ b/angr/engines/light/__init__.py
@@ -1,3 +1,3 @@
 
 from .data import ArithmeticExpression, SpOffset, RegisterOffset
-from .engine import SimEngineLightVEX, SimEngineLightAIL
+from .engine import SimEngineLight, SimEngineLightVEXMixin, SimEngineLightAILMixin, SimEngineLightVEX, SimEngineLightAIL

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -35,7 +35,7 @@ class SimEngineLight(SimEngine):
         raise NotImplementedError()
 
     def _check(self, state, *args, **kwargs):
-        raise NotImplementedError()
+        return True
 
     #
     # Helper methods
@@ -47,7 +47,7 @@ class SimEngineLight(SimEngine):
 
 class SimEngineLightVEXMixin:
 
-    def _process(self, state, successors, block=None, whitelist=None):  # pylint:disable=arguments-differ
+    def _process(self, state, successors, block=None, whitelist=None):  # pylint:disable=arguments-differ,unused-argument
 
         assert block is not None
 
@@ -206,7 +206,7 @@ class SimEngineLightVEXMixin:
 
         return None
 
-    def _handle_CCall(self, expr):
+    def _handle_CCall(self, expr):  # pylint:disable=useless-return
         self.l.warning('Unsupported expression type CCall with callee %s.', str(expr.cee))
         return None
 
@@ -352,7 +352,7 @@ class SimEngineLightVEXMixin:
 
 class SimEngineLightAILMixin:
 
-    def _process(self, state, successors, block=None, whitelist=None):  # pylint:disable=arguments-differ
+    def _process(self, state, successors, block=None, whitelist=None):  # pylint:disable=arguments-differ,unused-argument
 
         self.tmps = {}
         self.block = block


### PR DESCRIPTION
With this refactor, we eventually get rid of the ugly and dirty `get_engine(engine)` method.

`SimLightEngineVEX` and `SimLightEngineAIL` are deprecated and will be removed in a future release. Please use `SimLightEngineVEXMixin` and `SimLightEngineAILMixin` instead.