### PR TITLE
Sorting solutions returned by the concretization strategy even when loading memory

### DIFF
--- a/angr/storage/memory_mixins/address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/address_concretization_mixin.py
@@ -237,7 +237,7 @@ class AddressConcretizationMixin(MemoryMixin):
             return self._default_value(None, size, name='symbolic_read_unconstrained', **kwargs)
 
         try:
-            concrete_addrs = self.concretize_read_addr(addr)
+            concrete_addrs = sorted(self.concretize_read_addr(addr))
         except SimMemoryError:
             if options.CONSERVATIVE_READ_STRATEGY in self.state.options:
                 return self._default_value(None, size, name='symbolic_read_unconstrained', **kwargs)


### PR DESCRIPTION
Like the title said, I think it's better to sort the solutions returned like we are doing in the _store:https://github.com/angr/angr/blob/f4a75e41088b3cef4446b24c3c7b0b925924751c/angr/storage/memory_mixins/address_concretization_mixin.py#L284 to avoid different results in different symbolic analyses. 