### PR TITLE
CFGFast: Fix: ud2 on x86 goes undetected. Fixes #1963.

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3403,6 +3403,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             nodecode = False
             irsb = None
             irsb_string = None
+            lifted_block = None
             try:
                 lifted_block = self._lift(addr, size=distance, opt_level=self._iropt_level, collect_data_refs=True,
                                           strict_block_end=True)
@@ -3462,21 +3463,22 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                 else:
                     irsb_size = irsb.size
                 # special handling for ud, ud1, and ud2 on x86 and x86-64
-                if is_x86_x64_arch \
-                        and len(irsb_string) >= 2 \
-                        and irsb_string[-2:] in {
+                if irsb_string[-2:] == b'\x0f\x0b' and self.project.arch.name == 'AMD64':
+                    # VEX supports ud2 and make it part of the block size, only in AMD64.
+                    valid_ins = True
+                    nodecode_size = 0
+                elif lifted_block is not None \
+                        and is_x86_x64_arch \
+                        and len(lifted_block.bytes) - irsb_size > 2 \
+                        and lifted_block.bytes[irsb_size : irsb_size + 2] in {
                             b'\x0f\xff',  # ud0
                             b'\x0f\xb9',  # ud1
                             b'\x0f\x0b',  # ud2
                         }:
                     # ud0, ud1, and ud2 are actually valid instructions.
                     valid_ins = True
-                    if irsb_string[-2:] == b'\x0f\x0b':
-                        # VEX supports ud2 and make it part of the block size.
-                        nodecode_size = 0
-                    else:
-                        # VEX does not support ud0 or ud1. they are not part of the block size.
-                        nodecode_size = 2
+                    # VEX does not support ud0 or ud1 or ud2 under AMD64. they are not part of the block size.
+                    nodecode_size = 2
                 else:
                     valid_ins = False
                     nodecode_size = 1

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -334,10 +334,23 @@ def test_amd64_ud012_behaviors():
     block_1 = a.factory.block(0)
     assert block_1.size == 2
 
-    # according to VEX, ud2 *is* part of the block
+    # according to VEX, ud2 under AMD64 *is* part of the block
     a = load_shellcode(b"\x90\x90\x0f\x0b", "amd64")
     block_2 = a.factory.block(0)
     assert block_2.size == 4
+
+
+def test_x86_ud2_behaviors():
+
+    # Test if VEX's lifter behaves as what CFGFast expects
+    #
+    # Note: if such behaviors change in the future, you also need to fix the ud2 handling logic in
+    # CFGFast._generate_cfgnode().
+
+    # according to VEX, ud2 on x86 is not part of the block
+    a = load_shellcode(b"\x90\x90\x0f\x0b", "x86")
+    block_0 = a.factory.block(0)
+    assert block_0.size == 2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Apparently VEX doesn't treat ud2 as part of a block on X86.