### PR TITLE
Fix signature in closelog simprocedure

### DIFF
--- a/angr/procedures/libc/closelog.py
+++ b/angr/procedures/libc/closelog.py
@@ -8,6 +8,6 @@ import angr
 class closelog(angr.SimProcedure):
     #pylint:disable=arguments-differ
 
-    def run(self, ident, option, facility):
+    def run(self):
         # A stub for closelog that does not do anything yet.
         return


### PR DESCRIPTION
closelog was copy&pasted from openlog without removing the args.