### PR TITLE
Revert "Do not rely on type aliases in archinfo."

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2,6 +2,7 @@ import logging
 
 import claripy
 import archinfo
+from archinfo import RegisterName
 from typing import Union, Optional, List
 
 from .sim_type import SimType
@@ -93,7 +94,7 @@ class SimRegArg(SimFunctionArgument):
     :ivar string reg_name:    The name of the represented register.
     :ivar int size:           The size of the register, in number of bytes.
     """
-    def __init__(self, reg_name: str, size: int, alt_offsets=None):
+    def __init__(self, reg_name: RegisterName, size: int, alt_offsets=None):
         SimFunctionArgument.__init__(self, size)
         self.reg_name = reg_name
         self.alt_offsets = {} if alt_offsets is None else alt_offsets


### PR DESCRIPTION
This reverts commit 54b8db75625c9528134cce948c96b4c2bc1a7a51.

This is now handled in archinfo, by declaring RegisterName as a Type Alias
https://docs.python.org/3/library/typing.html#type-aliases instead of a
NewType https://docs.python.org/3/library/typing.html#newtype

see https://github.com/angr/archinfo/pull/86