### PR TITLE
Set LIB_ANGR_NATIVE to angr_native.so on FreeBSD

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -2,6 +2,9 @@ UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
 	LIB_ANGR_NATIVE=angr_native.dylib
 endif
+ifeq ($(UNAME), FreeBSD)
+	LIB_ANGR_NATIVE=angr_native.so
+endif
 ifeq ($(UNAME), Linux)
 	LIB_ANGR_NATIVE=angr_native.so
 endif


### PR DESCRIPTION
This is one of the local patches that we have in the FreeBSD Ports, which allows us to build angr.