### PR TITLE
Pre-constraining the stack pointer

### DIFF
--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -142,10 +142,13 @@ class SimOS:
             state.memory.mem._preapproved_stack = IRange(actual_stack_end - stack_size, actual_stack_end)
 
         if state.arch.sp_offset is not None:
-            state.regs.sp = state.solver.BVS("precon_sp", 64)
-            ## preconstraining the stack pointer
-            state.preconstrainer.preconstrain(actual_stack_end, state.regs.sp)
-
+            ## preconstraining the stack pointer if replcement solver is used
+            if o.REPLACEMENT_SOLVER in state.options:
+                state.regs.sp = state.solver.BVS("precon_sp", 64)
+                state.preconstrainer.preconstrain(actual_stack_end, state.regs.sp)
+            else:
+                state.regs.sp = actual_stack_end
+                
         if initial_prefix is not None:
             for reg in state.arch.default_symbolic_registers:
                 state.registers.store(reg, state.solver.BVS(

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -137,13 +137,14 @@ class SimOS:
         actual_brk = (last_addr - last_addr % 0x1000 + 0x1000) if brk is None else brk
         state.register_plugin('posix', SimSystemPosix(stdin=stdin, brk=actual_brk))
 
-
         actual_stack_end = state.arch.initial_sp if stack_end is None else stack_end
         if o.ABSTRACT_MEMORY not in state.options:
             state.memory.mem._preapproved_stack = IRange(actual_stack_end - stack_size, actual_stack_end)
 
         if state.arch.sp_offset is not None:
-            state.regs.sp = actual_stack_end
+            state.regs.sp = state.solver.BVS("precon_sp", 64)
+            ## preconstraining the stack pointer
+            state.preconstrainer.preconstrain(actual_stack_end, state.regs.sp)
 
         if initial_prefix is not None:
             for reg in state.arch.default_symbolic_registers:

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -148,7 +148,6 @@ class SimOS:
                 state.preconstrainer.preconstrain(actual_stack_end, state.regs.sp)
             else:
                 state.regs.sp = actual_stack_end
-                
         if initial_prefix is not None:
             for reg in state.arch.default_symbolic_registers:
                 state.registers.store(reg, state.solver.BVS(

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -283,7 +283,7 @@ class SimSolver(SimStatePlugin):
                 )
         elif o.ABSTRACT_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverVSA()
-        elif o.SYMBOLIC in self.state.options and o.REPLACEMENT_SOLVER in self.state.options:
+        if o.REPLACEMENT_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverReplacement(auto_replace=False)
         elif o.SYMBOLIC in self.state.options and o.CACHELESS_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverCacheless(track=track)

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -283,7 +283,7 @@ class SimSolver(SimStatePlugin):
                 )
         elif o.ABSTRACT_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverVSA()
-        if o.REPLACEMENT_SOLVER in self.state.options:
+        elif o.REPLACEMENT_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverReplacement(auto_replace=False)
         elif o.SYMBOLIC in self.state.options and o.CACHELESS_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverCacheless(track=track)


### PR DESCRIPTION
- The stack pointer is assigned a constant value in `simos.py`, this results in wrong assumptions/results when doing certain analysis like Constant Propagation which shows that the stack pointer is constant. 
- Keeping the stack pointer symbolic and pre-constraining to a fixed value time avoids the above problem. Also, using the Replacement Solver helps avoid actually solving for its value(also works in fastpath mode).
- The sp is pre-constrained only if the replacement solver is used, otherwise, it behaves regularly
- Also removed the need for the `SYMBOLIC` option to use the replacement solver.