### PR TITLE
Reassembler: Raise an exception on an unexpected path to avoid undefined variable exceptions in rare cases.

### DIFF
--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -372,6 +372,12 @@ class SymbolManager(object):
                 else:
                     raise Exception('Unsupported symbol type %s. Bug Fish about it!' % symbol.type)
 
+            else:
+                raise Exception("the symbol %s is not owned by the main object. Try reload the project with"
+                                "\"auto_load_libs=False\". If that does not solve the issue, please report to GitHub."
+                                % symbol.name
+                                )
+
         elif (addr is not None and addr in self.cfg.functions) or is_function:
             # It's a function identified by angr's CFG recovery
 


### PR DESCRIPTION
https://github.com/angr/angr/issues/1625 is such a case. Although I couldn't reproduce the issue, I definitely see why that could happen. With this fix, it will at least display a proper warning instead of throwing a random crash.