### PR TITLE
VR-AIL: Recognize stack variables that are only referenced once.

### DIFF
--- a/angr/analyses/typehoon/typevars.py
+++ b/angr/analyses/typehoon/typevars.py
@@ -1,5 +1,8 @@
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, TYPE_CHECKING
 from itertools import count
+
+if TYPE_CHECKING:
+    from angr.sim_variable import SimVariable
 
 
 # Type variables and constraints
@@ -292,7 +295,7 @@ class DerivedTypeVariable(TypeVariable):
 
 class TypeVariables:
     def __init__(self):
-        self._typevars = { }
+        self._typevars: Dict[SimVariable,TypeVariable] = { }
 
     def merge(self, tvs):
         merged = TypeVariables()
@@ -315,7 +318,7 @@ class TypeVariables:
         #)
         return "{TypeVars: %d items}" % len(self._typevars)
 
-    def add_type_variable(self, var, codeloc, typevar):  # pylint:disable=unused-argument
+    def add_type_variable(self, var: 'SimVariable', codeloc, typevar: TypeVariable):  # pylint:disable=unused-argument
 
         #if var not in self._typevars:
         #    self._typevars[var] = { }
@@ -328,7 +331,7 @@ class TypeVariables:
 
         return self._typevars[var] #[codeloc]
 
-    def has_type_variable_for(self, var, codeloc):  # pylint:disable=unused-argument
+    def has_type_variable_for(self, var: 'SimVariable', codeloc):  # pylint:disable=unused-argument
         if var not in self._typevars:
             return False
         return True

--- a/angr/analyses/typehoon/typevars.py
+++ b/angr/analyses/typehoon/typevars.py
@@ -295,7 +295,7 @@ class DerivedTypeVariable(TypeVariable):
 
 class TypeVariables:
     def __init__(self):
-        self._typevars: Dict[SimVariable,TypeVariable] = { }
+        self._typevars: Dict['SimVariable',TypeVariable] = { }
 
     def merge(self, tvs):
         merged = TypeVariables()

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -161,10 +161,10 @@ class SimEngineVRAIL(
 
         return RichR(r.data, typevar=typevar)
 
-    def _ail_handle_StackBaseOffset(self, expr):
-        return RichR(
-            SpOffset(self.arch.bits, expr.offset, is_base=False)
-        )
+    def _ail_handle_StackBaseOffset(self, expr: ailment.Expr.StackBaseOffset):
+        richr = RichR(SpOffset(self.arch.bits, expr.offset, is_base=False))
+        self._reference(richr, self._codeloc(), src=expr)
+        return richr
 
     def _ail_handle_ITE(self, expr: ailment.Expr.ITE):
         # pylint:disable=unused-variable

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set
+from typing import Optional, Set, List, Tuple
 import logging
 
 from ...engines.light import SimEngineLight, SpOffset, ArithmeticExpression
@@ -72,6 +72,47 @@ class SimEngineVRBase(SimEngineLight):
     # Logic
     #
 
+    def _reference(self, richr: RichR, codeloc: CodeLocation, src=None):
+        data = richr.data
+        stack_offset = data.offset
+        existing_vars: List[Tuple[SimVariable,int]] = self.variable_manager[self.func_addr].find_variables_by_stmt(
+            self.block.addr,
+            self.stmt_idx,
+            'memory')
+
+        # find the correct variable
+        variable = None
+        for v, offset in existing_vars:
+            if offset == stack_offset:
+                variable = v
+                break
+
+        if variable is None:
+            # TODO: how to determine the size for a lea?
+            existing_vars = self.state.stack_region.get_variables_by_offset(stack_offset)
+            if not existing_vars:
+                lea_size = 1
+                variable = SimStackVariable(stack_offset, lea_size, base='bp',
+                                            ident=self.variable_manager[self.func_addr].next_variable_ident(
+                                                'stack'),
+                                            region=self.func_addr,
+                                            )
+
+                self.variable_manager[self.func_addr].add_variable('stack', stack_offset, variable)
+                l.debug('Identified a new stack variable %s at %#x.', variable, self.ins_addr)
+            else:
+                variable = next(iter(existing_vars))
+
+        self.state.stack_region.add_variable(stack_offset, variable)
+        typevar = typevars.TypeVariable() if richr.typevar is None else richr.typevar
+        self.state.typevars.add_type_variable(variable, codeloc, typevar)
+        base_offset = self.state.stack_region.get_base_addr(stack_offset)
+        for var in self.state.stack_region.get_variables_by_offset(base_offset):
+            offset_into_var = stack_offset - base_offset
+            if offset_into_var == 0: offset_into_var = None
+            self.variable_manager[self.func_addr].reference_at(var, offset_into_var, codeloc,
+                                                               atom=src)
+
     def _assign_to_register(self, offset, richr, size, src=None, dst=None):
         """
 
@@ -81,7 +122,7 @@ class SimEngineVRBase(SimEngineLight):
         :return:
         """
 
-        codeloc = self._codeloc()  # type: CodeLocation
+        codeloc: CodeLocation = self._codeloc()
         data = richr.data
 
         if offset == self.arch.sp_offset:
@@ -114,40 +155,7 @@ class SimEngineVRBase(SimEngineLight):
 
         if type(data) is SpOffset and isinstance(data.offset, int):
             # lea
-            stack_offset = data.offset
-            existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(self.block.addr,
-                                                                                         self.stmt_idx,
-                                                                                         'memory')
-
-            if not existing_vars:
-                # TODO: how to determine the size for a lea?
-                existing_vars = self.state.stack_region.get_variables_by_offset(stack_offset)
-                if not existing_vars:
-                    lea_size = 1
-                    variable = SimStackVariable(stack_offset, lea_size, base='bp',
-                                                ident=self.variable_manager[self.func_addr].next_variable_ident(
-                                                    'stack'),
-                                                region=self.func_addr,
-                                                )
-
-                    self.variable_manager[self.func_addr].add_variable('stack', stack_offset, variable)
-                    l.debug('Identified a new stack variable %s at %#x.', variable, self.ins_addr)
-                else:
-                    variable = next(iter(existing_vars))
-
-            else:
-                variable, _ = existing_vars[0]
-
-            self.state.stack_region.add_variable(stack_offset, variable)
-            typevar = typevars.TypeVariable() if richr.typevar is None else richr.typevar
-            self.state.typevars.add_type_variable(variable, codeloc, typevar)
-            base_offset = self.state.stack_region.get_base_addr(stack_offset)
-            for var in self.state.stack_region.get_variables_by_offset(base_offset):
-                offset_into_var = stack_offset - base_offset
-                if offset_into_var == 0: offset_into_var = None
-                self.variable_manager[self.func_addr].reference_at(var, offset_into_var, codeloc,
-                                                                   atom=src)
-
+            self._reference(richr, codeloc, src=src)
         else:
             pass
 

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -264,6 +264,8 @@ def test_decompiling_1after999():
     dec = p.analyses.Decompiler(f, cfg=cfg)
     if dec.codegen is not None:
         code = dec.codegen.text
+        assert "stack_base" not in code, "Some stack variables are not recognized"
+        assert "strncmp(s_78, &s_58, 0x40);" in code
         print(code)
     else:
         print("Failed to decompile function %r." % f)


### PR DESCRIPTION
Before:

```
ir_7 = strncmp(s_78, &stack_base-88, 0x40);
```

After:

```
ir_7 = strncmp(s_78, &s_58, 0x40);
```