### PR TITLE
setup.py: Unify unicorn version constraints.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,8 @@ if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
         # https://www.python.org/dev/peps/pep-0425/
         sys.argv.append(name.replace('.', '_').replace('-', '_'))
 
+_UNICORN = "unicorn>=1.0.2rc2"
+
 setup(
     name='angr',
     version='8.20.5.27',
@@ -146,7 +148,7 @@ setup(
         'progressbar2',
         'rpyc',
         'cffi>=1.7.0',
-        'unicorn>=1.0.2rc2',
+        _UNICORN,
         'archinfo==8.20.5.27',
         'claripy==8.20.5.27',
         'cle==8.20.5.27',
@@ -158,7 +160,7 @@ setup(
         'itanium_demangler',
         'protobuf',
     ],
-    setup_requires=['unicorn', 'pyvex'],
+    setup_requires=[_UNICORN, 'pyvex'],
     extras_require={
         'AngrDB': ['sqlalchemy'],
     },


### PR DESCRIPTION
We were not specifying version constraints for unicorn in
setup_requires, which makes bdist_wheel and build download the latest
stable version of unicorn (which is 1.0.1 at this moment), leading to
broken angr_native.dll being built on Windows. This fix addresses this
problem.