### PR TITLE
Fix getting thread ID on FreeBSD

### DIFF
--- a/native/log.c
+++ b/native/log.c
@@ -34,6 +34,9 @@
 #include <unistd.h>
 
 #include <sys/syscall.h>
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#endif
 
 static int log_fd = STDERR_FILENO;
 static bool log_fd_isatty = true;
@@ -107,7 +110,11 @@ void logLog(enum llevel_t ll, const char *fn, int ln, bool perr, const char *fmt
         dprintf(log_fd, "%s", logLevels[ll].prefix);
     }
     if (logLevels[ll].print_funcline) {
+#ifdef __FreeBSD__
+        dprintf(log_fd, "[%s][%s][%d] %s():%d ", timestr, logLevels[ll].descr, (pid_t)pthread_getthreadid_np, fn, ln);
+#else
         dprintf(log_fd, "[%s][%s][%d] %s():%d ", timestr, logLevels[ll].descr, (pid_t)syscall(__NR_gettid), fn, ln);
+#endif
     }
 
     va_list args;


### PR DESCRIPTION
This is another patch we've been apply to angr in order to package it for FreeBSD.