### PR TITLE
RDA: Keep `DataSet` displayable

### DIFF
--- a/tests/knowledge_plugins/key_definitions/test_dataset.py
+++ b/tests/knowledge_plugins/key_definitions/test_dataset.py
@@ -26,3 +26,22 @@ class TestDataSet(TestCase):
 
         self.assertSetEqual(result.data, {1, 2, 3})
         self.assertEqual(result._bits, UNKNOWN_SIZE)
+
+    def test_representation_shortens_content_with_repeated_character(self):
+        size = 30
+        long_string = 'test: ' + 'a' * size + 'b' * size
+        dataset = DataSet({long_string}, len(long_string))
+
+        self.assertEqual(
+            "%s" % dataset,
+            "DataSet<%s>: ['test: a...(repeats 30 times)b...(repeats 30 times)']" % (len(long_string))
+        )
+
+    def test_representation_does_not_shorten_content_of_reasonable_length(self):
+        string = 'not too long'
+        dataset = DataSet({string}, len(string))
+
+        self.assertEqual(
+            "%s" % dataset,
+            "DataSet<%s>: ['not too long']" % (len(string))
+        )


### PR DESCRIPTION
Avoid clobbering the output when a `DataSet` contain super long strings.

Signed-off-by: Pamplemousse <xav.maso@gmail.com>