### PR TITLE
upgrading to maintained version of progressbar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
         'dpkt',
         'mulpyplexer',
         'networkx>=2.0',
-        'progressbar',
+        'progressbar2',
         'rpyc',
         'cffi>=1.7.0',
         'unicorn',


### PR DESCRIPTION
progressbar hasnt been updated since jul-2018 and has a bunch of inactive issues (https://github.com/niltonvolpato/python-progressbar/issues) 
progressbar2 is under active development, with the most recent release coming in Sep-2019

I manually checked that the usage of progressbar in angr is compatible with progressbar2 

**I** need it this change because one of my projects uses features in progressbar2 that are not available in progressbar and they share the same namespace. 



 