### PR TITLE
Fix typedef copying in sim_type parsing

### DIFF
--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -1512,7 +1512,7 @@ def parse_file(defn, preprocess=True):
             if piece.name is not None:
                 out[piece.name] = ty
         elif isinstance(piece, pycparser.c_ast.Typedef):
-            extra_types[piece.name] = copy.copy(_decl_to_type(piece.type, extra_types))
+            extra_types[piece.name] = _decl_to_type(piece.type, extra_types)
             extra_types[piece.name].label = piece.name
 
     for ty in ignoreme:


### PR DESCRIPTION
We shouldn't copy typedef type
e.g. due to copying, structure A will have no fields
```
typedef struct _A A;

struct _A {
    int a;
    int b;
};
```