### PR TITLE
Clear CALLER_SAVED_ARGS from SimCCARM

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1170,7 +1170,7 @@ class SimCCAMD64WindowsSyscall(SimCC):
 class SimCCARM(SimCC):
     ARG_REGS = [ 'r0', 'r1', 'r2', 'r3' ]
     FP_ARG_REGS = []    # TODO: ???
-    CALLER_SAVED_REGS = [ 'r0', 'r1', 'r2', 'r3' ]
+    CALLER_SAVED_REGS = []
     RETURN_ADDR = SimRegArg('lr', 4)
     RETURN_VAL = SimRegArg('r0', 4)
     ARCH = archinfo.ArchARM


### PR DESCRIPTION
According to ARM CC:

"**Subroutines** must preserve the contents of r4 to r11 and the stack pointer (perhaps by saving them to the stack in the function prologue, then using them as scratch space, then restoring them from the stack in the function epilogue)"

Therefore, this list must be empty otherwise we possibly have incorrect results in the analyses.