### PR TITLE
Definition should not take into account its data.

### DIFF
--- a/angr/analyses/reaching_definitions/dataset.py
+++ b/angr/analyses/reaching_definitions/dataset.py
@@ -165,6 +165,6 @@ class DataSet:
         if undefined in self.data:
             data_string = str(self.data)
         else:
-            data_string = str([ hex(i) for i in self.data ])
+            data_string = str([ hex(i) if isinstance(i, int) else i for i in self.data ])
 
         return 'DataSet<%d>: %s' % (self._bits, data_string)

--- a/angr/analyses/reaching_definitions/definition.py
+++ b/angr/analyses/reaching_definitions/definition.py
@@ -30,14 +30,14 @@ class Definition:
             self.data = DataSet(self.data, self.data.bits)
 
     def __eq__(self, other):
-        return self.atom == other.atom and self.codeloc == other.codeloc and self.data == other.data
+        return self.atom == other.atom and self.codeloc == other.codeloc
 
     def __repr__(self):
         return '<Definition {Atom:%s, Codeloc:%s, Data:%s%s}>' % (self.atom, self.codeloc, self.data,
                                                                   "" if not self.dummy else " dummy")
 
     def __hash__(self):
-        return hash((self.atom, self.codeloc, self.data))
+        return hash((self.atom, self.codeloc))
 
     @property
     def offset(self):


### PR DESCRIPTION
The .data field is just there acting as a handy value storage during
analysis. It has nothing to do with what a definition is.

Also fix a bug in `Dataset.__repr__()`.