### PR TITLE
Display demangled C++ function names in disasm and decompiler.

### DIFF
--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -10,6 +10,7 @@ from ...sim_type import (SimTypeLongLong, SimTypeInt, SimTypeShort, SimTypeChar,
     SimTypeBottom, SimTypeArray, SimTypeFunction)
 from ...sim_variable import SimVariable, SimTemporaryVariable, SimStackVariable, SimRegisterVariable, SimMemoryVariable
 from ...utils.constants import is_alignment_mask
+from ...utils.library import get_cpp_function_name
 from ...errors import UnsupportedNodeTypeError
 from .. import Analysis, register_analysis
 from .region_identifier import MultiNode
@@ -178,7 +179,11 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
         yield self.functy.returnty.c_repr(), None
         yield " ", None
         # function name
-        yield self.demangled_name or self.name, None
+        if self.demangled_name:
+            normalized_name = get_cpp_function_name(self.demangled_name, specialized=False, qualified=False)
+        else:
+            normalized_name = self.name
+        yield normalized_name, None
         # argument list
         yield "(", None
         for i, (arg_type, arg) in enumerate(zip(self.functy.args, self.arg_list)):
@@ -517,7 +522,10 @@ class CFunctionCall(CStatement):
             yield " = ", None
 
         if self.callee_func is not None:
-            func_name = self.callee_func.demangled_name or self.callee_func.name
+            if self.callee_func.demangled_name:
+                func_name = get_cpp_function_name(self.callee_func.demangled_name, specialized=False, qualified=True)
+            else:
+                func_name = self.callee_func.name
             yield func_name, self
         else:
             yield from CExpression._try_c_repr_chunks(self.callee_target)

--- a/angr/project.py
+++ b/angr/project.py
@@ -340,7 +340,15 @@ class Project:
                 else:
                     if not func.is_weak:
                         l.info("Using stub SimProcedure for unresolved %s", export.name)
-                        self.hook_symbol(export.rebased_addr, missing_libs[0].get(export.name, sim_proc_arch))
+                        if export.name and export.name.startswith("_Z"):
+                            # GNU C++ name. Use a C++ library to create the stub
+                            the_lib = SIM_LIBRARIES.get('libstdc++.so', None)
+                            if the_lib is None:
+                                l.critical("Does not find any C++ library in SIM_LIBRARIES. We may not correctly "
+                                           "create the stub or resolve the function prototype for name %s.", export.name)
+                                the_lib = missing_libs[0]
+
+                        self.hook_symbol(export.rebased_addr, the_lib.get(export.name, sim_proc_arch))
 
             # Step 2.5: If 2.4 didn't work (we have NO SimLibraries to work with), just
             # use the vanilla ReturnUnconstrained, assuming that this isn't a weak func

--- a/angr/project.py
+++ b/angr/project.py
@@ -340,13 +340,14 @@ class Project:
                 else:
                     if not func.is_weak:
                         l.info("Using stub SimProcedure for unresolved %s", export.name)
+                        the_lib = missing_libs[0]
                         if export.name and export.name.startswith("_Z"):
                             # GNU C++ name. Use a C++ library to create the stub
-                            the_lib = SIM_LIBRARIES.get('libstdc++.so', None)
-                            if the_lib is None:
+                            if 'libstdc++.so' in SIM_LIBRARIES:
+                                the_lib = SIM_LIBRARIES['libstdc++.so']
+                            else:
                                 l.critical("Does not find any C++ library in SIM_LIBRARIES. We may not correctly "
                                            "create the stub or resolve the function prototype for name %s.", export.name)
-                                the_lib = missing_libs[0]
 
                         self.hook_symbol(export.rebased_addr, the_lib.get(export.name, sim_proc_arch))
 

--- a/angr/utils/library.py
+++ b/angr/utils/library.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Optional
 
-from ..sim_type import parse_file, parse_cpp_file, SimTypeCppFunction
+from ..sim_type import parse_file, parse_cpp_file, normalize_cpp_function_name, SimTypeCppFunction
 
 
 def get_function_name(s):
@@ -127,3 +127,22 @@ def cprotos2py(cprotos):
         func_name, proto_, str_ = convert_cproto_to_py(decl)  # pylint:disable=unused-variable
         s += " " * 8 + str_.replace("\n", "\n" + " " * 8) + "\n"
     return s
+
+
+def get_cpp_function_name(demangled_name, specialized=True, qualified=True):
+    if not specialized:
+        # remove "<???>"s
+        name = normalize_cpp_function_name(demangled_name)
+    else:
+        name = demangled_name
+
+    if not qualified:
+        # remove leading namespaces
+        chunks = name.split("::")
+        name = "::".join(chunks[-2:])
+
+    # remove arguments
+    if "(" in name:
+        name = name[: name.find("(")]
+
+    return name


### PR DESCRIPTION
Also fix a bug where C++ stubs miss function prototypes because of the
non-determinism of the order of missing_libs.