### PR TITLE
More misc CFG fixes for ARM

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2026,6 +2026,10 @@ class CFGBase(Analysis):
                 if op0.reg == op1.mem.base and op1.mem.index == 0 and op1.mem.disp == 0:
                     return True
         elif insn_name == 'mov':
+            if len(insn.operands) > 2:
+                # mov reg_a, imm1, shift imm2
+                # This is not a NOP
+                return False
             # mov reg_a, reg_a
             op0, op1 = insn.operands
             if op0.type == 1 and op1.type == 1:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2275,6 +2275,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :return: a tuple of (data type, size). (None, None) if we fail to determine the type or the size.
         :rtype: tuple
         """
+        if max_size is None:
+            max_size = 0
 
         # quick check: if it's at the beginning of a binary, it might be the ELF header
         elfheader_sort, elfheader_size = self._guess_data_type_elfheader(data_addr, max_size)
@@ -2288,8 +2290,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         except StopIteration:
             irsb_addr, stmt_idx = None, None
 
-        if max_size is None:
-            max_size = 0
 
         if self._seg_list.is_occupied(data_addr) and self._seg_list.occupied_by_sort(data_addr) == 'code':
             # it's a code reference


### PR DESCRIPTION
MOV instructions can have more than two args; MemoryData objects can have zero size, fix CFG on some ARM binaries.

Needed for #1668 