### PR TITLE
Guess who's back, back again, Symbion's back, tell a friend.

### DIFF
--- a/angr/engines/concrete.py
+++ b/angr/engines/concrete.py
@@ -43,7 +43,8 @@ class SimEngineConcrete(SuccessorsMixin):
     def process_successors(self, successors, *args, ** kwargs):
         new_state = self.state
         # setup the concrete process and resume the execution
-        self.to_engine(new_state, kwargs['extra_stop_points'], kwargs['concretize'], kwargs['timeout'])
+        self.to_engine(new_state, kwargs['extra_stop_points'], kwargs['memory_concretize'],
+                       kwargs['register_concretize'], kwargs['timeout'])
 
         # sync angr with the current state of the concrete process using
         # the state plugin
@@ -52,10 +53,10 @@ class SimEngineConcrete(SuccessorsMixin):
         successors.engine = "SimEngineConcrete"
         successors.sort = "SimEngineConcrete"
         successors.add_successor(new_state, new_state.ip, new_state.solver.true, new_state.unicorn.jumpkind)
-        successors.description = "Concrete Successors "
+        successors.description = "Concrete Successors"
         successors.processed = True
 
-    def to_engine(self, state, extra_stop_points, concretize, timeout):
+    def to_engine(self, state, extra_stop_points, memory_concretize, register_concretize, timeout):
         """
         Handle the concrete execution of the process
         This method takes care of:
@@ -66,8 +67,9 @@ class SimEngineConcrete(SuccessorsMixin):
         :param state:               The state with which to execute
         :param extra_stop_points:   list of a addresses where to stop the concrete execution and return to the
                                     simulated one
-        :param concretize:          list of tuples (address, symbolic variable) that are going to be written
-                                    in the concrete process memory
+        :param memory_concretize:   list of tuples (address, symbolic variable) that are going to be written
+                                    in the concrete process memory.
+        :param register_concretize:  list of tuples (reg_name, symbolic variable) that are going to be written
         :param timeout:             how long we should wait the concrete target to reach the breakpoint
         :return: None
         """
@@ -79,14 +81,22 @@ class SimEngineConcrete(SuccessorsMixin):
         l.debug("Entering in SimEngineConcrete: simulated address %#x concrete address %#x stop points %s",
                 state.addr, self.target.read_register("pc"), map(hex, extra_stop_points))
 
-        if concretize:
-            l.debug("SimEngineConcrete is concretizing variables before resuming the concrete process")
+        if memory_concretize:
+            l.debug("SimEngineConcrete is concretizing memory variables before resuming the concrete process")
 
-            for sym_var in concretize:
+            for sym_var in memory_concretize:
                 sym_var_address = state.solver.eval(sym_var[0])
                 sym_var_value = state.solver.eval(sym_var[1], cast_to=bytes)
                 l.debug("Concretize memory at address %#x with value %s", sym_var_address, str(sym_var_value))
                 self.target.write_memory(sym_var_address, sym_var_value, raw=True)
+
+        if register_concretize:
+            l.debug("SimEngineConcrete is concretizing registers variables before resuming the concrete process")
+            for reg in register_concretize:
+                register_name = reg[0]
+                register_value = state.solver.eval(reg[1])
+                l.debug("Concretize register %s with value %s", register_name, str(register_value))
+                self.target.write_register(register_name, register_value)
 
         # Set breakpoint on remote target
         for stop_point in extra_stop_points:

--- a/angr/engines/concrete.py
+++ b/angr/engines/concrete.py
@@ -2,11 +2,11 @@ import logging
 import threading
 
 from angr.errors import AngrError
-from .engine import SimEngine, SuccessorsMixin
+from .engine import SuccessorsMixin
 from ..errors import SimConcreteMemoryError, SimConcreteRegisterError
 
 l = logging.getLogger("angr.engines.concrete")
-l.setLevel(logging.DEBUG)
+#l.setLevel(logging.DEBUG)
 
 try:
     from angr_targets.concrete import ConcreteTarget
@@ -37,14 +37,15 @@ class SimEngineConcrete(SuccessorsMixin):
 
         self.segment_registers_already_init = False
 
-    def __check(self, state, *args, **kwargs):
+    def __check(self, _, *args, **kwargs):  #pylint:disable=unused-argument
         return True
 
-    def process_successors(self, successors, *args, ** kwargs):
+    def process_successors(self, successors, extra_stop_points=None, memory_concretize=None,
+                           register_concretize=None, timeout=0, *args, **kwargs):
+
         new_state = self.state
         # setup the concrete process and resume the execution
-        self.to_engine(new_state, kwargs['extra_stop_points'], kwargs['memory_concretize'],
-                       kwargs['register_concretize'], kwargs['timeout'])
+        self.to_engine(new_state, extra_stop_points, memory_concretize, register_concretize, timeout)
 
         # sync angr with the current state of the concrete process using
         # the state plugin

--- a/angr/engines/concrete.py
+++ b/angr/engines/concrete.py
@@ -37,9 +37,6 @@ class SimEngineConcrete(SuccessorsMixin):
 
         self.segment_registers_already_init = False
 
-    def __check(self, _, *args, **kwargs):  #pylint:disable=unused-argument
-        return True
-
     def process_successors(self, successors, extra_stop_points=None, memory_concretize=None,
                            register_concretize=None, timeout=0, *args, **kwargs):
 

--- a/angr/exploration_techniques/symbion.py
+++ b/angr/exploration_techniques/symbion.py
@@ -9,15 +9,16 @@ l = logging.getLogger("angr.exploration_techniques.symbion")
 
 class Symbion(ExplorationTechnique):
     """
-     The Symbion exploration technique uses the SimEngineConcrete available to step a SimState.
+    The Symbion exploration technique uses the SimEngineConcrete available to step a SimState.
 
-     :param find: address or list of addresses that we want to reach, these will be translated into breakpoints
-                  inside the concrete process using the ConcreteTarget interface provided by the user
-                  inside the SimEngineConcrete.
-    :param memory_concretize:   list of tuples (address, symbolic variable) that are going to be written
-                                in the concrete process memory.
-    :param register_concretize:  list of tuples (reg_name, symbolic variable) that are going to be written
-    :param timeout:             how long we should wait the concrete target to reach the breakpoint
+    :param find: address or list of addresses that we want to reach, these will be translated into breakpoints
+        inside the concrete process using the ConcreteTarget interface provided by the user
+        inside the SimEngineConcrete.
+    :param memory_concretize: list of tuples (address, symbolic variable) that are going to be written
+        in the concrete process memory.
+    :param register_concretize: list of tuples (reg_name, symbolic variable) that are going to be written
+    :param timeout: how long we should wait the concrete target to reach the breakpoint
+
     """
 
     def __init__(self, find=None, memory_concretize=None, register_concretize=None, timeout=0, find_stash='found'):

--- a/angr/exploration_techniques/symbion.py
+++ b/angr/exploration_techniques/symbion.py
@@ -52,7 +52,6 @@ class Symbion(ExplorationTechnique):
         return simgr.step(stash=stash, **kwargs)
 
     def step_state(self, simgr, *args, **kwargs):
-
         state = args[0]
         ss = self.successors(state=state, simgr=simgr, engine=self.project.factory.concrete_engine,
                                           extra_stop_points=self.breakpoints,

--- a/angr/exploration_techniques/symbion.py
+++ b/angr/exploration_techniques/symbion.py
@@ -2,6 +2,7 @@
 import logging
 from .common import condition_to_lambda
 
+from ..engines import SimEngineConcrete
 from . import ExplorationTechnique
 
 l = logging.getLogger("angr.exploration_techniques.symbion")
@@ -49,11 +50,13 @@ class Symbion(ExplorationTechnique):
 
         return simgr.step(stash=stash, **kwargs)
 
-    def step_state(self, simgr, state, **kwargs):
-        ss = self.project.factory.successors(state, engines=['concrete'],
-                                             extra_stop_points=self.breakpoints,
-                                             concretize=self.concretize,
-                                             timeout=self.timeout)
+    def step_state(self, simgr, *args, **kwargs):
+        state = args[0]
+
+        ss = self.successors(state=state, simgr=simgr, engine=self.project.factory.concrete_engine,
+                                          extra_stop_points=self.breakpoints,
+                                          concretize=self.concretize,
+                                          timeout=self.timeout)
 
         new_state = ss.successors
 

--- a/angr/exploration_techniques/symbion.py
+++ b/angr/exploration_techniques/symbion.py
@@ -16,17 +16,20 @@ class Symbion(ExplorationTechnique):
      :param find: address or list of addresses that we want to reach, these will be translated into breakpoints
                   inside the concrete process using the ConcreteTarget interface provided by the user
                   inside the SimEngineConcrete.
-     :param concretize: list of tuples (address, symbolic variable) to concretize and write inside
-                        the concrete process.
+    :param memory_concretize:   list of tuples (address, symbolic variable) that are going to be written
+                                in the concrete process memory.
+    :param register_concretize:  list of tuples (reg_name, symbolic variable) that are going to be written
+    :param timeout:             how long we should wait the concrete target to reach the breakpoint
     """
 
-    def __init__(self, find=None, concretize=None, timeout=0, find_stash='found'):
+    def __init__(self, find=None, memory_concretize=None, register_concretize=None, timeout=0, find_stash='found'):
         super(Symbion, self).__init__()
 
         # need to keep the raw list of addresses to
         self.breakpoints = find
         self.find = condition_to_lambda(find)
-        self.concretize = concretize
+        self.memory_concretize = memory_concretize
+        self.register_concretize = register_concretize
         self.find_stash = find_stash
         self.timeout = timeout
 
@@ -55,7 +58,8 @@ class Symbion(ExplorationTechnique):
 
         ss = self.successors(state=state, simgr=simgr, engine=self.project.factory.concrete_engine,
                                           extra_stop_points=self.breakpoints,
-                                          concretize=self.concretize,
+                                          memory_concretize=self.memory_concretize,
+                                          register_concretize=self.register_concretize,
                                           timeout=self.timeout)
 
         new_state = ss.successors

--- a/angr/exploration_techniques/symbion.py
+++ b/angr/exploration_techniques/symbion.py
@@ -51,7 +51,7 @@ class Symbion(ExplorationTechnique):
 
         return simgr.step(stash=stash, **kwargs)
 
-    def step_state(self, simgr, *args, **kwargs):
+    def step_state(self, simgr, *args, **kwargs): #pylint:disable=arguments-differ
         state = args[0]
         ss = self.successors(state=state, simgr=simgr, engine=self.project.factory.concrete_engine,
                                           extra_stop_points=self.breakpoints,

--- a/angr/exploration_techniques/symbion.py
+++ b/angr/exploration_techniques/symbion.py
@@ -1,8 +1,6 @@
 
 import logging
 from .common import condition_to_lambda
-
-from ..engines import SimEngineConcrete
 from . import ExplorationTechnique
 
 l = logging.getLogger("angr.exploration_techniques.symbion")
@@ -54,8 +52,8 @@ class Symbion(ExplorationTechnique):
         return simgr.step(stash=stash, **kwargs)
 
     def step_state(self, simgr, *args, **kwargs):
-        state = args[0]
 
+        state = args[0]
         ss = self.successors(state=state, simgr=simgr, engine=self.project.factory.concrete_engine,
                                           extra_stop_points=self.breakpoints,
                                           memory_concretize=self.memory_concretize,

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -26,6 +26,8 @@ class AngrObjectFactory(object):
 
         if project.concrete_target:
             self.concrete_engine = SimEngineConcrete(project)
+        else:
+            self.concrete_engine = None
 
     def snippet(self, addr, jumpkind=None, **block_opts):
         if self.project.is_hooked(addr) and jumpkind != 'Ijk_NoHook':

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -5,7 +5,7 @@ from .sim_state import SimState
 from .calling_conventions import DEFAULT_CC, SimRegArg, SimStackArg, PointerWrapper
 from .callable import Callable
 from .errors import AngrAssemblyError
-from .engines import UberEngine, ProcedureEngine
+from .engines import UberEngine, ProcedureEngine, SimEngineConcrete
 
 
 l = logging.getLogger(name=__name__)
@@ -23,6 +23,9 @@ class AngrObjectFactory(object):
         self._default_cc = DEFAULT_CC[project.arch.name]
         self.default_engine = default_engine(project)
         self.procedure_engine = ProcedureEngine(project)
+
+        if project.concrete_target:
+            self.concrete_engine = SimEngineConcrete(project)
 
     def snippet(self, addr, jumpkind=None, **block_opts):
         if self.project.is_hooked(addr) and jumpkind != 'Ijk_NoHook':
@@ -48,7 +51,6 @@ class AngrObjectFactory(object):
 
         Additional keyword arguments will be passed directly into each engine's process method.
         """
-
         if engine is not None:
             return engine.process(*args, **kwargs)
         return self.default_engine.process(*args, **kwargs)

--- a/angr/procedures/win32/GetLastInputInfo.py
+++ b/angr/procedures/win32/GetLastInputInfo.py
@@ -1,0 +1,38 @@
+import angr
+import logging
+
+l = logging.getLogger(name=__name__)
+#l.setLevel("DEBUG")
+
+'''
+BOOL GetLastInputInfo(
+  PLASTINPUTINFO plii
+);
+
+typedef struct tagLASTINPUTINFO {
+  UINT  cbSize;  // The size of the structure, in bytes.
+                 // This member must be set to sizeof(LASTINPUTINFO).
+  DWORD dwTime;
+} LASTINPUTINFO, *PLASTINPUTINFO;
+
+'''
+class GetLastInputInfo(angr.SimProcedure):
+    cbSize = None
+    dwTime = None
+
+    def run(self, plii):  #pylint:disable=arguments-differ
+        self.fill_symbolic()
+        l.info("Setting symbolic memory at %s", str(plii))
+
+        self.state.mem[plii].dword = self.cbSize
+        self.state.mem[plii+4].dword = self.dwTime
+
+        return 1
+
+    def fill_symbolic(self):
+        self.cbSize = self.state.solver.BVS('tagLASTINPUTINFO_cbSize', 32, key=('api', 'tagLASTINPUTINFO_cbSize'))
+        self.dwTime = self.state.solver.BVS('tagLASTINPUTINFO_dwTime', 32, key=('api', 'tagLASTINPUTINFO_dwTime'))
+
+    def fill_concrete(self):
+        self.cbSize = self.state.solver.BVV(3, 32)
+        self.dwTime = self.state.solver.BVV(3, 32)

--- a/angr/procedures/win32/GetLastInputInfo.py
+++ b/angr/procedures/win32/GetLastInputInfo.py
@@ -4,19 +4,17 @@ import logging
 l = logging.getLogger(name=__name__)
 #l.setLevel("DEBUG")
 
-'''
-BOOL GetLastInputInfo(
-  PLASTINPUTINFO plii
-);
-
-typedef struct tagLASTINPUTINFO {
-  UINT  cbSize;  // The size of the structure, in bytes.
-                 // This member must be set to sizeof(LASTINPUTINFO).
-  DWORD dwTime;
-} LASTINPUTINFO, *PLASTINPUTINFO;
-
-'''
 class GetLastInputInfo(angr.SimProcedure):
+    """ BOOL GetLastInputInfo(
+      PLASTINPUTINFO plii
+    );
+
+    typedef struct tagLASTINPUTINFO {
+      UINT  cbSize;  // The size of the structure, in bytes.
+                     // This member must be set to sizeof(LASTINPUTINFO).
+      DWORD dwTime;
+    } LASTINPUTINFO, *PLASTINPUTINFO;
+    """
     cbSize = None
     dwTime = None
 

--- a/angr/procedures/win32/GetLastInputInfo.py
+++ b/angr/procedures/win32/GetLastInputInfo.py
@@ -4,24 +4,23 @@ import logging
 l = logging.getLogger(name=__name__)
 #l.setLevel("DEBUG")
 
-class GetLastInputInfo(angr.SimProcedure):
-    """ BOOL GetLastInputInfo(
-      PLASTINPUTINFO plii
-    );
+""" BOOL GetLastInputInfo(
+  PLASTINPUTINFO plii
+);
 
-    typedef struct tagLASTINPUTINFO {
-      UINT  cbSize;  // The size of the structure, in bytes.
-                     // This member must be set to sizeof(LASTINPUTINFO).
-      DWORD dwTime;
-    } LASTINPUTINFO, *PLASTINPUTINFO;
-    """
+typedef struct tagLASTINPUTINFO {
+  UINT  cbSize;  // The size of the structure, in bytes.
+                 // This member must be set to sizeof(LASTINPUTINFO).
+  DWORD dwTime;
+} LASTINPUTINFO, *PLASTINPUTINFO;
+"""
+class GetLastInputInfo(angr.SimProcedure):
     cbSize = None
     dwTime = None
 
     def run(self, plii):  #pylint:disable=arguments-differ
         self.fill_symbolic()
         l.info("Setting symbolic memory at %s", str(plii))
-
         self.state.mem[plii].dword = self.cbSize
         self.state.mem[plii+4].dword = self.dwTime
 

--- a/angr/procedures/win32/GetProcessAffinityMask.py
+++ b/angr/procedures/win32/GetProcessAffinityMask.py
@@ -1,0 +1,33 @@
+import angr
+import logging
+
+l = logging.getLogger(name=__name__)
+#l.setLevel("DEBUG")
+
+'''
+BOOL GetProcessAffinityMask(
+  HANDLE     hProcess,
+  PDWORD_PTR lpProcessAffinityMask,
+  PDWORD_PTR lpSystemAffinityMask
+);
+'''
+class GetProcessAffinityMask(angr.SimProcedure):
+    paffinity_mask = None
+    saffinity_mask = None
+
+    def run(self, _, lpProcessAffinityMask, lpSystemAffinityMask): #pylint:disable=arguments-differ
+        self.fill_symbolic()
+        l.info("Setting symbolic memory at %s %s", str(lpProcessAffinityMask), str(lpSystemAffinityMask))
+
+        self.state.mem[lpProcessAffinityMask].dword = self.paffinity_mask
+        self.state.mem[lpSystemAffinityMask].dword = self.saffinity_mask
+
+        return 1
+
+    def fill_symbolic(self):
+        self.paffinity_mask = self.state.solver.BVS('lpProcessAffinityMask', 32, key=('api', 'lpProcessAffinityMask'))
+        self.saffinity_mask = self.state.solver.BVS('lpSystemAffinityMask', 32, key=('api', 'lpSystemAffinityMask'))
+
+    def fill_concrete(self):
+        self.paffinity_mask = self.state.solver.BVV(3, 32)
+        self.saffinity_mask = self.state.solver.BVV(3, 32)

--- a/angr/procedures/win32/GetProcessAffinityMask.py
+++ b/angr/procedures/win32/GetProcessAffinityMask.py
@@ -4,13 +4,13 @@ import logging
 l = logging.getLogger(name=__name__)
 #l.setLevel("DEBUG")
 
+""" BOOL GetProcessAffinityMask(
+  HANDLE     hProcess,
+  PDWORD_PTR lpProcessAffinityMask,
+  PDWORD_PTR lpSystemAffinityMask
+);
+"""
 class GetProcessAffinityMask(angr.SimProcedure):
-    """ BOOL GetProcessAffinityMask(
-      HANDLE     hProcess,
-      PDWORD_PTR lpProcessAffinityMask,
-      PDWORD_PTR lpSystemAffinityMask
-    );
-    """
     paffinity_mask = None
     saffinity_mask = None
 

--- a/angr/procedures/win32/GetProcessAffinityMask.py
+++ b/angr/procedures/win32/GetProcessAffinityMask.py
@@ -4,14 +4,13 @@ import logging
 l = logging.getLogger(name=__name__)
 #l.setLevel("DEBUG")
 
-'''
-BOOL GetProcessAffinityMask(
-  HANDLE     hProcess,
-  PDWORD_PTR lpProcessAffinityMask,
-  PDWORD_PTR lpSystemAffinityMask
-);
-'''
 class GetProcessAffinityMask(angr.SimProcedure):
+    """ BOOL GetProcessAffinityMask(
+      HANDLE     hProcess,
+      PDWORD_PTR lpProcessAffinityMask,
+      PDWORD_PTR lpSystemAffinityMask
+    );
+    """
     paffinity_mask = None
     saffinity_mask = None
 

--- a/angr/procedures/win32/gethostbyname.py
+++ b/angr/procedures/win32/gethostbyname.py
@@ -1,13 +1,10 @@
 import angr
 import logging
-import claripy
 
 l = logging.getLogger('angr.procedures.win32.gethostbyname')
 
 class gethostbyname(angr.SimProcedure):
 
     def run(self, _): #pylint:disable=arguments-differ
-        self.argument_types = {0: self.ty_ptr(angr.sim_type.SimTypeString()), }
-        self.return_type = self.ty_ptr(angr.sim_type.SimTypeTop(self.state.arch))
-        ret_expr = claripy.BVS('gethostbyname_retval', 32)
+        ret_expr = self.state.solver.BVS('gethostbyname_retval', 32)
         return ret_expr

--- a/angr/procedures/win32/gethostbyname.py
+++ b/angr/procedures/win32/gethostbyname.py
@@ -1,0 +1,13 @@
+import angr
+import logging
+import claripy
+
+l = logging.getLogger('angr.procedures.win32.gethostbyname')
+
+class gethostbyname(angr.SimProcedure):
+
+    def run(self, _): #pylint:disable=arguments-differ
+        self.argument_types = {0: self.ty_ptr(angr.sim_type.SimTypeString()), }
+        self.return_type = self.ty_ptr(angr.sim_type.SimTypeTop(self.state.arch))
+        ret_expr = claripy.BVS('gethostbyname_retval', 32)
+        return ret_expr

--- a/angr/procedures/win32/gethostbyname.py
+++ b/angr/procedures/win32/gethostbyname.py
@@ -6,5 +6,5 @@ l = logging.getLogger('angr.procedures.win32.gethostbyname')
 class gethostbyname(angr.SimProcedure):
 
     def run(self, _): #pylint:disable=arguments-differ
-        ret_expr = self.state.solver.BVS('gethostbyname_retval', 32)
+        ret_expr = self.state.solver.BVS('gethostbyname_retval', 32, key=('api', 'gethostbyname_retval'))
         return ret_expr

--- a/angr/procedures/win32/heap.py
+++ b/angr/procedures/win32/heap.py
@@ -1,17 +1,26 @@
 import angr
 
+
 class GetProcessHeap(angr.SimProcedure):
     def run(self):
-        return 1 # fake heap handle
+        return 1  # fake heap handle
+
 
 class HeapCreate(angr.SimProcedure):
     def run(self, flOptions, dwInitialSize, dwMaximumSize):
-        return 1 # still a fake heap handle
+        return 1  # still a fake heap handle
+
 
 class HeapAlloc(angr.SimProcedure):
     def run(self, HeapHandle, Flags, Size):
         return self.state.heap._malloc(Size)
 
+
 class GlobalAlloc(HeapAlloc):
     def run(self, Flags, Size):
         return super(GlobalAlloc, self).run(1, Flags, Size)
+
+
+class HeapFree(angr.SimProcedure):
+    def run(self, HeapHandle, Flags, lpMem): #pylint:disable=arguments-differ
+        return 1

--- a/angr/procedures/win32/heap.py
+++ b/angr/procedures/win32/heap.py
@@ -7,12 +7,12 @@ class GetProcessHeap(angr.SimProcedure):
 
 
 class HeapCreate(angr.SimProcedure):
-    def run(self, flOptions, dwInitialSize, dwMaximumSize):
+    def run(self, flOptions, dwInitialSize, dwMaximumSize): #pylint:disable=arguments-differ, unused-argument
         return 1  # still a fake heap handle
 
 
 class HeapAlloc(angr.SimProcedure):
-    def run(self, HeapHandle, Flags, Size):
+    def run(self, HeapHandle, Flags, Size): #pylint:disable=arguments-differ, unused-argument
         return self.state.heap._malloc(Size)
 
 
@@ -22,5 +22,5 @@ class GlobalAlloc(HeapAlloc):
 
 
 class HeapFree(angr.SimProcedure):
-    def run(self, HeapHandle, Flags, lpMem): #pylint:disable=arguments-differ
+    def run(self, HeapHandle, Flags, lpMem): #pylint:disable=arguments-differ, unused-argument
         return 1

--- a/angr/project.py
+++ b/angr/project.py
@@ -554,7 +554,7 @@ class Project:
         self.unhook(hook_addr)
         return True
 
-    def rehook_symbol(self, new_address, symbol_name):
+    def rehook_symbol(self, new_address, symbol_name, stubs_on_sync):
         """
         Move the hook for a symbol to a specific address
         :param new_address: the new address that will trigger the SimProc execution
@@ -563,6 +563,11 @@ class Project:
         """
         new_sim_procedures = {}
         for key_address, simproc_obj in self._sim_procedures.items():
+
+            # if we don't want stubs during the sync let's skip those, we will execute the real function.
+            if not stubs_on_sync and simproc_obj.is_stub:
+                continue
+
             if simproc_obj.display_name == symbol_name:
                 new_sim_procedures[new_address] = simproc_obj
             else:

--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -341,6 +341,9 @@ class SimulationManager:
                 continue
 
             pre_errored = len(self._errored)
+
+
+            
             successors = self.step_state(state, successor_func=successor_func, **run_args)
 
             # handle degenerate stepping cases here. desired behavior:

--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -342,10 +342,7 @@ class SimulationManager:
 
             pre_errored = len(self._errored)
 
-
-            
             successors = self.step_state(state, successor_func=successor_func, **run_args)
-
             # handle degenerate stepping cases here. desired behavior:
             # if a step produced only unsat states, always add them to the unsat stash since this usually indicates a bug
             # if a step produced sat states and save_unsat is False, drop the unsats

--- a/angr/sim_options.py
+++ b/angr/sim_options.py
@@ -298,6 +298,12 @@ CGC_NON_BLOCKING_FDS = 'CGC_NON_BLOCKING_FDS'
 # Sacrafice performance for more fine tune memory read size
 MEMORY_CHUNK_INDIVIDUAL_READS = "MEMORY_CHUNK_INDIVIDUAL_READS"
 
+# Synchronize memory mapping reported by angr with the concrete process.
+SYMBION_SYNC_CLE = "SYMBION_SYNC_CLE"
+# Removes stubs SimProc on synchronization with concrete process.
+# We will execute SimProc for functions for which we have one, and the real function for the one we have not.
+SYMBION_KEEP_STUBS_ON_SYNC = "SYMBION_KEEP_STUBS_ON_SYNC"
+
 #
 # Register those variables as Boolean state options
 #

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -380,7 +380,7 @@ class SimLinux(SimUserland):
         # Synchronize the address of vsyscall in simprocedures dictionary with the concrete value
         _vsyscall_address = concrete_target.read_memory(gs + 0x10, state.project.arch.bits / 8)
         _vsyscall_address = struct.unpack(state.project.arch.struct_fmt(), _vsyscall_address)[0]
-        state.project.rehook_symbol(_vsyscall_address, '_vsyscall')
+        state.project.rehook_symbol(_vsyscall_address, '_vsyscall', True)
 
         return gdt
 

--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -231,7 +231,7 @@ class Concrete(SimStatePlugin):
                 # l.debug("reloc.rebased_addr: %#x " % reloc.rebased_addr)
 
                 if self.state.project.simos.name == 'Win32':
-                    func_address = self.state.project.concrete_target.read_memory(reloc.rebased_addr, self.state.project.arch.bits / 8)
+                    func_address = self.state.project.concrete_target.read_memory(reloc.rebased_addr, self.state.project.arch.bits // self.arch.byte_width)
                     func_address = struct.unpack(self.state.project.arch.struct_fmt(), func_address)[0]
                 elif self.state.project.simos.name == 'Linux':
                     try:

--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -9,7 +9,6 @@ import struct
 from .plugin import SimStatePlugin
 from ..errors import SimConcreteRegisterError
 from archinfo import ArchX86, ArchAMD64
-from .. import sim_options as options
 
 l = logging.getLogger("state_plugin.concrete")
 #l.setLevel(logging.DEBUG)
@@ -30,7 +29,7 @@ class Concrete(SimStatePlugin):
         else:
             self.whitelist = whitelist
 
-        self.sync_cle = False
+        self.synchronize_cle = False
         self.stubs_on_sync = False
 
         self.fs_register_bp = fs_register_bp
@@ -93,7 +92,7 @@ class Concrete(SimStatePlugin):
 
         # Configure plugin with state options
         if options.SYMBION_SYNC_CLE in self.state.options:
-            self.sync_cle = True
+            self.synchronize_cle = True
         if options.SYMBION_KEEP_STUBS_ON_SYNC in self.state.options:
             self.stubs_on_sync = True
 
@@ -119,7 +118,7 @@ class Concrete(SimStatePlugin):
             # finally let's synchronize the whole register
             self._sync_registers([register.name], target)
 
-        if self.sync_cle:
+        if self.synchronize_cle:
             self._sync_cle(target)
 
         # Synchronize the imported functions addresses (.got, IAT) in the
@@ -271,4 +270,5 @@ class Concrete(SimStatePlugin):
 
 
 from ..sim_state import SimState
+from .. import sim_options as options
 SimState.register_default('concrete', Concrete)

--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -231,10 +231,11 @@ class Concrete(SimStatePlugin):
                 # l.debug("reloc.rebased_addr: %#x " % reloc.rebased_addr)
 
                 if self.state.project.simos.name == 'Win32':
-                    func_address = self.state.project.concrete_target.read_memory(reloc.rebased_addr, self.state.project.arch.bits // self.arch.byte_width)
+                    func_address = self.state.project.concrete_target.read_memory(reloc.rebased_addr, self.state.arch.bytes)
                     func_address = struct.unpack(self.state.project.arch.struct_fmt(), func_address)[0]
                 elif self.state.project.simos.name == 'Linux':
                     try:
+                        import ipdb; ipdb.set_trace()
                         func_address = self.state.project.loader.main_object.plt[reloc.symbol.name]
                     except KeyError:
                         continue


### PR DESCRIPTION
1-Ported the SimEngineConcrete to the new engine system.
2-Included the new features in #1743 (closed now).
3-Refactored the test-cases in angr-targets to match the new Symbion's interface.
4-CLE synchronization with the concrete process memory mapping is controllable by a state option
5-New option to control the synchronization of the SimProcedures when importing a concrete state:the user can now decide to execute the real function code for functions for which we don't have SimProc instead of using stubs. (See discussion in #1743 )