### PR TITLE
add project.filename as part of cfg_key for cfg_cache

### DIFF
--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -103,7 +103,7 @@ class CallTracingFilter(object):
                 l.debug('Rejecting target 0x%x - syscall %s not in whitelist', addr, type(next_run))
                 return REJECT
 
-        cfg_key = (addr, jumpkind)
+        cfg_key = (addr, jumpkind, self.project.filename)
         if cfg_key not in self.cfg_cache:
             new_blacklist = self.blacklist[ :: ]
             new_blacklist.append(addr)
@@ -528,7 +528,7 @@ class Veritesting(Analysis):
         state = self._input_state
         ip_int = state.addr
 
-        cfg_key = (ip_int, state.history.jumpkind)
+        cfg_key = (ip_int, state.history.jumpkind, self.project.filename)
         if cfg_key in self.cfg_cache:
             cfg, cfg_graph_with_loops = self.cfg_cache[cfg_key]
         else:


### PR DESCRIPTION
Veritesting analyses in angr uses `cfg_cache` to save the cfg it generated before. 

But the `cfg_key` only consists of `addr` and `jumpkind`, without the project filename. It would mistakenly hit `cfg_cache` when we analyze several projects very similar to each others in sequence ( i.e.,  a binary without security patch and its patched version). 

Adding `project.filename` to `cfg_key` would fix the problem.