### PR TITLE
`KB.functions`: Deeper copy in the `FunctionManager`

### DIFF
--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -79,6 +79,8 @@ class FunctionManager(KnowledgeBasePlugin, collections.abc.Mapping):
     def copy(self):
         fm = FunctionManager(self._kb)
         fm._function_map = self._function_map.copy()
+        for address, function in fm._function_map.items():
+            fm._function_map[address] = function.copy()
         fm.callgraph = networkx.MultiDiGraph(self.callgraph)
         fm._arg_registers = self._arg_registers.copy()
 

--- a/angr/knowledge_plugins/functions/soot_function.py
+++ b/angr/knowledge_plugins/functions/soot_function.py
@@ -78,6 +78,8 @@ class SootFunction(Function):
         # Whether this function returns or not. `None` means it's not determined yet
         self._returning = None
 
+        self.alignment = None
+
         # Determine returning status for SimProcedures and Syscalls
         hooker = None
         if self.is_simprocedure:


### PR DESCRIPTION
Rationale:
When copying the `FunctionManager`, one would expect to get copies of its stored `Function`s.

---

  * As of now, only the container is copied, but all the references to
  the values (`Function`s) aren't touched;
  * Force the values inside the dictionary to be copied to.