### PR TITLE
Stop concrete execution if any symbolic values on stack are deallocated

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -114,6 +114,7 @@ class STOP:  # stop_t
     STOP_UNSUPPORTED_STMT_UNKNOWN = 26
     STOP_UNSUPPORTED_EXPR_UNKNOWN = 27
     STOP_UNKNOWN_MEMORY_WRITE     = 28
+    STOP_SYMBOLIC_MEM_DEP_NOT_LIVE = 29
 
     stop_message = {}
     stop_message[STOP_NORMAL]        = "Reached maximum steps"
@@ -145,10 +146,11 @@ class STOP:  # stop_t
     stop_message[STOP_UNSUPPORTED_STMT_UNKNOWN]= "Canoo propagate symbolic taint for unsupported VEX statement type"
     stop_message[STOP_UNSUPPORTED_EXPR_UNKNOWN]= "Cannot propagate symbolic taint for unsupported VEX expression"
     stop_message[STOP_UNKNOWN_MEMORY_WRITE]    = "Cannot find a memory write at instruction; likely because unicorn reported PC value incorrectly"
+    stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE] = "A symbolic memory dependency on stack is no longer in scope"
 
     symbolic_stop_reasons = [STOP_SYMBOLIC_CONDITION, STOP_SYMBOLIC_PC, STOP_SYMBOLIC_READ_ADDR,
         STOP_SYMBOLIC_READ_SYMBOLIC_TRACKING_DISABLED, STOP_SYMBOLIC_WRITE_ADDR,
-        STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET]
+        STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET, STOP_SYMBOLIC_MEM_DEP_NOT_LIVE]
 
     unsupported_reasons = [STOP_UNSUPPORTED_STMT_PUTI, STOP_UNSUPPORTED_STMT_STOREG, STOP_UNSUPPORTED_STMT_LOADG,
         STOP_UNSUPPORTED_STMT_CAS, STOP_UNSUPPORTED_STMT_LLSC, STOP_UNSUPPORTED_STMT_DIRTY,

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -150,7 +150,7 @@ class STOP:  # stop_t
 
     symbolic_stop_reasons = [STOP_SYMBOLIC_CONDITION, STOP_SYMBOLIC_PC, STOP_SYMBOLIC_READ_ADDR,
         STOP_SYMBOLIC_READ_SYMBOLIC_TRACKING_DISABLED, STOP_SYMBOLIC_WRITE_ADDR,
-        STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET, STOP_SYMBOLIC_MEM_DEP_NOT_LIVE]
+        STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET]
 
     unsupported_reasons = [STOP_UNSUPPORTED_STMT_PUTI, STOP_UNSUPPORTED_STMT_STOREG, STOP_UNSUPPORTED_STMT_LOADG,
         STOP_UNSUPPORTED_STMT_CAS, STOP_UNSUPPORTED_STMT_LLSC, STOP_UNSUPPORTED_STMT_DIRTY,
@@ -1168,7 +1168,7 @@ class Unicorn(SimStatePlugin):
             stdout.write_data(string)
             i += 1
 
-        if self.stop_reason in (STOP.STOP_NORMAL, STOP.STOP_SYSCALL):
+        if self.stop_reason in (STOP.STOP_NORMAL, STOP.STOP_SYSCALL, STOP.STOP_SYMBOLIC_MEM_DEP_NOT_LIVE):
             self.countdown_nonunicorn_blocks = 0
         elif self.stop_reason == STOP.STOP_STOPPOINT:
             self.countdown_nonunicorn_blocks = 0

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1814,12 +1814,12 @@ static void hook_block(uc_engine *uc, uint64_t address, int32_t size, void *user
 		return;
 	}
 	state->commit();
+	state->update_previous_stack_top();
 	state->step(address, size);
 
 	if (!state->stopped) {
 		state->start_propagating_taint(address, size);
 	}
-	state->update_previous_stack_top();
 	return;
 }
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1668,7 +1668,7 @@ bool State::is_block_next_target_symbolic() const {
 	return (block_next_target_taint_status != TAINT_STATUS_CONCRETE);
 }
 
-address_t State::get_instruction_pointer() {
+address_t State::get_instruction_pointer() const {
 	address_t out = 0;
 	unsigned int reg = arch_pc_reg();
 	if (reg == -1) {
@@ -1680,7 +1680,7 @@ address_t State::get_instruction_pointer() {
 	return out;
 }
 
-address_t State::get_stack_pointer() {
+address_t State::get_stack_pointer() const {
 	address_t out = 0;
 	unsigned int reg = arch_sp_reg();
 	if (reg == -1) {

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -653,9 +653,9 @@ class State {
 
 		void continue_propagating_taint();
 
-		address_t get_instruction_pointer();
+		address_t get_instruction_pointer() const;
 
-		address_t get_stack_pointer();
+		address_t get_stack_pointer() const;
 
 		// Inline functions
 

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -132,12 +132,14 @@ struct register_value_t {
 
 struct instr_details_t {
 	address_t instr_addr;
-	bool has_memory_dep;
+	bool has_concrete_memory_dep;
+	bool has_symbolic_memory_dep;
 	memory_value_t *memory_values;
 	uint64_t memory_values_count;
 
 	bool operator==(const instr_details_t &other_instr) const {
-		if ((instr_addr != other_instr.instr_addr) || (has_memory_dep != other_instr.has_memory_dep) ||
+		if ((instr_addr != other_instr.instr_addr) || (has_concrete_memory_dep != other_instr.has_concrete_memory_dep) ||
+			(has_symbolic_memory_dep != other_instr.has_symbolic_memory_dep) ||
 			(memory_values_count != other_instr.memory_values_count)) {
 				return false;
 		}
@@ -211,6 +213,7 @@ enum stop_t {
 	STOP_UNSUPPORTED_EXPR_GETI,
 	STOP_UNSUPPORTED_EXPR_UNKNOWN,
 	STOP_UNKNOWN_MEMORY_WRITE,
+	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE,
 };
 
 typedef std::vector<std::pair<taint_entity_t, std::unordered_set<taint_entity_t>>> taint_vector_t;
@@ -388,6 +391,7 @@ class State {
 	uint32_t taint_engine_stop_mem_read_count;
 
 	address_t unicorn_next_instr_addr;
+	address_t prev_stack_top_addr;
 
 	// Vector of values from previous memory reads. Serves as archival storage for pointers in details
 	// of symbolic instructions returned via ctypes to Python land.
@@ -653,6 +657,8 @@ class State {
 
 		void continue_propagating_taint();
 
+		bool check_symbolic_stack_mem_dependencies_liveness() const;
+
 		address_t get_instruction_pointer() const;
 
 		address_t get_stack_pointer() const;
@@ -681,6 +687,11 @@ class State {
 
 		inline void decrement_pending_mem_reads_count() {
 			taint_engine_stop_mem_read_count--;
+			return;
+		}
+
+		inline void update_previous_stack_top() {
+			prev_stack_top_addr = get_stack_pointer();
 			return;
 		}
 };


### PR DESCRIPTION
Symbolic values on the stack go out of scope when the stack frame they belong to is deallocated and successive instructions can overwrite the same locations on the stack. This becomes a problem when re-executing instructions that touch symbolic data since we save concrete memory dependencies only for later use and not symbolic memory dependencies(which I believe cannot be saved in native interface). If such a case happens, this fix stops concrete execution to re-execute the symbolic instructions before continuing. I believe this is the best possible fix for this scenario but I am open to suggestions for possible alternate approaches.