### PR TITLE
Bug fix: Edge data got wrapped twice during AIL graph conversion.

### DIFF
--- a/angr/analyses/decompiler/ailgraph_walker.py
+++ b/angr/analyses/decompiler/ailgraph_walker.py
@@ -39,12 +39,12 @@ class AILGraphWalker:
 
                     for src, _, data in in_edges:
                         if src is node:
-                            self.graph.add_edge(r, r, data=data)
+                            self.graph.add_edge(r, r, **data)
                         else:
-                            self.graph.add_edge(src, r, data=data)
+                            self.graph.add_edge(src, r, **data)
 
                     for _, dst, data in out_edges:
                         if dst is node:
-                            self.graph.add_edge(r, r, data=data)
+                            self.graph.add_edge(r, r, **data)
                         else:
-                            self.graph.add_edge(r, dst, data=data)
+                            self.graph.add_edge(r, dst, **data)

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -91,12 +91,12 @@ class OptimizationPass(Analysis):
         for src, _, data in in_edges:
             if src is old_block:
                 src = new_block
-            self.out_graph.add_edge(src, new_block, data=data)
+            self.out_graph.add_edge(src, new_block, **data)
 
         for _, dst, data in out_edges:
             if dst is old_block:
                 dst = new_block
-            self.out_graph.add_edge(new_block, dst, data=data)
+            self.out_graph.add_edge(new_block, dst, **data)
 
     def _remove_block(self, block):
 

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -101,7 +101,7 @@ class RegionIdentifier(Analysis):
                     if len(list(graph.successors(src))) == 1 and len(list(graph.predecessors(dst))) == 1:
                         self._merge_nodes(graph, src, dst, force_multinode=True)
                         break
-                if type_ == 'call':
+                elif type_ == 'call':
                     graph.remove_node(dst)
                     break
             else:

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -149,11 +149,6 @@ class SimEngineRDAIL(
         ip = Register(self.arch.ip_offset, self.arch.bytes)
         self.state.kill_definitions(ip, self._codeloc())
 
-        # if arguments exist, use them
-        if stmt.args:
-            for arg in stmt.args:
-                self._expr(arg)
-
         # When stmt.args are available, used registers/stack variables are decided by stmt.args. Otherwise we fall-back
         # to using all argument registers.
         if stmt.args is not None:


### PR DESCRIPTION
The bug effectively disabled RegionIdentifier._make_supergraph(), which
led to much more workload in region identification. As a result, fixing
this bug significantly speeds up RegionIdentifier on large functions
with many function calls.