### PR TITLE
LoopSeer: Handle edge cases where we exit the loop not through the header

### DIFF
--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -97,12 +97,20 @@ class LoopSeer(ExplorationTechnique):
             kwargs['num_inst'] = min(kwargs.get('num_inst', float('inf')), len(node.instruction_addrs))
         succs = simgr.successors(state, **kwargs)
 
+
+        # Edge case: When limiting concrete loops, we may not want to do so
+        # via the header.  If there is a way out of the loop, and we can
+        # chose not to take it (e.g., the loop is not concrete), increase the trip count
+        at_loop_exit = False
+        for succ_state in succs.successors:
+            if succ_state.loop_data.current_loop:
+                if succ_state.addr in succ_state.loop_data.current_loop[-1][1]:
+                    at_loop_exit = True
         for succ_state in succs.successors:
             # Processing a currently running loop
             if succ_state.loop_data.current_loop:
                 loop = succ_state.loop_data.current_loop[-1][0]
                 header = loop.entry.addr
-
                 if succ_state.addr == header:
                     continue_addrs = [e[0].addr for e in loop.continue_edges]
                     # If there's only one successor, the loop is "concrete"
@@ -114,10 +122,17 @@ class LoopSeer(ExplorationTechnique):
                         succ_state.loop_data.header_trip_counts[succ_state.addr][-1] += 1
                 elif succ_state.addr in succ_state.loop_data.current_loop[-1][1]:
                     succ_state.loop_data.current_loop.pop()
-
-                if self.bound is not None:
-                    counts = succ_state.loop_data.back_edge_trip_counts[header][-1] if not self.use_header else \
-                             succ_state.loop_data.header_trip_counts[header][-1]
+                elif at_loop_exit:
+                    # We're not at the header, but we're where we exit the loop
+                    if self.limit_concrete_loops or len(succs.successors) > 1:
+                        succ_state.loop_data.back_edge_trip_counts[succ_state.addr][-1] += 1
+                if self.bound is not None and succ_state.loop_data.current_loop:
+                    counts = 0
+                    if self.use_header:
+                        counts = succ_state.loop_data.header_trip_counts[header][-1]
+                    else:
+                        if succ_state.addr in succ_state.loop_data.back_edge_trip_counts:
+                            counts = succ_state.loop_data.back_edge_trip_counts[succ_state.addr][-1]
                     if counts > self.bound:
                         if self.bound_reached is not None:
                             simgr = self.bound_reached(simgr)
@@ -138,6 +153,8 @@ class LoopSeer(ExplorationTechnique):
                 exits = [e[1].addr for e in loop.break_edges]
 
                 succ_state.loop_data.back_edge_trip_counts[header].append(0)
+                for node in loop.body_nodes:
+                    succ_state.loop_data.back_edge_trip_counts[node.addr].append(0)
                 succ_state.loop_data.header_trip_counts[header].append(0)
                 succ_state.loop_data.current_loop.append((loop, exits))
         return succs


### PR DESCRIPTION
We previously assumed that the splitting of states due to loop iterations would happen at the loop's "header" / "entry" -- this isn't always true, you can have what LoopFinder calls "break edges", where the loop will exit via an explicit break, a return, or something else.
A loop is concrete if, when it takes one of these break edges, this is the *only* way out.
If we come to such a break edge, and we could also go back into the loop, the loop isn't concrete, and when `limit_concrete_loops=False`, we should still increase the loop count.
