### PR TITLE
JumptableResolver: Avoid redundant memory writes for symbolic addrs.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -12,6 +12,7 @@ import archinfo
 from archinfo.arch_soot import SootAddressDescriptor
 from archinfo.arch_arm import is_arm_arch, get_real_address_if_arm
 
+from ...sim_options import SYMBOL_FILL_UNCONSTRAINED_REGISTERS, SYMBOL_FILL_UNCONSTRAINED_MEMORY
 from ...knowledge_plugins.functions import FunctionManager, Function
 from ...knowledge_plugins.cfg import IndirectJump, CFGNode, CFGENode, CFGModel  # pylint:disable=unused-import
 from ...misc.ux import deprecated
@@ -1543,7 +1544,10 @@ class CFGBase(Analysis):
             #       jmp loc_8049562
             #
             last_addr = endpoint_addr
-            tmp_state = self.project.factory.blank_state(mode='fastpath')
+            tmp_state = self.project.factory.blank_state(mode='fastpath', add_options={
+                SYMBOL_FILL_UNCONSTRAINED_REGISTERS,
+                SYMBOL_FILL_UNCONSTRAINED_MEMORY,
+            })
             while True:
                 try:
                     # do not follow hooked addresses (such as SimProcedures)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -997,9 +997,11 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         self._function_exits = defaultdict(set)
 
         # Create an initial state. Store it to self so we can use it globally.
-        self._initial_state = self.project.factory.blank_state(mode="fastpath")
+        self._initial_state = self.project.factory.blank_state(mode="fastpath",
+                                                               add_options={o.SYMBOL_FILL_UNCONSTRAINED_MEMORY,
+                                                                            o.SYMBOL_FILL_UNCONSTRAINED_REGISTERS})
         initial_options = self._initial_state.options - {o.TRACK_CONSTRAINTS} - o.refs
-        initial_options |= {o.SUPER_FASTPATH, o.SYMBOL_FILL_UNCONSTRAINED_REGISTERS, o.SYMBOL_FILL_UNCONSTRAINED_MEMORY}
+        initial_options |= {o.SUPER_FASTPATH}
         # initial_options.remove(o.COW_STATES)
         self._initial_state.options = initial_options
 

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -5,6 +5,7 @@ from collections import defaultdict, OrderedDict
 import pyvex
 from archinfo.arch_arm import is_arm_arch
 
+from ....concretization_strategies import SimConcretizationStrategyAny
 from ....knowledge_plugins.cfg import IndirectJump, IndirectJumpType
 from ....engines.vex.claripy import ccall
 from ....engines.light import SimEngineLightVEXMixin, SimEngineLight, SpOffset, RegisterOffset
@@ -668,6 +669,10 @@ class JumpTableResolver(IndirectJumpResolver):
             self._cached_memread_addrs.clear()
             init_registers_on_demand_bp = BP(when=BP_BEFORE, enabled=True, action=self._init_registers_on_demand)
             start_state.inspect.add_breakpoint('mem_read', init_registers_on_demand_bp)
+
+            # use Any as the concretization strategy
+            start_state.memory.read_strategies = [SimConcretizationStrategyAny()]
+            start_state.memory.write_strategies = [SimConcretizationStrategyAny()]
 
             # Create the slicecutor
             simgr = self.project.factory.simulation_manager(start_state, resilience=True)

--- a/angr/concretization_strategies/__init__.py
+++ b/angr/concretization_strategies/__init__.py
@@ -87,3 +87,4 @@ from .norepeats_range import SimConcretizationStrategyNorepeatsRange
 from .range import SimConcretizationStrategyRange
 from .single import SimConcretizationStrategySingle
 from .solutions import SimConcretizationStrategySolutions
+from .unlimited_range import SimConcretizationStrategyUnlimitedRange

--- a/angr/concretization_strategies/__init__.py
+++ b/angr/concretization_strategies/__init__.py
@@ -1,4 +1,7 @@
-class SimConcretizationStrategy(object):
+import claripy
+
+
+class SimConcretizationStrategy:
     """
     Concretization strategies control the resolution of symbolic memory indices
     in SimuVEX. By subclassing this class and setting it as a concretization strategy
@@ -40,6 +43,8 @@ class SimConcretizationStrategy(object):
         """
         Gets n solutions for an address.
         """
+        if isinstance(addr, claripy.vsa.StridedInterval):
+            return addr.eval(n)
         return memory.state.solver.eval_upto(addr, n, exact=kwargs.pop('exact', self._exact), **kwargs)
 
     def _range(self, memory, addr, **kwargs):

--- a/angr/concretization_strategies/unlimited_range.py
+++ b/angr/concretization_strategies/unlimited_range.py
@@ -1,0 +1,14 @@
+from . import SimConcretizationStrategy
+
+class SimConcretizationStrategyUnlimitedRange(SimConcretizationStrategy):
+    """
+    Concretization strategy that resolves addresses to a range without checking if the number of possible addresses is
+    within the limit.
+    """
+
+    def __init__(self, limit, **kwargs): #pylint:disable=redefined-builtin
+        super().__init__(**kwargs)
+        self._limit = limit
+
+    def _concretize(self, memory, addr):
+        return self._eval(memory, addr, self._limit)

--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -147,7 +147,8 @@ class __libc_start_main(angr.SimProcedure):
     def static_exits(self, blocks):
         # Execute those blocks with a blank state, and then dump the arguments
         blank_state = angr.SimState(project=self.project, mode="fastpath", cle_memory_backer=self.project.loader.memory,
-                                    add_options={angr.options.SYMBOL_FILL_UNCONSTRAINED_MEMORY})
+                                    add_options={angr.options.SYMBOL_FILL_UNCONSTRAINED_MEMORY,
+                                                 angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS})
         # set up the stack pointer
         blank_state.regs.sp = 0x7ffffff0
 

--- a/angr/storage/memory_mixins/__init__.py
+++ b/angr/storage/memory_mixins/__init__.py
@@ -161,7 +161,7 @@ from .paged_memory.pages import *
 
 from .slotted_memory import SlottedMemoryMixin
 from .regioned_memory import RegionedMemoryMixin, RegionCategoryMixin, StaticFindMixin, AbstractMergerMixin, \
-    MemoryRegionMetaMixin
+    MemoryRegionMetaMixin, RegionedAddressConcretizationMixin
 from .keyvalue_memory import KeyValueMemoryMixin
 from .javavm_memory import JavaVmMemoryMixin
 
@@ -254,6 +254,7 @@ class AbstractMemory(
     #InspectMixinLow,
     ActionsMixinLow,
     ConditionalMixin,
+    RegionedAddressConcretizationMixin,
     # -----
     RegionedMemoryMixin,
 ):

--- a/angr/storage/memory_mixins/bvv_conversion_mixin.py
+++ b/angr/storage/memory_mixins/bvv_conversion_mixin.py
@@ -5,6 +5,7 @@ from angr.storage.memory_mixins import MemoryMixin
 
 l = logging.getLogger(__name__)
 
+
 class DataNormalizationMixin(MemoryMixin):
     """
     Normalizes the data field for a store and the fallback field for a load to be BVs.

--- a/angr/storage/memory_mixins/regioned_memory/__init__.py
+++ b/angr/storage/memory_mixins/regioned_memory/__init__.py
@@ -3,3 +3,4 @@ from .region_category_mixin import RegionCategoryMixin
 from .static_find_mixin import StaticFindMixin
 from .abstract_merger_mixin import AbstractMergerMixin
 from .region_meta_mixin import MemoryRegionMetaMixin
+from .regioned_address_concretization_mixin import RegionedAddressConcretizationMixin

--- a/angr/storage/memory_mixins/regioned_memory/regioned_address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_address_concretization_mixin.py
@@ -1,0 +1,116 @@
+from typing import Optional, Generator
+
+import claripy
+
+from ....sim_options import HYBRID_SOLVER, APPROXIMATE_FIRST
+from .... import concretization_strategies
+from ....errors import SimMergeError, SimMemoryAddressError
+from .. import MemoryMixin
+from .abstract_address_descriptor import AbstractAddressDescriptor
+from .region_data import AddressWrapper
+
+
+class RegionedAddressConcretizationMixin(MemoryMixin):
+    def __init__(self, read_strategies=None, write_strategies=None, **kwargs):
+        super().__init__(**kwargs)
+
+        self.read_strategies = read_strategies
+        self.write_strategies = write_strategies
+
+    def set_state(self, state):
+        super().set_state(state)
+
+        if self.state is not None:
+            if self.read_strategies is None:
+                self._create_default_read_strategies()
+            if self.write_strategies is None:
+                self._create_default_write_strategies()
+
+    @MemoryMixin.memo
+    def copy(self, memo):
+        o = super().copy(memo)
+        o.read_strategies = list(self.read_strategies)
+        o.write_strategies = list(self.write_strategies)
+        return o
+
+    def merge(self, others, merge_conditions, common_ancestor=None) -> bool:
+        r = super().merge(others, merge_conditions, common_ancestor=common_ancestor)
+        self.read_strategies = self._merge_strategies(self.read_strategies, *[
+            o.read_strategies for o in others
+        ])
+        self.write_strategies = self._merge_strategies(self.write_strategies, *[
+            o.write_strategies for o in others
+        ])
+        return r
+
+    def _create_default_read_strategies(self):
+        """
+        This function is used to populate `self.read_strategies` if by set-state time none have been provided
+        It uses state options to pick defaults.
+        """
+        self.read_strategies = [concretization_strategies.SimConcretizationStrategyUnlimitedRange(self._read_targets_limit)]
+
+    def _create_default_write_strategies(self):
+        """
+        This function is used to populate `self.write_strategies` if by set-state time none have been provided.
+        It uses state options to pick defaults.
+        """
+        self.write_strategies = [concretization_strategies.SimConcretizationStrategyUnlimitedRange(self._write_targets_limit)]
+
+    @staticmethod
+    def _merge_strategies(*strategy_lists):
+        """
+        Utility function for merging. Does the merge operation on lists of strategies
+        """
+        if len(set(len(sl) for sl in strategy_lists)) != 1:
+            raise SimMergeError("unable to merge memories with amounts of strategies")
+
+        merged_strategies = [ ]
+        for strategies in zip(*strategy_lists):
+            if len(set(s.__class__ for s in strategies)) != 1:
+                raise SimMergeError("unable to merge memories with different types of strategies")
+
+            unique = list(set(strategies))
+            if len(unique) > 1:
+                unique[0].merge(unique[1:])
+            merged_strategies.append(unique[0])
+        return merged_strategies
+
+    def _apply_concretization_strategies(self, addr, strategies):
+        """
+        Applies concretization strategies on the address until one of them succeeds.
+        """
+
+        for s in strategies:
+            a = s.concretize(self, addr)
+            # return the result if not None!
+            if a is not None:
+                return a
+
+        # well, we tried
+        raise SimMemoryAddressError(
+            "Unable to concretize address with the provided strategies."
+        )
+
+    def _concretize_address_descriptor(self, desc: AbstractAddressDescriptor, original_addr: claripy.ast.Bits,
+                                       is_write: bool=False,
+                                       target_region: Optional[str]=None) -> Generator[AddressWrapper,None,None]:
+
+        strategies = self.write_strategies if is_write else self.read_strategies
+        targets_limit = self._write_targets_limit if is_write else self._read_targets_limit
+
+        for region, addr_si in desc:
+            concrete_addrs = self._apply_concretization_strategies(addr_si, strategies)
+            if len(concrete_addrs) == targets_limit and HYBRID_SOLVER in self.state.options:
+                exact = True if APPROXIMATE_FIRST not in self.state.options else None
+                solutions = self.state.solver.eval_upto(original_addr, targets_limit, exact=exact)
+
+                if len(solutions) < len(concrete_addrs):
+                    concrete_addrs = [addr_si.intersection(s).eval(1)[0] for s in solutions]
+
+            for c in concrete_addrs:
+                yield self._normalize_address_core(region, c, target_region=target_region)
+
+    def _normalize_address_core(self, region_id: str, relative_address: int,
+                                target_region: Optional[str]=None) -> AddressWrapper:
+        return super()._normalize_address_core(region_id, relative_address, target_region)

--- a/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
@@ -295,26 +295,13 @@ class RegionedMemoryMixin(MemoryMixin):
                                  )
 
     #
-    # Address conversion
+    # Address concretization and conversion
     #
 
     def _concretize_address_descriptor(self, desc: AbstractAddressDescriptor, original_addr: claripy.ast.Bits,
                                        is_write: bool=False,
                                        target_region: Optional[str]=None) -> Generator[AddressWrapper,None,None]:
-
-        targets_limit = self._write_targets_limit if is_write else self._read_targets_limit
-
-        for region, addr_si in desc:
-            concrete_addrs = addr_si.eval(targets_limit)
-            if len(concrete_addrs) == targets_limit and HYBRID_SOLVER in self.state.options:
-                exact = True if APPROXIMATE_FIRST not in self.state.options else None
-                solutions = self.state.solver.eval_upto(original_addr, targets_limit, exact=exact)
-
-                if len(solutions) < len(concrete_addrs):
-                    concrete_addrs = [addr_si.intersection(s).eval(1)[0] for s in solutions]
-
-            for c in concrete_addrs:
-                yield self._normalize_address_core(region, c, target_region=target_region)
+        raise NotImplementedError()
 
     def _normalize_address(self, addr: claripy.ast.Bits, condition=None) -> AbstractAddressDescriptor:
         """


### PR DESCRIPTION
This commit implements concretization strategy support for
RegionedMemory, and default the jumptable resolver to using Any
instead of UnlimitedRange as address concretization strategies.

This PR speeds up the resolving of some jumptables.