### PR TITLE
WIP: add option to symbolize pointers at state creation time

### DIFF
--- a/angr/sim_options.py
+++ b/angr/sim_options.py
@@ -324,6 +324,9 @@ CGC_NON_BLOCKING_FDS = 'CGC_NON_BLOCKING_FDS'
 # Sacrafice performance for more fine tune memory read size
 MEMORY_CHUNK_INDIVIDUAL_READS = "MEMORY_CHUNK_INDIVIDUAL_READS"
 
+# This option causes states to have all pointers tagged symbolically, to make them trackable.
+INITIALIZE_SYMBOLIC_POINTERS = "INITIALIZE_SYMBOLIC_POINTERS"
+
 #
 # Register those variables as Boolean state options
 #

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import struct
 
@@ -186,6 +187,16 @@ class SimOS:
         state.scratch.bbl_addr = addr
         state.scratch.stmt_idx = 0
         state.history.jumpkind = 'Ijk_Boring'
+
+        # symbolize pointers if desired
+        if state.options.INITIALIZE_SYMBOLIC_POINTERS:
+            for obj in self.project.loader.all_objects:
+                for ptrobj in itertools.chain(obj.relocs, obj.imports.values()):
+                    if hasattr(ptrobj, 'rebased_addr'):
+                        concrete_value = self.project.loader.memory.unpack_word(ptrobj.rebased_addr)
+                        symbolic_value = state.solver.BVS("pointer", state.arch.bits)
+                        state.solver.add(symbolic_value == concrete_value)
+                        state.memory.store(ptrobj.rebased_addr, symbolic_value)
 
         return state
 


### PR DESCRIPTION
This should re-enable something pwnrex-like. Steps to finish this up (or polish after merge):

- [ ] Use one variable per region, rather than one variable per pointer.
- [ ] Some of the relocations might not be pointers, but we're symbolizing all of them.