### PR TITLE
Importing ABC from collections.abc instead of collections. Fixes #1903

### DIFF
--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -1,5 +1,5 @@
 import logging
-import collections
+import collections.abc
 from sortedcontainers import SortedDict
 import networkx
 
@@ -58,7 +58,7 @@ class FunctionDict(SortedDict):
             raise KeyError(addr)
 
 
-class FunctionManager(KnowledgeBasePlugin, collections.Mapping):
+class FunctionManager(KnowledgeBasePlugin, collections.abc.Mapping):
     """
     This is a function boundaries management tool. It takes in intermediate
     results during CFG generation, and manages a function map of the binary.

--- a/angr/sim_variable.py
+++ b/angr/sim_variable.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import claripy
 
 class SimVariable:
@@ -229,7 +229,7 @@ class SimStackVariable(SimMemoryVariable):
         return hash((self.ident, self.base, self.offset, self.size))
 
 
-class SimVariableSet(collections.MutableSet):
+class SimVariableSet(collections.abc.MutableSet):
     """
     A collection of SimVariables.
     """

--- a/angr/vaults.py
+++ b/angr/vaults.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import contextlib
 import tempfile
 import weakref
@@ -42,7 +42,7 @@ class VaultUnpickler(pickle.Unpickler):
     def persistent_load(self, pid):
         return self.vault.load(pid)
 
-class Vault(collections.MutableMapping):
+class Vault(collections.abc.MutableMapping):
     """
     The vault is a serializer for angr.
     """


### PR DESCRIPTION
Importing Abstract Base Classes (ABC) from `collections` module is deprecated since Python 3.4 and will be removed in Python 3.9

I have tried fixing as many instances I could find in the codebase. If I missed some, please mention them below.