### PR TITLE
Refactored resolved_addrs kb to store resolves

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2282,7 +2282,7 @@ class CFGBase(Analysis):
 
         addr = jump.addr if jump is not None else jump_addr
         l.debug('The indirect jump at %#x is successfully resolved by %s. It has %d targets.', addr, resolved_by, len(targets))
-        self.kb.resolved_indirect_jumps.add(addr)
+        self.kb.indirect_jumps.update_resolved_addrs(addr, targets)
 
     def _indirect_jump_unresolved(self, jump):
         """

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -2326,8 +2326,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                             all_successors.insert(0, a)
 
                         l.debug('The indirect jump is successfully resolved.')
-
-                        self.kb.resolved_indirect_jumps.add(cfg_node.addr)
+                        self.kb.indirect_jumps.update_resolved_addrs(cfg_node.addr, more_successors)
 
                     else:
                         l.debug('Failed to resolve the indirect jump.')
@@ -2379,7 +2378,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                         successors = self._symbolically_back_traverse(sim_successors, artifacts, cfg_node)
                         # mark jump as resolved if we got successors
                         if successors:
-                            self.kb.resolved_indirect_jumps.add(cfg_node.addr)
+                            self.kb.indirect_jumps.update_resolved_addrs(cfg_node.addr, successors)
                         else:
                             self.kb.unresolved_indirect_jumps.add(cfg_node.addr)
                         l.debug("Got %d concrete exits in symbolic mode.", len(successors))
@@ -2401,7 +2400,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
                         # mark jump as resolved if we got successors
                         if successors:
-                            self.kb.resolved_indirect_jumps.add(cfg_node.addr)
+                            self.kb.indirect_jumps.update_resolved_addrs(cfg_node.addr, successors)
                         else:
                             self.kb.unresolved_indirect_jumps.add(cfg_node.addr)
                         l.debug('Got %d concrete exits in symbolic mode', len(successors))

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -2419,7 +2419,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         return successors
 
-    def _backward_slice_indirect(self, cfgnode: object, sim_successors: object, current_function_addr: object) -> object:
+    def _backward_slice_indirect(self, cfgnode, sim_successors, current_function_addr):
         """
         Try to resolve an indirect jump by slicing backwards
         """

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -2378,7 +2378,8 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
                         successors = self._symbolically_back_traverse(sim_successors, artifacts, cfg_node)
                         # mark jump as resolved if we got successors
                         if successors:
-                            self.kb.indirect_jumps.update_resolved_addrs(cfg_node.addr, successors)
+                            succ_addrs = [s.addr for s in successors]
+                            self.kb.indirect_jumps.update_resolved_addrs(cfg_node.addr, succ_addrs)
                         else:
                             self.kb.unresolved_indirect_jumps.add(cfg_node.addr)
                         l.debug("Got %d concrete exits in symbolic mode.", len(successors))
@@ -2400,7 +2401,8 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
                         # mark jump as resolved if we got successors
                         if successors:
-                            self.kb.indirect_jumps.update_resolved_addrs(cfg_node.addr, successors)
+                            succ_addrs = [s.addr for s in successors]
+                            self.kb.indirect_jumps.update_resolved_addrs(cfg_node.addr, succ_addrs)
                         else:
                             self.kb.unresolved_indirect_jumps.add(cfg_node.addr)
                         l.debug('Got %d concrete exits in symbolic mode', len(successors))
@@ -2417,7 +2419,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         return successors
 
-    def _backward_slice_indirect(self, cfgnode, sim_successors, current_function_addr):
+    def _backward_slice_indirect(self, cfgnode: object, sim_successors: object, current_function_addr: object) -> object:
         """
         Try to resolve an indirect jump by slicing backwards
         """

--- a/angr/knowledge_plugins/indirect_jumps.py
+++ b/angr/knowledge_plugins/indirect_jumps.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .plugin import KnowledgeBasePlugin
 
 
@@ -18,7 +20,7 @@ class IndirectJumps(KnowledgeBasePlugin, dict):
         for k, v in self.resolved.items():
             o.resolved[k] = v
 
-    def update_resolved_addrs(self, indirect_address: int, resolved_addresses: list):
+    def update_resolved_addrs(self, indirect_address: int, resolved_addresses: List[int]):
         # sanity check on usage
         if indirect_address is None:
             return

--- a/angr/knowledge_plugins/indirect_jumps.py
+++ b/angr/knowledge_plugins/indirect_jumps.py
@@ -6,13 +6,25 @@ class IndirectJumps(KnowledgeBasePlugin, dict):
     def __init__(self, kb):
         super(IndirectJumps, self).__init__()
         self._kb = kb
-        self.resolved = set()
         self.unresolved = set()
+
+        # dict format: {indirect_address: [resolved_addresses]}
+        self.resolved = {}
 
     def copy(self):
         o = IndirectJumps(self._kb)
-        o.resolved.update(self.resolved)
         o.unresolved.update(self.unresolved)
+        o.resolved = {k: v for k, v in self.resolved.items()}
+
+    def update_resolved_addrs(self, indirect_address: int, resolved_addresses: list):
+        # sanity check on usage
+        if indirect_address is None:
+            return
+
+        if indirect_address in self.resolved:
+            self.resolved[indirect_address] + resolved_addresses
+        else:
+            self.resolved[indirect_address] = resolved_addresses
 
 
 KnowledgeBasePlugin.register_default('indirect_jumps', IndirectJumps)

--- a/angr/knowledge_plugins/indirect_jumps.py
+++ b/angr/knowledge_plugins/indirect_jumps.py
@@ -14,7 +14,9 @@ class IndirectJumps(KnowledgeBasePlugin, dict):
     def copy(self):
         o = IndirectJumps(self._kb)
         o.unresolved.update(self.unresolved)
-        o.resolved = {k: v for k, v in self.resolved.items()}
+        o.resolved = {}
+        for k, v in self.resolved.items():
+            o.resolved[k] = v
 
     def update_resolved_addrs(self, indirect_address: int, resolved_addresses: list):
         # sanity check on usage
@@ -22,9 +24,9 @@ class IndirectJumps(KnowledgeBasePlugin, dict):
             return
 
         if indirect_address in self.resolved:
-            self.resolved[indirect_address] + resolved_addresses
+            self.resolved[indirect_address] += list(resolved_addresses)
         else:
-            self.resolved[indirect_address] = resolved_addresses
+            self.resolved[indirect_address] = list(resolved_addresses)
 
 
 KnowledgeBasePlugin.register_default('indirect_jumps', IndirectJumps)

--- a/tests/test_kb_plugins.py
+++ b/tests/test_kb_plugins.py
@@ -16,7 +16,7 @@ def test_kb_plugins():
     nose.tools.assert_is_instance(p.kb.comments, angr.knowledge_plugins.Comments)
 
     nose.tools.assert_is_instance(p.kb.callgraph, networkx.Graph)
-    nose.tools.assert_is_instance(p.kb.resolved_indirect_jumps, set)
+    nose.tools.assert_is_instance(p.kb.resolved_indirect_jumps, dict)
     nose.tools.assert_is_instance(p.kb.unresolved_indirect_jumps, set)
 
     nose.tools.assert_is_not_none(dir(p.kb))


### PR DESCRIPTION
* Converted kb.resolved_indirect_jumps to a dictionary to store resolves
* Added an "update" method to keep continue to update resolves of indirect_jumps
* Refactored all old code that used the old set of resolved_indirect_jumps