### PR TITLE
Typehoon: Infer types of loads from non-constant offsets.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -392,7 +392,7 @@ class Clinic(Analysis):
         tmp_kb.variables[self.function.addr].remove_types()
         # run type inference
         try:
-            tp = self.project.analyses.Typehoon(vr.type_constraints, kb=tmp_kb)
+            tp = self.project.analyses.Typehoon(vr.type_constraints, kb=tmp_kb, var_mapping=vr.var_to_typevar)
             tp.update_variable_types(self.function.addr, vr.var_to_typevar)
         except Exception:  # pylint:disable=broad-except
             l.warning("Typehoon analysis failed. Variables will not have types. Please report to GitHub.",

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -726,12 +726,20 @@ class CVariable(CExpression):
                                     return
 
                         elif isinstance(self.variable.type.pts_to, SimTypeArray):
-                            # it's pointing to an array!
-                            yield from self.variable.c_repr_chunks()
-                            yield "[", None
-                            yield str(self.offset), self.offset
-                            yield "]", None
-                            return
+                            if isinstance(self.offset, int):
+                                # it's pointing to an array! take the corresponding element
+                                yield from self.variable.c_repr_chunks()
+                                yield "[", None
+                                yield str(self.offset), self.offset
+                                yield "]", None
+                                return
+
+                        # other cases
+                        yield from self.variable.c_repr_chunks()
+                        yield "[", None
+                        yield from self.offset.c_repr_chunks()
+                        yield "]", None
+                        return
 
                 # default output
                 yield "*(", None

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -724,6 +724,10 @@ class CVariable(CExpression):
                                     yield "->", None
                                     yield from c_field.c_repr_chunks()
                                     return
+                                else:
+                                    # accessing beyond known offset - indicates a bug in type inference
+                                    l.warning("Accessing non-existent offset %d in struct %s. This indicates a bug in "
+                                              "the type inference engine.", self.offset, self.variable.type.pts_to)
 
                         elif isinstance(self.variable.type.pts_to, SimTypeArray):
                             if isinstance(self.offset, int):
@@ -737,7 +741,10 @@ class CVariable(CExpression):
                         # other cases
                         yield from self.variable.c_repr_chunks()
                         yield "[", None
-                        yield from self.offset.c_repr_chunks()
+                        if isinstance(self.offset, CVariable):
+                            yield from self.offset.c_repr_chunks()
+                        else:
+                            yield str(self.offset), self.offset
                         yield "]", None
                         return
 

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 import networkx
 
-from .typevars import Existence, Equivalence, Subtype, TypeVariable, DerivedTypeVariable, HasField
+from .typevars import Existence, Equivalence, Subtype, TypeVariable, DerivedTypeVariable, HasField, Add, Sub
 from .typeconsts import (BottomType, TopType, TypeConstant, Int, Int8, Int16, Int32, Int64, Pointer32, Pointer64,
                          Struct, int_type, TypeVariableReference)
 
@@ -32,7 +32,12 @@ class SimpleSolver:
     """
     SimpleSolver is, literally, a simple, unification-based type constraint solver.
     """
-    def __init__(self, constraints):
+    def __init__(self, bits: int, constraints):
+
+        if bits not in (32, 64):
+            raise ValueError("Pointer size %d is not supported. Expect 32 or 64." % bits)
+
+        self.bits = bits
         self._constraints = constraints
 
         #
@@ -51,6 +56,8 @@ class SimpleSolver:
         # pprint.pprint(self._constraints)
 
         constraints = self._handle_equivalence()
+        subtype_constraints = self._subtype_constraints_from_add()
+        constraints.update(subtype_constraints)
         subtypevars, supertypevars = self._calculate_closure(constraints)
         self._find_recursive_types(subtypevars)
         self._compute_lower_upper_bounds(subtypevars, supertypevars)
@@ -109,21 +116,11 @@ class SimpleSolver:
 
         # collect equivalence relations
         for constraint in self._constraints:
-
-            if isinstance(constraint, Existence):
-                pass
-
-            elif isinstance(constraint, Equivalence):
+            if isinstance(constraint, Equivalence):
                 # type_a == type_b
                 # we apply unification and removes one of them
                 ta, tb = constraint.type_a, constraint.type_b
                 graph.add_edge(ta, tb)
-
-            elif isinstance(constraint, Subtype):
-                pass
-
-            else:
-                raise NotImplementedError("Unsupported instance type %s." % type(constraint))
 
         for components in networkx.connected_components(graph):
             components_lst = list(components)
@@ -159,6 +156,18 @@ class SimpleSolver:
 
         self._equivalence = replacements
         return constraints
+
+    def _subtype_constraints_from_add(self):
+        """
+        Handle Add constraints.
+        """
+        new_constraints = set()
+        for constraint in self._constraints:
+            if isinstance(constraint, Add):
+                # we want to be conservative and take a guess here - normally the resulting type variable is a subtype
+                # of the first type variable
+                new_constraints.add(Subtype(constraint.type_0, constraint.type_r))
+        return new_constraints
 
     @staticmethod
     def _calculate_closure(constraints):

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 import networkx
 
-from .typevars import Existence, Equivalence, Subtype, TypeVariable, DerivedTypeVariable, HasField, Add, Sub
+from .typevars import Existence, Equivalence, Subtype, TypeVariable, DerivedTypeVariable, HasField, Add
 from .typeconsts import (BottomType, TopType, TypeConstant, Int, Int8, Int16, Int32, Int64, Pointer32, Pointer64,
                          Struct, int_type, TypeVariableReference)
 

--- a/angr/analyses/typehoon/typeconsts.py
+++ b/angr/analyses/typehoon/typeconsts.py
@@ -9,6 +9,9 @@ class TypeConstant:
 
     SIZE = None
 
+    def pp_str(self, mapping) -> str:  # pylint:disable=unused-argument
+        return repr(self)
+
     def __eq__(self, other):
         return type(self) == type(other)
 

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -191,16 +191,24 @@ class SimEngineVRAIL(
 
         try:
             typevar = None
+            type_constraints = set()
             if r0.typevar is not None and isinstance(r1.data, int):
+                # addition with constants. create a derived type variable
                 typevar = typevars.DerivedTypeVariable(r0.typevar, typevars.AddN(r1.data))
+            else:
+                # create a new type variable and add constraints accordingly
+                typevar = typevars.TypeVariable()
+                type_constraints.add(typevars.Add(r0.typevar, r1.typevar, typevar))
 
             sum_ = None
             if r0.data is not None and r1.data is not None:
                 sum_ = r0.data + r1.data
 
+            type_constraints.add(typevars.Subtype(r0.typevar, r1.typevar))
+
             return RichR(sum_,
                          typevar=typevar,
-                         type_constraints={ typevars.Subtype(r0.typevar, r1.typevar) }
+                         type_constraints=type_constraints,
                          )
         except TypeError:
             return RichR(ailment.Expr.BinaryOp(expr.idx, 'Add', [r0, r1], **expr.tags))

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -375,6 +375,9 @@ class SimEngineVRBase(SimEngineLight):
             return RichR(data, variable=var, typevar=typevar)
 
         # Loading data from a pointer
+        if richr_addr.type_constraints:
+            for tc in richr_addr.type_constraints:
+                self.state.add_type_constraint(tc)
 
         # parse the loading offset
         offset = 0
@@ -385,13 +388,16 @@ class SimEngineVRBase(SimEngineLight):
         else:
             richr_addr_typevar = richr_addr.typevar
 
-        # create a type constraint
-        typevar = typevars.DerivedTypeVariable(
-            typevars.DerivedTypeVariable(richr_addr_typevar, typevars.Load()),
-            typevars.HasField(size * 8, offset)
-        )
-        self.state.add_type_constraint(typevars.Existence(typevar))
-        return RichR(None, typevar=typevar)
+        if richr_addr_typevar is not None:
+            # create a type constraint
+            typevar = typevars.DerivedTypeVariable(
+                typevars.DerivedTypeVariable(richr_addr_typevar, typevars.Load()),
+                typevars.HasField(size * 8, offset)
+            )
+            self.state.add_type_constraint(typevars.Existence(typevar))
+            return RichR(None, typevar=typevar)
+        else:
+            return RichR(None)
 
     def _read_from_register(self, offset, size, expr=None):
         """

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -305,6 +305,27 @@ def test_decompiling_libsoap():
         assert False
 
 
+def test_decompiling_strings_local_strlen():
+    bin_path = os.path.join(test_location, "x86_64", "types", "strings")
+    p = angr.Project(bin_path, auto_load_libs=False)
+
+    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    func = cfg.functions['local_strlen']
+
+    _ = p.analyses.VariableRecoveryFast(func)
+    cca = p.analyses.CallingConvention(func, cfg=cfg)
+    func.calling_convention = cca.cc
+
+    dec = p.analyses.Decompiler(func, cfg=cfg)
+    assert dec.codegen is not None, "Failed to decompile function %r." % func
+
+    code = dec.codegen.text
+    print(code)
+    # Make sure argument a0 is correctly typed to char*
+    lines = code.split("\n")
+    assert "local_strlen(char* a0)" in lines[0], "Argument a0 seems to be incorrectly typed: %s" % lines[0]
+
+
 if __name__ == "__main__":
     for k, v in list(globals().items()):
         if k.startswith('test_') and callable(v):


### PR DESCRIPTION
Also:

- Add a pp_constraints() method to Typehoon for pretty-printing type
constraints between variables.

- Fix an issue in StructuredCodeGen with non-constant offset array
loads.