### PR TITLE
Decompiler: Support arguments in function prototypes.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -10,7 +10,7 @@ from ...knowledge_base import KnowledgeBase
 from ...codenode import BlockNode
 from ...utils import timethis
 from ...calling_conventions import SimRegArg, SimStackArg, SimFunctionArgument
-from ...sim_type import SimTypeChar, SimTypePointer, SimTypeInt, SimTypeLongLong, SimTypeShort, SimTypeFunction
+from ...sim_type import SimTypeChar, SimTypeInt, SimTypeLongLong, SimTypeShort, SimTypeFunction
 from ...sim_variable import SimVariable, SimStackVariable, SimRegisterVariable
 from .. import Analysis, register_analysis
 from ..reaching_definitions.constants import OP_BEFORE, OP_AFTER

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -57,7 +57,7 @@ class Decompiler(Analysis):
         s = self.project.analyses.RegionSimplifier(rs.result, kb=self.kb)
 
         codegen = self.project.analyses.StructuredCodeGenerator(self.func, s.result, cfg=self._cfg,
-                                                                arg_list=clinic.arg_list,
+                                                                func_args=clinic.arg_list,
                                                                 kb=self.kb,
                                                                 variable_kb=clinic.variable_kb)
 

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -56,7 +56,10 @@ class Decompiler(Analysis):
         # simplify it
         s = self.project.analyses.RegionSimplifier(rs.result, kb=self.kb)
 
-        codegen = self.project.analyses.StructuredCodeGenerator(self.func, s.result, cfg=self._cfg, kb=self.kb)
+        codegen = self.project.analyses.StructuredCodeGenerator(self.func, s.result, cfg=self._cfg,
+                                                                arg_list=clinic.arg_list,
+                                                                kb=self.kb,
+                                                                variable_kb=clinic.variable_kb)
 
         self.clinic = clinic
         self.codegen = codegen

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 from collections import defaultdict
 import logging
 
@@ -121,8 +121,8 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
 
     __slots__ = ('name', 'functy', 'arg_list', 'statements', 'variables_in_use', 'variable_manager', 'demangled_name', )
 
-    def __init__(self, name, functy: SimTypeFunction, arg_list, statements, variables_in_use, variable_manager,
-                 demangled_name=None):
+    def __init__(self, name, functy: SimTypeFunction, arg_list: List['CExpression'], statements, variables_in_use,
+                 variable_manager, demangled_name=None):
 
         super(CFunction, self).__init__()
 
@@ -1067,7 +1067,8 @@ class CDirtyExpression(CExpression):
 
 
 class StructuredCodeGenerator(Analysis):
-    def __init__(self, func, sequence, indent=0, cfg=None, variable_kb=None, arg_list=None):
+    def __init__(self, func, sequence, indent=0, cfg=None, variable_kb=None,
+                 func_args: Optional[List[SimVariable]]=None):
 
         self._handlers = {
             CodeNode: self._handle_Code,
@@ -1102,7 +1103,7 @@ class StructuredCodeGenerator(Analysis):
         }
 
         self._func = func
-        self._arg_list = arg_list
+        self._func_args = func_args
         self._cfg = cfg
         self._sequence = sequence
         self._variable_kb = variable_kb if variable_kb is not None else self.kb
@@ -1119,7 +1120,10 @@ class StructuredCodeGenerator(Analysis):
     def _analyze(self):
 
         self._variables_in_use = {}
-        arg_list = [self._handle(arg) for arg in self._arg_list]
+        if self._func_args:
+            arg_list = [self._handle(arg) for arg in self._func_args]
+        else:
+            arg_list = [ ]
         obj = self._handle(self._sequence)
 
         func = CFunction(self._func.name, self._func.prototype, arg_list, obj, self._variables_in_use,

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -7,7 +7,7 @@ from sortedcontainers import SortedDict
 from ailment import Block, Expr, Stmt
 
 from ...sim_type import (SimTypeLongLong, SimTypeInt, SimTypeShort, SimTypeChar, SimTypePointer, SimStruct, SimType,
-    SimTypeBottom, SimTypeArray)
+    SimTypeBottom, SimTypeArray, SimTypeFunction)
 from ...sim_variable import SimVariable, SimTemporaryVariable, SimStackVariable, SimRegisterVariable, SimMemoryVariable
 from ...utils.constants import is_alignment_mask
 from ...errors import UnsupportedNodeTypeError
@@ -119,13 +119,16 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
     Represents a function in C.
     """
 
-    __slots__ = ('name', 'statements', 'variables_in_use', 'variable_manager', 'demangled_name', )
+    __slots__ = ('name', 'functy', 'arg_list', 'statements', 'variables_in_use', 'variable_manager', 'demangled_name', )
 
-    def __init__(self, name, statements, variables_in_use, variable_manager, demangled_name=None):
+    def __init__(self, name, functy: SimTypeFunction, arg_list, statements, variables_in_use, variable_manager,
+                 demangled_name=None):
 
         super(CFunction, self).__init__()
 
         self.name = name
+        self.functy = functy
+        self.arg_list = arg_list
         self.statements = statements
         self.variables_in_use = variables_in_use
         self.variable_manager = variable_manager
@@ -171,7 +174,21 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
         indent_str = self.indent_str(indent)
 
         yield indent_str, None
-        yield "void {}()\n".format(self.demangled_name or self.name), None
+        # return type
+        yield self.functy.returnty.c_repr(), None
+        yield " ", None
+        # function name
+        yield self.demangled_name or self.name, None
+        # argument list
+        yield "(", None
+        for i, (arg_type, arg) in enumerate(zip(self.functy.args, self.arg_list)):
+            yield arg_type.c_repr(), None
+            yield " ", None
+            yield from arg.c_repr_chunks()
+            if i != len(self.arg_list) - 1:
+                yield ", ", None
+        yield ")\n", None
+        # function body
         yield indent_str, None
         yield "{\n", None
         yield from self.variable_list_repr_chunks(indent=indent + INDENT_DELTA)
@@ -1050,7 +1067,7 @@ class CDirtyExpression(CExpression):
 
 
 class StructuredCodeGenerator(Analysis):
-    def __init__(self, func, sequence, indent=0, cfg=None):
+    def __init__(self, func, sequence, indent=0, cfg=None, variable_kb=None, arg_list=None):
 
         self._handlers = {
             CodeNode: self._handle_Code,
@@ -1085,8 +1102,10 @@ class StructuredCodeGenerator(Analysis):
         }
 
         self._func = func
+        self._arg_list = arg_list
         self._cfg = cfg
         self._sequence = sequence
+        self._variable_kb = variable_kb if variable_kb is not None else self.kb
 
         self._variables_in_use: Optional[Dict] = None
 
@@ -1100,10 +1119,11 @@ class StructuredCodeGenerator(Analysis):
     def _analyze(self):
 
         self._variables_in_use = {}
+        arg_list = [self._handle(arg) for arg in self._arg_list]
         obj = self._handle(self._sequence)
 
-        func = CFunction(self._func.name, obj, self._variables_in_use, self.kb.variables[self._func.addr],
-                         demangled_name=self._func.demangled_name)
+        func = CFunction(self._func.name, self._func.prototype, arg_list, obj, self._variables_in_use,
+                         self._variable_kb.variables[self._func.addr], demangled_name=self._func.demangled_name)
         self._variables_in_use = None
 
         self.posmap = PositionMapping()
@@ -1128,9 +1148,9 @@ class StructuredCodeGenerator(Analysis):
 
     def _get_variable_type(self, var, is_global=False):
         if is_global:
-            return self.kb.variables['global'].get_variable_type(var)
+            return self._variable_kb.variables['global'].get_variable_type(var)
         else:
-            return self.kb.variables[self._func.addr].get_variable_type(var)
+            return self._variable_kb.variables[self._func.addr].get_variable_type(var)
 
     #
     # Util methods

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -152,9 +152,8 @@ class SimEngineVRBase(SimEngineLight):
             pass
 
         # handle register writes
-        existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(self.block.addr, self.stmt_idx,
-                                                                                     'register'
-                                                                                     )
+        existing_vars = self.variable_manager[self.func_addr].find_variables_by_atom(self.block.addr, self.stmt_idx,
+                                                                                     dst)
         if not existing_vars:
             variable = SimRegisterVariable(offset, size,
                                            ident=self.variable_manager[self.func_addr].next_variable_ident(

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -1,4 +1,4 @@
-
+from typing import Optional, List
 import logging
 from collections import defaultdict
 
@@ -8,7 +8,7 @@ import ailment
 from ...block import Block
 from ...errors import AngrVariableRecoveryError, SimEngineError
 from ...knowledge_plugins import Function
-from ...sim_variable import SimStackVariable
+from ...sim_variable import SimStackVariable, SimRegisterVariable, SimVariable
 from ...engines.vex.claripy.irop import vexop_to_simop
 from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor
 from ..typehoon.typevars import Equivalence, TypeVariable
@@ -206,7 +206,8 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
     accurately. However, it is not a requirement.
     """
 
-    def __init__(self, func, func_graph=None, max_iterations=1, low_priority=False, track_sp=True):
+    def __init__(self, func, func_graph=None, max_iterations=1, low_priority=False, track_sp=True,
+                 func_args: Optional[List[SimVariable]]=None):
         """
 
         :param knowledge.Function func:  The function to analyze.
@@ -227,6 +228,7 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
         self._low_priority = low_priority
         self._job_ctr = 0
         self._track_sp = track_sp
+        self._func_args = func_args
 
         self._ail_engine = SimEngineVRAIL(self.project, self.kb)
         self._vex_engine = SimEngineVRVEX(self.project, self.kb)
@@ -287,6 +289,17 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  #pylint:disa
                                             region=self.function.addr, category='return_address',
                                             )
             state.stack_region.add_variable(ret_addr_offset, ret_addr_var)
+
+        if self._func_args:
+            for arg in self._func_args:
+                if isinstance(arg, SimRegisterVariable):
+                    state.register_region.set_variable(arg.reg, arg)
+                    self.variable_manager[self.function.addr].add_variable('register', arg.reg, arg)
+                elif isinstance(arg, SimStackVariable):
+                    state.stack_region.set_variable(arg.offset, arg)
+                    self.variable_manager[self.function.addr].add_variable('stack', arg.offset, arg)
+                else:
+                    raise TypeError("Unsupported function argument type %s." % type(arg))
 
         return state
 


### PR DESCRIPTION
Also with the following fixes:

- The base engine in VariableRecoveryFast: Fix how existing variables
are found in _assign_to_register(). This fix addresses conflicts where a
statement touches (reads/writes) more than one variables.

- Decompiling a function no longer removes the already-recovered
variables on VEX code in the knowledge base. Now it always write
varibles that are discovered in AIL to a new variable-kb.