### PR TITLE
Incorrect length calculation for store() in merge()

### DIFF
--- a/angr/storage/memory_mixins/paged_memory/pages/list_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/list_page.py
@@ -139,7 +139,7 @@ class ListPage(MemoryObjectMixin, PageBase):
 
                 self.store(b,
                            SimMemoryObject(merged_val, mo_base, endness='Iend_BE'),
-                           size=mo_length,
+                           size=mo_length - (page_addr + b - mo_base),
                            cooperate=True
                            )
                 # merged_objects.add(new_object)


### PR DESCRIPTION
The offset at which the data should be stored was not being taken into account for the `size` calculation in store