### PR TITLE
Save running resolves in kb

### DIFF
--- a/angr/knowledge_plugins/indirect_jumps.py
+++ b/angr/knowledge_plugins/indirect_jumps.py
@@ -9,10 +9,15 @@ class IndirectJumps(KnowledgeBasePlugin, dict):
         self.resolved = set()
         self.unresolved = set()
 
+        # variable for storing addresses actively being resolved
+        # dict format:    {indirect_addr: [resolved_addr]}
+        self.active_resolves = {}
+
     def copy(self):
         o = IndirectJumps(self._kb)
         o.resolved.update(self.resolved)
         o.unresolved.update(self.unresolved)
+        o.active_resolves = self.active_resolves
 
 
 KnowledgeBasePlugin.register_default('indirect_jumps', IndirectJumps)


### PR DESCRIPTION
* adds a variable to indirect call kb for easy access to _running resolves_ for access in other analyses