### PR TITLE
Workaround for ARM syscalls when using unicorn engine

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -115,6 +115,7 @@ class STOP:  # stop_t
     STOP_UNSUPPORTED_EXPR_UNKNOWN = 27
     STOP_UNKNOWN_MEMORY_WRITE     = 28
     STOP_SYMBOLIC_MEM_DEP_NOT_LIVE = 29
+    STOP_SYSCALL_ARM    = 30
 
     stop_message = {}
     stop_message[STOP_NORMAL]        = "Reached maximum steps"
@@ -147,10 +148,11 @@ class STOP:  # stop_t
     stop_message[STOP_UNSUPPORTED_EXPR_UNKNOWN]= "Cannot propagate symbolic taint for unsupported VEX expression"
     stop_message[STOP_UNKNOWN_MEMORY_WRITE]    = "Cannot find a memory write at instruction; likely because unicorn reported PC value incorrectly"
     stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE] = "A symbolic memory dependency on stack is no longer in scope"
+    stop_message[STOP_SYSCALL_ARM]   = "ARM syscalls are currently not supported by SimEngineUnicorn"
 
     symbolic_stop_reasons = [STOP_SYMBOLIC_CONDITION, STOP_SYMBOLIC_PC, STOP_SYMBOLIC_READ_ADDR,
         STOP_SYMBOLIC_READ_SYMBOLIC_TRACKING_DISABLED, STOP_SYMBOLIC_WRITE_ADDR,
-        STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET]
+        STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET, STOP_SYSCALL_ARM]
 
     unsupported_reasons = [STOP_UNSUPPORTED_STMT_PUTI, STOP_UNSUPPORTED_STMT_STOREG, STOP_UNSUPPORTED_STMT_LOADG,
         STOP_UNSUPPORTED_STMT_CAS, STOP_UNSUPPORTED_STMT_LLSC, STOP_UNSUPPORTED_STMT_DIRTY,

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1591,6 +1591,11 @@ void State::start_propagating_taint(address_t block_address, int32_t block_size)
 			}
 			return;
 		}
+		if ((arch == UC_ARCH_ARM) && (lift_ret->irsb->jumpkind == Ijk_Sys_syscall)) {
+			// This block invokes a syscall. For now, such blocks are handled by VEX engine.
+			stop(STOP_SYSCALL_ARM);
+			return;
+		}
 		auto block_taint_entry = process_vex_block(lift_ret->irsb, block_address);
 		// Add entry to taint relations cache
 		block_taint_cache.emplace(block_address, block_taint_entry);

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -214,6 +214,7 @@ enum stop_t {
 	STOP_UNSUPPORTED_EXPR_UNKNOWN,
 	STOP_UNKNOWN_MEMORY_WRITE,
 	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE,
+	STOP_SYSCALL_ARM,
 };
 
 typedef std::vector<std::pair<taint_entity_t, std::unordered_set<taint_entity_t>>> taint_vector_t;


### PR DESCRIPTION
My understanding is that ARM syscalls require setting up exception vector tables and/or other data structures so that the `svc` instruction is emulated correctly. For now, we workaround all that by handling such blocks in VEX engine.