### PR TITLE
Request for Identifier Analysis does not work with Windows SimOS on Linux (#2413)

### DIFF
--- a/angr/analyses/identifier/runner.py
+++ b/angr/analyses/identifier/runner.py
@@ -29,8 +29,11 @@ assert len(FLAG_DATA) == 0x1000
 
 class Runner(object):
     def __init__(self, project, cfg):
-        # this is kind of fucked up
-        project.simos.syscall_library.update(SIM_LIBRARIES['cgcabi_tracer'])
+        if hasattr(project.simos, 'syscall_library'):
+            # this is kind of fucked up
+            project.simos.syscall_library.update(SIM_LIBRARIES['cgcabi_tracer'])
+        else:
+            raise Exception("Identifier analysis cannot be run with SimOS %s" % project.simos.name)
 
         self.project = project
         self.cfg = cfg


### PR DESCRIPTION
Pull request to perform an attribute check prior to using it and throwing an exception if the SimOS does not have that attribute.