### PR TITLE
The ARM XRefs Party? Making XRefs useable in angr

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -465,15 +465,15 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :param bool force_segment:      Force CFGFast to rely on binary segments instead of sections.
         :param bool force_complete_scan:    Perform a complete scan on the binary and maximize the number of identified
                                             code blocks.
-        :param bool data_references: Enables the collection of references to data used by individual instructions.
-        This does not collect 'cross-references', particularly those that involve multiple instructions.  For that,
-        see `cross_references`
-        :param bool cross_references:  Whether CFGFast should collect "cross-references" from the entire program or not.
-        This will populate the Knowledge Base with references to and from each recognizable address constant found in
-        the code. Note that, because this performs constant propagation on the entire program, it may be much slower
-        and consume more memory.
-
-        Implies `data_references=True`
+        :param bool data_references:    Enables the collection of references to data used by individual instructions.
+                                        This does not collect 'cross-references', particularly those that involve
+                                        multiple instructions.  For that, see `cross_references`
+        :param bool cross_references:   Whether CFGFast should collect "cross-references" from the entire program or
+                                        not. This will populate the knowledge base with references to and from each
+                                        recognizable address constant found in the code. Note that, because this
+                                        performs constant propagation on the entire program, it may be much slower and
+                                        consume more memory.
+                                        This option implies `data_references=True`.
         :param bool normalize:          Normalize the CFG as well as all function graphs after CFG recovery.
         :param bool start_at_entry:     Begin CFG recovery at the entry point of this project. Setting it to False
                                         prevents CFGFast from viewing the entry point as one of the starting points of
@@ -1250,16 +1250,16 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 f = self.functions[f_addr]
                 if f.is_simprocedure:
                     continue
-                l.debug("\tFunction %s" % f.name)
+                l.debug("\tFunction %s", f.name)
                 # constant prop
                 prop = self.project.analyses.Propagator(func=f, base_state=state)
                 # Collect all the refs
                 self.project.analyses.XRefs(func=f, replacements=prop.replacements)
             except Exception:  # pylint: disable=broad-except
                 if f is not None:
-                    l.exception("Error collecting XRefs for function %s", f.name)
+                    l.exception("Error collecting XRefs for function %s.", f.name, exc_info=True)
                 else:
-                    l.exception("Error collecting XRefs for function %#08x", f_addr)
+                    l.exception("Error collecting XRefs for function %#x.", f_addr, exc_info=True)
 
     # Methods to get start points for scanning
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1257,7 +1257,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 self.project.analyses.XRefs(func=f, replacements=prop.replacements)
             except Exception as e:
                 if f is not None:
-                    l.exception("Error collecting XRefs for function", f.name)
+                    l.exception("Error collecting XRefs for function %s", f.name)
                 else:
                     l.exception("Error collecting XRefs for function %#08x" % f_addr)
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1255,11 +1255,11 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 prop = self.project.analyses.Propagator(func=f, base_state=state)
                 # Collect all the refs
                 self.project.analyses.XRefs(func=f, replacements=prop.replacements)
-            except Exception as e:
+            except Exception:  # pylint: disable=broad-except
                 if f is not None:
                     l.exception("Error collecting XRefs for function %s", f.name)
                 else:
-                    l.exception("Error collecting XRefs for function %#08x" % f_addr)
+                    l.exception("Error collecting XRefs for function %#08x", f_addr)
 
     # Methods to get start points for scanning
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -446,6 +446,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                  model=None,
                  start=None,  # deprecated
                  end=None,  # deprecated
+                 collect_data_references=False, # deprecated
+                 extra_cross_references=False, # deprecated
                  **extra_arch_options
                  ):
         """
@@ -525,6 +527,15 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                       'which may take significantly more time than expected. You may reload the binary with '
                       '"auto_load_libs" disabled, or specify "regions" to limit the scope of CFG recovery.'
                       )
+
+        if collect_data_references is not None:
+            l.warning('"collect_data_references" is deprecated and will be removed soon. Please use '
+                      '"data_references" instead')
+            data_references = collect_data_references
+        if extra_cross_references is not None:
+            l.warning('"extra_cross_references" is deprecated and will be removed soon. Please use '
+                      '"cross_references" instead')
+            cross_references = extra_cross_references
 
         if start is not None or end is not None:
             l.warning('"start" and "end" are deprecated and will be removed soon. Please use "regions" to specify one '

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -470,6 +470,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         This will populate the Knowledge Base with references to and from each recognizable address constant found in
         the code. Note that, because this performs constant propagation on the entire program, it may be much slower
         and consume more memory.
+
+        Implies `data_references=True`
         :param bool normalize:          Normalize the CFG as well as all function graphs after CFG recovery.
         :param bool start_at_entry:     Begin CFG recovery at the entry point of this project. Setting it to False
                                         prevents CFGFast from viewing the entry point as one of the starting points of
@@ -562,7 +564,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         self._regions = SortedDict(regions)
 
         self._pickle_intermediate_results = pickle_intermediate_results
-        self._collect_data_ref = data_references
 
         self._use_symbols = symbols
         self._use_function_prologues = function_prologues
@@ -581,6 +582,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         self._extra_memory_regions = extra_memory_regions
 
         self._cross_references = cross_references
+        # You need data refs to get cross refs
+        self._collect_data_ref = data_references or self._cross_references
 
         self._arch_options = arch_options if arch_options is not None else CFGArchOptions(
                 self.project.arch, **extra_arch_options)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -446,8 +446,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                  model=None,
                  start=None,  # deprecated
                  end=None,  # deprecated
-                 collect_data_references=False, # deprecated
-                 extra_cross_references=False, # deprecated
+                 collect_data_references=None, # deprecated
+                 extra_cross_references=None, # deprecated
                  **extra_arch_options
                  ):
         """

--- a/angr/analyses/propagator/engine_vex.py
+++ b/angr/analyses/propagator/engine_vex.py
@@ -34,7 +34,7 @@ class SimEnginePropagatorVEX(
         return state
 
     def _allow_loading(self, addr, size):
-        if addr == TOP or addr == BOTTOM:
+        if addr in (TOP, BOTTOM):
             return False
         if self._load_callback is None:
             return True
@@ -101,6 +101,7 @@ class SimEnginePropagatorVEX(
             self.state.store_register(stmt.offset, size, data)
 
     def _store_data(self, addr, data, size, endness):
+        # pylint: disable=unused-argument,no-self-use
         if isinstance(addr, SpOffset):
             # Local variables
             self.state.store_local_variable(addr.offset, size, data)

--- a/angr/analyses/propagator/engine_vex.py
+++ b/angr/analyses/propagator/engine_vex.py
@@ -34,6 +34,8 @@ class SimEnginePropagatorVEX(
         return state
 
     def _allow_loading(self, addr, size):
+        if addr == TOP or addr == BOTTOM:
+            return False
         if self._load_callback is None:
             return True
         return self._load_callback(addr, size)
@@ -156,3 +158,6 @@ class SimEnginePropagatorVEX(
         size = expr.result_size(self.tyenv) // self.arch.byte_width
 
         return self._load_data(addr, size, expr.endness)
+
+    def _handle_CCall(self, expr):
+        return None

--- a/angr/analyses/propagator/values.py
+++ b/angr/analyses/propagator/values.py
@@ -9,11 +9,56 @@ class Top:
     def __sub__(self, other):
         return self
 
+    def __rsub__(self, other):
+        return self
+
+    def __radd__(self, other):
+        return self
+
+    def __ror__(self, other):
+        return self
+
+    def __rand__(self, other):
+        return self
+
+    def __mul__(self, other):
+        return self
+
+    def __rmul__(self, other):
+        return self
+
+    def __rdiv__(self, other):
+        return self
+
+    def __floordiv__(self, other):
+        return self
+
+    def __rfloordiv__(self, other):
+        return self
+
+    def __invert__(self):
+        return self
+
+    def __rshift__(self, other):
+        return self
+
+    def __lshift__(self, other):
+        return self
+
+    def __xor__(self, other):
+        return self
+
+    def __or__(self, other):
+        return self
+
     def __repr__(self):
         return "TOP"
 
     def __eq__(self, other):
         return type(other) is Top
+
+    def __neg__(self):
+        return self
 
     def __hash__(self):
         return hash(Top)

--- a/angr/analyses/propagator/values.py
+++ b/angr/analyses/propagator/values.py
@@ -28,22 +28,22 @@ class Top:
         return self
 
     def __rdiv__(self, other):
-        return self
+        return self  # pylint: disable=unused-argument
 
     def __floordiv__(self, other):
-        return self
+        return self  # pylint: disable=unused-argument
 
     def __rfloordiv__(self, other):
-        return self
+        return self  # pylint: disable=unused-argument
 
     def __invert__(self):
-        return self
+        return self  # pylint: disable=unused-argument
 
     def __rshift__(self, other):
-        return self
+        return self  # pylint: disable=unused-argument
 
     def __lshift__(self, other):
-        return self
+        return self  # pylint: disable=unused-argument
 
     def __xor__(self, other):
         return self

--- a/angr/analyses/propagator/values.py
+++ b/angr/analyses/propagator/values.py
@@ -1,4 +1,6 @@
 
+# pylint: disable=unused-argument
+
 class Top:
     def __add__(self, other):
         return self
@@ -28,22 +30,22 @@ class Top:
         return self
 
     def __rdiv__(self, other):
-        return self  # pylint: disable=unused-argument
+        return self
 
     def __floordiv__(self, other):
-        return self  # pylint: disable=unused-argument
+        return self
 
     def __rfloordiv__(self, other):
-        return self  # pylint: disable=unused-argument
+        return self
 
     def __invert__(self):
-        return self  # pylint: disable=unused-argument
+        return self
 
     def __rshift__(self, other):
-        return self  # pylint: disable=unused-argument
+        return self
 
     def __lshift__(self, other):
-        return self  # pylint: disable=unused-argument
+        return self
 
     def __xor__(self, other):
         return self

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -2345,7 +2345,7 @@ class Reassembler(Analysis):
             self._section_alignments[section.name] = alignment
 
         l.debug('Generating CFG...')
-        cfg = self.project.analyses.CFG(normalize=True, resolve_indirect_jumps=True, collect_data_references=True,
+        cfg = self.project.analyses.CFG(normalize=True, resolve_indirect_jumps=True, data_references=True,
                                         extra_memory_regions=[(0x4347c000, 0x4347c000 + 0x1000)],
                                         data_type_guessing_handlers=[
                                             self._sequence_handler,

--- a/angr/analyses/xrefs.py
+++ b/angr/analyses/xrefs.py
@@ -84,6 +84,7 @@ class SimEngineXRefsVEX(
         return None
 
     def _handle_function(self, func):
+        # pylint: disable=unused-argument,no-self-use
         return None # TODO: Maybe add an execute-type XRef?
 
 class XRefsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-method

--- a/angr/analyses/xrefs.py
+++ b/angr/analyses/xrefs.py
@@ -80,6 +80,11 @@ class SimEngineXRefsVEX(
                 addr = self.replacements[blockloc][addr_tmp]
                 self.add_xref(XRefType.Read, self._codeloc(), addr)
 
+    def _handle_CCall(self, expr):
+        return None
+
+    def _handle_function(self, func):
+        return None # TODO: Maybe add an execute-type XRef?
 
 class XRefsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-method
     """

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -382,7 +382,6 @@ class SimEngineLightVEXMixin:
             self.l.warning(ex)
             return None
 
-
     def _handle_CmpNE(self, expr):
         arg0, arg1 = expr.args
         expr_0 = self._expr(arg0)

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -1,3 +1,6 @@
+
+# pylint:disable=no-self-use
+
 import logging
 
 import ailment
@@ -305,7 +308,7 @@ class SimEngineLightVEXMixin:
         if expr_0 is None:
             return None
         try:
-            return ~expr_0
+            return ~expr_0  # pylint:disable=invalid-unary-operand-type
         except TypeError as e:
             self.l.exception(e)
             return None
@@ -385,7 +388,6 @@ class SimEngineLightVEXMixin:
         except TypeError as e:
             self.l.warning(e)
             return None
-
 
     def _handle_Xor(self, expr):
         arg0, arg1 = expr.args
@@ -512,7 +514,7 @@ class SimEngineLightVEXMixin:
             self.l.warning(ex)
             return None
 
-    def _handle_MBE(self, expr):
+    def _handle_MBE(self, expr):  # pylint:disable=unused-argument
         # Yeah.... no.
         return None
 
@@ -779,13 +781,13 @@ class SimEngineLightAILMixin:
             if type(data) is int:
                 return data
         return None
-    
+
     def _ail_handle_Not(self, expr):
 
         data = self._expr(expr.operand)
 
         try:
-            return ~data
+            return ~data  # pylint:disable=invalid-unary-operand-type
         except TypeError:
             return ailment.Expr.UnaryOp(expr.idx, 'Not', data, **expr.tags)
 

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -193,6 +193,10 @@ class SimEngineLightVEXMixin:
             handler = '_handle_Add'
         elif expr.op.startswith('Iop_Sub'):
             handler = '_handle_Sub'
+        elif expr.op.startswith('Iop_Mul'):
+            handler = "_handle_Mul"
+        elif expr.op.startswith('Iop_Div'):
+            handler = "_handle_Div"
         elif expr.op.startswith('Iop_Xor'):
             handler = '_handle_Xor'
         elif expr.op.startswith('Iop_Shl'):
@@ -346,6 +350,43 @@ class SimEngineLightVEXMixin:
             self.l.warning(e)
             return None
 
+    def _handle_Mul(self, expr):
+        arg0, arg1 = expr.args
+        expr_0 = self._expr(arg0)
+        if expr_0 is None:
+            return None
+        expr_1 = self._expr(arg1)
+        if expr_1 is None:
+            return None
+
+        try:
+            if isinstance(expr_0, int) and isinstance(expr_1, int):
+                # self.tyenv is not used
+                mask = (1 << expr.result_size(self.tyenv)) - 1
+                return (expr_0 * expr_1) & mask
+            else:
+                return expr_0 * expr_1
+        except TypeError as e:
+            self.l.warning(e)
+            return None
+
+    def _handle_Div(self, expr):
+        arg0, arg1 = expr.args
+        expr_0 = self._expr(arg0)
+        if expr_0 is None:
+            return None
+        expr_1 = self._expr(arg1)
+        if expr_1 is None:
+            return None
+
+        try:
+            # TODO: Probably should take care of the sign
+            return expr_0 // expr_1
+        except TypeError as e:
+            self.l.warning(e)
+            return None
+
+
     def _handle_Xor(self, expr):
         arg0, arg1 = expr.args
         expr_0 = self._expr(arg0)
@@ -441,6 +482,39 @@ class SimEngineLightVEXMixin:
             self.l.warning(ex)
             return None
 
+    def _handle_CmpLE(self, expr):
+        arg0, arg1 = expr.args
+        expr_0 = self._expr(arg0)
+        if expr_0 is None:
+            return None
+        expr_1 = self._expr(arg1)
+        if expr_1 is None:
+            return None
+
+        try:
+            return expr_0 <= expr_1
+        except TypeError as ex:
+            self.l.warning(ex)
+            return None
+
+    def _handle_CmpLT(self, expr):
+        arg0, arg1 = expr.args
+        expr_0 = self._expr(arg0)
+        if expr_0 is None:
+            return None
+        expr_1 = self._expr(arg1)
+        if expr_1 is None:
+            return None
+
+        try:
+            return expr_0 < expr_1
+        except TypeError as ex:
+            self.l.warning(ex)
+            return None
+
+    def _handle_MBE(self, expr):
+        # Yeah.... no.
+        return None
 
 class SimEngineLightAILMixin:
 

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -263,6 +263,20 @@ class SimEngineLightVEXMixin:
             self.l.warning(e)
             return None
 
+    def _handle_Not1(self, expr):
+        return self._handle_Not(expr)
+
+    def _handle_Not(self, expr):
+        arg0 = expr.args[0]
+        expr_0 = self._expr(arg0)
+        if expr_0 is None:
+            return None
+        try:
+            return ~expr_0
+        except TypeError as e:
+            self.l.exception(e)
+            return None
+
     def _handle_Add(self, expr):
         arg0, arg1 = expr.args
         expr_0 = self._expr(arg0)
@@ -352,6 +366,22 @@ class SimEngineLightVEXMixin:
         except TypeError as e:
             self.l.warning(e)
             return None
+
+    def _handle_CmpEQ(self, expr):
+        arg0, arg1 = expr.args
+        expr_0 = self._expr(arg0)
+        if expr_0 is None:
+            return None
+        expr_1 = self._expr(arg1)
+        if expr_1 is None:
+            return None
+
+        try:
+            return expr_0 == expr_1
+        except TypeError as ex:
+            self.l.warning(ex)
+            return None
+
 
     def _handle_CmpNE(self, expr):
         arg0, arg1 = expr.args

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -150,6 +150,20 @@ class SimEngineLightVEXMixin:
     def _handle_Load(self, expr):
         raise NotImplementedError('Please implement the Load handler with your own logic.')
 
+    def _handle_Exit(self, expr):
+        self._expr(expr.guard)
+        self._expr(expr.dst)
+
+    def _handle_ITE(self, expr):
+        # EDG says: Not sure how generic this is.
+        cond = self._expr(expr.cond)
+        if cond is True:
+            return self._expr(expr.iftrue)
+        elif cond is False:
+            return self._expr(expr.iffalse)
+        else:
+            return None
+
     def _handle_Unop(self, expr):
         handler = None
 
@@ -217,6 +231,21 @@ class SimEngineLightVEXMixin:
     #
     # Unary operation handlers
     #
+
+    def _handle_U32(self, expr):
+        return expr.value
+
+    def _handle_U64(self, expr):
+        return expr.value
+
+    def _handle_U16(self, expr):
+        return expr.value
+
+    def _handle_U8(self, expr):
+        return expr.value
+
+    def _handle_U1(self, expr):
+        return expr.value
 
     def _handle_Const(self, expr):  # pylint:disable=no-self-use
         return expr.con.value
@@ -361,6 +390,21 @@ class SimEngineLightVEXMixin:
         if expr_1 is None:
             return None
 
+        try:
+            return expr_0 >> expr_1
+        except TypeError as e:
+            self.l.warning(e)
+            return None
+
+    def _handle_Sar(self, expr):
+        # EDG asks: is this right?
+        arg0, arg1 = expr.args
+        expr_0 = self._expr(arg0)
+        if expr_0 is None:
+            return None
+        expr_1 = self._expr(arg1)
+        if expr_1 is None:
+            return None
         try:
             return expr_0 >> expr_1
         except TypeError as e:

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -132,6 +132,11 @@ class CFGNode(Serializable):
         return self._cfg_model.get_predecessors(self)
 
     def get_data_references(self, kb=None):
+        """
+        Get the known data references for this CFGNode via the knowledge base
+        :param kb: Which knowledge base to use; uses the global KB by default if none is provided
+        :return: Generator yielding xrefs to this CFGNode's block.
+        """
         if self._cfg_model.ident != 'CFGFast':
             raise ValueError("Memory data is currently only supported in CFGFast.")
         if not kb:
@@ -144,19 +149,13 @@ class CFGNode(Serializable):
             for ref in refs:
                 yield ref
 
-
     @property
     def accessed_data_references(self):
-        if self._cfg_model.ident != 'CFGFast':
-            raise ValueError("Memory data is currently only supported in CFGFast.")
-        kb = self._cfg_model.project.kb
-        if not kb:
-            raise ValueError("The default Knowledge Base does not exist!")
-
-        for instr_addr in self.instruction_addrs:
-            refs = list(kb.xrefs.get_xrefs_by_ins_addr(instr_addr))
-            for ref in refs:
-                yield ref
+        """
+        Property providing a view of all the known data references for this CFGNode via the global knowledge base
+        :return:
+        """
+        return self.get_data_references()
 
     @property
     def is_simprocedure(self):

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -133,9 +133,11 @@ class CFGNode(Serializable):
 
     def get_data_references(self, kb=None):
         """
-        Get the known data references for this CFGNode via the knowledge base
-        :param kb: Which knowledge base to use; uses the global KB by default if none is provided
-        :return: Generator yielding xrefs to this CFGNode's block.
+        Get the known data references for this CFGNode via the knowledge base.
+
+        :param kb:  Which knowledge base to use; uses the global KB by default if none is provided
+        :return:    Generator yielding xrefs to this CFGNode's block.
+        :rtype:     iter
         """
         if self._cfg_model.ident != 'CFGFast':
             raise ValueError("Memory data is currently only supported in CFGFast.")
@@ -153,7 +155,9 @@ class CFGNode(Serializable):
     def accessed_data_references(self):
         """
         Property providing a view of all the known data references for this CFGNode via the global knowledge base
-        :return:
+
+        :return:    Generator yielding xrefs to this CFGNode's block.
+        :rtype:     iter
         """
         return self.get_data_references()
 

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -135,10 +135,14 @@ class CFGNode(Serializable):
     def accessed_data_references(self):
         if self._cfg_model.ident != 'CFGFast':
             raise ValueError("Memory data is currently only supported in CFGFast.")
+        kb = self._cfg_model.project.kb
+        if not kb:
+            raise ValueError("The default Knowledge Base does not exist!")
 
         for instr_addr in self.instruction_addrs:
-            if instr_addr in self._cfg_model.insn_addr_to_memory_data:
-                yield self._cfg_model.insn_addr_to_memory_data[instr_addr]
+            refs = list(kb.xrefs.get_xrefs_by_ins_addr(instr_addr))
+            for ref in refs:
+                yield ref
 
     @property
     def is_simprocedure(self):

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -131,6 +131,20 @@ class CFGNode(Serializable):
     def predecessors(self):
         return self._cfg_model.get_predecessors(self)
 
+    def get_data_references(self, kb=None):
+        if self._cfg_model.ident != 'CFGFast':
+            raise ValueError("Memory data is currently only supported in CFGFast.")
+        if not kb:
+            kb = self._cfg_model.project.kb
+        if not kb:
+            raise ValueError("The Knowledge Base does not exist!")
+
+        for instr_addr in self.instruction_addrs:
+            refs = list(kb.xrefs.get_xrefs_by_ins_addr(instr_addr))
+            for ref in refs:
+                yield ref
+
+
     @property
     def accessed_data_references(self):
         if self._cfg_model.ident != 'CFGFast':

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -677,12 +677,12 @@ def test_blanket_fauxware():
 # Data references
 #
 
-def test_collect_data_references():
+def test_data_references():
 
     path = os.path.join(test_location, 'x86_64', 'fauxware')
     proj = angr.Project(path, auto_load_libs=False)
 
-    cfg = proj.analyses.CFGFast(collect_data_references=True)
+    cfg = proj.analyses.CFGFast(data_references=True)
 
     memory_data = cfg.memory_data
     # There is no code reference
@@ -747,7 +747,7 @@ def run_all():
     test_block_instruction_addresses_armhf()
     test_tail_call_optimization_detection_armel()
     test_blanket_fauxware()
-    test_collect_data_references()
+    test_data_references()
     test_function_leading_blocks_merging()
 
 

--- a/tests/test_constantpropagation.py
+++ b/tests/test_constantpropagation.py
@@ -33,7 +33,7 @@ def test_libc_x86():
 def test_lwip_udpecho_bm():
     bin_path = os.path.join(test_location, "armel", "lwip_udpecho_bm.elf")
     p = angr.Project(bin_path, auto_load_libs=False)
-    cfg = p.analyses.CFG(collect_data_references=True)
+    cfg = p.analyses.CFG(data_references=True)
 
     func = cfg.functions[0x23c9]
     state = p.factory.blank_state()

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -9,7 +9,7 @@ def test_decompiling_all_x86_64():
     bin_path = os.path.join(test_location, "x86_64", "all")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(collect_data_references=True)
+    cfg = p.analyses.CFG(data_references=True)
     for f in cfg.functions.values():
         if f.is_simprocedure:
             print("Skipping SimProcedure %s." % repr(f))
@@ -25,7 +25,7 @@ def test_decompiling_babypwn_i386():
     bin_path = os.path.join(test_location, "i386", "decompiler", "codegate2017_babypwn")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(normalize=True, collect_data_references=True)
+    cfg = p.analyses.CFG(normalize=True, data_references=True)
     for f in cfg.functions.values():
         if f.is_simprocedure:
             print("Skipping SimProcedure %s." % repr(f))
@@ -43,7 +43,7 @@ def test_decompiling_loop_x86_64():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "loop")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(normalize=True, collect_data_references=True)
+    cfg = p.analyses.CFG(normalize=True, data_references=True)
     f = cfg.functions['loop']
     dec = p.analyses.Decompiler(f, cfg=cfg)
     if dec.codegen is not None:
@@ -56,7 +56,7 @@ def test_decompiling_all_i386():
     bin_path = os.path.join(test_location, "i386", "all")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(collect_data_references=True)
+    cfg = p.analyses.CFG(data_references=True)
 
     f = cfg.functions['main']
     dec = p.analyses.Decompiler(f, cfg=cfg)
@@ -74,7 +74,7 @@ def test_decompiling_aes_armel():
     # It is incorrectly linked. We override this here
     p = angr.Project(bin_path, arch='ARMEL', auto_load_libs=False)
 
-    cfg = p.analyses.CFG(collect_data_references=True)
+    cfg = p.analyses.CFG(data_references=True)
 
     f = cfg.functions['main']
     dec = p.analyses.Decompiler(f, cfg=cfg)

--- a/tests/test_structurer.py
+++ b/tests/test_structurer.py
@@ -12,7 +12,7 @@ test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 
 def test_smoketest():
 
     p = angr.Project(os.path.join(test_location, 'x86_64', 'all'), auto_load_libs=False)
-    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
+    cfg = p.analyses.CFG(data_references=True, normalize=True)
 
     main_func = cfg.kb.functions['main']
 
@@ -50,7 +50,7 @@ def test_smoketest_cm3_firmware():
 def test_simple():
 
     p = angr.Project(os.path.join(test_location, 'x86_64', 'all'), auto_load_libs=False)
-    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
+    cfg = p.analyses.CFG(data_references=True, normalize=True)
 
     main_func = cfg.kb.functions['main']
 
@@ -73,7 +73,7 @@ def test_simple():
 def test_simple_loop():
 
     p = angr.Project(os.path.join(test_location, 'x86_64', 'cfg_loop_unrolling'), auto_load_libs=False)
-    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
+    cfg = p.analyses.CFG(data_references=True, normalize=True)
 
     test_func = cfg.kb.functions['test_func']
 
@@ -99,7 +99,7 @@ def test_simple_loop():
 def test_recursive_structuring():
     p = angr.Project(os.path.join(test_location, 'x86_64', 'cfg_loop_unrolling'),
                      auto_load_libs=False)
-    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
+    cfg = p.analyses.CFG(data_references=True, normalize=True)
 
     test_func = cfg.kb.functions['test_func']
 
@@ -122,7 +122,7 @@ def test_recursive_structuring():
 def test_while_true_break():
     p = angr.Project(os.path.join(test_location, 'x86_64', 'test_decompiler_loops_O0'),
                      auto_load_libs=False)
-    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
+    cfg = p.analyses.CFG(data_references=True, normalize=True)
 
     test_func = cfg.kb.functions['_while_true_break']
 
@@ -146,7 +146,7 @@ def test_while_true_break():
 def test_while():
     p = angr.Project(os.path.join(test_location, 'x86_64', 'test_decompiler_loops_O0'),
                      auto_load_libs=False)
-    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
+    cfg = p.analyses.CFG(data_references=True, normalize=True)
 
     test_func = cfg.kb.functions['_while']
 

--- a/tests/test_xrefs.py
+++ b/tests/test_xrefs.py
@@ -12,12 +12,28 @@ test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 
 def test_lwip_udpecho_bm():
     bin_path = os.path.join(test_location, "armel", "lwip_udpecho_bm.elf")
     p = angr.Project(bin_path, auto_load_libs=False)
-    cfg = p.analyses.CFG(collect_data_references=True)
+    cfg = p.analyses.CFG(data_references=True)
 
     func = cfg.functions[0x23c9]
     state = p.factory.blank_state()
     prop = p.analyses.Propagator(func=func, base_state=state)
     _ = p.analyses.XRefs(func=func, replacements=prop.replacements)
+
+    timenow_cp_xrefs = p.kb.xrefs.get_xrefs_by_dst(0x23d4)  # the constant in the constant pool
+    timenow_xrefs = p.kb.xrefs.get_xrefs_by_dst(0x1fff36f4)  # the value in .bss
+
+    nose.tools.assert_equal(len(timenow_cp_xrefs), 1)
+    nose.tools.assert_equal(next(iter(timenow_cp_xrefs)),
+                            XRef(ins_addr=0x23c9, dst=0x23d4, xref_type=XRefType.Read)
+                            )
+
+    nose.tools.assert_equal(len(timenow_xrefs), 2)
+
+
+def test_lwip_udpecho_bm_the_better_way():
+    bin_path = os.path.join(test_location, "armel", "lwip_udpecho_bm.elf")
+    p = angr.Project(bin_path, auto_load_libs=False)
+    cfg = p.analyses.CFG(cross_references=True)
 
     timenow_cp_xrefs = p.kb.xrefs.get_xrefs_by_dst(0x23d4)  # the constant in the constant pool
     timenow_xrefs = p.kb.xrefs.get_xrefs_by_dst(0x1fff36f4)  # the value in .bss

--- a/tests/test_xrefs.py
+++ b/tests/test_xrefs.py
@@ -33,7 +33,7 @@ def test_lwip_udpecho_bm():
 def test_lwip_udpecho_bm_the_better_way():
     bin_path = os.path.join(test_location, "armel", "lwip_udpecho_bm.elf")
     p = angr.Project(bin_path, auto_load_libs=False)
-    cfg = p.analyses.CFG(cross_references=True)
+    cfg = p.analyses.CFG(cross_references=True)  # pylint:disable=unused-variable
 
     timenow_cp_xrefs = p.kb.xrefs.get_xrefs_by_dst(0x23d4)  # the constant in the constant pool
     timenow_xrefs = p.kb.xrefs.get_xrefs_by_dst(0x1fff36f4)  # the value in .bss

--- a/tests/test_xrefs.py
+++ b/tests/test_xrefs.py
@@ -42,8 +42,8 @@ def test_lwip_udpecho_bm_the_better_way():
     nose.tools.assert_equal(next(iter(timenow_cp_xrefs)),
                             XRef(ins_addr=0x23c9, dst=0x23d4, xref_type=XRefType.Read)
                             )
-
-    nose.tools.assert_equal(len(timenow_xrefs), 2)
+    # time_init, sys_now, time_isr == 3
+    nose.tools.assert_equal(len(timenow_xrefs), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This branch adds a bunch of QoL and functionality fixes to help those who have the question "how does this code interact with other code, indirectly?"

Specifically:

* Fix CFGNode so that it views the KB's notion of xrefs for the node. Querying `accessed_data_references` now gives you something meaningful.
* Fix CFGFast so that `extra_cross_references` actually gets _all_ the cross references.  All of them.  Every last one. We maybe should add a warning there, this will slow down your CFG, but if you need xrefs, this is the only actually cool option, particularly on ARM.
* Add some missing ops to SimEngineLight (this quiets Jumptable and XRefs both)
* Rename the CFG options affecting data refs to `data_references` and `cross_references`, where the data ones are direct, single instruction references only that can be built statically via the VEX optimizer and CFG, and `cross_references` use constant propagation and fancy stuff Fish came up with, and are the IDA-style refs most people expect.

Bugs left:
* A few minor unsupported ops relating to our register and stack offset domain thingies
* ARM `bx lr`s generate a reference to zero.  Yeah, zero is mapped, but that's still weird, and not intended.