### PR TITLE
Improve RDA: Tag definitions on function calls

### DIFF
--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -628,9 +628,9 @@ class SimEngineRDVEX(
                     reg_offset, reg_size = self.arch.registers[cc.RETURN_VAL.reg_name]
                     atom = Register(reg_offset, reg_size)
                     if func_addr is not None and len(func_addr) == 1 and self.functions is not None and type(func_addr_int) != Undefined:
-                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tag=ReturnValueTag(metadata=hex(func_addr_int)))
+                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tags={ReturnValueTag(metadata=hex(func_addr_int))})
                     else:
-                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tag=ReturnValueTag())
+                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tags={ReturnValueTag()})
 
             if cc.CALLER_SAVED_REGS is not None:
                 for reg in cc.CALLER_SAVED_REGS:

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -6,11 +6,11 @@ import pyvex
 from ...engines.light import SimEngineLight, SimEngineLightVEXMixin, SpOffset, RegisterOffset
 from ...engines.vex.claripy.irop import operations as vex_operations
 from ...errors import SimEngineError
-from ...calling_conventions import DEFAULT_CC, SimRegArg, SimStackArg
+from ...calling_conventions import DEFAULT_CC, SimRegArg, SimStackArg, SimCC
 from ...utils.constants import DEFAULT_STATEMENT
 from ...knowledge_plugins.key_definitions.definition import Definition
-from ...knowledge_plugins.key_definitions.tag import ReturnValueTag
-from ...knowledge_plugins.key_definitions.atoms import Register, MemoryLocation, Parameter, Tmp
+from ...knowledge_plugins.key_definitions.tag import LocalVariableTag, ParameterTag, ReturnValueTag, Tag
+from ...knowledge_plugins.key_definitions.atoms import Atom, Register, MemoryLocation, Parameter, Tmp
 from ...knowledge_plugins.key_definitions.constants import OP_BEFORE, OP_AFTER
 from ...knowledge_plugins.key_definitions.dataset import DataSet
 from ...knowledge_plugins.key_definitions.undefined import Undefined, undefined
@@ -19,7 +19,6 @@ from .rd_state import ReachingDefinitionsState
 from .external_codeloc import ExternalCodeLocation
 
 if TYPE_CHECKING:
-    from ...calling_conventions import SimCC
     from ...knowledge_plugins import FunctionManager
 
 
@@ -596,47 +595,45 @@ class SimEngineRDVEX(
 
         return skip_cc
 
-    def _handle_function_cc(self, func_addr: Optional[DataSet]):  # pylint:disable=unused-argument
-
-        cc: Optional['SimCC'] = None
+    def _handle_function_cc(self, func_addr: Optional[DataSet]):
+        _cc = None
         if func_addr is not None and len(func_addr) == 1 and self.functions is not None:
-            func_addr_int = next(iter(func_addr))
+            func_addr_int: Union[int,Undefined] = next(iter(func_addr))
             if self.functions.contains_addr(func_addr_int):
-                cc = self.functions[func_addr_int].calling_convention
+                _cc = self.functions[func_addr_int].calling_convention
+        cc: SimCC = _cc or DEFAULT_CC.get(self.arch.name, None)(self.arch)
 
-        if cc is None:
-            cc = DEFAULT_CC.get(self.arch.name, None)(self.arch)
-
-        if cc is not None:
-            # follow the calling convention and:
-            # - add uses for arguments
-            # - kill return value registers
-            # - caller-saving registers
-            if cc.args:
-                code_loc = self._codeloc()
-                for arg in cc.args:
-                    if isinstance(arg, SimRegArg):
-                        reg_offset, reg_size = self.arch.registers[arg.reg_name]
-                        self.state.add_use(Register(reg_offset, reg_size), code_loc)
-                    elif isinstance(arg, SimStackArg):
-                        self.state.add_use(MemoryLocation(SpOffset(self.arch.bits,
-                                                                   arg.stack_offset),
-                                                          arg.size * self.arch.byte_width),
-                                           code_loc)
-            if cc.RETURN_VAL is not None:
-                if isinstance(cc.RETURN_VAL, SimRegArg):
-                    reg_offset, reg_size = self.arch.registers[cc.RETURN_VAL.reg_name]
+        # follow the calling convention and:
+        # - add uses for arguments
+        # - kill return value registers
+        # - caller-saving registers
+        if cc.args:
+            code_loc = self._codeloc()
+            for arg in cc.args:
+                if isinstance(arg, SimRegArg):
+                    reg_offset, reg_size = self.arch.registers[arg.reg_name]
                     atom = Register(reg_offset, reg_size)
-                    if func_addr is not None and len(func_addr) == 1 and self.functions is not None and type(func_addr_int) != Undefined:
-                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tags={ReturnValueTag(metadata=hex(func_addr_int))})
-                    else:
-                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tags={ReturnValueTag()})
+                elif isinstance(arg, SimStackArg):
+                    atom = MemoryLocation(SpOffset(self.arch.bits,
+                                          arg.stack_offset),
+                                          arg.size * self.arch.byte_width)
+                self.state.add_use(atom, code_loc)
+                self._tag_definitions_of_atom(atom, func_addr_int)
 
-            if cc.CALLER_SAVED_REGS is not None:
-                for reg in cc.CALLER_SAVED_REGS:
-                    reg_offset, reg_size = self.arch.registers[reg]
-                    atom = Register(reg_offset, reg_size)
-                    self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8))
+        if cc.RETURN_VAL is not None:
+            if isinstance(cc.RETURN_VAL, SimRegArg):
+                reg_offset, reg_size = self.arch.registers[cc.RETURN_VAL.reg_name]
+                atom = Register(reg_offset, reg_size)
+                if type(func_addr_int) != Undefined:
+                    self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tags={ReturnValueTag(metadata=hex(func_addr_int))})
+                else:
+                    self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tags={ReturnValueTag()})
+
+        if cc.CALLER_SAVED_REGS is not None:
+            for reg in cc.CALLER_SAVED_REGS:
+                reg_offset, reg_size = self.arch.registers[reg]
+                atom = Register(reg_offset, reg_size)
+                self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8))
 
         if self.arch.call_pushes_ret is True:
             # pop return address if necessary
@@ -663,4 +660,17 @@ class SimEngineRDVEX(
                 raise TypeError('Invalid type %s for stack pointer.' % type(sp_addr).__name__)
 
             atom = Register(self.arch.sp_offset, self.arch.bytes)
-            self.state.kill_and_add_definition(atom, self._codeloc(), DataSet(sp_addr, self.arch.bits))
+            tag = ReturnValueTag(metadata = {
+                'tagged_by': 'SimEngineRDVEX._handle_function_cc',
+                'function': hex(func_addr_int)
+            })
+            self.state.kill_and_add_definition(atom, self._codeloc(), DataSet(sp_addr, self.arch.bits), tags={tag})
+
+    def _tag_definitions_of_atom(self, atom: Atom, func_addr: int):
+        definitions = self.state.get_definitions(atom)
+        tag = ParameterTag(
+            function = func_addr,
+            metadata = {'tagged_by': 'SimEngineRDVEX._handle_function_cc'}
+        )
+        for definition in definitions:
+            definition.tags |= {tag}

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -8,7 +8,8 @@ from ...engines.vex.claripy.irop import operations as vex_operations
 from ...errors import SimEngineError
 from ...calling_conventions import DEFAULT_CC, SimRegArg, SimStackArg
 from ...utils.constants import DEFAULT_STATEMENT
-from ...knowledge_plugins.key_definitions.definition import Definition, RetValueTag
+from ...knowledge_plugins.key_definitions.definition import Definition
+from ...knowledge_plugins.key_definitions.tag import ReturnValueTag
 from ...knowledge_plugins.key_definitions.atoms import Register, MemoryLocation, Parameter, Tmp
 from ...knowledge_plugins.key_definitions.constants import OP_BEFORE, OP_AFTER
 from ...knowledge_plugins.key_definitions.dataset import DataSet
@@ -627,9 +628,9 @@ class SimEngineRDVEX(
                     reg_offset, reg_size = self.arch.registers[cc.RETURN_VAL.reg_name]
                     atom = Register(reg_offset, reg_size)
                     if func_addr is not None and len(func_addr) == 1 and self.functions is not None and type(func_addr_int) != Undefined:
-                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tag=RetValueTag(metadata=hex(func_addr_int)))
+                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tag=ReturnValueTag(metadata=hex(func_addr_int)))
                     else:
-                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tag=RetValueTag())
+                        self.state.kill_and_add_definition(atom, self._codeloc(), DataSet({undefined}, reg_size * 8), tag=ReturnValueTag())
 
             if cc.CALLER_SAVED_REGS is not None:
                 for reg in cc.CALLER_SAVED_REGS:

--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -127,13 +127,13 @@ class ReachingDefinitionsState:
     def _initialize_function(self, cc: SimCC, func_addr: int, rtoc_value: Optional[int]=None):
         # initialize stack pointer
         sp = Register(self.arch.sp_offset, self.arch.bytes)
-        sp_def = Definition(sp, ExternalCodeLocation(), DataSet(SpOffset(self.arch.bits, 0), self.arch.bits), tag=InitialValueTag())
+        sp_def = Definition(sp, ExternalCodeLocation(), DataSet(SpOffset(self.arch.bits, 0), self.arch.bits), tags={InitialValueTag()})
         self.register_definitions.set_object(sp_def.offset, sp_def, sp_def.size)
         if self.arch.name.startswith('MIPS'):
             if func_addr is None:
                 l.warning("func_addr must not be None to initialize a function in mips")
             t9 = Register(self.arch.registers['t9'][0], self.arch.bytes)
-            t9_def = Definition(t9, ExternalCodeLocation(), DataSet(func_addr, self.arch.bits), tag=InitialValueTag())
+            t9_def = Definition(t9, ExternalCodeLocation(), DataSet(func_addr, self.arch.bits), tags={InitialValueTag()})
             self.register_definitions.set_object(t9_def.offset,t9_def,t9_def.size)
 
         if cc is not None and cc.args is not None:
@@ -143,13 +143,13 @@ class ReachingDefinitionsState:
                     # FIXME: implement reg_offset handling in SimRegArg
                     reg_offset = self.arch.registers[arg.reg_name][0]
                     reg = Register(reg_offset, self.arch.bytes)
-                    reg_def = Definition(reg, ExternalCodeLocation(), DataSet(undefined, self.arch.bits), tag=ParameterTag())
+                    reg_def = Definition(reg, ExternalCodeLocation(), DataSet(undefined, self.arch.bits), tags={ParameterTag()})
                     self.register_definitions.set_object(reg.reg_offset, reg_def, reg.size)
                 # initialize stack parameters
                 elif isinstance(arg, SimStackArg):
                     sp_offset = SpOffset(self.arch.bits, arg.stack_offset)
                     ml = MemoryLocation(sp_offset, arg.size)
-                    ml_def = Definition(ml, ExternalCodeLocation(), DataSet(undefined, arg.size * 8), tag=ParameterTag())
+                    ml_def = Definition(ml, ExternalCodeLocation(), DataSet(undefined, arg.size * 8), tags={ParameterTag()})
                     self.stack_definitions.set_object(arg.stack_offset, ml_def, ml.size)
                 else:
                     raise TypeError('Unsupported parameter type %s.' % type(arg).__name__)
@@ -160,12 +160,12 @@ class ReachingDefinitionsState:
                 raise TypeError("rtoc_value must be provided on PPC64.")
             offset, size = self.arch.registers['rtoc']
             rtoc = Register(offset, size)
-            rtoc_def = Definition(rtoc, ExternalCodeLocation(), DataSet(rtoc_value, self.arch.bits), tag=InitialValueTag())
+            rtoc_def = Definition(rtoc, ExternalCodeLocation(), DataSet(rtoc_value, self.arch.bits), tags=InitialValueTag())
             self.register_definitions.set_object(rtoc.reg_offset, rtoc_def, rtoc.size)
         elif self.arch.name.lower().find('mips64') > -1:
             offset, size = self.arch.registers['t9']
             t9 = Register(offset, size)
-            t9_def = Definition(t9, ExternalCodeLocation(), DataSet({func_addr}, self.arch.bits), tag=InitialValueTag())
+            t9_def = Definition(t9, ExternalCodeLocation(), DataSet({func_addr}, self.arch.bits), tags=InitialValueTag())
             self.register_definitions.set_object(t9.reg_offset, t9_def, t9.size)
 
     def copy(self) -> 'ReachingDefinitionsState':
@@ -206,7 +206,7 @@ class ReachingDefinitionsState:
             self.current_codeloc = code_loc
             self.codeloc_uses = set()
 
-    def kill_definitions(self, atom: Atom, code_loc: CodeLocation, data: Optional[DataSet]=None, dummy=True, tag: Tag=None) -> None:
+    def kill_definitions(self, atom: Atom, code_loc: CodeLocation, data: Optional[DataSet]=None, dummy=True, tags: Set[Tag]=None) -> None:
         """
         Overwrite existing definitions w.r.t 'atom' with a dummy definition instance. A dummy definition will not be
         removed during simplification.
@@ -220,14 +220,14 @@ class ReachingDefinitionsState:
         if data is None:
             data = DataSet(undefined, atom.size)
 
-        self.kill_and_add_definition(atom, code_loc, data, dummy=dummy, tag=tag)
+        self.kill_and_add_definition(atom, code_loc, data, dummy=dummy, tags=tags)
 
     def kill_and_add_definition(self, atom: Atom, code_loc: CodeLocation, data: Optional[DataSet],
-                                dummy=False, tag: Tag=None) -> Optional[Definition]:
+                                dummy=False, tags: Set[Tag]=None) -> Optional[Definition]:
         self._cycle(code_loc)
 
         definition: Optional[Definition]
-        definition = self.live_definitions.kill_and_add_definition(atom, code_loc, data, dummy=dummy, tag=tag)
+        definition = self.live_definitions.kill_and_add_definition(atom, code_loc, data, dummy=dummy, tags=tags)
 
         if definition is not None:
             self.all_definitions.add(definition)

--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -5,7 +5,8 @@ import archinfo
 
 from ...knowledge_plugins.key_definitions import LiveDefinitions
 from ...knowledge_plugins.key_definitions.atoms import Atom, GuardUse, Register, MemoryLocation
-from ...knowledge_plugins.key_definitions.definition import Definition, Tag, ParamTag, InitValueTag
+from ...knowledge_plugins.key_definitions.definition import Definition
+from ...knowledge_plugins.key_definitions.tag import InitialValueTag, ParameterTag, Tag
 from ...knowledge_plugins.key_definitions.undefined import undefined
 from ...knowledge_plugins.key_definitions.dataset import DataSet
 from ...calling_conventions import SimCC, SimRegArg, SimStackArg
@@ -126,13 +127,13 @@ class ReachingDefinitionsState:
     def _initialize_function(self, cc: SimCC, func_addr: int, rtoc_value: Optional[int]=None):
         # initialize stack pointer
         sp = Register(self.arch.sp_offset, self.arch.bytes)
-        sp_def = Definition(sp, ExternalCodeLocation(), DataSet(SpOffset(self.arch.bits, 0), self.arch.bits), tag=InitValueTag())
+        sp_def = Definition(sp, ExternalCodeLocation(), DataSet(SpOffset(self.arch.bits, 0), self.arch.bits), tag=InitialValueTag())
         self.register_definitions.set_object(sp_def.offset, sp_def, sp_def.size)
         if self.arch.name.startswith('MIPS'):
             if func_addr is None:
                 l.warning("func_addr must not be None to initialize a function in mips")
             t9 = Register(self.arch.registers['t9'][0], self.arch.bytes)
-            t9_def = Definition(t9, ExternalCodeLocation(), DataSet(func_addr, self.arch.bits), tag=InitValueTag())
+            t9_def = Definition(t9, ExternalCodeLocation(), DataSet(func_addr, self.arch.bits), tag=InitialValueTag())
             self.register_definitions.set_object(t9_def.offset,t9_def,t9_def.size)
 
         if cc is not None and cc.args is not None:
@@ -142,13 +143,13 @@ class ReachingDefinitionsState:
                     # FIXME: implement reg_offset handling in SimRegArg
                     reg_offset = self.arch.registers[arg.reg_name][0]
                     reg = Register(reg_offset, self.arch.bytes)
-                    reg_def = Definition(reg, ExternalCodeLocation(), DataSet(undefined, self.arch.bits), tag=ParamTag())
+                    reg_def = Definition(reg, ExternalCodeLocation(), DataSet(undefined, self.arch.bits), tag=ParameterTag())
                     self.register_definitions.set_object(reg.reg_offset, reg_def, reg.size)
                 # initialize stack parameters
                 elif isinstance(arg, SimStackArg):
                     sp_offset = SpOffset(self.arch.bits, arg.stack_offset)
                     ml = MemoryLocation(sp_offset, arg.size)
-                    ml_def = Definition(ml, ExternalCodeLocation(), DataSet(undefined, arg.size * 8), tag=ParamTag())
+                    ml_def = Definition(ml, ExternalCodeLocation(), DataSet(undefined, arg.size * 8), tag=ParameterTag())
                     self.stack_definitions.set_object(arg.stack_offset, ml_def, ml.size)
                 else:
                     raise TypeError('Unsupported parameter type %s.' % type(arg).__name__)
@@ -159,12 +160,12 @@ class ReachingDefinitionsState:
                 raise TypeError("rtoc_value must be provided on PPC64.")
             offset, size = self.arch.registers['rtoc']
             rtoc = Register(offset, size)
-            rtoc_def = Definition(rtoc, ExternalCodeLocation(), DataSet(rtoc_value, self.arch.bits), tag=InitValueTag())
+            rtoc_def = Definition(rtoc, ExternalCodeLocation(), DataSet(rtoc_value, self.arch.bits), tag=InitialValueTag())
             self.register_definitions.set_object(rtoc.reg_offset, rtoc_def, rtoc.size)
         elif self.arch.name.lower().find('mips64') > -1:
             offset, size = self.arch.registers['t9']
             t9 = Register(offset, size)
-            t9_def = Definition(t9, ExternalCodeLocation(), DataSet({func_addr}, self.arch.bits), tag=InitValueTag())
+            t9_def = Definition(t9, ExternalCodeLocation(), DataSet({func_addr}, self.arch.bits), tag=InitialValueTag())
             self.register_definitions.set_object(t9.reg_offset, t9_def, t9.size)
 
     def copy(self) -> 'ReachingDefinitionsState':

--- a/angr/knowledge_plugins/key_definitions/definition.py
+++ b/angr/knowledge_plugins/key_definitions/definition.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 from ...engines.light import SpOffset
 from ...code_location import CodeLocation
 from .atoms import Atom, MemoryLocation, Register
@@ -14,27 +16,28 @@ class Definition:
     :ivar data:     A concrete value (or many concrete values) that the atom holds when the definition is created.
     :ivar dummy:    Tell whether the definition should be considered dummy or not. During simplification by AILment,
                     definitions marked as dummy will not be removed.
+    :ivar tags:     A set of tags containing information about the definition gathered during analyses.
     """
 
-    __slots__ = ('atom', 'codeloc', 'data', 'dummy', 'tag')
+    __slots__ = ('atom', 'codeloc', 'data', 'dummy', 'tags')
 
-    def __init__(self, atom: Atom, codeloc: CodeLocation, data: DataSet, dummy: bool=False, tag: Tag=None):
+    def __init__(self, atom: Atom, codeloc: CodeLocation, data: DataSet, dummy: bool=False, tags: Set[Tag]=None):
 
         self.atom: Atom = atom
         self.codeloc: CodeLocation = codeloc
         self.dummy: bool = dummy
         self.data: DataSet = data
-        self.tag = tag
+        self.tags = tags or set()
 
     def __eq__(self, other):
         return self.atom == other.atom and self.codeloc == other.codeloc
 
     def __repr__(self):
-        if not self.tag:
+        if not self.tags:
             return '<Definition {Atom:%s, Codeloc:%s, Data:%s%s}>' % (self.atom, self.codeloc, self.data,
                                                                   "" if not self.dummy else "dummy")
         else:
-            return '<Definition {Tag:%s, Atom:%s, Codeloc:%s, Data:%s%s}>' % (repr(self.tag), self.atom, self.codeloc, self.data,
+            return '<Definition {Tags:%s, Atom:%s, Codeloc:%s, Data:%s%s}>' % (repr(self.tags), self.atom, self.codeloc, self.data,
                                                                   "" if not self.dummy else " dummy")
     def __hash__(self):
         return hash((self.atom, self.codeloc))

--- a/angr/knowledge_plugins/key_definitions/definition.py
+++ b/angr/knowledge_plugins/key_definitions/definition.py
@@ -2,52 +2,7 @@ from ...engines.light import SpOffset
 from ...code_location import CodeLocation
 from .atoms import Atom, MemoryLocation, Register
 from .dataset import DataSet
-
-
-class Tag:
-    """
-    A tag for a Definition that can carry different kinds of metadata.
-    """
-    def __repr__(self):
-        raise NotImplementedError()
-
-
-class ParamTag(Tag):
-    """
-    A tag for a definition of a parameter.
-    """
-
-    def __init__(self, metadata: object=None):
-        super(ParamTag, self).__init__()
-        self.metadata = metadata
-
-    def __repr__(self):
-        return '<ParamTag {Metadata:%s}>' % (self.metadata)
-
-
-class RetValueTag(Tag):
-    """
-    A tag for a definiton of a return value
-    of a function.
-    """
-    def __init__(self, metadata: object=None):
-        super(RetValueTag, self).__init__()
-        self.metadata = metadata
-
-    def __repr__(self):
-        return '<RetValueTag {Metadata:%s}>' % (self.metadata)
-
-
-class InitValueTag(Tag):
-    """
-    A tag for a definiton of an initial value
-    """
-    def __init__(self, metadata: object=None):
-        super(InitValueTag, self).__init__()
-        self.metadata = metadata
-
-    def __repr__(self):
-        return '<InitValueTag {Metadata:%s}>' % (self.metadata)
+from .tag import Tag
 
 
 class Definition:

--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -95,7 +95,7 @@ class LiveDefinitions:
 
         return state
 
-    def kill_definitions(self, atom: Atom, code_loc: CodeLocation, data: Optional[DataSet]=None, dummy=True, tag: Tag=None) -> None:
+    def kill_definitions(self, atom: Atom, code_loc: CodeLocation, data: Optional[DataSet]=None, dummy=True, tags: Set[Tag]=None) -> None:
         """
         Overwrite existing definitions w.r.t 'atom' with a dummy definition instance. A dummy definition will not be
         removed during simplification.
@@ -106,12 +106,12 @@ class LiveDefinitions:
         """
 
         data = DataSet(undefined, atom.size)
-        self.kill_and_add_definition(atom, code_loc, data, dummy=dummy, tag=tag)
+        self.kill_and_add_definition(atom, code_loc, data, dummy=dummy, tags=tags)
 
     def kill_and_add_definition(self, atom: Atom, code_loc: CodeLocation, data: Optional[DataSet],
-                                dummy=False, tag: Tag=None) -> Optional[Definition]:
+                                dummy=False, tags: Set[Tag]=None) -> Optional[Definition]:
         data = data or DataSet(undefined, atom.size)
-        definition: Definition = Definition(atom, code_loc, data, dummy=dummy, tag=tag)
+        definition: Definition = Definition(atom, code_loc, data, dummy=dummy, tags=tags)
 
         # set_object() replaces kill (not implemented) and add (add) in one step
         if isinstance(atom, Register):

--- a/angr/knowledge_plugins/key_definitions/tag.py
+++ b/angr/knowledge_plugins/key_definitions/tag.py
@@ -1,3 +1,14 @@
+"""
+Classes to structure the different types of <Tag>s that can be attached to <Definition>s.
+
+- Tag
+    - FunctionTag
+        - ParameterTag
+        - LocalVariableTag
+        - ReturnValueTag
+    - InitialValueTag
+"""
+
 class Tag:
     """
     A tag for a Definition that can carry different kinds of metadata.
@@ -8,17 +19,33 @@ class Tag:
     def __repr__(self):
         return "<%s {Metadata: %s}>" % (self.__class__.__name__, self.metadata)
 
-class ParameterTag(Tag):
+class FunctionTag(Tag):
+    """
+    A tag for a definition created (or used) in the context of a function.
+    """
+
+    def __init__(self, function: int=None, metadata: object=None):
+        super(FunctionTag, self).__init__(metadata)
+        self.function = function
+
+    def __repr__(self):
+        if self.function:
+            return '<%s {Function: %#x, Metadata:%s}>' % (self.__class__.__name__, self.function, self.metadata)
+        else:
+            return super(FunctionTag, self).__repr__()
+
+
+class ParameterTag(FunctionTag):
     """
     A tag for a definition of a parameter.
     """
 
-class LocalVariableTag(Tag):
+class LocalVariableTag(FunctionTag):
     """
     A tag for a definiton of a local variable of a function.
     """
 
-class ReturnValueTag(Tag):
+class ReturnValueTag(FunctionTag):
     """
     A tag for a definiton of a return value
     of a function.

--- a/angr/knowledge_plugins/key_definitions/tag.py
+++ b/angr/knowledge_plugins/key_definitions/tag.py
@@ -35,6 +35,14 @@ class FunctionTag(Tag):
             return super(FunctionTag, self).__repr__()
 
 
+class SideEffectTag(FunctionTag):
+    """
+    A tag for a definition created or used as a side-effect of a function.
+
+    Example: The <MemoryLocation> pointed by `rdi` during a `sprintf`.
+    """
+
+
 class ParameterTag(FunctionTag):
     """
     A tag for a definition of a parameter.

--- a/angr/knowledge_plugins/key_definitions/tag.py
+++ b/angr/knowledge_plugins/key_definitions/tag.py
@@ -1,0 +1,26 @@
+class Tag:
+    """
+    A tag for a Definition that can carry different kinds of metadata.
+    """
+    def __init__(self, metadata: object=None):
+        self.metadata = metadata
+
+    def __repr__(self):
+        return "<%s {Metadata: %s}>" % (self.__class__.__name__, self.metadata)
+
+
+class ParameterTag(Tag):
+    """
+    A tag for a definition of a parameter.
+    """
+
+class ReturnValueTag(Tag):
+    """
+    A tag for a definiton of a return value
+    of a function.
+    """
+
+class InitialValueTag(Tag):
+    """
+    A tag for a definiton of an initial value
+    """

--- a/angr/knowledge_plugins/key_definitions/tag.py
+++ b/angr/knowledge_plugins/key_definitions/tag.py
@@ -8,10 +8,14 @@ class Tag:
     def __repr__(self):
         return "<%s {Metadata: %s}>" % (self.__class__.__name__, self.metadata)
 
-
 class ParameterTag(Tag):
     """
     A tag for a definition of a parameter.
+    """
+
+class LocalVariableTag(Tag):
+    """
+    A tag for a definiton of a local variable of a function.
     """
 
 class ReturnValueTag(Tag):


### PR DESCRIPTION
  * Make use of tagging to get more info during an inter-procedural analysis!
    - When a function is called, its calling convention tells which `Atom`
      are used.
    - Tag the `Definition`s for this `Atom` with info regarding its usage
      as a parameter.
  * Tag local variables

Signed-off-by: Pamplemousse <xav.maso@gmail.com>