### PR TITLE
RDA: `def_use_graph` property to have its own class

### DIFF
--- a/angr/analyses/reaching_definitions/def_use_graph.py
+++ b/angr/analyses/reaching_definitions/def_use_graph.py
@@ -1,0 +1,53 @@
+import networkx
+
+from .definition import Definition
+
+
+def _is_definition(node):
+    return isinstance(node, Definition)
+
+
+class DefUseGraph:
+    """
+    The representation of a definition-use graph: a directed graph, where nodes are definitions, and edges represent uses.
+
+    Mostly a wrapper around a <networkx.DiGraph>.
+    """
+
+    def __init__(self, graph=None):
+        """
+        :param networkx.DiGraph graph: A graph where nodes are definitions, and edges represent uses.
+        """
+        if not isinstance(graph, networkx.DiGraph):
+            self._graph = networkx.DiGraph()
+            return
+
+        if not all(map(_is_definition, graph.nodes)):
+            raise TypeError("In a DefUseGraph, nodes need to be <%s>s." % Definition.__name__)
+
+        self._graph = graph
+
+    @property
+    def graph(self):
+        return self._graph
+
+    def add_node(self, node):
+        """
+        :param Definition node: The definition to add to the definition-use graph.
+        """
+        if not _is_definition(node):
+            raise TypeError("In a DefUseGraph, nodes need to be <%s>s." % Definition.__name__)
+
+        self._graph.add_node(node)
+
+    def add_edge(self, source, destination):
+        """
+        The edge to add to the definition-use graph. Will create nodes that are not yet present.
+
+        :param Definition source: The "source" definition, used by the "destination".
+        :param Definition destination: The "destination" definition, using the variable defined by "source".
+        """
+        if not _is_definition(source) and not _is_definition(destination):
+            raise TypeError("In a DefUseGraph, edges need to be between <%s>s." % Definition.__name__)
+
+        self._graph.add_edge(source, destination)

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -25,8 +25,10 @@ class SimEngineRDVEX(
         self._maximum_local_call_depth = maximum_local_call_depth
         self._function_handler = function_handler
         self._visited_blocks = None
+        self._def_use_graph = None
 
     def process(self, state, *args, **kwargs):
+        self._def_use_graph = kwargs.pop('def_use_graph', None)
         self._visited_blocks = kwargs.pop('visited_blocks', None)
 
         # we are using a completely different state. Therefore, we directly call our _process() method before

--- a/tests/test_def_use_graph.py
+++ b/tests/test_def_use_graph.py
@@ -1,0 +1,49 @@
+import networkx
+import nose
+
+from unittest import mock
+
+from angr.analyses.reaching_definitions.dataset import DataSet
+from angr.analyses.reaching_definitions.definition import Definition
+from angr.analyses.reaching_definitions.def_use_graph import DefUseGraph
+
+
+def test_def_use_graph_has_a_default_graph():
+    def_use_graph = DefUseGraph()
+    nose.tools.assert_equal(isinstance(def_use_graph.graph, networkx.DiGraph), True)
+
+
+def test_def_use_graph_refuses_to_instanciate_with_an_inadequate_graph():
+    a_graph = networkx.DiGraph([(1, 2)])
+    nose.tools.assert_raises(TypeError, DefUseGraph, a_graph)
+
+
+def test_refuses_to_add_non_definition_nodes():
+    def_use_graph = DefUseGraph()
+    nose.tools.assert_raises(TypeError, def_use_graph.add_node, 1)
+
+
+@mock.patch.object(networkx.DiGraph, 'add_node')
+def test_delegate_add_node_to_the_underlying_graph_object(digraph_add_node_mock):
+    definition = Definition(None, None, DataSet(set(), 8), None)
+    def_use_graph = DefUseGraph()
+    def_use_graph.add_node(definition)
+
+    digraph_add_node_mock.assert_called_once_with(definition)
+
+
+def test_refuses_to_add_edge_between_non_definition_nodes():
+    def_use_graph = DefUseGraph()
+    nose.tools.assert_raises(TypeError, def_use_graph.add_edge, 1, 2)
+
+
+@mock.patch.object(networkx.DiGraph, 'add_edge')
+def test_delegate_add_edge_to_the_underlying_graph_object(digraph_add_edge_mock):
+    use = (
+        Definition(None, None, DataSet(set(), 8), None),
+        Definition(None, None, DataSet(set(), 8), None),
+    )
+    def_use_graph = DefUseGraph()
+    def_use_graph.add_edge(*use)
+
+    digraph_add_edge_mock.assert_called_once_with(*use)

--- a/tests/test_reachingdefinitions.py
+++ b/tests/test_reachingdefinitions.py
@@ -292,18 +292,18 @@ def test_def_use_graph():
     rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=False)
     guard_use = list(filter(
         lambda def_: type(def_.atom) is GuardUse and def_.codeloc.block_addr == main.addr,
-        rda.def_use_graph.nodes()
+        rda.def_use_graph._graph.nodes()
     ))[0]
     nose.tools.assert_equal(
-        len(rda.def_use_graph.pred[guard_use]),
+        len(rda.def_use_graph._graph.pred[guard_use]),
         4
     )
     nose.tools.assert_equal(
-        all(type(def_.atom) is Register for def_ in rda.def_use_graph.pred[guard_use]),
+        all(type(def_.atom) is Register for def_ in rda.def_use_graph._graph.pred[guard_use]),
         True
     )
     nose.tools.assert_equal(
-        set(def_.atom.reg_offset for def_ in rda.def_use_graph.pred[guard_use]),
+        set(def_.atom.reg_offset for def_ in rda.def_use_graph._graph.pred[guard_use]),
         {reg.vex_offset for reg in project.arch.register_list if reg.name.startswith('cc_')}
     )
 
@@ -311,14 +311,14 @@ def test_def_use_graph():
     rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=True)
     tmp_7 = list(filter(
         lambda def_: type(def_.atom) is Tmp and def_.atom.tmp_idx == 7 and def_.codeloc.block_addr == main.addr,
-        rda.def_use_graph.nodes()
+        rda.def_use_graph._graph.nodes()
     ))[0]
     nose.tools.assert_equal(
-        len(rda.def_use_graph.succ[tmp_7]),
+        len(rda.def_use_graph._graph.succ[tmp_7]),
         1
     )
     nose.tools.assert_equal(
-        type(list(rda.def_use_graph.succ[tmp_7])[0].atom),
+        type(list(rda.def_use_graph._graph.succ[tmp_7])[0].atom),
         GuardUse
     )
 


### PR DESCRIPTION
  * Generally better design to wrap external objects into ours (Facade
  pattern here);
  * Expose methods used by production code, not the ones only used in
  tests.

Sync: https://github.com/angr/angr-doc/pull/294