### PR TITLE
Deeper copy in `CFGManager`

### DIFF
--- a/angr/knowledge_plugins/cfg/cfg_manager.py
+++ b/angr/knowledge_plugins/cfg/cfg_manager.py
@@ -42,7 +42,10 @@ class CFGManager(KnowledgeBasePlugin):
 
     def copy(self):
         cm = CFGManager(self._kb)
-        cm.cfgs = self.cfgs.copy()
+        cm.cfgs = dict(map(
+            lambda x: (x[0], x[1].copy()),
+            self.cfgs.items()
+        ))
         return cm
 
     #

--- a/tests/test_cfg_manager.py
+++ b/tests/test_cfg_manager.py
@@ -1,0 +1,25 @@
+import os
+
+import nose
+
+from angr.project import Project
+
+
+def test_cfg_manager_copies_cfg_graphs():
+    binary_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        '..', '..', 'binaries', 'tests', 'x86_64',
+        'all'
+    )
+    project = Project(binary_path, auto_load_libs=False)
+    _ = project.analyses.CFGFast()
+
+    original_cfgs = project.kb.cfgs
+    new_cfgs = project.kb.cfgs.copy()
+
+    original_graph = original_cfgs.cfgs['CFGFast'].graph
+    new_graph = new_cfgs.cfgs['CFGFast'].graph
+
+    nose.tools.assert_equals(original_graph.edges(), new_graph.edges())
+    nose.tools.assert_equals(original_graph.nodes(), new_graph.nodes())
+    nose.tools.assert_false(original_graph is new_graph)


### PR DESCRIPTION
  * its `cfgs` attribute is a dict, which is shallow-copied by default
  * for some reason `copy.deepcopy()` raise a very nebulous error
  * reproduce the dict using the graph's `copy()` method

---

Before this change, this is the behavior I had (when breaking in `CFGManager.copy()`:
```
ipdb> id(self.cfgs)
140222354359952
ipdb> id(cm.cfgs)
140222351599408
ipdb> id(cm.cfgs['CFGFast'].copy())
140222354888272
ipdb> id(self.cfgs['CFGFast'].copy())
140222354888272
```