### PR TITLE
SimRegNameView on arm: fix dir()

### DIFF
--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -80,7 +80,7 @@ class SimRegNameView(SimStatePlugin):
         if self.state.arch.name in ('X86', 'AMD64'):
             return list(self.state.arch.registers.keys()) + ['st%d' % n for n in range(8)] + ['tag%d' % n for n in range(8)] + ['flags', 'eflags', 'rflags']
         elif is_arm_arch(self.state.arch):
-            return self.state.arch.registers.keys() + ['flags']
+            return list(self.state.arch.registers.keys()) + ['flags']
         return self.state.arch.registers.keys()
 
     @SimStatePlugin.memo


### PR DESCRIPTION
Looks like it was forgotten when migrating to py3.
Without this change, `dir(state.regs)` crashes: `TypeError: unsupported operand type(s) for +: 'dict_keys' and 'list'`