### PR TITLE
Support for explicit text modes "rt" and "wt" in fopen

### DIFF
--- a/angr/procedures/libc/fopen.py
+++ b/angr/procedures/libc/fopen.py
@@ -10,6 +10,8 @@ def mode_to_flag(mode):
     # TODO improve this: handle mode = strings
     if mode[-1] == ord('b'): # lol who uses windows
         mode = mode[:-1]
+    elif mode[-1] == ord('t'): # Rarely modes rt or wt are used, but identical to r and w
+        mode = mode[:-1]
     mode = mode.replace(b'c', b'').replace(b'e', b'')
     all_modes = {
         b"r"  : angr.storage.file.Flags.O_RDONLY,


### PR DESCRIPTION
Rarely modes rt or wt are used, but identical to r and w - see also https://stackoverflow.com/questions/23051062/open-files-in-rt-and-wt-modes