### PR TITLE
Don't assume func_ty exists for every calling convention

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -14,6 +14,7 @@ from .sim_type import SimTypeDouble
 from .sim_type import SimTypeReg
 from .sim_type import SimStruct
 from .sim_type import parse_file
+from .sim_type import SimTypeTop
 
 from .state_plugins.sim_action_object import SimActionObject
 
@@ -947,10 +948,16 @@ class SimCC:
         :param angr.SimState state: The state to evaluate and extract the values from
         :return:    A list of tuples, where the nth tuple is (type, name, location, value) of the nth argument
         """
-        argument_types = self.func_ty.args
-        argument_names = self.func_ty.arg_names if self.func_ty.arg_names else ['unknown'] * len(self.func_ty.args)
+
         argument_locations = self.arg_locs(is_fp=is_fp, sizes=sizes)
         argument_values = self.get_args(state, is_fp=is_fp, sizes=sizes)
+
+        if self.func_ty:
+            argument_types = self.func_ty.args
+            argument_names = self.func_ty.arg_names if self.func_ty.arg_names else ['unknown'] * len(self.func_ty.args)
+        else:
+            argument_types = [SimTypeTop] * len(argument_locations)
+            argument_names = ['unknown'] * len(argument_locations)
         return list(zip(argument_types, argument_names, argument_locations, argument_values))
 
 class SimLyingRegArg(SimRegArg):


### PR DESCRIPTION
Small issue I ran into, probably no one but me uses this code but it might as well have some saner assumptions before anyone does.