### PR TITLE
Make GUI more responsive during CFG recovery.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1297,7 +1297,7 @@ class CFGBase(Analysis):
         for i, fn in enumerate(sorted(function_nodes, key=lambda n: n.addr)):
 
             if self._low_priority:
-                self._release_gil(i, 20)
+                self._release_gil(i, 2)
 
             if self._show_progressbar or self._progress_callback:
                 progress = min_stage_2_progress + (max_stage_2_progress - min_stage_2_progress) * (i * 1.0 / nodes_count)
@@ -2196,7 +2196,7 @@ class CFGBase(Analysis):
         all_targets = set()
         for idx, jump in enumerate(self._indirect_jumps_to_resolve):  # type:int,IndirectJump
             if self._low_priority:
-                self._release_gil(idx, 20, 0.0001)
+                self._release_gil(idx, 2, sleep_time=0.0001)
             all_targets |= self._process_one_indirect_jump(jump)
 
         self._indirect_jumps_to_resolve.clear()

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1012,7 +1012,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         """
 
         if self._low_priority:
-            self._release_gil(len(self._nodes), 20, 0.0001)
+            self._release_gil(len(self._nodes), 2, sleep_time=0.0001)
 
         # a new entry is picked. Deregister it
         self._deregister_analysis_job(job.func_addr, job)


### PR DESCRIPTION
I made the current GIL-release strategy more aggressive in this PR. angr management does become more responsive. However, CFG recovery is also noticeably slower (because of the sleep() for every node recovered).

Maybe we can find the right balance by fine-tuning the parameters. Or maybe @mborgerson you have a better solution?