### PR TITLE
Help remove tmp variables in AIL statements

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
@@ -164,6 +164,8 @@ class StackCanarySimplifier(OptimizationPass):
                     continue
 
                 expr = condition.operands[0]
+                if not isinstance(expr, ailment.Expr.UnaryOp):
+                    continue
                 if expr.op != "Xor":
                     continue
                 op0, op1 = expr.operands

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -39,11 +39,18 @@ class SimEnginePropagatorAIL(
                 self.state.store_variable(dst, src)
 
         elif type(dst) is Expr.Register:
-            l.debug("New replacement: %s with %s", dst, src)
-            self.state.store_variable(dst, src)
-
-            # remove previous replacements whose source contains this register
-            self.state.filter_variables(dst)
+            if type(src) is Expr.Tmp:
+                l.debug("%s = %s, replace %s with %s.", dst, src, src, dst)
+                l.debug("New replacement: %s with %s", src, dst)
+                self.state.filter_variables(src)
+                self.state.store_variable(src, dst)
+            elif type(src) is Expr.Const:
+                l.debug("%s = %s, replace %s with %s.", dst, src, dst, src)
+                l.debug("New replacement: %s with %s", dst, src)
+                self.state.filter_variables(dst)
+                self.state.store_variable(dst, src)
+            else:
+                l.debug("%s = %s", dst, src)
         else:
             l.warning('Unsupported type of Assignment dst %s.', type(dst).__name__)
 
@@ -108,7 +115,8 @@ class SimEnginePropagatorAIL(
         if new_expr is not None:
             l.debug("Add a replacement: %s with %s", expr, new_expr)
             self.state.add_replacement(self._codeloc(), expr, new_expr)
-            expr = new_expr
+            if type(new_expr) in [Expr.Register, Expr.Const, Expr.Convert]:
+                expr = new_expr
 
         return expr
 

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -115,7 +115,7 @@ class SimEnginePropagatorAIL(
         if new_expr is not None:
             l.debug("Add a replacement: %s with %s", expr, new_expr)
             self.state.add_replacement(self._codeloc(), expr, new_expr)
-            if type(new_expr) in [Expr.Register, Expr.Const, Expr.Convert]:
+            if type(new_expr) in [Expr.Register, Expr.Const, Expr.Convert, Expr.StackBaseOffset, Expr.BasePointerOffset]:
                 expr = new_expr
 
         return expr

--- a/angr/analyses/reaching_definitions/dataset.py
+++ b/angr/analyses/reaching_definitions/dataset.py
@@ -111,6 +111,12 @@ class DataSet:
     def __sub__(self, other):
         return self._bin_op(other, operator.sub)
 
+    def __mul__(self, other):
+        return self._bin_op(other, operator.mul)
+
+    def __div__(self, other):
+        return self._bin_op(other, operator.floordiv)
+
     def __lshift__(self, other):
         return self._bin_op(other, operator.lshift)
 

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -669,6 +669,46 @@ class SimEngineLightAILMixin:
         except TypeError:
             return ailment.Expr.BinaryOp(expr.idx, 'Sub', [expr_0, expr_1], **expr.tags)
 
+    def _ail_handle_Div(self, expr):
+
+        arg0, arg1 = expr.operands
+
+        expr_0 = self._expr(arg0)
+        expr_1 = self._expr(arg1)
+
+        if expr_0 is None:
+            expr_0 = arg0
+        if expr_1 is None:
+            expr_1 = arg1
+
+        try:
+            return expr_0 // expr_1
+        except TypeError:
+            return ailment.Expr.BinaryOp(expr.idx, 'Div', [expr_0, expr_1], **expr.tags)
+    
+    def _ail_handle_DivMod(self, expr):
+        return self._ail_handle_Div(expr)
+
+    def _ail_handle_Mul(self, expr):
+
+        arg0, arg1 = expr.operands
+
+        expr_0 = self._expr(arg0)
+        expr_1 = self._expr(arg1)
+
+        if expr_0 is None:
+            expr_0 = arg0
+        if expr_1 is None:
+            expr_1 = arg1
+
+        try:
+            return expr_0 * expr_1
+        except TypeError:
+            return ailment.Expr.BinaryOp(expr.idx, 'Mul', [expr_0, expr_1], **expr.tags)
+    
+    def _ail_handle_Mull(self, expr):
+        return self._ail_handle_Mul(expr)
+
     def _ail_handle_And(self, expr):
 
         arg0, arg1 = expr.operands

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -685,7 +685,7 @@ class SimEngineLightAILMixin:
             return expr_0 // expr_1
         except TypeError:
             return ailment.Expr.BinaryOp(expr.idx, 'Div', [expr_0, expr_1], **expr.tags)
-    
+
     def _ail_handle_DivMod(self, expr):
         return self._ail_handle_Div(expr)
 
@@ -705,7 +705,7 @@ class SimEngineLightAILMixin:
             return expr_0 * expr_1
         except TypeError:
             return ailment.Expr.BinaryOp(expr.idx, 'Mul', [expr_0, expr_1], **expr.tags)
-    
+
     def _ail_handle_Mull(self, expr):
         return self._ail_handle_Mul(expr)
 


### PR DESCRIPTION
- Propagator need some these handlers when it meets some conditions.
- Modified assignment handler in propagator engine to help remove tmp variables!