### PR TITLE
Update Function.info after CFGFast.make_functions.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1407,6 +1407,11 @@ class CFGBase(Analysis):
             if node.addr in blockaddr_to_function:
                 node.function_address = blockaddr_to_function[node.addr].addr
 
+        # Update function.info
+        for func in self.kb.functions.values():
+            if func.addr in tmp_functions:
+                func.info = tmp_functions[func.addr].info
+
     def _remove_dummy_plt_stubs(self, functions):
 
         def _is_function_a_plt_stub(arch_, func):

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -846,6 +846,16 @@ def test_indirect_jump_to_outside():
     nose.tools.assert_equal(len(list(cfg.functions[0x404ee4].blocks)), 3)
     nose.tools.assert_equal(set(ep.addr for ep in cfg.functions[0x404ee4].endpoints), { 0x404f00, 0x404f08 })
 
+def test_generate_special_info():
+
+    path = os.path.join(test_location, "mipsel", "fauxware")
+    proj = angr.Project(path, auto_load_libs=False)
+
+    cfg = proj.analyses.CFGFast()
+
+    nose.tools.assert_true(any(func.info for func in cfg.functions.values()))
+    nose.tools.assert_equal(cfg.functions['main'].info['gp'], 0x418ca0)
+
 
 def run_all():
 
@@ -887,6 +897,7 @@ def run_all():
     test_function_leading_blocks_merging()
     test_cfg_with_patches()
     test_indirect_jump_to_outside()
+    test_generate_special_info()
 
 
 def main():


### PR DESCRIPTION
Fixing #2284 , `CFGBase._addr_to_function` create new `Function` object but forget about `Function.info` property collected from scanning IRSB.