### PR TITLE
Fix the issue when generating cdg from cfg_fast

### DIFF
--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -89,6 +89,9 @@ class CDG(Analysis):
         Form by Ron Cytron, etc.
         """
 
+        if not self._cfg._model.ident.startswith('CFGEmulated'):
+            raise ValueError("CDG is only supported by CFGEmulated.")
+
         self._acyclic_cfg = self._cfg.copy()
         # TODO: Cycle-removing is not needed - confirm it later
         # The CFG we use should be acyclic!
@@ -174,9 +177,6 @@ class CDG(Analysis):
         connection to the next BBL
         """
         loop_back_edges = self._cfg.get_loop_back_edges()
-
-        if loop_back_edges is None:
-            return
 
         for b1, b2 in loop_back_edges:
             # The edge between b1 and b2 is manually broken

--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -175,6 +175,9 @@ class CDG(Analysis):
         """
         loop_back_edges = self._cfg.get_loop_back_edges()
 
+        if loop_back_edges is None:
+            return
+
         for b1, b2 in loop_back_edges:
             # The edge between b1 and b2 is manually broken
             # The post dominator of b1 should be b2 (or not?)


### PR DESCRIPTION
When generating the CDG from a CFG_FAST, I got an error showing:

> File ".../angr-dev/angr/angr/analyses/cdg.py", line 181, in _pd_post_process
        for b1, b2 in loop_back_edges:
    TypeError: 'NoneType' object is not iterable

The cause is that when CFG_FAST inherits from CFG_BASE, there is no initialization to the variable `_loop_back_edges` (which is by default None).

I fixed this by adding a condition check before iterating this variable. Of course, we can also add the initialization of the variable `_loop_back_edges` in the `__init__` function of class CFG_FAST, while it's not that intuitive compared with this fix. 