### PR TITLE
Either fix or workaround some other bug with labels

### DIFF
--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -46,7 +46,9 @@ class Labels(KnowledgeBasePlugin):
 
     def __delitem__(self, k):
         if k in self._labels:
-            del self._reverse_labels[self._labels[k]]
+            l = self._labels[k]
+            if l in self._reverse_labels:
+                del self._reverse_labels[l]
             del self._labels[k]
 
     def __contains__(self, k):


### PR DESCRIPTION
Managed to get a situation where the this was needed. Maybe this is some other bug that this happened in the first place. The function originally had the name `_start`, tried renaming to `_main` for what it's worth. 