### PR TITLE
[wip] Add tests using real firmware (aka The Great ARM CFG Challenge)

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -9,6 +9,8 @@ except ImportError:
     tracer = None
 
 bin_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries')
+bin_priv_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries-private')
+
 if not os.path.isdir(bin_location):
     raise Exception("Can't find the angr/binaries repo for holding testcases. It should be cloned into the same folder as the rest of your angr modules.")
 

--- a/tests/test_real_firmware.py
+++ b/tests/test_real_firmware.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+
+# A note from EDG:
+#
+# Hello angr community! We're insane, so we test angr on the real-est real binaries on the planet.
+# How real? Well, so real we can't give them to you. Sorry!
+# But rest assured, these are big, massive, complex binaries, with interrupts, weird hardware, DMA, etc, and no
+# operating system to make things easier.
+#
+# If these tests break, contact @subwire (or, likely, he will find you)
+
+from common import bin_priv_location, slow_test
+import os
+import angr
+
+
+def load_econet():
+    b = os.path.join(bin_priv_location, "firmware_party", "rheem_econet", "RH-WIFI-02-01-05.bin")
+    p = angr.Project(b, main_opts={'base_addr': 0x1f000000, 'arch': 'ARMCortexM', 'backend': 'blob', 'entry_point': 0x1f0051b9})
+    return p
+
+
+def load_mycarelink():
+    b = os.path.join(bin_priv_location, "firmware_party", "mycarelink", "mycarelink-from_app.bin")
+    p = angr.Project(b, main_opts={'base_addr': 0x08044000,
+                                   'arch': 'ARMCortexM',
+                                   'backend': 'blob',
+                                   'entry_point': 0x08049509})
+    return p
+
+
+def load_omnipod():
+    b = os.path.join(bin_priv_location, "firmware_party", "omnipod_pdm", "flash.bin")
+    p = angr.Project(b, main_opts={'base_addr': 0xc8000000, 'arch': 'ARMEL', 'backend': 'blob', 'entry_point': 0xc8000000})
+    return p
+
+
+def load_controllogix():
+    b = os.path.join(bin_priv_location, "firmware_party", "ab_controllogix", "PN-337140.bin")
+    p = angr.Project(b, main_opts={'base_addr': 0x100000, 'arch': 'ARMEL', 'backend': 'blob', 'entry_point': 0x100000})
+    return p
+
+
+def cfg_it(p):
+    cfg = p.analyses.CFGFast(function_prologues=True,
+                             resolve_indirect_jumps=True,
+                             force_complete_scan=False,
+                             show_progressbar=True,
+                             normalize=True,
+                             detect_tail_calls=True,
+                             cross_references=True)
+    return cfg
+
+@slow_test
+def test_econet_cfg():
+    """
+    Econet CFG smoketest
+    :return:
+    """
+    p = load_econet()
+    _ = cfg_it(p)
+
+
+@slow_test
+def test_controllogix_cfg():
+    """
+    ControlLogix CFG smoketest
+    :return:
+    """
+    p = load_controllogix()
+    _ = cfg_it(p)
+
+
+@slow_test
+def test_omnipod_cfg():
+    """
+    MyCareLink CFG smoketest
+    :return:
+    """
+    p = load_omnipod()
+    _ = cfg_it(p)
+
+@slow_test
+def test_mycarelink_cfg():
+    p = load_mycarelink()
+    _ = cfg_it(p)
+
+if __name__ == '__main__':
+    test_mycarelink_cfg()
+    test_controllogix_cfg()
+    test_econet_cfg()
+    test_omnipod_cfg()
+    


### PR DESCRIPTION
It's like the gross "great american challenge" the undergrads do, but instead you have to race to finish the CFG of:
- A 30-pack of ARM firmware example code
- An extra-large PLC
- A 30-gallon smart water heater
- The insulin pump you'd need after doing the real "great american challenge"
- An actual [redacted so they don't send the lawyers]

...and then attempt to solve reaching definitions, all before midnight.  If you OOM or coredump all over the place, you're out.

Can you survive the challenge? #NeverSkipARMDay


(Joking aside, these are huge real-world tests extracted from actual stuff.  We can't release them, so they're in binaries-private. If these tests break, ask me or Fish.  They are rigged to eventually run in the forthcoming nightly CI.  They are collectively responsible for the discovery of most of the ARM CFG bugs in the past year. As of this writing, these tests murder my system, which is why I'm not merging them immediately)