### PR TITLE
LoopSeer: Optionally don't increase the loop count if a back-edge is the _only_ edge

### DIFF
--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -41,7 +41,6 @@ class LoopSeer(ExplorationTechnique):
         self.use_header = use_header
         self.limit_concrete_loops = limit_concrete_loops
         self.loops = {}
-        self.cut_succs = []
         if type(loops) is Loop:
             loops = [loops]
 

--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -15,7 +15,9 @@ class LoopSeer(ExplorationTechnique):
     free to add something else).
     """
 
-    def __init__(self, cfg=None, functions=None, loops=None, use_header=False, bound=None, bound_reached=None, discard_stash='spinning'):
+    def __init__(self, cfg=None, functions=None, loops=None, use_header=False,
+                 bound=None, bound_reached=None, discard_stash='spinning',
+                 limit_concrete_loops=True):
         """
         :param cfg:             Normalized CFG is required.
         :param functions:       Function(s) containing the loop(s) to be analyzed.
@@ -26,6 +28,8 @@ class LoopSeer(ExplorationTechnique):
                                 a SimulationManager. Will be called when loop execution reach the given bound.
                                 Default to moving states that exceed the loop limit to a discard stash.
         :param discard_stash:   Name of the stash containing states exceeding the loop limit.
+        :param limit_concrete_loops: If False, do not limit a loop back-edge if it is the only successor
+                                (Defaults to True to maintain the original behavior)
         """
 
         super(LoopSeer, self).__init__()
@@ -35,8 +39,9 @@ class LoopSeer(ExplorationTechnique):
         self.bound_reached = bound_reached
         self.discard_stash = discard_stash
         self.use_header = use_header
-
+        self.limit_concrete_loops = limit_concrete_loops
         self.loops = {}
+        self.cut_succs = []
         if type(loops) is Loop:
             loops = [loops]
 
@@ -79,31 +84,47 @@ class LoopSeer(ExplorationTechnique):
                     entry = loop.entry_edges[0][0]
                     self.loops[entry.addr] = loop
 
-    def step(self, simgr, stash='active', **kwargs):
-        for state in simgr.stashes[stash]:
+    def filter(self, simgr, state, **kwargs):
+        if state in self.cut_succs:
+            return self.discard_stash
+        else:
+            return simgr.filter(state, **kwargs)
+
+    def successors(self, simgr, state, **kwargs):
+        node = self.cfg.model.get_any_node(state.addr)
+        if node is not None:
+            kwargs['num_inst'] = min(kwargs.get('num_inst', float('inf')), len(node.instruction_addrs))
+        succs = simgr.successors(state, **kwargs)
+
+        cut_succs = []
+        for succ_state in succs.successors:
             # Processing a currently running loop
-            if state.loop_data.current_loop:
-                loop = state.loop_data.current_loop[-1][0]
+            if succ_state.loop_data.current_loop:
+                loop = succ_state.loop_data.current_loop[-1][0]
                 header = loop.entry.addr
 
-                if state.addr == header:
+                if succ_state.addr == header:
                     continue_addrs = [e[0].addr for e in loop.continue_edges]
-                    if state.history.addr in continue_addrs:
-                        state.loop_data.back_edge_trip_counts[state.addr][-1] += 1
-                    state.loop_data.header_trip_counts[state.addr][-1] += 1
-
-                elif state.addr in state.loop_data.current_loop[-1][1]:
-                    state.loop_data.current_loop.pop()
+                    # If there's only one successor, the loop is "concrete"
+                    # We may wish not to cut loops that are concrete, as this can dead-end
+                    # the path prematurely, even when there won't be state explosion.
+                    if self.limit_concrete_loops or len(succs.successors) > 1:
+                        if succ_state.history.addr in continue_addrs:
+                            succ_state.loop_data.back_edge_trip_counts[succ_state.addr][-1] += 1
+                        succ_state.loop_data.header_trip_counts[succ_state.addr][-1] += 1
+                elif succ_state.addr in succ_state.loop_data.current_loop[-1][1]:
+                    succ_state.loop_data.current_loop.pop()
 
                 if self.bound is not None:
-                    counts = state.loop_data.back_edge_trip_counts[header][-1] if not self.use_header else \
-                             state.loop_data.header_trip_counts[header][-1]
+                    counts = succ_state.loop_data.back_edge_trip_counts[header][-1] if not self.use_header else \
+                             succ_state.loop_data.header_trip_counts[header][-1]
                     if counts > self.bound:
                         if self.bound_reached is not None:
                             simgr = self.bound_reached(simgr)
                         else:
-                            simgr.stashes[stash].remove(state)
-                            simgr.stashes[self.discard_stash].append(state)
+                            # Remove the state from the successors object
+                            self.cut_succs.append(succ_state)
+
 
                 l.debug("%s back edge based trip counts %s", state, state.loop_data.back_edge_trip_counts)
                 l.debug("%s header based trip counts %s", state, state.loop_data.header_trip_counts)
@@ -111,25 +132,15 @@ class LoopSeer(ExplorationTechnique):
             # Loop entry detected. This test is put here because in case of
             # nested loops, we want to handle the outer loop before proceeding
             # the inner loop.
-            if state.addr in self.loops:
-                loop = self.loops[state.addr]
+            if succ_state.addr in self.loops:
+                loop = self.loops[succ_state.addr]
                 header = loop.entry.addr
                 exits = [e[1].addr for e in loop.break_edges]
 
-                state.loop_data.back_edge_trip_counts[header].append(0)
-                state.loop_data.header_trip_counts[header].append(0)
-                state.loop_data.current_loop.append((loop, exits))
-
-        simgr.step(stash=stash, **kwargs)
-
-        return simgr
-
-    def successors(self, simgr, state, **kwargs):
-        node = self.cfg.model.get_any_node(state.addr)
-        if node is not None:
-            kwargs['num_inst'] = min(kwargs.get('num_inst', float('inf')), len(node.instruction_addrs))
-        return simgr.successors(state, **kwargs)
-
+                succ_state.loop_data.back_edge_trip_counts[header].append(0)
+                succ_state.loop_data.header_trip_counts[header].append(0)
+                succ_state.loop_data.current_loop.append((loop, exits))
+        return succs
     def _get_function(self, func):
         f = None
         if type(func) is str:

--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -41,6 +41,7 @@ class LoopSeer(ExplorationTechnique):
         self.use_header = use_header
         self.limit_concrete_loops = limit_concrete_loops
         self.loops = {}
+        self.cut_succs = []
         if type(loops) is Loop:
             loops = [loops]
 
@@ -85,6 +86,7 @@ class LoopSeer(ExplorationTechnique):
 
     def filter(self, simgr, state, **kwargs):
         if state in self.cut_succs:
+            self.cut_succs.remove(state)
             return self.discard_stash
         else:
             return simgr.filter(state, **kwargs)
@@ -95,7 +97,6 @@ class LoopSeer(ExplorationTechnique):
             kwargs['num_inst'] = min(kwargs.get('num_inst', float('inf')), len(node.instruction_addrs))
         succs = simgr.successors(state, **kwargs)
 
-        cut_succs = []
         for succ_state in succs.successors:
             # Processing a currently running loop
             if succ_state.loop_data.current_loop:

--- a/tests/test_loop_seer.py
+++ b/tests/test_loop_seer.py
@@ -147,7 +147,8 @@ def test_loop_limiter_constant_loop():
     nose.tools.assert_true(simgr.deadended[0].regs.eax.concrete)
     val = simgr.deadended[0].solver.eval_one(simgr.deadended[0].regs.eax)
     nose.tools.assert_equal(val, 420)
-    
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         globals()['test_' + sys.argv[1]]()

--- a/tests/test_loop_seer.py
+++ b/tests/test_loop_seer.py
@@ -133,6 +133,19 @@ def test_loop_limiter():
     nose.tools.assert_equal(simgr.spinning[0].loop_data.back_edge_trip_counts[0x4005fd][0], 6)
 
 
+def test_loop_limiter_constant_loop():
+    p = angr.Project(os.path.join(test_location, 'x86_64', 'constant_loopseer'), auto_load_libs=False)
+
+    cfg = p.analyses.CFGFast(normalize=True)
+
+    state = p.factory.entry_state()
+    simgr = p.factory.simulation_manager(state)
+
+    simgr.use_technique(angr.exploration_techniques.LoopSeer(cfg=cfg, functions='main', bound=5, limit_concrete_loops=False))
+
+    simgr.run()
+    nose.tools.assert_equal(simgr.deadended[0].regs.eax, 420)
+    
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         globals()['test_' + sys.argv[1]]()

--- a/tests/test_loop_seer.py
+++ b/tests/test_loop_seer.py
@@ -144,7 +144,9 @@ def test_loop_limiter_constant_loop():
     simgr.use_technique(angr.exploration_techniques.LoopSeer(cfg=cfg, functions='main', bound=5, limit_concrete_loops=False))
 
     simgr.run()
-    nose.tools.assert_equal(simgr.deadended[0].regs.eax, 420)
+    nose.tools.assert_true(simgr.deadended[0].regs.eax.concrete)
+    val = simgr.deadended[0].solver.eval_one(simgr.deadended[0].regs.eax)
+    nose.tools.assert_equal(val, 420)
     
 if __name__ == "__main__":
     if len(sys.argv) > 1:


### PR DESCRIPTION
Why would you want to do this, you ask?
If a concretely-bounded loop gets cut by LoopSeer, not only do you cut the loop, but you deadend exploration entirely, unless there's a path around the loop.
This option lets you control that behavior.  Now, if there was only one path (say a for-loop from 0 to 10), you'll actually do it all, and continue on with your path.

Now, you can still state-explode: if the loop body branches a lot, things will still get out of hand.  But if your alternative was deadending entirely, well you were done anyway.  This pairs well with other ETs designed to keep memory footprint down.

