### PR TITLE
ForwardAnalysis: remove unnecessary function in visitors

### DIFF
--- a/angr/analyses/forward_analysis/visitors/call_graph.py
+++ b/angr/analyses/forward_analysis/visitors/call_graph.py
@@ -12,16 +12,6 @@ class CallGraphVisitor(GraphVisitor):
 
         self.reset()
 
-    def startpoints(self):
-        # TODO: make sure all connected components are covered
-        start_nodes = [node for node in self.callgraph.nodes() if self.callgraph.in_degree(node) == 0]
-
-        if not start_nodes:
-            # randomly pick one
-            start_nodes = [ self.callgraph.nodes()[0] ]
-
-        return start_nodes
-
     def successors(self, node):
         return list(self.callgraph.successors(node))
 

--- a/angr/analyses/forward_analysis/visitors/function_graph.py
+++ b/angr/analyses/forward_analysis/visitors/function_graph.py
@@ -17,9 +17,6 @@ class FunctionGraphVisitor(GraphVisitor):
 
         self.reset()
 
-    def startpoints(self):
-        return [ self.function.startpoint ]
-
     def successors(self, node):
         return list(self.graph.successors(node))
 

--- a/angr/analyses/forward_analysis/visitors/graph.py
+++ b/angr/analyses/forward_analysis/visitors/graph.py
@@ -17,15 +17,6 @@ class GraphVisitor:
     # Interfaces
     #
 
-    def startpoints(self):
-        """
-        Get all start points to begin the traversal.
-
-        :return: A list of startpoints that the traversal should begin with.
-        """
-
-        raise NotImplementedError()
-
     def successors(self, node):
         """
         Get successors of a node. The node should be in the graph.

--- a/angr/analyses/forward_analysis/visitors/loop.py
+++ b/angr/analyses/forward_analysis/visitors/loop.py
@@ -12,9 +12,6 @@ class LoopVisitor(GraphVisitor):
 
         self.reset()
 
-    def startpoints(self):
-        return [ self.loop.entry ]
-
     def successors(self, node):
         return self.loop.graph.successors(node)
 

--- a/angr/analyses/forward_analysis/visitors/single_node_graph.py
+++ b/angr/analyses/forward_analysis/visitors/single_node_graph.py
@@ -11,9 +11,6 @@ class SingleNodeGraphVisitor(GraphVisitor):
 
         self.reset()
 
-    def startpoints(self):
-        return [ self.node.addr ]
-
     def successors(self, node):
         return [ ]
 


### PR DESCRIPTION
As per discussion with @ltfish; The visit start from the first
element of the `sort_nodes` OrderedSet.