### PR TITLE
CFGEmulated: Pending jobs with the same dst should not overwrite each other.

### DIFF
--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -1085,7 +1085,7 @@ class BinDiff(Analysis):
         initial_matches += self._get_name_matches()
         initial_matches += self._get_function_matches(self.attributes_a, self.attributes_b)
         for (a, b) in initial_matches:
-            l.debug("Initally matched (%#x, %#x)", a, b)
+            l.debug("Initially matched (%#x, %#x)", a, b)
 
         # Use a queue so we process matches in the order that they are found
         to_process = deque(initial_matches)

--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -1131,9 +1131,11 @@ class BinDiff(Analysis):
             # for each of the possible new matches add it if it improves the matching
             for (x, y) in new_matches:
                 # skip none functions and syscalls
-                if self.cfg_a.kb.functions.function(x) is None or self.cfg_a.kb.functions.function(x).is_syscall:
+                func_a = self.cfg_a.kb.functions.function(x)
+                if func_a is None or func_a.is_simprocedure or func_a.is_syscall:
                     continue
-                if self.cfg_b.kb.functions.function(y) is None or self.cfg_b.kb.functions.function(y).is_syscall:
+                func_b = self.cfg_b.kb.functions.function(y)
+                if func_b is None or func_b.is_simprocedure or func_b.is_syscall:
                     continue
 
                 if (x, y) not in processed_matches:

--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -2,7 +2,7 @@
 import logging
 import math
 import types
-from collections import deque
+from collections import deque, defaultdict
 
 import networkx
 from . import Analysis
@@ -1055,20 +1055,23 @@ class BinDiff(Analysis):
         return plt_matches
 
     def _get_name_matches(self):
-        names_to_addrs_a = dict()
+        names_to_addrs_a = defaultdict(list)
         for f in self.cfg_a.functions.values():
             if not f.name.startswith("sub_"):
-                names_to_addrs_a[f.name] = f.addr
+                names_to_addrs_a[f.name].append(f.addr)
 
-        names_to_addrs_b = dict()
+        names_to_addrs_b = defaultdict(list)
         for f in self.cfg_b.functions.values():
             if not f.name.startswith("sub_"):
-                names_to_addrs_b[f.name] = f.addr
+                names_to_addrs_b[f.name].append(f.addr)
 
         name_matches = []
-        for name, addr in names_to_addrs_a.items():
+        for name, addrs in names_to_addrs_a.items():
             if name in names_to_addrs_b:
-                name_matches.append((addr, names_to_addrs_b[name]))
+                for addr_a, addr_b in zip(addrs, names_to_addrs_b[name]):
+                    # if binary a and binary b have different numbers of functions with the same name, we will see them
+                    # in unmatched functions in the end.
+                    name_matches.append((addr_a, addr_b))
 
         return name_matches
 

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -285,8 +285,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         # imprecision of the concrete execution. So we save those simulated
         # exits here to increase our code coverage. Of course the real retn from
         # that call always precedes those "fake" retns.
-        # type: Dict[BlockID, List[PendingJob]]
-        self._pending_jobs = defaultdict(list)
+        self._pending_jobs = defaultdict(list) # Dict[BlockID, List[PendingJob]]
 
         # Counting how many times a basic block is traced into
         self._traced_addrs = defaultdict(lambda: defaultdict(int))

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 import sys
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from functools import reduce
 
 import claripy
@@ -285,8 +285,8 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         # imprecision of the concrete execution. So we save those simulated
         # exits here to increase our code coverage. Of course the real retn from
         # that call always precedes those "fake" retns.
-        # Tuple --> (Initial state, call_stack)
-        self._pending_jobs = OrderedDict()
+        # type: Dict[BlockID, List[PendingJob]]
+        self._pending_jobs = defaultdict(list)
 
         # Counting how many times a basic block is traced into
         self._traced_addrs = defaultdict(lambda: defaultdict(int))
@@ -979,7 +979,11 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         :return: A CFGJob instance or None
         """
 
-        pending_job_key, pending_job = self._pending_jobs.popitem()
+        pending_job_key = next(iter(self._pending_jobs.keys()))
+        pending_job = self._pending_jobs[pending_job_key].pop()
+        if len(self._pending_jobs[pending_job_key]) == 0:
+            del self._pending_jobs[pending_job_key]
+
         pending_job_state = pending_job.state
         pending_job_call_stack = pending_job.call_stack
         pending_job_src_block_id = pending_job.src_block_id
@@ -1175,29 +1179,32 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         # See if this job cancels another FakeRet
         # This should be done regardless of whether this job should be skipped or not, otherwise edges will go missing
-        # in the CFG or function transiton graphs.
+        # in the CFG or function transition graphs.
         if job.jumpkind == 'Ijk_FakeRet' or \
                 (job.jumpkind == 'Ijk_Ret' and block_id in self._pending_jobs):
             # The fake ret is confirmed (since we are returning from the function it calls). Create an edge for it
             # in the graph.
 
+            the_jobs = [ ]
             if block_id in self._pending_jobs:
-                the_job = self._pending_jobs.pop(block_id)  # type: PendingJob
-                self._deregister_analysis_job(the_job.caller_func_addr, the_job)
+                the_jobs = self._pending_jobs.pop(block_id)
+                for the_job in the_jobs:  # type: Pendingjob
+                    self._deregister_analysis_job(the_job.caller_func_addr, the_job)
             else:
-                the_job = job
+                the_jobs = [job]
 
-            self._graph_add_edge(the_job.src_block_id, block_id,
-                                 jumpkind='Ijk_FakeRet',
-                                 stmt_idx=the_job.src_exit_stmt_idx,
-                                 ins_addr=src_ins_addr
-                                 )
-            self._update_function_transition_graph(the_job.src_block_id, block_id,
-                                                   jumpkind='Ijk_FakeRet',
-                                                   ins_addr=src_ins_addr,
-                                                   stmt_idx=the_job.src_exit_stmt_idx,
-                                                   confirmed=True
-                                                   )
+            for the_job in the_jobs:
+                self._graph_add_edge(the_job.src_block_id, block_id,
+                                     jumpkind='Ijk_FakeRet',
+                                     stmt_idx=the_job.src_exit_stmt_idx,
+                                     ins_addr=src_ins_addr
+                                     )
+                self._update_function_transition_graph(the_job.src_block_id, block_id,
+                                                       jumpkind='Ijk_FakeRet',
+                                                       ins_addr=src_ins_addr,
+                                                       stmt_idx=the_job.src_exit_stmt_idx,
+                                                       confirmed=True
+                                                       )
 
         if sim_successors is None or should_skip:
             # We cannot retrieve the block, or we should skip the analysis of this node
@@ -1569,43 +1576,44 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         pending_exits_to_remove = [ ]
 
-        for block_id, pe in self._pending_jobs.items():
-            if pe.returning_source is None:
-                # The original call failed. This pending exit must be followed.
-                continue
+        for block_id, jobs in self._pending_jobs.items():
+            for pe in jobs:
+                if pe.returning_source is None:
+                    # The original call failed. This pending exit must be followed.
+                    continue
 
-            func = self.kb.functions.function(pe.returning_source)
-            if func is None:
-                # Why does it happen?
-                l.warning("An expected function at %s is not found. Please report it to Fish.",
-                          hex(pe.returning_source) if pe.returning_source is not None else 'None')
-                continue
+                func = self.kb.functions.function(pe.returning_source)
+                if func is None:
+                    # Why does it happen?
+                    l.warning("An expected function at %s is not found. Please report it to Fish.",
+                              hex(pe.returning_source) if pe.returning_source is not None else 'None')
+                    continue
 
-            if func.returning is False:
-                # Oops, it's not returning
-                # Remove this pending exit
-                pending_exits_to_remove.append(block_id)
+                if func.returning is False:
+                    # Oops, it's not returning
+                    # Remove this pending exit
+                    pending_exits_to_remove.append(block_id)
 
-                # We want to mark that call as not returning in the current function
-                current_function_addr = self._block_id_current_func_addr(block_id)
-                if current_function_addr is not None:
-                    current_function = self.kb.functions.function(current_function_addr)
-                    if current_function is not None:
-                        call_site_addr = self._block_id_addr(pe.src_block_id)
-                        current_function._call_sites[call_site_addr] = (func.addr, None)
-                    else:
-                        l.warning('An expected function at %#x is not found. Please report it to Fish.',
-                                  current_function_addr
-                                  )
+                    # We want to mark that call as not returning in the current function
+                    current_function_addr = self._block_id_current_func_addr(block_id)
+                    if current_function_addr is not None:
+                        current_function = self.kb.functions.function(current_function_addr)
+                        if current_function is not None:
+                            call_site_addr = self._block_id_addr(pe.src_block_id)
+                            current_function._call_sites[call_site_addr] = (func.addr, None)
+                        else:
+                            l.warning('An expected function at %#x is not found. Please report it to Fish.',
+                                      current_function_addr
+                                      )
 
         for block_id in pending_exits_to_remove:
-            l.debug('Removing a pending exit to %#x since the target function %#x does not return',
+            l.debug('Removing all pending exits to %#x since the target function %#x does not return',
                     self._block_id_addr(block_id),
-                    self._pending_jobs[block_id].returning_source,
+                    next(iter(self._pending_jobs[block_id])).returning_source,
                     )
 
-            to_remove = self._pending_jobs[block_id]
-            self._deregister_analysis_job(to_remove.caller_func_addr, to_remove)
+            for to_remove in self._pending_jobs[block_id]:
+                self._deregister_analysis_job(to_remove.caller_func_addr, to_remove)
 
             del self._pending_jobs[block_id]
 
@@ -1786,7 +1794,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                             suc_exit_ins_addr,
                             new_call_stack
                             )
-            self._pending_jobs[new_tpl] = pe
+            self._pending_jobs[new_tpl].append(pe)
             self._register_analysis_job(pe.caller_func_addr, pe)
             job.successor_status[state] = "Pended"
 


### PR DESCRIPTION
This bug is demonstrated by having two basic blocks with the same end
address and both generating fake ret successors. In the old implementation
where _pending_jobs is indexed by destination block IDs, the second
pending job will overwrite the first pending job. It was once considered a
non-issue since the generated CFG will be the same, only a fake-ret edge
will be missing. Now I believe that fixing it and never missing any
fake-ret edges is obviously better.

Also, use dict instead of OrderedDict for _pending_jobs since starting
from Python 3.7 dict will keep elements ordered.