### PR TITLE
RDA: Refactor, create Subject type

### DIFF
--- a/angr/analyses/reaching_definitions/subject.py
+++ b/angr/analyses/reaching_definitions/subject.py
@@ -1,0 +1,71 @@
+from enum import Enum
+
+import ailment
+
+from ...block import Block
+from ...knowledge_plugins.functions.function_manager import Function
+from ..forward_analysis import FunctionGraphVisitor, SingleNodeGraphVisitor
+
+
+class SubjectType(Enum):
+    Function = 1
+    Block = 2
+
+
+class Subject:
+    def __init__(self, content, cfg, func_graph=None, cc=None, init_func=None):
+        """
+        The thing being analysed, and the way (visitor) to analyse it.
+
+        :param ailment.Block|angr.Block|Function content:
+            Thing to be analysed.
+        :param angr.knowledge_plugins.cfg.cfg_model.CFGModel cfg:
+            CFG of the program the thing was found in. Only used when analysing a slice.
+        :param networkx.DiGraph func_graph: Alternative graph for function.graph.
+        :param SimCC cc: Calling convention of the function.
+        :param Boolean init_func: Whether stack and arguments are initialized or not.
+        """
+
+        self._content = content
+
+        if isinstance(content, Function):
+            self._cc = cc
+            self._func_graph = func_graph
+            self._init_func = init_func
+            self._type = SubjectType.Function
+            self._visitor = FunctionGraphVisitor(content, func_graph)
+        elif isinstance(content, (ailment.Block, Block)):
+            self._type = SubjectType.Block
+            self._visitor = SingleNodeGraphVisitor(content)
+        else:
+            raise TypeError('Unsupported analysis target.')
+
+    @property
+    def cc(self):
+        if self.type is not SubjectType.Function:
+            raise TypeError('There are no `cc` attribute for <%s>.' % self.type)
+        return self._cc
+
+    @property
+    def content(self):
+        return self._content
+
+    @property
+    def func_graph(self):
+        if self.type is not SubjectType.Function:
+            raise TypeError('There are no `func_graph` attribute for <%s>.' % self.type)
+        return self._func_graph
+
+    @property
+    def init_func(self):
+        if self.type is not SubjectType.Function:
+            raise TypeError('There are no `init_func` attribute for <%s>.' % self.type)
+        return self._init_func
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def visitor(self):
+        return self._visitor

--- a/tests/test_reachingdefinitions.py
+++ b/tests/test_reachingdefinitions.py
@@ -15,7 +15,6 @@ import archinfo
 from angr.analyses.reaching_definitions.live_definitions import LiveDefinitions
 from angr.analyses.reaching_definitions.constants import OP_BEFORE, OP_AFTER
 from angr.analyses.reaching_definitions.atoms import GuardUse, Tmp, Register
-
 from angr.block import Block
 
 LOGGER = logging.getLogger('test_reachingdefinitions')
@@ -190,7 +189,7 @@ class ReachingDefinitionsAnalysisTest(TestCase):
             InsnAndNodeObserveTestingUtils.setup(observation_points)
 
         code_block = main_function._addr_to_block_node[main_function.addr] # pylint: disable=W0212
-        block = angr.block.Block(addr=0x43, byte_string=code_block.bytestr, project=project)
+        block = Block(addr=0x43, byte_string=code_block.bytestr, project=project)
         statement = block.vex.statements[0]
 
         reaching_definition.insn_observe(0x43, statement, block, state, OP_BEFORE)
@@ -216,7 +215,7 @@ class ReachingDefinitionsAnalysisTest(TestCase):
             InsnAndNodeObserveTestingUtils.setup(observation_points)
 
         code_block = main_function._addr_to_block_node[main_function.addr] # pylint: disable=W0212
-        block = angr.block.Block(addr=0x43, byte_string=code_block.bytestr, project=project)
+        block = Block(addr=0x43, byte_string=code_block.bytestr, project=project)
         # When observing OP_AFTER an instruction, the statement has to be the last of a block
         # (or preceding an IMark)
         statement = block.vex.statements[-1]
@@ -234,54 +233,6 @@ class ReachingDefinitionsAnalysisTest(TestCase):
             lambda x: InsnAndNodeObserveTestingUtils.assert_equals_for_live_definitions(x[0], x[1]),
             zip(results, expected_results)
         ))
-
-
-    def test_reaching_definition_analysis_returns_an_error_without_suject(self):
-        binary_path = os.path.join(TESTS_LOCATION, 'x86_64', 'all')
-        project = angr.Project(binary_path, load_options={'auto_load_libs': False})
-
-        with nose.tools.assert_raises(ValueError) as reaching_definitions:
-            project.analyses.ReachingDefinitions()
-
-        nose.tools.assert_equal("%s" % reaching_definitions.exception, 'Unsupported analysis target.')
-
-
-    def test_reaching_definition_analysis_with_a_function_as_suject(self):
-        binary_path = os.path.join(TESTS_LOCATION, 'x86_64', 'all')
-        project = angr.Project(binary_path, load_options={'auto_load_libs': False})
-        cfg = project.analyses.CFGFast()
-
-        main_function = cfg.kb.functions['main']
-        # Valuable to test that `init_func` and `cc` are assigned correctly.
-        # However, set `init_func` to False so `cc` content does not get checked (which would fail here because it is
-        # not supposed to be a string).
-        init_func = False
-        cc = "cc_mock"
-
-        reaching_definitions = project.analyses.ReachingDefinitions(
-            subject=main_function, init_func=init_func, cc=cc
-        )
-
-        nose.tools.assert_equal(reaching_definitions._function, main_function)
-        nose.tools.assert_equal(reaching_definitions._block, None)
-        nose.tools.assert_equal(reaching_definitions._init_func, init_func)
-        nose.tools.assert_equal(reaching_definitions._cc, cc)
-
-
-    def test_reaching_definition_analysis_with_a_block_as_subject(self):
-        binary_path = os.path.join(TESTS_LOCATION, 'x86_64', 'all')
-        project = angr.Project(binary_path, load_options={'auto_load_libs': False})
-        cfg = project.analyses.CFGFast()
-
-        main_function = cfg.kb.functions['main']
-        main_block = Block(addr=main_function.addr, project=project)
-
-        reaching_definitions = project.analyses.ReachingDefinitions(subject=main_block)
-
-        nose.tools.assert_equal(reaching_definitions._function, None)
-        nose.tools.assert_equal(reaching_definitions._block, main_block)
-        nose.tools.assert_equal(reaching_definitions._init_func, False)
-        nose.tools.assert_equal(reaching_definitions._cc, None)
 
 
 class LiveDefinitionsTest(TestCase):

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -1,0 +1,87 @@
+from unittest import mock
+
+import nose
+
+import ailment
+
+from archinfo.arch_x86 import ArchX86
+from angr.analyses.forward_analysis.visitors import FunctionGraphVisitor
+from angr.analyses.reaching_definitions.subject import Subject, SubjectType
+from angr.block import Block
+from angr.knowledge_plugins import Function
+
+
+def _a_mock_function(address, name):
+    return Function(None, address, name=name, syscall=False, is_simprocedure=False, is_plt=False, returning=False)
+
+@mock.patch.object(Function, '_get_initial_binary_name', return_value='binary')
+def test_can_be_instantiated_with_a_function(_):
+    function = _a_mock_function(0x42, 'function_name')
+    subject = Subject(function, None)
+
+    nose.tools.assert_equals(subject.content, function)
+    nose.tools.assert_equals(subject.type, SubjectType.Function)
+
+
+@mock.patch.object(Block, '_parse_vex_info', return_value=None)
+def test_can_be_instantiated_with_a_block(_):
+    arch = ArchX86()
+    block = Block(0x42, byte_string=b'', arch=arch)
+    subject = Subject(block, None)
+
+    nose.tools.assert_equals(subject.content, block)
+    nose.tools.assert_equals(subject.type, SubjectType.Block)
+
+
+def test_can_be_instantiated_with_an_ailment_block():
+    block = ailment.Block(0x42, original_size=4)
+    subject = Subject(block, None)
+
+    nose.tools.assert_equals(subject.content, block)
+    nose.tools.assert_equals(subject.type, SubjectType.Block)
+
+
+def test_fails_when_instanciated_with_an_inadequate_object():
+    nose.tools.assert_raises(TypeError, Subject, 'test-me', None)
+
+
+@mock.patch.object(Function, '_get_initial_binary_name', return_value='binary')
+@mock.patch.object(FunctionGraphVisitor, 'sort_nodes')
+def test_when_instanciated_with_a_function_need_other_attributes(_, __):
+    function = _a_mock_function(0x42, 'function_name')
+    func_graph = 'mock_func_graph'
+    cc = 'mock_cc'
+    init_func = 'mock_init_func'
+
+    subject = Subject(function, None, func_graph, cc, init_func)
+
+    nose.tools.assert_equals(subject.func_graph, func_graph)
+    nose.tools.assert_equals(subject.cc, cc)
+    nose.tools.assert_equals(subject.init_func, init_func)
+
+
+def test_cc_attribute_should_raise_error_when_subject_is_a_block():
+    arch = ArchX86()
+    block = Block(0x42, byte_string=b'', arch=arch)
+    subject = Subject(block, None)
+
+    with nose.tools.assert_raises(TypeError):
+        _ = subject.cc
+
+
+def test_func_graph_attribute_should_raise_error_when_subject_is_a_block():
+    arch = ArchX86()
+    block = Block(0x42, byte_string=b'', arch=arch)
+    subject = Subject(block, None)
+
+    with nose.tools.assert_raises(TypeError):
+        _ = subject.func_graph
+
+
+def test_init_func_attribute_should_raise_error_when_subject_is_a_block():
+    arch = ArchX86()
+    block = Block(0x42, byte_string=b'', arch=arch)
+    subject = Subject(block, None)
+
+    with nose.tools.assert_raises(TypeError):
+        _ = subject.init_func


### PR DESCRIPTION
  * in a dedicated (and somewhat tested) class
  * use enum for the existing kind of subject

As part of an effort to isolate "state-relevant" information out of the
`ReachingDefinitionAnalysis` class to debloat it.