### PR TITLE
SimCC.arg_logs(): Check the existence of both func_ty and args.

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -498,8 +498,12 @@ class SimCC:
             if is_fp is None:
                 raise ValueError('"is_fp" must be provided when no function prototype is available.')
         else:
-            # let's rely on the func_ty for the number of arguments and whether each argument is FP or not
-            is_fp = [ True if isinstance(arg, (SimTypeFloat, SimTypeDouble)) else False for arg in self.func_ty.args ]
+            # let's rely on the func_ty or self.args for the number of arguments and whether each argument is FP or not
+            if self.func_ty is not None:
+                args = self.func_ty.args
+            else:
+                args = self.args
+            is_fp = [ True if isinstance(arg, (SimTypeFloat, SimTypeDouble)) else False for arg in args ]
 
         if sizes is None: sizes = [self.arch.bytes] * len(is_fp)
         return [session.next_arg(ifp, size=sz) for ifp, sz in zip(is_fp, sizes)]

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -493,8 +493,8 @@ class SimCC:
         If you've customized this CC, this will sanity-check the provided locations with the given list.
         """
         session = self.arg_session
-        if self.func_ty is None:
-            # No function prototype is provided. `is_fp` must be provided.
+        if self.func_ty is None and self.args is None:
+            # No function prototype is provided, no args is provided. `is_fp` must be provided.
             if is_fp is None:
                 raise ValueError('"is_fp" must be provided when no function prototype is available.')
         else:


### PR DESCRIPTION
Some analyses, such as calling convention analysis, may set `SimCC.args` without knowing what the actual function prototype is. Thus, this check should be loosened.