### PR TITLE
DefaultFiller now handles ConcreteTarget

### DIFF
--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -98,9 +98,6 @@ class Concrete(SimStatePlugin):
 
         target = self.state.project.concrete_target
 
-        # Setting a concrete memory backend
-        self.state.memory._clemory_backer.set_concrete_target(target)
-
         # Sync angr registers with the one getting from the concrete target
         # registers that we don't want to concretize.
         l.debug("Synchronizing general purpose registers")

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -15,7 +15,6 @@ class DefaultFillerMixin(MemoryMixin):
                        **kwargs):
         if self.state.project.concrete_target:
             return self.state.project.concrete_target.read_memory(addr, size)
-        
         if fill_missing is False:
             raise MemoryMissingException(addr, size)
 

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -13,7 +13,10 @@ class MemoryMissingException(Exception):
 class DefaultFillerMixin(MemoryMixin):
     def _default_value(self, addr, size, name=None, inspect=True, events=True, key=None, fill_missing: bool=True,
                        **kwargs):
-
+        
+        if self.state.project.concrete_target:
+            return self.state.project.concrete_target.read_memory(addr, size)
+        
         if fill_missing is False:
             raise MemoryMissingException(addr, size)
 

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -13,7 +13,7 @@ class MemoryMissingException(Exception):
 class DefaultFillerMixin(MemoryMixin):
     def _default_value(self, addr, size, name=None, inspect=True, events=True, key=None, fill_missing: bool=True,
                        **kwargs):
-        if self.state.project.concrete_target:
+        if self.state.project and self.state.project.concrete_target:
             return self.state.project.concrete_target.read_memory(addr, size)
         if fill_missing is False:
             raise MemoryMissingException(addr, size)

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -13,7 +13,6 @@ class MemoryMissingException(Exception):
 class DefaultFillerMixin(MemoryMixin):
     def _default_value(self, addr, size, name=None, inspect=True, events=True, key=None, fill_missing: bool=True,
                        **kwargs):
-        
         if self.state.project.concrete_target:
             return self.state.project.concrete_target.read_memory(addr, size)
         


### PR DESCRIPTION
DefaultFillerMixin redirects the memory reads to the concrete target (if present) when initializing a memory page.