### PR TITLE
`LiveDefinitions` does not need a loader

### DIFF
--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -245,7 +245,7 @@ class SimEngineRDAIL(
                         l.info('Memory at address %#x undefined, ins_addr = %#x.', addr, self.ins_addr)
                 else:
                     try:
-                        data.add(self.state.loader.memory.unpack_word(addr, size=size))
+                        data.add(self.project.loader.memory.unpack_word(addr, size=size))
                     except KeyError:
                         pass
 
@@ -361,12 +361,12 @@ class SimEngineRDAIL(
 
         is_internal = False
         ext_func_name = None
-        if self.state.loader.main_object.contains_addr(ip_addr) is True:
-            ext_func_name = self.state.loader.find_plt_stub_name(ip_addr)
+        if self.project.loader.main_object.contains_addr(ip_addr) is True:
+            ext_func_name = self.project.loader.find_plt_stub_name(ip_addr)
             if ext_func_name is None:
                 is_internal = True
         else:
-            symbol = self.state.loader.find_symbol(ip_addr)
+            symbol = self.project.loader.find_symbol(ip_addr)
             if symbol is not None:
                 ext_func_name = symbol.name
 

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -210,7 +210,7 @@ class SimEngineRDVEX(
                         l.info('Memory at address %#x undefined, ins_addr = %#x.', a, self.ins_addr)
                 else:
                     try:
-                        data.add(self.state.loader.memory.unpack_word(a, size=size))
+                        data.add(self.project.loader.memory.unpack_word(a, size=size))
                     except KeyError:
                         pass
 
@@ -425,12 +425,12 @@ class SimEngineRDVEX(
 
         is_internal = False
         ext_func_name = None
-        if self.state.loader.main_object.contains_addr(ip_addr) is True:
-            ext_func_name = self.state.loader.find_plt_stub_name(ip_addr)
+        if self.project.loader.main_object.contains_addr(ip_addr) is True:
+            ext_func_name = self.project.loader.find_plt_stub_name(ip_addr)
             if ext_func_name is None:
                 is_internal = True
         else:
-            symbol = self.state.loader.find_symbol(ip_addr)
+            symbol = self.project.loader.find_symbol(ip_addr)
             if symbol is not None:
                 ext_func_name = symbol.name
 

--- a/tests/test_reachingdefinitions.py
+++ b/tests/test_reachingdefinitions.py
@@ -1,14 +1,17 @@
 import logging
-import pickle
 import os
+import pickle
+import random
 
 import nose
+import unittest
+from unittest import TestCase
 
+import archinfo
 import angr
-
+from angr.analyses.reaching_definitions import LiveDefinitions
 
 l = logging.getLogger('test_reachingdefinitions')
-
 
 TESTS_LOCATION = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
@@ -16,66 +19,72 @@ TESTS_LOCATION = os.path.join(
 )
 
 
-def run_reaching_definition_analysis(project, func, result_path):
-    tmp_kb = angr.KnowledgeBase(project)
-    rd = project.analyses.ReachingDefinitions(func, init_func=True, kb=tmp_kb, observe_all=True)
+class ReachingDefinitionAnalysisTest(TestCase):
+    def _run_reaching_definition_analysis(self, project, func, result_path):
+        tmp_kb = angr.KnowledgeBase(project)
+        rd = project.analyses.ReachingDefinitions(func, init_func=True, kb=tmp_kb, observe_all=True)
 
-    unsorted_result = map(
-        lambda x: {'key': x[0],\
-                   'register_definitions': x[1].register_definitions,\
-                   'stack_definitions': x[1].stack_definitions,\
-                   'memory_definitions': x[1].memory_definitions},
-        rd.observed_results.items()
-    )
-    result = list(sorted(
-        unsorted_result,
-        key=lambda x: x['key']
-    ))
-
-    with open(result_path, 'rb') as f:
-        expected_result = pickle.load(f)
-
-    nose.tools.assert_list_equal(result, expected_result)
-
-
-def test_reaching_definition_analysis():
-    def _binary_path(binary_name):
-        return os.path.join(TESTS_LOCATION, 'x86_64', binary_name)
-    def _result_path(binary_name):
-        return os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
-            'reachingdefinitions_results',
-            'x86_64',
-            binary_name + '.pickle'
+        unsorted_result = map(
+            lambda x: {'key': x[0],\
+                       'register_definitions': x[1].register_definitions,\
+                       'stack_definitions': x[1].stack_definitions,\
+                       'memory_definitions': x[1].memory_definitions},
+            rd.observed_results.items()
         )
+        result = list(sorted(
+            unsorted_result,
+            key=lambda x: x['key']
+        ))
 
-    binaries_and_results = list(map(
-        lambda binary: (_binary_path(binary), _result_path(binary)),
-        ['all', 'fauxware', 'loop']
-    ))
+        with open(result_path, 'rb') as f:
+            expected_result = pickle.load(f)
 
-    for binary, result_path in binaries_and_results:
-        project = angr.Project(binary, load_options={'auto_load_libs': False})
-        cfg = project.analyses.CFGFast()
-
-        yield run_reaching_definition_analysis, project, cfg.kb.functions['main'], result_path
+        nose.tools.assert_list_equal(result, expected_result)
 
 
-def main():
-    test_functions = list(filter(
-        lambda f: f[0].startswith('test_') and hasattr(f[1], '__call__'),
-        globals().items()
-    ))
+    def test_reaching_definition_analysis(self):
+        def _binary_path(binary_name):
+            return os.path.join(TESTS_LOCATION, 'x86_64', binary_name)
+        def _result_path(binary_name):
+            return os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                'reachingdefinitions_results',
+                'x86_64',
+                binary_name + '.pickle'
+            )
 
-    for func_name, func in test_functions:
-        print(func_name)
-        for testfunc_and_args in func():
-            testfunc, args = testfunc_and_args[0], testfunc_and_args[1:]
-            testfunc(*args)
+        binaries_and_results = list(map(
+            lambda binary: (_binary_path(binary), _result_path(binary)),
+            ['all', 'fauxware', 'loop']
+        ))
+
+        for binary, result_path in binaries_and_results:
+            project = angr.Project(binary, load_options={'auto_load_libs': False})
+            cfg = project.analyses.CFGFast()
+
+            yield self._run_reaching_definition_analysis, project, cfg.kb.functions['main'], result_path
+
+
+class LiveDefinitionsTest(TestCase):
+    def test_initializing_live_definitions_for_ppc_without_rtoc_value_should_raise_an_error(self):
+        arch = archinfo.arch_ppc64.ArchPPC64()
+        nose.tools.assert_raises(ValueError, LiveDefinitions, arch=arch, init_func=True)
+
+
+    def test_initializing_live_definitions_for_ppc_with_rtoc_value(self):
+        arch = archinfo.arch_ppc64.ArchPPC64()
+        rtoc_value = random.randint(0, 0xffffffffffffffff)
+        live_definition = LiveDefinitions(arch=arch, init_func=True, rtoc_value=rtoc_value)
+
+        rtoc_offset = arch.registers['rtoc'][0]
+        rtoc_definition = next(iter(live_definition.register_definitions.get_objects_by_offset(rtoc_offset)))
+        rtoc_definition_value = rtoc_definition.data.get_first_element()
+
+        nose.tools.assert_equals(rtoc_definition_value, rtoc_value)
 
 
 if __name__ == '__main__':
     l.setLevel(logging.DEBUG)
     logging.getLogger('angr.analyses.reaching_definitions').setLevel(logging.DEBUG)
 
-    main()
+    nose.core.runmodule()

--- a/tests/test_reachingdefinitions.py
+++ b/tests/test_reachingdefinitions.py
@@ -62,7 +62,7 @@ class ReachingDefinitionAnalysisTest(TestCase):
             project = angr.Project(binary, load_options={'auto_load_libs': False})
             cfg = project.analyses.CFGFast()
 
-            yield self._run_reaching_definition_analysis, project, cfg.kb.functions['main'], result_path
+            self._run_reaching_definition_analysis(project, cfg.kb.functions['main'], result_path)
 
 
 class LiveDefinitionsTest(TestCase):


### PR DESCRIPTION
  * on ppc64 arch, we need another argument (the rtoc -register- value)
  * use the loader provided by the project in the engines
  * add some tests
  * let the test runner run in case of a call from `ipython
  tests/test_reachingdefinitions.py`