### PR TITLE
RDA: Add a `unknown_size` for unsized data in `DataSet`

### DIFF
--- a/angr/knowledge_plugins/key_definitions/atoms.py
+++ b/angr/knowledge_plugins/key_definitions/atoms.py
@@ -129,7 +129,9 @@ class MemoryLocation(Atom):
     def __repr__(self):
         address_format = hex(self.addr) if type(self.addr) is int else self.addr
         stack_format = ' (stack)' if self.is_on_stack else ''
-        return "<Mem %s<%d>%s>" % (address_format, self.size, stack_format)
+        size = "%d" % self.size if isinstance(self.size, int) else self.size
+
+        return "<Mem %s<%s>%s>" % (address_format, size, stack_format)
 
     @property
     def is_on_stack(self) -> bool:

--- a/angr/knowledge_plugins/key_definitions/dataset.py
+++ b/angr/knowledge_plugins/key_definitions/dataset.py
@@ -5,6 +5,7 @@ import operator
 from ...engines.light import RegisterOffset
 from .constants import DEBUG
 from .undefined import Undefined, UNDEFINED
+from .unknown_size import UnknownSize
 
 l = logging.getLogger(name=__name__)
 
@@ -20,18 +21,18 @@ class DataSet:
     Data must always include a set.
 
     :ivar set data:    The set of data to represent.
-    :ivar int bits:    The size of an element of the set, in number of bits its representation takes.
+    :ivar Union[int,UnknownSize] bits: The size of an element of the set, in number of bits its representation takes.
     """
     maximum_size = 5
 
-    def __init__(self, data: Union[Set[Union[Undefined,RegisterOffset,int]],Undefined,RegisterOffset,int], bits: int):
+    def __init__(self, data: Union[Set[Union[Undefined,RegisterOffset,int]],Undefined,RegisterOffset,int], bits: Union[int,UnknownSize]):
         self.data: Set[Union[Undefined,RegisterOffset,int]] = data if isinstance(data, set) else {data}
         self._bits = bits
         self._mask = (1 << bits) - 1
         self._limit()
 
     @property
-    def bits(self) -> int:
+    def bits(self) -> Union[int,UnknownSize]:
         return self._bits
 
     @property
@@ -168,5 +169,6 @@ class DataSet:
             data_string = str(self.data)
         else:
             data_string = str([ hex(i) if isinstance(i, int) else i for i in self.data ])
+        size = "%d" % self._bits if isinstance(self._bits, int) else self._bits
 
-        return 'DataSet<%d>: %s' % (self._bits, data_string)
+        return 'DataSet<%s>: %s' % (size, data_string)

--- a/angr/knowledge_plugins/key_definitions/unknown_size.py
+++ b/angr/knowledge_plugins/key_definitions/unknown_size.py
@@ -1,0 +1,76 @@
+class UnknownSize:
+    """
+    A value indicating an unknown size for elements of DataSets.
+    Should "behave" like an integer.
+    """
+    def __init__(self):
+        self.__ge__ = self.__gt__
+        self.__le__ = self.__lt__
+
+    def __add__(self, other):
+        return self
+
+    def __radd__(self, other):
+        return self
+
+    def __sub__(self, other):
+        return self
+
+    def __rsub__(self, other):
+        return self
+
+    def __lshift__(self, other):
+        return self
+
+    def __rlshift__(self, other):
+        return self
+
+    def __rshift__(self, other):
+        return self
+
+    def __rrshift__(self, other):
+        return self
+
+    def __and__(self, other):
+        return self
+
+    def __rand__(self, other):
+        return self
+
+    def __xor__(self, other):
+        return self
+
+    def __rxor__(self, other):
+        return self
+
+    def __or__(self, other):
+        return self
+
+    def __ror__(self, other):
+        return self
+
+    def __neg__(self):
+        return self
+
+    def __eq__(self, other):
+        return type(other) is UnknownSize
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __lt__(self, other):
+        return False
+
+    def __gt__(self, other):
+        return True
+
+    def __hash__(self):
+        return hash('unknown size')
+
+    def __str__(self):
+        return '<UnknownSize>'
+
+    def __repr__(self):
+        return "<UnknownSize>"
+
+UNKNOWN_SIZE = UnknownSize()


### PR DESCRIPTION
Which happen quite frequently when dealing with Strings:
  "aaaa" and "bb" can be pointed by the same `MemoryLocation`
  (or `SpOffset`), but don't have the same unique size...

Signed-off-by: Pamplemousse <xav.maso@gmail.com>