### PR TITLE
SimSymbolicMemory: optionally add constraint in make_symbolic

### DIFF
--- a/angr/state_plugins/symbolic_memory.py
+++ b/angr/state_plugins/symbolic_memory.py
@@ -296,9 +296,9 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
     # Symbolicizing!
     #
 
-    def make_symbolic(self, name, addr, length=None):
+    def make_symbolic(self, name, addr, length=None, add_constraints=True):
         """
-        Replaces `length` bytes starting at `addr` with a symbolic variable named name. Adds a constraint equaling that
+        Replaces `length` bytes starting at `addr` with a symbolic variable named name. Optionally adds a constraint equaling that
         symbolic variable to the value previously at `addr`, and returns the variable.
         """
         l.debug("making %s bytes symbolic", length)
@@ -312,9 +312,12 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         r = self.load(addr, length)
 
         v = self.get_unconstrained_bytes(name, r.size())
-        self.store(addr, v)
-        self.state.add_constraints(r == v)
-        l.debug("... eq constraints: %s", r == v)
+        self.store(addr, v, add_constraints=add_constraints)
+
+        if add_constraints:
+            self.state.add_constraints(r == v)
+            l.debug("... eq constraints: %s", r == v)
+
         return v
 
     #


### PR DESCRIPTION
Without this change, `SimSymbolicMemory.make_symbolic` always adds a
constraint equaling the value previously stored at the given address.
Occasionally it might be desirable to make memory symbolic without
adding such a constraint, thus this commit introduces a new named
parameter which allows configuring this behavior.

IMHO, this is more intuitive than manually making memory symbolic
using `SimSymbolicMemory.get_unconstrained_bytes()` and
`SimSymbolicMemory.store()` when needing unconstrained symbolic memory.