### PR TITLE
Fix format printing for non-address targets

### DIFF
--- a/angr/knowledge_plugins/xrefs/xref.py
+++ b/angr/knowledge_plugins/xrefs/xref.py
@@ -34,9 +34,9 @@ class XRef(Serializable):
 
     def __repr__(self):
         return "<XRef %s: %s->%s>" % (
-                XRefType.to_string(self.type),
+                self.type_string,
                 "%#x" % self.ins_addr if self.ins_addr is not None else "%#x[%d]" % (self.block_addr, self.stmt_idx),
-                "%#x" % (self.dst if self.dst is not None else self.memory_data.addr)
+                "%s" % self.dst if self.dst is not None else "%#x" % (self.memory_data.addr)
         )
 
     def __eq__(self, other):


### PR DESCRIPTION
Regarding Issue https://github.com/angr/angr/issues/1727 

This patch fixes the issue for me.
But since i'm not sure which types the src and dst can have, maybe @ltfish should take a look at this and if it's not sufficient i can add the missing type formats.

Best regards,
Alex