### PR TITLE
Do not filter THUMB successors if they are obviously legit.

### DIFF
--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1456,8 +1456,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         """
 
         if sim_successors.sort == 'IRSB' and input_state.thumb:
-            successors = self._arm_thumb_filter_jump_successors(sim_successors.addr,
-                                                                sim_successors.artifacts['irsb'].size,
+            successors = self._arm_thumb_filter_jump_successors(sim_successors.artifacts['irsb'],
                                                                 successors,
                                                                 lambda state: state.scratch.ins_addr,
                                                                 lambda state: state.scratch.exit_stmt_idx

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1459,7 +1459,8 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             successors = self._arm_thumb_filter_jump_successors(sim_successors.artifacts['irsb'],
                                                                 successors,
                                                                 lambda state: state.scratch.ins_addr,
-                                                                lambda state: state.scratch.exit_stmt_idx
+                                                                lambda state: state.scratch.exit_stmt_idx,
+                                                                lambda state: state.history.jumpkind,
                                                                 )
 
         # If there is a call exit, we shouldn't put the default exit (which

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1075,7 +1075,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             successors = self._arm_thumb_filter_jump_successors(irsb,
                                                                 successors,
                                                                 lambda tpl: tpl[1],
-                                                                lambda tpl: tpl[0]
+                                                                lambda tpl: tpl[0],
+                                                                lambda tpl: tpl[3],
                                                                 )
 
         return successors

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1068,12 +1068,11 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
     def _widen_jobs(self, *jobs):
         pass
 
-    def _post_process_successors(self, addr, size, successors):
+    def _post_process_successors(self, irsb, successors):
 
-        if is_arm_arch(self.project.arch) and addr % 2 == 1:
+        if is_arm_arch(self.project.arch) and irsb.addr % 2 == 1:
             # we are in thumb mode. filter successors
-            successors = self._arm_thumb_filter_jump_successors(addr,
-                                                                size,
+            successors = self._arm_thumb_filter_jump_successors(irsb,
                                                                 successors,
                                                                 lambda tpl: tpl[1],
                                                                 lambda tpl: tpl[0]
@@ -1536,7 +1535,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         entries = [ ]
 
-        successors = self._post_process_successors(addr, irsb.size, successors)
+        successors = self._post_process_successors(irsb, successors)
 
         # Process each successor
         for suc in successors:

--- a/angr/blade.py
+++ b/angr/blade.py
@@ -85,14 +85,14 @@ class Blade:
 
         s = ""
 
-        block_addrs = list(set([ a for a, _ in self.slice.nodes() ]))
+        block_addrs = { a for a, _ in self.slice.nodes() }
 
         for block_addr in block_addrs:
             block_str = "       IRSB %#x\n" % block_addr
 
             block = self.project.factory.block(block_addr, backup_state=self._base_state).vex
 
-            included_stmts = set([ stmt for _, stmt in self.slice.nodes() if _ == block_addr ])
+            included_stmts = { stmt for _, stmt in self.slice.nodes() if _ == block_addr }
             default_exit_included = any(stmt == DEFAULT_STATEMENT for _, stmt in self.slice.nodes() if _ == block_addr)
 
             for i, stmt in enumerate(block.statements):
@@ -155,7 +155,7 @@ class Blade:
                 raise AngrBladeError("Project must be specified if you give me all addresses for SimRuns")
 
         else:
-            raise AngrBladeError('Unsupported SimRun argument type %s', type(v))
+            raise AngrBladeError('Unsupported SimRun argument type %s' % type(v))
 
     def _get_cfgnode(self, thing):
         """
@@ -168,7 +168,8 @@ class Blade:
 
         return self._cfg.get_any_node(self._get_addr(thing))
 
-    def _get_addr(self, v):
+    @staticmethod
+    def _get_addr(v):
         """
         Get address of the basic block or CFG node specified by v.
         :param v: Can be one of the following: a CFGNode, or an address.


### PR DESCRIPTION
These new checks will handle the majority of cases and prevent them from going through the slow path in ARM THUMB binaries that I tested.