### PR TITLE
Full-program calling convention analysis (and variable recovery)

### DIFF
--- a/angr/analyses/__init__.py
+++ b/angr/analyses/__init__.py
@@ -32,3 +32,4 @@ from .decompiler import Decompiler
 from .soot_class_hierarchy import SootClassHierarchy
 from .propagator import PropagatorAnalysis
 from .xrefs import XRefsAnalysis
+from .complete_calling_conventions import CompleteCallingConventionsAnalysis

--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -221,7 +221,7 @@ class CallingConventionAnalysis(Analysis):
                 arg = next(iter(a for a in args if isinstance(a, SimRegArg) and a.reg_name == reg_name))
             except StopIteration:
                 # have we reached the end of the args list?
-                if [ a for a in args if not isinstance(a, SimRegArg) ]:
+                if [ a for a in args if isinstance(a, SimRegArg) ]:
                     # nope
                     arg = SimRegArg(reg_name, self.project.arch.bytes)
                 else:

--- a/angr/analyses/cfg/cfg_utils.py
+++ b/angr/analyses/cfg/cfg_utils.py
@@ -2,7 +2,7 @@
 import networkx
 
 
-class SCCPlaceholder(object):
+class SCCPlaceholder:
     __slots__ = ['scc_id']
 
     def __init__(self, scc_id):
@@ -15,7 +15,7 @@ class SCCPlaceholder(object):
         return hash('scc_placeholder_%d' % self.scc_id)
 
 
-class CFGUtils(object):
+class CFGUtils:
     """
     A helper class with some static methods and algorithms implemented, that in fact, might take more than just normal
     CFGs.

--- a/angr/analyses/complete_calling_conventions.py
+++ b/angr/analyses/complete_calling_conventions.py
@@ -1,0 +1,85 @@
+
+import logging
+
+from ..analyses.cfg import CFGUtils
+from . import Analysis, register_analysis
+
+_l = logging.getLogger(name=__name__)
+
+
+class CompleteCallingConventionsAnalysis(Analysis):
+
+    def __init__(self, recover_variables=False, low_priority=False):
+
+        self._recover_variables = recover_variables
+        self._low_priority = low_priority
+
+        self._analyze()
+
+    def _analyze(self):
+        """
+        Infer calling conventions for all functions in the current project.
+
+        :return:
+        """
+
+        # get an ordering of functions based on the call graph
+        sorted_funcs = CFGUtils.quasi_topological_sort_nodes(self.kb.functions.callgraph)
+        total_funcs = len(sorted_funcs)
+
+        self._update_progress(0)
+
+        for idx, func_addr in enumerate(reversed(sorted_funcs)):
+            func = self.kb.functions.get_by_addr(func_addr)
+
+            if func.calling_convention is None:
+                if func.alignment:
+                    # skil all alignments
+                    continue
+
+                # if it's a normal function, we attempt to perform variable recovery
+                if self._recover_variables and self.function_needs_variable_recovery(func):
+                    _l.info("Performing variable recovery on %r...", func)
+                    _ = self.project.analyses.VariableRecoveryFast(func, kb=self.kb, low_priority=self._low_priority)
+
+                # determine the calling convention of each function
+                cc_analysis = self.project.analyses.CallingConvention(func)
+                if cc_analysis.cc is not None:
+                    _l.info("Determined calling convention for %r.", func)
+                    func.calling_convention = cc_analysis.cc
+                else:
+                    _l.info("Cannot determine calling convention for %r.", func)
+
+            percentage = (idx + 1) / total_funcs * 100.0
+            self._update_progress(percentage)
+            if self._low_priority:
+                self._release_gil(idx, 5, 0.0001)
+
+    #
+    # Static methods
+    #
+
+    @staticmethod
+    def function_needs_variable_recovery(func):
+        """
+        Check if running variable recovery on the function is the only way to determine the calling convention of the
+        this function.
+
+        We do not need to run variable recovery to determine the calling convention of a function if:
+        - The function is a SimProcedure.
+        - The function is a PLT stub.
+        - The function is a library function and we already know its prototype.
+
+        :param func:    The function object.
+        :return:        True if we must run VariableRecovery before we can determine what the calling convention of this
+                        function is. False otherwise.
+        :rtype:         bool
+        """
+
+        if func.is_simprocedure or func.is_plt:
+            return False
+        # TODO: Check SimLibraries
+        return True
+
+
+register_analysis(CompleteCallingConventionsAnalysis, "CompleteCallingConventions")

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -7,7 +7,6 @@ import ailment
 
 from ...knowledge_base import KnowledgeBase
 from ...codenode import BlockNode
-from ..calling_convention import CallingConventionAnalysis
 from .. import Analysis, register_analysis
 from .optimization_passes import get_optimization_passes
 
@@ -22,7 +21,7 @@ class Clinic(Analysis):
     def __init__(self, func, optimization_passes=None, sp_tracker_track_memory=True):
 
         # Delayed import
-        import ailment.analyses  # pylint:disable=redefined-outer-name,unused-import
+        import ailment.analyses  # pylint:disable=redefined-outer-name,unused-import,import-outside-toplevel
 
         if not func.normalized:
             raise ValueError("Decompilation must work on normalized function graphs.")

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -85,7 +85,8 @@ class Clinic(Analysis):
 
     def _analyze(self):
 
-        CallingConventionAnalysis.recover_calling_conventions(self.project)
+        # Make sure calling conventions of all functions have been recovered
+        self.project.analyses.CompleteCallingConventions()
 
         # initialize the AIL conversion manager
         self._ail_manager = ailment.Manager(arch=self.project.arch)

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -387,6 +387,16 @@ class SimEngineVRVEX(
 
         return self._load(addr, size)
 
+    def _handle_CCall(self, expr):
+        # ccalls don't matter
+        return None
+
+    # Function handlers
+
+    def _handle_function(self, func_addr):
+        # TODO: Adjust the stack pointer
+        return None
+
 
 class SimEngineVRAIL(
     SimEngineLightAILMixin,

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -596,7 +596,7 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
     Recover "variables" from a function by keeping track of stack pointer offsets and  pattern matching VEX statements.
     """
 
-    def __init__(self, func, max_iterations=1, clinic=None):
+    def __init__(self, func, max_iterations=1, clinic=None, low_priority=False):
         """
 
         :param knowledge.Function func:  The function to analyze.
@@ -615,6 +615,8 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
                                  graph_visitor=function_graph_visitor)
 
         self._clinic = clinic
+        self._low_priority = low_priority
+        self._job_ctr = 0
 
         self._ail_engine = SimEngineVRAIL(self.project)
         self._vex_engine = SimEngineVRVEX(self.project)
@@ -644,7 +646,9 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
                 self._node_to_cc[callsite_node.addr] = func_node.calling_convention
 
     def _pre_job_handling(self, job):
-        pass
+        self._job_ctr += 1
+        if self._low_priority:
+            self._release_gil(self._job_ctr, 5, 0.0001)
 
     def _initial_abstract_state(self, node):
 

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -8,7 +8,6 @@ from ...engines.light import SpOffset, ArithmeticExpression, SimEngineLight, Sim
 from ...errors import SimEngineError, AngrVariableRecoveryError
 from ...knowledge_plugins import Function
 from ...sim_variable import SimStackVariable, SimRegisterVariable
-from ..calling_convention import CallingConventionAnalysis
 from ..code_location import CodeLocation
 from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor
 from .variable_recovery_base import VariableRecoveryBase, VariableRecoveryStateBase
@@ -393,7 +392,7 @@ class SimEngineVRVEX(
 
     # Function handlers
 
-    def _handle_function(self, func_addr):
+    def _handle_function(self, func_addr):  # pylint:disable=unused-argument,no-self-use
         # TODO: Adjust the stack pointer
         return None
 

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -596,7 +596,7 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
     Recover "variables" from a function by keeping track of stack pointer offsets and  pattern matching VEX statements.
     """
 
-    def __init__(self, func, max_iterations=3, clinic=None):
+    def __init__(self, func, max_iterations=1, clinic=None):
         """
 
         :param knowledge.Function func:  The function to analyze.

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -627,8 +627,6 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
 
         self.initialize_dominance_frontiers()
 
-        CallingConventionAnalysis.recover_calling_conventions(self.project)
-
         # initialize node_to_cc map
         function_nodes = [n for n in self.function.transition_graph.nodes() if isinstance(n, Function)]
         for func_node in function_nodes:

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1138,7 +1138,7 @@ class SimCCAMD64WindowsSyscall(SimCC):
 class SimCCARM(SimCC):
     ARG_REGS = [ 'r0', 'r1', 'r2', 'r3' ]
     FP_ARG_REGS = []    # TODO: ???
-    CALLER_SAVED_REGS = []   # TODO: ???
+    CALLER_SAVED_REGS = [ 'r0', 'r1', 'r2', 'r3' ]
     RETURN_ADDR = SimRegArg('lr', 4)
     RETURN_VAL = SimRegArg('r0', 4)
     ARCH = archinfo.ArchARM

--- a/angr/keyed_region.py
+++ b/angr/keyed_region.py
@@ -446,6 +446,6 @@ class KeyedRegion:
                     item.set_object(stored_object)
                     return
 
-            l.warning("Overlapping objects %s.", str({stored_object.obj} | item.internal_objects))
+            # l.warning("Overlapping objects %s.", str({stored_object.obj} | item.internal_objects))
             # import ipdb; ipdb.set_trace()
         item.add_object(stored_object)

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -499,8 +499,9 @@ class Function(Serializable):
 
     def __repr__(self):
         if self.is_syscall:
-            return '<Syscall function %s (%s)>' % (self.name, self.addr)
-        return '<Function %s (%s)>' % (self.name, self.addr)
+            return '<Syscall function %s (%s)>' % (self.name,
+                                                   hex(self.addr) if isinstance(self.addr, int) else self.addr)
+        return '<Function %s (%s)>' % (self.name, hex(self.addr) if isinstance(self.addr, int) else self.addr)
 
     @property
     def endpoints(self):

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -330,6 +330,9 @@ class VariableManagerInternal:
         input_variables = [ ]
 
         for variable, accesses in self._variable_accesses.items():
+            if variable in self._phi_variables:
+                # a phi variable is definitely not an input variable
+                continue
             if not has_write_access(accesses) and has_read_access(accesses):
                 if not exclude_specials or not variable.category:
                     input_variables.append(variable)

--- a/angr/sim_variable.py
+++ b/angr/sim_variable.py
@@ -15,6 +15,20 @@ class SimVariable:
         self.region = region if region is not None else ""
         self.category = category
 
+    #
+    # Operations
+    #
+
+    def __add__(self, other):
+        if isinstance(other, int) and other == 0:
+            return self
+        return None
+
+    def __sub__(self, other):
+        if isinstance(other, int) and other == 0:
+            return self
+        return None
+
 
 class SimConstantVariable(SimVariable):
 

--- a/tests/test_calling_convention_analysis.py
+++ b/tests/test_calling_convention_analysis.py
@@ -7,7 +7,6 @@ import nose.tools
 import archinfo
 import angr
 from angr.calling_conventions import SimStackArg, SimRegArg, SimCCCdecl, SimCCSystemVAMD64
-from angr.analyses.calling_convention import CallingConventionAnalysis
 
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(str(__file__))), '..', '..',
@@ -36,9 +35,9 @@ def run_cgc(binary_name):
 
     categorization = project.analyses.FunctionCategorizationAnalysis()
 
-    tag_manager = categorization.function_tag_manager
-    #print "INPUT:", map(hex, tag_manager.input_functions())
-    #print "OUTPUT:", map(hex, tag_manager.output_functions())
+    # tag_manager = categorization.function_tag_manager
+    # print "INPUT:", map(hex, tag_manager.input_functions())
+    # print "OUTPUT:", map(hex, tag_manager.output_functions())
 
 
 def test_fauxware():

--- a/tests/test_calling_convention_analysis.py
+++ b/tests/test_calling_convention_analysis.py
@@ -7,6 +7,7 @@ import nose.tools
 import archinfo
 import angr
 from angr.calling_conventions import SimStackArg, SimRegArg, SimCCCdecl, SimCCSystemVAMD64
+from angr.analyses.calling_convention import CallingConventionAnalysis
 
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(str(__file__))), '..', '..',
@@ -77,6 +78,17 @@ def disabled_cgc():
 
     for binary in binaries:
         yield run_cgc, binary
+
+
+def test_dir_gcc_O0():
+
+    binary_path = os.path.join(test_location, 'tests', 'x86_64', 'dir_gcc_-O0')
+    proj = angr.Project(binary_path, auto_load_libs=False, load_debug_info=False)
+
+    cfg = proj.analyses.CFG()  # fill in the default kb
+
+    CallingConventionAnalysis.recover_calling_conventions(proj)
+
 
 
 def run_all():

--- a/tests/test_calling_convention_analysis.py
+++ b/tests/test_calling_convention_analysis.py
@@ -87,7 +87,7 @@ def test_dir_gcc_O0():
 
     cfg = proj.analyses.CFG()  # fill in the default kb
 
-    CallingConventionAnalysis.recover_calling_conventions(proj, variable_recovery=True)
+    proj.analyses.CompleteCallingConventions(recover_variables=True)
 
     funcs = cfg.kb.functions
     # check args

--- a/tests/test_calling_convention_analysis.py
+++ b/tests/test_calling_convention_analysis.py
@@ -87,13 +87,14 @@ def test_dir_gcc_O0():
 
     cfg = proj.analyses.CFG()  # fill in the default kb
 
-    CallingConventionAnalysis.recover_calling_conventions(proj)
+    CallingConventionAnalysis.recover_calling_conventions(proj, variable_recovery=True)
 
+    funcs = cfg.kb.functions
+    # check args
+    nose.tools.assert_true(funcs['c_ispunct'].calling_convention.args[0].reg_name, 'rdi')
 
 
 def run_all():
-    logging.getLogger("angr.analyses.variable_recovery.variable_recovery_fast").setLevel(logging.DEBUG)
-
     for args in test_fauxware():
         func, args = args[0], args[1:]
         func(*args)
@@ -104,4 +105,7 @@ def run_all():
 
 
 if __name__ == "__main__":
+    # logging.getLogger("angr.analyses.variable_recovery.variable_recovery_fast").setLevel(logging.DEBUG)
+    logging.getLogger("angr.analyses.calling_convention").setLevel(logging.INFO)
     run_all()
+    # test_dir_gcc_O0()

--- a/tests/test_calling_convention_analysis.py
+++ b/tests/test_calling_convention_analysis.py
@@ -131,7 +131,7 @@ def test_x8664_dir_gcc_O0():
         'emit_ancillary_info': ['r_rdi'],
         'emit_try_help': [ ],
         'dev_ino_push': ['r_rdi', 'r_rsi'],
-        'main': ['r_rdi', 'r_rsi', 'r_rdx'],
+        'main': ['r_rdi', 'r_rsi'],
         'queue_directory': ['r_rdi', 'r_rsi', 'r_rdx'],
     }
 

--- a/tests/test_calling_convention_analysis.py
+++ b/tests/test_calling_convention_analysis.py
@@ -78,6 +78,9 @@ def disabled_cgc():
     for binary in binaries:
         yield run_cgc, binary
 
+#
+# Full-binary calling convention analysis
+#
 
 def check_arg(arg, expected_str):
 
@@ -106,7 +109,7 @@ def _a(funcs, func_name):
     return funcs[func_name].calling_convention.args
 
 
-def test_dir_gcc_O0():
+def test_x8664_dir_gcc_O0():
 
     binary_path = os.path.join(test_location, 'tests', 'x86_64', 'dir_gcc_-O0')
     proj = angr.Project(binary_path, auto_load_libs=False, load_debug_info=False)
@@ -130,6 +133,28 @@ def test_dir_gcc_O0():
         'dev_ino_push': ['r_rdi', 'r_rsi'],
         'main': ['r_rdi', 'r_rsi', 'r_rdx'],
         'queue_directory': ['r_rdi', 'r_rsi', 'r_rdx'],
+    }
+
+    for func_name, args in expected_args.items():
+        check_args(func_name, _a(funcs, func_name), args)
+
+
+def test_armel_fauxware():
+    binary_path = os.path.join(test_location, 'tests', 'armel', 'fauxware')
+    proj = angr.Project(binary_path, auto_load_libs=False, load_debug_info=False)
+
+    cfg = proj.analyses.CFG()  # fill in the default kb
+
+    proj.analyses.CompleteCallingConventions(recover_variables=True)
+
+    funcs = cfg.kb.functions
+
+    # check args
+    expected_args = {
+        'main': ['r_r0', 'r_r1'],
+        'accepted': ['r_r0', 'r_r1', 'r_r2', 'r_r3'],
+        'rejected': [ ],
+        'authenticate': ['r_r0', 'r_r1'],
     }
 
     for func_name, args in expected_args.items():


### PR DESCRIPTION
Finally, we support performing calling convention analysis for all functions in a project in one go!

TODO:

- [ ] ~Call-site based calling convention inference.~
- [x] Properly test function arguments in test_calling_convention_analysis.py.
- [x] Build more test cases.