### PR TITLE
Fix the issue when checking the type of a CFG.

### DIFF
--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -150,7 +150,7 @@ class CFGNode(Serializable):
         :return:    Generator yielding xrefs to this CFGNode's block.
         :rtype:     iter
         """
-        if self._cfg_model.ident != 'CFGFast':
+        if not self._cfg_model.ident.startswith('CFGFast'):
             raise ValueError("Memory data is currently only supported in CFGFast.")
         if not kb:
             kb = self._cfg_model.project.kb


### PR DESCRIPTION
When there are multiple CFGs, the syntax for `self._cfg_model.ident` is "CFGFast_%d". Simply compare the `ident` variable with 'CFGFast' can't catch all the error situation. 