### PR TITLE
RDA: Register hash should not rely on mutable data

### DIFF
--- a/angr/analyses/reaching_definitions/atoms.py
+++ b/angr/analyses/reaching_definitions/atoms.py
@@ -66,7 +66,7 @@ class Register(Atom):
                self.size == other.size
 
     def __hash__(self):
-        return hash(('reg', self.reg_offset, self.size))
+        return hash(('reg', self.reg_offset))
 
     @property
     def bits(self):


### PR DESCRIPTION
As highlighted by #2088:
  * mutated attributes should not be used to compute a hash
  * there are some conversion that might change the size of a register