### PR TITLE
Decompilation improvements 03/28/2020.

### DIFF
--- a/angr/analyses/decompiler/__init__.py
+++ b/angr/analyses/decompiler/__init__.py
@@ -4,3 +4,4 @@ from .structured_codegen import StructuredCodeGenerator
 from .clinic import Clinic
 from .region_simplifier import RegionSimplifier
 from .decompiler import Decompiler
+from .decompilation_options import options, options_by_category

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -254,7 +254,8 @@ class Clinic(Analysis):
 
         # variable recovery
         tmp_kb = KnowledgeBase(self.project)
-        vr = self.project.analyses.VariableRecoveryFast(self.function, clinic=self, kb=tmp_kb)  # pylint:disable=unused-variable
+        # stack pointers have been removed at this point
+        vr = self.project.analyses.VariableRecoveryFast(self.function, clinic=self, kb=tmp_kb, track_sp=False)  # pylint:disable=unused-variable
 
         # TODO: The current mapping implementation is kinda hackish...
 

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -19,7 +19,11 @@ class Clinic(Analysis):
     """
     A Clinic deals with AILments.
     """
-    def __init__(self, func, optimization_passes=None, sp_tracker_track_memory=True):
+    def __init__(self, func,
+                 remove_dead_memdefs=True,
+                 sp_tracker_track_memory=True,
+                 optimization_passes=None,
+                 ):
 
         # Delayed import
         import ailment.analyses  # pylint:disable=redefined-outer-name,unused-import,import-outside-toplevel
@@ -34,6 +38,7 @@ class Clinic(Analysis):
         self._ail_manager = None
         self._blocks = { }
 
+        self._remove_dead_memdefs = remove_dead_memdefs
         self._sp_tracker_track_memory = sp_tracker_track_memory
 
         # sanity checks
@@ -179,7 +184,11 @@ class Clinic(Analysis):
         :return:                        A simplified AIL block.
         """
 
-        simp = self.project.analyses.AILBlockSimplifier(ail_block, stack_pointer_tracker=stack_pointer_tracker)
+        simp = self.project.analyses.AILBlockSimplifier(
+            ail_block,
+            remove_dead_memdefs=self._remove_dead_memdefs,
+            stack_pointer_tracker=stack_pointer_tracker,
+        )
         return simp.result_block
 
     def _simplify_function(self):
@@ -193,7 +202,12 @@ class Clinic(Analysis):
         rd = self.project.analyses.ReachingDefinitions(subject=self.function, func_graph=self.graph,
                                                        observe_callback=self._simplify_function_rd_observe_callback)
 
-        simp = self.project.analyses.AILSimplifier(self.function, func_graph=self.graph, reaching_definitions=rd)
+        simp = self.project.analyses.AILSimplifier(
+            self.function,
+            func_graph=self.graph,
+            remove_dead_memdefs=self._remove_dead_memdefs,
+            reaching_definitions=rd
+        )
 
         for key in list(self._blocks.keys()):
             old_block = self._blocks[key]
@@ -297,7 +311,7 @@ class Clinic(Analysis):
             if len(reg_vars) == 1:
                 reg_var, offset = next(iter(reg_vars))
                 expr.variable = reg_var
-                expr.offset = offset
+                expr.variable_offset = offset
 
         elif type(expr) is ailment.Expr.Load:
             # import ipdb; ipdb.set_trace()
@@ -311,14 +325,14 @@ class Clinic(Analysis):
                             )
                 var, offset = next(iter(variables))
                 expr.variable = var
-                expr.offset = offset
+                expr.variable_offset = offset
 
         elif type(expr) is ailment.Expr.BinaryOp:
             variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
             if len(variables) == 1:
                 var, offset = next(iter(variables))
                 expr.referenced_variable = var
-                expr.offset = offset
+                expr.variable_offset = offset
             else:
                 self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands[0])
                 self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands[1])
@@ -328,7 +342,7 @@ class Clinic(Analysis):
             if len(variables) == 1:
                 var, offset = next(iter(variables))
                 expr.referenced_variable = var
-                expr.offset = offset
+                expr.variable_offset = offset
             else:
                 self._link_variables_on_expr(variable_manager, block, stmt_idx, stmt, expr.operands)
 
@@ -340,7 +354,7 @@ class Clinic(Analysis):
             if len(variables) == 1:
                 var, offset = next(iter(variables))
                 expr.referenced_variable = var
-                expr.offset = offset
+                expr.variable_offset = offset
 
     def _update_graph(self):
 

--- a/angr/analyses/decompiler/decompilation_options.py
+++ b/angr/analyses/decompiler/decompilation_options.py
@@ -1,0 +1,35 @@
+# decompilation options
+
+from collections import defaultdict
+
+
+class DecompilationOption:
+    def __init__(self, name, description, value_type, cls, param, value_range=None, category="General"):
+        self.name = name
+        self.description = description
+        self.value_type = value_type
+        self.cls = cls
+        self.param = param
+        self.value_range = value_range
+        self.category = category
+
+
+O = DecompilationOption
+
+options = [
+    O(
+        "Remove dead memdefs",
+        "Allow the decompiler to remove memory definitions (such as stack variables) that are deemed dead. Generally, "
+        "enabling this option will generate cleaner pseudocode; But when prior analyses go wrong, angr may miss "
+        "certain uses to a memory definition, which may cause the removal of a memory definition that is in use.",
+        bool,
+        "clinic",
+        "remove_dead_memdefs",
+        category="Data flows"
+    ),
+]
+
+options_by_category = defaultdict(list)
+
+for o in options:
+    options_by_category[o.category].append(o)

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -1,11 +1,17 @@
 
+from collections import defaultdict
+from typing import List, Tuple, Any
+
+
 from .. import Analysis, AnalysesHub
+from .decompilation_options import DecompilationOption
 
 
 class Decompiler(Analysis):
-    def __init__(self, func, cfg=None, optimization_passes=None, sp_tracker_track_memory=True):
+    def __init__(self, func, cfg=None, options=None, optimization_passes=None, sp_tracker_track_memory=True):
         self.func = func
         self._cfg = cfg
+        self._options = options
         self._optimization_passes = optimization_passes
         self._sp_tracker_track_memory = sp_tracker_track_memory
 
@@ -19,11 +25,19 @@ class Decompiler(Analysis):
         if self.func.is_simprocedure:
             return
 
+        options_by_class = defaultdict(list)
+
+        if self._options:
+            for o, v in self._options:
+                options_by_class[o.cls].append((o, v))
+
         # convert function blocks to AIL blocks
         clinic = self.project.analyses.Clinic(self.func,
                                               kb=self.kb,
                                               optimization_passes=self._optimization_passes,
-                                              sp_tracker_track_memory=self._sp_tracker_track_memory)
+                                              sp_tracker_track_memory=self._sp_tracker_track_memory,
+                                              **self.options_to_params(options_by_class['clinic'])
+                                              )
 
         # recover regions
         ri = self.project.analyses.RegionIdentifier(self.func, graph=clinic.graph, kb=self.kb)
@@ -38,6 +52,18 @@ class Decompiler(Analysis):
 
         self.clinic = clinic
         self.codegen = codegen
+
+    def options_to_params(self, options):
+        """
+
+        :param List[Tuple[DecompilationOption, Any]] options:
+        :return:
+        """
+
+        d = { }
+        for option, value in options:
+            d[option.param] = value
+        return d
 
 
 AnalysesHub.register_default('Decompiler', Decompiler)

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -1,4 +1,4 @@
-
+# pylint:disable=unused-import
 from collections import defaultdict
 from typing import List, Tuple, Any
 
@@ -53,11 +53,14 @@ class Decompiler(Analysis):
         self.clinic = clinic
         self.codegen = codegen
 
-    def options_to_params(self, options):
+    @staticmethod
+    def options_to_params(options):
         """
+        Convert decompilation options to a dict of params.
 
-        :param List[Tuple[DecompilationOption, Any]] options:
-        :return:
+        :param List[Tuple[DecompilationOption, Any]] options:   The decompilation options.
+        :return:                                                A dict of keyword arguments.
+        :rtype:                                                 dict
         """
 
         d = { }

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -1269,8 +1269,8 @@ class StructuredCodeGenerator(Analysis):
     def _handle_Expr_Load(self, expr):
 
         if hasattr(expr, 'variable') and expr.variable is not None:
-            if expr.offset is not None:
-                offset = self._handle(expr.offset)
+            if expr.variable_offset is not None:
+                offset = self._handle(expr.variable_offset)
             else:
                 offset = None
             return CVariable(expr.variable, offset=offset)

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -8,6 +8,7 @@ from ... import sim_options
 from ...engines.light import SpOffset
 from ...keyed_region import KeyedRegion
 from .. import register_analysis
+from ..code_location import CodeLocation
 from ..analysis import Analysis
 from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor, SingleNodeGraphVisitor
 from .values import TOP
@@ -20,10 +21,12 @@ _l = logging.getLogger(name=__name__)
 # The base state
 
 class PropagatorState:
-    def __init__(self, arch, replacements=None):
+    def __init__(self, arch, replacements=None, prop_count=None):
         self.arch = arch
         self.gpr_size = arch.bits // arch.byte_width  # size of the general-purpose registers
 
+        # propagation count of each expression
+        self._prop_count = defaultdict(int) if prop_count is None else prop_count
         self._replacements = defaultdict(dict) if replacements is None else replacements
 
     def __repr__(self):
@@ -51,13 +54,25 @@ class PropagatorState:
         return state
 
     def add_replacement(self, codeloc, old, new):
+        """
+        Add a replacement record: Replacing expression `old` with `new` at program location `codeloc`.
+
+        :param CodeLocation codeloc:    The code location.
+        :param old:                     The expression to be replaced.
+        :param new:                     The expression to replace with.
+        :return:                        None
+        """
         self._replacements[codeloc][old] = new
+
+    def filter_replacements(self):
+        pass
+
 
 # VEX state
 
 class PropagatorVEXState(PropagatorState):
-    def __init__(self, arch, registers=None, local_variables=None, replacements=None):
-        super().__init__(arch, replacements=replacements)
+    def __init__(self, arch, registers=None, local_variables=None, replacements=None, prop_count=None):
+        super().__init__(arch, replacements=replacements, prop_count=prop_count)
         self.registers = {} if registers is None else registers  # offset to values
         self.local_variables = {} if local_variables is None else local_variables  # offset to values
 
@@ -70,6 +85,7 @@ class PropagatorVEXState(PropagatorState):
             registers=self.registers.copy(),
             local_variables=self.local_variables.copy(),
             replacements=self._replacements.copy(),
+            prop_count=self._prop_count.copy()
         )
 
         return cp
@@ -121,11 +137,12 @@ class PropagatorVEXState(PropagatorState):
         except KeyError:
             return TOP
 
+
 # AIL state
 
 class PropagatorAILState(PropagatorState):
-    def __init__(self, arch, replacements=None):
-        super().__init__(arch, replacements=replacements)
+    def __init__(self, arch, replacements=None, prop_count=None):
+        super().__init__(arch, replacements=replacements, prop_count=prop_count)
 
         self._stack_variables = KeyedRegion()
         self._registers = KeyedRegion()
@@ -138,6 +155,7 @@ class PropagatorAILState(PropagatorState):
         rd = PropagatorAILState(
             self.arch,
             replacements=self._replacements.copy(),
+            prop_count=self._prop_count.copy(),
         )
 
         rd._stack_variables = self._stack_variables.copy()
@@ -209,11 +227,35 @@ class PropagatorAILState(PropagatorState):
             return next(iter(objs))
         return None
 
+    def add_replacement(self, codeloc, old, new):
+
+        prop_count = 0
+        if isinstance(new, ailment.Expr.Expression) and not isinstance(new, ailment.Expr.Const):
+            self._prop_count[new] += 1
+            prop_count = self._prop_count[new]
+
+        if prop_count <= 1:
+            # we can propagate this expression
+            super().add_replacement(codeloc, old, new)
+
+    def filter_replacements(self):
+
+        to_remove = set()
+
+        for old, new in self._replacements.items():
+            if isinstance(new, ailment.Expr.Expression) and not isinstance(new, ailment.Expr.Const):
+                if self._prop_count[new] > 1:
+                    # do not propagate this expression
+                    to_remove.add(old)
+
+        for old in to_remove:
+            del self._replacements[old]
 
 class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-method
     """
-    PropagatorAnalysis propagates values, either constants or variables, across a block or a function. It supports both
-    VEX and AIL. It performs certain arithmetic operations between constants, including but are not limited to:
+    PropagatorAnalysis propagates values (either constant values or variables) and expressions inside a block or across
+    a function. It supports both VEX and AIL. It performs certain arithmetic operations between constants, including
+    but are not limited to:
 
     - addition
     - subtraction
@@ -302,6 +344,7 @@ class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-
             self._base_state.options.add(sim_options.SYMBOL_FILL_UNCONSTRAINED_MEMORY)
         state = engine.process(state, block=block, project=self.project, base_state=self._base_state,
                                load_callback=self._load_callback, fail_fast=self._fail_fast)
+        state.filter_replacements()
 
         self._node_iterations[block_key] += 1
         self._states[block_key] = state

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -8,7 +8,7 @@ from ... import sim_options
 from ...engines.light import SpOffset
 from ...keyed_region import KeyedRegion
 from .. import register_analysis
-from ..code_location import CodeLocation
+from ..code_location import CodeLocation  # pylint:disable=unused-import
 from ..analysis import Analysis
 from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor, SingleNodeGraphVisitor
 from .values import TOP

--- a/angr/analyses/reaching_definitions/dep_graph.py
+++ b/angr/analyses/reaching_definitions/dep_graph.py
@@ -9,9 +9,9 @@ def _is_definition(node):
     return isinstance(node, Definition)
 
 
-class DefUseGraph:
+class DepGraph:
     """
-    The representation of a definition-use graph: a directed graph, where nodes are definitions, and edges represent uses.
+    The representation of a dependency graph: a directed graph, where nodes are definitions, and edges represent uses.
 
     Mostly a wrapper around a <networkx.DiGraph>.
     """

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -252,6 +252,7 @@ class SimEngineRDAIL(
         addrs = self._expr(expr.addr)
         size = expr.size
         bits = expr.bits
+        codeloc = self._codeloc()
 
         data = set()
         for addr in addrs:
@@ -259,6 +260,7 @@ class SimEngineRDAIL(
                 current_defs = self.state.memory_definitions.get_objects_by_offset(addr)
                 if current_defs:
                     for current_def in current_defs:
+                        # self.state.add_use(current_def, codeloc)
                         data.update(current_def.data)
                     if any(type(d) is Undefined for d in data):
                         l.info('Memory at address %#x undefined, ins_addr = %#x.', addr, self.ins_addr)
@@ -269,18 +271,19 @@ class SimEngineRDAIL(
                         pass
 
                 # FIXME: _add_memory_use() iterates over the same loop
-                self.state.add_use(MemoryLocation(addr, size), self._codeloc())
+                self.state.add_use(MemoryLocation(addr, size), codeloc)
             elif isinstance(addr, SpOffset):
                 current_defs = self.state.stack_definitions.get_objects_by_offset(addr.offset)
                 if current_defs:
                     for current_def in current_defs:
+                        # self.state.add_use(current_def, codeloc)
                         data.update(current_def.data)
                     if any(type(d) is Undefined for d in data):
                         l.info('Stack access at offset %#x undefined, ins_addr = %#x.', addr.offset, self.ins_addr)
                 else:
                     data.add(undefined)
 
-                self.state.add_use(addr, self._codeloc())
+                self.state.add_use(addr, codeloc)
             else:
                 l.info('Memory address undefined, ins_addr = %#x.', self.ins_addr)
 

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -25,10 +25,10 @@ class SimEngineRDVEX(
         self._maximum_local_call_depth = maximum_local_call_depth
         self._function_handler = function_handler
         self._visited_blocks = None
-        self._def_use_graph = None
+        self._dep_graph = None
 
     def process(self, state, *args, **kwargs):
-        self._def_use_graph = kwargs.pop('def_use_graph', None)
+        self._dep_graph = kwargs.pop('dep_graph', None)
         self._visited_blocks = kwargs.pop('visited_blocks', None)
 
         # we are using a completely different state. Therefore, we directly call our _process() method before

--- a/angr/analyses/reaching_definitions/live_definitions.py
+++ b/angr/analyses/reaching_definitions/live_definitions.py
@@ -287,14 +287,12 @@ class LiveDefinitions:
     def _kill_and_add_register_definition(self, atom, code_loc, data, dummy=False):
 
         # FIXME: check correctness
-        current_defs = self.register_definitions.get_objects_by_offset(atom.reg_offset)
         definition = Definition(atom, code_loc, data, dummy=dummy)
         # set_object() replaces kill (not implemented) and add (add) in one step
         self.register_definitions.set_object(atom.reg_offset, definition, atom.size)
         return definition
 
     def _kill_and_add_stack_definition(self, atom, code_loc, data, dummy=False):
-        current_defs = self.stack_definitions.get_objects_by_offset(atom.offset)
         definition = Definition(atom, code_loc, data, dummy=dummy)
         self.stack_definitions.set_object(atom.offset, definition, data.bits // 8)
         return definition

--- a/angr/analyses/reaching_definitions/live_definitions.py
+++ b/angr/analyses/reaching_definitions/live_definitions.py
@@ -23,7 +23,7 @@ class LiveDefinitions:
 
     __slots__ = ('arch', '_subject', '_track_tmps', 'analysis', 'register_definitions', 'stack_definitions',
                  'memory_definitions', 'tmp_definitions', 'register_uses', 'stack_uses', 'memory_uses',
-                 'uses_by_codeloc', 'tmp_uses', '_dead_virgin_definitions', )
+                 'uses_by_codeloc', 'tmp_uses', 'all_definitions', )
 
     """
     Represents the internal state of the ReachingDefinitionsAnalysis.
@@ -51,16 +51,15 @@ class LiveDefinitions:
         self.stack_definitions = KeyedRegion()
         self.memory_definitions = KeyedRegion()
         self.tmp_definitions = {}
+        self.all_definitions = set()
 
-        self._set_initialisation_values(subject, rtoc_value)
+        self._set_initialization_values(subject, rtoc_value)
 
         self.register_uses = Uses()
         self.stack_uses = Uses()
         self.memory_uses = Uses()
         self.uses_by_codeloc = defaultdict(set)
         self.tmp_uses = defaultdict(set)
-
-        self._dead_virgin_definitions = set()  # definitions that are killed before used
 
     def __repr__(self):
         ctnt = "LiveDefs, %d regdefs, %d stackdefs, %d memdefs" % (
@@ -72,12 +71,16 @@ class LiveDefinitions:
             ctnt += ", %d tmpdefs" % len(self.tmp_definitions)
         return "<%s>" % ctnt
 
-    def _set_initialisation_values(self, subject, rtoc_value=None):
+    @property
+    def dep_graph(self):
+        return self.analysis.dep_graph
+
+    def _set_initialization_values(self, subject, rtoc_value=None):
         if subject.type is SubjectType.Function:
             if isinstance(self.arch, archinfo.arch_ppc64.ArchPPC64) and not rtoc_value:
                 raise ValueError('The architecture being ppc64, the parameter `rtoc_value` should be provided.')
 
-            self._initialise_function(
+            self._initialize_function(
                 subject.cc,
                 subject.content.addr,
                 rtoc_value,
@@ -87,7 +90,7 @@ class LiveDefinitions:
 
         return self
 
-    def _initialise_function(self, cc, func_addr, rtoc_value=None):
+    def _initialize_function(self, cc, func_addr, rtoc_value=None):
         # initialize stack pointer
         sp = Register(self.arch.sp_offset, self.arch.bytes)
         sp_def = Definition(sp, ExternalCodeLocation(), DataSet(self.arch.initial_sp, self.arch.bits))
@@ -145,10 +148,9 @@ class LiveDefinitions:
         rd.stack_uses = self.stack_uses.copy()
         rd.memory_uses = self.memory_uses.copy()
         rd.tmp_uses = self.tmp_uses.copy()
-        rd._dead_virgin_definitions = self._dead_virgin_definitions.copy()
+        rd.all_definitions = self.all_definitions.copy()
 
         return rd
-
 
     def get_sp(self):
         """
@@ -162,12 +164,11 @@ class LiveDefinitions:
         # Assuming sp_definition has only one concrete value.
         return sp_definition.data.get_first_element()
 
-
     def merge(self, *others):
 
         state = self.copy()
 
-        for other in others:
+        for other in others:  # type: LiveDefinitions
             state.register_definitions.merge(other.register_definitions)
             state.stack_definitions.merge(other.stack_definitions)
             state.memory_definitions.merge(other.memory_definitions)
@@ -176,7 +177,7 @@ class LiveDefinitions:
             state.stack_uses.merge(other.stack_uses)
             state.memory_uses.merge(other.memory_uses)
 
-            state._dead_virgin_definitions |= other._dead_virgin_definitions
+            state.all_definitions.update(other.all_definitions)
 
         return state
 
@@ -216,16 +217,18 @@ class LiveDefinitions:
             raise NotImplementedError()
 
         if definition is not None:
-            self.analysis.def_use_graph.add_node(definition)
-            for used in self.analysis.codeloc_uses:
-                # Moderately confusing misnomers. This is an edge from a def to a use, since the
-                # "uses" are actually the definitions that we're using and the "definition" is the
-                # new definition; i.e. The def that the old def is used to construct so this is
-                # really a graph where nodes are defs and edges are uses.
-                self.analysis.def_use_graph.add_edge(used, definition)
+            self.all_definitions.add(definition)
+
+            if self.dep_graph is not None:
+                self.dep_graph.add_node(definition)
+                for used in self.analysis.codeloc_uses:
+                    # Moderately confusing misnomers. This is an edge from a def to a use, since the
+                    # "uses" are actually the definitions that we're using and the "definition" is the
+                    # new definition; i.e. The def that the old def is used to construct so this is
+                    # really a graph where nodes are defs and edges are uses.
+                    self.dep_graph.add_edge(used, definition)
 
         return definition
-
 
     def add_use(self, atom, code_loc):
         self._cycle(code_loc)
@@ -271,9 +274,11 @@ class LiveDefinitions:
         self._cycle(code_loc)
         atom = GuardUse(target)
         kinda_definition = Definition(atom, code_loc, data)
-        self.analysis.def_use_graph.add_node(kinda_definition)
-        for used in self.analysis.codeloc_uses:
-            self.analysis.def_use_graph.add_edge(used, kinda_definition)
+
+        if self.dep_graph is not None:
+            self.dep_graph.add_node(kinda_definition)
+            for used in self.analysis.codeloc_uses:
+                self.dep_graph.add_edge(used, kinda_definition)
 
     #
     # Private methods
@@ -283,13 +288,6 @@ class LiveDefinitions:
 
         # FIXME: check correctness
         current_defs = self.register_definitions.get_objects_by_offset(atom.reg_offset)
-        if current_defs:
-            uses = set()
-            for current_def in current_defs:
-                uses |= self.register_uses.get_uses(current_def)
-            if not uses:
-                self._dead_virgin_definitions |= current_defs
-
         definition = Definition(atom, code_loc, data, dummy=dummy)
         # set_object() replaces kill (not implemented) and add (add) in one step
         self.register_definitions.set_object(atom.reg_offset, definition, atom.size)
@@ -297,13 +295,6 @@ class LiveDefinitions:
 
     def _kill_and_add_stack_definition(self, atom, code_loc, data, dummy=False):
         current_defs = self.stack_definitions.get_objects_by_offset(atom.offset)
-        if current_defs:
-            uses = set()
-            for current_def in current_defs:
-                uses |= self.stack_uses.get_uses(current_def)
-            if not uses:
-                self._dead_virgin_definitions |= current_defs
-
         definition = Definition(atom, code_loc, data, dummy=dummy)
         self.stack_definitions.set_object(atom.offset, definition, data.bits // 8)
         return definition
@@ -352,6 +343,9 @@ class LiveDefinitions:
     def _add_stack_use_by_def(self, def_, code_loc):
         self.stack_uses.add_use(def_, code_loc)
         self.uses_by_codeloc[code_loc].add(def_)
+
+        if self.dep_graph is not None:
+            self.dep_graph.add_edge(def_, code_loc)
 
     def _add_memory_use(self, atom, code_loc):
 

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -1,6 +1,6 @@
 
 import logging
-from typing import Optional
+from typing import Optional  # pylint:disable=unused-import
 from collections import defaultdict
 
 import ailment
@@ -19,7 +19,6 @@ from .engine_vex import SimEngineRDVEX
 from .live_definitions import LiveDefinitions
 from .subject import Subject
 from .uses import Uses
-from .dep_graph import DepGraph
 
 
 l = logging.getLogger(name=__name__)

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -1,4 +1,6 @@
+
 import logging
+from typing import Optional
 from collections import defaultdict
 
 import ailment
@@ -12,11 +14,12 @@ from ..forward_analysis import ForwardAnalysis
 from ..code_location import CodeLocation
 from .atoms import Register
 from .constants import OP_BEFORE, OP_AFTER
-from .def_use_graph import DefUseGraph
 from .engine_ail import SimEngineRDAIL
 from .engine_vex import SimEngineRDVEX
 from .live_definitions import LiveDefinitions
 from .subject import Subject
+from .uses import Uses
+from .dep_graph import DepGraph
 
 
 l = logging.getLogger(name=__name__)
@@ -39,7 +42,7 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
     def __init__(self, subject=None, func_graph=None, max_iterations=3, track_tmps=False,
                  observation_points=None, init_state=None, cc=None, function_handler=None,
                  current_local_call_depth=1, maximum_local_call_depth=5, observe_all=False, visited_blocks=None,
-                 def_use_graph=None, observe_callback=None):
+                 dep_graph=None, observe_callback=None):
         """
         :param Block|Function subject: The subject of the analysis: a function, or a single basic block.
         :param func_graph:                      Alternative graph for function.graph.
@@ -52,7 +55,7 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
         :param angr.analyses.reaching_definitions.LiveDefinitions init_state:
                                                 An optional initialization state. The analysis creates and works on a
                                                 copy.
-                                                Default to None: the analysis then initialise its own abstract state,
+                                                Default to None: the analysis then initialize its own abstract state,
                                                 based on the given <Subject>.
         :param SimCC cc:                        Calling convention of the function.
         :param list function_handler:           Handler for functions, naming scheme: handle_<func_name>|local_function(
@@ -62,8 +65,8 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
         :param Boolean observe_all:             Observe every statement, both before and after.
         :param List<ailment.Block|Block|CodeNode|CFGNode> visited_blocks:
                                                 A list of previously visited blocks.
-        :param angr.analyses.reaching_definitions.def_use_graph.DefUseGraph def_use_graph:
-                                                An initial definition-use graph to add the result of the analysis to.
+        :param Optional[DepGraph] dep_graph:    An initial dependency graph to add the result of the analysis to. Set it
+                                                to None to skip dependency graph generation.
         """
 
         self._subject = Subject(subject, self.kb.cfgs['CFGFast'], func_graph, cc)
@@ -80,7 +83,7 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
         self._current_local_call_depth = current_local_call_depth
         self._maximum_local_call_depth = maximum_local_call_depth
 
-        self._def_use_graph = def_use_graph or DefUseGraph()
+        self._dep_graph = dep_graph
         self.current_codeloc = None
         self.codeloc_uses = set()
 
@@ -113,6 +116,8 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
         self._visited_blocks = visited_blocks or []
 
         self.observed_results = {}
+        self.all_definitions = set()
+        self.all_uses = Uses()
 
         self._analyze()
 
@@ -127,8 +132,8 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
         return next(iter(self.observed_results.values()))
 
     @property
-    def def_use_graph(self):
-        return self._def_use_graph
+    def dep_graph(self):
+        return self._dep_graph
 
     @property
     def visited_blocks(self):
@@ -149,8 +154,8 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
     def get_reaching_definitions_by_node(self, node_addr, op_type):
         key = 'node', node_addr, op_type
         if key not in self.observed_results:
-            raise KeyError(("Reaching definitions are not available at observation point %s. "
-                            "Did you specify that observation point?") % key)
+            raise KeyError("Reaching definitions are not available at observation point %s. "
+                            "Did you specify that observation point?" % str(key))
 
         return self.observed_results[key]
 
@@ -237,6 +242,13 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
         return states[0].merge(*states[1:])
 
     def _run_on_node(self, node, state):
+        """
+
+        :param node:
+        :param LiveDefinitions state:
+        :return:
+        """
+
         self._visited_blocks.append(node)
 
         if isinstance(node, ailment.Block):
@@ -259,7 +271,7 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
             block=block,
             fail_fast=self._fail_fast,
             visited_blocks=self._visited_blocks
-        )
+        )  # type: LiveDefinitions, set
 
         self._node_iterations[block_key] += 1
 
@@ -276,6 +288,11 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
             state.kill_definitions(Register(self.project.arch.ip_offset, self.project.arch.bytes),
                                    codeloc)
         self.node_observe(node.addr, state, OP_AFTER)
+
+        # update all definitions and all uses
+        self.all_definitions |= state.all_definitions
+        for use in [state.stack_uses, state.register_uses]:
+            self.all_uses.merge(use)
 
         if self._node_iterations[block_key] < self._max_iterations:
             return True, state

--- a/tests/test_reachingdefinitions.py
+++ b/tests/test_reachingdefinitions.py
@@ -342,7 +342,7 @@ def test_dep_graph():
     )
 
     # build a def-use graph for main() of /bin/true. check that t7 in the first block is only used by the guard
-    rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=True)
+    rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=True, dep_graph=DepGraph())
     tmp_7 = list(filter(
         lambda def_: type(def_.atom) is Tmp and def_.atom.tmp_idx == 7 and def_.codeloc.block_addr == main.addr,
         rda.dep_graph._graph.nodes()

--- a/tests/test_reachingdefinitions.py
+++ b/tests/test_reachingdefinitions.py
@@ -16,6 +16,7 @@ from angr.analyses.reaching_definitions.atoms import GuardUse, Tmp, Register
 from angr.analyses.reaching_definitions.constants import OP_BEFORE, OP_AFTER
 from angr.analyses.reaching_definitions.live_definitions import LiveDefinitions
 from angr.analyses.reaching_definitions.subject import Subject, SubjectType
+from angr.analyses.reaching_definitions.dep_graph import DepGraph
 from angr.block import Block
 
 LOGGER = logging.getLogger('test_reachingdefinitions')
@@ -315,27 +316,28 @@ class LiveDefinitionsTest(TestCase):
 
         nose.tools.assert_equal(sp_value, project.arch.initial_sp)
 
-def test_def_use_graph():
+
+def test_dep_graph():
     project = angr.Project(os.path.join(TESTS_LOCATION, 'x86_64', 'true'), auto_load_libs=False)
     cfg = project.analyses.CFGFast()
     main = cfg.functions['main']
 
     # build a def-use graph for main() of /bin/true without tmps. check that the only dependency of the first block's guard is the four cc registers
-    rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=False)
+    rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=False, dep_graph=DepGraph())
     guard_use = list(filter(
         lambda def_: type(def_.atom) is GuardUse and def_.codeloc.block_addr == main.addr,
-        rda.def_use_graph._graph.nodes()
+        rda.dep_graph._graph.nodes()
     ))[0]
     nose.tools.assert_equal(
-        len(rda.def_use_graph._graph.pred[guard_use]),
+        len(rda.dep_graph._graph.pred[guard_use]),
         4
     )
     nose.tools.assert_equal(
-        all(type(def_.atom) is Register for def_ in rda.def_use_graph._graph.pred[guard_use]),
+        all(type(def_.atom) is Register for def_ in rda.dep_graph._graph.pred[guard_use]),
         True
     )
     nose.tools.assert_equal(
-        set(def_.atom.reg_offset for def_ in rda.def_use_graph._graph.pred[guard_use]),
+        set(def_.atom.reg_offset for def_ in rda.dep_graph._graph.pred[guard_use]),
         {reg.vex_offset for reg in project.arch.register_list if reg.name.startswith('cc_')}
     )
 
@@ -343,14 +345,14 @@ def test_def_use_graph():
     rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=True)
     tmp_7 = list(filter(
         lambda def_: type(def_.atom) is Tmp and def_.atom.tmp_idx == 7 and def_.codeloc.block_addr == main.addr,
-        rda.def_use_graph._graph.nodes()
+        rda.dep_graph._graph.nodes()
     ))[0]
     nose.tools.assert_equal(
-        len(rda.def_use_graph._graph.succ[tmp_7]),
+        len(rda.dep_graph._graph.succ[tmp_7]),
         1
     )
     nose.tools.assert_equal(
-        type(list(rda.def_use_graph._graph.succ[tmp_7])[0].atom),
+        type(list(rda.dep_graph._graph.succ[tmp_7])[0].atom),
         GuardUse
     )
 


### PR DESCRIPTION
- Rename DefUseGraph to DepGraph, which is what it should have been.

- Remove dead_virgin_definitions.

- Add all_definitions to ReachingDefinitionsAnalysis. Now dead
assignment elimination can be done properly by finding all definitions
without any uses (instead of using the half-assed dead-virgin
definitions, which does not work correctly in cases where a def is only
used on one path but not the other path).

- Implement propagation count limit to avoid some excessive expression
propagation.

- Add decompilation options.