### PR TITLE
Add a pointer symbolization plugin

### DIFF
--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -5,7 +5,7 @@ from archinfo.arch_soot import ArchSoot
 import logging
 l = logging.getLogger(name=__name__)
 
-class SimSuccessors(object):
+class SimSuccessors:
     """
     This class serves as a categorization of all the kinds of result states that can come from a
     SimEngine run.

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -208,7 +208,10 @@ class SimSuccessors:
 
             state._inspect('call', BP_AFTER)
         else:
-            while state.solver.is_true(state.regs._sp > state.callstack.top.stack_ptr):
+            while True:
+                cur_sp = state.solver.max(state.regs._sp) if state.has_plugin('symbolizer') else state.regs._sp
+                if not state.solver.is_true(cur_sp > state.callstack.top.stack_ptr):
+                    break
                 state._inspect('return', BP_BEFORE, function_address=state.callstack.top.func_addr)
                 state.callstack.pop()
                 state._inspect('return', BP_AFTER)

--- a/angr/project.py
+++ b/angr/project.py
@@ -164,8 +164,6 @@ class Project:
         self._support_selfmodifying_code = support_selfmodifying_code
         self._translation_cache = translation_cache
         self._executing = False # this is a flag for the convenience API, exec() and terminate_execution() below
-        self._is_java_project = None
-        self._is_java_jni_project = None
 
         if self._support_selfmodifying_code:
             if self._translation_cache is True:
@@ -213,6 +211,9 @@ class Project:
             self.simos = os_mapping[self.loader.main_object.os](self)
         else:
             raise ValueError("Invalid OS specification or non-matching architecture.")
+
+        self.is_java_project = isinstance(self.arch, ArchSoot)
+        self.is_java_jni_project = isinstance(self.arch, ArchSoot) and self.simos.is_javavm_with_jni_support
 
         # Step 6: Register simprocedures as appropriate for library functions
         if isinstance(self.arch, ArchSoot) and self.simos.is_javavm_with_jni_support:
@@ -688,21 +689,6 @@ class Project:
 
     def __repr__(self):
         return '<Project %s>' % (self.filename if self.filename is not None else 'loaded from stream')
-
-    #
-    # Properties
-    #
-
-    def __getattr__(self, a):
-        if a.lstrip('_') == 'is_java_project':
-            v = isinstance(self.arch, ArchSoot)
-        elif a.lstrip('_') == 'is_java_jni_project':
-            v = isinstance(self.arch, ArchSoot) and self.simos.is_javavm_with_jni_support
-        else:
-            raise AttributeError(a)
-
-        setattr(self, a, v)
-        return v
 
     #
     # Compatibility

--- a/angr/project.py
+++ b/angr/project.py
@@ -159,7 +159,7 @@ class Project:
         self._default_analysis_mode = default_analysis_mode
         self._exclude_sim_procedures_func = exclude_sim_procedures_func
         self._exclude_sim_procedures_list = exclude_sim_procedures_list
-        self._should_use_sim_procedures = use_sim_procedures
+        self.use_sim_procedures = use_sim_procedures
         self._ignore_functions = ignore_functions
         self._support_selfmodifying_code = support_selfmodifying_code
         self._translation_cache = translation_cache
@@ -365,7 +365,7 @@ class Project:
         Has symbol name `f` been marked for exclusion by any of the user
         parameters?
         """
-        return not self._should_use_sim_procedures or \
+        return not self.use_sim_procedures or \
             f in self._exclude_sim_procedures_list or \
             f in self._ignore_functions or \
             (self._exclude_sim_procedures_func is not None and self._exclude_sim_procedures_func(f))
@@ -693,28 +693,16 @@ class Project:
     # Properties
     #
 
-    @property
-    def use_sim_procedures(self):
-        return self._should_use_sim_procedures
+    def __getattr__(self, a):
+        if a.lstrip('_') == 'is_java_project':
+            v = isinstance(self.arch, ArchSoot)
+        elif a.lstrip('_') == 'is_java_jni_project':
+            v = isinstance(self.arch, ArchSoot) and self.simos.is_javavm_with_jni_support
+        else:
+            raise AttributeError(a)
 
-    @property
-    def is_java_project(self):
-        """
-        Indicates if the project's main binary is a Java Archive.
-        """
-        if self._is_java_project is None:
-            self._is_java_project = isinstance(self.arch, ArchSoot)
-        return self._is_java_project
-
-    @property
-    def is_java_jni_project(self):
-        """
-        Indicates if the project's main binary is a Java Archive, which
-        interacts during its execution with native libraries (via JNI).
-        """
-        if self._is_java_jni_project is None:
-            self._is_java_jni_project = isinstance(self.arch, ArchSoot) and self.simos.is_javavm_with_jni_support
-        return self._is_java_jni_project
+        setattr(self, a, v)
+        return v
 
     #
     # Compatibility

--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -385,6 +385,7 @@ class SimulationManager:
                        'unconstrained': successors.unconstrained_successors}
 
         except (SimUnsatError, claripy.UnsatError) as e:
+            raise
             if self._hierarchy:
                 self._hierarchy.unreachable_state(state)
                 self._hierarchy.simplify()

--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -385,7 +385,6 @@ class SimulationManager:
                        'unconstrained': successors.unconstrained_successors}
 
         except (SimUnsatError, claripy.UnsatError) as e:
-            raise
             if self._hierarchy:
                 self._hierarchy.unreachable_state(state)
                 self._hierarchy.simplify()

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -61,6 +61,10 @@ class SimState(PluginHub):
         super(SimState, self).__init__()
         self.project = project
 
+        # Java & Java JNI
+        self._is_java_project = self.project and self.project.is_java_project
+        self._is_java_jni_project = self.project and self.project.is_java_jni_project
+
         # Arch
         if self._is_java_jni_project:
             self._arch = { "soot" : project.arch,
@@ -360,21 +364,6 @@ class SimState(PluginHub):
     #
     # Java support
     #
-
-    def __getattr__(self, a):
-        if a == '_is_java_project':
-            # Indicates if the project's main binary is a Java Archive.
-            v = self.project and self.project.is_java_project
-        elif a == '_is_java_jni_project':
-            # Indicates if the project's main binary is a Java Archive, which
-            # interacts during its execution with native libraries (via JNI).
-            v = self.project and self.project.is_java_jni_project
-        else:
-            return super().__getattr__(a)
-
-        setattr(self, a, v)
-        return v
-
 
     @property
     def javavm_memory(self):

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -9,7 +9,7 @@ l = logging.getLogger(name=__name__)
 import angr # type annotations; pylint:disable=unused-import
 import claripy
 import archinfo
-from archinfo.arch_soot import ArchSoot, SootAddressDescriptor
+from archinfo.arch_soot import SootAddressDescriptor
 
 from .misc.plugins import PluginHub, PluginPreset
 from .sim_state_options import SimStateOptions
@@ -89,7 +89,7 @@ class SimState(PluginHub):
             options |= add_options
         if remove_options is not None:
             options -= remove_options
-        self._options = options
+        self.options = options
         self.mode = mode
         self.supports_inspect = False
 
@@ -297,19 +297,6 @@ class SimState(PluginHub):
         return self.solver.eval_one(self.regs._ip)
 
     @property
-    def options(self):
-        return self._options
-
-    @options.setter
-    def options(self, v):
-        if isinstance(v, (set, list)):
-            self._options = SimStateOptions(v)
-        elif isinstance(v, SimStateOptions):
-            self._options = v
-        else:
-            raise SimStateError("Unsupported type '%s' in SimState.options.setter()." % type(v))
-
-    @property
     def arch(self):
         if self._is_java_jni_project:
             return self._arch['soot'] if self.ip_is_soot_addr else self._arch['vex']
@@ -374,20 +361,20 @@ class SimState(PluginHub):
     # Java support
     #
 
-    @property
-    def _is_java_project(self):
-        """
-        Indicates if the project's main binary is a Java Archive.
-        """
-        return self.project and self.project.is_java_project
+    def __getattr__(self, a):
+        if a == '_is_java_project':
+            # Indicates if the project's main binary is a Java Archive.
+            v = self.project and self.project.is_java_project
+        elif a == '_is_java_jni_project':
+            # Indicates if the project's main binary is a Java Archive, which
+            # interacts during its execution with native libraries (via JNI).
+            v = self.project and self.project.is_java_jni_project
+        else:
+            return super().__getattr__(a)
 
-    @property
-    def _is_java_jni_project(self):
-        """
-        Indicates if the project's main binary is a Java Archive, which
-        interacts during its execution with native libraries (via JNI).
-        """
-        return self.project and self.project.is_java_jni_project
+        setattr(self, a, v)
+        return v
+
 
     @property
     def javavm_memory(self):

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -232,6 +232,22 @@ class SimState(PluginHub):
 
         return "<SimState @ %s>" % ip_str
 
+    def __setattr__(self, key, value):
+        if key == 'options':
+            # set options
+            # this is done to both keep compatibility and make access to .options fast.
+            self._set_options(value)
+            return
+        super().__setattr__(key, value)
+
+    def _set_options(self, v):
+        if isinstance(v, (set, list)):
+            super().__setattr__("options", SimStateOptions(v))
+        elif isinstance(v, SimStateOptions):
+            super().__setattr__("options", v)
+        else:
+            raise SimStateError("Unsupported type '%s' in SimState.options.setter()." % type(v))
+
     #
     # Easier access to some properties
     #

--- a/angr/state_plugins/__init__.py
+++ b/angr/state_plugins/__init__.py
@@ -30,3 +30,4 @@ from .heap import *
 from .concrete import *
 from .jni_references import *
 from .javavm_classloader import *
+from .symbolizer import *

--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -116,7 +116,7 @@ class Concrete(SimStatePlugin):
 
         # Synchronize the imported functions addresses (.got, IAT) in the
         # concrete process with ones used in the SimProcedures dictionary
-        if self.state.project._should_use_sim_procedures and not self.state.project.loader.main_object.pic:
+        if self.state.project.use_sim_procedures and not self.state.project.loader.main_object.pic:
             self._sync_simproc()
         else:
             l.debug("SimProc not restored, you are going to simulate also the code of external libraries!")

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -28,6 +28,7 @@ event_types = {
     'vfg_handle_successor',
     'vfg_widen_state',
     'engine_process',
+    'memory_page_map',
 }
 
 inspect_attributes = {
@@ -123,6 +124,10 @@ inspect_attributes = {
     # engine_process
     'sim_engine',
     'sim_successors',
+
+    # memory mapping
+    'mapped_page',
+    'mapped_address',
     }
 
 NO_OVERRIDE = object()

--- a/angr/state_plugins/symbolizer.py
+++ b/angr/state_plugins/symbolizer.py
@@ -248,5 +248,5 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
         sc.page_symbols = dict(sc.page_symbols)
         return sc
 
-from angr.sim_state import SimState
+from ..sim_state import SimState
 SimState.register_default('symbolizer', SimSymbolizer)

--- a/angr/state_plugins/symbolizer.py
+++ b/angr/state_plugins/symbolizer.py
@@ -17,8 +17,8 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
 
         self._symbolize_all = False
         self.symbolization_target_pages = set()
-        self.pointer_symbols = { }
         self.ignore_target_pages = set()
+        self.symbolized_count = 0
 
         self._LE_FMT = None
         self._BE_FMT = None
@@ -33,19 +33,23 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
         if not isinstance(self.state.inspect.mem_write_length, int) and self.state.inspect.mem_write_length.symbolic:
             return
 
-        length = self.state.solver.eval_one(self.state.inspect.mem_write_length)
-        if length != self.state.arch.bytes:
-            return
+        #length = self.state.solver.eval_one(self.state.inspect.mem_write_length)
+        #if length != self.state.arch.bytes:
+        #   return
 
-        expr = self.state.solver.eval_one(self.state.inspect.mem_write_expr)
-        if self._should_symbolize(expr):
-            print("asdf", self.state.inspect.mem_write_expr, self.state.inspect.mem_write_length)
-            self.state.inspect.mem_write_expr = self._preconstrain('symbolic_ptr_mem', expr)
+        write_expr = self.state.inspect.mem_write_expr
+        byte_expr = self.state.solver.eval_one(self.state.inspect.mem_write_expr, cast_to=bytes).rjust(write_expr.length//8)
+        replacement_expr = self._resymbolize_data(byte_expr)
+        if replacement_expr is not None:
+            assert replacement_expr.length == write_expr.length
+            self.state.inspect.mem_write_expr = replacement_expr
 
     def _reg_write_callback(self):
         if not isinstance(self.state.inspect.reg_write_expr, int) and self.state.inspect.reg_write_expr.symbolic:
             return
         if not isinstance(self.state.inspect.reg_write_length, int) and self.state.inspect.reg_write_length.symbolic:
+            return
+        if self.state.inspect.reg_write_offset == self.state.arch.ip_offset:
             return
 
         length = self.state.solver.eval_one(self.state.inspect.reg_write_length)
@@ -54,7 +58,6 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
 
         expr = self.state.solver.eval_one(self.state.inspect.reg_write_expr)
         if self._should_symbolize(expr):
-            print("fdsa", self.state.inspect.reg_write_expr, self.state.inspect.reg_write_length)
             self.state.inspect.reg_write_expr = self._preconstrain('symbolic_ptr_reg', expr)
 
     def init_state(self):
@@ -71,7 +74,7 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
         self.state.inspect.make_breakpoint('memory_page_map', when=self.state.inspect.BP_BEFORE, action=_page_map_cb)
         self.state.inspect.make_breakpoint('mem_write', when=self.state.inspect.BP_BEFORE, action=_mem_write_cb)
         #self.state.inspect.make_breakpoint('mem_read', when=self.state.inspect.BP_BEFORE, action=_mem_read_cb)
-        self.state.inspect.make_breakpoint('reg_write', when=self.state.inspect.BP_BEFORE, action=_reg_write_cb)
+        #self.state.inspect.make_breakpoint('reg_write', when=self.state.inspect.BP_BEFORE, action=_reg_write_cb)
         #self.state.inspect.make_breakpoint('reg_read', when=self.state.inspect.BP_BEFORE, action=_reg_read_cb)
 
     def set_symbolization_for_all_pages(self):
@@ -94,11 +97,47 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
     def _preconstrain(self, name, value):
         symbol = claripy.BVS(name, self.state.arch.bits)
         self.state.solver.add(symbol == claripy.BVV(value, self.state.arch.bits))
-        self.pointer_symbols[name] = symbol
+        self.symbolized_count += 1
         return symbol
 
     def _should_symbolize(self, addr):
         return addr//0x1000 in self.symbolization_target_pages and not addr//0x1000 in self.ignore_target_pages
+
+    def _resymbolize_data(self, data, prefix=b"", base=0, skip=()):
+        replacement_parts = [ prefix ]
+
+        replaced = False
+        for offset in range(0, len(data), self.state.arch.bytes):
+            if base + offset in skip:
+                continue
+
+            word = data[offset:offset+self.state.arch.bytes]
+            if len(word) < self.state.arch.bytes:
+                replacement_parts.append(claripy.BVV(word))
+                break
+
+            ptr_be = struct.unpack(self._BE_FMT, word)[0]
+            if ptr_be == 0: # common case
+                replacement_parts.append(claripy.BVV(0, self.state.arch.bits))
+                continue
+            ptr_le = struct.unpack(self._LE_FMT, word)[0]
+
+            ptr_mapped = ptr_be if self._should_symbolize(ptr_be) else ptr_le if self._should_symbolize(ptr_le) else None
+            ptr_endness = 'Iend_BE' if ptr_be is ptr_mapped else 'Iend_LE'
+            if ptr_mapped:
+                replaced = True
+                symbol = self._preconstrain('symbolic_pointer', ptr_mapped)
+                l.debug("Replacing %#x (at %#x, endness %s) with %s!", ptr_mapped, base+offset, ptr_endness, symbol)
+                if ptr_endness == 'Iend_LE':
+                    symbol = symbol.reversed
+                replacement_parts.append(symbol)
+            else:
+                replacement_parts.append(claripy.BVV(word))
+
+        if replaced:
+            return claripy.Concat(*replacement_parts)
+        else:
+            return None
 
     def _resymbolize_region(self, storage, addr, length):
         assert type(addr) is int
@@ -113,7 +152,7 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
                 l.debug("Skipping symbolic memory object %s.", mo)
                 continue
 
-            aligned_base = mo.base + mo.base % (self.state.arch.bytes)
+            aligned_base = mo.base - mo.base % (-self.state.arch.bytes)
             remaining_len = mo.last_addr + 1 - aligned_base
             if remaining_len < self.state.arch.bytes:
                 continue
@@ -123,45 +162,23 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
                 data = self.state.solver.eval_one(data, cast_to=bytes)
             #assert self.state.solver.eval_one(storage.load(aligned_base, remaining_len, endness='Iend_BE'), cast_to=bytes).rjust(self.state.arch.bytes) == data
 
-            replacement_parts = [ ]
-            if aligned_base != mo.base:
-                replacement_parts.append(mo.bytes_at(mo.base, mo.length - remaining_len))
-
-            replaced = False
-            for offset in range(0, remaining_len, self.state.arch.bytes):
-                word = data[offset:offset+self.state.arch.bytes]
-                if len(word) < self.state.arch.bytes:
-                    replacement_parts.append(claripy.BVV(word))
-                    break
-
-                ptr_be = struct.unpack(self._BE_FMT, word)[0]
-                if ptr_be == 0: # common case
-                    replacement_parts.append(claripy.BVV(0, self.state.arch.bits))
-                    continue
-                ptr_le = struct.unpack(self._LE_FMT, word)[0]
-
-                ptr_mapped = ptr_be if self._should_symbolize(ptr_be) else ptr_le if self._should_symbolize(ptr_le) else None
-                ptr_endness = 'Iend_BE' if ptr_be is ptr_mapped else 'Iend_LE'
-                if ptr_mapped:
-                    replaced = True
-                    symbol = self._preconstrain('symbolic_pointer', ptr_mapped)
-                    if ptr_endness == 'Iend_LE':
-                        symbol = symbol.reversed
-                    replacement_parts.append(symbol)
-                else:
-                    replacement_parts.append(claripy.BVV(word))
-
-            if replaced:
-                replacement_content = claripy.Concat(*replacement_parts)
+            replacement_content = self._resymbolize_data(
+                data,
+                base=aligned_base,
+                prefix=mo.bytes_at(mo.base, mo.length - remaining_len) if aligned_base != mo.base else b"",
+                skip=() if storage is self.state.memory else (self.state.arch.ip_offset)
+            )
+            if replacement_content is not None:
                 storage.mem.replace_memory_object(mo, replacement_content)
 
     def resymbolize(self):
-        for i, p_id in enumerate(self.state.registers.mem._pages):
-            if i % 100 == 0:
-                l.debug("%s/%s register pages symbolized", i, len(self.state.registers.mem._pages))
-            addr_start = self.state.registers.mem._page_addr(p_id)
-            length = self.state.registers.mem._page_size
-            self._resymbolize_region(self.state.registers, addr_start, length)
+        #for i, p_id in enumerate(self.state.registers.mem._pages):
+        #   if i % 100 == 0:
+        #       l.debug("%s/%s register pages symbolized", i, len(self.state.registers.mem._pages))
+        #   addr_start = self.state.registers.mem._page_addr(p_id)
+        #   length = self.state.registers.mem._page_size
+        #   self._resymbolize_region(self.state.registers, addr_start, length)
+        #self._resymbolize_region(self.state.registers, self.state.arch.sp_offset, 8)
 
         for i, p_id in enumerate(self.state.memory.mem._pages):
             if i % 100 == 0:
@@ -176,7 +193,7 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
         sc._symbolize_all = self._symbolize_all
         sc.symbolization_target_pages = set(self.symbolization_target_pages)
         sc.ignore_target_pages = set(self.ignore_target_pages)
-        sc.pointer_symbols = dict(self.pointer_symbols)
+        sc.symbolized_count = self.symbolized_count
         sc._LE_FMT = self._LE_FMT
         sc._BE_FMT = self._BE_FMT
         return sc

--- a/angr/state_plugins/symbolizer.py
+++ b/angr/state_plugins/symbolizer.py
@@ -198,7 +198,7 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
     def resymbolize(self):
         #for i, p_id in enumerate(self.state.registers.mem._pages):
         #   if i % 100 == 0:
-        #       l.debug("%s/%s register pages symbolized", i, len(self.state.registers.mem._pages))
+        #       l.info("%s/%s register pages symbolized", i, len(self.state.registers.mem._pages))
         #   addr_start = self.state.registers.mem._page_addr(p_id)
         #   length = self.state.registers.mem._page_size
         #   self._resymbolize_region(self.state.registers, addr_start, length)
@@ -206,7 +206,7 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
 
         for i, p_id in enumerate(self.state.memory.mem._pages):
             if i % 100 == 0:
-                l.debug("%s/%s memory pages symbolized", i, len(self.state.memory.mem._pages))
+                l.info("%s/%s memory pages symbolized", i, len(self.state.memory.mem._pages))
             addr_start = self.state.memory.mem._page_addr(p_id)
             length = self.state.memory.mem._page_size
             self._resymbolize_region(self.state.memory, addr_start, length)

--- a/angr/state_plugins/symbolizer.py
+++ b/angr/state_plugins/symbolizer.py
@@ -1,0 +1,185 @@
+import logging
+import claripy
+import struct
+
+l = logging.getLogger(name=__name__)
+
+def _mem_write_cb(s): s.symbolizer._mem_write_callback()
+def _mem_read_cb(s): s.symbolizer._mem_read_callback()
+def _reg_write_cb(s): s.symbolizer._reg_write_callback()
+def _reg_read_cb(s): s.symbolizer._reg_read_callback()
+def _page_map_cb(s): s.symbolizer._page_map_callback()
+
+from .plugin import SimStatePlugin
+class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
+    def __init__(self):
+        SimStatePlugin.__init__(self)
+
+        self._symbolize_all = False
+        self.symbolization_target_pages = set()
+        self.pointer_symbols = { }
+        self.ignore_target_pages = set()
+
+        self._LE_FMT = None
+        self._BE_FMT = None
+
+    def _page_map_callback(self):
+        if self._symbolize_all:
+            self.symbolization_target_pages.add(self.state.inspect.mapped_address//0x1000)
+
+    def _mem_write_callback(self):
+        if not isinstance(self.state.inspect.mem_write_expr, int) and self.state.inspect.mem_write_expr.symbolic:
+            return
+        if not isinstance(self.state.inspect.mem_write_length, int) and self.state.inspect.mem_write_length.symbolic:
+            return
+
+        length = self.state.solver.eval_one(self.state.inspect.mem_write_length)
+        if length != self.state.arch.bytes:
+            return
+
+        expr = self.state.solver.eval_one(self.state.inspect.mem_write_expr)
+        if self._should_symbolize(expr):
+            print("asdf", self.state.inspect.mem_write_expr, self.state.inspect.mem_write_length)
+            self.state.inspect.mem_write_expr = self._preconstrain('symbolic_ptr_mem', expr)
+
+    def _reg_write_callback(self):
+        if not isinstance(self.state.inspect.reg_write_expr, int) and self.state.inspect.reg_write_expr.symbolic:
+            return
+        if not isinstance(self.state.inspect.reg_write_length, int) and self.state.inspect.reg_write_length.symbolic:
+            return
+
+        length = self.state.solver.eval_one(self.state.inspect.reg_write_length)
+        if length != self.state.arch.bytes:
+            return
+
+        expr = self.state.solver.eval_one(self.state.inspect.reg_write_expr)
+        if self._should_symbolize(expr):
+            print("fdsa", self.state.inspect.reg_write_expr, self.state.inspect.reg_write_length)
+            self.state.inspect.reg_write_expr = self._preconstrain('symbolic_ptr_reg', expr)
+
+    def init_state(self):
+        super().init_state()
+        self._LE_FMT = self.state.arch.struct_fmt(endness='Iend_LE')
+        self._BE_FMT = self.state.arch.struct_fmt(endness='Iend_BE')
+
+        # ignore CLE pages
+        for i in range(0, self.state.project.loader.kernel_object.map_size, 0x1000):
+            self.ignore_target_pages.add((self.state.project.loader.kernel_object.mapped_base+i)//0x1000)
+        for i in range(0, self.state.project.loader.extern_object.map_size, 0x1000):
+            self.ignore_target_pages.add((self.state.project.loader.extern_object.mapped_base+i)//0x1000)
+
+        self.state.inspect.make_breakpoint('memory_page_map', when=self.state.inspect.BP_BEFORE, action=_page_map_cb)
+        self.state.inspect.make_breakpoint('mem_write', when=self.state.inspect.BP_BEFORE, action=_mem_write_cb)
+        #self.state.inspect.make_breakpoint('mem_read', when=self.state.inspect.BP_BEFORE, action=_mem_read_cb)
+        self.state.inspect.make_breakpoint('reg_write', when=self.state.inspect.BP_BEFORE, action=_reg_write_cb)
+        #self.state.inspect.make_breakpoint('reg_read', when=self.state.inspect.BP_BEFORE, action=_reg_read_cb)
+
+    def set_symbolization_for_all_pages(self):
+        self._symbolize_all = True
+        self.symbolization_target_pages.update(set(self.state.memory.mem._pages.keys()))
+        # handle bigger pages
+        for pg in self.state.memory.mem._pages.values():
+            if pg._page_size != 0x1000:
+                self.symbolization_target_pages.update(pg._page_size + i for i in range(0, pg._page_size, 0x1000))
+
+    def set_symbolized_target_range(self, base, length):
+        base_page = base // 0x1000
+        pages = (length + base % 0x1000 + 0x999) // 0x1000
+        assert pages > 0
+        self.symbolization_target_pages.update(range(base_page, base_page+pages))
+
+    def set_symbolized_target(self, base):
+        return self.set_symbolized_target_range(base, 1)
+
+    def _preconstrain(self, name, value):
+        symbol = claripy.BVS(name, self.state.arch.bits)
+        self.state.solver.add(symbol == claripy.BVV(value, self.state.arch.bits))
+        self.pointer_symbols[name] = symbol
+        return symbol
+
+    def _should_symbolize(self, addr):
+        return addr//0x1000 in self.symbolization_target_pages and not addr//0x1000 in self.ignore_target_pages
+
+    def _resymbolize_region(self, storage, addr, length):
+        assert type(addr) is int
+        assert type(length) is int
+
+        self.state.scratch.push_priv(True)
+        memory_objects = storage.mem.load_objects(addr, length)
+        self.state.scratch.pop_priv()
+
+        for _,mo in memory_objects:
+            if not mo.is_bytes and mo.object.symbolic:
+                l.debug("Skipping symbolic memory object %s.", mo)
+                continue
+
+            aligned_base = mo.base + mo.base % (self.state.arch.bytes)
+            remaining_len = mo.last_addr + 1 - aligned_base
+            if remaining_len < self.state.arch.bytes:
+                continue
+
+            data = mo.bytes_at(aligned_base, remaining_len, allow_concrete=True)
+            if not mo.is_bytes:
+                data = self.state.solver.eval_one(data, cast_to=bytes)
+            #assert self.state.solver.eval_one(storage.load(aligned_base, remaining_len, endness='Iend_BE'), cast_to=bytes).rjust(self.state.arch.bytes) == data
+
+            replacement_parts = [ ]
+            if aligned_base != mo.base:
+                replacement_parts.append(mo.bytes_at(mo.base, mo.length - remaining_len))
+
+            replaced = False
+            for offset in range(0, remaining_len, self.state.arch.bytes):
+                word = data[offset:offset+self.state.arch.bytes]
+                if len(word) < self.state.arch.bytes:
+                    replacement_parts.append(claripy.BVV(word))
+                    break
+
+                ptr_be = struct.unpack(self._BE_FMT, word)[0]
+                if ptr_be == 0: # common case
+                    replacement_parts.append(claripy.BVV(0, self.state.arch.bits))
+                    continue
+                ptr_le = struct.unpack(self._LE_FMT, word)[0]
+
+                ptr_mapped = ptr_be if self._should_symbolize(ptr_be) else ptr_le if self._should_symbolize(ptr_le) else None
+                ptr_endness = 'Iend_BE' if ptr_be is ptr_mapped else 'Iend_LE'
+                if ptr_mapped:
+                    replaced = True
+                    symbol = self._preconstrain('symbolic_pointer', ptr_mapped)
+                    if ptr_endness == 'Iend_LE':
+                        symbol = symbol.reversed
+                    replacement_parts.append(symbol)
+                else:
+                    replacement_parts.append(claripy.BVV(word))
+
+            if replaced:
+                replacement_content = claripy.Concat(*replacement_parts)
+                storage.mem.replace_memory_object(mo, replacement_content)
+
+    def resymbolize(self):
+        for i, p_id in enumerate(self.state.registers.mem._pages):
+            if i % 100 == 0:
+                l.debug("%s/%s register pages symbolized", i, len(self.state.registers.mem._pages))
+            addr_start = self.state.registers.mem._page_addr(p_id)
+            length = self.state.registers.mem._page_size
+            self._resymbolize_region(self.state.registers, addr_start, length)
+
+        for i, p_id in enumerate(self.state.memory.mem._pages):
+            if i % 100 == 0:
+                l.debug("%s/%s memory pages symbolized", i, len(self.state.memory.mem._pages))
+            addr_start = self.state.memory.mem._page_addr(p_id)
+            length = self.state.memory.mem._page_size
+            self._resymbolize_region(self.state.memory, addr_start, length)
+
+    @SimStatePlugin.memo
+    def copy(self, memo): # pylint: disable=unused-argument
+        sc = SimSymbolizer()
+        sc._symbolize_all = self._symbolize_all
+        sc.symbolization_target_pages = set(self.symbolization_target_pages)
+        sc.ignore_target_pages = set(self.ignore_target_pages)
+        sc.pointer_symbols = dict(self.pointer_symbols)
+        sc._LE_FMT = self._LE_FMT
+        sc._BE_FMT = self._BE_FMT
+        return sc
+
+from angr.sim_state import SimState
+SimState.register_default('symbolizer', SimSymbolizer)

--- a/angr/state_plugins/symbolizer.py
+++ b/angr/state_plugins/symbolizer.py
@@ -209,7 +209,7 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
                 data,
                 base=aligned_base,
                 prefix=mo.bytes_at(mo.base, mo.length - remaining_len) if aligned_base != mo.base else b"",
-                skip=() if storage is self.state.memory else (self.state.arch.ip_offset)
+                skip=() if storage is self.state.memory else (self.state.arch.ip_offset,)
             )
             if replacement_content is not None:
                 storage.mem.replace_memory_object(mo, replacement_content)

--- a/angr/state_plugins/symbolizer.py
+++ b/angr/state_plugins/symbolizer.py
@@ -75,6 +75,8 @@ class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
 
     def init_state(self):
         super().init_state()
+        assert self.state.memory.mem._page_size == PAGE_SIZE
+
         self._LE_FMT = self.state.arch.struct_fmt(endness='Iend_LE')
         self._BE_FMT = self.state.arch.struct_fmt(endness='Iend_BE')
 

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -473,8 +473,7 @@ class SimPagedMemory:
                     if ret_on_segv:
                         break
                     raise SimSegfaultError(addr, 'read-miss')
-                else:
-                    continue
+                continue
 
             if self.allow_segv and not page.concrete_permissions & Page.PROT_READ:
                 #print "... SEGV"
@@ -499,7 +498,7 @@ class SimPagedMemory:
         )
 
         if self.state:
-            self.state._inspect('memory_page_map', BP_BEFORE, mapped_page=pg)
+            self.state._inspect('memory_page_map', BP_AFTER, mapped_page=pg)
             self.state._inspect_getattr('mapped_page', pg)
         return pg
 
@@ -757,8 +756,7 @@ class SimPagedMemory:
         except KeyError:
             if self.allow_segv:
                 raise SimSegfaultError(mo.base, 'write-miss')
-            else:
-                raise
+            raise
         if self.allow_segv and not page.concrete_permissions & Page.PROT_WRITE:
             raise SimSegfaultError(mo.base, 'non-writable')
 

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -490,13 +490,17 @@ class SimPagedMemory:
     #
 
     def _create_page(self, page_num, permissions=None):
-        self.state._inspect('memory_page_map', BP_BEFORE, mapped_address=page_num*self._page_size)
+        if self.state:
+            self.state._inspect('memory_page_map', BP_BEFORE, mapped_address=page_num*self._page_size)
+
         pg = Page(
             page_num*self._page_size, self._page_size,
             executable=self._executable_pages, permissions=permissions
         )
-        self.state._inspect('memory_page_map', BP_BEFORE, mapped_page=pg)
-        self.state._inspect_getattr('mapped_page', pg)
+
+        if self.state:
+            self.state._inspect('memory_page_map', BP_BEFORE, mapped_page=pg)
+            self.state._inspect_getattr('mapped_page', pg)
         return pg
 
     def _initialize_page(self, n, new_page):

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -490,10 +490,14 @@ class SimPagedMemory:
     #
 
     def _create_page(self, page_num, permissions=None):
-        return Page(
+        self.state._inspect('memory_page_map', BP_BEFORE, mapped_address=page_num*self._page_size)
+        pg = Page(
             page_num*self._page_size, self._page_size,
             executable=self._executable_pages, permissions=permissions
         )
+        self.state._inspect('memory_page_map', BP_BEFORE, mapped_page=pg)
+        self.state._inspect_getattr('mapped_page', pg)
+        return pg
 
     def _initialize_page(self, n, new_page):
         if n in self._initialized:
@@ -1141,3 +1145,4 @@ class SimPagedMemory:
 
 
 from .. import sim_options as o
+from ..state_plugins.inspect import BP_BEFORE, BP_AFTER

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -489,7 +489,7 @@ class SimPagedMemory:
     #
 
     def _create_page(self, page_num, permissions=None):
-        if self.state:
+        if self.state is not None:
             self.state._inspect('memory_page_map', BP_BEFORE, mapped_address=page_num*self._page_size)
 
         pg = Page(
@@ -497,7 +497,7 @@ class SimPagedMemory:
             executable=self._executable_pages, permissions=permissions
         )
 
-        if self.state:
+        if self.state is not None:
             self.state._inspect('memory_page_map', BP_AFTER, mapped_page=pg)
             self.state._inspect_getattr('mapped_page', pg)
         return pg

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -792,7 +792,7 @@ class SimPagedMemory:
         :returns: the new memory object
         """
 
-        if old.object.size() != new_content.size():
+        if (old.object.size() if not old.is_bytes else len(old.object)*self.state.arch.byte_width) != new_content.size():
             raise SimMemoryError("memory objects can only be replaced by the same length content")
 
         new = SimMemoryObject(new_content, old.base, byte_width=self.byte_width)

--- a/tests/test_symbolization.py
+++ b/tests/test_symbolization.py
@@ -1,0 +1,26 @@
+import angr
+import os
+
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
+
+def test_fauxware_symbolization():
+	p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"))
+	sm = p.factory.simulation_manager()
+
+	assert not sm.one_active.regs.rsp.symbolic
+
+	sm.one_active.symbolizer.set_symbolization_for_all_pages()
+	sm.one_active.symbolizer.resymbolize()
+
+	assert sm.one_active.regs.rsp.symbolic
+	assert sm.one_active.symbolizer.pointer_symbols
+
+	# make sure pointers get symbolized at runtime
+	n = len(sm.one_active.symbolizer.pointer_symbols)
+	sm.run()
+	assert not sm.errored
+	assert not sm.active
+	assert len(sm.one_deadended.symbolizer.pointer_symbols) > n
+
+if __name__ == '__main__':
+	test_fauxware_symbolization()

--- a/tests/test_symbolization.py
+++ b/tests/test_symbolization.py
@@ -12,15 +12,15 @@ def test_fauxware_symbolization():
 	sm.one_active.symbolizer.set_symbolization_for_all_pages()
 	sm.one_active.symbolizer.resymbolize()
 
-	assert sm.one_active.regs.rsp.symbolic
-	assert sm.one_active.symbolizer.pointer_symbols
+	#assert sm.one_active.regs.rsp.symbolic
+	assert sm.one_active.symbolizer.symbolized_count
 
 	# make sure pointers get symbolized at runtime
-	n = len(sm.one_active.symbolizer.pointer_symbols)
+	n = sm.one_active.symbolizer.symbolized_count
 	sm.run()
 	assert not sm.errored
 	assert not sm.active
-	assert len(sm.one_deadended.symbolizer.pointer_symbols) > n
+	assert sm.one_deadended.symbolizer.symbolized_count > n
 
 if __name__ == '__main__':
 	test_fauxware_symbolization()


### PR DESCRIPTION
This moves the ad-hoc pointer symbolization functionality into an angr plugin. By using `state.symbolizer`, one can ensure that every pointer written to memory turns into a symbolic expression representing its offset from a per-page symbolic variable.

A lot of effort was made to make this as fast as possible, while maintaining generality.