### PR TITLE
Fixed indirect_jump_resolvers reusing func_addr for ijk_calls to outs…

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2532,7 +2532,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         jump.resolved_targets = targets
         all_targets = set(targets)
         for addr in all_targets:
-            to_outside = addr in self.functions or not self._addrs_belong_to_same_section(jump.addr, addr)
+            to_outside = jump.jumpkind == 'Ijk_Call' or addr in self.functions or not self._addrs_belong_to_same_section(jump.addr, addr)
 
             # TODO: get a better estimate of the function address
             target_func_addr = jump.func_addr if not to_outside else addr


### PR DESCRIPTION
…ide functions

When updating targets for a resolved indirect_jump in cfg_fast, to_outside
does not consider that an ijk_call is naturally a jump to an outside function
and should be set to True for any ijk_call jumpkind.