### PR TITLE
CFGFast: Fix: Decoding ud2 marks the next two bytes as nodecode.

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3471,7 +3471,12 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                         }:
                     # ud0, ud1, and ud2 are actually valid instructions.
                     valid_ins = True
-                    nodecode_size = 2
+                    if irsb_string[-2:] == b'\x0f\x0b':
+                        # VEX supports ud2 and make it part of the block size.
+                        nodecode_size = 0
+                    else:
+                        # VEX does not support ud0 or ud1. they are not part of the block size.
+                        nodecode_size = 2
                 else:
                     valid_ins = False
                     nodecode_size = 1

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -4,7 +4,7 @@ import logging
 import pyvex
 import claripy
 
-from angr import SimState
+from angr import SimState, load_shellcode
 from angr.engines import HeavyVEXMixin
 import angr.engines.vex.claripy.ccall as s_ccall
 
@@ -315,6 +315,29 @@ def test_loadg_no_constraint_creation():
     assert state.scratch.temps[0] is not None
     assert state.scratch.temps[0].variables.issuperset(state.scratch.temps[1].variables)
     assert state.scratch.temps[0].op == 'If'
+
+
+def test_amd64_ud012_behaviors():
+
+    # Test if VEX's lifter behaves as what CFGFast expects
+    #
+    # Note: if such behaviors change in the future, you also need to fix the ud{0,1,2} handling logic in
+    # CFGFast._generate_cfgnode().
+
+    # according to VEX, ud0 is not part of the block
+    a = load_shellcode(b"\x90\x90\x0f\xff", "amd64")
+    block_0 = a.factory.block(0)
+    assert block_0.size == 2
+
+    # according to VEX, ud1 is not part of the block
+    a = load_shellcode(b"\x90\x90\x0f\xb9", "amd64")
+    block_1 = a.factory.block(0)
+    assert block_1.size == 2
+
+    # according to VEX, ud2 *is* part of the block
+    a = load_shellcode(b"\x90\x90\x0f\x0b", "amd64")
+    block_2 = a.factory.block(0)
+    assert block_2.size == 4
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a weird behavior: VEX considers ud2 to be part of a block but
not ud0 or ud1. This behavior may change in the future in VEX, so I also
added a test case in test_vex.py to enforce the behavior.