### PR TITLE
Clear P-code translation cache before lifting

### DIFF
--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -963,6 +963,8 @@ class PcodeBasicBlockLifter:
         # may be garbage collected while processing!
         self.data = bytearray(data)
         self.loader.setData(baseaddr, self.data, len(data))
+        self.trans.reset(self.loader, self.context)
+        self.trans.initialize(self.docstorage)
         irsb.behaviors = self.behaviors
 
         # Lift basic block to pcode


### PR DESCRIPTION
Necessary to prevent cached ops from being returned when memory contents differ at a given location between lifting calls (e.g. when calling `load_shellcode` multiple times with different code at the same offset).