### PR TITLE
CHESSathon PR from Lukas: trace overrides

### DIFF
--- a/angr/engines/vex/statements/dirty.py
+++ b/angr/engines/vex/statements/dirty.py
@@ -10,8 +10,11 @@ def SimIRStmt_Dirty(engine, state, stmt):
     with state.history.subscribe_actions() as deps:
         exprs = [engine.handle_expression(state, e) for e in stmt.args]
 
-    if hasattr(dirty, stmt.cee.name):
-        func = getattr(dirty, stmt.cee.name)
+    func = state.trace_replay_overrides.override_for_dirtyhelper(stmt.cee.name)
+    if func is None:
+        func = getattr(dirty, stmt.cee.name, None)
+
+    if func is not None:
         retval, retval_constraints = func(state, *exprs)
         state.solver.add(*retval_constraints)
 

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -128,7 +128,9 @@ class SimProcedure:
         override = None
         if inst.is_syscall:
             state.history.recent_syscall_count = 1
-            if len(state.posix.queued_syscall_returns):
+            override = state.trace_replay_overrides.override_for_syscall(self.display_name)
+
+            if not override and len(state.posix.queued_syscall_returns):
                 override = state.posix.queued_syscall_returns.pop(0)
 
         if callable(override):

--- a/angr/state_plugins/__init__.py
+++ b/angr/state_plugins/__init__.py
@@ -30,3 +30,4 @@ from .heap import *
 from .concrete import *
 from .jni_references import *
 from .javavm_classloader import *
+from .trace_replay_overrides import *

--- a/angr/state_plugins/trace_replay_overrides.py
+++ b/angr/state_plugins/trace_replay_overrides.py
@@ -1,0 +1,31 @@
+import functools
+from .plugin import SimStatePlugin
+
+
+# TODO: write testcases for this behavior
+class TraceReplayOverrides(SimStatePlugin):
+    def __init__(self, syscall_overrides=None, dirty_overrides=None):
+        super(TraceReplayOverrides, self).__init__()
+        self.dirty_overrides = dirty_overrides if dirty_overrides is not None else list()
+        self.syscall_overrides = syscall_overrides if syscall_overrides is not None else list()
+
+    @SimStatePlugin.memo
+    def copy(self, memo):
+        return TraceReplayOverrides(self.syscall_overrides, self.dirty_overrides)
+
+    def override_for_dirtyhelper(self, name):
+        for condition, override in self.dirty_overrides:
+            if condition(self.state, name):
+                return functools.partial(override, name)
+        return None
+
+    def override_for_syscall(self, name):
+        for condition, override in self.syscall_overrides:
+            if condition(self.state, name):
+                return functools.partial(override, name)
+        return None
+
+
+from angr.sim_state import SimState
+
+SimState.register_default('trace_replay_overrides', TraceReplayOverrides)


### PR DESCRIPTION
This adds the ability to override dirty calls and simprocedures during tracing through a new plugin. This is a *first stab* at the problem, and we'll refactor it post-CHESSathon, but we need to merge it into master so that everyone can move off of various secret dev branches.