### PR TITLE
Typehoon: Infer types of stores to non-constant offsets.

### DIFF
--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -741,10 +741,7 @@ class CVariable(CExpression):
                         # other cases
                         yield from self.variable.c_repr_chunks()
                         yield "[", None
-                        if isinstance(self.offset, CVariable):
-                            yield from self.offset.c_repr_chunks()
-                        else:
-                            yield str(self.offset), self.offset
+                        yield from CExpression._try_c_repr_chunks(self.offset)
                         yield "]", None
                         return
 
@@ -1367,9 +1364,16 @@ class StructuredCodeGenerator(Analysis):
                 elif isinstance(cvariable.rhs, CConstant) and isinstance(cvariable.lhs, CVariable):
                     offset = cvariable.rhs.value
                     base = cvariable.lhs
+                elif isinstance(cvariable.lhs, CVariable) and isinstance(cvariable.rhs, CTypeCast):
+                    offset = cvariable.rhs
+                    base = cvariable.lhs
+                elif isinstance(cvariable.rhs, CVariable) and isinstance(cvariable.lhs, CTypeCast):
+                    offset = cvariable.lhs
+                    base = cvariable.rhs
                 else:
-                    base = None
-                    offset = None
+                    # GUESS: we need some guessing here
+                    base = cvariable.lhs
+                    offset = cvariable.rhs
 
             if base is not None and offset is not None:
                 cvariable = self._cvariable(base, offset=offset, variable_type=base.variable_type)

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -395,8 +395,17 @@ class SimpleSolver:
                 else:
                     raise Exception("Impossible")
                 fields[offset] = v
-            return Struct(fields)
+            return Struct(fields=fields)
 
+        # single element and single-element struct
+        if issubclass(t2_cls, Int) and t1_cls is Struct:
+            # swap them
+            t1, t1_cls, t2, t2_cls = t2, t2_cls, t1, t1_cls
+        if issubclass(t1_cls, Int) and t2_cls is Struct and len(t2.fields) == 1 and 0 in t2.fields:
+            # e.g., char & struct {0: char}
+            return Struct(fields={0: self._join(t1, t2.fields[0], translate)})
+
+        # Struct and Pointers
         if t1_cls is Pointer64 and t2_cls is Struct:
             # swap them
             t1, t1_cls, t2, t2_cls = t2, t2_cls, t1, t1_cls

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -74,7 +74,7 @@ class SimEngineVRAIL(
                 ret_expr: SimRegArg = self.project.factory.cc().RETURN_VAL
             ret_reg_offset = self.project.arch.registers[ret_expr.reg_name][0]
 
-        # discovery the prototype
+        # discover the prototype
         prototype: Optional[SimTypeFunction] = None
         if stmt.calling_convention is not None:
             prototype = stmt.calling_convention.func_ty
@@ -90,6 +90,8 @@ class SimEngineVRAIL(
                 ret_ty = TypeLifter(self.arch.bits).lift(prototype.returnty)
             else:
                 ret_ty = None
+            if isinstance(ret_ty, typeconsts.BottomType):
+                ret_ty = None
 
             self._assign_to_register(
                 ret_reg_offset,
@@ -103,7 +105,7 @@ class SimEngineVRAIL(
             for arg, arg_type in zip(args, prototype.args):
                 arg_ty = TypeLifter(self.arch.bits).lift(arg_type)
                 type_constraint = typevars.Subtype(
-                    arg.typevar, arg_ty
+                    arg_ty, arg.typevar
                 )
                 self.state.add_type_constraint(type_constraint)
 

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -258,27 +258,34 @@ class SimEngineVRBase(SimEngineLight):
         addr_variable = richr_addr.variable
         codeloc = self._codeloc()
 
+        # Storing data into a pointer
+        if richr_addr.type_constraints:
+            for tc in richr_addr.type_constraints:
+                self.state.add_type_constraint(tc)
+
         if richr_addr.typevar is None:
             typevar = typevars.TypeVariable()
         else:
             typevar = richr_addr.typevar
-        if isinstance(typevar, typevars.DerivedTypeVariable) and isinstance(typevar.label, typevars.AddN):
-            base_typevar = typevar.type_var
-            field_offset = typevar.label.n
-        else:
-            base_typevar = typevar
-            field_offset = 0
 
-        # if addr_variable is not None:
-        #     self.variable_manager[self.func_addr].reference_at(addr_variable, field_offset, codeloc, atom=stmt)
+        if typevar is not None:
+            if isinstance(typevar, typevars.DerivedTypeVariable) and isinstance(typevar.label, typevars.AddN):
+                base_typevar = typevar.type_var
+                field_offset = typevar.label.n
+            else:
+                base_typevar = typevar
+                field_offset = 0
 
-        store_typevar = typevars.DerivedTypeVariable(
-            typevars.DerivedTypeVariable(base_typevar, typevars.Store()),
-            typevars.HasField(size * 8, field_offset)
-        )
-        if addr_variable is not None:
-            self.state.typevars.add_type_variable(addr_variable, codeloc, typevar)
-        self.state.add_type_constraint(typevars.Existence(store_typevar))
+            # if addr_variable is not None:
+            #     self.variable_manager[self.func_addr].reference_at(addr_variable, field_offset, codeloc, atom=stmt)
+
+            store_typevar = typevars.DerivedTypeVariable(
+                typevars.DerivedTypeVariable(base_typevar, typevars.Store()),
+                typevars.HasField(size * 8, field_offset)
+            )
+            if addr_variable is not None:
+                self.state.typevars.add_type_variable(addr_variable, codeloc, typevar)
+            self.state.add_type_constraint(typevars.Existence(store_typevar))
 
     def _load(self, richr_addr, size, expr=None):
         """


### PR DESCRIPTION
Also fixed the following bugs:

- Subtype relations between actual parameters and formal parameters was
inverted.

- StructuredCodeGen could not properly print non-constant array offsets.

- SimpleSolver could not properly join an Int and a single-field Struct.