### PR TITLE
Don't use `is not` with literals

### DIFF
--- a/angr/analyses/backward_slice.py
+++ b/angr/analyses/backward_slice.py
@@ -181,7 +181,7 @@ class BackwardSlice(Analysis):
         anno_cfg = AnnotatedCFG(self.project, self._cfg)
 
         for simrun, stmt_idx in self._targets:
-            if stmt_idx is not -1:
+            if stmt_idx != -1:
                 anno_cfg.set_last_statement(simrun.addr, stmt_idx)
 
         for n in self._cfg.graph.nodes():

--- a/angr/procedures/java_jni/__init__.py
+++ b/angr/procedures/java_jni/__init__.py
@@ -30,7 +30,7 @@ class JNISimProcedure(SimProcedure):
         # Setup a SimCC using the correct type for the return value
         if not self.return_ty:
             raise ValueError("Classes implementing JNISimProcedure's must set the return type.")
-        elif self.return_ty is not 'void':
+        elif self.return_ty != 'void':
             func_ty = SimTypeFunction(args=[],
                                       returnty=state.project.simos.get_native_type(self.return_ty))
             self.cc = DefaultCC[state.arch.name](state.arch, func_ty=func_ty)


### PR DESCRIPTION
This fixes a few warnings that pop up when running angr under python 3.8.