### PR TITLE
Add import CFGBase

### DIFF
--- a/angr/analyses/cfg/__init__.py
+++ b/angr/analyses/cfg/__init__.py
@@ -1,6 +1,7 @@
 
 # analyses
 from .cfg_fast import CFGFast
+from .cfg_base import CFGBase
 from .cfg_emulated import CFGEmulated
 from .cfg import CFG
 from .cfb import CFBlanket


### PR DESCRIPTION
`cfg.CFGBase` is [referenced in angr-management](https://github.com/angr/angr-management/blob/d95391feecef64d5b6cd65122c75ffcceb2cb4e0/angrmanagement/data/instance.py#L31) but wasn't imported here.

It must have gone missing in some merge somewhere or something... the last commit I see in the history for this file by @rhelmot added this same line.