### PR TITLE
Fix possible iteration bugs getting block address 

### DIFF
--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -1,7 +1,6 @@
 
 import logging
 
-import pyvex
 import angr
 
 l = logging.getLogger(name=__name__)
@@ -155,9 +154,7 @@ class __libc_start_main(angr.SimProcedure):
         # Execute each block
         state = blank_state
         for b in blocks:
-            # state.regs.ip = next(iter(stmt for stmt in b.statements if isinstance(stmt, pyvex.IRStmt.IMark))).addr
-            irsb = self.project.factory.default_engine.process(state, b,
-                    force_addr=next(iter(stmt for stmt in b.statements if isinstance(stmt, pyvex.IRStmt.IMark))).addr)
+            irsb = self.project.factory.default_engine.process(state, b, force_addr=b.addr)
             if irsb.successors:
                 state = irsb.successors[0]
             else:

--- a/angr/procedures/posix/pthread.py
+++ b/angr/procedures/posix/pthread.py
@@ -1,5 +1,4 @@
 import angr
-import pyvex
 
 # pylint: disable=arguments-differ,unused-argument,no-self-use,inconsistent-return-statements
 
@@ -25,9 +24,7 @@ class pthread_create(angr.SimProcedure):
         # Execute each block
         state = blank_state
         for b in blocks:
-            irsb = self.project.factory.default_engine.process(state, b,
-                    force_addr=next(iter(stmt for stmt in b.statements if isinstance(stmt, pyvex.IRStmt.IMark))).addr
-                                                  )
+            irsb = self.project.factory.default_engine.process(state, b, force_addr=b.addr)
             if irsb.successors:
                 state = irsb.successors[0]
             else:


### PR DESCRIPTION
Iterating over an IRSB`s `statements` property may fail if the
list is empty. Instead, grab the block address from the block's addr
property.