### PR TITLE
Null terminated based loop variable and buffer identification

### DIFF
--- a/angr/analyses/function_prototype/descriptors.py
+++ b/angr/analyses/function_prototype/descriptors.py
@@ -2,6 +2,19 @@
 class BaseDescriptor:
     pass
 
+class CounterLoopVariable(BaseDescriptor):
+    def __init__(self, bits:int, lbound:int, interval:int, is_string: str=False):
+        self.bits = bits
+        self.lbound = lbound
+        self.ubound = None
+        self.interval = interval
+        self.is_string = is_string
+
+    def __repr__(self):
+        return "[LoopVar %s-?, step %s]" % (
+            self.lbound if self.lbound is not None else "unknown",
+            self.interval if self.interval is not None else "unknown",
+        )
 
 class SimpleLoopVariable(BaseDescriptor):
     def __init__(self, bits:int, lbound:int, ubound:int, interval:int):

--- a/angr/analyses/function_prototype/domain.py
+++ b/angr/analyses/function_prototype/domain.py
@@ -432,6 +432,7 @@ class CmpEQN(CmpBase):
             variables = rep_dict[self.variable]
         else:
             variables = { self.variable }
+            variables |= self.variable.replace(rep_dict)
         if len(variables) == 1 and next(iter(variables)) is self.variable:
             return { self }
         return set(CmpEQN(v, self.n) for v in variables)
@@ -581,6 +582,7 @@ class Load(BaseConstraint):
     def __init__(self, addr: BaseExpression, size: int):
         self.addr = addr
         self.size = size
+        self.variable = addr
 
     def replace(self, rep_dict: Dict[BaseExpression,Set[BaseExpression]]) -> Set['Load']:
         if self.addr in rep_dict:
@@ -600,7 +602,7 @@ class Load(BaseConstraint):
         return hash((Load, self.addr, self.size))
 
     def __repr__(self):
-        return "X:= *(%r,%d)" % (self.addr, self.size)
+        return "*(%r,%d)" % (self.addr, self.size)
 
     def __contains__(self, other):
-        return other == self
+        return other in self.addr

--- a/angr/analyses/function_prototype/domain.py
+++ b/angr/analyses/function_prototype/domain.py
@@ -21,6 +21,9 @@ class Parameter(BaseExpression):
     def __repr__(self):
         return "Param %d" % self.idx
 
+    def __contains__(self, other):
+        return isinstance(other, Parameter) and other.idx == self.idx
+
 
 class LocalVariable(BaseExpression):
     def __init__(self, atom, code_location):
@@ -41,6 +44,9 @@ class LocalVariable(BaseExpression):
     def __repr__(self):
         return "%r@%r" % (self.atom, self.code_location)
 
+    def __contains__(self, other):
+        return self == other
+
 
 class Constant(BaseExpression):
     def __init__(self, con: int):
@@ -58,6 +64,9 @@ class Constant(BaseExpression):
 
     def __repr__(self):
         return str(self.con)
+
+    def __contains__(self, other):
+        return isinstance(other, int) and other == self.con
 
 class Shl(BaseExpression):
     def __init__(self, variable: BaseExpression, expression: BaseExpression):
@@ -90,6 +99,9 @@ class Shl(BaseExpression):
     def __repr__(self):
         return "%r<<%r" % (self.variable, self.expression)
 
+    def __contains__(self, other):
+        return (other in self.variable) or (other in self.expression)
+
 class ShlN(BaseExpression):
     def __init__(self, variable: BaseExpression, n: int):
         self.variable = variable
@@ -115,6 +127,74 @@ class ShlN(BaseExpression):
     def __repr__(self):
         return "%r<<%d" % (self.variable, self.n)
 
+    def __contains__(self, other):
+        return (other == variable) or (other == self.n)
+
+    def __contains__(self, other):
+        return (other in self.variable) or (other == self.n)
+
+class And(BaseExpression):
+    def __init__(self, variable: BaseExpression, expression: BaseExpression):
+        self.variable = variable
+        self.expression = expression
+
+    def replace(self, rep_dict: Dict[BaseExpression,Set[BaseExpression]]) -> Set['And']:
+        if self.variable in rep_dict:
+            variables = rep_dict[self.variable]
+        else:
+            variables = { self.variable }
+        if self.expression in rep_dict:
+            expressions = rep_dict[self.expression]
+        else:
+            expressions = self.expression.replace(rep_dict)
+        if len(variables) == 1 and next(iter(variables)) is self.variable \
+                and len(expressions) == 1 and next(iter(expressions)) is self.expression:
+            return { self }
+
+        return set(And(v, ex) for v, ex in itertools.product(variables, expressions))
+
+    def __eq__(self, other):
+        return isinstance(other, And) \
+                and self.variable == other.variable \
+                and self.expression == other.expression
+
+    def __hash__(self):
+        return hash((And, self.variable, self.expression))
+
+    def __repr__(self):
+        return "%r+%r" % (self.variable, self.expression)
+
+    def __contains__(self, other):
+        return (other in self.variable) or (other in self.expression)
+
+
+class AndN(BaseExpression):
+    def __init__(self, variable: BaseExpression, n: int):
+        self.variable = variable
+        self.n = n
+
+    def replace(self, rep_dict: Dict[BaseExpression,BaseExpression]) -> Set['AndN']:
+        if self.variable in rep_dict:
+            variables = rep_dict[self.variable]
+        else:
+            variables = { self.variable }
+        if len(variables) == 1 and next(iter(variables)) is self.variable:
+            return { self }
+        return set(AndN(v, self.n) for v in variables)
+
+    def __eq__(self, other):
+        return isinstance(other, AndN) \
+                and self.variable == other.variable \
+                and self.n == other.n
+
+    def __hash__(self):
+        return hash((AndN, self.variable, self.n))
+
+    def __repr__(self):
+        return "%r&%d" % (self.variable, self.n)
+
+    def __contains__(self, other):
+        return (other in self.variable) or (other == self.n)
 
 class Add(BaseExpression):
     def __init__(self, variable: BaseExpression, expression: BaseExpression):
@@ -147,6 +227,8 @@ class Add(BaseExpression):
     def __repr__(self):
         return "%r+%r" % (self.variable, self.expression)
 
+    def __contains__(self, other):
+        return (other in self.variable) or (other in self.expression)
 
 class AddN(BaseExpression):
     def __init__(self, variable: BaseExpression, n: int):
@@ -173,7 +255,8 @@ class AddN(BaseExpression):
     def __repr__(self):
         return "%r%+d" % (self.variable, self.n)
 
-
+    def __contains__(self, other):
+        return (other in self.variable) or (other == self.n)
 #
 # Values
 #
@@ -186,11 +269,14 @@ class ValuedVariable:
 
     def __eq__(self, other):
         return isinstance(other, ValuedVariable) \
-                and other.variable == self.variable \
+                and other.variable in self.variable \
                 and other.value == self.value
 
     def __hash__(self):
         return hash((ValuedVariable, self.variable, self.value))
+
+    def __str__(self):
+        return "(VV:{} {})".format(self.variable, self.value)
 
 
 #
@@ -232,10 +318,137 @@ class Assignment(BaseConstraint):
     def __repr__(self):
         return "%r := %r" % (self.variable, self.expression)
 
+    def __contains__(self, other):
+        return (other in self.variable) or (other in self.expression)
+
 
 class CmpBase(BaseConstraint):
     def __init__(self, variable: BaseExpression):
         self.variable = variable
+
+class CmpNEExpr(CmpBase):
+    def __init__(self, variable: BaseExpression, expression: BaseExpression):
+        super().__init__(variable)
+        self.expression = expression
+
+    def replace(self, rep_dict: Dict[BaseExpression,Set[BaseExpression]]) -> Set['CmpNEExpr']:
+        if self.variable in rep_dict:
+            variables = rep_dict[self.variable]
+        else:
+            variables = { self.variable }
+        if self.expression in rep_dict:
+            expressions = rep_dict[self.expression]
+        else:
+            expressions = self.expression.replace(rep_dict)
+        if len(variables) == 1 and next(iter(variables)) is self.variable \
+                and len(expressions) == 1 and next(iter(expressions)) is self.expression:
+            return { self }
+        return set(CmpNEExpr(v, ex) for v, ex in itertools.product(variables, expressions))
+
+    def __eq__(self, other):
+        return isinstance(other, CmpNEExpr) \
+                and self.variable == other.variable \
+                and self.expression == other.expression
+
+    def __hash__(self):
+        return hash((CmpNEExpr, self.variable, self.expression))
+
+    def __repr__(self):
+        return "%r == %r" % (self.variable, self.expression)
+
+    def __contains__(self, other):
+        return (other in self.variable) or (other in self.expression)
+
+
+class CmpNEN(CmpBase):
+    def __init__(self, variable: BaseExpression, n: int):
+        super().__init__(variable)
+        self.n = n
+
+    def replace(self, rep_dict: Dict[BaseExpression,BaseExpression]) -> Set['CmpNEN']:
+        if self.variable in rep_dict:
+            variables = rep_dict[self.variable]
+        else:
+            variables = { self.variable }
+        if len(variables) == 1 and next(iter(variables)) is self.variable:
+            return { self }
+        return set(CmpNEN(v, self.n) for v in variables)
+
+    def __eq__(self, other):
+        return isinstance(other, CmpNEN) \
+                and self.variable == other.variable \
+                and self.n == other.n
+
+    def __hash__(self):
+        return hash((CmpNEN, self.variable, self.n))
+
+    def __repr__(self):
+        return "%r == %+d" % (self.variable, self.n)
+
+    def __contains__(self, other):
+        return (other in self.variable) or (other == self.n)
+
+class CmpEQExpr(CmpBase):
+    def __init__(self, variable: BaseExpression, expression: BaseExpression):
+        super().__init__(variable)
+        self.expression = expression
+
+    def replace(self, rep_dict: Dict[BaseExpression,Set[BaseExpression]]) -> Set['CmpEQExpr']:
+        if self.variable in rep_dict:
+            variables = rep_dict[self.variable]
+        else:
+            variables = { self.variable }
+        if self.expression in rep_dict:
+            expressions = rep_dict[self.expression]
+        else:
+            expressions = self.expression.replace(rep_dict)
+        if len(variables) == 1 and next(iter(variables)) is self.variable \
+                and len(expressions) == 1 and next(iter(expressions)) is self.expression:
+            return { self }
+        return set(CmpEQExpr(v, ex) for v, ex in itertools.product(variables, expressions))
+
+    def __eq__(self, other):
+        return isinstance(other, CmpEQExpr) \
+                and self.variable == other.variable \
+                and self.expression == other.expression
+
+    def __hash__(self):
+        return hash((CmpEQExpr, self.variable, self.expression))
+
+    def __repr__(self):
+        return "%r == %r" % (self.variable, self.expression)
+
+    def __contains__(self, other):
+        return (other in self.variable) or (other in self.expression)
+
+
+class CmpEQN(CmpBase):
+    def __init__(self, variable: BaseExpression, n: int):
+        super().__init__(variable)
+        self.n = n
+
+    def replace(self, rep_dict: Dict[BaseExpression,BaseExpression]) -> Set['CmpEQN']:
+        if self.variable in rep_dict:
+            variables = rep_dict[self.variable]
+        else:
+            variables = { self.variable }
+        if len(variables) == 1 and next(iter(variables)) is self.variable:
+            return { self }
+        return set(CmpEQN(v, self.n) for v in variables)
+
+    def __eq__(self, other):
+        return isinstance(other, CmpEQN) \
+                and self.variable == other.variable \
+                and self.n == other.n
+
+    def __hash__(self):
+        return hash((CmpEQN, self.variable, self.n))
+
+    def __repr__(self):
+        return "%r == %+d" % (self.variable, self.n)
+
+    def __contains__(self, other):
+        return (other in self.variable) or (other == self.n)
 
 
 class CmpLtExpr(CmpBase):
@@ -268,6 +481,9 @@ class CmpLtExpr(CmpBase):
     def __repr__(self):
         return "%r < %r" % (self.variable, self.expression)
 
+    def __contains__(self, other):
+        return (other in self.variable) or (other in self.expression)
+
 
 class CmpLtN(CmpBase):
     def __init__(self, variable: BaseExpression, n: int):
@@ -293,6 +509,9 @@ class CmpLtN(CmpBase):
 
     def __repr__(self):
         return "%r < %+d" % (self.variable, self.n)
+
+    def __contains__(self, other):
+        return (other in self.variable) or (other == self.n)
 
 
 class CmpLeExpr(CmpBase):
@@ -325,6 +544,9 @@ class CmpLeExpr(CmpBase):
     def __repr__(self):
         return "%r <= %r" % (self.variable, self.expression)
 
+    def __contains__(self, other):
+        return (other in self.variable) or (other in self.expression)
+
 
 class Store(BaseConstraint):
     def __init__(self, addr: BaseExpression, size: int):
@@ -351,6 +573,9 @@ class Store(BaseConstraint):
     def __repr__(self):
         return "*(%r,%d) := X" % (self.addr, self.size)
 
+    def __contains__(self, other):
+        return other == self
+
 
 class Load(BaseConstraint):
     def __init__(self, addr: BaseExpression, size: int):
@@ -376,3 +601,6 @@ class Load(BaseConstraint):
 
     def __repr__(self):
         return "X:= *(%r,%d)" % (self.addr, self.size)
+
+    def __contains__(self, other):
+        return other == self

--- a/angr/analyses/function_prototype/types.py
+++ b/angr/analyses/function_prototype/types.py
@@ -19,12 +19,13 @@ class BaseType:
 
 class Buffer(BaseType):
     def __init__(self, lbound: Optional[int]=None, ubound: Optional[int]=None, element_size: Optional[int]=None,
-                 element_count: Optional[int]=None, in_: bool=True, out_: bool=False):
+                 element_count: Optional[int]=None, in_: bool=True, out_: bool=False, is_string: bool=False):
         super().__init__(in_, out_)
         self.lbound = lbound
         self.ubound = ubound
         self.element_size = element_size
         self.element_count = element_count
+        self.is_string = is_string
 
     def __eq__(self, other):
         return isinstance(other, Buffer) \
@@ -39,7 +40,7 @@ class Buffer(BaseType):
         return hash((Buffer, self.lbound, self.ubound, self.element_size, self.element_count, self.in_, self.out_))
 
     def __repr__(self):
-        return self.io_repr() + "Buffer %s-%s" % (self.lbound, self.ubound)
+        return self.io_repr() + "%sBuffer %s-%s" % (("" if not self.is_string else "String "), self.lbound, self.ubound)
 
 
 class Pointer(BaseType):


### PR DESCRIPTION
Looks for inc-expressions that depend on a loop counter without an upper bound lop condition, then finds a null comparison for the loaded expression. Some constraints were not being properly logged into the state's constraints which were required to correlate the null byte check and buffer load.