### PR TITLE
Handle case when binary path is unavailable in function knowledge

### DIFF
--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -696,7 +696,7 @@ class Function(Serializable):
             if hooker is not None:
                 binary_name = hooker.library_name
 
-        if binary_name is None and self.binary is not None:
+        if binary_name is None and self.binary is not None and self.binary.binary:
             binary_name = os.path.basename(self.binary.binary)
 
         return binary_name


### PR DESCRIPTION
For example, loading from a blob in memory (BytesIO) as we do with
load_shellcode.