### PR TITLE
Fixes for subregisters taint propagation in native interface

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1279,15 +1279,16 @@ bool State::is_symbolic_register(vex_reg_offset_t reg_offset) const {
 		}
 		return false;
 	}
+	reg_offset = get_full_register_offset(reg_offset);
 	// The register is not a CPU flag and so we check every byte of the register
-	for (int i = 0; i < reg_size_map.at(reg_offset); i++) {
+	for (auto i = 0; i < reg_size_map.at(reg_offset); i++) {
 		// If any of the register's bytes are symbolic, we deem the register to be symbolic
 		if (block_symbolic_registers.count(reg_offset + i) > 0) {
 			return true;
 		}
 	}
 	bool is_concrete = true;
-	for (int i = 0; i < reg_size_map.at(reg_offset); i++) {
+	for (auto i = 0; i < reg_size_map.at(reg_offset); i++) {
 		if (block_concrete_registers.count(reg_offset) == 0) {
 			is_concrete = false;
 			break;
@@ -1299,7 +1300,7 @@ bool State::is_symbolic_register(vex_reg_offset_t reg_offset) const {
 	}
 	// If we reach here, it means that the register is not marked symbolic or concrete in the block
 	// level taint status tracker. We check the state's symbolic register list.
-	for (int i = 0; i < reg_size_map.at(reg_offset); i++) {
+	for (auto i = 0; i < reg_size_map.at(reg_offset); i++) {
 		if (symbolic_registers.count(reg_offset + i) > 0) {
 			return true;
 		}

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -448,6 +448,14 @@ class State {
 		if (vex_sub_reg_mapping_entry != vex_sub_reg_map.end()) {
 			return vex_sub_reg_mapping_entry->second;
 		}
+		if (reg_size_map.find(reg_offset) != reg_size_map.end()) {
+			return reg_offset;
+		}
+		for (auto &entry: reg_size_map) {
+			if ((entry.first <= reg_offset) && (reg_offset <= entry.first + entry.second)) {
+				return entry.first;
+			}
+		}
 		return reg_offset;
 	}
 


### PR DESCRIPTION
Taint propagation for subregisters were not correctly handled in the native interface. This PR fixes those issues.