### PR TITLE
Improve def use graph

### DIFF
--- a/angr/analyses/reaching_definitions/def_use_graph.py
+++ b/angr/analyses/reaching_definitions/def_use_graph.py
@@ -20,6 +20,9 @@ class DefUseGraph:
         """
         :param networkx.DiGraph graph: A graph where nodes are definitions, and edges represent uses.
         """
+        # Used for memoization of the `transitive_closure` method.
+        self._transitive_closures = {}
+
         if not isinstance(graph, networkx.DiGraph):
             self._graph = networkx.DiGraph()
             return
@@ -42,17 +45,56 @@ class DefUseGraph:
 
         self._graph.add_node(node)
 
-    def add_edge(self, source, destination):
+    def add_edge(self, source, destination, **labels):
         """
         The edge to add to the definition-use graph. Will create nodes that are not yet present.
 
         :param Definition source: The "source" definition, used by the "destination".
         :param Definition destination: The "destination" definition, using the variable defined by "source".
+        :param labels: Optional keyword arguments to represent edge labels.
         """
         if not _is_definition(source) and not _is_definition(destination):
             raise TypeError("In a DefUseGraph, edges need to be between <%s>s." % Definition.__name__)
 
-        self._graph.add_edge(source, destination)
+        self._graph.add_edge(source, destination, **labels)
+
+    def transitive_closure(self, definition):
+        """
+        Compute the "transitive closure" of a given definition.
+        Obtained by transitively aggregating the ancestors of this definition in the graph.
+
+        Note: Each definition is memoized to avoid any kind of recomputation accross the lifetime of this object.
+
+        :param Definition definition: The <Definition> to return the top-level ancestors for.
+        :return List[Definition]: The list of top-level definitions flowing into the <node>.
+        """
+
+        def _transitive_closure(definition, graph, result=None):
+            if definition in self._transitive_closures.keys():
+                return self._transitive_closures[definition]
+
+            predecessors = list(graph.predecessors(definition))
+
+            result.add_node(definition)
+            result.add_edges_from(list(map(
+                lambda e: (*e, graph.get_edge_data(*e)),
+                map(
+                    lambda p: (p, definition),
+                    predecessors
+                )
+            )))
+
+            closure = reduce(
+                lambda acc, definition: _transitive_closure(definition, graph, acc),
+                predecessors,
+                result
+            )
+
+            self._transitive_closures[definition] = closure
+            return closure
+
+        return _transitive_closure(definition, self._graph, networkx.DiGraph())
+
 
     def top_predecessors(self, definition):
         """

--- a/tests/test_def_use_graph.py
+++ b/tests/test_def_use_graph.py
@@ -49,10 +49,12 @@ def test_refuses_to_add_edge_between_non_definition_nodes():
 @mock.patch.object(networkx.DiGraph, 'add_edge')
 def test_delegate_add_edge_to_the_underlying_graph_object(digraph_add_edge_mock):
     use = (_a_mock_definition(), _a_mock_definition())
-    def_use_graph = DefUseGraph()
-    def_use_graph.add_edge(*use)
+    labels = { 'attribute1': 'value1', 'attribute2': 'value2' }
 
-    digraph_add_edge_mock.assert_called_once_with(*use)
+    def_use_graph = DefUseGraph()
+    def_use_graph.add_edge(*use, **labels)
+
+    digraph_add_edge_mock.assert_called_once_with(*use, **labels)
 
 
 def test_top_predecessors():
@@ -98,3 +100,44 @@ def test_top_predecessors_should_not_contain_duplicates():
     result = def_use_graph.top_predecessors(D)
 
     nose.tools.assert_list_equal(result, [A])
+
+
+def test_transitive_closure_of_a_node():
+    def_use_graph = DefUseGraph()
+
+    # A -> B, B -> D, C -> D
+    A = _a_mock_definition()
+    B = _a_mock_definition()
+    C = _a_mock_definition()
+    D = _a_mock_definition()
+    uses = [
+        (A, B),
+        (B, D),
+        (C, D),
+    ]
+
+    for use in uses:
+        def_use_graph.add_edge(*use)
+
+    result = def_use_graph.transitive_closure(D)
+    result_nodes = set(result.nodes)
+    result_edges = set(result.edges)
+
+    nose.tools.assert_set_equal(result_nodes, {D, B, C, A})
+    nose.tools.assert_set_equal(result_edges, {(B, D), (C, D), (A, B)})
+
+
+def test_transitive_closure_of_a_node_should_copy_labels_from_original_graph():
+    def_use_graph = DefUseGraph()
+
+    # A -> B
+    A = _a_mock_definition()
+    B = _a_mock_definition()
+    uses = [(A, B)]
+
+    for use in uses:
+        def_use_graph.add_edge(*use, label='some data')
+
+    result = def_use_graph.transitive_closure(B).get_edge_data(A, B)['label']
+
+    nose.tools.assert_equals(result, 'some data')

--- a/tests/test_def_use_graph.py
+++ b/tests/test_def_use_graph.py
@@ -1,11 +1,20 @@
 import networkx
 import nose
 
+from random import randrange
 from unittest import mock
 
+from angr.analyses.code_location import CodeLocation
 from angr.analyses.reaching_definitions.dataset import DataSet
 from angr.analyses.reaching_definitions.definition import Definition
 from angr.analyses.reaching_definitions.def_use_graph import DefUseGraph
+
+
+def _a_mock_definition():
+    # Randomise code locations to forcefully produce "different" <Definition>s.
+    statement_index = randrange(1000)
+    code_location = CodeLocation(0x42, statement_index)
+    return Definition(None, code_location, DataSet(set(), 8), None)
 
 
 def test_def_use_graph_has_a_default_graph():
@@ -25,7 +34,7 @@ def test_refuses_to_add_non_definition_nodes():
 
 @mock.patch.object(networkx.DiGraph, 'add_node')
 def test_delegate_add_node_to_the_underlying_graph_object(digraph_add_node_mock):
-    definition = Definition(None, None, DataSet(set(), 8), None)
+    definition = _a_mock_definition()
     def_use_graph = DefUseGraph()
     def_use_graph.add_node(definition)
 
@@ -39,11 +48,53 @@ def test_refuses_to_add_edge_between_non_definition_nodes():
 
 @mock.patch.object(networkx.DiGraph, 'add_edge')
 def test_delegate_add_edge_to_the_underlying_graph_object(digraph_add_edge_mock):
-    use = (
-        Definition(None, None, DataSet(set(), 8), None),
-        Definition(None, None, DataSet(set(), 8), None),
-    )
+    use = (_a_mock_definition(), _a_mock_definition())
     def_use_graph = DefUseGraph()
     def_use_graph.add_edge(*use)
 
     digraph_add_edge_mock.assert_called_once_with(*use)
+
+
+def test_top_predecessors():
+    def_use_graph = DefUseGraph()
+
+    # A -> B, B -> D, C -> D
+    A = _a_mock_definition()
+    B = _a_mock_definition()
+    C = _a_mock_definition()
+    D = _a_mock_definition()
+    uses = [
+        (A, B),
+        (B, D),
+        (C, D),
+    ]
+
+    for use in uses:
+        def_use_graph.add_edge(*use)
+
+    result = def_use_graph.top_predecessors(D)
+
+    nose.tools.assert_list_equal(result, [A, C])
+
+
+def test_top_predecessors_should_not_contain_duplicates():
+    def_use_graph = DefUseGraph()
+
+    # A -> B, A -> C, B -> D, C -> D
+    A = _a_mock_definition()
+    B = _a_mock_definition()
+    C = _a_mock_definition()
+    D = _a_mock_definition()
+    uses = [
+        (A, B),
+        (A, C),
+        (B, D),
+        (C, D),
+    ]
+
+    for use in uses:
+        def_use_graph.add_edge(*use)
+
+    result = def_use_graph.top_predecessors(D)
+
+    nose.tools.assert_list_equal(result, [A])


### PR DESCRIPTION
  * `add_edge` now forward labels
  * `top_predecessors` method to compute the "entrypoints" leading to a given definition
  * `transitive_closure` method to get the subgraph of all paths leading to a given definition