### PR TITLE
Add endness parameter to functions from SimActionObject initializer u…

### DIFF
--- a/angr/state_plugins/sim_action.py
+++ b/angr/state_plugins/sim_action.py
@@ -50,13 +50,13 @@ class SimAction(SimEvent):
     #       setattr(self, k, v)
 
     @staticmethod
-    def _make_object(v):
+    def _make_object(v, endness=None):
         if v is None:
             return None
         elif isinstance(v, SimActionObject):
             return v
         else:
-            return SimActionObject(v, reg_deps=None, tmp_deps=None)
+            return SimActionObject(v, reg_deps=None, tmp_deps=None, endness=endness)
 
     @staticmethod
     def _copy_object(v):
@@ -205,7 +205,7 @@ class SimActionData(SimAction):
     OPERATE = 'operate'
 
     def __init__(self, state, region_type, action, tmp=None, addr=None, size=None, data=None, condition=None,
-                 fallback=None, fd=None):
+                 fallback=None, fd=None, endness=None):
         super(SimActionData, self).__init__(state, region_type)
         self.action = action
 
@@ -227,7 +227,7 @@ class SimActionData(SimAction):
                     self.offset = state.solver.eval_one(addr)
         self.addr = self._make_object(addr)
         self.size = self._make_object(size)
-        self.data = self._make_object(data)
+        self.data = self._make_object(data, endness=endness)
         self.condition = self._make_object(condition)
         self.fallback = self._make_object(fallback)
         self.fd = self._make_object(fd)

--- a/angr/state_plugins/sim_action_object.py
+++ b/angr/state_plugins/sim_action_object.py
@@ -62,10 +62,13 @@ class SimActionObject:
     """
     A SimActionObject tracks an AST and its dependencies.
     """
-    def __init__(self, ast, reg_deps=None, tmp_deps=None, deps=None, state=None):
+    def __init__(self, ast, reg_deps=None, tmp_deps=None, deps=None, state=None, endness=None):
         if type(ast) is SimActionObject:
             raise SimActionError("SimActionObject inception!!!")
+
+        self.endness = endness
         self.ast = ast
+
         if deps is not None:
             if len(deps) == 0 or (state is not None and o.ACTION_DEPS not in state.options):
                 self.reg_deps = _noneset

--- a/angr/storage/memory_mixins/actions_mixin.py
+++ b/angr/storage/memory_mixins/actions_mixin.py
@@ -29,7 +29,7 @@ class ActionsMixinHigh(MemoryMixin):
 
     def store(self, addr, data, size=None, disable_actions=False, action=None, condition=None, **kwargs):
         if not disable_actions and o.AUTO_REFS in self.state.options and action is None:
-            action = self.__make_action('write', addr, size, data, condition, None)
+            action = self.__make_action('write', addr, size, data, condition, None, kwargs['endness'])
 
         super().store(addr, data, size=size, action=action, condition=condition, **kwargs)
 
@@ -38,7 +38,7 @@ class ActionsMixinHigh(MemoryMixin):
             # In that case, we do not add the action.
             self.state.history.add_action(action)
 
-    def __make_action(self, kind, addr, size, data, condition, fallback):
+    def __make_action(self, kind, addr, size, data, condition, fallback, endness=None):
         ref_size = size * self.state.arch.byte_width if size is not None else len(data) if data is not None else None
         region_type = self.category if self.category != "file" else self.id
         action = SimActionData(self.state, region_type, kind,
@@ -46,7 +46,8 @@ class ActionsMixinHigh(MemoryMixin):
                                data=data,
                                size=ref_size,
                                condition=condition,
-                               fallback=fallback)
+                               fallback=fallback,
+                               endness=endness)
 
         action.added_constraints = self.state.solver.true
         return action


### PR DESCRIPTION
Currently, SimProcedure return values get stored in SimActionObjects with wrong endianness, in state history.  This may be a potential fix by adding the 'endness' parameter (defaulting to None as to not mess with other callers) to SAO initializers, up the call tree to the actions mixin.