### PR TITLE
ConvenientMappingsMixin should not always create fillers.

### DIFF
--- a/angr/storage/memory_mixins/convenient_mappings_mixin.py
+++ b/angr/storage/memory_mixins/convenient_mappings_mixin.py
@@ -34,10 +34,10 @@ class ConvenientMappingsMixin(MemoryMixin):
             return super().store(addr, data, size=size, **kwargs)
 
         try:
-            # remove this address for the old variables
-            old_obj = self.load(addr, size=size)
-
             if options.REVERSE_MEMORY_NAME_MAP in self.state.options:
+                # remove this address for the old variables
+                old_obj = self.load(addr, size=size, fill_missing=False)
+
                 obj_vars = old_obj.variables
                 for v in obj_vars:
                     self._mark_updated_mapping(self._name_mapping, v)

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -6,8 +6,14 @@ from ...misc.ux import once
 
 l = logging.getLogger(__name__)
 
+
 class DefaultFillerMixin(MemoryMixin):
-    def _default_value(self, addr, size, name=None, inspect=True, events=True, key=None, **kwargs):
+    def _default_value(self, addr, size, name=None, inspect=True, events=True, key=None, fill_missing: bool=True,
+                       **kwargs):
+
+        if fill_missing is False:
+            raise KeyError("Missing %d bytes at %s." % (size, addr))
+
         bits = size * self.state.arch.byte_width
 
         if type(addr) is int:

--- a/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
@@ -35,11 +35,13 @@ class UltraPage(MemoryObjectMixin, PageBase):
         o.symbolic_data = SortedDict(self.symbolic_data)
         return o
 
-    def load(self, addr, size=None, page_addr=None, endness=None, memory=None, cooperate=False, **kwargs):
+    def load(self, addr, size=None, page_addr=None, endness=None, memory=None, cooperate=False, fill_missing=True,
+             **kwargs):
         concrete_run = []
         symbolic_run = ...
         last_run = None
         result = []
+
         def get_object(start):
             try:
                 place = next(self.symbolic_data.irange(maximum=start, reverse=True))
@@ -54,7 +56,10 @@ class UltraPage(MemoryObjectMixin, PageBase):
 
         def cycle(end):
             if last_run is symbolic_run and symbolic_run is None:
-                fill(end)
+                if fill_missing:
+                    fill(end)
+                else:
+                    raise KeyError()
             elif last_run is concrete_run:
                 new_ast = claripy.BVV(concrete_run, (end - result[-1][0]) * 8)
                 new_obj = SimMemoryObject(new_ast, result[-1][0], endness)

--- a/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
@@ -35,8 +35,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
         o.symbolic_data = SortedDict(self.symbolic_data)
         return o
 
-    def load(self, addr, size=None, page_addr=None, endness=None, memory=None, cooperate=False, fill_missing=True,
-             **kwargs):
+    def load(self, addr, size=None, page_addr=None, endness=None, memory=None, cooperate=False, **kwargs):
         concrete_run = []
         symbolic_run = ...
         last_run = None
@@ -56,10 +55,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
 
         def cycle(end):
             if last_run is symbolic_run and symbolic_run is None:
-                if fill_missing:
-                    fill(end)
-                else:
-                    raise KeyError()
+                fill(end)
             elif last_run is concrete_run:
                 new_ast = claripy.BVV(concrete_run, (end - result[-1][0]) * 8)
                 new_obj = SimMemoryObject(new_ast, result[-1][0], endness)


### PR DESCRIPTION
ConvenientMappingsMixin conflicts with DefaultFillerMixin in an
unexpected way. Whenever a store() is called, ConvenientMappingsMixin
will attempt to load from the same address and expect a KeyError to be
raised if the content does not exist. However, UltraPage and the
DefaultFillerMixin will always fill in default content and will never
raise a KeyError.

This PR adds a new parameter `fill_missing` to load() and will cause
UltraPage to raise a KeyError when fill_missing is set to False, which
allows memory mixins to bypass the missing-value-filling logic.