### PR TITLE
fix #2264: handle ZeroDivsionError in SimEngineLightVEXMixin

### DIFF
--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -423,6 +423,9 @@ class SimEngineLightVEXMixin:
         except TypeError as e:
             self.l.warning(e)
             return None
+        except ZeroDivisionError as e:
+            self.l.warning(e)
+            return None
 
     def _handle_Xor(self, expr):
         arg0, arg1 = expr.args


### PR DESCRIPTION
Add `ZeroDivisionError` exception handling when dealing with `div` statements.