### PR TITLE
Initial ARM support for angr's Unicorn Engine

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -43,7 +43,7 @@ class SimEngineUnicorn(SuccessorsMixin):
 
         # if we have a concrete target we want the program to synchronize the segment
         # registers before, otherwise undefined behavior could happen.
-        if state.project.concrete_target:
+        if state.project.concrete_target and self.project.arch.name in ('x86', 'x86_64'):
             if not state.concrete.segment_registers_initialized:
                 l.debug("segment register must be synchronized with the concrete target before using unicorn engine")
                 return False

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -108,7 +108,7 @@ class Uniwrapper(unicorn.Uc if unicorn is not None else object):
         self.wrapped_mapped = set()
         self.wrapped_hooks = set()
         self.id = None
-        if is_thumb:
+        if thumb:
             uc_mode = arch.uc_mode_thumb
         else:
             uc_mode = arch.uc_mode
@@ -490,7 +490,7 @@ class Unicorn(SimStatePlugin):
     @property
     def uc(self):
         new_id = next(_unicounter)
-        is_thumb = self.state.arch.qemu_name == 'arm' and self.arch.is_thumb(self.state.addr)
+        is_thumb = self.state.arch.qemu_name == 'arm' and self.state.arch.is_thumb(self.state.addr)
         if (
             not hasattr(_unicorn_tls, "uc") or
             _unicorn_tls.uc is None or
@@ -1060,7 +1060,7 @@ class Unicorn(SimStatePlugin):
 
         # handle ARM's "cpsr" register, equivalent of x86's eflags
         elif self.state.arch.qemu_name == 'arm':
-            flags = self._process_value(self.state.regs.cpsr, 'reg')
+            flags = self._process_value(self.state.regs.flags, 'reg')
             if flags is None:
                 raise SimValueError('symbolic cpsr')
             elif flags.symbolic:

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -101,6 +101,19 @@ def test_longinit_i386():
 def test_longinit_x86_64():
     run_longinit('x86_64')
 
+def test_fauxware_arm():
+    p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'armel', 'fauxware'))
+    s_unicorn = p.factory.entry_state(add_options=so.unicorn) # unicorn
+    pg = p.factory.simulation_manager(s_unicorn)
+    pg.explore()
+    assert all("Unicorn" in ''.join(p.history.descriptions.hardcopy) for p in pg.deadended)
+    nose.tools.assert_equal(sorted(pg.mp_deadended.posix.dumps(1).mp_items), sorted((
+        b'Username: \nPassword: \nWelcome to the admin console, trusted user!\n',
+        b'Username: \nPassword: \nGo away!',
+        b'Username: \nPassword: \nWelcome to the admin console, trusted user!\n'
+    )))
+
+
 def test_fauxware():
     p = angr.Project(os.path.join(test_location, 'binaries', 'tests', 'i386', 'fauxware'))
     s_unicorn = p.factory.entry_state(add_options=so.unicorn) # unicorn
@@ -341,3 +354,4 @@ if __name__ == '__main__':
                         fa = ft[1:]
                         print('...', fa)
                         fo(*fa)
+

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -4,8 +4,9 @@ import pickle
 import re
 from angr import options as so
 from nose.plugins.attrib import attr
-
+import gc
 import os
+
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
 
 
@@ -199,7 +200,6 @@ def test_unicorn_pickle():
 
     pgp = pickle.dumps(pg, -1)
     del pg
-    import gc
     gc.collect()
     pg2 = pickle.loads(pgp)
     pg2.explore()
@@ -354,4 +354,3 @@ if __name__ == '__main__':
                         fa = ft[1:]
                         print('...', fa)
                         fo(*fa)
-


### PR DESCRIPTION
Unicorns don't have arms, nor thumbs, but that doesn't mean they get to skip ARM day!!

This enables support for Unicorn Engine for the 32bit ARM architecture.  It should be as fully-featured as x86, with the exception of missing hardfloat support (because how do you even hardfloat idk)
This, too, could be trivially added if someone spends the few hours bludgeoning themselves with ARM's horrific documentation, and probably rectifying the QEMU/VEX inconsistencies there.

#NeverSkipARMDay #DoYouEvenLift

xref https://github.com/angr/archinfo/pull/92