### PR TITLE
ReachingDefinitionsAnalysis: update VEX engine

### DIFF
--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -168,6 +168,13 @@ class SimEngineRDVEX(
     # VEX expression handlers
     #
 
+    def _expr(self, stmt):
+        data = super()._expr(stmt)
+        if data is None:
+            bits = stmt.result_size(self.tyenv)
+            data = DataSet(undefined, bits)
+        return data
+
     def _handle_RdTmp(self, expr):
         tmp = expr.tmp
 
@@ -175,8 +182,7 @@ class SimEngineRDVEX(
 
         if tmp in self.tmps:
             return self.tmps[tmp]
-        bits = expr.result_size(self.tyenv)
-        return DataSet(undefined, bits)
+        return None
 
     # e.g. t0 = GET:I64(rsp), rsp might be defined multiple times
     def _handle_Get(self, expr):

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -168,10 +168,10 @@ class SimEngineRDVEX(
     # VEX expression handlers
     #
 
-    def _expr(self, stmt):
-        data = super()._expr(stmt)
+    def _expr(self, expr):
+        data = super()._expr(expr)
         if data is None:
-            bits = stmt.result_size(self.tyenv)
+            bits = expr.result_size(self.tyenv)
             data = DataSet(undefined, bits)
         return data
 

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -153,9 +153,9 @@ class SimEngineLightVEXMixin:
     def _handle_Load(self, expr):
         raise NotImplementedError('Please implement the Load handler with your own logic.')
 
-    def _handle_Exit(self, expr):
-        self._expr(expr.guard)
-        self._expr(expr.dst)
+    def _handle_Exit(self, stmt):
+        self._expr(stmt.guard)
+        self._expr(stmt.dst)
 
     def _handle_ITE(self, expr):
         # EDG says: Not sure how generic this is.


### PR DESCRIPTION
Add a default behavior for handling VEX expressions.
As per, and solves #1742 .