### PR TITLE
Handle tailcalls when making return edges with detect_tail_calls set

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -84,6 +84,7 @@ class CFGBase(Analysis):
         self._loop_back_edges = None
         self._overlapped_loop_headers = None
         self._thumb_addrs = set()
+        self._tail_calls = set()
 
         # Store all the functions analyzed before the set is cleared
         # Used for performance optimization
@@ -1956,6 +1957,7 @@ class CFGBase(Analysis):
                     self.kb.functions._add_outside_transition_to(src_function.addr, src_node, dst_node,
                                                                  to_function_addr=dst_addr
                                                                  )
+                    self._tail_calls.add(dst_addr)
 
             # is it a jump to another function?
             if isinstance(dst_addr, SootAddressDescriptor):

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3026,6 +3026,32 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         return endpoints
 
+    def _get_tail_caller(self, tailnode, seen):
+        """
+        recursively search predecessors for the actual caller
+        for a tailnode that we will return to
+
+        :return: list of callers for a possible tailnode
+        """
+
+        if tailnode.addr in seen:
+            return []
+        seen.add(tailnode.addr)
+
+        callers = self.model.get_predecessors(tailnode, jumpkind='Ijk_Call')
+        direct_jumpers = self.model.get_predecessors(tailnode, jumpkind='Ijk_Boring')
+        jump_funcs = [self.model.get_any_node(jn.function_address) for jn in direct_jumpers]
+        jump_callers = []
+
+        for jf in jump_funcs:
+            if jf is not None:
+                jump_callers.extend(self._get_tail_caller(jf, seen))
+
+        callers.extend(jump_callers)
+
+        return callers
+
+
     def _make_return_edges(self):
         """
         For each returning function, create return edges in self.graph.
@@ -3052,6 +3078,14 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
             # get all callers
             callers = self.model.get_predecessors(startpoint, jumpkind='Ijk_Call')
+
+            # handle callers for tailcall optimizations if flag is enabled
+            if self._detect_tail_calls and startpoint.addr in self._tail_calls:
+                l.debug("Handling return address for tail call for func %x", func_addr)
+                seen = set()
+                tail_callers = self._get_tail_caller(startpoint, seen)
+                callers.extend(tail_callers)
+
             # for each caller, since they all end with a call instruction, get the immediate successor
             return_targets = itertools.chain.from_iterable(
                 self.model.get_successors(caller, excluding_fakeret=False, jumpkind='Ijk_FakeRet') for caller in callers

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3040,10 +3040,10 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         callers = self.model.get_predecessors(tailnode, jumpkind='Ijk_Call')
         direct_jumpers = self.model.get_predecessors(tailnode, jumpkind='Ijk_Boring')
-        jump_funcs = [self.model.get_any_node(jn.function_address) for jn in direct_jumpers]
         jump_callers = []
 
-        for jf in jump_funcs:
+        for jn in direct_jumpers:
+            jf = self.model.get_any_node(jn.function_address)
             if jf is not None:
                 jump_callers.extend(self._get_tail_caller(jf, seen))
 

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -657,6 +657,36 @@ def test_tail_call_optimization_detection_armel():
     for member in tail_call_funcs:
         nose.tools.assert_in(member, all_func_addrs)
 
+    # also test for tailcall return addresses
+
+    # mapping of return blocks to return addrs that are the actual callers of certain tail-calls endpoints
+    tail_call_return_addrs = {0x8002bd9: [0x800275f],   # 0x8002bc1
+                              0x80046d7: [0x800275f],   # 0x80046c1
+                              0x80046ed: [0x800275f],   # 0x80046c1
+                              0x8001be7: [0x800068d, 0x8000695],   # 0x8001bdb ??
+                              0x800284d: [0x800028b, 0x80006e1, 0x80006e7],   # 0x8002839
+                              0x80037f5: [0x800270b, 0x8002733, 0x8002759, 0x800098f, 0x8000997], # 0x80037ad
+                              0x80037ef: [0x800270b, 0x8002733, 0x8002759, 0x800098f, 0x8000997], # 0x80037ad
+                              0x8002cc9: [0x8002d3b, 0x8002b99, 0x8002e9f, 0x80041ad,
+                                          0x8004c87, 0x8004d35, 0x8002efb, 0x8002be9,
+                                          0x80046eb, 0x800464f, 0x8002a09, 0x800325f,
+                                          0x80047c1],    # 0x8002c09
+                              0x8004183: [0x8002713],    # 0x8004165
+                              0x8004c31: [0x8002713],    # 0x8004be1
+                              0x8004c69: [0x8002713],    # 0x8004be1
+                              0x8002ef1: [0x800273b]}    # 0x8002eb1
+
+    # check all expected return addrs are present
+    for returning_block_addr, expected_return_addrs in tail_call_return_addrs.items():
+        returning_block = cfg.model.get_any_node(returning_block_addr)
+        return_block_addrs = [rb.addr for rb in cfg.model.get_successors(returning_block)]
+        msg = "%x: unequal sizes of expected_addrs [%d] and return_block_addrs [%d]" % \
+                            (returning_block_addr, len(expected_return_addrs), len(return_block_addrs))
+        nose.tools.assert_equal(len(return_block_addrs), len(expected_return_addrs), msg)
+        for expected_addr in expected_return_addrs:
+                msg = "expected retaddr %x not found for returning_block %x" % \
+                                        (expected_addr, returning_block_addr)
+                nose.tools.assert_in(expected_addr, return_block_addrs, msg)
 
 #
 # Incorrect function-leading blocks merging


### PR DESCRIPTION
_make_return_edges only checks immediate predecessors for return addrs
when determining successors for return edges. This skips functions
that are tailcalls, as the caller it returns to is by definition
not the immediate predecessor, leading to an inaccurate cfg.

Since tailcall detection is already done under cfg_base, added a set
to track tailcall addrs found when detect_tail_calls is set, so
implementations like cfg_fast can reuse this information.