### PR TITLE
Heap "management" for `ReachingDefinitionsAnalysis`

### DIFF
--- a/angr/analyses/reaching_definitions/heap_allocator.py
+++ b/angr/analyses/reaching_definitions/heap_allocator.py
@@ -1,0 +1,69 @@
+import logging
+
+from typing import Set, Union
+
+from ...knowledge_plugins.key_definitions.heap_address import HeapAddress
+from ...knowledge_plugins.key_definitions.unknown_size import UnknownSize
+from ...knowledge_plugins.key_definitions.undefined import Undefined
+
+_l = logging.getLogger(name=__name__)
+
+
+class HeapAllocator:
+    """
+    A simple modelisation to help represent heap memory management during a <ReachingDefinitionsAnalysis>:
+    - Act as if allocations were always done in consecutive memory segments;
+    - Take care of the size not to screw potential pointer arithmetic (avoid overlapping segments).
+
+    The content of the heap itself is modeled using a <KeyedRegion> attribute in the <LiveDefinitions> state;
+    This class serves to generate consistent heap addresses to be used by the aforementionned.
+
+    *Note:* This has **NOT** been made to help detect heap vulnerabilities.
+    """
+    def __init__(self, canonical_size: int):
+        """
+        :param canonical_size: The concrete size an <UNKNOWN_SIZE> defaults to.
+        """
+        self._next_heap_address: HeapAddress = HeapAddress(0)
+        self._allocated_addresses: Set[HeapAddress] = [self._next_heap_address]
+        self._canonical_size: int = canonical_size
+
+    def allocate(self, size: Union[int, UnknownSize]) -> HeapAddress:
+        """
+        Gives an address for a new memory chunck of <size> bytes.
+
+        :param size: The requested size for the chunck, in number of bytes.
+        :return: The address of the chunck.
+        """
+        address = self._next_heap_address
+
+        size = self._canonical_size if isinstance(size, UnknownSize) else size
+        self._next_heap_address = HeapAddress(self._next_heap_address.value + size)
+
+        self._allocated_addresses += [self._next_heap_address]
+
+        return address
+
+    def free(self, address: Union[Undefined,HeapAddress]):
+        """
+        Mark the chunck pointed by <address> as freed.
+
+        :param address: The address of the chunck to free.
+        """
+
+        if isinstance(address, Undefined):
+            _l.debug('free(), Undefined address provided')
+        elif isinstance(address, HeapAddress):
+            try:
+                self._allocated_addresses.remove(address)
+            except ValueError:
+                _l.warning("free(), address %s had not been allocated", address)
+        else:
+            _l.warning("free(), expected HeapAddress, or Undefined, got %s", type(address).__name__)
+
+    @property
+    def allocated_addresses(self):
+        """
+        :return: The list of addresses that are currently allocated on the heap.
+        """
+        return self._allocated_addresses

--- a/angr/analyses/reaching_definitions/heap_allocator.py
+++ b/angr/analyses/reaching_definitions/heap_allocator.py
@@ -38,7 +38,7 @@ class HeapAllocator:
         address = self._next_heap_address
 
         size = self._canonical_size if isinstance(size, UnknownSize) else size
-        self._next_heap_address = HeapAddress(self._next_heap_address.value + size)
+        self._next_heap_address += size
 
         self._allocated_addresses += [self._next_heap_address]
 

--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -37,6 +37,9 @@ class ReachingDefinitionsState:
                               variables, false otherwise.
     :param analysis: The analysis that generated the state represented by this object.
     :param rtoc_value: When the targeted architecture is ppc64, the initial function needs to know the `rtoc_value`.
+    :param live_definitions:
+    :param canonical_size:
+        The sizes (in bytes) that objects with an UNKNOWN_SIZE are treated as for operations where sizes are necessary.
     """
 
     __slots__ = ('arch', '_subject', '_track_tmps', 'analysis', 'current_codeloc', 'codeloc_uses', 'live_definitions',

--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -13,6 +13,7 @@ from ...calling_conventions import SimCC, SimRegArg, SimStackArg
 from ...engines.light import SpOffset
 from ...code_location import CodeLocation
 from .external_codeloc import ExternalCodeLocation
+from .heap_allocator import HeapAllocator
 from .subject import Subject, SubjectType
 
 if TYPE_CHECKING:
@@ -40,14 +41,15 @@ class ReachingDefinitionsState:
     :param live_definitions:
     :param canonical_size:
         The sizes (in bytes) that objects with an UNKNOWN_SIZE are treated as for operations where sizes are necessary.
+    :param heap_allocator: Mechanism to model the management of heap memory.
     """
 
     __slots__ = ('arch', '_subject', '_track_tmps', 'analysis', 'current_codeloc', 'codeloc_uses', 'live_definitions',
-                 'all_definitions', '_canonical_size')
+                 'all_definitions', '_canonical_size', 'heap_allocator' )
 
     def __init__(self, arch: archinfo.Arch, subject: Subject, track_tmps: bool=False,
                  analysis: Optional['ReachingDefinitionsAnalysis']=None, rtoc_value=None,
-                 live_definitions=None, canonical_size=8):
+                 live_definitions=None, canonical_size: int=8, heap_allocator: HeapAllocator=None):
 
         # handy short-hands
         self.arch = arch
@@ -66,6 +68,8 @@ class ReachingDefinitionsState:
             self.live_definitions = live_definitions
 
         self.all_definitions: Set[Definition] = set()
+
+        self.heap_allocator = heap_allocator or HeapAllocator(canonical_size)
 
         self.current_codeloc: Optional[CodeLocation] = None
         self.codeloc_uses: Set[Definition] = set()
@@ -87,6 +91,12 @@ class ReachingDefinitionsState:
 
     @property
     def stack_uses(self): return self.live_definitions.stack_uses
+
+    @property
+    def heap_definitions(self): return self.live_definitions.heap_definitions
+
+    @property
+    def heap_uses(self): return self.live_definitions.heap_uses
 
     @property
     def memory_uses(self): return self.live_definitions.memory_uses
@@ -181,6 +191,7 @@ class ReachingDefinitionsState:
             analysis=self.analysis,
             live_definitions=self.live_definitions.copy(),
             canonical_size=self._canonical_size,
+            heap_allocator=self.heap_allocator,
         )
 
         return rd

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -41,7 +41,7 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
     * Some more documentation and examples would be nice.
     """
 
-    def __init__(self, subject: [Subject,ailment.Block,Block,Function]=None, func_graph=None, max_iterations=3,
+    def __init__(self, subject: Union[Subject,ailment.Block,Block,Function]=None, func_graph=None, max_iterations=3,
                  track_tmps=False, observation_points=None, init_state: ReachingDefinitionsState=None, cc=None,
                  function_handler=None, call_stack: Optional[List[int]]=None, maximum_local_call_depth=5,
                  observe_all=False, visited_blocks=None, dep_graph: Optional['DepGraph']=None, observe_callback=None,
@@ -346,7 +346,7 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
 
         # update all definitions and all uses
         self.all_definitions |= state.all_definitions
-        for use in [state.stack_uses, state.register_uses]:
+        for use in [state.stack_uses, state.heap_uses, state.register_uses]:
             self.all_uses.merge(use)
 
         if self._node_iterations[block_key] < self._max_iterations:

--- a/angr/knowledge_plugins/key_definitions/heap_address.py
+++ b/angr/knowledge_plugins/key_definitions/heap_address.py
@@ -1,0 +1,18 @@
+from typing import Union
+
+from .undefined import Undefined
+
+
+class HeapAddress:
+    """
+    The representation of an address on the heap.
+    """
+    def __init__(self, value: Union[int,Undefined]):
+        self._value = value
+
+    @property
+    def value(self): return self._value
+
+    def __repr__(self):
+        address_as_string = ("%#x" % self._value) if isinstance(self._value, int) else ("%s" % self._value)
+        return "HeapAddress<%s>" % address_as_string

--- a/angr/knowledge_plugins/key_definitions/heap_address.py
+++ b/angr/knowledge_plugins/key_definitions/heap_address.py
@@ -27,3 +27,6 @@ class HeapAddress:
 
     def __eq__(self, other):
         return isinstance(other, HeapAddress) and self._value == other._value
+
+    def __hash__(self):
+        return hash(self._value)

--- a/angr/knowledge_plugins/key_definitions/heap_address.py
+++ b/angr/knowledge_plugins/key_definitions/heap_address.py
@@ -16,3 +16,14 @@ class HeapAddress:
     def __repr__(self):
         address_as_string = ("%#x" % self._value) if isinstance(self._value, int) else ("%s" % self._value)
         return "HeapAddress<%s>" % address_as_string
+
+    def __add__(self, value):
+        if not isinstance(value, int):
+            raise TypeError("Can only add int to HeapAddress, got %s" % type(value).__name__)
+        return HeapAddress(self.value + value)
+
+    def __radd__(self, value):
+        return self.__add__(value)
+
+    def __eq__(self, other):
+        return isinstance(other, HeapAddress) and self._value == other._value

--- a/tests/analyses/reaching_definitions/test_heap_allocator.py
+++ b/tests/analyses/reaching_definitions/test_heap_allocator.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+
+from angr.analyses.reaching_definitions.heap_allocator import HeapAllocator
+from angr.knowledge_plugins.key_definitions.heap_address import HeapAddress
+from angr.knowledge_plugins.key_definitions.unknown_size import UNKNOWN_SIZE
+
+
+class TestHeapAllocator(TestCase):
+    UNKNOWN_SIZE_DEFAULT_CONCRETE_VALUE = 8
+
+    def setUp(self):
+        self.heap_allocator = HeapAllocator(self.UNKNOWN_SIZE_DEFAULT_CONCRETE_VALUE)
+
+
+    def test_allocate_returns_an_entry_address(self):
+        address = self.heap_allocator.allocate(0x10)
+        self.assertTrue(isinstance(address, HeapAddress))
+
+    def test_allocate_create_an_entry_after_the_previous_one(self):
+        size_of_first_chunck = 0x10
+        address = self.heap_allocator.allocate(size_of_first_chunck)
+        other_address = self.heap_allocator.allocate(0x10)
+
+        self.assertEqual(other_address.value - address.value, size_of_first_chunck)
+
+    def test_allocate_given_an_undefined_size_still_gives_a_concrete_address(self):
+        size_of_first_chunck = UNKNOWN_SIZE
+        address = self.heap_allocator.allocate(size_of_first_chunck)
+        other_address = self.heap_allocator.allocate(0x10)
+
+        self.assertEqual(other_address.value - address.value, self.UNKNOWN_SIZE_DEFAULT_CONCRETE_VALUE)
+
+    def test_allocated_addresses_keeps_track_of_memory_chuncks_in_use(self):
+        address = self.heap_allocator.allocate(0x10)
+
+        self.assertTrue(address in self.heap_allocator.allocated_addresses)
+
+    def test_free_removes_the_address_from_list_of_allocated_ones(self):
+        address = self.heap_allocator.allocate(0x10)
+        self.heap_allocator.free(address)
+
+        self.assertFalse(address in self.heap_allocator.allocated_addresses)

--- a/tests/analyses/reaching_definitions/test_rd_state.py
+++ b/tests/analyses/reaching_definitions/test_rd_state.py
@@ -1,7 +1,7 @@
 import os
 import random
 
-import nose
+from unittest import TestCase
 
 import archinfo
 
@@ -25,27 +25,26 @@ class _MockFunctionSubject:
         self.cc = None
         self.content = self._MockFunction()
 
+class TestReachingDefinitionsState(TestCase):
+    def test_initializing_rd_state_for_ppc_without_rtoc_value_should_raise_an_error(self):
+        arch = archinfo.arch_ppc64.ArchPPC64()
+        self.assertRaises(
+           ValueError,
+           ReachingDefinitionsState, arch=arch, subject=_MockFunctionSubject()
+        )
 
-def test_initializing_rd_state_for_ppc_without_rtoc_value_should_raise_an_error():
-    arch = archinfo.arch_ppc64.ArchPPC64()
-    nose.tools.assert_raises(
-       ValueError,
-       ReachingDefinitionsState, arch=arch, subject=_MockFunctionSubject()
-    )
+    def test_initializing_rd_state_for_ppc_with_rtoc_value(self):
+        arch = archinfo.arch_ppc64.ArchPPC64()
+        rtoc_value = random.randint(0, 0xffffffffffffffff)
 
+        state = ReachingDefinitionsState(
+           arch=arch, subject=_MockFunctionSubject(), rtoc_value=rtoc_value
+        )
 
-def test_initializing_rd_state_for_ppc_with_rtoc_value():
-    arch = archinfo.arch_ppc64.ArchPPC64()
-    rtoc_value = random.randint(0, 0xffffffffffffffff)
+        rtoc_offset = arch.registers['rtoc'][0]
+        rtoc_definition = next(iter(
+            state.register_definitions.get_objects_by_offset(rtoc_offset)
+        ))
+        rtoc_definition_value = rtoc_definition.data.get_first_element()
 
-    state = ReachingDefinitionsState(
-       arch=arch, subject=_MockFunctionSubject(), rtoc_value=rtoc_value
-    )
-
-    rtoc_offset = arch.registers['rtoc'][0]
-    rtoc_definition = next(iter(
-        state.register_definitions.get_objects_by_offset(rtoc_offset)
-    ))
-    rtoc_definition_value = rtoc_definition.data.get_first_element()
-
-    nose.tools.assert_equals(rtoc_definition_value, rtoc_value)
+        self.assertEquals(rtoc_definition_value, rtoc_value)

--- a/tests/analyses/reaching_definitions/test_rd_state.py
+++ b/tests/analyses/reaching_definitions/test_rd_state.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 import archinfo
 
+from angr.analyses.reaching_definitions.heap_allocator import HeapAllocator
 from angr.analyses.reaching_definitions.rd_state import ReachingDefinitionsState
 from angr.analyses.reaching_definitions.subject import SubjectType
 
@@ -47,4 +48,10 @@ class TestReachingDefinitionsState(TestCase):
         ))
         rtoc_definition_value = rtoc_definition.data.get_first_element()
 
-        self.assertEquals(rtoc_definition_value, rtoc_value)
+        self.assertEqual(rtoc_definition_value, rtoc_value)
+
+    def test_rd_state_gets_a_default_heap_allocator(self):
+        arch = archinfo.arch_arm.ArchARM()
+        state = ReachingDefinitionsState(arch, _MockFunctionSubject())
+
+        self.assertTrue(isinstance(state.heap_allocator, HeapAllocator))

--- a/tests/knowledge_plugins/key_definitions/test_heap_address.py
+++ b/tests/knowledge_plugins/key_definitions/test_heap_address.py
@@ -7,3 +7,16 @@ class TestHeapAddress(TestCase):
     def test_expose_its_value_as_a_property(self):
         address = HeapAddress(0x42)
         self.assertEqual(address.value, 0x42)
+
+    def test_add_fails_if_value_added_is_not_int(self):
+        address = HeapAddress(0x0)
+        self.assertRaises(TypeError, address + 0x8)
+
+    def test_add_increase_the_heap_address_value_by_the_right_amount(self):
+        address = HeapAddress(0x0)
+        new_address = address + 0x8
+        self.assertEqual(new_address.value, 0x8)
+
+    def test_add_is_commutative(self):
+        address = HeapAddress(0x0)
+        self.assertEqual(address + 0x8, 0x8 + address)

--- a/tests/knowledge_plugins/key_definitions/test_heap_address.py
+++ b/tests/knowledge_plugins/key_definitions/test_heap_address.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+from angr.knowledge_plugins.key_definitions.heap_address import HeapAddress
+
+
+class TestHeapAddress(TestCase):
+    def test_expose_its_value_as_a_property(self):
+        address = HeapAddress(0x42)
+        self.assertEqual(address.value, 0x42)


### PR DESCRIPTION
This PR adds the following:
  * `HeapAllocator` for `HeapAddress`es management: generate sound addresses (w.r.t. `KeyedRegion` restrictions: no overlapping!), don't try to mimic real allocator behavior;
  * `LiveDefinitions.heap_definitions` and `LiveDefinitions.heap_uses` to allow RDA analysis to keep track of the **content** of the heap.

And incidentally, I updated tests for `rd_state` to get rid of `nose`.