### PR TITLE
XRefs: Add ability to get xrefs to or from regions

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -7,6 +7,7 @@ import networkx
 import pyvex
 from claripy.utils.orderedset import OrderedSet
 from cle import ELF, PE, Blob, TLSObject, MachO, ExternObject, KernelObject
+from cle.backends import NamedRegion
 from archinfo.arch_soot import SootAddressDescriptor
 from archinfo.arch_arm import is_arm_arch, get_real_address_if_arm
 
@@ -604,7 +605,9 @@ class CFGBase(Analysis):
                 # a blob is entirely executable
                 tpl = (b.min_addr, b.max_addr)
                 memory_regions.append(tpl)
-
+            elif isinstance(b, NamedRegion):
+                # NamedRegions have no content! Ignore
+                pass
             elif isinstance(b, self._cle_pseudo_objects):
                 pass
 

--- a/angr/knowledge_plugins/xrefs/xref_manager.py
+++ b/angr/knowledge_plugins/xrefs/xref_manager.py
@@ -55,6 +55,33 @@ class XRefManager(KnowledgeBasePlugin, Serializable):
     def get_xrefs_by_dst(self, dst):
         return self.xrefs_by_dst.get(dst, set())
 
+    def get_xrefs_by_dst_region(self, start, end):
+        """
+        Get a set of XRef objects that point to a given address region
+        bounded by start and end.
+        Will only return absolute xrefs, not relative ones (like SP offsets)
+        """
+        f = lambda x: isinstance(x, int) and start <= x <= end
+        addrs = filter(f, self.xrefs_by_dst.keys())
+        refs = set()
+        for addr in addrs:
+            refs = refs.union(self.xrefs_by_dst[addr])
+        return refs
+
+    def get_xrefs_by_ins_addr_region(self, start, end):
+        """
+        Get a set of XRef objects that originate at a given address region
+        bounded by start and end.  Useful for finding references from a basic block or function.
+        """
+        f = lambda x: isinstance(x, int) and start <= x <= end
+        addrs = filter(f, self.xrefs_by_ins_addr.keys())
+        refs = set()
+        for addr in addrs:
+            refs = refs.union(self.xrefs_by_ins_addr[addr])
+        return refs
+
+    # TODO: Maybe add some helpers that accept Function or Block objects for the sake of clean analyses.
+
     @classmethod
     def _get_cmsg(cls):
         return xrefs_pb2.XRefs()


### PR DESCRIPTION
Add helpers to get XRefs to or from a region.

Also ignore NamedRegions while building the CFG (which quiets CFG and XRefs errors)