### PR TITLE
Fix #2178: Handle SimTypeFixedSizeArray in SimCC.arg_locs().

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -512,7 +512,7 @@ class SimCC:
                 sizes = [ ]
                 for a in args:
                     if isinstance(a, SimType):
-                        if a.size is NotImplemented:
+                        if isinstance(a, SimTypeFixedSizeArray) or a.size is NotImplemented:
                             sizes.append(self.arch.bytes)
                         else:
                             sizes.append(a.size // 8)  # SimType.size is in bits


### PR DESCRIPTION
if an argument of a simprocedure is the type of `SimTypeFixedSizeArray`, it might generate a error size and fails to generate CFGFast like it is showed in #2178 .