### PR TITLE
Fix the issue of missing edges when generating CFGEmulated with a base graph.

### DIFF
--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1127,6 +1127,9 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
              len(job.call_stack) > self._call_depth and \
              (self._call_tracing_filter is None or self._call_tracing_filter(job.state, job.jumpkind)):
             should_skip = True
+        # Skip this job if there is another job in the _job_info_queue sharing the same block id
+        elif self._base_graph is not None and next((en for en in self._job_info_queue[1:] if en.job.block_id == block_id), None):
+            should_skip = True
 
         # SimInspect breakpoints support
         job.state._inspect('cfg_handle_job', BP_BEFORE)
@@ -1825,12 +1828,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         if not pw:
             return [ ]
-
-        if self._base_graph is not None:
-            # remove all existing jobs that has the same block ID
-            if next((en for en in self.jobs if en.block_id == pw.block_id), None):
-                # TODO: this is very hackish. Reimplement this logic later
-                self._job_info_queue = [entry for entry in self._job_info_queue if entry.job.block_id != pw.block_id]
 
         # register the job
         self._register_analysis_job(pw.func_addr, pw)


### PR DESCRIPTION
### Problem 
When I try to generate a CFGEmulated from a given base graph, I encountered an issue of missing edges. For example, comparing with the expected result in fig-2, the edge from block 0x40114d to block 0x401154 is missing in fig-1.
| ![fig-1](https://user-images.githubusercontent.com/43049320/104119433-2e2f7e00-52fd-11eb-9c67-8bc816ecb147.png ) | 
|:--:| 
| *Fig-1: The current wrong result* |

| ![fig-2](https://user-images.githubusercontent.com/43049320/104119478-82d2f900-52fd-11eb-83a0-8cd9608f19da.png ) | 
|:--:| 
| *Fig-2: Expected result* |

### Solution
In the current implementation, when handling a CFGJob, there are mainly three parts: `_pre_job_handling()`, `_process_job_and_get_successors()` and `_post_job_handling()`. The adding of an edge between the current block and its predecessor resides in [CFGEmulated::_pre_job_handling](https://github.com/angr/angr/blob/f30bca25ea11db26c0430e91480e9b018ed45d85/angr/analyses/cfg/cfg_emulated.py#L1085), and the removing of existing jobs in the `self._job_info_queue` with the same block ID happens in [CFGEmulated::_handle_successor](https://github.com/angr/angr/blob/f30bca25ea11db26c0430e91480e9b018ed45d85/angr/analyses/cfg/cfg_emulated.py#L1652) which was called in [ForwardAnalysis::_process_job_and_get_successors](https://github.com/angr/angr/blob/f30bca25ea11db26c0430e91480e9b018ed45d85/angr/analyses/forward_analysis/forward_analysis.py#L376). The problem of the current implementation is that when a job is removed from the `self._job_info_queue`, since the `_pre_job_handling()` function will not be executed, the edge between this CFGNode and its predecessor will be missing.  

Essentially, my solution is allowing a job to execute `_pre_job_handling()`, but skip `_process_job_and_get_successors()` if there exists another job in the `self._job_info_queue` with the same block ID. I reuse the existing flag `should_skip` for this purpose. In this way, we can still avoid processing duplicate jobs while correctly adding the edges.

### Question
I noticed that there is a [conditional check](https://github.com/angr/angr/blob/f30bca25ea11db26c0430e91480e9b018ed45d85/angr/analyses/cfg/cfg_emulated.py#L1829) for the existence of `self._base_graph` before removing duplicate jobs, and I also keep it in my solution. But I don't understand the necessity of this check, can somebody explains it to me?