### PR TITLE
[WIP] Update MIPS CallingConventions

### DIFF
--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -312,7 +312,7 @@ class CallingConventionAnalysis(Analysis):
             return 24 <= variable.reg < 40  # a0-a3
 
         elif arch.name == 'MIPS64':
-            return 48 <= variable.reg < 80 or 112 <= variable.reg < 208 # a0-a3 or t4-t7
+            return 48 <= variable.reg < 80 or 112 <= variable.reg < 144 # a0-a3 or t4-t7
 
         elif arch.name == 'PPC32':
             return 28 <= variable.reg < 60  # r3-r10

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1392,6 +1392,8 @@ CC = {
         SimCCO32,
     ],
     'MIPS64': [
+        SimCCN64,
+        SimCCN32,
         SimCCO64,
     ],
     'PPC32': [

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1219,8 +1219,7 @@ class SimCCAArch64LinuxSyscall(SimCC):
 
 class SimCCO32(SimCC):
     ARG_REGS = [ 'a0', 'a1', 'a2', 'a3' ]
-    FP_ARG_REGS = []    # TODO: ???
-    STACKARG_SP_BUFF = 16
+    FP_ARG_REGS = [ 'f12', 'f13', 'f14', 'f15' ]
     CALLER_SAVED_REGS = []   # TODO: ???
     RETURN_ADDR = SimRegArg('lr', 4)
     RETURN_VAL = SimRegArg('v0', 4)
@@ -1243,13 +1242,28 @@ class SimCCO32LinuxSyscall(SimCC):
     def syscall_num(state):
         return state.regs.v0
 
-class SimCCO64(SimCC):      # TODO: add n32 and n64
+class SimCCO64(SimCC):
     ARG_REGS = [ 'a0', 'a1', 'a2', 'a3' ]
-    FP_ARG_REGS = []    # TODO: ???
-    STACKARG_SP_BUFF = 32
-    RETURN_ADDR = SimRegArg('lr', 8)
+    FP_ARG_REGS = [ 'f12', 'f13', 'f14' ]
+    RETURN_ADDR = SimRegArg('ra', 8)
     RETURN_VAL = SimRegArg('v0', 8)
     ARCH = archinfo.ArchMIPS64
+
+class SimCCN32(SimCC):
+    ARG_REGS = [ 'a0', 'a1', 'a2', 'a3', 't4', 't5', 't6', 't7' ]
+    FP_ARG_REGS = [ 'f12', 'f13', 'f14', 'f15', 'f16', 'f17', 'f18', 'f19' ]
+    RETURN_ADDR = SimRegArg('ra', 8)
+    RETURN_VAL = SimRegArg('v0', 8)
+    ARCH = archinfo.ArchMIPS64
+    STACK_ALIGNMENT = 16
+
+class SimCCN64(SimCC):
+    ARG_REGS = [ 'a0', 'a1', 'a2', 'a3', 't4', 't5', 't6', 't7' ]
+    FP_ARG_REGS = [ 'f12', 'f13', 'f14', 'f15', 'f16', 'f17', 'f18', 'f19' ]
+    RETURN_ADDR = SimRegArg('ra', 8)
+    RETURN_VAL = SimRegArg('v0', 8)
+    ARCH = archinfo.ArchMIPS64
+    STACK_ALIGNMENT = 16
 
 class SimCCO64LinuxSyscall(SimCC):
     # TODO: Make sure all the information is correct


### PR DESCRIPTION
As discussed with @ltfish and @rhelmot, this is kind of a best-effort approach: Do what seems right, and don't break the tests.

So, this PR is about improving the state of calling conventions for MIPS:
  * add n32/n64 calling conventions
  * the return pointer is not on the stack, so no `STACKARG_SP_BUFF`
  * set the floating points arguments according to:
    - https://gcc.gnu.org/projects/mipso64-abi.html
    - > Up to eight floating point registers ($f12 .. $f19) may be used to pass
      > floating pointarguments. [The o32-bit ABI uses only the four registers
      > $f12 .. $f15, with the oddregisters used only for halves of
      > double-precision arguments.]

      https://www.linux-mips.org/pub/linux/mips/doc/ABI/MIPS-N32-ABI-Handbook.pdf

Signed-off-by: Pamplemousse <xav.maso@gmail.com>