### PR TITLE
refactor `ReachingDefinitionAnalysis`

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -186,7 +186,7 @@ class Clinic(Analysis):
         """
 
         # Computing reaching definitions
-        rd = self.project.analyses.ReachingDefinitions(func=self.function, func_graph=self.graph, observe_all=True)
+        rd = self.project.analyses.ReachingDefinitions(subject=self.function, func_graph=self.graph, observe_all=True)
 
         simp = self.project.analyses.AILSimplifier(self.function, func_graph=self.graph, reaching_definitions=rd)
 
@@ -218,7 +218,7 @@ class Clinic(Analysis):
         """
 
         # Computing reaching definitions
-        rd = self.project.analyses.ReachingDefinitions(func=self.function, func_graph=self.graph, observe_all=True)
+        rd = self.project.analyses.ReachingDefinitions(subject=self.function, func_graph=self.graph, observe_all=True)
 
         for key in self._blocks:
             block = self._blocks[key]

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -9,6 +9,7 @@ from ...calling_conventions import SimRegArg, SimStackArg
 from ...engines.light import SpOffset
 from ...keyed_region import KeyedRegion
 from ...block import Block
+from ...knowledge_plugins.functions.function_manager import Function
 from ...codenode import CodeNode
 from ...misc.ux import deprecated
 from .. import register_analysis
@@ -306,14 +307,11 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
     * Some more documentation and examples would be nice.
     """
 
-    def __init__(self, func=None, block=None, func_graph=None, max_iterations=3, track_tmps=False,
+    def __init__(self, subject=None, func_graph=None, max_iterations=3, track_tmps=False,
                  observation_points=None, init_state=None, init_func=False, cc=None, function_handler=None,
                  current_local_call_depth=1, maximum_local_call_depth=5, observe_all=False):
         """
-
-        :param angr.knowledge.Function func:    The function to run reaching definition analysis on.
-        :param block:                           A single block to run reaching definition analysis on. You cannot
-                                                specify both `func` and `block`.
+        :param Block|Function subject: The subject of the analysis: a function, or a single basic block.
         :param func_graph:                      Alternative graph for function.graph.
         :param int max_iterations:              The maximum number of iterations before the analysis is terminated.
         :param Boolean track_tmps:              Whether or not temporary variables should be taken into consideration
@@ -333,24 +331,26 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
         :param Boolean observe_all:             Observe every statement, both before and after.
         """
 
-        if func is not None:
-            if block is not None:
-                raise ValueError('You cannot specify both "func" and "block".')
-            # traversing a function
-            graph_visitor = FunctionGraphVisitor(func, func_graph)
-        elif block is not None:
-            # traversing a block
-            graph_visitor = SingleNodeGraphVisitor(block)
-        else:
-            raise ValueError('Unsupported analysis target.')
+        def _init_subject(subject):
+            """
+            :param ailment.Block|angr.Block|Function subject:
+            :return Tuple[ailment.Block|angr.Block, SimCC, Function, GraphVisitor, Boolean]:
+                 Return the values for `_block`, `_cc`, `_function`, `_graph_visitor`, `_init_func`.
+            """
+            if isinstance(subject, Function):
+                return (None, cc, subject, FunctionGraphVisitor(subject, func_graph), init_func)
+            elif isinstance(subject, (ailment.Block, Block)):
+                return (subject, None, None, SingleNodeGraphVisitor(subject), False)
+            else:
+                raise ValueError('Unsupported analysis target.')
+
+        self._block, self._cc, self._function, self._graph_visitor, self._init_func = _init_subject(subject)
 
         ForwardAnalysis.__init__(self, order_jobs=True, allow_merging=True, allow_widening=False,
-                                 graph_visitor=graph_visitor)
+                                 graph_visitor=self._graph_visitor)
 
         self._track_tmps = track_tmps
         self._max_iterations = max_iterations
-        self._function = func
-        self._block = block
         self._observation_points = observation_points
         self._init_state = init_state
         self._function_handler = function_handler
@@ -360,14 +360,6 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
         if self._init_state is not None:
             self._init_state = self._init_state.copy()
             self._init_state.analysis = self
-
-        # ignore initialization parameters if a block was passed
-        if self._function is not None:
-            self._init_func = init_func
-            self._cc = cc
-        else:
-            self._init_func = False
-            self._cc = None
 
         self._observe_all = observe_all
 

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -365,11 +365,9 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
         if self._function is not None:
             self._init_func = init_func
             self._cc = cc
-            self._func_addr = func.addr
         else:
             self._init_func = False
             self._cc = None
-            self._func_addr = None
 
         self._observe_all = observe_all
 
@@ -477,8 +475,9 @@ class ReachingDefinitionAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=a
         if self._init_state is not None:
             return self._init_state
         else:
+            func_addr = self._function.addr if self._function else None
             return LiveDefinitions(self.project.arch, track_tmps=self._track_tmps, analysis=self,
-                                   init_func=self._init_func, cc=self._cc, func_addr=self._func_addr)
+                                   init_func=self._init_func, cc=self._cc, func_addr=func_addr)
 
     def _merge_states(self, node, *states):
         return states[0].merge(*states[1:])


### PR DESCRIPTION
Constructor took `Block` **and** `Function` as parameter, but could neveranalyse both.
Use an enum-like kind-of logic: a single parameter, that can be either a `Block` or a `Function` and have separated behavior based on which it is.
    
Motivation: cleaner code, and easier to add "structure" to analyse (such as slices...).