### PR TITLE
add some syscall handlers

### DIFF
--- a/angr/procedures/linux_kernel/getrlimit.py
+++ b/angr/procedures/linux_kernel/getrlimit.py
@@ -19,3 +19,6 @@ class getrlimit(angr.SimProcedure):
         else:
             l.debug('running getrlimit(other)')
             return self.state.solver.Unconstrained("rlimit", self.state.arch.bits, key=('api', 'rlimit', 'other'))
+
+class ugetrlimit(getrlimit):
+    pass

--- a/angr/procedures/linux_kernel/sigaction.py
+++ b/angr/procedures/linux_kernel/sigaction.py
@@ -1,6 +1,11 @@
 import angr
 
 class sigaction(angr.SimProcedure):
-    def run(self, addr, length): #pylint:disable=arguments-differ,unused-argument
+    def run(self, signum, act, oldact): #pylint:disable=arguments-differ,unused-argument
+        # TODO: actually do something
+        return self.state.solver.BVV(0, self.state.arch.bits)
+
+class rt_sigaction(angr.SimProcedure):
+    def run(self, signum, act, oldact, sigsetsize): #pylint:disable=arguments-differ,unused-argument
         # TODO: actually do something
         return self.state.solver.BVV(0, self.state.arch.bits)

--- a/angr/procedures/linux_kernel/uid.py
+++ b/angr/procedures/linux_kernel/uid.py
@@ -7,3 +7,19 @@ class getuid(angr.SimProcedure):
 class getgid(angr.SimProcedure):
     def run(self):
         return self.state.posix.gid
+
+class getresgid(angr.SimProcedure):
+    def run(self, rgid_addr, egid_addr, sgid_addr):
+        gid = self.state.posix.gid
+        self.state.memory.store(rgid_addr, gid)
+        self.state.memory.store(egid_addr, gid)
+        self.state.memory.store(sgid_addr, gid)
+        return 0
+
+class getresuid(angr.SimProcedure):
+    def run(self, ruid_addr, euid_addr, suid_addr):
+        uid = self.state.posix.uid
+        self.state.memory.store(ruid_addr, uid)
+        self.state.memory.store(euid_addr, uid)
+        self.state.memory.store(suid_addr, uid)
+        return 0


### PR DESCRIPTION
It looks like `vsyscall` should have the same semantic as `int 0x80` on i386. The only difference should be `vsyscall` is faster(in fact, the `vsyscall` handler that glibc uses is to call `sysenter` with some setup).
So my idea is to reuse the syscall infrastructure instead of creating everything all over again inside `vsyscall`.
However, I'm not sure whether the implementation is good or bad.