### PR TITLE
Small fixes to sim_procedures chdir and time

### DIFF
--- a/angr/procedures/linux_kernel/cwd.py
+++ b/angr/procedures/linux_kernel/cwd.py
@@ -17,7 +17,7 @@ class getcwd(angr.SimProcedure):
 
 class chdir(angr.SimProcedure):
     def run(self, buf):
-        cwd = self.state.mem[buf].string
+        cwd = self.state.mem[buf].string.concrete
         l.info('chdir(%r)', cwd)
         self.state.fs.cwd = cwd
         return 0

--- a/angr/procedures/linux_kernel/time.py
+++ b/angr/procedures/linux_kernel/time.py
@@ -15,7 +15,7 @@ class time(angr.SimProcedure):
     def run(self, pointer):
         if angr.options.USE_SYSTEM_TIMES in self.state.options:
             ts = int(_time.time())
-            ts_bv = self.state.solver.BVV(ts, 64)
+            ts_bv = self.state.solver.BVV(ts, self.state.arch.bits)
             if self.state.solver.eval(pointer) != 0:
                 self.state.memory.store(pointer, ts_bv, endness=self.state.arch.memory_endness)
             return ts_bv


### PR DESCRIPTION
Hello,

I propose two little fixes for simprocedures:
- chdir : where string is not concretize which could leads to problem in the filesystem (concatenation of strings)
- time : where 64 bits are used for the BVV, I switch to self.state.arch.bits