### PR TITLE
add windows x64 FINIT dirty call with the same as x86 one.

### DIFF
--- a/angr/engines/vex/heavy/dirty.py
+++ b/angr/engines/vex/heavy/dirty.py
@@ -338,6 +338,8 @@ def x86g_dirtyhelper_FINIT(state, gsptr): #pylint:disable=unused-argument
     state.regs.ftop = 0
     return None, [ ]
 
+amd64g_dirtyhelper_FINIT = x86g_dirtyhelper_FINIT
+
 def x86g_dirtyhelper_write_cr0(state, value):
     # make a deep copy of the arch before modifying it so we don't accidentally modify it for all other states
     state.arch = state.arch.copy()


### PR DESCRIPTION
When analyzing programs running on windows x64 platform, like the following example:     
Demo program, compiled by `gcc (x86_64-posix-seh-rev1, Built by MinGW-W64 project) 7.2.0`:
```c
#include<stdio.h>
int main()
{
	printf("hello world");
	return 0;
}
```
Demo angr python script:    
```python
import angr

p = angr.Project('test.exe')
state = p.factory.entry_state()
sm = p.factory.simulation_manager(state)

sm.run()

for s in sm.deadended:
    print(s.posix.dumps(0), s.posix.dumps(1))
print('end')
```

All the states will finally change to errored(not deadended), with error reason `UnsupportedDirtyError('Unsupported dirty helper amd64g_dirtyhelper_FINIT')`.      
This error is thrown from `angr\engines\vex\heavy\heavy.py`, `line 259`. It seems that `dirty.py` lacks x64 FINIT function. The function `x86g_dirtyhelper_FINIT` could also be used on windows x64.    

According to [Intel64 and IA-32 Architectures Software Developer's Manual](https://software.intel.com/content/www/us/en/develop/download/intel-64-and-ia-32-architectures-sdm-combined-volumes-1-2a-2b-2c-2d-3a-3b-3c-3d-and-4.html), about `FINIT` on `Page 955`, `This instruction's operation is the same in non-64-bits modes and 64-bit mode`. So, using the same function as x86's one should be plausible.
