### PR TITLE
Modyfied Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ run apt-get update &&									\
 
 run useradd -s /bin/bash -m angr
 
-run su - angr -c "git clone https://github.com/angr/angr-dev && cd angr-dev && ./setup.sh -e angr"
+run su - angr -c "git clone https://github.com/angr/angr-dev"
+cmd su - angr -c "cd angr-dev && ./setup.sh -i -e angr"
+
 run su - angr -c "echo 'workon angr' >> /home/angr/.bashrc"
 cmd su - angr


### PR DESCRIPTION
Without this small modification I faced the following error once I tried to build the image locally.
`[+] 14:22:25 Checking dependencies...
[!!] 14:22:25 Please install the following packages: openjdk-8-jdk zlib1g:i386 libtinfo5:i386 libstdc++6:i386 libgcc1:i386 libc6:i386 libssl-dev nasm binutils-multiarch qtdeclarative5-dev python3-setuptools python3-dev python3-pip 
[+] Checking dependencies...
[!!] Please install the following packages: openjdk-8-jdk zlib1g:i386 libtinfo5:i386 libstdc++6:i386 libgcc1:i386 libc6:i386 libssl-dev nasm binutils-multiarch qtdeclarative5-dev python3-setuptools python3-dev python3-pip 
The command '/bin/sh -c cd /home/angr/angr-dev && pwd && ./setup.sh -e angr' returned a non-zero code: 1`