### PR TITLE
Check for ENOENT in the unlink SimProcedure

### DIFF
--- a/angr/procedures/linux_kernel/unlink.py
+++ b/angr/procedures/linux_kernel/unlink.py
@@ -17,8 +17,7 @@ class unlink(angr.SimProcedure): #pylint:disable=W0622
 
         # Check if entity exists before attempting to unlink
         if not self.state.fs.get(str_val):
-            self.state.libc.ret_errno('ENOENT')
-            return -1
+            return self.state.libc.ret_errno('ENOENT')
 
         if self.state.fs.delete(str_val):
             return 0

--- a/angr/procedures/linux_kernel/unlink.py
+++ b/angr/procedures/linux_kernel/unlink.py
@@ -15,6 +15,11 @@ class unlink(angr.SimProcedure): #pylint:disable=W0622
         str_expr = self.state.memory.load(path_addr, p_strlen.max_null_index, endness='Iend_BE')
         str_val = self.state.solver.eval(str_expr, cast_to=bytes)
 
+        # Check if entity exists before attempting to unlink
+        if not self.state.fs.get(str_val):
+            self.state.libc.ret_errno('ENOENT')
+            return -1
+
         if self.state.fs.delete(str_val):
             return 0
         else:

--- a/tests/test_unlink.py
+++ b/tests/test_unlink.py
@@ -1,6 +1,10 @@
 import angr
 import nose
+import os
 from unittest.mock import patch, PropertyMock
+
+fauxware_path = \
+str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests/x86_64/fauxware'))
 
 @patch('angr.state_plugins.libc.SimStateLibc.errno',
        new_callable=PropertyMock)
@@ -36,7 +40,7 @@ def test_file_unlink(mock_errno):
             mock_errno.assert_called_once_with(self.state.posix.ENOENT)
 
     # Load the 'fauxware' binary and hook TestProc
-    project = angr.Project('../../binaries/tests/x86_64/fauxware')
+    project = angr.Project(fauxware_path)
     project.hook_symbol('main', TestProc())
     simgr = project.factory.simulation_manager()
     simgr.run()

--- a/tests/test_unlink.py
+++ b/tests/test_unlink.py
@@ -1,47 +1,36 @@
-# pylint: disable=unused-argument, arguments-differ
 import angr
 import nose
-import os
-from unittest.mock import patch, PropertyMock
 
-fauxware_path = \
-str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests/x86_64/fauxware'))
+def test_file_unlink():
+    # Initialize a blank state with an arbitrary errno location
+    state = angr.SimState(arch="AMD64", mode="symbolic")
+    state.libc.errno_location = 0xa0000000
+    state.libc.errno = 0
 
-@patch('angr.state_plugins.libc.SimStateLibc.errno',
-       new_callable=PropertyMock)
-def test_file_unlink(mock_errno):
-    class TestProc(angr.SimProcedure):
-        def run(self, argc, argv):
-            # Load the unlink SimProcedure
-            unlink = angr.SIM_PROCEDURES['posix']['unlink']
+    # Create a file 'test'
+    fd = state.posix.open(b'test', 1)
+    state.posix.close(fd)
 
-            # Create a file 'test'
-            fd = self.state.posix.open(b'test', 1)
-            self.state.posix.close(fd)
+    # Ensure 'test' was in fact created
+    nose.tools.assert_in(b'/test', state.fs._files)
 
-            # Ensure 'test' was in fact created
-            nose.tools.assert_in(b'/home/user/test', self.state.fs._files)
+    # Store the filename in memory
+    path_addr = 0xb0000000
+    state.memory.store(path_addr, b'test\x00')
 
-            # Store the filename in memory
-            malloc = angr.SIM_PROCEDURES['libc']['malloc']
-            addr = self.inline_call(malloc, len('test')).ret_expr
-            self.state.memory.store(addr, b'test\x00')
+    # Unlink 'test': should return 0 and leave ERRNO unchanged
+    unlink = angr.SIM_PROCEDURES['posix']['unlink']()
+    state.scratch.sim_procedure = unlink
+    rval = unlink.execute(state, arguments=[path_addr]).ret_expr
+    nose.tools.assert_equal(rval, 0)
+    nose.tools.assert_equal(state.solver.eval(state.libc.errno), 0)
 
-            # Unlink 'test': should return 0 and leave ERRNO unchanged
-            rval = self.inline_call(unlink, addr).ret_expr
-            nose.tools.assert_equal(rval, 0)
-            mock_errno.assert_not_called()
+    # Check that 'test' was in fact deleted
+    nose.tools.assert_equal(state.fs._files, {})
 
-            # Check that 'test' was in fact deleted
-            nose.tools.assert_equal(self.state.fs._files, {})
-
-            # Unlink again: should return -1 and set ERRNO to ENOENT
-            rval = self.inline_call(unlink, addr).ret_expr
-            nose.tools.assert_equal(rval, -1)
-            mock_errno.assert_called_once_with(self.state.posix.ENOENT)
-
-    # Load the 'fauxware' binary and hook TestProc
-    project = angr.Project(fauxware_path)
-    project.hook_symbol('main', TestProc())
-    simgr = project.factory.simulation_manager()
-    simgr.run()
+    # Unlink again: should return -1 and set ERRNO to ENOENT
+    unlink = angr.SIM_PROCEDURES['posix']['unlink']()
+    state.scratch.sim_procedure = unlink
+    rval = unlink.execute(state, arguments=[path_addr]).ret_expr
+    nose.tools.assert_equal(rval, -1)
+    nose.tools.assert_equal(state.solver.eval(state.libc.errno), state.posix.ENOENT)

--- a/tests/test_unlink.py
+++ b/tests/test_unlink.py
@@ -1,0 +1,42 @@
+import angr
+import nose
+from unittest.mock import patch, PropertyMock
+
+@patch('angr.state_plugins.libc.SimStateLibc.errno',
+       new_callable=PropertyMock)
+def test_file_unlink(mock_errno):
+    class TestProc(angr.SimProcedure):
+        def run(self, argc, argv):
+            # Load the unlink SimProcedure
+            unlink = angr.SIM_PROCEDURES['posix']['unlink']
+            
+            # Create a file 'test'
+            fd = self.state.posix.open(b'test', 1)
+            self.state.posix.close(fd)
+
+            # Ensure 'test' was in fact created
+            nose.tools.assert_in(b'/home/user/test', self.state.fs._files)
+
+            # Store the filename in memory
+            malloc = angr.SIM_PROCEDURES['libc']['malloc']
+            addr = self.inline_call(malloc, len('test')).ret_expr
+            self.state.memory.store(addr, b'test\x00')
+            
+            # Unlink 'test': should return 0 and leave ERRNO unchanged
+            rval = self.inline_call(unlink, addr).ret_expr
+            nose.tools.assert_equal(rval, 0)
+            mock_errno.assert_not_called()
+
+            # Check that 'test' was in fact deleted
+            nose.tools.assert_equal(self.state.fs._files, {})
+
+            # Unlink again: should return -1 and set ERRNO to ENOENT
+            rval = self.inline_call(unlink, addr).ret_expr
+            nose.tools.assert_equal(rval, -1)
+            mock_errno.assert_called_once_with(self.state.posix.ENOENT)
+
+    # Load the 'fauxware' binary and hook TestProc
+    project = angr.Project('../../binaries/tests/x86_64/fauxware')
+    project.hook_symbol('main', TestProc())
+    simgr = project.factory.simulation_manager()
+    simgr.run()

--- a/tests/test_unlink.py
+++ b/tests/test_unlink.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-argument, arguments-differ
 import angr
 import nose
 import os
@@ -13,7 +14,7 @@ def test_file_unlink(mock_errno):
         def run(self, argc, argv):
             # Load the unlink SimProcedure
             unlink = angr.SIM_PROCEDURES['posix']['unlink']
-            
+
             # Create a file 'test'
             fd = self.state.posix.open(b'test', 1)
             self.state.posix.close(fd)
@@ -25,7 +26,7 @@ def test_file_unlink(mock_errno):
             malloc = angr.SIM_PROCEDURES['libc']['malloc']
             addr = self.inline_call(malloc, len('test')).ret_expr
             self.state.memory.store(addr, b'test\x00')
-            
+
             # Unlink 'test': should return 0 and leave ERRNO unchanged
             rval = self.inline_call(unlink, addr).ret_expr
             nose.tools.assert_equal(rval, 0)


### PR DESCRIPTION
Fixes #1633 

* Adds code in `procedures/linux_kernel/unlink.py` to check whether the entity being deleted exists in the filesystem before attempting to delete it. If the entity does not exist, `state.libc.errno` is set to `ENOENT`.

* Adds a test to check that `state.libc.errno` is set correctly by the unlink syscall.