### PR TITLE
Fix some decompiler issues

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -583,7 +583,7 @@ class ConditionProcessor:
             if condition.bits == 1:
                 var = claripy.BoolV('ailtmp_%d' % condition.tmp_idx)
             else:
-                var = claripy.BVS('ailtmp_%d' % condition.tmp_idx, condition.bits)
+                var = claripy.BVS('ailtmp_%d' % condition.tmp_idx, condition.bits, explicit_name=True)
             self._condition_mapping[var.args[0]] = condition
             return var
 

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -910,10 +910,12 @@ class CBinaryOp(CExpression):
         }
 
         handler = OP_MAP.get(self.op, None)
+        yield "(", None
         if handler is not None:
             yield from handler()
         else:
             yield "BinaryOp %s" % (self.op), None
+        yield ")", None
 
     #
     # Handlers

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -910,12 +910,10 @@ class CBinaryOp(CExpression):
         }
 
         handler = OP_MAP.get(self.op, None)
-        yield "(", None
         if handler is not None:
             yield from handler()
         else:
             yield "BinaryOp %s" % (self.op), None
-        yield ")", None
 
     #
     # Handlers

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -711,7 +711,10 @@ class CVariable(CExpression):
     def c_repr_chunks(self):
         if self.offset is None:
             if isinstance(self.variable, SimVariable):
-                yield str(self.variable.name), self
+                if self.variable.name:
+                    yield self.variable.name, self
+                else:
+                    yield str(self.variable), self
             elif isinstance(self.variable, CExpression):
                 if isinstance(self.variable, CVariable) and self.variable.type is not None:
                     if isinstance(self.variable.type, SimTypePointer):

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -141,6 +141,9 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
 
         # output each variable and its type
         for var, cvar in self.variables_in_use.items():
+            if cvar in self.arg_list:
+                continue
+
             var_type = self.variable_manager.get_variable_type(var)
 
             if var_type is None:

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -431,7 +431,7 @@ def test_decompilation_excessive_condition_removal():
 
     code = code.replace(" ", "").replace("\n", "")
     # s_1a += 1 should not be wrapped inside any if-statements. it is always reachable.
-    assert "}s_1a=s_1a+1;}" in code
+    assert "}s_1a=(s_1a+1);}" in code
 
 
 if __name__ == "__main__":

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -431,7 +431,7 @@ def test_decompilation_excessive_condition_removal():
 
     code = code.replace(" ", "").replace("\n", "")
     # s_1a += 1 should not be wrapped inside any if-statements. it is always reachable.
-    assert "}s_1a=(s_1a+1);}" in code
+    assert "}s_1a=s_1a+1;}" in code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### fix if-then-else structures ec8b5ed
before:
`<Bool LShR(ailexpr_Conv(8->32, <BV8 ailtmp_197_20_8>) << 0x1c, 0x1e) != 0x0>`
`<Bool LShR(ailexpr_Conv(8->32, <BV8 ailtmp_197_19_8>) << 0x1c, 0x1e) == 0x0>`
```c
if ((int)None << 28 >> 30 != 0)
{
    // if statements
    goto 134218717;
}
if ((int)None << 28 >> 30 == 0)
{
    // else statements
}
// addr: 134218717
```
after:
`<Bool LShR(ailexpr_Conv(8->32, <BV8 ailtmp_197>) << 0x1c, 0x1e) != 0x0>`
`<Bool LShR(ailexpr_Conv(8->32, <BV8 ailtmp_197>) << 0x1c, 0x1e) == 0x0>`

```c
if ((int)None << 28 >> 30 != 0)
{
    // if statements
}
else
{
    // else statements
}
```
---
### remove function args from local variable declarations 29afc7d
before:
```c
void function_name(char[5]* a0, struct struct_0* a1) {
    char[5]* a0;
    struct struct_0* a1;
    unsigned int ir_0;
    unsigned int ir_1;
    unsigned int ir_2;
    // statements
}
```
after:
```c
void function_name(char[5]* a0, struct struct_0* a1) {
    unsigned int ir_0;
    unsigned int ir_1;
    unsigned int ir_2;
    // statements
}
```
---
### fix 'None' varibles in function body e1816f6
before:
```c
void function_name(char[5]* a0, struct struct_0* a1) {
    BOT <tmp 197>;
    BOT <tmp 12>;
    // more declarations..

    None = a0[4];
    None = (int)a0[4] << 28;
    // more statements...
}
```
after:
```c
void function_name(char[5]* a0, struct struct_0* a1) {
    BOT <tmp 197>;
    BOT <tmp 12>;
    // more declarations..

    <tmp 197> = a0[4];
    <tmp 12> = (int)a0[4] << 28;
    // more statements...
}
```
---
### fix operation precedence issue by adding parentheses e1a314d
before:
```c
if (ir_0 << 8 + ir_2 << 16 >> 16 > 0)
```
after:
```c
if ((((((ir_0 << 8) + ir_2) << 16 ) >> 16) > 0))
```
they are different because "+" has higher priority over "<<".
