### PR TITLE
Refactor tests to not do anything intense during test generation

### DIFF
--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -15,7 +15,8 @@ arch_data = { # (steps, [hit addrs], finished)
     'aarch64': (197, (0x1020b04, 0x400430, 0x4003b8, 0x400538), False),        # blocked on syscalls
 }
 
-def emulate(p, steps, hit_addrs, finished):
+def emulate(arch, binary, use_sim_procs, steps, hit_addrs, finished):
+    p = angr.Project(os.path.join(test_location, arch, binary), use_sim_procedures=use_sim_procs)
     state = p.factory.full_init_state(args=['./test_arrays'], add_options={angr.options.STRICT_PAGE_ACCESS, angr.options.ENABLE_NX, angr.options.CGC_ZERO_FILL_UNCONSTRAINED_MEMORY, angr.options.USE_SYSTEM_TIMES})
 
     pg = p.factory.simulation_manager(state, resilience=True)
@@ -52,12 +53,10 @@ def emulate(p, steps, hit_addrs, finished):
 def test_emulation():
     for arch in arch_data:
         steps, hit_addrs, finished = arch_data[arch]
-        filepath = os.path.join(test_location, arch, 'test_arrays')
-        p = angr.Project(filepath, use_sim_procedures=False)
-        yield emulate, p, steps, hit_addrs, finished
+        yield emulate, arch, 'test_arrays', False, steps, hit_addrs, finished
 
 def test_windows():
-    yield emulate, angr.Project(os.path.join(test_location, 'i386', 'test_arrays.exe')), 41, [], False # blocked on GetLastError or possibly dynamic loading
+    yield emulate, 'i386', 'test_arrays.exe', True, 41, [], False # blocked on GetLastError or possibly dynamic loading
 
 def test_locale():
     p = angr.Project(os.path.join(test_location, 'i386', 'isalnum'), use_sim_procedures=False)

--- a/tests/test_variablerecovery.py
+++ b/tests/test_variablerecovery.py
@@ -74,7 +74,11 @@ def _compare_register_variable(variable, variable_info):  # pylint:disable=unuse
     return True
 
 
-def run_variable_recovery_analysis(project, func, groundtruth, is_fast):
+def run_variable_recovery_analysis(func_name, groundtruth, is_fast):
+    binary_path = os.path.join(test_location, 'x86_64', 'fauxware')
+    project = angr.Project(binary_path, load_options={'auto_load_libs': False})
+    cfg = project.analyses.CFG(normalize=True)
+    func = cfg.kb.functions[func_name]
 
     # Create a temporary KnowledgeBase instance
     tmp_kb = angr.KnowledgeBase(project)
@@ -128,11 +132,6 @@ def run_variable_recovery_analysis(project, func, groundtruth, is_fast):
 
 
 def test_variable_recovery_fauxware():
-
-    binary_path = os.path.join(test_location, 'x86_64', 'fauxware')
-    project = angr.Project(binary_path, load_options={'auto_load_libs': False})
-    cfg = project.analyses.CFG(normalize=True)
-
     groundtruth = {
         'authenticate': {
             'variables_by_instruction': {
@@ -198,8 +197,8 @@ def test_variable_recovery_fauxware():
     }
 
     for func_name, truth in groundtruth.items():
-        yield run_variable_recovery_analysis, project, cfg.kb.functions[func_name], truth, True
-        yield run_variable_recovery_analysis, project, cfg.kb.functions[func_name], truth, False
+        yield run_variable_recovery_analysis, func_name, truth, True
+        yield run_variable_recovery_analysis, func_name, truth, False
 
 
 def main():

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -4,7 +4,8 @@ import angr
 class A:
 	n = 0
 
-def do_vault_identity(v):
+def do_vault_identity(v_factory):
+	v = v_factory()
 	v.uuid_dedup.add(A)
 	assert len(v.keys()) == 0
 
@@ -37,7 +38,8 @@ def do_vault_identity(v):
 	bbb = v.load(bid)
 	assert bbb.n == 1
 
-def do_vault_noidentity(v):
+def do_vault_noidentity(v_factory):
+	v = v_factory()
 	assert len(v.keys()) == 0
 
 	a = A()
@@ -68,7 +70,8 @@ def do_vault_noidentity(v):
 	v.store(cc)
 	assert len(v.keys()) == 6
 
-def do_ast_vault(v):
+def do_ast_vault(v_factory):
+	v = v_factory()
 	x = claripy.BVS("x", 32)
 	y = claripy.BVS("y", 32)
 	z = x + y
@@ -85,17 +88,17 @@ def do_ast_vault(v):
 	assert zzz is z
 
 def test_vault():
-	yield do_vault_noidentity, angr.vaults.VaultDir()
-	yield do_vault_noidentity, angr.vaults.VaultShelf()
-	yield do_vault_noidentity, angr.vaults.VaultDict()
-	yield do_vault_identity, angr.vaults.VaultDir()
-	yield do_vault_identity, angr.vaults.VaultShelf()
-	yield do_vault_identity, angr.vaults.VaultDict()
+	yield do_vault_noidentity, angr.vaults.VaultDir
+	yield do_vault_noidentity, angr.vaults.VaultShelf
+	yield do_vault_noidentity, angr.vaults.VaultDict
+	yield do_vault_identity, angr.vaults.VaultDir
+	yield do_vault_identity, angr.vaults.VaultShelf
+	yield do_vault_identity, angr.vaults.VaultDict
 
 def test_ast_vault():
-	yield do_ast_vault, angr.vaults.VaultDir()
-	yield do_ast_vault, angr.vaults.VaultShelf()
-	yield do_ast_vault, angr.vaults.VaultDict()
+	yield do_ast_vault, angr.vaults.VaultDir
+	yield do_ast_vault, angr.vaults.VaultShelf
+	yield do_ast_vault, angr.vaults.VaultDict
 
 def test_project():
 	v = angr.vaults.VaultDir()


### PR DESCRIPTION
On CI, test generators are run both when nose2 collects test names and when nose2 runs for each runner. Therefore, doing anything non-trivial in generators will cause it to be run 11 times, and possibly failing the build step. Nothing should be logically changed here, just moving some constructors into functions to run later during the testing phase.