### PR TITLE
Clinic: Remove alignment blocks from function graphs.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2139,8 +2139,8 @@ class CFGBase(Analysis):
         # the block is a noop block if it only has IMark statements **and** it jumps to its immediate successor. VEX
         # will generate such blocks when opt_level==1 and cross_insn_opt is True
         fallthrough_addr = block.addr + block.size
-        next = block.vex.next
-        if isinstance(next, pyvex.IRExpr.Const) and next.con.value == fallthrough_addr:
+        next_ = block.vex.next
+        if isinstance(next_, pyvex.IRExpr.Const) and next_.con.value == fallthrough_addr:
             if all((type(stmt) is pyvex.IRStmt.IMark) for stmt in block.vex.statements):
                 return True
 
@@ -2154,7 +2154,7 @@ class CFGBase(Analysis):
             if block.vex.statements:
                 last_stmt = block.vex.statements[-1]
                 if isinstance(last_stmt, pyvex.IRStmt.IMark):
-                    if isinstance(next, pyvex.IRExpr.Const) and next.con.value == fallthrough_addr:
+                    if isinstance(next_, pyvex.IRExpr.Const) and next_.con.value == fallthrough_addr:
                         return True
         return False
 

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2136,10 +2136,13 @@ class CFGBase(Analysis):
                     return True
 
         # Fallback
-        # the block is a noop block if it only has IMark statements. VEX will generate such blocks when opt_level==1
-        # and cross_insn_opt is True
-        if all((type(stmt) is pyvex.IRStmt.IMark) for stmt in block.vex.statements):
-            return True
+        # the block is a noop block if it only has IMark statements **and** it jumps to its immediate successor. VEX
+        # will generate such blocks when opt_level==1 and cross_insn_opt is True
+        fallthrough_addr = block.addr + block.size
+        next = block.vex.next
+        if isinstance(next, pyvex.IRExpr.Const) and next.con.value == fallthrough_addr:
+            if all((type(stmt) is pyvex.IRStmt.IMark) for stmt in block.vex.statements):
+                return True
 
         # the block is a noop block if it only has IMark statements and IP-setting statements that set the IP to the
         # next location. VEX will generate such blocks when opt_level==1 and cross_insn_opt is False
@@ -2151,9 +2154,7 @@ class CFGBase(Analysis):
             if block.vex.statements:
                 last_stmt = block.vex.statements[-1]
                 if isinstance(last_stmt, pyvex.IRStmt.IMark):
-                    fallthrough_addr = last_stmt.addr + last_stmt.delta + last_stmt.len
-                    n = block.vex.next
-                    if isinstance(n, pyvex.IRExpr.Const) and n.con.value == fallthrough_addr:
+                    if isinstance(next, pyvex.IRExpr.Const) and next.con.value == fallthrough_addr:
                         return True
         return False
 

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -14,6 +14,7 @@ from ...sim_type import SimTypeChar, SimTypeInt, SimTypeLongLong, SimTypeShort, 
 from ...sim_variable import SimVariable, SimStackVariable, SimRegisterVariable
 from ...knowledge_plugins.key_definitions.constants import OP_BEFORE, OP_AFTER
 from .. import Analysis, register_analysis
+from ..cfg.cfg_base import CFGBase
 from .ailgraph_walker import AILGraphWalker
 from .optimization_passes import get_default_optimization_passes
 
@@ -100,6 +101,9 @@ class Clinic(Analysis):
         # Set up the function graph according to configurations
         self._set_function_graph()
 
+        # Remove alignment blocks
+        self._remove_alignment_blocks()
+
         # Make sure calling conventions of all functions have been recovered
         self._recover_calling_conventions()
 
@@ -148,6 +152,15 @@ class Clinic(Analysis):
     @timethis
     def _set_function_graph(self):
         self._func_graph = self.function.graph_ex(exception_edges=self._exception_edges)
+
+    @timethis
+    def _remove_alignment_blocks(self):
+        """
+        Alignment blocks are basic blocks that only consist of nops. They should not be included in the graph.
+        """
+        for node in list(self._func_graph.nodes()):
+            if CFGBase._is_noop_block(self.project.arch, self.project.factory.block(node.addr, node.size)):
+                self._func_graph.remove_node(node)
 
     @timethis
     def _recover_calling_conventions(self):

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -104,6 +104,10 @@ class Clinic(Analysis):
         # Remove alignment blocks
         self._remove_alignment_blocks()
 
+        # if the graph is empty, don't continue
+        if not self._func_graph:
+            return
+
         # Make sure calling conventions of all functions have been recovered
         self._recover_calling_conventions()
 
@@ -159,7 +163,8 @@ class Clinic(Analysis):
         Alignment blocks are basic blocks that only consist of nops. They should not be included in the graph.
         """
         for node in list(self._func_graph.nodes()):
-            if CFGBase._is_noop_block(self.project.arch, self.project.factory.block(node.addr, node.size)):
+            if self._func_graph.in_degree(node) == 0 and \
+                    CFGBase._is_noop_block(self.project.arch, self.project.factory.block(node.addr, node.size)):
                 self._func_graph.remove_node(node)
 
     @timethis

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -44,6 +44,11 @@ class Decompiler(Analysis):
                                               sp_tracker_track_memory=self._sp_tracker_track_memory,
                                               **self.options_to_params(options_by_class['clinic'])
                                               )
+        self.clinic = clinic
+
+        if clinic.graph is None:
+            # the function is empty
+            return
 
         cond_proc = ConditionProcessor()
 
@@ -61,7 +66,6 @@ class Decompiler(Analysis):
                                                                 kb=self.kb,
                                                                 variable_kb=clinic.variable_kb)
 
-        self.clinic = clinic
         self.codegen = codegen
 
     def _set_global_variables(self):

--- a/angr/analyses/decompiler/optimization_passes/base_ptr_save_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/base_ptr_save_simplifier.py
@@ -75,6 +75,8 @@ class BasePointerSaveSimplifier(OptimizationPass):
         """
 
         first_block = self._get_block(self._func.addr)
+        if first_block is None:
+            return None
 
         for idx, stmt in enumerate(first_block.statements):
             if isinstance(stmt, ailment.Stmt.Store) \

--- a/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
@@ -129,6 +129,8 @@ class StackCanarySimplifier(OptimizationPass):
     def _find_canary_init_stmt(self):
 
         first_block = self._get_block(self._func.addr)
+        if first_block is None:
+            return None
 
         for idx, stmt in enumerate(first_block.statements):
             if isinstance(stmt, ailment.Stmt.Store) \

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -73,7 +73,10 @@ class RegionIdentifier(Analysis):
 
     @staticmethod
     def _get_start_node(graph):
-        return next(n for n in graph.nodes() if graph.in_degree(n) == 0)
+        try:
+            return next(n for n in graph.nodes() if graph.in_degree(n) == 0)
+        except StopIteration:
+            return None
 
     def _test_reducibility(self):
 

--- a/angr/analyses/decompiler/structurer.py
+++ b/angr/analyses/decompiler/structurer.py
@@ -835,11 +835,10 @@ class Structurer(Analysis):
             for case_node in cases.values():
                 walker.walk(case_node)
 
-            try:
-                switch_end_addr = sorted(goto_addrs.items(), key=lambda x: x[1], reverse=True)[0][0]
-            except StopIteration:
+            if not goto_addrs:
                 # there is no Goto statement - perfect
                 return
+            switch_end_addr = sorted(goto_addrs.items(), key=lambda x: x[1], reverse=True)[0][0]
 
         # rewrite all _goto switch_end_addr_ to _break_
 

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -233,8 +233,14 @@ def test_decompiling_switch2_x86_64():
 
     cfg = p.analyses.CFG(normalize=True, data_references=True)
 
+    # disable eager returns simplifier
+    all_optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes("AMD64",
+                                                                                                           "linux")
+    all_optimization_passes = [ p for p in all_optimization_passes
+                                if p is not angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier ]
+
     f = cfg.functions['main']
-    dec = p.analyses.Decompiler(f, cfg=cfg)
+    dec = p.analyses.Decompiler(f, cfg=cfg, optimization_passes=all_optimization_passes)
     if dec.codegen is not None:
         code = dec.codegen.text
         assert "switch" in code


### PR DESCRIPTION
Alignment blocks break RegionIdentifier and cause incorrectly identified
regions.