### PR TITLE
RDA: `LiveDefinitions.get_sp()` not to fail

### DIFF
--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -107,6 +107,8 @@ class ReachingDefinitionsState:
     @property
     def uses_by_codeloc(self): return self.live_definitions.uses_by_codeloc
 
+    def get_sp(self) -> int: return self.live_definitions.get_sp()
+
     @property
     def dep_graph(self):
         return self.analysis.dep_graph
@@ -195,18 +197,6 @@ class ReachingDefinitionsState:
         )
 
         return rd
-
-    def get_sp(self) -> int:
-        """
-        Return the concrete value contained by the stack pointer.
-        """
-        sp_definitions = self.register_definitions.get_objects_by_offset(self.arch.sp_offset)
-
-        assert len(sp_definitions) == 1
-        [sp_definition] = sp_definitions
-
-        # Assuming sp_definition has only one concrete value.
-        return sp_definition.data.get_first_element()
 
     def merge(self, *others):
 

--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -80,12 +80,15 @@ class LiveDefinitions:
         Return the concrete value contained by the stack pointer.
         """
         sp_definitions = self.register_definitions.get_objects_by_offset(self.arch.sp_offset)
+        [first_value, *other_values] = [ d.data.get_first_element() for d in sp_definitions ]
 
-        assert len(sp_definitions) == 1
-        [sp_definition] = sp_definitions
+        # If there are several definitions for SP, all values must be the same.
+        if len(sp_definitions) > 1:
+            [first_value, *other_values] = [ d.data.get_first_element() for d in sp_definitions ]
+            all_have_same_value = all(map(lambda v: v == first_value, other_values))
+            assert all_have_same_value
 
-        # Assuming sp_definition has only one concrete value.
-        return sp_definition.data.get_first_element()
+        return first_value
 
     def merge(self, *others):
 

--- a/tests/analyses/reaching_definitions/test_rd_state.py
+++ b/tests/analyses/reaching_definitions/test_rd_state.py
@@ -1,13 +1,14 @@
 import os
 import random
 
-from unittest import TestCase
+from unittest import mock, TestCase
 
 import archinfo
 
 from angr.analyses.reaching_definitions.heap_allocator import HeapAllocator
 from angr.analyses.reaching_definitions.rd_state import ReachingDefinitionsState
 from angr.analyses.reaching_definitions.subject import SubjectType
+from angr.knowledge_plugins.key_definitions.live_definitions import LiveDefinitions
 
 
 TESTS_LOCATION = os.path.join(
@@ -55,3 +56,16 @@ class TestReachingDefinitionsState(TestCase):
         state = ReachingDefinitionsState(arch, _MockFunctionSubject())
 
         self.assertTrue(isinstance(state.heap_allocator, HeapAllocator))
+
+    def test_get_sp_delegates_to_the_underlying_live_definitions(self):
+        arch = archinfo.arch_arm.ArchARM()
+        live_definitions = LiveDefinitions(arch)
+
+        state = ReachingDefinitionsState(
+           arch=arch, subject=_MockFunctionSubject(), live_definitions=live_definitions
+        )
+
+        with mock.patch.object(LiveDefinitions, 'get_sp') as live_definitions_get_sp_mock:
+            state.get_sp()
+
+            live_definitions_get_sp_mock.assert_called_once()

--- a/tests/knowledge_plugins/key_definitions/test_live_definitions.py
+++ b/tests/knowledge_plugins/key_definitions/test_live_definitions.py
@@ -1,0 +1,61 @@
+from unittest import TestCase
+
+import archinfo
+
+from angr.knowledge_plugins.key_definitions.atoms import Register, SpOffset
+from angr.knowledge_plugins.key_definitions.dataset import DataSet
+from angr.knowledge_plugins.key_definitions.live_definitions import LiveDefinitions
+
+
+class TestLiveDefinitions(TestCase):
+    def setUp(self):
+        self.arch = archinfo.arch_arm.ArchARM()
+
+        sp_offset = self.arch.registers['sp'][0]
+        self.sp_register = Register(sp_offset, self.arch.bytes)
+
+    def test_get_sp_retrieves_the_value_of_sp_register(self):
+        address = SpOffset(self.arch.bits, 0)
+        sp_value = DataSet({address}, self.arch.bits)
+
+        live_definitions = LiveDefinitions(self.arch)
+        live_definitions.kill_and_add_definition(self.sp_register, None, sp_value)
+
+        retrieved_sp_value = live_definitions.get_sp()
+
+        self.assertEqual(retrieved_sp_value, address)
+
+    def test_get_sp_fails_if_there_are_different_definitions_for_sp_with_different_values(self):
+        address = SpOffset(self.arch.bits, 0)
+        sp_value = DataSet({address}, self.arch.bits)
+        other_address = SpOffset(self.arch.bits, 20)
+        other_sp_value = DataSet({other_address}, self.arch.bits)
+
+        # To get multiple definitions of SP cohabiting, we need to create a `LiveDefinitions` via `.merge`:
+        # Let's create the "base" `LiveDefinitions`, holding *DIFFERENT* values.
+        live_definitions = LiveDefinitions(self.arch)
+        live_definitions.kill_and_add_definition(self.sp_register, 0x0, sp_value)
+        other_live_definitions = LiveDefinitions(self.arch)
+        other_live_definitions.kill_and_add_definition(self.sp_register, 0x1, other_sp_value)
+        # Then merge them.
+        live_definitions_with_multiple_sps = live_definitions.merge(other_live_definitions)
+
+        self.assertRaises(AssertionError, live_definitions_with_multiple_sps.get_sp)
+
+
+    def test_get_sp_retrieves_the_value_of_sp_register_even_if_it_has_several_definitions(self):
+        address = SpOffset(self.arch.bits, 0)
+        sp_value = DataSet({address}, self.arch.bits)
+
+        # To get multiple definitions of SP cohabiting, we need to create a `LiveDefinitions` via `.merge`:
+        # Let's create the "base" `LiveDefinitions`, holding *THE SAME* values.
+        live_definitions = LiveDefinitions(self.arch)
+        live_definitions.kill_and_add_definition(self.sp_register, 0x1, sp_value)
+        other_live_definitions = LiveDefinitions(self.arch)
+        other_live_definitions.kill_and_add_definition(self.sp_register, 0x2, sp_value)
+        # Then merge them.
+        live_definitions_with_multiple_sps = live_definitions.merge(other_live_definitions)
+
+        retrieved_sp_value = live_definitions_with_multiple_sps.get_sp()
+
+        self.assertEqual(retrieved_sp_value, address)


### PR DESCRIPTION
  * deduplicate `get_sp` implementations
  * make it not fail when several definitions for SP are present

Signed-off-by: Pamplemousse <xav.maso@gmail.com>