### PR TITLE
Attempt to fix posix.fstat

### DIFF
--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -268,6 +268,16 @@ class SimMount(SimStatePlugin):
         """
         raise NotImplementedError
 
+    def lookup(self, sim_file):
+        """
+        Look up the path of a SimFile in the mountpoint
+
+        :param sim_file:        A SimFile object needs to be looked up
+        :return:                A string representing the path of the file in the mountpoint
+                                Or None if the SimFile does not exist in the mountpoint
+        """
+        raise NotImplementedError
+
 class SimConcreteFilesystem(SimMount):
     """
     Abstract SimMount allowing the user to import files from some external source into the guest
@@ -309,6 +319,12 @@ class SimConcreteFilesystem(SimMount):
         path = self.pathsep.join(x.decode() for x in path_elements)
         self.deleted_list.add(path)
         return self.cache.pop(path, None) is not None
+
+    def lookup(self, sim_file):
+        for key, val in self.cache.items():
+            if sim_file == val:
+                return key
+        return None
 
     @SimStatePlugin.memo
     def copy(self, memo):
@@ -361,6 +377,7 @@ class SimConcreteFilesystem(SimMount):
         Takes a list of directories from the root and joins them into a string path
         """
         return self.pathsep + self.pathsep.join(keys)
+
 
 class SimHostFilesystem(SimConcreteFilesystem):
     """

--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -85,7 +85,7 @@ class SimFilesystem(SimStatePlugin): # pretends links don't exist
             try:
                 subdeck = [o._mountpoints[fname] for o in others]
             except KeyError:
-                raise SimMergeError("Can't merge filesystems with disparate file sets")
+                raise SimMergeError("Can't merge filesystems with disparate file sets") # pylint: disable=raise-missing-from
 
             if common_ancestor is not None and fname in common_ancestor._mountpoints:
                 common_mp = common_ancestor._mountpoints[fname]

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -390,9 +390,9 @@ class SimSystemPosix(SimStatePlugin):
     def fstat(self, sim_fd): #pylint:disable=unused-argument
         # sizes are AMD64-specific for symbolic files for now
         fd = None
-        sim_file = None
         mount = None
         mode = None
+        guest_path = None
 
         if not self.state.solver.symbolic(sim_fd):
             fd = self.state.solver.eval(sim_fd)
@@ -403,12 +403,13 @@ class SimSystemPosix(SimStatePlugin):
             if isinstance(fd_desc, SimFileDescriptor):
                 sim_file = fd_desc.file
                 mount = self.state.fs.get_mountpoint(sim_file.name)[0]
+                guest_path = mount.lookup(sim_file)
 
         # if it is mounted, let the filesystem figure out the stat
-        if sim_file is not None and mount is not None:
-            stat = mount._get_stat(sim_file.name)
+        if guest_path is not None and mount is not None:
+            stat = mount._get_stat(guest_path)
             if stat is None:
-                raise SimPosixError("file %s does not exist on mount %s" % (sim_file.name, mount))
+                raise SimPosixError("file %s does not exist on mount %s" % (guest_path, mount))
             size = stat.st_size
             mode = stat.st_mode
         else:

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -413,7 +413,8 @@ class SimSystemPosix(SimStatePlugin):
             if isinstance(fd_desc, SimFileDescriptor):
                 sim_file = fd_desc.file
                 mount = self.state.fs.get_mountpoint(sim_file.name)[0]
-                guest_path = mount.lookup(sim_file)
+                if mount:
+                    guest_path = mount.lookup(sim_file)
 
         # if it is mounted, let the filesystem figure out the stat
         if guest_path is not None and mount is not None:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,9 +1,10 @@
-
+import os
 import nose.tools
 
 import angr
 from angr.state_plugins.posix import Flags
 
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
 
 def test_files():
     s = angr.SimState(arch='AMD64')
@@ -31,7 +32,18 @@ def test_file_read_missing_content():
     nose.tools.assert_equal(len(data.variables), 1)
     nose.tools.assert_in("oops", next(iter(data.variables)))  # file name should be part of the variable name
 
+def test_concrete_fs_resolution():
+    bin_path = os.path.join(test_location, 'binaries', 'tests', 'i386', 'fauxware')
+    proj = angr.Project(bin_path)
+    state = proj.factory.entry_state(concrete_fs=True)
+    fd = state.posix.open(bin_path, Flags.O_RDONLY)
+    stat = state.posix.fstat(fd)
+    size = state.solver.eval(stat.st_blksize)
+
+    nose.tools.assert_true(stat)
+    nose.tools.assert_not_equal(stat, 0)
 
 if __name__ == '__main__':
     test_files()
     test_file_read_missing_content()
+    test_concrete_fs_resolution()

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -41,7 +41,7 @@ def test_concrete_fs_resolution():
     size = state.solver.eval(stat.st_blksize)
 
     nose.tools.assert_true(stat)
-    nose.tools.assert_not_equal(stat, 0)
+    nose.tools.assert_not_equal(size, 0)
 
 if __name__ == '__main__':
     test_files()

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -38,12 +38,26 @@ def test_concrete_fs_resolution():
     state = proj.factory.entry_state(concrete_fs=True)
     fd = state.posix.open(bin_path, Flags.O_RDONLY)
     stat = state.posix.fstat(fd)
-    size = state.solver.eval(stat.st_blksize)
+    size = stat.st_size
+    int_size = state.solver.eval(size)
 
     nose.tools.assert_true(stat)
-    nose.tools.assert_not_equal(size, 0)
+    nose.tools.assert_not_equal(int_size, 0)
+    nose.tools.assert_false(state.solver.symbolic(size))
+
+def test_sim_fs_resolution():
+    bin_path = os.path.join(test_location, 'binaries', 'tests', 'i386', 'fauxware')
+    proj = angr.Project(bin_path)
+    state = proj.factory.entry_state()
+    fd = state.posix.open(bin_path, Flags.O_RDONLY)
+    stat = state.posix.fstat(fd)
+    size = stat.st_size
+
+    nose.tools.assert_true(stat)
+    nose.tools.assert_true(state.solver.symbolic(size))
 
 if __name__ == '__main__':
     test_files()
     test_file_read_missing_content()
     test_concrete_fs_resolution()
+    test_sim_fs_resolution()


### PR DESCRIPTION
The issue here is that there is no good way to resolve the guest path of a file given its `SimFile` object at this moment.
The hierarchy here is `SimFileSystem` -> `SimMount` -> `SimFile`.
Given a file path, it's easy to lookup its `SimFile` by following this hierarchy.
However, given a `SimFile`, looking up a file path is not easy with current implementation since mount information is not stored in `SimFile`. There are `ident` and `name` attributes in `SimFile`, but they are both fake identifiers and shouldn't be used for path resolution theoretically. 
A good approach is to add a backward reference to `SimMount` in `SimFile`. I couldn't make it work by adding the logic in `mount.insert`. And also, it raises a design question: is a `SimFile` allowed to be mounted in multiple `SimMount`?

This patch makes `fstat` work, but it is still not a proper fix because "given a SimFile, how to look up its `SimMount`" is still not resolved. Currently, I'm basically assuming the mount is at `/`