### PR TITLE
claripy: ccall: add adcx/adox support

### DIFF
--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -146,6 +146,10 @@ data['AMD64']['OpTypes']['G_CC_OP_SMULW'] = 50
 data['AMD64']['OpTypes']['G_CC_OP_SMULL'] = 51
 data['AMD64']['OpTypes']['G_CC_OP_SMULQ'] = 52
 data['AMD64']['OpTypes']['G_CC_OP_NUMBER'] = 53
+data['AMD64']['OpTypes']['G_CC_OP_ADCXL'] = 61
+data['AMD64']['OpTypes']['G_CC_OP_ADCXQ'] = 62
+data['AMD64']['OpTypes']['G_CC_OP_ADOXL'] = 63
+data['AMD64']['OpTypes']['G_CC_OP_ADOXQ'] = 64
 
 data['X86']['CondTypes']['CondO']      = 0
 data['X86']['CondTypes']['CondNO']     = 1
@@ -328,6 +332,33 @@ def pc_actions_ADC(state, nbits, cc_dep1, cc_dep2, cc_ndep, platform=None):
 
     return pc_make_rdata(data[platform]['size'], cf, pf, af, zf, sf, of, platform=platform)
 
+def pc_actions_ADCX(state, nbits, cc_dep1, cc_dep2, cc_ndep, is_adc, platform=None):
+    pf = claripy.If(cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_P'] != 0, claripy.BVV(1, 1), claripy.BVV(0, 1))
+    af = claripy.If(cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_A'] != 0, claripy.BVV(1, 1), claripy.BVV(0, 1))
+    zf = claripy.If(cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_Z'] != 0, claripy.BVV(1, 1), claripy.BVV(0, 1))
+    sf = claripy.If(cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_S'] != 0, claripy.BVV(1, 1), claripy.BVV(0, 1))
+    if is_adc:
+        carry = cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_C']
+        of = claripy.If(cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_O'] != 0, claripy.BVV(1, 1), claripy.BVV(0, 1))
+    else:
+        carry = cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_O']
+        cf = claripy.If(cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_C'] != 0, claripy.BVV(1, 1), claripy.BVV(0, 1))
+    arg_l = cc_dep1
+    arg_r = cc_dep2 ^ carry
+    res = (arg_l + arg_r) + carry
+
+    carry = claripy.If(
+            carry != 0,
+            claripy.If(res <= arg_l, claripy.BVV(1, 1), claripy.BVV(0, 1)),
+            claripy.If(res < arg_l, claripy.BVV(1, 1), claripy.BVV(0, 1))
+    )
+    if is_adc:
+        cf = carry
+    else:
+        of = carry
+
+    return pc_make_rdata(data[platform]['size'], cf, pf, af, zf, sf, of, platform=platform)
+
 def pc_actions_SBB(state, nbits, cc_dep1, cc_dep2, cc_ndep, platform=None):
     old_c = cc_ndep[data[platform]['CondBitOffsets']['G_CC_SHIFT_C']].zero_extend(nbits-1)
     arg_l = cc_dep1
@@ -500,6 +531,13 @@ def pc_calculate_rdata_all_WRK(state, cc_op, cc_dep1_formal, cc_dep2_formal, cc_
     if cc_str == 'G_CC_OP_SMULQ':
         l.debug("cc_str: SMULQ")
         return pc_actions_SMULQ(state, nbits, cc_dep1_formal, cc_dep2_formal, cc_ndep_formal, platform=platform)
+
+    if cc_str in [ 'G_CC_OP_ADOXL', 'G_CC_OP_ADOXQ' ]:
+        l.debug("cc_str: ADOX")
+        return pc_actions_ADCX(state, nbits, cc_dep1_formal, cc_dep2_formal, cc_ndep_formal, False, platform=platform)
+    if cc_str in [ 'G_CC_OP_ADCXL', 'G_CC_OP_ADCXQ' ]:
+        l.debug("cc_str: ADCX")
+        return pc_actions_ADCX(state, nbits, cc_dep1_formal, cc_dep2_formal, cc_ndep_formal, True, platform=platform)
 
     l.error("Unsupported cc_op %d in in pc_calculate_rdata_all_WRK", cc_op)
     raise SimCCallError("Unsupported cc_op in pc_calculate_rdata_all_WRK")

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -130,6 +130,36 @@ def test_ccall():
     nose.tools.assert_true(s.solver.is_true(sf == 0))
     nose.tools.assert_true(s.solver.is_true(of == 0))
 
+    l.debug("Testing amd64_actions_ADCX")
+
+    l.debug("(ADCX, 32-bit) 0xffffffff + 1...")
+    arg_l = s.solver.BVV(0xffffffff, 32)
+    arg_r = s.solver.BVV(1, 32)
+    cf, pf, af, zf, sf, of = s_ccall.pc_actions_ADCX(s, 32, arg_l, arg_r, 0, True, platform='AMD64')
+    nose.tools.assert_true(s.solver.is_true(cf == 1))
+    nose.tools.assert_true(s.solver.is_true(of == 0))
+
+    l.debug("(ADOX, 32-bit) 0xffffffff + 1...")
+    arg_l = s.solver.BVV(0xffffffff, 32)
+    arg_r = s.solver.BVV(1, 32)
+    cf, pf, af, zf, sf, of = s_ccall.pc_actions_ADCX(s, 32, arg_l, arg_r, 0, False, platform='AMD64')
+    nose.tools.assert_true(s.solver.is_true(cf == 0))
+    nose.tools.assert_true(s.solver.is_true(of == 1))
+
+    l.debug("(ADCX, 64-bit) 0xffffffffffffffff + 1...")
+    arg_l = s.solver.BVV(0xffffffffffffffff, 64)
+    arg_r = s.solver.BVV(1, 64)
+    cf, pf, af, zf, sf, of = s_ccall.pc_actions_ADCX(s, 64, arg_l, arg_r, 0, True, platform='AMD64')
+    nose.tools.assert_true(s.solver.is_true(cf == 1))
+    nose.tools.assert_true(s.solver.is_true(of == 0))
+
+    l.debug("(ADOX, 64-bit) 0xffffffffffffffff + 1...")
+    arg_l = s.solver.BVV(0xffffffffffffffff, 64)
+    arg_r = s.solver.BVV(1, 64)
+    cf, pf, af, zf, sf, of = s_ccall.pc_actions_ADCX(s, 64, arg_l, arg_r, 0, False, platform='AMD64')
+    nose.tools.assert_true(s.solver.is_true(cf == 0))
+    nose.tools.assert_true(s.solver.is_true(of == 1))
+
 def test_aarch64_32bit_ccalls():
 
     # GitHub issue #1238


### PR DESCRIPTION
This wires up the VEX support for adcx/adox to claripy.

Requires https://github.com/angr/vex/pull/31 for VEX support.