### PR TITLE
fix #2224: correct CFGFast successors information for mips binaries.

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3692,7 +3692,6 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                     break
             elif isinstance(stmt, pyvex.IRStmt.Put) and stmt.offset == self.project.arch.registers['gp'][0]:
                 last_gp_setting_insn_id = insn_ctr
-                break
 
         if last_gp_setting_insn_id is None:
             return None


### PR DESCRIPTION
I looked into the issue and found that this is because of the error `$gp` value produced by `_mips_determine_function_gp`.
If we set a conditional breakpoint at `angr/analyses/cfg/cfg_fast.py:3677` when `func_addr==0x453e14`. The `$gp` value is `0x560000`.
![image](https://user-images.githubusercontent.com/9366279/86124688-1c7b4b80-bb0e-11ea-85bc-170437cec708.png)
But the actually `$gp` value is `0x561ba0`.
![image](https://user-images.githubusercontent.com/9366279/86124943-7714a780-bb0e-11ea-918a-ab034a64cdbd.png)

The bug is at `_mips_determine_function_gp`, `last_gp_setting_insn_id` is equal to the the first `Put` statement for `$gp`, but look at the disassembly code from binary ninja, there is another `addiu   $gp, $gp, 0x1ba0` instruction updating `$gp`. The error `$gp` value leads to the error successors when calling plt function. 
```py
    def _mips_determine_function_gp(self, addr: int, irsb: pyvex.IRSB, func_addr: int) -> Optional[int]:
        # check if gp is being written to
        last_gp_setting_insn_id = None
        insn_ctr = 0

        if not irsb.statements:
            # Get an IRSB with statements
            irsb = self.project.factory.block(irsb.addr, size=irsb.size, opt_level=1, cross_insn_opt=False).vex

        for stmt in irsb.statements:
            if isinstance(stmt, pyvex.IRStmt.IMark):
                insn_ctr += 1
                if insn_ctr >= 10:
                    break
            elif isinstance(stmt, pyvex.IRStmt.Put) and stmt.offset == self.project.arch.registers['gp'][0]:
                last_gp_setting_insn_id = insn_ctr
                break
```
So I correct this by deleting the `break`, letting `last_gp_setting_insn_id` become the actual last statement.
Again, if we run the test script, we can get the correct result.
```python
import angr

example = "./httpd"

proj = angr.Project(example, auto_load_libs=False)

cfg = proj.analyses.CFGFast(show_progressbar=True)

node1 = cfg.model.get_any_node(0x4544f0)
print(node1.successors)
print(node1.successors[0].name)

node2 = cfg.model.get_any_node(0x41c198)
print(node2.successors)
print(node2.successors[0].name)
```
result:
```
[<CFGNode strcmp [0]>]
strcmp
[<CFGNode strcmp [0]>]
strcmp
```

