### PR TITLE
Function Definitions application and some related changes

### DIFF
--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -4,7 +4,8 @@ import networkx
 import string
 import itertools
 from collections import defaultdict
-from typing import Union, Optional, Type
+from typing import Union, Optional
+from typing import Type # For some reasons the linter doesn't recognize the use in apply_definition but PyCharm needs it imported to correctly recognize it # pylint: disable=unused-import
 
 from itanium_demangler import parse
 
@@ -23,7 +24,7 @@ from .function_parser import FunctionParser
 l = logging.getLogger(name=__name__)
 
 from ...sim_type import SimTypeFunction, parse_defns
-from ...calling_conventions import SimCC, DefaultCC
+from ...calling_conventions import SimCC
 from ...project import Project
 
 
@@ -1323,7 +1324,7 @@ class Function(Serializable):
 
         :param str definition:
         :param Optional[Union[SimCC, Type[SimCC]]] calling_convention:
-        :return:
+        :return None:
         """
         if not definition.endswith(";"):
             definition += ";"
@@ -1349,11 +1350,6 @@ class Function(Serializable):
 
         else:
             raise TypeError("calling_convention has to be one of: [SimCC, type(SimCC), None]")
-
-
-
-
-        return
 
     def copy(self):
         func = Function(self._function_manager, self.addr, name=self.name, syscall=self.is_syscall)

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1328,13 +1328,12 @@ class Function(Serializable):
         """
         if not definition.endswith(";"):
             definition += ";"
-        func_def = parse_defns(definition) # type: Union
+        func_def = parse_defns(definition)
         if len(func_def.keys()) > 1:
             raise Exception("Too many definitions: %s " % list(func_def.keys()))
 
-        name, ty = func_def.popitem()
+        name, ty = func_def.popitem() # type: str, SimTypeFunction
         self.name = name
-
         # setup the calling convention
         # If a SimCC object is passed assume that this is sane and just use it
         if isinstance(calling_convention, SimCC):

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -332,11 +332,11 @@ class Function(Serializable):
     @prototype.setter
     def prototype(self, proto):
         """
-        :param SimTypeFunction proto:
+        :param Optional[SimTypeFunction] proto:
         :return:
         """
         if self.calling_convention:
-            self.calling_convention.func_ty = proto.with_arch(self.project.arch)
+            self.calling_convention.func_ty = proto.with_arch(self.project.arch) if proto else None
             logging.warning("Changing function prototype while calling convention is set, please use .calling_convention.func_ty")
         else:
             self._prototype = proto

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -336,7 +336,7 @@ class Function(Serializable):
         """
         if self.calling_convention:
             self.calling_convention.func_ty = proto.with_arch(self.project.arch)
-            raise DeprecationWarning("Changing function prototype while calling convention is set, please use .calling_convention.func_ty")
+            logging.warning("Changing function prototype while calling convention is set, please use .calling_convention.func_ty")
         else:
             self._prototype = proto
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -33,7 +33,8 @@ def test_function_definition_application():
 
     # Check prototype of function
     nose.tools.assert_equal(func_main.prototype.args,
-                            [angr.sim_type.SimTypeInt(), angr.sim_type.SimTypePointer(angr.sim_type.SimTypePointer(angr.sim_type.SimTypeChar()))])
+                            [angr.sim_type.SimTypeInt().with_arch(p.arch), angr.sim_type.SimTypePointer(
+                                angr.sim_type.SimTypePointer(angr.sim_type.SimTypeChar()).with_arch(p.arch)).with_arch(p.arch)])
     # Check that the default calling convention of the architecture was applied
     nose.tools.assert_true(isinstance(func_main.calling_convention, angr.calling_conventions.DefaultCC[p.arch.name]))
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -23,6 +23,21 @@ def test_function_serialization():
     nose.tools.assert_equal(func_main.addr, f.addr)
     nose.tools.assert_equal(func_main.name, f.name)
 
+def test_function_definition_application():
+    p = angr.Project(os.path.join(test_location, 'x86_64', 'fauxware'), auto_load_libs=False)
+    cfg = p.analyses.CFG()
+    func_main = cfg.kb.functions['main'] # type: angr.knowledge_plugins.Function
+
+
+    func_main.apply_definition("int main(int argc, char** argv)")
+
+    # Check prototype of function
+    nose.tools.assert_equal(func_main.prototype.args,
+                            [angr.sim_type.SimTypeInt(), angr.sim_type.SimTypePointer(angr.sim_type.SimTypePointer(angr.sim_type.SimTypeChar()))])
+    # Check that the default calling convention of the architecture was applied
+    nose.tools.assert_true(isinstance(func_main.calling_convention, angr.calling_conventions.DefaultCC[p.arch.name]))
+
+    func_main.apply_definition("int main(int argc, char** argv)")
 
 def test_function_instruction_addr_from_any_addr():
 
@@ -40,4 +55,5 @@ def test_function_instruction_addr_from_any_addr():
 
 if __name__ == "__main__":
     test_function_serialization()
+    test_function_definition_application()
     test_function_instruction_addr_from_any_addr()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -164,6 +164,11 @@ def test_arg_names():
     sig = fdef['f']
     nose.tools.assert_equal(sig.arg_names, ['param_1', 'param_2'])
 
+    # Check that arg_names survive a with_arch call
+    nsig = sig.with_arch(angr.archinfo.ArchAMD64())
+    nose.tools.assert_equal(sig.arg_names, nsig.arg_names,
+                            "Function type generated with .with_arch() doesn't have identical arg_names")
+
     # If for some reason only some of the parameters are named, the list can only be partially not None, but has to match the positions
     fdef = angr.types.parse_defns("int f(int param1, int);") # type: Dict[str, SimTypeFunction]
     sig = fdef['f']


### PR DESCRIPTION
I wanted a function that I could use to quickly apply a signature like `'int main(int argc, char** argv)'` to a function object in the kb. Preferably with some way to also specify (or even parse from the definition) a calling convention in the form of `'stdcall'` and apply this.

One issue is that `function.prototype` and `function.calling_convention.func_ty` both contain more or less the same information (the latter just with arch information?) and could lead to inconsistent information, so I changed prototype to a wrapper that proxies `function.calling_convention.func_ty` if a calling convention exists. This is heavily opinionated, and I am open for suggestions how else to deal with this and avoid inconsistencies while retaining the possibility to specify a prototype without calling convention information.

Concerning the calling convention names: I am not sure if something like `'stdcall'` is already specific enough to generate a calling convention object for some architecture for or if this also requires compiler information. I could not find some mapping from this kind of name to the angr SimCC Classes (in this case `angr.calling_conventions.SimCCStdcall` ). Maybe some dictionary to store this for a project would be helpful, so one could just export the definition of `stdcall` from some other tool like Ghidra once, to then use this when exporting function signatures from that tool without having to convert the calling convention representation every time.
I am also unsure if it is reasonable to just set the default calling convention if a definition is applied or if no calling convention should be set and just the prototype be stored. This would depend on how the conflict between `function.prototype` and `function.calling_convention.func_ty` is dealt with.

Also some type hints because they make the code significantly easier to understand and navigate. 