### PR TITLE
time.clock was removed in python 3.8

### DIFF
--- a/angr/engines/vex/heavy/dirty.py
+++ b/angr/engines/vex/heavy/dirty.py
@@ -26,7 +26,7 @@ def ppc32g_dirtyhelper_MFSPR_287(state):
 
 def amd64g_dirtyhelper_RDTSC(state):
     if o.USE_SYSTEM_TIMES in state.options:
-        val = state.solver.BVV(int(time.clock() * 1000000) + 12345678, 64)
+        val = state.solver.BVV(int(time.process_time() * 1000000) + 12345678, 64)
     else:
         val = state.solver.BVS('RDTSC', 64, key=('hardware', 'rdtsc'))
     return val, []


### PR DESCRIPTION
Looks like time.clock was deprecated back in 3.3 and finally removed in 3.8. Looks like [process_time](https://docs.python.org/3/library/time.html#time.process_time) and [perf_counter](https://docs.python.org/3/library/time.html#time.perf_counter) replaced it.