### PR TITLE
feture request #2271: passing register value for propagator analysis.

### DIFF
--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -370,7 +370,16 @@ class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-
             state = PropagatorAILState(arch=self.project.arch, only_consts=self._only_consts)
         else:
             # VEX
-            state = PropagatorVEXState(arch=self.project.arch, only_consts=self._only_consts)
+            # load registers from base_state
+            registers = {}
+            if self._base_state:
+                for reg_name in self.project.arch.register_names.values():
+                    bv = self._base_state.registers.load(reg_name)
+                    if bv.concrete:
+                        value = self._base_state.solver.eval(bv)
+                        registers[self.project.arch.get_register_offset(reg_name)] = value
+
+            state = PropagatorVEXState(arch=self.project.arch, only_consts=self._only_consts, registers=registers)
             state.store_register(self.project.arch.sp_offset,
                                  self.project.arch.bytes,
                                  SpOffset(self.project.arch.bits, 0)

--- a/tests/test_constantpropagation.py
+++ b/tests/test_constantpropagation.py
@@ -41,7 +41,23 @@ def test_lwip_udpecho_bm():
 
     nose.tools.assert_greater(len(prop.replacements), 0)
 
+def test_mips_drapa_ping():
+    bin_path = os.path.join(test_location, "mipsel", "darpa_ping")
+    p = angr.Project(bin_path, auto_load_libs=False)
+    cfg = p.analyses.CFG(data_references=False)
+    func = cfg.functions[0x402f54]
+    state = p.factory.blank_state()
+    state.regs.t9 = func.addr
+    prop = p.analyses.Propagator(func=func, base_state=state, only_consts=True)
+    target_replacement = None
+    for loc, replacement in prop.replacements.items():
+        if loc.block_addr == 0x403338:
+            target_replacement = replacement
+
+    consts = list(filter(lambda x: type(x) == int, target_replacement.values()))
+    nose.tools.assert_in(0x408198, consts)
 
 if __name__ == "__main__":
     test_libc_x86()
     test_lwip_udpecho_bm()
+    test_mips_drapa_ping()


### PR DESCRIPTION
Loading the corresponding register value from `base_state` if it has a concrete value, so we can propagate the value.
My intent was passing the correct `$t9` value for mips binaries when performing propagation analysis, so we can collect references.