### PR TITLE
Remove broken dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,6 @@ setup(
         'capstone>=3.0.5rc2',
         'cooldict',
         'dpkt',
-        'futures; python_version == "2.7"',
         'mulpyplexer',
         'networkx>=2.0',
         'progressbar',


### PR DESCRIPTION
Closes #1667 .

  * [futures](https://pypi.org/project/futures/) is a backport to Python2
  of the `concurrent.futures` module in the Python3 standard library;
  * And angr does not support Python2 anymore.