### PR TITLE
Fixed HeapAlloc crash with SimHeapBrk

### DIFF
--- a/angr/procedures/win32/heap.py
+++ b/angr/procedures/win32/heap.py
@@ -13,14 +13,17 @@ class HeapCreate(angr.SimProcedure):
 
 class HeapAlloc(angr.SimProcedure):
     def run(self, HeapHandle, Flags, Size): #pylint:disable=arguments-differ, unused-argument
-        addr = self.state.heap.malloc(Size)
+        addr = self.state.heap._malloc(Size)
 
         # conditionally zero the allocated memory
         if self.state.solver.solution(Flags & 8, 8):
-            # allocated size might be greater than requested
-            data_size = self.state.solver.eval_one(
-                self.state.heap.chunk_from_mem(addr).get_data_size()
-            )
+            if isinstance(self.state.heap, angr.SimHeapPTMalloc):
+                # allocated size might be greater than requested
+                data_size = self.state.solver.eval_one(
+                    self.state.heap.chunk_from_mem(addr).get_data_size()
+                )
+            else:
+                data_size = self.state.heap._conc_alloc_size(Size)
             data = self.state.solver.BVV(0, data_size * 8)
             self.state.memory.store(addr, data, size=data_size, condition=Flags & 8 == 8)
         return addr


### PR DESCRIPTION
Some recent changes to `HeapAlloc` cause a crash when using the default `SimHeapBrk`. Since `SimHeapBrk` allocates the size requested, the number of bytes to zero out when the `HEAP_ZERO_MEMORY` flag is set should be the concretized value of `Size`.