### PR TITLE
Rename AVR to AVR8 in CC lookup table

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1503,7 +1503,7 @@ DEFAULT_CC: Dict[str,Type[SimCC]] = {
     'PPC64': SimCCPowerPC64,
     'AARCH64': SimCCAArch64,
     'Soot': SimCCSoot,
-    'AVR': SimCCUnknown,
+    'AVR8': SimCCUnknown,
     'MSP': SimCCUnknown,
     'S390X': SimCCS390X,
 }


### PR DESCRIPTION
Relevant following https://github.com/angr/archinfo/pull/95