### PR TITLE
calloc: set final_size correctly

### DIFF
--- a/angr/state_plugins/heap/heap_brk.py
+++ b/angr/state_plugins/heap/heap_brk.py
@@ -76,9 +76,10 @@ class SimHeapBrk(SimHeapBase):
         else:
             size = self.state.solver.eval(sim_size)
 
-        final_size = size * nmemb
-        if final_size > plugin.max_variable_size:
+        if self.state.solver.symbolic(sim_nmemb) or self.state.solver.symbolic(sim_size):
             final_size = plugin.max_variable_size
+        else:
+            final_size = size * nmemb
 
         addr = self.state.heap.allocate(final_size)
         v = self.state.solver.BVV(0, final_size * 8)

--- a/angr/state_plugins/heap/heap_brk.py
+++ b/angr/state_plugins/heap/heap_brk.py
@@ -76,10 +76,11 @@ class SimHeapBrk(SimHeapBase):
         else:
             size = self.state.solver.eval(sim_size)
 
+        final_size = size * nmemb
+
         if self.state.solver.symbolic(sim_nmemb) or self.state.solver.symbolic(sim_size):
-            final_size = plugin.max_variable_size
-        else:
-            final_size = size * nmemb
+            if final_size > plugin.max_variable_size:
+                final_size = plugin.max_variable_size
 
         addr = self.state.heap.allocate(final_size)
         v = self.state.solver.BVV(0, final_size * 8)


### PR DESCRIPTION
The maximum size of memory allocated by calloc was always equal to plugin.max_variable_size (apparently 128 bytes), changed it to only when args are symbolic.