### PR TITLE
Fix ordering of node addrs for _libc_start_main

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1000,7 +1000,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         if self._start_at_entry and self.project.entry is not None and self._inside_regions(self.project.entry) and \
                 self.project.entry not in starting_points:
             # make sure self.project.entry is inserted
-            starting_points += [ self.project.entry ]
+            starting_points = [ self.project.entry ] + starting_points
 
         # Create jobs for all starting points
         for sp in starting_points:


### PR DESCRIPTION
As symbols are identified and processed first, _libc_start_main
can be encountered before the entry node in certian binaries.
this causes the procedure to be run on the wrong entry block addr,
leading to an incorrect parsing of the init/main/fini arguments
and subsequent missing blocks from the generated cfg.

Reordering the starting_points ensures the correct entry addr is
used as the src_node when _lib_start_main procedure is called