### PR TITLE
RDA: `dep_graph.transitive_closure` handles loops

### DIFF
--- a/angr/analyses/reaching_definitions/dep_graph.py
+++ b/angr/analyses/reaching_definitions/dep_graph.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, Set
 from functools import reduce
 
 import networkx
@@ -66,7 +66,7 @@ class DepGraph:
         :return:            A graph of the transitive closure of the given definition.
         """
 
-        def _transitive_closure(def_: Definition, graph: networkx.DiGraph, result: networkx.DiGraph):
+        def _transitive_closure(def_: Definition, graph: networkx.DiGraph, result: networkx.DiGraph, visited: Optional[Set[Definition]]=None):
             if def_ in self._transitive_closures.keys():
                 return self._transitive_closures[def_]
 
@@ -81,9 +81,13 @@ class DepGraph:
                 )
             )))
 
+            visited = visited or set()
+            visited.add(def_)
+            predecessors_to_visit = set(predecessors) - set(visited)
+
             closure = reduce(
-                lambda acc, definition: _transitive_closure(definition, graph, acc),
-                predecessors,
+                lambda acc, definition: _transitive_closure(definition, graph, acc, visited),
+                predecessors_to_visit,
                 result
             )
 

--- a/tests/test_dep_graph.py
+++ b/tests/test_dep_graph.py
@@ -106,3 +106,29 @@ def test_transitive_closure_of_a_node_should_copy_labels_from_original_graph():
     result = dep_graph.transitive_closure(B).get_edge_data(A, B)['label']
 
     nose.tools.assert_equals(result, 'some data')
+
+
+def test_transitive_closure_of_a_node_on_a_graph_with_loops_should_still_terminate():
+    dep_graph = DepGraph()
+
+    # A -> B, B -> C, C -> D, D -> A
+    A = _a_mock_definition()
+    B = _a_mock_definition()
+    C = _a_mock_definition()
+    D = _a_mock_definition()
+    uses = [
+        (A, B),
+        (B, C),
+        (C, D),
+        (D, A),
+    ]
+
+    for use in uses:
+        dep_graph.add_edge(*use)
+
+    result = dep_graph.transitive_closure(C)
+    result_nodes = set(result.nodes)
+    result_edges = set(result.edges)
+
+    nose.tools.assert_set_equal(result_nodes, {A, B, C, D})
+    nose.tools.assert_set_equal(result_edges, {(A, B), (B, C), (C, D), (D, A)})


### PR DESCRIPTION
Don't fall into infinite recursion when there are loops in the
dependency graph.