### PR TITLE
Structurer: _bool_variable_from_ail_condition() should return a Bool when proper.

### DIFF
--- a/angr/analyses/decompiler/structurer.py
+++ b/angr/analyses/decompiler/structurer.py
@@ -911,7 +911,7 @@ class Structurer(Analysis):
             return var
         elif isinstance(condition, ailment.Expr.Tmp):
             l.warning("Left-over ailment.Tmp variable %s.", condition)
-            var = claripy.BVS('ailtmp_%d' % condition.tmp_idx, condition.bits)
+            var = claripy.BoolV('ailtmp_%d' % condition.tmp_idx)
             self._condition_mapping[var] = condition
             return var
 

--- a/angr/analyses/decompiler/structurer.py
+++ b/angr/analyses/decompiler/structurer.py
@@ -911,7 +911,10 @@ class Structurer(Analysis):
             return var
         elif isinstance(condition, ailment.Expr.Tmp):
             l.warning("Left-over ailment.Tmp variable %s.", condition)
-            var = claripy.BoolV('ailtmp_%d' % condition.tmp_idx)
+            if condition.bits == 1:
+                var = claripy.BoolV('ailtmp_%d' % condition.tmp_idx)
+            else:
+                var = claripy.BVS('ailtmp_%d' % condition.tmp_idx, condition.bits)
             self._condition_mapping[var] = condition
             return var
 


### PR DESCRIPTION
Related to #1818, this PR handles the following failure:

```
Sample of AttributeError: 'NotImplementedType' object has no attribute '_first_backend' (3336653 occurences): 
    ### EVENT: DECOMPILER_FAIL
    ### Package: http://cdn-fastly.deb.debian.org/debian/pool/main/r/r-cran-modelmetrics/r-cran-modelmetrics_1.1.0-1_mipsel.deb
    ### Binary: ./usr/lib/R/site-library/ModelMetrics/libs/ModelMetrics.so
    ### Function: __do_global_dtors_aux - 0x4055c0
    ### Exception:
    Traceback (most recent call last):
    File "./process.py", line 21, in catcher
    yield
    File "./process.py", line 73, in doit_raw
    decompilation = elf.analyses.Decompiler(cfg.functions[a], cfg=cfg)
    File "/home/angr/angr-dev/angr/angr/analyses/analysis.py", line 109, in __call__
    oself.__init__(*args, **kwargs)
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/decompiler.py", line 14, in __init__
    self._decompile()
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/decompiler.py", line 31, in _decompile
    rs = self.project.analyses.RecursiveStructurer(ri.region, kb=self.kb)
    File "/home/angr/angr-dev/angr/angr/analyses/analysis.py", line 109, in __call__
    oself.__init__(*args, **kwargs)
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/structurer.py", line 203, in __init__
    self._analyze()
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/structurer.py", line 230, in _analyze
    st = self.project.analyses.Structurer(current_region, parent_map=parent_map)
    File "/home/angr/angr-dev/angr/angr/analyses/analysis.py", line 109, in __call__
    oself.__init__(*args, **kwargs)
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/structurer.py", line 261, in __init__
    self._analyze()
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/structurer.py", line 268, in _analyze
    self._analyze_acyclic()
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/structurer.py", line 294, in _analyze_acyclic
    self._recover_reaching_conditions()
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/structurer.py", line 556, in _recover_reaching_conditions
    reaching_conditions[node] = self._simplify_condition(reaching_condition)
    File "/home/angr/angr-dev/angr/angr/analyses/decompiler/structurer.py", line 932, in _simplify_condition
    claripy_simplified = claripy.simplify(cond)
    File "/home/angr/angr-dev/claripy/claripy/ast/base.py", line 1016, in simplify
    s = e._first_backend('simplify')
    AttributeError: 'NotImplementedType' object has no attribute '_first_backend'
```