### PR TITLE
Fix CFG get_all_predecessors/successors. Add depth_limit parameter

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -268,12 +268,12 @@ class CFGBase(Analysis):
         return self._model.get_successors_and_jumpkind(node, excluding_fakeret=excluding_fakeret)
 
     @deprecated(replacement="self.model.get_all_predecessors()")
-    def get_all_predecessors(self, cfgnode):
-        return self._model.get_all_predecessors(cfgnode)
+    def get_all_predecessors(self, cfgnode, depth_limit=None):
+        return self._model.get_all_predecessors(cfgnode, depth_limit)
 
     @deprecated(replacement="self.model.get_all_successors()")
-    def get_all_successors(self, cfgnode):
-        return self._model.get_all_successors(cfgnode)
+    def get_all_successors(self, cfgnode, depth_limit=None):
+        return self._model.get_all_successors(cfgnode, depth_limit)
 
     @deprecated(replacement="self.model.get_node()")
     def get_node(self, block_id):

--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -406,26 +406,32 @@ class CFGModel(Serializable):
                 successors.append((suc, data['jumpkind']))
         return successors
 
-    def get_all_predecessors(self, cfgnode):
+    def get_all_predecessors(self, cfgnode, depth_limit=None):
         """
         Get all predecessors of a specific node on the control flow graph.
 
         :param CFGNode cfgnode: The CFGNode object
+        :param int depth_limit: Optional depth limit for the depth-first search
         :return: A list of predecessors in the CFG
         :rtype: list
         """
-        s = set()
-        for child, parent in networkx.dfs_predecessors(self.graph, cfgnode).items():
-            s.add(child)
-            s.add(parent)
-        return list(s)
+        # use the reverse graph and query for successors (networkx.dfs_predecessors is misleading)
+        # dfs_successors returns a dict of (node, [predecessors]). We ignore the keyset and use the values
+        predecessors = set().union(*networkx.dfs_successors(self.graph.reverse(), cfgnode, depth_limit).values())
+        return list(predecessors)
 
-    def get_all_successors(self, cfgnode):
-        s = set()
-        for parent, children in networkx.dfs_successors(self.graph, cfgnode).items():
-            s.add(parent)
-            s = s.union(children)
-        return list(s)
+    def get_all_successors(self, cfgnode, depth_limit=None):
+        """
+        Get all successors of a specific node on the control flow graph.
+
+        :param CFGNode cfgnode: The CFGNode object
+        :param int depth_limit: Optional depth limit for the depth-first search
+        :return: A list of successors in the CFG
+        :rtype: list
+        """
+        # dfs_successors returns a dict of (node, [predecessors]). We ignore the keyset and use the values
+        successors = set().union(*networkx.dfs_successors(self.graph, cfgnode, depth_limit).values())
+        return list(successors)
 
     def get_branching_nodes(self):
         """


### PR DESCRIPTION
In the previous implementation the source node was always included as a successor of itself.
Also, the networkx.dfs_predecessors method returns the successors as a (node, predecessor) list, to fix this the graph is reversed and queried for successors.
depth_limit is added as an optional parameter