### PR TITLE
RDA: remove unused (and weird) function

### DIFF
--- a/angr/analyses/reaching_definitions/dep_graph.py
+++ b/angr/analyses/reaching_definitions/dep_graph.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, List
+from typing import Optional, Dict
 from functools import reduce
 
 import networkx
@@ -91,27 +91,3 @@ class DepGraph:
             return closure
 
         return _transitive_closure(definition, self._graph, networkx.DiGraph())
-
-    def top_predecessors(self, definition: Definition) -> List[Definition]:
-        """
-        Recover the "entrypoint definitions" flowing into a given definition.
-        Obtained by transitively computing the top-level ancestors (nodes without predecessors) of this definition in
-        the graph.
-
-        :param definition: The <Definition> to return the top-level ancestors for.
-        :return: The list of top-level definitions flowing into the <node>.
-        """
-
-        def _top_predecessors(def_: Definition, graph: networkx.DiGraph, result: List[Definition]):
-            predecessors = list(graph.predecessors(def_))
-
-            if len(predecessors) == 0 and def_ not in result:
-                return result + [ def_ ]
-
-            return reduce(
-                lambda acc, definition: _top_predecessors(definition, graph, acc),
-                predecessors,
-                result
-            )
-
-        return _top_predecessors(definition, self._graph, [])

--- a/tests/test_dep_graph.py
+++ b/tests/test_dep_graph.py
@@ -67,51 +67,6 @@ def test_delegate_add_edge_to_the_underlying_graph_object(digraph_add_edge_mock)
     digraph_add_edge_mock.assert_called_once_with(*use, **labels)
 
 
-def test_top_predecessors():
-    dep_graph = DepGraph()
-
-    # A -> B, B -> D, C -> D
-    A = _a_mock_definition()
-    B = _a_mock_definition()
-    C = _a_mock_definition()
-    D = _a_mock_definition()
-    uses = [
-        (A, B),
-        (B, D),
-        (C, D),
-    ]
-
-    for use in uses:
-        dep_graph.add_edge(*use)
-
-    result = dep_graph.top_predecessors(D)
-
-    nose.tools.assert_list_equal(result, [A, C])
-
-
-def test_top_predecessors_should_not_contain_duplicates():
-    dep_graph = DepGraph()
-
-    # A -> B, A -> C, B -> D, C -> D
-    A = _a_mock_definition()
-    B = _a_mock_definition()
-    C = _a_mock_definition()
-    D = _a_mock_definition()
-    uses = [
-        (A, B),
-        (A, C),
-        (B, D),
-        (C, D),
-    ]
-
-    for use in uses:
-        dep_graph.add_edge(*use)
-
-    result = dep_graph.top_predecessors(D)
-
-    nose.tools.assert_list_equal(result, [A])
-
-
 def test_transitive_closure_of_a_node():
     dep_graph = DepGraph()
 


### PR DESCRIPTION
Fixes #1904.

  * less useful than `transitive_closure` (the latter has all the info
  expected, and even more)
  * not clearly defined on looping graphs, ex:
  `A -> B, B -> C, C -> B`, what is `top_predecessors(C)`?