### PR TITLE
Fix native library resolution on macOS

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -7,8 +7,8 @@ ifeq ($(UNAME), Linux)
 endif
 
 CC := gcc
-C++C := g++
-CFLAGS := -I "${UNICORN_INCLUDE_PATH}" -I "${PYVEX_INCLUDE_PATH}" \
+CXX := g++
+CXXFLAGS := -I "${UNICORN_INCLUDE_PATH}" -I "${PYVEX_INCLUDE_PATH}" \
 	-L "${UNICORN_LIB_PATH}" -L "${PYVEX_LIB_PATH}" \
 	-O3 -fPIC -std=c++11
 ifneq ($(DEBUG), )
@@ -16,7 +16,7 @@ ifneq ($(DEBUG), )
 endif
 
 OBJS := log.o
-LIBS := -lunicorn -lpyvex
+LDLIBS := -lunicorn -lpyvex
 
 all: ${LIB_ANGR_NATIVE}
 
@@ -24,7 +24,7 @@ log.o: log.c log.h
 	${CC} -fPIC -c -O3 -o $@ $<
 
 ${LIB_ANGR_NATIVE}: ${OBJS} sim_unicorn.cpp
-	${C++C} ${CFLAGS} -shared -o $@ $^ ${LIBS}
+	${CXX} ${CXXFLAGS} -shared -o $@ $^ ${LDLIBS}
 
 clean:
 	rm -f "${LIB_ANGR_NATIVE}" *.o arch/*.o

--- a/native/Makefile
+++ b/native/Makefile
@@ -16,7 +16,11 @@ ifneq ($(DEBUG), )
 endif
 
 OBJS := log.o
-LDLIBS := -lunicorn -lpyvex
+ifeq ($(UNAME), Darwin)
+	LDFLAGS := -Wl,-weak-lunicorn,-weak-lpyvex
+else
+	LDLIBS := -lunicorn -lpyvex
+endif
 
 all: ${LIB_ANGR_NATIVE}
 
@@ -24,7 +28,7 @@ log.o: log.c log.h
 	${CC} -fPIC -c -O3 -o $@ $<
 
 ${LIB_ANGR_NATIVE}: ${OBJS} sim_unicorn.cpp
-	${CXX} ${CXXFLAGS} -shared -o $@ $^ ${LDLIBS}
+	${CXX} ${CXXFLAGS} -shared -o $@ $^ ${LDLIBS} ${LDFLAGS}
 
 clean:
 	rm -f "${LIB_ANGR_NATIVE}" *.o arch/*.o


### PR DESCRIPTION
Macs are finicky with how they pick up libraries, so we need to some sort of rpath trickery to get angr to discover all of them. I have submitted two other pull requests in projects that angr depends on (https://github.com/angr/pyvex/pull/201, https://github.com/unicorn-engine/unicorn/pull/1195) that will allow this one to work. Also, there's an optional commit that modifies the naming conventions; feel free to take it or leave it if it's not welcome.