### PR TITLE
Update MANIFEST.in to include hpp files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include LICENSE
 include README.md
-recursive-include native *.c *.cpp *.h *.def Makefile Makefile-win
+recursive-include native *.c *.cpp *.h *.hpp *.def Makefile Makefile-win


### PR DESCRIPTION
This change will cause *.hpp files to be included in angr source distributions, necessary for building wheels and successfully releasing angr.