### PR TITLE
Add new engine based on Ghidra's P-Code IR

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -17,7 +17,12 @@ from ....exploration_techniques.slicecutor import Slicecutor
 from ....exploration_techniques.explorer import Explorer
 from ....utils.constants import DEFAULT_STATEMENT
 from .resolver import IndirectJumpResolver
+from ....misc.ux import once
 
+try:
+    from ....engines import pcode
+except ImportError:
+    pcode = None
 
 l = logging.getLogger(name=__name__)
 
@@ -519,6 +524,10 @@ class JumpTableResolver(IndirectJumpResolver):
         self._find_bss_region()
 
     def filter(self, cfg, addr, func_addr, block, jumpkind):
+        if pcode is not None and isinstance(block.vex, pcode.lifter.IRSB):
+            if once('pcode__indirect_jump_resolver'):
+                l.warning('JumpTableResolver does not support P-Code IR yet; CFG may be incomplete.')
+            return False
 
         if is_arm_arch(self.project.arch):
             # For ARM, we support both jump tables and "call tables" (because of how crazy ARM compilers are...)

--- a/angr/engines/__init__.py
+++ b/angr/engines/__init__.py
@@ -13,3 +13,9 @@ from .soot import SootMixin
 class UberEngine(SimEngineFailure, SimEngineSyscall, HooksMixin, SimEngineUnicorn, SuperFastpathMixin, TrackActionsMixin, SimInspectMixin, HeavyResilienceMixin, SootMixin, HeavyVEXMixin):
     pass
 
+try:
+	from .pcode import HeavyPcodeMixin
+	class UberEnginePcode(SimEngineFailure, SimEngineSyscall, HooksMixin, HeavyPcodeMixin): # pylint:disable=abstract-method
+		pass
+except ImportError:
+	pass

--- a/angr/engines/pcode/__init__.py
+++ b/angr/engines/pcode/__init__.py
@@ -1,0 +1,1 @@
+from .engine import HeavyPcodeMixin

--- a/angr/engines/pcode/behavior.py
+++ b/angr/engines/pcode/behavior.py
@@ -1,0 +1,981 @@
+import operator
+from typing import Callable, Iterable
+
+from pypcode import OpCode, Sleigh
+import claripy
+from claripy.ast.bv import BV
+
+# pylint:disable=abstract-method
+
+# FIXME: Unimplemented ops (mostly floating point related) have associated C++
+# reference code from Ghidra which will need to be ported.
+
+class OpBehavior:
+    """
+    Base class for all operation behaviors.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special")
+    opcode: int
+    is_unary: bool
+    is_special: bool
+
+    def __init__(self, opcode: int, is_unary: bool, is_special: bool = False) -> None:
+        self.opcode = opcode
+        self.is_unary = is_unary
+        self.is_special = is_special
+
+    def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
+        raise NotImplementedError("Not implemented!")
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        raise NotImplementedError("Not implemented!")
+
+    @staticmethod
+    def generic_compare(args: Iterable[BV], comparison: Callable[[BV, BV], BV]) -> BV:
+        return claripy.If(
+            comparison(args[0], args[1]), claripy.BVV(1, 1), claripy.BVV(0, 1)
+        )
+
+
+class OpBehaviorCopy(OpBehavior):
+    """
+    Behavior for the COPY operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_COPY, True)
+
+    def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
+        return in1
+
+
+class OpBehaviorEqual(OpBehavior):
+    """
+    Behavior for the INT_EQUAL operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_EQUAL, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return self.generic_compare((in1, in2), operator.eq)
+
+
+class OpBehaviorNotEqual(OpBehavior):
+    """
+    Behavior for the INT_NOTEQUAL operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_NOTEQUAL, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return self.generic_compare((in1, in2), operator.ne)
+
+
+class OpBehaviorIntSless(OpBehavior):
+    """
+    Behavior for the INT_SLESS operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SLESS, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return self.generic_compare((in1, in2), claripy.SLT)
+
+
+class OpBehaviorIntSlessEqual(OpBehavior):
+    """
+    Behavior for the INT_SLESSEQUAL operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SLESSEQUAL, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return self.generic_compare((in1, in2), claripy.SLE)
+
+
+class OpBehaviorIntLess(OpBehavior):
+    """
+    Behavior for the INT_LESS operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_LESS, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return self.generic_compare((in1, in2), claripy.ULT)
+
+
+class OpBehaviorIntLessEqual(OpBehavior):
+    """
+    Behavior for the INT_LESSEQUAL operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_LESSEQUAL, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return self.generic_compare((in1, in2), claripy.ULE)
+
+
+class OpBehaviorIntZext(OpBehavior):
+    """
+    Behavior for the INT_ZEXT operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_ZEXT, True)
+
+    def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
+        return in1.zero_extend((size_out-size_in)*8)
+
+
+class OpBehaviorIntSext(OpBehavior):
+    """
+    Behavior for the INT_SEXT operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SEXT, True)
+
+    def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
+        return in1.sign_extend((size_out-size_in)*8)
+
+
+class OpBehaviorIntAdd(OpBehavior):
+    """
+    Behavior for the INT_ADD operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_ADD, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 + in2
+
+
+class OpBehaviorIntSub(OpBehavior):
+    """
+    Behavior for the INT_SUB operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SUB, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 - in2
+
+
+class OpBehaviorIntCarry(OpBehavior):
+    """
+    Behavior for the INT_CARRY operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_CARRY, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        # origin: ccall.py pc_actions_ADD
+        res = in1 + in2
+        return claripy.If(claripy.ULT(res, in1), claripy.BVV(1, 1), claripy.BVV(0, 1))
+
+
+class OpBehaviorIntScarry(OpBehavior):
+    """
+    Behavior for the INT_SCARRY operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SCARRY, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        res = in1 + in2
+
+        a = (in1>>(size_in*8-1))&1
+        b = (in2>>(size_in*8-1))&1
+        r = (res>>(size_in*8-1))&1
+
+        r ^= a
+        a ^= b
+        a ^= 1
+        r &= a
+
+        return r
+
+
+class OpBehaviorIntSborrow(OpBehavior):
+    """
+    Behavior for the INT_SBORROW operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SBORROW, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        res = in1 - in2
+
+        a = (in1 >> (size_in * 8 - 1)) & 1  # Grab sign bit
+        b = (in2 >> (size_in * 8 - 1)) & 1  # Grab sign bit
+        r = (res >> (size_in * 8 - 1)) & 1  # Grab sign bit
+
+        a ^= r
+        r ^= b
+        r ^= 1
+        a &= r
+        return a
+
+
+class OpBehaviorInt2Comp(OpBehavior):
+    """
+    Behavior for the INT_2COMP operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_2COMP, True)
+
+    # uintb OpBehaviorInt2Comp::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   uintb res = uintb_negate(in1-1,size_in);
+    #   return res;
+    # }
+
+
+class OpBehaviorIntNegate(OpBehavior):
+    """
+    Behavior for the INT_NEGATE operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_NEGATE, True)
+
+    def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
+        return ~in1
+
+
+class OpBehaviorIntXor(OpBehavior):
+    """
+    Behavior for the INT_XOR operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_XOR, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 ^ in2
+
+
+class OpBehaviorIntAnd(OpBehavior):
+    """
+    Behavior for the INT_AND operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_AND, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 & in2
+
+
+class OpBehaviorIntOr(OpBehavior):
+    """
+    Behavior for the INT_OR operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_OR, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 | in2
+
+
+class OpBehaviorIntLeft(OpBehavior):
+    """
+    Behavior for the INT_LEFT operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_LEFT, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        if in2.size() < in1.size():
+            in2 = in2.sign_extend(in1.size() - in2.size())
+        return in1 << in2
+
+
+class OpBehaviorIntRight(OpBehavior):
+    """
+    Behavior for the INT_RIGHT operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_RIGHT, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        if in2.size() < in1.size():
+            in2 = in2.sign_extend(in1.size() - in2.size())
+        return in1.LShR(in2)
+
+
+class OpBehaviorIntSright(OpBehavior):
+    """
+    Behavior for the INT_SRIGHT operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SRIGHT, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        if in2.size() < in1.size():
+            in2 = in2.sign_extend(in1.size() - in2.size())
+        return in1 >> in2
+
+
+class OpBehaviorIntMult(OpBehavior):
+    """
+    Behavior for the INT_MULT operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_MULT, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 * in2
+
+
+class OpBehaviorIntDiv(OpBehavior):
+    """
+    Behavior for the INT_DIV operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_DIV, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 / in2
+
+
+class OpBehaviorIntSdiv(OpBehavior):
+    """
+    Behavior for the INT_SDIV operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SDIV, False)
+
+    # uintb OpBehaviorIntSdiv::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   if (in2 == 0)
+    #     throw EvaluationError("Divide by 0");
+    #   intb num = in1;               // Convert to signed
+    #   intb denom = in2;
+    #   sign_extend(num,8*size_in-1);
+    #   sign_extend(denom,8*size_in-1);
+    #   intb sres = num/denom;        // Do the signed division
+    #   zero_extend(sres,8*size_out-1); // Cut to appropriate size
+    #   return (uintb)sres;           // Recast as unsigned
+    # }
+
+
+class OpBehaviorIntRem(OpBehavior):
+    """
+    Behavior for the INT_REM operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_REM, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 % in2
+
+
+class OpBehaviorIntSrem(OpBehavior):
+    """
+    Behavior for the INT_SREM operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_INT_SREM, False)
+
+    # uintb OpBehaviorIntSrem::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   if (in2 == 0)
+    #     throw EvaluationError("Remainder by 0");
+    #   intb val = in1;
+    #   intb mod = in2;
+    #   sign_extend(val,8*size_in-1);  // Convert inputs to signed values
+    #   sign_extend(mod,8*size_in-1);
+    #   intb sres = in1 % in2;        // Do the remainder
+    #   zero_extend(sres,8*size_out-1); // Convert back to unsigned
+    #   return (uintb)sres;
+    # }
+
+
+class OpBehaviorBoolNegate(OpBehavior):
+    """
+    Behavior for the BOOL_NEGATE operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_BOOL_NEGATE, True)
+
+    def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
+        return in1 ^ 1
+
+
+class OpBehaviorBoolXor(OpBehavior):
+    """
+    Behavior for the BOOL_XOR operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_BOOL_XOR, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 ^ in2
+
+
+class OpBehaviorBoolAnd(OpBehavior):
+    """
+    Behavior for the BOOL_AND operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_BOOL_AND, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 & in2
+
+
+class OpBehaviorBoolOr(OpBehavior):
+    """
+    Behavior for the BOOL_OR operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_BOOL_OR, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        return in1 | in2
+
+
+class OpBehaviorFloatEqual(OpBehavior):
+    """
+    Behavior for the FLOAT_EQUAL operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_EQUAL, False)
+
+    # uintb OpBehaviorFloatEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateBinary(size_out,size_in,in1,in2);
+    #
+    #   return format->opEqual(in1,in2);
+    # }
+
+
+class OpBehaviorFloatNotEqual(OpBehavior):
+    """
+    Behavior for the FLOAT_NOTEQUAL operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_NOTEQUAL, False)
+
+    # uintb OpBehaviorFloatNotEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateBinary(size_out,size_in,in1,in2);
+    #
+    #   return format->opNotEqual(in1,in2);
+    # }
+
+
+class OpBehaviorFloatLess(OpBehavior):
+    """
+    Behavior for the FLOAT_LESS operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_LESS, False)
+
+    # uintb OpBehaviorFloatLess::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateBinary(size_out,size_in,in1,in2);
+    #
+    #   return format->opLess(in1,in2);
+    # }
+
+
+class OpBehaviorFloatLessEqual(OpBehavior):
+    """
+    Behavior for the FLOAT_LESSEQUAL operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_LESSEQUAL, False)
+
+    # uintb OpBehaviorFloatLessEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateBinary(size_out,size_in,in1,in2);
+    #
+    #   return format->opLessEqual(in1,in2);
+    # }
+
+
+class OpBehaviorFloatNan(OpBehavior):
+    """
+    Behavior for the FLOAT_NAN operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_NAN, True)
+
+    # uintb OpBehaviorFloatNan::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opNan(in1);
+    # }
+
+
+class OpBehaviorFloatAdd(OpBehavior):
+    """
+    Behavior for the FLOAT_ADD operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_ADD, False)
+
+    # uintb OpBehaviorFloatAdd::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateBinary(size_out,size_in,in1,in2);
+    #
+    #   return format->opAdd(in1,in2);
+    # }
+
+
+class OpBehaviorFloatDiv(OpBehavior):
+    """
+    Behavior for the FLOAT_DIV operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_DIV, False)
+
+    # uintb OpBehaviorFloatDiv::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateBinary(size_out,size_in,in1,in2);
+    #
+    #   return format->opDiv(in1,in2);
+    # }
+
+
+class OpBehaviorFloatMult(OpBehavior):
+    """
+    Behavior for the FLOAT_MULT operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_MULT, False)
+
+    # uintb OpBehaviorFloatMult::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateBinary(size_out,size_in,in1,in2);
+    #
+    #   return format->opMult(in1,in2);
+    # }
+
+
+class OpBehaviorFloatSub(OpBehavior):
+    """
+    Behavior for the FLOAT_SUB operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_SUB, False)
+
+    # uintb OpBehaviorFloatSub::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateBinary(size_out,size_in,in1,in2);
+    #
+    #   return format->opSub(in1,in2);
+    # }
+
+
+class OpBehaviorFloatNeg(OpBehavior):
+    """
+    Behavior for the FLOAT_NEG operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_NEG, True)
+
+    # uintb OpBehaviorFloatNeg::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opNeg(in1);
+    # }
+
+
+class OpBehaviorFloatAbs(OpBehavior):
+    """
+    Behavior for the FLOAT_ABS operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_ABS, True)
+
+    # uintb OpBehaviorFloatAbs::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opAbs(in1);
+    # }
+
+
+class OpBehaviorFloatSqrt(OpBehavior):
+    """
+    Behavior for the FLOAT_SQRT operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_SQRT, True)
+
+    # uintb OpBehaviorFloatSqrt::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opSqrt(in1);
+    # }
+
+
+class OpBehaviorFloatInt2Float(OpBehavior):
+    """
+    Behavior for the FLOAT_INT2FLOAT operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_INT2FLOAT, True)
+
+    # uintb OpBehaviorFloatInt2Float::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_out);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opInt2Float(in1,size_in);
+    # }
+
+
+class OpBehaviorFloatFloat2Float(OpBehavior):
+    """
+    Behavior for the FLOAT_FLOAT2FLOAT operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_FLOAT2FLOAT, True)
+
+    # uintb OpBehaviorFloatFloat2Float::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *formatout = translate->getFloatFormat(size_out);
+    #   if (formatout == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #   const FloatFormat *formatin = translate->getFloatFormat(size_in);
+    #   if (formatin == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return formatin->opFloat2Float(in1,*formatout);
+    # }
+
+
+class OpBehaviorFloatTrunc(OpBehavior):
+    """
+    Behavior for the FLOAT_TRUNC operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_TRUNC, True)
+
+    # uintb OpBehaviorFloatTrunc::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opTrunc(in1,size_out);
+    # }
+
+
+class OpBehaviorFloatCeil(OpBehavior):
+    """
+    Behavior for the FLOAT_CEIL operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_CEIL, True)
+
+    # uintb OpBehaviorFloatCeil::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opCeil(in1);
+    # }
+
+
+class OpBehaviorFloatFloor(OpBehavior):
+    """
+    Behavior for the FLOAT_FLOOR operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_FLOOR, True)
+
+    # uintb OpBehaviorFloatFloor::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opFloor(in1);
+    # }
+
+
+class OpBehaviorFloatRound(OpBehavior):
+    """
+    Behavior for the FLOAT_ROUND operation.
+    """
+
+    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
+    _translate: Sleigh
+
+    def __init__(self, trans: Sleigh) -> None:
+        self._translate = trans
+        super().__init__(OpCode.CPUI_FLOAT_ROUND, True)
+
+    # uintb OpBehaviorFloatRound::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
+    #
+    # {
+    #   const FloatFormat *format = translate->getFloatFormat(size_in);
+    #   if (format == (const FloatFormat *)0)
+    #     return OpBehavior::evaluateUnary(size_out,size_in,in1);
+    #
+    #   return format->opRound(in1);
+    # }
+
+
+class OpBehaviorPiece(OpBehavior):
+    """
+    Behavior for the PIECE operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_PIECE, False)
+
+    # uintb OpBehaviorPiece::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
+    #
+    # {
+    #   uintb res = ( in1<<((size_out-size_in)*8)) | in2;
+    #   return res;
+    # }
+
+
+class OpBehaviorSubpiece(OpBehavior):
+    """
+    Behavior for the SUBPIECE operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_SUBPIECE, False)
+
+    def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
+        if in2.size() < in1.size():
+            in2 = in2.sign_extend(in1.size() - in2.size())
+        return (in1>>(in2*8)) & (2**(size_out*8)-1)
+
+
+class OpBehaviorPopcount(OpBehavior):
+    """
+    Behavior for the POPCOUNT operation.
+    """
+    def __init__(self) -> None:
+        super().__init__(OpCode.CPUI_POPCOUNT, True)
+
+    def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
+        expr = claripy.BVV(0, size_out*8)
+        for a in range(len(in1)):
+            expr += claripy.Extract(a, a, in1).zero_extend(size_out*8-1)
+        return expr
+
+
+class BehaviorFactory:
+    """
+    Returns the behavior object for a given opcode.
+    """
+    def __init__(self, trans: Sleigh = None) -> None:
+        self._trans = trans
+        self._behaviors = {}
+        self._register_behaviors()
+
+    def get_behavior_for_opcode(self, opcode: int) -> OpBehavior:
+        return self._behaviors[opcode]
+
+    def _register_behaviors(self) -> None:
+        self._behaviors.update({
+            OpCode.CPUI_COPY: OpBehaviorCopy(),
+            OpCode.CPUI_LOAD: OpBehavior(OpCode.CPUI_LOAD, False, True),
+            OpCode.CPUI_STORE: OpBehavior(OpCode.CPUI_STORE, False, True),
+            OpCode.CPUI_BRANCH: OpBehavior(OpCode.CPUI_BRANCH, False, True),
+            OpCode.CPUI_CBRANCH: OpBehavior(OpCode.CPUI_CBRANCH, False, True),
+            OpCode.CPUI_BRANCHIND: OpBehavior(OpCode.CPUI_BRANCHIND, False, True),
+            OpCode.CPUI_CALL: OpBehavior(OpCode.CPUI_CALL, False, True),
+            OpCode.CPUI_CALLIND: OpBehavior(OpCode.CPUI_CALLIND, False, True),
+            OpCode.CPUI_CALLOTHER: OpBehavior(OpCode.CPUI_CALLOTHER, False, True),
+            OpCode.CPUI_RETURN: OpBehavior(OpCode.CPUI_RETURN, False, True),
+            OpCode.CPUI_MULTIEQUAL: OpBehavior(OpCode.CPUI_MULTIEQUAL, False, True),
+            OpCode.CPUI_INDIRECT: OpBehavior(OpCode.CPUI_INDIRECT, False, True),
+            OpCode.CPUI_PIECE: OpBehaviorPiece(),
+            OpCode.CPUI_SUBPIECE: OpBehaviorSubpiece(),
+            OpCode.CPUI_INT_EQUAL: OpBehaviorEqual(),
+            OpCode.CPUI_INT_NOTEQUAL: OpBehaviorNotEqual(),
+            OpCode.CPUI_INT_SLESS: OpBehaviorIntSless(),
+            OpCode.CPUI_INT_SLESSEQUAL: OpBehaviorIntSlessEqual(),
+            OpCode.CPUI_INT_LESS: OpBehaviorIntLess(),
+            OpCode.CPUI_INT_LESSEQUAL: OpBehaviorIntLessEqual(),
+            OpCode.CPUI_INT_ZEXT: OpBehaviorIntZext(),
+            OpCode.CPUI_INT_SEXT: OpBehaviorIntSext(),
+            OpCode.CPUI_INT_ADD: OpBehaviorIntAdd(),
+            OpCode.CPUI_INT_SUB: OpBehaviorIntSub(),
+            OpCode.CPUI_INT_CARRY: OpBehaviorIntCarry(),
+            OpCode.CPUI_INT_SCARRY: OpBehaviorIntScarry(),
+            OpCode.CPUI_INT_SBORROW: OpBehaviorIntSborrow(),
+            OpCode.CPUI_INT_2COMP: OpBehaviorInt2Comp(),
+            OpCode.CPUI_INT_NEGATE: OpBehaviorIntNegate(),
+            OpCode.CPUI_INT_XOR: OpBehaviorIntXor(),
+            OpCode.CPUI_INT_AND: OpBehaviorIntAnd(),
+            OpCode.CPUI_INT_OR: OpBehaviorIntOr(),
+            OpCode.CPUI_INT_LEFT: OpBehaviorIntLeft(),
+            OpCode.CPUI_INT_RIGHT: OpBehaviorIntRight(),
+            OpCode.CPUI_INT_SRIGHT: OpBehaviorIntSright(),
+            OpCode.CPUI_INT_MULT: OpBehaviorIntMult(),
+            OpCode.CPUI_INT_DIV: OpBehaviorIntDiv(),
+            OpCode.CPUI_INT_SDIV: OpBehaviorIntSdiv(),
+            OpCode.CPUI_INT_REM: OpBehaviorIntRem(),
+            OpCode.CPUI_INT_SREM: OpBehaviorIntSrem(),
+            OpCode.CPUI_BOOL_NEGATE: OpBehaviorBoolNegate(),
+            OpCode.CPUI_BOOL_XOR: OpBehaviorBoolXor(),
+            OpCode.CPUI_BOOL_AND: OpBehaviorBoolAnd(),
+            OpCode.CPUI_BOOL_OR: OpBehaviorBoolOr(),
+            OpCode.CPUI_CAST: OpBehavior(OpCode.CPUI_CAST, False, True),
+            OpCode.CPUI_PTRADD: OpBehavior(OpCode.CPUI_PTRADD, False, True),
+            OpCode.CPUI_PTRSUB: OpBehavior(OpCode.CPUI_PTRSUB, False, True),
+            OpCode.CPUI_FLOAT_EQUAL: OpBehaviorFloatEqual(self._trans),
+            OpCode.CPUI_FLOAT_NOTEQUAL: OpBehaviorFloatNotEqual(self._trans),
+            OpCode.CPUI_FLOAT_LESS: OpBehaviorFloatLess(self._trans),
+            OpCode.CPUI_FLOAT_LESSEQUAL: OpBehaviorFloatLessEqual(self._trans),
+            OpCode.CPUI_FLOAT_NAN: OpBehaviorFloatNan(self._trans),
+            OpCode.CPUI_FLOAT_ADD: OpBehaviorFloatAdd(self._trans),
+            OpCode.CPUI_FLOAT_DIV: OpBehaviorFloatDiv(self._trans),
+            OpCode.CPUI_FLOAT_MULT: OpBehaviorFloatMult(self._trans),
+            OpCode.CPUI_FLOAT_SUB: OpBehaviorFloatSub(self._trans),
+            OpCode.CPUI_FLOAT_NEG: OpBehaviorFloatNeg(self._trans),
+            OpCode.CPUI_FLOAT_ABS: OpBehaviorFloatAbs(self._trans),
+            OpCode.CPUI_FLOAT_SQRT: OpBehaviorFloatSqrt(self._trans),
+            OpCode.CPUI_FLOAT_INT2FLOAT: OpBehaviorFloatInt2Float(self._trans),
+            OpCode.CPUI_FLOAT_FLOAT2FLOAT: OpBehaviorFloatFloat2Float(self._trans),
+            OpCode.CPUI_FLOAT_TRUNC: OpBehaviorFloatTrunc(self._trans),
+            OpCode.CPUI_FLOAT_CEIL: OpBehaviorFloatCeil(self._trans),
+            OpCode.CPUI_FLOAT_FLOOR: OpBehaviorFloatFloor(self._trans),
+            OpCode.CPUI_FLOAT_ROUND: OpBehaviorFloatRound(self._trans),
+            OpCode.CPUI_SEGMENTOP: OpBehavior(OpCode.CPUI_SEGMENTOP, False, True),
+            OpCode.CPUI_CPOOLREF: OpBehavior(OpCode.CPUI_CPOOLREF, False, True),
+            OpCode.CPUI_NEW: OpBehavior(OpCode.CPUI_NEW, False, True),
+            OpCode.CPUI_INSERT: OpBehavior(OpCode.CPUI_INSERT, False, True),
+            OpCode.CPUI_EXTRACT: OpBehavior(OpCode.CPUI_EXTRACT, False, True),
+            OpCode.CPUI_POPCOUNT: OpBehaviorPopcount(),
+            })

--- a/angr/engines/pcode/emulate.py
+++ b/angr/engines/pcode/emulate.py
@@ -1,0 +1,376 @@
+import logging
+from typing import Union
+
+import pypcode
+from pypcode import OpCode, VarnodeData, PcodeOpRaw
+import claripy
+from claripy.ast.bv import BV
+
+from ..engine import SimEngineBase
+from ...utils.constants import DEFAULT_STATEMENT
+from .lifter import IRSB, PcodeInstruction
+from .behavior import OpBehavior
+
+l = logging.getLogger(__name__)
+
+class PcodeEmulatorMixin(SimEngineBase):
+    """
+    Mixin for P-Code execution.
+    """
+
+    _current_ins:      Union[PcodeInstruction, None]
+    _current_op:       Union[PcodeOpRaw, None]
+    _current_behavior: Union[OpBehavior, None]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._current_ins = None
+        self._current_op = None
+        self._current_behavior = None
+        self._special_op_handlers = {
+            OpCode.CPUI_LOAD:       self._execute_load,
+            OpCode.CPUI_STORE:      self._execute_store,
+            OpCode.CPUI_BRANCH:     self._execute_branch,
+            OpCode.CPUI_CBRANCH:    self._execute_cbranch,
+            OpCode.CPUI_BRANCHIND:  self._execute_branchind,
+            OpCode.CPUI_CALL:       self._execute_call,
+            OpCode.CPUI_CALLIND:    self._execute_callind,
+            OpCode.CPUI_CALLOTHER:  self._execute_callother,
+            OpCode.CPUI_RETURN:     self._execute_ret,
+            OpCode.CPUI_MULTIEQUAL: self._execute_multiequal,
+            OpCode.CPUI_INDIRECT:   self._execute_indirect,
+            OpCode.CPUI_SEGMENTOP:  self._execute_segment_op,
+            OpCode.CPUI_CPOOLREF:   self._execute_cpool_ref,
+            OpCode.CPUI_NEW:        self._execute_new,
+        }
+
+    def handle_pcode_block(self, irsb: IRSB) -> None:
+        """
+        Execute a single IRSB.
+
+        :param irsb: The block to be executed.
+        """
+        self.irsb = irsb
+        # Hack on a handler here to track whether exit has been handled or not
+        # FIXME: Vex models this as a known exit statement, which we should also
+        # do here. For now, handle it this way.
+        self.state.scratch.exit_handled = False
+
+        fallthru_addr = None
+        for i, ins in enumerate(irsb._instructions):
+            l.debug("Executing machine instruction @ %#x (%d of %d)", ins.addr.getOffset(), i+1, len(irsb._instructions))
+
+            # Execute a single instruction of the emulated machine
+            self._current_ins = ins
+            self.state.scratch.ins_addr = self._current_ins.addr.getOffset()
+
+            # FIXME: Hacking this on here but ideally should use "scratch".
+            self._pcode_tmps = {}  # FIXME: Consider alignment requirements
+
+            for op in self._current_ins.ops:
+                self._current_op = op
+                self._current_behavior = irsb.behaviors.get_behavior_for_opcode(self._current_op.getOpcode())
+                l.debug("Executing p-code op: %s", self._current_ins.pp_op_str(self._current_op))
+                self._execute_current_op()
+
+            self._current_op = None
+            self._current_behavior = None
+            fallthru_addr = ins.addr.getOffset() + ins.length
+
+        if not self.state.scratch.exit_handled:
+            self.successors.add_successor(
+                self.state,
+                fallthru_addr,
+                self.state.scratch.guard,
+                "Ijk_Boring",
+                exit_stmt_idx=DEFAULT_STATEMENT,
+                exit_ins_addr=self.state.scratch.ins_addr,
+            )
+
+    def _execute_current_op(self) -> None:
+        """
+        Execute the current p-code operation.
+        """
+        assert self._current_behavior is not None
+
+        if self._current_behavior.is_special:
+            self._special_op_handlers[self._current_behavior.opcode]()
+        elif self._current_behavior.is_unary:
+            self._execute_unary()
+        else:
+            self._execute_binary()
+
+    def _map_register_name(self, var_data: VarnodeData) -> int:
+        """
+        Map SLEIGH register offset to ArchInfo register offset based on name.
+
+        :param var_data: The varnode to translate.
+        :return:         The register file offset.
+        """
+        # FIXME: Will need performance optimization
+        # FIXME: Should not get trans object this way. Moreover, should have a faster mapping method than going through trans
+        trans = self.irsb._instructions[0].trans
+        reg_name = trans.getRegisterName(var_data.space, var_data.offset, var_data.size)
+        try:
+            reg_offset = self.state.project.arch.get_register_offset(reg_name.lower())
+            l.debug("Mapped register '%s' to offset %x", reg_name, reg_offset)
+        except ValueError:
+            reg_offset = var_data.offset + 0x100000
+            l.debug("Could not map register '%s' from archinfo. Mapping to %x", reg_name, reg_offset)
+        return reg_offset
+
+    @staticmethod
+    def _adjust_value_size(num_bits: int, v_in: BV) -> BV:
+        """
+        Ensure given bv is num_bits bits long by either zero extending or truncating.
+        """
+        if v_in.size() > num_bits:
+            v_out = v_in[num_bits-1:0]
+            l.debug('Truncating value %s (%d bits) to %s (%d bits)',
+                    v_in,
+                    v_in.size(),
+                    v_out,
+                    num_bits)
+            return v_out
+        elif v_in.size() < num_bits:
+            v_out = v_in.zero_extend(num_bits-v_in.size())
+            l.debug('Extending value %s (%d bits) to %s (%d bits)',
+                    v_in,
+                    v_in.size(),
+                    v_out,
+                    num_bits)
+            return v_out
+        else:
+            return v_in
+
+    def _set_value(self, var_data: VarnodeData, value: BV) -> None:
+        """
+        Store a value for a given varnode.
+
+        This method stores to the appropriate register, or unique space,
+        depending on the space indicated by the varnode.
+
+        :param var_data: The varnode to store into.
+        :param value:    The value to store.
+        """
+        space_name = var_data.space.getName()
+
+        # FIXME: Consider moving into behavior.py
+        value = self._adjust_value_size(var_data.size*8, value)
+        assert var_data.size*8 == value.size()
+
+        l.debug("Storing %s %x %s %d", space_name, var_data.offset, value, var_data.size)
+        if space_name == "register":
+            self.state.registers.store(
+                self._map_register_name(var_data), value, size=var_data.size
+            )
+
+        elif space_name == "unique":
+            self._pcode_tmps[var_data.offset] = value
+
+        elif space_name == "ram":
+            l.debug("Storing %s to offset %s", value, var_data.offset)
+            self.state.memory.store(var_data.offset, value, endness=self.project.arch.memory_endness)
+
+        else:
+            raise NotImplementedError()
+
+    def _get_value(self, var_data: VarnodeData) -> BV:
+        """
+        Get a value for a given varnode.
+
+        This method loads from the appropriate const, register, unique, or RAM
+        space, depending on the space indicated by the varnode.
+
+        :param var_data: The varnode to load from.
+        :return:         The value loaded.
+        """
+        space_name = var_data.space.getName()
+        size = var_data.size
+        l.debug("Loading %s - %x x %d", space_name, var_data.offset, size)
+        if space_name == "const":
+            return claripy.BVV(var_data.offset, size*8)
+        elif space_name == "register":
+            return self.state.registers.load(self._map_register_name(var_data), size=size)
+        elif space_name == "unique":
+            # FIXME: Support loading data of different sizes. For now, assume
+            # size of values read are same as size written.
+            assert self._pcode_tmps[var_data.offset].size() == size*8
+            return self._pcode_tmps[var_data.offset]
+        elif space_name == "ram":
+            val = self.state.memory.load(var_data.offset, endness=self.project.arch.memory_endness, size=size)
+            l.debug("Loaded %s from offset %s", val, var_data.offset)
+            return val
+        else:
+            raise NotImplementedError()
+
+    def _execute_unary(self) -> None:
+        """
+        Execute the unary behavior of the current op.
+        """
+        in1 = self._get_value(self._current_op.getInput(0))
+        l.debug("in1 = %s", in1)
+        out = self._current_behavior.evaluate_unary(
+            self._current_op.getOutput().size, self._current_op.getInput(0).size, in1
+        )
+        l.debug("out unary = %s", out)
+        self._set_value(self._current_op.getOutput(), out)
+
+    def _execute_binary(self) -> None:
+        """
+        Execute the binary behavior of the current op.
+        """
+        in1 = self._get_value(self._current_op.getInput(0))
+        in2 = self._get_value(self._current_op.getInput(1))
+        l.debug("in1 = %s", in1)
+        l.debug("in2 = %s", in2)
+        out = self._current_behavior.evaluate_binary(
+            self._current_op.getOutput().size, self._current_op.getInput(0).size, in1, in2
+        )
+        l.debug("out binary = %s", out)
+        self._set_value(self._current_op.getOutput(), out)
+
+    def _execute_load(self) -> None:
+        """
+        Execute a p-code load operation.
+        """
+        spc = pypcode.Address.getSpaceFromConst(self._current_op.getInput(0).getAddr())
+        assert spc.getName() == "ram"
+        off = self._get_value(self._current_op.getInput(1))
+        out = self._current_op.getOutput()
+        res = self.state.memory.load(off, out.size, endness=self.project.arch.memory_endness)
+        l.debug("Loaded %s from offset %s", res, off)
+        self._set_value(out, res)
+
+    def _execute_store(self) -> None:
+        """
+        Execute a p-code store operation.
+        """
+        spc = pypcode.Address.getSpaceFromConst(self._current_op.getInput(0).getAddr())
+        assert spc.getName() == "ram"
+        off = self._get_value(self._current_op.getInput(1))
+        data = self._get_value(self._current_op.getInput(2))
+        l.debug("Storing %s at offset %s", data, off)
+        self.state.memory.store(off, data, endness=self.project.arch.memory_endness)
+
+    def _execute_branch(self) -> None:
+        """
+        Execute a p-code branch operation.
+        """
+        dest_addr = self._current_op.getInput(0).getAddr()
+        if dest_addr.isConstant():
+            raise NotImplementedError("P-code relative branch not supported yet")
+
+        self.state.scratch.exit_handled = True
+        expr = dest_addr.getOffset()
+        self.successors.add_successor(
+            self.state,
+            expr,
+            self.state.scratch.guard,
+            "Ijk_Boring",
+            exit_stmt_idx=DEFAULT_STATEMENT,
+            exit_ins_addr=self.state.scratch.ins_addr,
+        )
+
+    def _execute_cbranch(self) -> None:
+        """
+        Execute a p-code conditional branch operation.
+        """
+        cond = self._get_value(self._current_op.getInput(1))
+        dest_addr = self._current_op.getInput(0).getAddr()
+        if dest_addr.isConstant():
+            raise NotImplementedError("P-code relative branch not supported yet")
+
+        exit_state = self.state.copy()
+        self.successors.add_successor(
+            exit_state,
+            dest_addr.getOffset(),
+            cond != 0,
+            "Ijk_Boring",
+            exit_stmt_idx=DEFAULT_STATEMENT,
+            exit_ins_addr=self.state.scratch.ins_addr,
+        )
+
+        cont_state = self.state
+        cont_condition = cond == 0
+        cont_state.add_constraints(cont_condition)
+        cont_state.scratch.guard = claripy.And(
+            cont_state.scratch.guard, cont_condition
+        )
+
+    def _execute_ret(self) -> None:
+        """
+        Execute a p-code return operation.
+        """
+        self.state.scratch.exit_handled = True
+        self.successors.add_successor(
+            self.state,
+            self.state.regs.ip,
+            self.state.scratch.guard,
+            "Ijk_Ret",
+            exit_stmt_idx=DEFAULT_STATEMENT,
+            exit_ins_addr=self.state.scratch.ins_addr,
+        )
+
+    def _execute_branchind(self) -> None:
+        """
+        Execute a p-code indirect branch operation.
+        """
+        self.state.scratch.exit_handled = True
+        expr = self._get_value(self._current_op.getInput(0))
+        self.successors.add_successor(
+            self.state,
+            expr,
+            self.state.scratch.guard,
+            "Ijk_Boring",
+            exit_stmt_idx=DEFAULT_STATEMENT,
+            exit_ins_addr=self.state.scratch.ins_addr,
+        )
+
+    def _execute_call(self) -> None:
+        """
+        Execute a p-code call operation.
+        """
+        self.state.scratch.exit_handled = True
+        expr = self._current_op.getInput(0).getAddr().getOffset()
+        self.successors.add_successor(
+            self.state,
+            expr,
+            self.state.scratch.guard,
+            "Ijk_Call",
+            exit_stmt_idx=DEFAULT_STATEMENT,
+            exit_ins_addr=self.state.scratch.ins_addr,
+        )
+
+    def _execute_callind(self) -> None:
+        """
+        Execute a p-code indirect call operation.
+        """
+        self.state.scratch.exit_handled = True
+        expr = self._get_value(self._current_op.getInput(0))
+        self.successors.add_successor(
+            self.state,
+            expr,
+            self.state.scratch.guard,
+            "Ijk_Call",
+            exit_stmt_idx=DEFAULT_STATEMENT,
+            exit_ins_addr=self.state.scratch.ins_addr,
+        )
+
+    def _execute_callother(self) -> None:
+        raise NotImplementedError("CALLOTHER emulation not currently supported")
+
+    def _execute_multiequal(self) -> None:
+        raise NotImplementedError("MULTIEQUAL appearing in unheritaged code?")
+
+    def _execute_indirect(self) -> None:
+        raise NotImplementedError("INDIRECT appearing in unheritaged code?")
+
+    def _execute_segment_op(self) -> None:
+        raise NotImplementedError("SEGMENTOP emulation not currently supported")
+
+    def _execute_cpool_ref(self) -> None:
+        raise NotImplementedError("Cannot currently emulate cpool operator")
+
+    def _execute_new(self) -> None:
+        raise NotImplementedError("Cannot currently emulate new operator")

--- a/angr/engines/pcode/engine.py
+++ b/angr/engines/pcode/engine.py
@@ -1,0 +1,245 @@
+from typing import Optional, Iterable
+
+import claripy
+import logging
+
+from angr.engines.engine import SuccessorsMixin, SimSuccessors
+from ...utils.constants import DEFAULT_STATEMENT
+from ... import sim_options as o
+from ... import errors
+from .lifter import PcodeLifterEngineMixin, lifters, IRSB
+from .emulate import PcodeEmulatorMixin
+
+l = logging.getLogger(__name__)
+
+# pylint:disable=abstract-method
+
+class HeavyPcodeMixin(
+    SuccessorsMixin,
+    PcodeLifterEngineMixin,
+    PcodeEmulatorMixin,
+):
+    """
+    Execution engine based on P-code, Ghidra's IR.
+
+    Responds to the following parameters to the step stack:
+
+    - irsb:        The P-Code IRSB object to use for execution. If not provided one will be lifted.
+    - skip_stmts:  The number of statements to skip in processing
+    - last_stmt:   Do not execute any statements after this statement
+    - thumb:       Whether the block should be force to be lifted in ARM's THUMB mode. (FIXME)
+    - extra_stop_points:
+                   An extra set of points at which to break basic blocks
+    - insn_bytes:  A string of bytes to use for the block instead of the project.
+    - size:        The maximum size of the block, in bytes.
+    - num_inst:    The maximum number of instructions.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._addr = None
+        self._insn_bytes = None
+        self._thumb = None
+        self._size = None
+        self._num_inst = None
+        self._extra_stop_points = None
+
+    def process_successors(
+        self,
+        successors: SimSuccessors,
+        irsb: Optional[IRSB] = None,
+        insn_text: Optional[str] = None,
+        insn_bytes: Optional[bytes] = None,
+        thumb: bool = False,
+        size: Optional[int] = None,
+        num_inst: Optional[int] = None,
+        extra_stop_points: Optional[Iterable[int]] = None,
+        **kwargs
+    ) -> None:
+        # pylint:disable=arguments-differ
+        if not lifters[self.state.arch.name] or type(successors.addr) is not int:
+            return super().process_successors(successors,
+                                              extra_stop_points=extra_stop_points,
+                                              num_inst=num_inst,
+                                              size=size,
+                                              insn_text=insn_text,
+                                              insn_bytes=insn_bytes,
+                                              **kwargs)
+
+        if insn_text is not None:
+            if insn_bytes is not None:
+                raise errors.SimEngineError(
+                    "You cannot provide both 'insn_bytes' and 'insn_text'!"
+                )
+
+            insn_bytes = self.project.arch.asm(
+                insn_text, addr=successors.addr, thumb=thumb
+            )
+            if insn_bytes is None:
+                raise errors.AngrAssemblyError(
+                    "Assembling failed. Please make sure keystone is installed, and the"
+                    " assembly string is correct."
+                )
+
+        successors.sort = "IRSB"
+        successors.description = "IRSB"
+        self.state.history.recent_block_count = 1
+        self.state.scratch.guard = claripy.true
+        self.state.scratch.sim_procedure = None
+        addr = successors.addr
+        self.state.scratch.bbl_addr = addr
+        self.state.scratch.irsb = irsb
+
+        self._addr = addr
+        self._insn_bytes = insn_bytes
+        self._thumb = thumb
+        self._size = size
+        self._num_inst = num_inst
+        self._extra_stop_points = extra_stop_points
+
+        # Lift and process the block to get successors, retry if necessary
+        finished = False
+        while not finished:
+            self._lift_irsb()
+            self._probe_access()
+            self._store_successor_artifacts(successors)
+            finished = self._process_irsb()
+
+        self._process_successor_exits(successors)
+        successors.processed = True
+
+    def _lift_irsb(self):
+        irsb = self.state.scratch.irsb
+        if irsb is None:
+            irsb = self.lift_pcode(
+                addr=self._addr,
+                state=self.state,
+                insn_bytes=self._insn_bytes,
+                thumb=self._thumb,
+                size=self._size,
+                num_inst=self._num_inst,
+                extra_stop_points=self._extra_stop_points,
+            )
+        if irsb.size == 0:
+            if (
+                irsb.jumpkind == "Ijk_NoDecode"
+                and not self.state.project.is_hooked(irsb.addr)
+            ):
+                raise errors.SimIRSBNoDecodeError(
+                    "IR decoding error at %#x. You can hook this instruction with "
+                    "a python replacement using project.hook"
+                    "(%#x, your_function, length=length_of_instruction)."
+                    % (self._addr, self._addr)
+                )
+            raise errors.SimIRSBError("Empty IRSB passed to HeavyPcodeMixin.")
+        self.state.scratch.irsb = irsb
+
+    def _store_successor_artifacts(self, successors: SimSuccessors) -> None:
+        """
+        Update successors.artifacts with IRSB details.
+        """
+        irsb = self.state.scratch.irsb
+        successors.artifacts["irsb"] = irsb
+        successors.artifacts["irsb_size"] = irsb.size
+        successors.artifacts["irsb_direct_next"] = irsb.direct_next
+        successors.artifacts["irsb_default_jumpkind"] = irsb.jumpkind
+        successors.artifacts["insn_addrs"] = []
+
+    def _probe_access(self) -> None:
+        """
+        Check permissions, are we allowed to execute here? Do we care?
+        """
+        if o.STRICT_PAGE_ACCESS not in self.state.options:
+            return
+        try:
+            perms = self.state.memory.permissions(self._addr)
+        except errors.SimMemoryError:
+            raise errors.SimSegfaultError(self._addr, "exec-miss") from errors.SimMemoryError
+        else:
+            if not perms.symbolic:
+                perms = self.state.solver.eval(perms)
+                if not perms & 4 and o.ENABLE_NX in self.state.options:
+                    raise errors.SimSegfaultError(self._addr, "non-executable")
+
+    def _process_irsb(self) -> bool:
+        """
+        Execute the IRSB. Returns True if successfully processed.
+        """
+        try:
+            self.handle_pcode_block(self.state.scratch.irsb)
+            return True
+        except errors.SimReliftException as e:
+            self.state = e.state
+            if self._insn_bytes is not None:
+                raise errors.SimEngineError(
+                    "You cannot pass self-modifying code as insn_bytes!!!"
+                )
+            new_ip = self.state.scratch.ins_addr
+            if self._size is not None:
+                self._size -= new_ip - self._addr
+            if self._num_inst is not None:
+                self._num_inst -= self.state.scratch.num_insns
+            self._addr = new_ip
+
+            # clear the stage before creating the new IRSB
+            self.state.scratch.dirty_addrs.clear()
+            self.state.scratch.irsb = None
+        except errors.SimError as ex:
+            ex.record_state(self.state)
+            raise
+        # FIXME:
+        # except VEXEarlyExit:
+        #     break
+        return False
+
+
+    def _process_successor_exits(self, successors: SimSuccessors) -> None:
+        """
+        Do return emulation and call-less stuff.
+        """
+        for exit_state in list(successors.all_successors):
+            exit_jumpkind = exit_state.history.jumpkind
+            if exit_jumpkind is None:
+                exit_jumpkind = ""
+
+            if o.CALLLESS in self.state.options and exit_jumpkind == "Ijk_Call":
+                exit_state.registers.store(
+                    exit_state.arch.ret_offset,
+                    exit_state.solver.Unconstrained(
+                        "fake_ret_value", exit_state.arch.bits
+                    ),
+                )
+                exit_state.scratch.target = exit_state.solver.BVV(
+                    successors.addr + self.state.scratch.irsb.size, exit_state.arch.bits
+                )
+                exit_state.history.jumpkind = "Ijk_Ret"
+                exit_state.regs.ip = exit_state.scratch.target
+                if exit_state.arch.call_pushes_ret:
+                    exit_state.regs.sp = exit_state.regs.sp + exit_state.arch.bytes
+
+            elif o.DO_RET_EMULATION in exit_state.options and (
+                exit_jumpkind == "Ijk_Call" or exit_jumpkind.startswith("Ijk_Sys")
+            ):
+                l.debug("%s adding postcall exit.", self)
+
+                ret_state = exit_state.copy()
+                guard = (
+                    ret_state.solver.true
+                    if o.TRUE_RET_EMULATION_GUARD in self.state.options
+                    else ret_state.solver.false
+                )
+                ret_target = ret_state.solver.BVV(
+                    successors.addr + self.state.scratch.irsb.size, ret_state.arch.bits
+                )
+                if ret_state.arch.call_pushes_ret and not exit_jumpkind.startswith(
+                    "Ijk_Sys"
+                ):
+                    ret_state.regs.sp = ret_state.regs.sp + ret_state.arch.bytes
+                successors.add_successor(
+                    ret_state,
+                    ret_target,
+                    guard,
+                    "Ijk_FakeRet",
+                    exit_stmt_idx=DEFAULT_STATEMENT,
+                    exit_ins_addr=self.state.scratch.ins_addr,
+                )

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -1,0 +1,1527 @@
+# FIXME:
+#     - Eliminate Vex references where possible
+#     - Consider moving pieces of lifter classes to higher abstraction layer
+#       to reduce duplication with Vex
+#     - Fix default_exit_target
+#     - Fix/remove NotImplementedError's
+
+from collections import defaultdict
+import logging
+import os
+import sys
+from typing import Union, Optional, Iterable, Sequence, Tuple
+
+import archinfo
+from archinfo import ArchARM
+import pypcode
+import cle
+from cachetools import LRUCache
+# FIXME: Reusing these errors from pyvex for compatibility. Eventually these
+# should be refactored to use common error classes.
+from pyvex.errors import PyVEXError, SkipStatementsError, LiftingException, NeedStatementsNotification
+
+from .behavior import BehaviorFactory
+from ..engine import SimEngineBase
+from ...state_plugins.inspect import BP_AFTER, BP_BEFORE
+from ...sim_state import SimState
+from ...misc.ux import once
+from ...errors import SimEngineError, SimTranslationError, SimError
+from ... import sim_options as o
+
+l = logging.getLogger(__name__)
+
+IRSB_MAX_SIZE = 400
+IRSB_MAX_INST = 99
+MAX_INSTRUCTIONS = 99999
+MAX_BYTES = 5000
+
+# This class exists to ease compatibility with CFGFast's processing of
+# exit_statements. See _scan_irsb method.
+class ExitStatement:
+    __slots__ = (
+        "dst",
+        "jumpkind"
+    )
+
+    dst: Optional[int]
+    jumpkind: str
+
+    def __init__(self, dst: Optional[int], jumpkind: str):
+        self.dst = dst
+        self.jumpkind = jumpkind
+
+class PcodeInstruction:
+    __slots__ = (
+        "addr",
+        "length",
+        "pcode",
+        "trans"
+    )
+
+    addr: pypcode.Address
+    length: int
+    pcode: pypcode.PcodeRawOutHelper
+    trans: pypcode.Sleigh
+
+    def __init__(self,
+                 addr: pypcode.Address,
+                 length: int,
+                 pcode: pypcode.PcodeRawOutHelper,
+                 trans: pypcode.Sleigh) -> None:
+        self.addr = addr
+        self.length = length
+        self.pcode = pcode
+        self.trans = trans
+
+    @property
+    def ops(self) -> pypcode.PcodeRawOutHelper:
+        return self.pcode.opcache
+
+    def pp_vardata(self, data: pypcode.VarnodeData) -> None:
+        space_name = data.space.getName()
+        if space_name == "register":
+            space_name = "reg"
+            regname = self.trans.getRegisterName(data.space, data.offset, data.size)
+            space_name += "{%s}" % regname
+        return "(%s, 0x%x, %d) " % (space_name, data.offset, data.size)
+
+    def pp(self) -> None:
+        for op in self.pcode.opcache:
+            out = op.getOutput()
+            if out:
+                sys.stdout.write("%-20s = " % (self.pp_vardata(out)))
+            else:
+                sys.stdout.write(" " * 23)
+            sys.stdout.write("%-12s " % pypcode.get_opname(op.getOpcode()))
+            for i in range(op.numInput()):
+                sys.stdout.write(self.pp_vardata(op.getInput(i)))
+            sys.stdout.write("\n")
+
+    def pp_op_str(self, op: pypcode.PcodeOpRaw) -> str:
+        s = ""
+        out = op.getOutput()
+        if out:
+            s += "%-20s = " % (self.pp_vardata(out))
+        else:
+            s += " " * 23
+        s += "%-12s " % pypcode.get_opname(op.getOpcode())
+
+        start = 0
+        if op.getOpcode() in [pypcode.OpCode.CPUI_LOAD, pypcode.OpCode.CPUI_STORE]:
+            s += "[%s] " % self.pp_space_from_constant_id(op)
+            start += 1
+
+        for i in range(start, op.numInput()):
+            s += "%-20s" % self.pp_vardata(op.getInput(i))
+
+        if op.getOpcode() == pypcode.OpCode.CPUI_CALLOTHER:
+            print(s)
+            assert False
+
+        return s
+
+    @staticmethod
+    def pp_space_from_constant_id(op: int) -> str:
+        # For these operations, input0 contains a constant id of the space which
+        # input1 is an offset into
+        assert op.getOpcode() in [pypcode.OpCode.CPUI_LOAD, pypcode.OpCode.CPUI_STORE]
+        return pypcode.Address.getSpaceFromConst(op.getInput(0).getAddr()).getName()
+
+
+class IRSB:
+    """
+    IRSB stands for *Intermediate Representation Super-Block*. An IRSB in is a
+    single-entry, multiple-exit code block.
+
+    :ivar arch:             The architecture this block is lifted under
+    :vartype arch:          :class:`archinfo.Arch`
+    :ivar statements:       The statements in this block
+    :vartype statements:    list of :class:`IRStmt`
+    :ivar next:             The expression for the default exit target of this block
+    :vartype next:          :class:`IRExpr`
+    :ivar int offsIP:       The offset of the instruction pointer in the VEX guest state
+    :ivar int stmts_used:   The number of statements in this IRSB
+    :ivar str jumpkind:     The type of this block's default jump (call, boring, syscall, etc) as a VEX enum string
+    :ivar bool direct_next: Whether this block ends with a direct (not indirect) jump or branch
+    :ivar int size:         The size of this block in bytes
+    :ivar int addr:         The address of this basic block, i.e. the address in the first IMark
+    """
+
+    __slots__ = (
+        "_direct_next",
+        "_exit_statements",
+        "_instruction_addresses",
+        "_instructions",
+        "_size",
+        "_statements",
+        "addr",
+        "arch",
+        "behaviors",
+        "data_refs",
+        "default_exit_target",
+        "jumpkind",
+        "next",
+    )
+
+    _direct_next: Optional[bool]
+    _exit_statements: Sequence[Tuple[int, int, ExitStatement]]
+    _instruction_addresses: Sequence[int]
+    _instructions: Sequence[PcodeInstruction]
+    _size: Optional[int]
+    _statements: Iterable # Note: currently unused
+    addr: int
+    arch: archinfo.Arch
+    behaviors: Optional[BehaviorFactory]
+    data_refs: Sequence # Note: currently unused
+    default_exit_target: Optional # Note: currently used
+    jumpkind: Optional[str]
+    next: Optional[int]
+
+    # The following constants shall match the defs in pyvex.h
+    MAX_EXITS = 400
+    MAX_DATA_REFS = 2000
+
+    def __init__(
+        self,
+        data: Union[str, bytes, None],
+        mem_addr: int,
+        arch: archinfo.Arch,
+        max_inst: Optional[int] = None,
+        max_bytes: Optional[int] = None,
+        bytes_offset: int = 0,
+        traceflags: int = 0,
+        opt_level: int = 1,
+        num_inst: Optional[int] = None,
+        num_bytes: Optional[int] = None,
+        strict_block_end: bool = False,
+        skip_stmts: bool = False,
+        collect_data_refs: bool = False,
+    ) -> None:
+        """
+        :param data:                The bytes to lift. Can be either a string of bytes or a cffi buffer object.
+                                    You may also pass None to initialize an empty IRSB.
+        :param int mem_addr:        The address to lift the data at.
+        :param arch:                The architecture to lift the data as.
+        :param max_inst:            The maximum number of instructions to lift. (See note below)
+        :param max_bytes:           The maximum number of bytes to use.
+        :param num_inst:            Replaces max_inst if max_inst is None. If set to None as well, no instruction limit is used.
+        :param num_bytes:           Replaces max_bytes if max_bytes is None. If set to None as well, no  byte limit is used.
+        :param bytes_offset:        The offset into `data` to start lifting at. Note that for ARM THUMB mode, both
+                                    `mem_addr` and `bytes_offset` must be odd (typically `bytes_offset` is set to 1).
+        :param traceflags:          Unused by P-Code lifter
+        :param opt_level:           Unused by P-Code lifter
+        :param strict_block_end:    Unused by P-Code lifter
+
+        .. note:: Explicitly specifying the number of instructions to lift (`max_inst`) may not always work
+                  exactly as expected. For example, on MIPS, it is meaningless to lift a branch or jump
+                  instruction without its delay slot. VEX attempts to Do The Right Thing by possibly decoding
+                  fewer instructions than requested. Specifically, this means that lifting a branch or jump
+                  on MIPS as a single instruction (`max_inst=1`) will result in an empty IRSB, and subsequent
+                  attempts to run this block will raise `SimIRSBError('Empty IRSB passed to SimIRSB.')`.
+
+        .. note:: If no instruction and byte limit is used, the lifter will continue lifting the block until the block
+                  ends properly or until it runs out of data to lift.
+        """
+        if max_inst is None:
+            max_inst = num_inst
+        if max_bytes is None:
+            max_bytes = num_bytes
+
+        self._direct_next = None
+        self._exit_statements = []
+        self._instruction_addresses = ()
+        self._instructions = []
+        self._size = None
+        self._statements = []
+        self.addr = mem_addr
+        self.arch = arch
+        self.behaviors = None
+        self.data_refs = ()
+        self.default_exit_target = None
+        self.jumpkind = None
+        self.next = None
+
+        if data is not None:
+            # This is the slower path (because we need to call _from_py() to copy the content in the returned IRSB to
+            # the current IRSB instance. You should always call `lift()` directly. This method is kept for compatibility
+            # concerns.
+            irsb = lift(
+                data,
+                mem_addr,
+                arch,
+                max_bytes=max_bytes,
+                max_inst=max_inst,
+                bytes_offset=bytes_offset,
+                opt_level=opt_level,
+                traceflags=traceflags,
+                strict_block_end=strict_block_end,
+                skip_stmts=skip_stmts,
+                collect_data_refs=collect_data_refs,
+            )
+            self._from_py(irsb)
+
+    @staticmethod
+    def empty_block(
+        arch: archinfo.Arch,
+        addr: int,
+        statements: Optional[Sequence] = None,
+        nxt: Optional[int] = None,
+        tyenv = None, # Unused, kept for compatibility
+        jumpkind: Optional[str] = None,
+        direct_next: Optional[bool] = None,
+        size: Optional[int] = None,
+    ) -> "IRSB":
+        block = IRSB(None, addr, arch)
+        block._set_attributes(statements, nxt, tyenv, jumpkind, direct_next, size=size)
+        return block
+
+    @property
+    def has_statements(self) -> bool:
+        return self.statements is not None and self.statements
+
+    @property
+    def exit_statements(self) -> Sequence[Tuple[int, int, ExitStatement]]:
+        return self._exit_statements
+
+    def copy(self) -> "IRSB":
+        raise NotImplementedError()
+
+    def extend(self, extendwith: "IRSB") -> None:
+        """
+        Appends an irsb to the current irsb. The irsb that is appended is invalidated. The appended irsb's jumpkind and
+        default exit are used.
+        :param extendwith: The IRSB to append to this IRSB
+        """
+        raise NotImplementedError()
+
+    def invalidate_direct_next(self) -> None:
+        self._direct_next = None
+
+    def pp(self) -> None:
+        """
+        Pretty-print the IRSB to stdout.
+        """
+        print(self._pp_str())
+
+    def __repr__(self) -> str:
+        return "IRSB <0x%x bytes, %s ins., %s> at 0x%x" % (
+            self.size,
+            self.instructions,
+            self.arch,
+            self.addr,
+        )
+
+    def __str__(self) -> str:
+        return self._pp_str()
+
+    #
+    # simple properties useful for analysis
+    #
+
+    @property
+    def stmts_used(self) -> int:
+        if self.statements is None:
+            return 0
+        return len(self.statements)
+
+    @property
+    def offsIP(self) -> int:
+        return self.arch.ip_offset
+
+    @property
+    def direct_next(self) -> bool:
+        if self._direct_next is None:
+            self._direct_next = self._is_defaultexit_direct_jump()
+        return self._direct_next
+
+    @property
+    def expressions(self):
+        """
+        Return an iterator of all expressions contained in the IRSB.
+        """
+        raise NotImplementedError()
+
+    # FIXME: Rename this to num_instructions or something + fix pyvex IRSB.
+    @property
+    def instructions(self) -> int:
+        """
+        The number of instructions in this block
+        """
+        return len(self._instructions)
+
+    @property
+    def instruction_addresses(self) -> Sequence[int]:
+        """
+        Addresses of instructions in this block.
+        """
+        return [ins.addr.getOffset() for ins in self._instructions]
+
+    @property
+    def size(self) -> int:
+        """
+        The size of this block, in bytes
+        """
+        return sum([ins.length for ins in self._instructions])
+
+    @property
+    def operations(self):
+        """
+        A list of all operations done by the IRSB, as libVEX enum names
+        """
+        raise NotImplementedError()
+
+    @property
+    def all_constants(self):
+        """
+        Returns all constants in the block (including incrementing of the program counter) as :class:`pyvex.const.IRConst`.
+        """
+        raise NotImplementedError()
+
+    @property
+    def constants(self):
+        """
+        The constants (excluding updates of the program counter) in the IRSB as :class:`pyvex.const.IRConst`.
+        """
+        raise NotImplementedError()
+
+    @property
+    def constant_jump_targets(self):
+        """
+        A set of the static jump targets of the basic block.
+        """
+        raise NotImplementedError()
+
+    @property
+    def constant_jump_targets_and_jumpkinds(self):
+        """
+        A dict of the static jump targets of the basic block to their jumpkind.
+        """
+        raise NotImplementedError()
+
+    #
+    # private methods
+    #
+
+    def _pp_str(self) -> str:
+        """
+        Return the pretty-printed IRSB.
+        """
+        sa = []
+        sa.append("IRSB {")
+        for i, ins in enumerate(self._instructions):
+            sa.append(
+                "   %02d | ------ %08x, %d ------"
+                % (i, ins.addr.getOffset(), ins.length)
+            )
+            for j, op in enumerate(ins.ops):
+                sa.append("  +%02d | %s" % (j, ins.pp_op_str(op)))
+
+        if isinstance(self.next, int):
+            next_str = '%x' % self.next
+        else:
+            next_str = str(self.next)
+        sa.append("   NEXT: %s; %s" % (next_str, self.jumpkind))
+        sa.append("}")
+        return "\n".join(sa)
+
+    def _is_defaultexit_direct_jump(self) -> bool:
+        """
+        Checks if the default of this IRSB a direct jump or not.
+        """
+        if not (
+            self.jumpkind == "Ijk_InvalICache"
+            or self.jumpkind == "Ijk_Boring"
+            or self.jumpkind == "Ijk_Call"
+        ):
+            return False
+
+        target = self.default_exit_target
+        return target is not None
+
+    def _set_attributes(
+        self,
+        statements: Iterable = None,
+        nxt: Optional[int] = None,
+        tyenv = None, # Unused, kept for compatibility
+        jumpkind: Optional[str] = None,
+        direct_next: Optional[bool] = None,
+        size: Optional[int] = None,
+        instructions: Optional[Iterable[PcodeInstruction]] = None,
+        instruction_addresses: Optional[Iterable[int]] = None,
+        exit_statements: Sequence[Tuple[int, int, ExitStatement]] = None,
+        default_exit_target: Optional = None,
+    ) -> None:
+        # pylint: disable=unused-argument
+        self._statements = statements if statements is not None else []
+        self.next = nxt
+        self.jumpkind = jumpkind
+        self._direct_next = direct_next
+        self._size = size
+        self._instructions = instructions or []
+        self._instruction_addresses = instruction_addresses
+        self._exit_statements = exit_statements
+        self.default_exit_target = default_exit_target
+
+    def _from_py(self, irsb: "IRSB") -> None:
+        self._set_attributes(
+            irsb.statements,
+            irsb.next,
+            None,
+            irsb.jumpkind,
+            irsb.direct_next,
+            irsb.size,
+            instructions=irsb._instructions,
+            instruction_addresses=irsb._instruction_addresses,
+            exit_statements=irsb.exit_statements,
+            default_exit_target=irsb.default_exit_target,
+        )
+
+    @property
+    def statements(self) -> Iterable:
+        # FIXME: For compatibility, may want to implement Ist_IMark and
+        # pyvex.IRStmt.Exit to ease analyses.
+        l.warning('Returning empty statements list!')
+        return []
+        # return self._statements
+
+
+class Lifter:
+    """
+    A lifter is a class of methods for processing a block.
+
+    :ivar data:             The bytes to lift as either a python string of bytes or a cffi buffer object.
+    :ivar bytes_offset:     The offset into `data` to start lifting at.
+    :ivar max_bytes:        The maximum number of bytes to lift. If set to None, no byte limit is used.
+    :ivar max_inst:         The maximum number of instructions to lift. If set to None, no instruction limit is used.
+    :ivar opt_level:        Unused by P-Code lifter
+    :ivar traceflags:       Unused by P-Code lifter
+    :ivar allow_arch_optimizations: Unused by P-Code lifter
+    :ivar strict_block_end: Unused by P-Code lifter
+    :ivar skip_stmts:       Unused by P-Code lifter
+    """
+
+    REQUIRE_DATA_C = False
+    REQUIRE_DATA_PY = False
+
+    __slots__ = (
+        "data",
+        "bytes_offset",
+        "opt_level",
+        "traceflags",
+        "allow_arch_optimizations",
+        "strict_block_end",
+        "collect_data_refs",
+        "max_inst",
+        "max_bytes",
+        "skip_stmts",
+        "irsb",
+        "arch",
+        "addr",
+    )
+
+    data: Union[str, bytes, None]
+    bytes_offset: Optional[int]
+    opt_level: int
+    traceflags: Optional[int]
+    allow_arch_optimizations: Optional[bool]
+    strict_block_end: Optional[bool]
+    collect_data_refs: bool
+    max_inst: Optional[int]
+    max_bytes: Optional[int]
+    skip_stmts: bool
+    irsb: IRSB
+    arch: archinfo.Arch
+    addr: int
+
+    def __init__(self, arch: archinfo.Arch, addr: int) -> None:
+        self.arch = arch
+        self.addr = addr
+        self.data = None
+        self.bytes_offset = None
+        self.opt_level = 1
+        self.traceflags = None
+        self.allow_arch_optimizations = None
+        self.strict_block_end = None
+        self.collect_data_refs = False
+        self.max_inst = None
+        self.max_bytes = None
+        self.skip_stmts = False
+        self.irsb = None
+
+    def _lift(
+        self,
+        data: Union[str, bytes, None],
+        bytes_offset: Optional[int] = None,
+        max_bytes: Optional[int] = None,
+        max_inst: Optional[int] = None,
+        opt_level: int = 1,
+        traceflags: Optional[int] = None,
+        allow_arch_optimizations: Optional[bool] = None,
+        strict_block_end: Optional[bool] = None,
+        skip_stmts: bool = False,
+        collect_data_refs: bool = False,
+    ) -> IRSB:
+        """
+        Wrapper around the `lift` method on Lifters. Should not be overridden in child classes.
+
+        :param data:                The bytes to lift as either a python string of bytes or a cffi buffer object.
+        :param bytes_offset:        The offset into `data` to start lifting at.
+        :param max_bytes:           The maximum number of bytes to lift. If set to None, no byte limit is used.
+        :param max_inst:            The maximum number of instructions to lift. If set to None, no instruction limit is used.
+        :param opt_level:           Unused by P-Code lifter
+        :param traceflags:          Unused by P-Code lifter
+        :param allow_arch_optimizations: Unused by P-Code lifter
+        :param strict_block_end:    Unused by P-Code lifter
+        :param skip_stmts:          Unused by P-Code lifter
+        :param collect_data_refs:   Unused by P-Code lifter
+        """
+        irsb = IRSB.empty_block(self.arch, self.addr)
+        self.data = data
+        self.bytes_offset = bytes_offset
+        self.opt_level = opt_level
+        self.traceflags = traceflags
+        self.allow_arch_optimizations = allow_arch_optimizations
+        self.strict_block_end = strict_block_end
+        self.collect_data_refs = collect_data_refs
+        self.max_inst = max_inst
+        self.max_bytes = max_bytes
+        self.skip_stmts = skip_stmts
+        self.irsb = irsb
+        self.lift()
+        return self.irsb
+
+    def lift(self) -> None:
+        """
+        Lifts the data using the information passed into _lift. Should be overridden in child classes.
+
+        Should set the lifted IRSB to self.irsb.
+        If a lifter raises a LiftingException on the data, this signals that the lifter cannot lift this data and arch
+        and the lifter is skipped.
+        If a lifter can lift any amount of data, it should lift it and return the lifted block with a jumpkind of
+        Ijk_NoDecode, signalling to pyvex that other lifters should be used on the undecodable data.
+
+        """
+        raise NotImplementedError()
+
+
+class Postprocessor:
+    def __init__(self, irsb: IRSB) -> None:
+        self.irsb = irsb
+
+    def postprocess(self) -> None:
+        """
+        Modify the irsb
+
+        All of the postprocessors will be used in the order that they are registered
+        """
+
+
+lifters = defaultdict(list)
+postprocessors = defaultdict(list)
+
+
+def lift(
+    data: Union[str, bytes, None],
+    addr: int,
+    arch: archinfo.Arch,
+    max_bytes: Optional[int] = None,
+    max_inst: Optional[int] = None,
+    bytes_offset: int = 0,
+    opt_level: int = 1,
+    traceflags: int = 0,
+    strict_block_end: bool = True,
+    inner: bool = False,
+    skip_stmts: bool = False,
+    collect_data_refs: bool = False,
+) -> IRSB:
+    """
+    Recursively lifts blocks using the registered lifters and postprocessors. Tries each lifter in the order in
+    which they are registered on the data to lift.
+
+    If a lifter raises a LiftingException on the data, it is skipped.
+    If it succeeds and returns a block with a jumpkind of Ijk_NoDecode, all of the lifters are tried on the rest
+    of the data and if they work, their output is appended to the first block.
+
+    :param arch:            The arch to lift the data as.
+    :param addr:            The starting address of the block. Effects the IMarks.
+    :param data:            The bytes to lift as either a python string of bytes or a cffi buffer object.
+    :param max_bytes:       The maximum number of bytes to lift. If set to None, no byte limit is used.
+    :param max_inst:        The maximum number of instructions to lift. If set to None, no instruction limit is used.
+    :param bytes_offset:    The offset into `data` to start lifting at.
+    :param opt_level:       Unused by P-Code lifter
+    :param traceflags:      Unused by P-Code lifter
+
+    .. note:: Explicitly specifying the number of instructions to lift (`max_inst`) may not always work
+              exactly as expected. For example, on MIPS, it is meaningless to lift a branch or jump
+              instruction without its delay slot. VEX attempts to Do The Right Thing by possibly decoding
+              fewer instructions than requested. Specifically, this means that lifting a branch or jump
+              on MIPS as a single instruction (`max_inst=1`) will result in an empty IRSB, and subsequent
+              attempts to run this block will raise `SimIRSBError('Empty IRSB passed to SimIRSB.')`.
+
+    .. note:: If no instruction and byte limit is used, the lifter will continue lifting the block until the block
+              ends properly or until it runs out of data to lift.
+    """
+    if max_bytes is not None and max_bytes <= 0:
+        raise PyVEXError("Cannot lift block with no data (max_bytes <= 0)")
+
+    if not data:
+        raise PyVEXError("Cannot lift block with no data (data is empty)")
+
+    if isinstance(data, str):
+        raise TypeError("Cannot pass unicode string as data to lifter")
+
+    if isinstance(data, bytes):
+        # py_data = data
+        # c_data = None
+        allow_arch_optimizations = False
+    else:
+        if max_bytes is None:
+            raise PyVEXError(
+                "Cannot lift block with ffi pointer and no size (max_bytes is None)"
+            )
+        # c_data = data
+        # py_data = None
+        allow_arch_optimizations = True
+
+    # In order to attempt to preserve the property that
+    # VEX lifts the same bytes to the same IR at all times when optimizations are disabled
+    # we hack off all of VEX's non-IROpt optimizations when opt_level == -1.
+    # This is intended to enable comparisons of the lifted IR between code that happens to be
+    # found in different contexts.
+    if opt_level < 0:
+        allow_arch_optimizations = False
+        opt_level = 0
+
+    for lifter in lifters[arch.name]:
+        try:
+            u_data = data
+
+            # FIXME
+            assert (not lifter.REQUIRE_DATA_C) and (not lifter.REQUIRE_DATA_PY)
+            # if lifter.REQUIRE_DATA_C:
+            #     if c_data is None:
+            #         u_data = ffi.new(
+            #             "unsigned char [%d]" % (len(py_data) + 8), py_data + b"\0" * 8
+            #         )
+            #         max_bytes = (
+            #             min(len(py_data), max_bytes)
+            #             if max_bytes is not None
+            #             else len(py_data)
+            #         )
+            #     else:
+            #         u_data = c_data
+            # elif lifter.REQUIRE_DATA_PY:
+            #     if py_data is None:
+            #         if max_bytes is None:
+            #             l.debug(
+            #                 "Cannot create py_data from c_data when no max length is"
+            #                 " given"
+            #             )
+            #             continue
+            #         u_data = ffi.buffer(c_data, max_bytes)[:]
+            #     else:
+            #         u_data = py_data
+
+            try:
+                final_irsb = lifter(arch, addr)._lift(
+                    u_data,
+                    bytes_offset,
+                    max_bytes,
+                    max_inst,
+                    opt_level,
+                    traceflags,
+                    allow_arch_optimizations,
+                    strict_block_end,
+                    skip_stmts,
+                    collect_data_refs,
+                )
+            except SkipStatementsError:
+                assert skip_stmts is True
+                final_irsb = lifter(arch, addr)._lift(
+                    u_data,
+                    bytes_offset,
+                    max_bytes,
+                    max_inst,
+                    opt_level,
+                    traceflags,
+                    allow_arch_optimizations,
+                    strict_block_end,
+                    skip_stmts=False,
+                    collect_data_refs=collect_data_refs,
+                )
+            # l.debug('block lifted by %s' % str(lifter))
+            # l.debug(str(final_irsb))
+            break
+        except LiftingException as ex:
+            l.debug("Lifting Exception: %s", ex)
+            continue
+    else:
+        final_irsb = IRSB.empty_block(
+            arch,
+            addr,
+            size=0,
+            nxt=addr,
+            jumpkind="Ijk_NoDecode",
+        )
+        final_irsb.invalidate_direct_next()
+        return final_irsb
+
+    if final_irsb.size > 0 and final_irsb.jumpkind == "Ijk_NoDecode":
+        # We have decoded a few bytes before we hit an undecodeable instruction.
+
+        # Determine if this is an intentional NoDecode, like the ud2 instruction on AMD64
+        # FIXME:
+        # nodecode_addr_expr = final_irsb.next
+        # if type(nodecode_addr_expr) is Const:
+        #     nodecode_addr = nodecode_addr_expr.con.value
+        #     next_irsb_start_addr = addr + final_irsb.size
+        #     if nodecode_addr != next_irsb_start_addr:
+        #         # The last instruction of the IRSB has a non-zero length. This is an intentional NoDecode.
+        #         # The very last instruction has been decoded
+        #         final_irsb.jumpkind = "Ijk_NoDecode"
+        #         final_irsb.next = final_irsb.next
+        #         final_irsb.invalidate_direct_next()
+        #         return final_irsb
+
+        # Decode more bytes
+        if skip_stmts:
+            # When gymrat will be invoked, we will merge future basic blocks to the current basic block. In this case,
+            # statements are usually required.
+            # TODO: In the future, we may further optimize it to handle cases where getting statements in gymrat is not
+            # TODO: required.
+            return lift(
+                data,
+                addr,
+                arch,
+                max_bytes=max_bytes,
+                max_inst=max_inst,
+                bytes_offset=bytes_offset,
+                opt_level=opt_level,
+                traceflags=traceflags,
+                strict_block_end=strict_block_end,
+                skip_stmts=False,
+                collect_data_refs=collect_data_refs,
+            )
+
+        next_addr = addr + final_irsb.size
+        if max_bytes is not None:
+            max_bytes -= final_irsb.size
+        if isinstance(data, (str, bytes, bytearray)):
+            data_left = data[final_irsb.size :]
+        else:
+            data_left = data + final_irsb.size
+        if max_inst is not None:
+            max_inst -= final_irsb.instructions
+        if (
+            (max_bytes is None or max_bytes > 0)
+            and (max_inst is None or max_inst > 0)
+            and data_left
+        ):
+            more_irsb = lift(
+                data_left,
+                next_addr,
+                arch,
+                max_bytes=max_bytes,
+                max_inst=max_inst,
+                bytes_offset=bytes_offset,
+                opt_level=opt_level,
+                traceflags=traceflags,
+                strict_block_end=strict_block_end,
+                inner=True,
+                skip_stmts=False,
+                collect_data_refs=collect_data_refs,
+            )
+            if more_irsb.size:
+                # Successfully decoded more bytes
+                final_irsb.extend(more_irsb)
+        elif max_bytes == 0:
+            # We have no more bytes left. Mark the jumpkind of the IRSB as Ijk_Boring
+            if final_irsb.size > 0 and final_irsb.jumpkind == "Ijk_NoDecode":
+                final_irsb.jumpkind = "Ijk_Boring"
+                final_irsb.next = final_irsb.addr + final_irsb.size
+
+    if not inner:
+        for postprocessor in postprocessors[arch.name]:
+            try:
+                postprocessor(final_irsb).postprocess()
+            except NeedStatementsNotification:
+                # The post-processor cannot work without statements. Re-lift the current block with skip_stmts=False
+                if not skip_stmts:
+                    # sanity check
+                    # Why does the post-processor raise NeedStatementsNotification when skip_stmts is False?
+                    raise TypeError(
+                        "Bad post-processor %s: NeedStatementsNotification is raised"
+                        " when statements are available."
+                        % postprocessor.__class__
+                    ) from NeedStatementsNotification
+
+                # Re-lift the current IRSB
+                return lift(
+                    data,
+                    addr,
+                    arch,
+                    max_bytes=max_bytes,
+                    max_inst=max_inst,
+                    bytes_offset=bytes_offset,
+                    opt_level=opt_level,
+                    traceflags=traceflags,
+                    strict_block_end=strict_block_end,
+                    inner=inner,
+                    skip_stmts=False,
+                    collect_data_refs=collect_data_refs,
+                )
+            except LiftingException:
+                continue
+
+    return final_irsb
+
+
+def register(lifter: Lifter, arch_name: str) -> None:
+    """
+    Registers a Lifter or Postprocessor to be used by the pcode lifter.
+    Lifters are are given priority based on the order in which they are
+    registered. Postprocessors will be run in registration order.
+
+    :param lifter:       The Lifter or Postprocessor to register
+    :vartype lifter:     :class:`Lifter` or :class:`Postprocessor`
+    """
+    if issubclass(lifter, Lifter):
+        l.debug(
+            "Registering lifter %s for architecture %s.", lifter.__name__, arch_name
+        )
+        lifters[arch_name].append(lifter)
+    if issubclass(lifter, Postprocessor):
+        l.debug(
+            "Registering postprocessor %s for architecture %s.",
+            lifter.__name__,
+            arch_name,
+        )
+        postprocessors[arch_name].append(lifter)
+
+
+class PcodeBasicBlockLifter:
+
+    sleighfilename: str
+    docstorage: pypcode.DocumentStorage
+    doc: pypcode.Element
+    context: pypcode.ContextInternal
+    loader: pypcode.SimpleLoadImage
+    trans: pypcode.Sleigh
+    behaviors: BehaviorFactory
+    data: Optional[bytearray]
+
+    def __init__(self, arch: archinfo.Arch) -> None:
+        if arch.name == "X86":
+            sleigh_arch = "x86"
+        elif arch.name == "AMD64":
+            sleigh_arch = "x86-64"
+        else:
+            # FIXME: Add more architectures
+            raise NotImplementedError()
+
+        self.sleighfilename = os.path.join(pypcode.SLEIGH_SPECFILES_PATH, sleigh_arch + ".sla")
+        if not os.path.exists(self.sleighfilename):
+            raise Exception("SLIEGH file not found for architecture %s" % sleigh_arch)
+        self.docstorage = pypcode.DocumentStorage()
+        self.doc = self.docstorage.openDocument(self.sleighfilename).getRoot()
+        self.docstorage.registerTag(self.doc)
+        self.context = pypcode.ContextInternal()
+        self.loader = pypcode.SimpleLoadImage(0, bytearray(b"\x00"), 1)
+        self.trans = pypcode.Sleigh(self.loader, self.context)
+        self.trans.initialize(self.docstorage)
+        self.behaviors = BehaviorFactory(self.trans)
+        self.data = None
+
+        # FIXME: Load from corresponding *.pspec instead of hardcoding here
+        if arch.name == "X86":
+            self.context.setVariableDefault("addrsize", 1)  # Address size is 32-bit
+            self.context.setVariableDefault("opsize", 1)  # Operand size is 32-bit
+        elif arch.name == "AMD64":
+            self.context.setVariableDefault("addrsize", 2)  # Address size is 64-bit
+            self.context.setVariableDefault("opsize", 1)  # Operand size is 64-bit
+            self.context.setVariableDefault("bit64", 1)
+            self.context.setVariableDefault("rexprefix", 0)
+        else:
+            raise NotImplementedError()
+
+    def lift(self,
+             irsb: IRSB,
+             baseaddr: int,
+             data: Union[bytes, bytearray],
+             bytes_offset: int = 0,
+             max_bytes: Optional[int] = None,
+             max_inst: Optional[int] = None) -> None:
+        if max_bytes is None or max_bytes > MAX_BYTES:
+            max_bytes = min(len(data), MAX_BYTES)
+        if max_inst is None or max_inst > MAX_INSTRUCTIONS:
+            max_inst = MAX_INSTRUCTIONS
+
+        addr = pypcode.Address(self.trans.getDefaultSpace(), baseaddr + bytes_offset)
+        lastaddr = pypcode.Address(self.trans.getDefaultSpace(), baseaddr + max_bytes)
+
+        # NOTE: It's important to retain this reference to the data or it
+        # may be garbage collected while processing!
+        self.data = bytearray(data)
+        self.loader.setData(baseaddr, self.data, len(data))
+        irsb.behaviors = self.behaviors
+
+        # Lift basic block to pcode
+        # FIXME: Move this to C++ eventually
+        irsb._exit_statements = []
+        end_basic_block = False
+        op_count = 0
+
+        irsb.next = addr.getOffset()
+        irsb.jumpkind = "Ijk_Boring"
+
+        while (not end_basic_block) and (addr < lastaddr) and (len(irsb._instructions) < max_inst):
+            has_internal_branch = False
+            has_external_branch = False
+            emit = pypcode.PcodeRawOutHelper(self.trans)
+            try:
+                length = self.trans.oneInstruction(emit, addr)
+            except: # pylint:disable=bare-except
+                # FIXME: Add nicer exception handling for failed translation
+                l.warning('Failed to decode instruction at %08x', addr.getOffset())
+                irsb.jumpkind = "Ijk_NoDecode"
+                break
+
+            if (addr+length) > lastaddr:
+                # Decoded past the acceptable limit. Stop here.
+                break
+
+            ins = PcodeInstruction(addr, length, emit, self.trans)
+            irsb._instructions.append(ins)
+            irsb.next = addr.getOffset() + length
+
+            # print('P-code ops for instruction at address %x' % addr.getOffset())
+            # for op_idx, op in enumerate(ins.pcode.opcache):
+            #     print(ins.pp_op_str(op))
+
+            for op in ins.pcode.opcache:
+                opcode = op.getOpcode()
+
+                if opcode in [
+                    pypcode.OpCode.CPUI_BRANCH,
+                    pypcode.OpCode.CPUI_CBRANCH,
+                ]:
+                    if op.getInput(0).space.getIndex() == pypcode.AddrSpace.constant_space_index:
+                        has_internal_branch = True
+                        raise NotImplementedError("P-code relative branches are not supported yet")
+
+                    has_external_branch = True
+                    assert not end_basic_block
+                    end_basic_block = True
+                    if opcode == pypcode.OpCode.CPUI_CBRANCH:
+                        ins_addr = addr.getOffset()
+                        exit_stmt = op.getInput(0).getAddr().getOffset()
+                        irsb._exit_statements.append((ins_addr, op_count, ExitStatement(exit_stmt, "Ijk_Boring")))
+
+                    elif opcode == pypcode.OpCode.CPUI_BRANCH:
+                        irsb.next = op.getInput(0).getAddr().getOffset()
+                        irsb.jumpkind = "Ijk_Boring"
+
+                elif opcode == pypcode.OpCode.CPUI_BRANCHIND:
+                    assert not end_basic_block
+                    end_basic_block = True
+                    irsb.next = None
+                    irsb.jumpkind = "Ijk_Boring"
+
+                elif opcode == pypcode.OpCode.CPUI_CALL:
+                    assert not end_basic_block
+                    end_basic_block = True
+                    irsb.next = op.getInput(0).getAddr().getOffset()
+                    irsb.jumpkind = "Ijk_Call"
+
+                elif opcode == pypcode.OpCode.CPUI_CALLIND:
+                    assert not end_basic_block
+                    end_basic_block = True
+                    irsb.next = None
+                    irsb.jumpkind = "Ijk_Call"
+
+                elif opcode == pypcode.OpCode.CPUI_RETURN:
+                    assert not end_basic_block
+                    end_basic_block = True
+                    irsb.next = None
+                    irsb.jumpkind = "Ijk_Ret"
+
+                op_count += 1
+
+            addr += length
+
+            # Should be okay but want to check. Not sure if any instructions do this.
+            assert not (has_internal_branch and has_external_branch), "CHECKME"
+
+
+class PcodeLifter(Lifter):
+    """
+    Handles calling into pypcode to lift a block
+    """
+
+    _lifter_cache = {}
+
+    def lift(self) -> None:
+        if self.arch not in PcodeLifter._lifter_cache:
+            PcodeLifter._lifter_cache[self.arch] = PcodeBasicBlockLifter(self.arch)
+        lifter = PcodeLifter._lifter_cache[self.arch]
+        lifter.lift(
+            self.irsb,
+            self.addr,
+            self.data,
+            bytes_offset=self.bytes_offset,
+            max_inst=self.max_inst,
+            max_bytes=self.max_bytes,
+        )
+
+        if self.irsb.size == 0:
+            l.debug('raising lifting exception')
+            raise LiftingException("pypcode: could not decode any instructions @ 0x%x" % self.addr)
+
+
+register(PcodeLifter, "X86")
+register(PcodeLifter, "AMD64")
+
+
+class PcodeLifterEngineMixin(SimEngineBase):
+    """
+    Lifter mixin to lift from machine code to P-Code.
+    """
+
+    def __init__(
+        self,
+        project,
+        use_cache: Optional[bool] = None,
+        cache_size: int = 50000,
+        default_opt_level: int = 1,
+        support_selfmodifying_code: Optional[bool] = None,
+        single_step: bool = False,
+        default_strict_block_end: bool = False,
+        **kwargs
+    ):
+        super().__init__(project, **kwargs)
+
+        self._use_cache = use_cache
+        self._default_opt_level = default_opt_level
+        self._cache_size = cache_size
+        self._support_selfmodifying_code = support_selfmodifying_code
+        self._single_step = single_step
+        self.default_strict_block_end = default_strict_block_end
+
+        if self._use_cache is None:
+            if self.project is not None:
+                self._use_cache = self.project._translation_cache
+            else:
+                self._use_cache = False
+        if self._support_selfmodifying_code is None:
+            if self.project is not None:
+                self._support_selfmodifying_code = (
+                    self.project._support_selfmodifying_code
+                )
+            else:
+                self._support_selfmodifying_code = False
+
+        # block cache
+        self._block_cache = None
+        self._block_cache_hits = 0
+        self._block_cache_misses = 0
+        self._initialize_block_cache()
+
+    def _initialize_block_cache(self) -> None:
+        self._block_cache = LRUCache(maxsize=self._cache_size)
+        self._block_cache_hits = 0
+        self._block_cache_misses = 0
+
+    def clear_cache(self) -> None:
+        self._block_cache = LRUCache(maxsize=self._cache_size)
+        self._block_cache_hits = 0
+        self._block_cache_misses = 0
+
+    # FIXME: Consider moving to higher abstraction layer to reduce duplication with vex
+    def lift_vex(
+        self,
+        addr: Optional[int] = None,
+        state: Optional[SimState] = None,
+        clemory: Optional[cle.Clemory] = None,
+        insn_bytes: Optional[bytes] = None,
+        arch: Optional[archinfo.Arch] = None,
+        size: Optional[int] = None,
+        num_inst: Optional[int] = None,
+        traceflags: int = 0,
+        thumb: bool = False,
+        extra_stop_points: Optional[Iterable[int]] = None,
+        opt_level: Optional[int] = None,
+        strict_block_end: Optional[bool] = None,
+        skip_stmts: bool = False,
+        collect_data_refs: bool = False,
+        cross_insn_opt: Optional[bool] = None,
+    ):
+        """
+        Temporary compatibility interface for integration with block code.
+        """
+        return self.lift_pcode(
+            addr,
+            state,
+            clemory,
+            insn_bytes,
+            arch,
+            size,
+            num_inst,
+            traceflags,
+            thumb,
+            extra_stop_points,
+            opt_level,
+            strict_block_end,
+            skip_stmts,
+            collect_data_refs,
+            cross_insn_opt)
+
+    def lift_pcode(
+        self,
+        addr: Optional[int] = None,
+        state: Optional[SimState] = None,
+        clemory: Optional[cle.Clemory] = None,
+        insn_bytes: Optional[bytes] = None,
+        arch: Optional[archinfo.Arch] = None,
+        size: Optional[int] = None,
+        num_inst: Optional[int] = None,
+        traceflags: int = 0,
+        thumb: bool = False,
+        extra_stop_points: Optional[Iterable[int]] = None,
+        opt_level: Optional[int] = None,
+        strict_block_end: Optional[bool] = None,
+        skip_stmts: bool = False,
+        collect_data_refs: bool = False,
+        cross_insn_opt: Optional[bool] = None,
+    ):
+        """
+        Lift an IRSB.
+
+        There are many possible valid sets of parameters. You at the very least must pass some
+        source of data, some source of an architecture, and some source of an address.
+
+        Sources of data in order of priority: insn_bytes, clemory, state
+
+        Sources of an address, in order of priority: addr, state
+
+        Sources of an architecture, in order of priority: arch, clemory, state
+
+        :param state:           A state to use as a data source.
+        :param clemory:         A cle.memory.Clemory object to use as a data source.
+        :param addr:            The address at which to start the block.
+        :param thumb:           Whether the block should be lifted in ARM's THUMB mode.
+        :param opt_level:       Unused for P-Code lifter
+        :param insn_bytes:      A string of bytes to use as a data source.
+        :param size:            The maximum size of the block, in bytes.
+        :param num_inst:        The maximum number of instructions.
+        :param traceflags:      Unused by P-Code lifter
+        :param strict_block_end: Unused by P-Code lifter
+        """
+        if cross_insn_opt:
+            l.debug('cross_insn_opt is ignored for p-code lifter')
+
+        # phase 0: sanity check
+        if not state and not clemory and not insn_bytes:
+            raise ValueError("Must provide state or clemory or insn_bytes!")
+        if not state and not clemory and not arch:
+            raise ValueError("Must provide state or clemory or arch!")
+        if addr is None and not state:
+            raise ValueError("Must provide state or addr!")
+        if arch is None:
+            arch = clemory._arch if clemory else state.arch
+        if arch.name.startswith("MIPS") and self._single_step:
+            l.error("Cannot specify single-stepping on MIPS.")
+            self._single_step = False
+
+        # phase 1: parameter defaults
+        if addr is None:
+            addr = state.solver.eval(state._ip)
+        if size is not None:
+            size = min(size, IRSB_MAX_SIZE)
+        if size is None:
+            size = IRSB_MAX_SIZE
+        if num_inst is not None:
+            num_inst = min(num_inst, IRSB_MAX_INST)
+        if num_inst is None and self._single_step:
+            num_inst = 1
+        if opt_level is None:
+            if state and o.OPTIMIZE_IR in state.options:
+                opt_level = 1
+            else:
+                opt_level = self._default_opt_level
+        if strict_block_end is None:
+            strict_block_end = self.default_strict_block_end
+        if self._support_selfmodifying_code:
+            if opt_level > 0:
+                if once("vex-engine-smc-opt-warning"):
+                    l.warning(
+                        "Self-modifying code is not always correctly optimized by"
+                        " PyVEX. To guarantee correctness, VEX optimizations have been"
+                        " disabled."
+                    )
+                opt_level = 0
+                if state and o.OPTIMIZE_IR in state.options:
+                    state.options.remove(o.OPTIMIZE_IR)
+        if skip_stmts is not True:
+            skip_stmts = False
+
+        use_cache = self._use_cache
+        if skip_stmts or collect_data_refs:
+            # Do not cache the blocks if skip_stmts or collect_data_refs are enabled
+            use_cache = False
+
+        # phase 2: thumb normalization
+        thumb = int(thumb)
+        if isinstance(arch, ArchARM):
+            if addr % 2 == 1:
+                thumb = 1
+            if thumb:
+                addr &= ~1
+        elif thumb:
+            l.error("thumb=True passed on non-arm architecture!")
+            thumb = 0
+
+        # phase 3: check cache
+        cache_key = None
+        if use_cache:
+            cache_key = (
+                addr,
+                insn_bytes,
+                size,
+                num_inst,
+                thumb,
+                opt_level,
+                strict_block_end,
+            )
+            if cache_key in self._block_cache:
+                self._block_cache_hits += 1
+                irsb = self._block_cache[cache_key]
+                stop_point = self._first_stoppoint(irsb, extra_stop_points)
+                if stop_point is None:
+                    return irsb
+                else:
+                    size = stop_point - addr
+                    # check the cache again
+                    cache_key = (
+                        addr,
+                        insn_bytes,
+                        size,
+                        num_inst,
+                        thumb,
+                        opt_level,
+                        strict_block_end,
+                    )
+                    if cache_key in self._block_cache:
+                        self._block_cache_hits += 1
+                        return self._block_cache[cache_key]
+                    else:
+                        self._block_cache_misses += 1
+            else:
+                # a special case: `size` is used as the maximum allowed size
+                tmp_cache_key = (
+                    addr,
+                    insn_bytes,
+                    IRSB_MAX_SIZE,
+                    num_inst,
+                    thumb,
+                    opt_level,
+                    strict_block_end,
+                )
+                try:
+                    irsb = self._block_cache[tmp_cache_key]
+                    if irsb.size <= size:
+                        self._block_cache_hits += 1
+                        return self._block_cache[tmp_cache_key]
+                except KeyError:
+                    self._block_cache_misses += 1
+
+        # vex_lift breakpoints only triggered when the cache isn't used
+        if state:
+            state._inspect(
+                "vex_lift", BP_BEFORE, mem_read_address=addr, mem_read_length=size
+            )
+
+        # phase 4: get bytes
+        if insn_bytes is not None:
+            buff, size = insn_bytes, len(insn_bytes)
+        else:
+            buff, size = self._load_bytes(addr, size, state, clemory)
+
+        if not buff or size == 0:
+            raise SimEngineError("No bytes in memory for block starting at %#x." % addr)
+
+        # phase 5: lift to pcode
+        l.debug("Creating pcode.IRSB of arch %s at %#x", arch.name, addr)
+        try:
+            for subphase in range(2):
+                irsb = lift(
+                    buff,
+                    addr + thumb,
+                    arch,
+                    max_bytes=size,
+                    max_inst=num_inst,
+                    bytes_offset=thumb,
+                    traceflags=traceflags,
+                    opt_level=opt_level,
+                    strict_block_end=strict_block_end,
+                    skip_stmts=skip_stmts,
+                    collect_data_refs=collect_data_refs,
+                )
+
+                if subphase == 0 and irsb.statements is not None:
+                    # check for possible stop points
+                    stop_point = self._first_stoppoint(irsb, extra_stop_points)
+                    if stop_point is not None:
+                        size = stop_point - addr
+                        continue
+
+                if use_cache:
+                    self._block_cache[cache_key] = irsb
+                if state:
+                    state._inspect(
+                        "vex_lift",
+                        BP_AFTER,
+                        mem_read_address=addr,
+                        mem_read_length=size,
+                    )
+                return irsb
+
+        # phase x: error handling
+        except PyVEXError as e:
+            l.debug("VEX translation error at %#x", addr)
+            # FIXME
+            # if isinstance(buff, bytes):
+            #     l.debug("Using bytes: %r", buff)
+            # else:
+            #     l.debug("Using bytes: %r", pyvex.ffi.buffer(buff, size))
+            raise SimTranslationError("Unable to translate bytecode") from e
+
+    def _load_bytes(self,
+        addr: int,
+        max_size: int,
+        state: Optional[SimState] = None,
+        clemory: Optional[cle.Clemory] = None) -> Tuple[bytes, int]:
+        if clemory is None and state is None:
+            raise SimEngineError('state and clemory cannot both be None in _load_bytes().')
+
+        buff, size = b"", 0
+
+        # Load from the clemory if we can
+        smc = self._support_selfmodifying_code
+
+        # skip loading from the clemory if we're using the ultra page
+        # TODO: is this a good change? it neuters lookback optimizations
+        # we can try concrete loading the full page but that has drawbacks too...
+        #if state is not None and issubclass(getattr(state.memory, 'PAGE_TYPE', object), UltraPage):
+        #    smc = True
+
+        # when smc is not enabled or when state is not provided, we *always* attempt to load concrete data first
+        if not smc or not state:
+            if isinstance(clemory, cle.Clemory):
+                try:
+                    start, backer = next(clemory.backers(addr))
+                except StopIteration:
+                    pass
+                else:
+                    if start <= addr:
+                        offset = addr - start
+                        if isinstance(backer, (bytes, bytearray)):
+                            # buff = pyvex.ffi.from_buffer(backer) + offset
+                            buff = backer[offset:]
+                            size = len(backer) - offset
+                        elif isinstance(backer, list):
+                            raise SimTranslationError("Cannot lift block for arch with strange byte width. If you think you ought to be able to, open an issue.")
+                            #buff_lst = backer[offset:offset+max_size]
+                            #if self.project is None:
+                            #    raise ValueError("You must set self.project if a list of integers are used as backers.")
+                            #byte_width = self.project.arch.byte_width
+                            #buff = claripy.Concat(*map(lambda v: claripy.BVV(v, byte_width), buff_lst))
+                            #size = len(buff_lst)
+                        else:
+                            raise TypeError("Unsupported backer type %s." % type(backer))
+            elif state:
+                if state.memory.SUPPORTS_CONCRETE_LOAD:
+                    buff = state.memory.concrete_load(addr, max_size)
+                else:
+                    buff = state.solver.eval(state.memory.load(addr, max_size, inspect=False), cast_to=bytes)
+                size = len(buff)
+
+        # If that didn't work and if smc is enabled, try to load from the state
+        if smc and state and size == 0:
+            if state.memory.SUPPORTS_CONCRETE_LOAD:
+                buff = state.memory.concrete_load(addr, max_size)
+            else:
+                buff = state.solver.eval(state.memory.load(addr, max_size, inspect=False), cast_to=bytes)
+            size = len(buff)
+            if size < min(max_size, 10):  # arbitrary metric for doing the slow path
+                l.debug("SMC slow path")
+                buff_lst = []
+                symbolic_warned = False
+                for i in range(max_size):
+                    try:
+                        byte = state.memory.load(addr + i, 1, inspect=False)
+                        if byte.symbolic and not symbolic_warned:
+                            symbolic_warned = True
+                            l.warning("Executing symbolic code at %#x", addr + i)
+                        buff_lst.append(state.solver.eval(byte))
+                    except SimError:
+                        break
+
+                buff = bytes(buff_lst)
+                size = len(buff)
+
+        size = min(max_size, size)
+        return buff, size
+
+    def _first_stoppoint(self,
+        irsb: IRSB,
+        extra_stop_points: Optional[Sequence[int]] = None) -> Optional[int]:
+        """
+        Enumerate the imarks in the block. If any of them (after the first one) are at a stop point, returns the address
+        of the stop point. None is returned otherwise.
+        """
+        if extra_stop_points is None and self.project is None:
+            return None
+
+        first_imark = True
+        for addr in irsb.instruction_addresses:
+            if not first_imark:
+                if self.__is_stop_point(addr, extra_stop_points):
+                    # could this part be moved by pyvex?
+                    return addr
+                first_imark = False
+        return None
+
+    def __is_stop_point(self,
+        addr: int,
+        extra_stop_points: Optional[Sequence[int]] = None) -> bool:
+        if self.project is not None and addr in self.project._sim_procedures:
+            return True
+        elif extra_stop_points is not None and addr in extra_stop_points:
+            return True
+        return False
+
+    def __getstate__(self):
+        ostate = super().__getstate__()
+        s = {
+            "_use_cache": self._use_cache,
+            "_default_opt_level": self._default_opt_level,
+            "_support_selfmodifying_code": self._support_selfmodifying_code,
+            "_single_step": self._single_step,
+            "_cache_size": self._cache_size,
+            "default_strict_block_end": self.default_strict_block_end,
+        }
+
+        return (s, ostate)
+
+    def __setstate__(self, state):
+        s, ostate = state
+        self._use_cache = s["_use_cache"]
+        self._default_opt_level = s["_default_opt_level"]
+        self._support_selfmodifying_code = s["_support_selfmodifying_code"]
+        self._single_step = s["_single_step"]
+        self._cache_size = s["_cache_size"]
+        self.default_strict_block_end = s["default_strict_block_end"]
+
+        # rebuild block cache
+        self._initialize_block_cache()
+        super().__setstate__(ostate)

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ setup(
     setup_requires=[_UNICORN, 'pyvex'],
     extras_require={
         'AngrDB': ['sqlalchemy'],
+        'pcode': ['pypcode==0.0.2'],
     },
     cmdclass=cmdclass,
     include_package_data=True,


### PR DESCRIPTION
This patch adds a new engine to angr that uses [Ghidra's](https://github.com/NationalSecurityAgency/ghidra) [P-Code intermediate representation](https://ghidra.re/courses/languages/html/pcoderef.html). Lifting is handled by the SLEIGH library, with bindings to Python via pypcode. Symbolic execution is supported for a majority of ops. This new engine is mature enough to be used to produce CFGs and handle the canonical test_fauxware.py, for example.

This new engine is not enabled by default, and is completely optional right now. In order to use it, [pypcode](https://github.com/angr/pypcode) will need to be installed from PyPI. Once pypcode is installed, selecting the P-Code engine is as easy as passing the `UberEnginePcode` engine when creating a `Project`, like this:

```python
import angr
p = angr.Project('/bin/true', engine=angr.engines.UberEnginePcode)
```

I have made conscious efforts to keep interfaces and structure as similar as reasonably possible to existing VEX-based lifting/execution. For example the IRSB, will look and feel like the current VEX IRSBs. As an example, lifting an IRSB to P-Code works exactly the same as before (except of course, P-Code is shown, instead of VEX IR):

```
p.factory.entry_state().block().vex.pp()                                                                                                                                                                   
IRSB {
   00 | ------ 00402610, 4 ------
   01 | ------ 00402614, 2 ------
  +00 | (reg{CF}, 0x200, 1)  = COPY         (const, 0x0, 1)     
  +01 | (reg{OF}, 0x20b, 1)  = COPY         (const, 0x0, 1)     
  +02 | (reg{EBP}, 0x28, 4)  = INT_XOR      (reg{EBP}, 0x28, 4) (reg{EBP}, 0x28, 4) 
[...truncated...]
   11 | ------ 00402638, 6 ------
  +00 | (reg{RSP}, 0x20, 8)  = INT_SUB      (reg{RSP}, 0x20, 8) (const, 0x8, 8)     
  +01 |                        STORE        [ram] (reg{RSP}, 0x20, 8) (const, 0x40263e, 8) 
  +02 |                        CALLIND      (ram, 0x409fe0, 8)  
   NEXT: None; Ijk_Call
}
```

Notice above that instead of the `Block.vex` property returning a VEX IRSB, a P-Code IRSB is returned. I implemented it this way to ease compatibility and ensure that P-Code blocks would work in several areas of the code base that produce a block this way when determining successors. This could be cleaner and implemented in such a way that the VEX engine mixins exist in harmony with the P-Code mixins, but some refactoring will be required. I opted to keep it simple for this PR, although the naming can lead to confusion.

There is significant room for improvement to this work in virtually every area, including: feature parity with VEX engine, performance, quality/coverage testing, code refactoring, documentation, etc. This should not yet be viewed as a complete, drop-in replacement for the VEX lifting/execution engine, although I would like to get it to that point.

Higher-level future plans for this work include:
- Adding test cases to:
  - Compare the results of the P-Code engine to the Unicorn/VEX engines, e.g. using the congruency analysis
  - Test execution of various architectures
- Improving pypcode by:
  - Adding simpler, C bindings
  - Enabling full cross-platform support (which has proved problematic in my testing with cppyy)
  - Integrating more SLEIGH files to include all supported architectures (currently only x86/x86-64 are present).
- Improving emulation of P-Code, by:
  - Supporting P-Code-relative control flow
  - Supporting floating point operations
  - Supporting functions which are not implemented in P-Code (`CALLOTHER`)
- Fixing some analyses which depend on VEX (e.g. indirect jump resolve, etc)
- Support lifting from P-Code to AIL

Finally, my apologies to reviewers for the 3k line jumbo patch. There is quite a bit to go through, but I think those most comfortable with code base will find the read pretty straightforward. Of course, I welcome any critical feedback on ways I can improve this PR before merge, if necessary. Thank you for your time!