### PR TITLE
Unsat conditional exits should not make the parent unsat.

### DIFF
--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -184,7 +184,7 @@ class SimSuccessors:
                     ret_addr = state.mem[state.regs._sp].long.concrete
                 else:
                     ret_addr = state.solver.eval(state.regs._lr)
-            except SimSolverModeError:
+            except (SimSolverModeError, SimUnsatError):
                 # Use the address for UnresolvableCallTarget instead.
                 ret_addr = state.project.simos.unresolvable_call_target
 
@@ -195,7 +195,7 @@ class SimSuccessors:
 
             try:
                 stack_ptr = state.solver.eval(state.regs._sp)
-            except SimSolverModeError:
+            except (SimSolverModeError, SimUnsatError):
                 stack_ptr = 0
 
             new_frame = CallStack(
@@ -517,7 +517,7 @@ class SimSuccessors:
 
 
 from ..state_plugins.inspect import BP_BEFORE, BP_AFTER
-from ..errors import SimSolverModeError, AngrUnsupportedSyscallError, AngrSyscallError, SimValueError
+from ..errors import SimSolverModeError, AngrUnsupportedSyscallError, AngrSyscallError, SimValueError, SimUnsatError
 from ..calling_conventions import SYSCALL_CC
 from ..state_plugins.sim_action_object import _raw_ast
 from ..state_plugins.callstack import CallStack

--- a/angr/engines/vex/heavy/heavy.py
+++ b/angr/engines/vex/heavy/heavy.py
@@ -242,10 +242,8 @@ class HeavyVEXMixin(SuccessorsMixin, ClaripyDataMixin, SimStateStorageMixin, VEX
             cont_state = self.state
 
         if exit_state is not None:
-            # is the guard satisfiable?
-            if exit_state.solver.satisfiable([guard]):
-                self.successors.add_successor(exit_state, target, guard, jumpkind,
-                                         exit_stmt_idx=self.stmt_idx, exit_ins_addr=self.state.scratch.ins_addr)
+            self.successors.add_successor(exit_state, target, guard, jumpkind,
+                                     exit_stmt_idx=self.stmt_idx, exit_ins_addr=self.state.scratch.ins_addr)
 
         if cont_state is None:
             raise VEXEarlyExit

--- a/angr/engines/vex/heavy/heavy.py
+++ b/angr/engines/vex/heavy/heavy.py
@@ -242,8 +242,10 @@ class HeavyVEXMixin(SuccessorsMixin, ClaripyDataMixin, SimStateStorageMixin, VEX
             cont_state = self.state
 
         if exit_state is not None:
-            self.successors.add_successor(exit_state, target, guard, jumpkind,
-                                     exit_stmt_idx=self.stmt_idx, exit_ins_addr=self.state.scratch.ins_addr)
+            # is the guard satisfiable?
+            if exit_state.solver.satisfiable([guard]):
+                self.successors.add_successor(exit_state, target, guard, jumpkind,
+                                         exit_stmt_idx=self.stmt_idx, exit_ins_addr=self.state.scratch.ins_addr)
 
         if cont_state is None:
             raise VEXEarlyExit


### PR DESCRIPTION
`add_successor()` may fail and raise a `SimUnsatError` if the `guard` is not satisfiable. In the case of a conditional exit, this exception will be thrown all the way up to `SimulationManager.step_state()` and will lead to pruning the _parent_ state, regardless of whether the default exit is satisfiable or not. This commit fixes the above bug.