### PR TITLE
FunctionSerializer: Load all function addresses into a set.

### DIFF
--- a/angr/angrdb/serializers/funcs.py
+++ b/angr/angrdb/serializers/funcs.py
@@ -43,7 +43,7 @@ class FunctionManagerSerializer:
         funcs = FunctionManager(kb)
 
         db_funcs = session.query(DbFunction).filter_by(kb=db_kb)
-        all_func_addrs = session.query(DbFunction.addr).filter_by(kb=db_kb)
+        all_func_addrs = set(map(lambda x: x[0], session.query(DbFunction.addr).filter_by(kb=db_kb)))
 
         for db_func in db_funcs:
             func = Function.parse(db_func.blob, function_manager=funcs, project=kb._project,

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -859,10 +859,6 @@ class Function(Serializable):
             raise AngrValueError('_register_nodes(): the "is_local" parameter must be a bool')
 
         for node in nodes:
-            if node in self.transition_graph:
-                # skip nodes that have already been added
-                node._graph = self.transition_graph
-                continue
             self.transition_graph.add_node(node)
             if not isinstance(node, CodeNode):
                 continue

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -859,6 +859,10 @@ class Function(Serializable):
             raise AngrValueError('_register_nodes(): the "is_local" parameter must be a bool')
 
         for node in nodes:
+            if node in self.transition_graph:
+                # skip nodes that have already been added
+                node._graph = self.transition_graph
+                continue
             self.transition_graph.add_node(node)
             if not isinstance(node, CodeNode):
                 continue

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -35,6 +35,8 @@ def test_angrdb_fauxware():
         assert func.normalized == new_func.normalized
 
         assert len(func.transition_graph.nodes()) == len(new_func.transition_graph.nodes())
+        assert set(map(lambda x: x.addr, func.transition_graph.nodes())) == set(map(lambda x: x.addr,
+                                                                                    new_func.transition_graph.nodes()))
         assert len(func.transition_graph.edges()) == len(new_func.transition_graph.edges())
 
     # compare CFG
@@ -101,6 +103,8 @@ def test_angrdb_open_multiple_times():
             assert func.normalized == new_func.normalized
 
             assert len(func.transition_graph.nodes()) == len(new_func.transition_graph.nodes())
+            assert set(map(lambda x: x.addr, func.transition_graph.nodes())) == set(
+                map(lambda x: x.addr, new_func.transition_graph.nodes()))
             assert len(func.transition_graph.edges()) == len(new_func.transition_graph.edges())
 
 


### PR DESCRIPTION
This speeds up future queries of whether a function address already
exist or not.