### PR TITLE
UnicornEngine: Don't need to skip syscall instrution anymore. 

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -553,7 +553,7 @@ class Unicorn(SimStatePlugin):
             sysno = uc.reg_read(self._uc_regs['v0'])
             pc = uc.reg_read(self._uc_regs['pc'])
             l.debug('hit sys_%d at %#x', sysno, pc)
-            self._syscall_pc = pc
+            self._syscall_pc = pc + 4  # skip syscall instruction
             self._handle_syscall(uc, user_data)
         else:
             l.warning('unhandled interrupt %d', intno)
@@ -585,7 +585,7 @@ class Unicorn(SimStatePlugin):
         sysno = uc.reg_read(self._uc_regs['rax'])
         pc = uc.reg_read(self._uc_regs['rip'])
         l.debug('hit sys_%d at %#x', sysno, pc)
-        self._syscall_pc = pc
+        self._syscall_pc = pc + 2  # skip syscall instruction
         self._handle_syscall(uc, user_data)
 
     def _hook_syscall_i386(self, uc, user_data):

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -553,7 +553,7 @@ class Unicorn(SimStatePlugin):
             sysno = uc.reg_read(self._uc_regs['v0'])
             pc = uc.reg_read(self._uc_regs['pc'])
             l.debug('hit sys_%d at %#x', sysno, pc)
-            self._syscall_pc = pc + 4
+            self._syscall_pc = pc
             self._handle_syscall(uc, user_data)
         else:
             l.warning('unhandled interrupt %d', intno)
@@ -585,14 +585,14 @@ class Unicorn(SimStatePlugin):
         sysno = uc.reg_read(self._uc_regs['rax'])
         pc = uc.reg_read(self._uc_regs['rip'])
         l.debug('hit sys_%d at %#x', sysno, pc)
-        self._syscall_pc = pc + 2 # skip syscall instruction
+        self._syscall_pc = pc
         self._handle_syscall(uc, user_data)
 
     def _hook_syscall_i386(self, uc, user_data):
         sysno = uc.reg_read(self._uc_regs['eax'])
         pc = uc.reg_read(self._uc_regs['eip'])
         l.debug('hit sys_%d at %#x', sysno, pc)
-        self._syscall_pc = pc + 2
+        self._syscall_pc = pc
         if not self._quick_syscall(sysno):
             self._handle_syscall(uc, user_data)
 
@@ -1282,9 +1282,6 @@ class Unicorn(SimStatePlugin):
 
         # some architecture-specific register fixups
         if self.state.arch.name in ('X86', 'AMD64'):
-            if self.jumpkind.startswith('Ijk_Sys'):
-                self.state.registers.store('ip_at_syscall', self.state.regs.ip - 2)
-
             # update the eflags
             self.state.regs.eflags = self.state.solver.BVV(self.uc.reg_read(self._uc_const.UC_X86_REG_EFLAGS), self.state.arch.bits)
 

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
         # https://www.python.org/dev/peps/pep-0425/
         sys.argv.append(name.replace('.', '_').replace('-', '_'))
 
-_UNICORN = "unicorn>=1.0.2rc2"
+_UNICORN = "unicorn>=1.0.2rc4"
 
 setup(
     name='angr',


### PR DESCRIPTION
This should handle a behavior change in the most recent unicorn engine RC release.

EDIT: The syscall hook callback in Unicorn 1.0.2rc4 behaves differently for x86 and amd64. On x86 guests the pc points to the instruction after the `int 80h` instruction. On amd64 guests the pc points to the `syscall` instruction. Not sure about MIPS, but we do not seem to support using unicorn on MIPS anyway.

This is probably a bug in the latest unicorn. @rhelmot might be able to find the deeper issue hidden in unicorn.