### PR TITLE
add fstat64 implementation and support mmap with fd

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -486,12 +486,14 @@ class Tracer(ExplorationTechnique):
         elif current_bin in self._aslr_slides:
             self._current_slide = self._aslr_slides[current_bin]
             return trace_addr == state_addr + self._current_slide
-        else:
-            if ((trace_addr - state_addr) & 0xfff) == 0:
+        elif ((trace_addr - state_addr) & 0xfff) == 0:
                 self._aslr_slides[current_bin] = self._current_slide = trace_addr - state_addr
                 return True
-            else:
-                raise AngrTracerError("Trace desynced on jumping into %s. Did you load the right version of this library?" % current_bin.provides)
+        # error handling
+        elif current_bin:
+            raise AngrTracerError("Trace desynced on jumping into %s. Did you load the right version of this library?" % current_bin.provides)
+        else:
+            raise AngrTracerError("Trace desynced on jumping into %#x, where no library is mapped!" % state_addr)
 
     def _analyze_misfollow(self, state, idx):
         angr_addr = state.addr

--- a/angr/procedures/linux_kernel/fstat64.py
+++ b/angr/procedures/linux_kernel/fstat64.py
@@ -1,12 +1,36 @@
 import angr
 
-class fstat(angr.SimProcedure):
+class fstat64(angr.SimProcedure):
 
     def run(self, fd, stat_buf):
         stat = self.state.posix.fstat(fd)
         # TODO: make arch-neutral
-        self._store_amd64(stat_buf, stat)
+        if self.arch.bits == 32:
+            self._store_i386(stat_buf, stat)
+        else:
+            self._store_amd64(stat_buf, stat)
         return 0
+
+    def _store_i386(self, stat_buf, stat):
+        store = lambda offset, val: self.state.memory.store(stat_buf + offset, val, endness='Iend_LE')
+        store(0x00, stat.st_dev)
+        store(0x0c, stat.st_ino)
+        store(0x10, stat.st_mode)
+        store(0x14, stat.st_nlink)
+        store(0x18, stat.st_uid)
+        store(0x1c, stat.st_gid)
+        store(0x20, stat.st_rdev)
+        store(0x2c, stat.st_size)
+        store(0x34, stat.st_blksize)
+        store(0x38, stat.st_blocks)
+        store(0x3c, self.state.solver.BVV(0, 32)) # padding
+        store(0x40, stat.st_atime)
+        store(0x44, stat.st_atimensec)
+        store(0x48, stat.st_mtime)
+        store(0x4c, stat.st_mtimensec)
+        store(0x50, stat.st_ctime)
+        store(0x54, stat.st_ctimensec)
+        store(0x5c, stat.st_ino) # weird verification st_ino
 
     def _store_amd64(self, stat_buf, stat):
         store = lambda offset, val: self.state.memory.store(stat_buf + offset, val, endness='Iend_LE')

--- a/angr/procedures/linux_kernel/fstat64.py
+++ b/angr/procedures/linux_kernel/fstat64.py
@@ -2,7 +2,7 @@ import angr
 
 class fstat64(angr.SimProcedure):
 
-    def run(self, fd, stat_buf):
+    def run(self, fd, stat_buf): # pylint:disable=arguments-differ
         stat = self.state.posix.fstat(fd)
         # TODO: make arch-neutral
         if self.arch.bits == 32:
@@ -55,21 +55,3 @@ class fstat64(angr.SimProcedure):
         store(0x78, self.state.solver.BVV(0, 64))
         store(0x80, self.state.solver.BVV(0, 64))
         store(0x88, self.state.solver.BVV(0, 64))
-
-        # return struct.pack('<QQQLLLxxxxQqqqQqQqQxxxxxxxxxxxxxxxxxxxxxxxx',
-        #                    stat.st_dev,
-        #                    stat.st_ino,
-        #                    stat.st_nlink,
-        #                    stat.st_mode,
-        #                    stat.st_uid,
-        #                    stat.st_gid,
-        #                    stat.st_rdev,
-        #                    stat.st_size,
-        #                    stat.st_blksize,
-        #                    stat.st_blocks,
-        #                    stat.st_atime,
-        #                    stat.st_atimensec,
-        #                    stat.st_mtime,
-        #                    stat.st_mtimesec,
-        #                    stat.st_ctime,
-        #                    state.st_ctimensec)

--- a/angr/procedures/posix/mmap.py
+++ b/angr/procedures/posix/mmap.py
@@ -1,4 +1,5 @@
 import angr
+from ...storage.file import SimFileDescriptor
 
 import logging
 l = logging.getLogger(name=__name__)
@@ -31,8 +32,11 @@ class mmap(angr.SimProcedure):
             if self.state.solver.symbolic(offset):
                 raise angr.errors.SimPosixError("Can't map with a symbolic offset!!")
             sim_fd = self.state.posix.get_fd(fd)
-            if sim_fd is None or sim_fd.file is None:
+            if sim_fd is None:
                 l.warning("Trying to map a non-exsitent fd")
+                return -1
+            if not isinstance(sim_fd, SimFileDescriptor) or sim_fd.file is None:
+                l.warning("Trying to map fd not supporting mmap (maybe a SimFileDescriptorDuplex?)")
                 return -1
 
         #

--- a/angr/procedures/posix/mmap.py
+++ b/angr/procedures/posix/mmap.py
@@ -21,8 +21,19 @@ class mmap(angr.SimProcedure):
         #   raise Exception("mmap with other than MAP_PRIVATE|MAP_ANONYMOUS unsupported")
         l.debug("mmap(%s, %s, %s, %s, %s, %s) = ...", addr, length, prot, flags, fd, offset)
 
+        #
+        # File descriptor sanity check
+        #
+        sim_fd = None
         if self.state.solver.is_false(fd[31:0] == -1):
-            raise angr.errors.SimPosixError("Trying to map a file descriptor. I cannot deal with this.")
+            if self.state.solver.symbolic(fd):
+                raise angr.errors.SimPosixError("Can't map a symbolic file descriptor!!")
+            if self.state.solver.symbolic(offset):
+                raise angr.errors.SimPosixError("Can't map with a symbolic offset!!")
+            sim_fd = self.state.posix.get_fd(fd)
+            if sim_fd is None or sim_fd.file is None:
+                l.warning("Trying to map a non-exsitent fd")
+                return -1
 
         #
         # Length
@@ -58,7 +69,7 @@ class mmap(angr.SimProcedure):
         #
 
         # Only want concrete flags
-        flags = self.state.solver.eval_upto(flags,2)
+        flags = self.state.solver.eval_upto(flags, 2)
 
         if len(flags) == 2:
             err = "Cannot handle symbolic flags argument for mmap."
@@ -72,11 +83,12 @@ class mmap(angr.SimProcedure):
             l.debug('... = -1 (bad flags)')
             return self.state.solver.BVV(-1, self.state.arch.bits)
 
+        # Do region mapping
         while True:
             try:
                 self.state.memory.map_region(addr, size, prot[2:0], init_zero=bool(flags & MAP_ANONYMOUS))
                 l.debug('... = %#x', addr)
-                return addr
+                break
 
             except angr.SimMemoryError:
                 # This page is already mapped
@@ -88,6 +100,25 @@ class mmap(angr.SimProcedure):
                 # Can't give you that address. Find a different one and loop back around to try again.
                 addr = self.allocate_memory(size)
 
+        # If the mapping comes with a file descriptor
+        if sim_fd:
+            if not sim_fd.file.seekable:
+                raise angr.errors.SimPosixError("Only support seekable SimFile at the moment.")
+
+            prot = self.state.solver.eval_exact(prot, 1)[0]
+
+            if prot & PROT_WRITE:
+                l.warning("Trying to map a file descriptor backed by a file")
+                l.warning("Updates to the mapping are not carried through to the underlying file")
+
+            # read data
+            saved_pos = sim_fd.tell()
+            sim_fd.seek(self.state.solver.eval(offset), whence="start")
+            data, _ = sim_fd.read_data(size)
+            sim_fd.seek(saved_pos, whence="start")
+            self.state.memory.store(addr, data)
+
+        return addr
 
     def allocate_memory(self,size):
 

--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -393,7 +393,6 @@ class SimHostFilesystem(SimConcreteFilesystem):
             return SimFile(name='file://' + path, content=content, size=len(content))
 
     def _get_stat(self, guest_path):
-        from .posix import Stat
         guest_path = guest_path.lstrip(self.pathsep)
         path = os.path.join(self.host_path, guest_path)
         try:

--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -1,13 +1,18 @@
 import os
 import logging
+from collections import namedtuple
 
 from .plugin import SimStatePlugin
 from ..storage.file import SimFile
 from ..errors import SimMergeError
 from ..misc.ux import once
-from .posix import Stat
 
 l = logging.getLogger(name=__name__)
+
+Stat = namedtuple('Stat', ('st_dev', 'st_ino', 'st_nlink', 'st_mode', 'st_uid',
+                           'st_gid', 'st_rdev', 'st_size', 'st_blksize',
+                           'st_blocks', 'st_atime', 'st_atimensec', 'st_mtime',
+                           'st_mtimensec', 'st_ctime', 'st_ctimensec'))
 
 class SimFilesystem(SimStatePlugin): # pretends links don't exist
     """
@@ -388,6 +393,7 @@ class SimHostFilesystem(SimConcreteFilesystem):
             return SimFile(name='file://' + path, content=content, size=len(content))
 
     def _get_stat(self, guest_path):
+        from .posix import Stat
         guest_path = guest_path.lstrip(self.pathsep)
         path = os.path.join(self.host_path, guest_path)
         try:

--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -291,6 +291,9 @@ class SimConcreteFilesystem(SimMount):
     def _load_file(self, guest_path):
         raise NotImplementedError
 
+    def _get_stat(self, guest_path):
+        raise NotImplementedError
+
     def insert(self, path_elements, simfile):
         path = self._join_chunks([x.decode() for x in path_elements])
         simfile.set_state(self.state)

--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -5,6 +5,7 @@ from .plugin import SimStatePlugin
 from ..storage.file import SimFile
 from ..errors import SimMergeError
 from ..misc.ux import once
+from .posix import Stat
 
 l = logging.getLogger(name=__name__)
 
@@ -386,6 +387,18 @@ class SimHostFilesystem(SimConcreteFilesystem):
         else:
             return SimFile(name='file://' + path, content=content, size=len(content))
 
+    def _get_stat(self, guest_path):
+        guest_path = guest_path.lstrip(self.pathsep)
+        path = os.path.join(self.host_path, guest_path)
+        try:
+            s = os.stat(path)
+            stat = Stat(s.st_dev, s.st_ino, s.st_nlink, s.st_mode, s.st_uid,
+                        s.st_gid, s.st_rdev, s.st_size, s.st_blksize, s.st_blocks,
+                        round(s.st_atime), s.st_atime_ns, round(s.st_mtime), s.st_mtime_ns,
+                        round(s.st_ctime), s.st_ctime_ns)
+            return stat
+        except OSError:
+            return None
 
 #class SimDirectory(SimStatePlugin):
 #    """

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -413,6 +413,8 @@ class SimSystemPosix(SimStatePlugin):
         # if it is mounted, let the filesystem figure out the stat
         if sim_file is not None and mount is not None:
             stat = mount._get_stat(sim_file.name)
+            if stat is None:
+                raise SimPosixError("file %s does not exist on mount %s" % (sim_file.name, mount))
             size = stat.st_size
             mode = stat.st_mode
         else:

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -1,19 +1,13 @@
 import logging
-from collections import namedtuple
 
 from .plugin import SimStatePlugin
-from .filesystem import SimMount
+from .filesystem import SimMount, Stat
 from ..storage.file import SimFile, SimPacketsStream, Flags, SimFileDescriptor, SimFileDescriptorDuplex
 from .. import sim_options as options
 
 l = logging.getLogger(name=__name__)
 
 max_fds = 8192
-
-Stat = namedtuple('Stat', ('st_dev', 'st_ino', 'st_nlink', 'st_mode', 'st_uid',
-                           'st_gid', 'st_rdev', 'st_size', 'st_blksize',
-                           'st_blocks', 'st_atime', 'st_atimensec', 'st_mtime',
-                           'st_mtimensec', 'st_ctime', 'st_ctimensec'))
 
 class PosixDevFS(SimMount): # this'll be mounted at /dev
     def get(self, path):


### PR DESCRIPTION
Things done in this pull request:
1. add fstat64 implementation that can work on i386 binaries.
2. if `concrete_fs` is enabled, try to get part of the stat from the concrete environment through a new function in each `SimMount`. (We don't use all the information because this will lead to something `angr` can not handle at the moment.)
3. partially support `mmap` with fd. Currently, it only supports seekable `SimFile`s.

I know these changes are drastic. I'm willing to change anything you suggest.