### PR TITLE
RegionIdentifier: Recompute endnodes after removing cycles from the graph.

### DIFF
--- a/angr/analyses/decompiler/__init__.py
+++ b/angr/analyses/decompiler/__init__.py
@@ -5,3 +5,4 @@ from .clinic import Clinic
 from .region_simplifier import RegionSimplifier
 from .decompiler import Decompiler
 from .decompilation_options import options, options_by_category
+from . import optimization_passes

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -289,7 +289,7 @@ class ConditionProcessor:
         if type(block) is LoopNode:
             return cls.get_last_statements(block.sequence_node)
         if type(block) is ConditionalBreakNode:
-            return None
+            return [ block ]
         if type(block) is ConditionNode:
             s = [ ]
             if block.true_node:
@@ -303,14 +303,19 @@ class ConditionProcessor:
                 s.extend(last_stmts)
             return s
         if type(block) is BreakNode:
-            return None
+            return [ block ]
         if type(block) is ContinueNode:
-            return None
+            return [ block ]
         if type(block) is SwitchCaseNode:
-            return None
+            s = [ ]
+            for case in block.cases:
+                s.extend(cls.get_last_statements(case))
+            if block.default_case is not None:
+                s.extend(cls.get_last_statements(block.default_case))
+            return s
         if type(block) is GraphRegion:
             # normally this should not happen. however, we have test cases that trigger this case.
-            return None
+            return [ ]
 
         raise NotImplementedError()
 

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -245,9 +245,18 @@ def test_decompiling_1after999_doit():
     cfg = p.analyses.CFG(normalize=True, data_references=True)
 
     f = cfg.functions['doit']
-    dec = p.analyses.Decompiler(f, cfg=cfg)
+    optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes(
+        p.arch, p.simos.name
+    ) + [
+        angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier,
+    ]
+    dec = p.analyses.Decompiler(f, cfg=cfg, optimization_passes=optimization_passes)
     if dec.codegen is not None:
-        print(dec.codegen.text)
+        code = dec.codegen.text
+        print(code)
+
+        # with EagerReturnSimplifier applied, there should be no goto!
+        assert "goto" not in code.lower()
     else:
         print("Failed to decompile function %r." % f)
         assert False


### PR DESCRIPTION
With this fix, the decompiled code of `1after909.doit` has no gotos.