### PR TITLE
Adding Posix String Formatter

### DIFF
--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -583,12 +583,12 @@ class SimSystemPosix(SimStatePlugin):
                             try:
                                 fmt_arg = int(data[idx])
                             # failed to convert to int
-                            except:
+                            except ValueError:
                                 # try to interpret as a simple string
                                 try:
                                     fmt_arg = str(data[idx][:data[idx].find(0)].decode('utf8'))
                                 # failed to interpret as a simple string
-                                except:
+                                except ValueError:
                                     # return non-formatted data
                                     fmt_arg = data[idx]
                         # Other types not supported yet
@@ -610,13 +610,13 @@ class SimSystemPosix(SimStatePlugin):
         data = self.get_fd(fd).concretize(**kwargs)
         # If formatter specified (in this case, concretize returns no list)
         # Single String Formatter
-        if 's' == fmt:
+        if fmt == 's':
             return str(data[:data.find(0)].decode('utf8'))
         # Single Int Formatter
-        elif 'i' == fmt:
+        elif fmt == 'i':
             return int(data)
         # Multiple Int Formatter
-        elif 'i'*len(fmt) == fmt:
+        elif fmt == 'i'*len(fmt):
             # Formatted Values
             formatted_list = []
             # split values
@@ -626,13 +626,13 @@ class SimSystemPosix(SimStatePlugin):
             # Return formatted Values
             return formatted_list
         # Guessing
-        elif '?' == fmt:
+        elif fmt == '?':
             # Interpret as a single int
             try:
                 formatted = int(data)
                 return formatted
             # Otherwise, return the original data (not enough information to guess)
-            except:
+            except ValueError:
                 return data
         # Others
         else:

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -577,6 +577,20 @@ class SimSystemPosix(SimStatePlugin):
                         # Integers
                         elif 'i' in _fmt:
                             fmt_arg = int(data[idx])
+                        # Guessing Formatter (when you do not know what to expect)
+                        elif '?' in _fmt:
+                            # try to convert to int
+                            try:
+                                fmt_arg = int(data[idx])
+                            # failed to convert to int
+                            except:
+                                # try to interpret as a simple string
+                                try:
+                                    fmt_arg = str(data[idx][:data[idx].find(0)].decode('utf8'))
+                                # failed to interpret as a simple string
+                                except:
+                                    # return non-formatted data
+                                    fmt_arg = data[idx]
                         # Other types not supported yet
                         else:
                             raise NotImplementedError()
@@ -609,6 +623,15 @@ class SimSystemPosix(SimStatePlugin):
                     formatted_list.append(int(val))
                 # Return formatted Values
                 return formatted_list
+            # Guessing
+            elif '?' == fmt:
+                # Interpret as a single int
+                try:
+                    formatted = int(data)
+                    return formatted
+                # Otherwise, return the original data (not enough information to guess)
+                except:
+                    return data
             # Others
             else:
                 raise NotImplementedError()

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -604,39 +604,39 @@ class SimSystemPosix(SimStatePlugin):
             # Return the merged stream
             return data
         # Any other file descriptor, concretize directly
+        if fmt is None:
+            return self.get_fd(fd).concretize(**kwargs)
+        # Case formatters set
         data = self.get_fd(fd).concretize(**kwargs)
         # If formatter specified (in this case, concretize returns no list)
-        if fmt is not None:
-            # Single String Formatter
-            if 's' == fmt:
-                return str(data[:data.find(0)].decode('utf8'))
-            # Single Int Formatter
-            elif 'i' == fmt:
-                return int(data)
-            # Multiple Int Formatter
-            elif 'i'*len(fmt) == fmt:
-                # Formatted Values
-                formatted_list = []
-                # split values
-                for val in str(data.decode('utf8')).split('+'):
-                    # Parse Each Value
-                    formatted_list.append(int(val))
-                # Return formatted Values
-                return formatted_list
-            # Guessing
-            elif '?' == fmt:
-                # Interpret as a single int
-                try:
-                    formatted = int(data)
-                    return formatted
-                # Otherwise, return the original data (not enough information to guess)
-                except:
-                    return data
-            # Others
-            else:
-                raise NotImplementedError()
-        # If no formatter specified, just return
-        return data
+        # Single String Formatter
+        if 's' == fmt:
+            return str(data[:data.find(0)].decode('utf8'))
+        # Single Int Formatter
+        elif 'i' == fmt:
+            return int(data)
+        # Multiple Int Formatter
+        elif 'i'*len(fmt) == fmt:
+            # Formatted Values
+            formatted_list = []
+            # split values
+            for val in str(data.decode('utf8')).split('+'):
+                # Parse Each Value
+                formatted_list.append(int(val))
+            # Return formatted Values
+            return formatted_list
+        # Guessing
+        elif '?' == fmt:
+            # Interpret as a single int
+            try:
+                formatted = int(data)
+                return formatted
+            # Otherwise, return the original data (not enough information to guess)
+            except:
+                return data
+        # Others
+        else:
+            raise NotImplementedError()
 
 from angr.sim_state import SimState
 SimState.register_default('posix', SimSystemPosix)

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -590,7 +590,30 @@ class SimSystemPosix(SimStatePlugin):
             # Return the merged stream
             return data
         # Any other file descriptor, concretize directly
-        return self.get_fd(fd).concretize(**kwargs)
+        data = self.get_fd(fd).concretize(**kwargs)
+        # If formatter specified (in this case, concretize returns no list)
+        if fmt is not None:
+            # Single String Formatter
+            if 's' == fmt:
+                return str(data[:data.find(0)].decode('utf8'))
+            # Single Int Formatter
+            elif 'i' == fmt:
+                return int(data)
+            # Multiple Int Formatter
+            elif 'i'*len(fmt) == fmt:
+                # Formatted Values
+                formatted_list = []
+                # split values
+                for val in str(data.decode('utf8')).split('+'):
+                    # Parse Each Value
+                    formatted_list.append(int(val))
+                # Return formatted Values
+                return formatted_list
+            # Others
+            else:
+                raise NotImplementedError()
+        # If no formatter specified, just return
+        return data
 
 from angr.sim_state import SimState
 SimState.register_default('posix', SimSystemPosix)


### PR DESCRIPTION
Considering the cases where posix.dumps() returns a stream like "foo\x0000\bar\x0000\x7". Wouldn't be better to have an option to get ['foo','bar',7]? I implemented this feature via optional format parameter. It takes struct-like args (in this case 'ssi') and returns formatted parameters. As it is optional, it does not break current dumps operation.