### PR TITLE
CallingConventionAnalysis: Deal with MIPS64

### DIFF
--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -311,6 +311,9 @@ class CallingConventionAnalysis(Analysis):
         elif arch.name == 'MIPS32':
             return 24 <= variable.reg < 40  # a0-a3
 
+        elif arch.name == 'MIPS64':
+            return 48 <= variable.reg < 80 or 112 <= variable.reg < 208 # a0-a3 or t4-t7
+
         elif arch.name == 'PPC32':
             return 28 <= variable.reg < 60  # r3-r10
 


### PR DESCRIPTION
Get rid of a bunch of critical logs, and get a calling convention when analysing `MIPS64` binaries.
I don't really know what I am doing, so I am unsure this is correct...

Signed-off-by: Pamplemousse <xav.maso@gmail.com>