### PR TITLE
Add header needed to find std::out_of_range

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <map>
 #include <set>
+#include <stdexcept>
 #include <unordered_set>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
On some platforms/configurations, `stdexcept` header is needed to find `std::out_of_range` used in native interface. This PR fixes #2385 .