### PR TITLE
Adding Posix String Formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ The original posix.dumps function returns a stream that looks like:
 
 ```python
 b'foo\x00\x01\x00\x02\x02\x02\x02\x89\x02\x02\x02\x02\x00\x02\x02\x00\x00\x01m\x08)J\x08\x02\x08\x00\x00)\x19)\x08\x19\x00\x19I\x19\x19J\x06\x00\x8a)\x00\x1a\x00\x00\x02\x02\x00\x04\x89\x89\x89\x89\x89\x89\x89bar\x00\x01\x00\x00\x08\x0e\x19\x89\x08\x08\x02\x00\x00\x89\x0e*\x00I\x89\x89\x89\x89\x89\x89\x19\x89\x08\x08\x89\x89\x02\x89\x89\x89*\x01F\x08\x00\x89\x02\x89\xd2\x89\x01\x00\x00\x00)\x02\x02\x00\x00\x00\x19\x00\x00xpto\x00\x08\x01\x08\x00\x00\x00\x02\x01\x00\x02\x00_\x00\x01\x00\x01\x08\x02\x02\x00\x00\x00\x02\x00\x01\x02\x02"\x01J\x02\x02\x01\x02\x02\x02\x01\x08\x10\x00\x19\x02\x89\x1d\x12\x02\xfd\x00\x10\x02\x02\x00\x02\x00\x00'
-'''
+```
 
 Now you can get formatted values if you now the expected output types:
 
 ```python
 ['foo', 'bar', 'xpto']
-'''
+```
 
 Just Type:
 
 ```python
 found.posix.dumps(0, fmt='sss')
-'''
+```
 
 ## Invoked Function Calls
 
@@ -38,7 +38,7 @@ found.history.events.hardcopy
 [<SimActionData __libc_start_main() reg/read>,
  <SimActionData __libc_start_main() reg/read>,
  <SimActionData __libc_start_main() reg/write>,
-'''
+```
 
 Now you can get information about specific function call invocations without digging into multiple states details:
 
@@ -48,7 +48,7 @@ found.history.calls.hardcopy
  ('strlen', True, <SAO <BV64 0x7fffffffffeff3a>>),
  ('strlen', True, <SAO <BV64 0x4008c7>>),
  ('strncmp', True, <SAO <BV64 0x7fffffffffeff3a>>, <SAO <BV64 0x4008c7>>, <SimProcedure strlen (inline)>, <SimProcedure strlen (inline)>)]
-'''
+```
 
 ## Pretty Printers
 
@@ -68,4 +68,4 @@ angr.pretty_printers.calls.pretty_print_calls(found.history.calls.hardcopy)
 	[+] strlen (<SAO <BV64 0x7fffffffffeff4e>>)
 	[+] strlen (<SAO <BV64 0x4008cf>>)
 	[+] strncmp (<SAO <BV64 0x7fffffffffeff4e>>, <SAO <BV64 0x4008cf>>, <SimProcedure strlen (inline)>, <SimProcedure strlen (inline)>)
-'''
+```

--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ Implemented features so-far:
 
 The original posix.dumps function returns a stream that looks like:
 
-```Python
+```python
 b'foo\x00\x01\x00\x02\x02\x02\x02\x89\x02\x02\x02\x02\x00\x02\x02\x00\x00\x01m\x08)J\x08\x02\x08\x00\x00)\x19)\x08\x19\x00\x19I\x19\x19J\x06\x00\x8a)\x00\x1a\x00\x00\x02\x02\x00\x04\x89\x89\x89\x89\x89\x89\x89bar\x00\x01\x00\x00\x08\x0e\x19\x89\x08\x08\x02\x00\x00\x89\x0e*\x00I\x89\x89\x89\x89\x89\x89\x19\x89\x08\x08\x89\x89\x02\x89\x89\x89*\x01F\x08\x00\x89\x02\x89\xd2\x89\x01\x00\x00\x00)\x02\x02\x00\x00\x00\x19\x00\x00xpto\x00\x08\x01\x08\x00\x00\x00\x02\x01\x00\x02\x00_\x00\x01\x00\x01\x08\x02\x02\x00\x00\x00\x02\x00\x01\x02\x02"\x01J\x02\x02\x01\x02\x02\x02\x01\x08\x10\x00\x19\x02\x89\x1d\x12\x02\xfd\x00\x10\x02\x02\x00\x02\x00\x00'
 '''
 
 Now you can get formatted values if you now the expected output types:
 
-```Python
+```python
 ['foo', 'bar', 'xpto']
 '''
 
 Just Type:
 
-```Python
+```python
 found.posix.dumps(0, fmt='sss')
 '''
 
@@ -33,7 +33,7 @@ found.posix.dumps(0, fmt='sss')
 
 The original events history displays information about unfiltered events:
 
-```Python
+```python
 found.history.events.hardcopy                                                                                
 [<SimActionData __libc_start_main() reg/read>,
  <SimActionData __libc_start_main() reg/read>,
@@ -42,7 +42,7 @@ found.history.events.hardcopy
 
 Now you can get information about specific function call invocations without digging into multiple states details:
 
-```Python
+```python
 found.history.calls.hardcopy                                                                                 
 [('strcmp', False, <SAO <BV64 0x7fffffffffeff3a>>, <SAO <BV64 0x4008c7>>),
  ('strlen', True, <SAO <BV64 0x7fffffffffeff3a>>),
@@ -54,7 +54,7 @@ found.history.calls.hardcopy
 
 You can format the previous list to get a better visualization:
 
-```Python
+```python
 angr.pretty_printers.calls.pretty_print_calls(found.history.calls.hardcopy)                                  
 [+] strcmp (<SAO <BV64 0x7fffffffffeff3a>>, <SAO <BV64 0x4008c7>>)
 	[+] strlen (<SAO <BV64 0x7fffffffffeff3a>>)

--- a/README_angr.md
+++ b/README_angr.md
@@ -1,0 +1,54 @@
+angr
+====
+
+[![Latest Release](https://img.shields.io/pypi/v/angr.svg)](https://pypi.python.org/pypi/angr/)
+[![PyPI Statistics](https://img.shields.io/pypi/dm/angr.svg)](https://pypistats.org/packages/angr)
+[![Build Status](https://dev.azure.com/angr/angr/_apis/build/status/angr?branchName=master)](https://dev.azure.com/angr/angr/_build/latest?definitionId=18&branchName=master)
+[![License](https://img.shields.io/github/license/angr/angr.svg)](https://github.com/angr/angr/blob/master/LICENSE)
+[![Gitbook](https://img.shields.io/badge/docs-gitbook-green.svg)](http://docs.angr.io)
+[![API Docs](https://img.shields.io/badge/docs-api-green.svg)](http://angr.io/api-doc)
+
+angr is a platform-agnostic binary analysis framework.
+It is brought to you by [the Computer Security Lab at UC Santa Barbara](https://seclab.cs.ucsb.edu), [SEFCOM at Arizona State University](http://sefcom.asu.edu),  their associated CTF team, [Shellphish](http://shellphish.net), the open source community, and **[@rhelmot](https://github.com/rhelmot)**.
+
+# What?
+
+angr is a suite of Python 3 libraries that let you load a binary and do a lot of cool things to it:
+
+- Disassembly and intermediate-representation lifting
+- Program instrumentation
+- Symbolic execution
+- Control-flow analysis
+- Data-dependency analysis
+- Value-set analysis (VSA)
+- Decompilation
+
+The most common angr operation is loading a binary: `p = angr.Project('/bin/bash')` If you do this in an enhanced REPL like IPython, you can use tab-autocomplete to browse the [top-level-accessible methods](http://docs.angr.io/docs/toplevel.html) and their docstrings.
+
+The short version of "how to install angr" is `mkvirtualenv --python=$(which python3) angr && python -m pip install angr`.
+
+# Example
+
+angr does a lot of binary analysis stuff.
+To get you started, here's a simple example of using symbolic execution to get a flag in a CTF challenge.
+
+```python
+import angr
+
+project = angr.Project("angr-doc/examples/defcamp_r100/r100", auto_load_libs=False)
+
+@project.hook(0x400844)
+def print_flag(state):
+    print("FLAG SHOULD BE:", state.posix.dumps(0))
+    project.terminate_execution()
+
+project.execute()
+```
+
+# Quick Start
+
+- [Install Instructions](http://docs.angr.io/INSTALL.html)
+- Documentation as [HTML](http://docs.angr.io/) and as a [Github repository](https://github.com/angr/angr-doc)
+- Dive right in: [top-level-accessible methods](http://docs.angr.io/docs/toplevel.html)
+- [Examples using angr to solve CTF challenges](http://docs.angr.io/docs/examples.html).
+- [API Reference](http://angr.io/api-doc/)

--- a/angr/__init__.py
+++ b/angr/__init__.py
@@ -65,5 +65,8 @@ from .state_plugins.heap import SimHeapBrk, SimHeapPTMalloc, PTChunk
 # for compatibility reasons
 from . import sim_manager as manager
 
+# Importing Pretty Printers
+from . import pretty_printers
+
 # now that we have everything loaded, re-grab the list of loggers
 loggers.load_all_loggers()

--- a/angr/pretty_printers/__init__.py
+++ b/angr/pretty_printers/__init__.py
@@ -1,0 +1,1 @@
+from .calls import *

--- a/angr/pretty_printers/calls.py
+++ b/angr/pretty_printers/calls.py
@@ -1,0 +1,18 @@
+def pretty_print_calls(calls=[]):
+    depth=0
+    for call in calls:
+        if call[1] is True:
+            depth=depth+1
+        else:
+            depth=0
+        for i in range(0,depth):
+            print("\t", end=''),
+        print("[+] %s (" % call[0], end='')
+        for i, arg in enumerate(call[2:]):
+            if i:
+                print(", ",end='')
+            print(arg,end='')
+
+        print(")")
+        if depth > 0:
+            depth=depth-1

--- a/angr/procedures/libc/closelog.py
+++ b/angr/procedures/libc/closelog.py
@@ -8,6 +8,6 @@ import angr
 class closelog(angr.SimProcedure):
     #pylint:disable=arguments-differ
 
-    def run(self):
+    def run(self, ident, option, facility):
         # A stub for closelog that does not do anything yet.
         return

--- a/angr/procedures/libc/strcmp.py
+++ b/angr/procedures/libc/strcmp.py
@@ -6,12 +6,15 @@ l = logging.getLogger(name=__name__)
 class strcmp(angr.SimProcedure):
     #pylint:disable=arguments-differ
 
-    def run(self, a_addr, b_addr, wchar=False, ignore_case=False):
+    def run(self, a_addr, b_addr, wchar=False, ignore_case=False, nested_call = False):
+        self.state.history.add_call(('strcmp', nested_call, a_addr,b_addr))
         strlen = angr.SIM_PROCEDURES['libc']['strlen']
 
         a_strlen = self.inline_call(strlen, a_addr, wchar=wchar)
+        self.state.history.add_call(('strlen', True, a_addr))
         b_strlen = self.inline_call(strlen, b_addr, wchar=wchar)
+        self.state.history.add_call(('strlen', True, b_addr))
         maxlen = self.state.solver.BVV(max(a_strlen.max_null_index, b_strlen.max_null_index), self.state.arch.bits)
 
-        strncmp = self.inline_call(angr.SIM_PROCEDURES['libc']['strncmp'], a_addr, b_addr, maxlen, a_len=a_strlen, b_len=b_strlen, wchar=wchar, ignore_case=ignore_case)
+        strncmp = self.inline_call(angr.SIM_PROCEDURES['libc']['strncmp'], a_addr, b_addr, maxlen, a_len=a_strlen, b_len=b_strlen, wchar=wchar, ignore_case=ignore_case, nested_call = True)
         return strncmp.ret_expr

--- a/angr/procedures/libc/strncmp.py
+++ b/angr/procedures/libc/strncmp.py
@@ -6,7 +6,8 @@ l = logging.getLogger(name=__name__)
 class strncmp(angr.SimProcedure):
     #pylint:disable=arguments-differ
 
-    def run(self, a_addr, b_addr, limit, a_len=None, b_len=None, wchar=False, ignore_case=False): #pylint:disable=arguments-differ
+    def run(self, a_addr, b_addr, limit, a_len=None, b_len=None, wchar=False, ignore_case=False, nested_call = False): #pylint:disable=arguments-differ
+        self.state.history.add_call(('strncmp', nested_call, a_addr, b_addr, a_len, b_len))
         strlen = angr.SIM_PROCEDURES['libc']['strlen']
 
         a_strlen = a_len if a_len is not None else self.inline_call(strlen, a_addr, wchar=wchar)

--- a/angr/procedures/linux_kernel/arm_user_helpers.py
+++ b/angr/procedures/linux_kernel/arm_user_helpers.py
@@ -3,5 +3,5 @@ import angr
 class _kernel_user_helper_get_tls(angr.SimProcedure):
     # pylint: disable=arguments-differ
     def run(self):
-        self.state.regs.r0 = self.project.loader.tls.threads[0].user_thread_pointer
+        self.state.regs.r0 = self.project.loader.tls_object.user_thread_pointer
         return

--- a/angr/procedures/linux_loader/__tls_get_addr.py
+++ b/angr/procedures/linux_loader/__tls_get_addr.py
@@ -10,8 +10,7 @@ class __tls_get_addr(angr.SimProcedure):
             raise SimValueError("__tls_get_addr called with symbolic module ID")
         module_id = self.state.solver.eval(module_id)
 
-        # TODO: this should manually load values from the dtv
-        return self.project.loader.tls.threads[0].get_addr(module_id, offset)
+        return self.project.loader.tls_object.get_addr(module_id, offset)
 
 
 # this is a rare and highly valuable TRIPLE-UNDERSCORE tls_get_addr. weird calling convention.

--- a/angr/state_plugins/history.py
+++ b/angr/state_plugins/history.py
@@ -41,6 +41,7 @@ class SimStateHistory(SimStatePlugin):
         self.jumpkind = None if clone is None else clone.jumpkind
 
         # the execution log for this history
+        self.proc_calls = [] if clone is None else list(clone.proc_calls)
         self.recent_events = [ ] if clone is None else list(clone.recent_events)
         self.recent_bbl_addrs = [ ] if clone is None else list(clone.recent_bbl_addrs)
         self.recent_ins_addrs = [ ] if clone is None else list(clone.recent_ins_addrs)
@@ -138,6 +139,8 @@ class SimStateHistory(SimStatePlugin):
         self.recent_events = [e.recent_events for e in itertools.chain([self], others)
                               if not isinstance(e, SimActionConstraint)
                               ]
+
+        self.proc_calls = [e.proc_calls for e in itertools.chain([self], others)]
 
         # rebuild recent constraints
         recent_constraints = [ h.constraints_since(common_ancestor) for h in itertools.chain([self], others) ]
@@ -327,6 +330,9 @@ class SimStateHistory(SimStatePlugin):
         new_event = SimEvent(self.state, event_type, **kwargs)
         self.recent_events.append(new_event)
 
+    def add_call(self, call):
+        self.proc_calls.append(call)
+
     def add_action(self, action):
         self.recent_events.append(action)
 
@@ -367,6 +373,9 @@ class SimStateHistory(SimStatePlugin):
     @property
     def events(self):
         return LambdaIterIter(self, operator.attrgetter('recent_events'))
+    @property
+    def calls(self):
+        return LambdaIterIter(self, operator.attrgetter('proc_calls'))
     @property
     def actions(self):
         return LambdaIterIter(self, operator.attrgetter('recent_actions'))

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -592,6 +592,7 @@ class SimSystemPosix(SimStatePlugin):
         # Any other file descriptor, concretize directly
         return self.get_fd(fd).concretize(**kwargs)
 
+
 from angr.sim_state import SimState
 SimState.register_default('posix', SimSystemPosix)
 


### PR DESCRIPTION
Considering the cases where posix.dumps() returns a stream like "foo\x0000\bar\x0000\x7". Wouldn't be better to have an option to get ['foo','bar',7]? I implemented this feature via optional format parameter. It takes struct-like args (in this case 'ssi') and returns formatted parameters. As it is optional, it does not break current dumps operation.