### PR TITLE
Added property to determine if SimActions involved symbolic data

### DIFF
--- a/angr/state_plugins/sim_action.py
+++ b/angr/state_plugins/sim_action.py
@@ -70,6 +70,10 @@ class SimAction(SimEvent):
         raise NotImplementedError()
 
     @property
+    def is_symbolic(self):
+        raise NotImplementedError()
+
+    @property
     def tmp_deps(self):
         return frozenset.union(*[v.tmp_deps for v in self.all_objects])
 
@@ -120,6 +124,10 @@ class SimActionExit(SimAction):
     def all_objects(self):
         return [ a for a in ( self.target, self.condition ) if a is not None ]
 
+    @property
+    def is_symbolic(self):
+        return getattr(self.target, "symbolic", False)
+
     def _copy_objects(self, c):
         c.exit_type = self.exit_type
         c.target = self._copy_object(self.target)
@@ -140,6 +148,10 @@ class SimActionConstraint(SimAction):
     @property
     def all_objects(self):
         return [ a for a in ( self.constraint, self.condition ) if a is not None ]
+
+    @property
+    def is_symbolic(self):
+        return getattr(self.constraint, "symbolic", False)
 
     def _copy_objects(self, c):
         c.constraint = self._copy_object(self.constraint)
@@ -168,6 +180,10 @@ class SimActionOperation(SimAction):
     @property
     def all_objects(self):
         return [ ex for ex in self.exprs if isinstance(ex, SimActionObject) ]
+
+    @property
+    def is_symbolic(self):
+        return any([ getattr(ex, "symbolic", False) for ex in self.exprs ])
 
     def _copy_objects(self, c):
         c.op = self.op
@@ -232,6 +248,10 @@ class SimActionData(SimAction):
     @property
     def all_objects(self):
         return [ a for a in [ self.addr, self.size, self.data, self.condition, self.fallback, self.fd ] if a is not None ]
+
+    @property
+    def is_symbolic(self):
+        return any([ getattr(a, "symbolic", False) for a in [ self.addr, self.size, self.data ] if a is not None ])
 
     @property
     def tmp_deps(self):


### PR DESCRIPTION
Added property to SimActions to determine if they operated on symbolic data. I chose some of the data members that can be symbolic and assumed they'll have a claripy AST data members. I checked with actual instances of `SimActionData` and `SimActionConstraint` but I couldn't find an instance of `SimActionExit` or `SimActionOperation` on some examples I tried so I'm unsure if the implementation for them is correct.

Alternatively, we could just test if all objects of the action instance are symbolic to determine if the action is symbolic. This can be done in base class SimAction itself.