### PR TITLE
`CFGManager`: Get the most accurate CFG easily

### DIFF
--- a/angr/knowledge_plugins/cfg/cfg_manager.py
+++ b/angr/knowledge_plugins/cfg/cfg_manager.py
@@ -1,3 +1,4 @@
+from functools import reduce
 
 from ..plugin import KnowledgeBasePlugin
 from .cfg_model import CFGModel
@@ -47,6 +48,20 @@ class CFGManager(KnowledgeBasePlugin):
             self.cfgs.items()
         ))
         return cm
+
+    def get_most_accurate(self):
+        """
+        :return: The most accurate CFG present in the CFGManager, or None if it does not hold any.
+        """
+        less_accurate_to_most_accurate = ['CFGFast', 'CFGEmulated']
+
+        # Try to get the most accurate first, then default to the next, ... all the way down to `None`.
+        # Equivalent to `self.cfgs.get(<LAST>, self.cfgs.get(<SECOND LAST>, ... self.cfgs.get(<FIRST>, None)))`.
+        return reduce(
+            lambda acc, cfg: self.cfgs.get(cfg, acc),
+            less_accurate_to_most_accurate,
+            None
+        )
 
     #
     # Pickling

--- a/tests/knowledge_plugins/cfg/test_cfg_manager.py
+++ b/tests/knowledge_plugins/cfg/test_cfg_manager.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from angr.knowledge_plugins.cfg import CFGManager
+
+
+class TestCFGManager(TestCase):
+    def setUp(self):
+        self.cfg_manager = CFGManager(None)
+
+    def test_when_both_cfg_emulated_and_cfg_fast_are_present(self):
+        self.cfg_manager['CFGEmulated'] = 'fake CFGEmulated'
+        self.cfg_manager['CFGFast'] = 'fake CFGFast'
+
+        result = self.cfg_manager.get_most_accurate()
+        self.assertEqual(result, 'fake CFGEmulated')
+
+    def test_when_only_cfg_emulated_is_present(self):
+        self.cfg_manager['CFGEmulated'] = 'fake CFGEmulated'
+
+        result = self.cfg_manager.get_most_accurate()
+        self.assertEqual(result, 'fake CFGEmulated')
+
+    def test_when_only_cfg_fast_is_present(self):
+        self.cfg_manager['CFGFast'] = 'fake CFGFast'
+
+        result = self.cfg_manager.get_most_accurate()
+        self.assertEqual(result, 'fake CFGFast')
+
+    def test_when_no_cfg_is_present(self):
+        result = self.cfg_manager.get_most_accurate()
+        self.assertEqual(result, None)


### PR DESCRIPTION
Avoid hardcoding a CFG name (e.g, when using `kb.cfgs['CFGFast']`) in consumer scripts.

Signed-off-by: Pamplemousse <xav.maso@gmail.com>