### PR TITLE
Stop concrete execution when symbolic dependencies are overwritten

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -411,6 +411,15 @@ class Tracer(ExplorationTechnique):
             try:
                 if self._compare_addr(self._trace[idx + 1], succ.addr):
                     res.append(succ)
+                else:
+                    *_, last_description = succ.history.descriptions
+                    if 'Unicorn' in last_description:
+                        # A new state was created in SimEngineUnicorn. Check every recent basic block to see if any
+                        # match the next expected index
+                        for bbl_addr in succ.history.recent_bbl_addrs:
+                            if self._compare_addr(self._trace[idx + 1], bbl_addr):
+                                res.append(succ)
+                                break
             except AngrTracerError:
                 pass
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -221,13 +221,23 @@ void State::commit() {
 	}
 	if (block_details.symbolic_instrs.size() > 0) {
 		for (auto &concrete_reg: block_concrete_dependencies) {
+			// Save values of all register dependencies of the block that were concrete at start of the block
 			block_details.register_values.emplace_back(block_start_reg_values.at(concrete_reg));
 		}
 		for (auto &symbolic_instr: block_details.symbolic_instrs) {
+			// Save all concrete memory dependencies of the block
 			if (symbolic_instr.has_concrete_memory_dep) {
 				archived_memory_values.emplace_back(mem_reads_map.at(symbolic_instr.instr_addr).memory_values);
 				symbolic_instr.memory_values = &(archived_memory_values.back()[0]);
 				symbolic_instr.memory_values_count = archived_memory_values.back().size();
+			}
+			if (symbolic_instr.has_symbolic_memory_dep) {
+				// Track all symbolic memory dependencies used by the block
+				for (auto &mem_value: mem_reads_map.at(symbolic_instr.instr_addr).memory_values) {
+					if (mem_value.is_value_symbolic) {
+						block_details.symbolic_mem_deps.push_back(std::make_pair(mem_value.address, mem_value.size));
+					}
+				}
 			}
 		}
 		blocks_with_symbolic_instrs.emplace_back(block_details);
@@ -532,6 +542,9 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 	if ((address & 0xfff) + size > 0x1000) {
 		int chopsize = 0x1000 - (address & 0xfff);
 		handle_write(address, chopsize, is_interrupt);
+		if (stopped) {
+			return;
+		}
 		handle_write(address + chopsize, size - chopsize, is_interrupt);
 		return;
 	}
@@ -590,6 +603,24 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 		else {
 			stop(STOP_UNKNOWN_MEMORY_WRITE);
 			return;
+		}
+	}
+	if (find_tainted(address, size) != -1) {
+		// We are writing to a memory location that is currently symbolic. If the destination if a memory dependency
+		// of some instruction to be re-executed, we need to re-execute that instruction before continuing.
+		auto write_start_addr = address;
+		auto write_end_addr = address + size;
+		for (auto &block: blocks_with_symbolic_instrs) {
+			for (auto &symbolic_mem_dep: block.symbolic_mem_deps) {
+				auto symbolic_start_addr = symbolic_mem_dep.first;
+				auto symbolic_end_addr = symbolic_mem_dep.first + symbolic_mem_dep.second;
+				if (!((symbolic_end_addr < write_start_addr) || (write_end_addr < symbolic_start_addr))) {
+					// No overlap condition test failed => there is some overlap. Thus, some symbolic memory dependency
+					// will be lost. Stop execution.
+					stop(STOP_SYMBOLIC_MEM_DEP_NOT_LIVE);
+					return;
+				}
+			}
 		}
 	}
 	if (data == NULL) {
@@ -1196,7 +1227,7 @@ taint_status_result_t State::get_final_taint_status(const std::unordered_set<tai
 				catch (std::out_of_range) {
 					assert(false && "[sim_unicorn] Taint sink depends on a read not executed yet! This should not happen!");
 				}
-				is_symbolic = mem_read_result.is_value_symbolic;
+				is_symbolic = mem_read_result.is_mem_read_symbolic;
 			}
 		}
 	}
@@ -1390,7 +1421,7 @@ void State::propagate_taint_of_mem_read_instr_and_continue(const address_t instr
 	}
 	auto mem_read_result = mem_reads_map.at(instr_addr);
 	if (block_details.vex_lift_failed) {
-		if (mem_read_result.is_value_symbolic || (symbolic_registers.size() > 0) || (block_symbolic_registers.size() > 0)) {
+		if (mem_read_result.is_mem_read_symbolic || (symbolic_registers.size() > 0) || (block_symbolic_registers.size() > 0)) {
 			// Either the memory value is symbolic or there are symbolic registers: thus, taint
 			// status of registers could change. But since VEX lift failed, the taint relations
 			// are not known and so we can't propagate taint. Stop concrete execution.
@@ -1417,7 +1448,7 @@ void State::propagate_taint_of_mem_read_instr_and_continue(const address_t instr
 	// and overtaint.
 	auto block_taint_entry = block_taint_cache.at(block_details.block_addr);
 	auto instr_taint_data_entry = block_taint_entry.block_instrs_taint_data_map.at(instr_addr);
-	if (mem_read_result.is_value_symbolic || (symbolic_registers.size() > 0) || (block_symbolic_registers.size() > 0)) {
+	if (mem_read_result.is_mem_read_symbolic || (symbolic_registers.size() > 0) || (block_symbolic_registers.size() > 0)) {
 		if (block_taint_entry.has_unsupported_stmt_or_expr_type) {
 			// There are symbolic registers and/or memory read was symbolic and there are VEX
 			// statements in block for which taint propagation is not supported.
@@ -1527,7 +1558,7 @@ instr_details_t State::compute_instr_details(address_t instr_addr, const instruc
 	instr_details.instr_addr = instr_addr;
 	if (instr_taint_entry.has_memory_read) {
 		auto mem_read_result = mem_reads_map.at(instr_addr);
-		if (!mem_read_result.is_value_symbolic) {
+		if (!mem_read_result.is_mem_read_symbolic) {
 			instr_details.has_concrete_memory_dep = true;
 			instr_details.has_symbolic_memory_dep = false;
 		}
@@ -1756,16 +1787,17 @@ static void hook_mem_read(uc_engine *uc, uc_mem_type type, uint64_t address, int
 		is_memory_value_symbolic = false;
 		state->read_memory_value(address, size, memory_read_value.value, MAX_MEM_ACCESS_SIZE);
 	}
+	memory_read_value.is_value_symbolic = is_memory_value_symbolic;
 	auto mem_reads_map_entry = state->mem_reads_map.find(curr_instr_addr);
 	if (mem_reads_map_entry == state->mem_reads_map.end()) {
 		mem_read_result_t mem_read_result;
 		mem_read_result.memory_values.emplace_back(memory_read_value);
-		mem_read_result.is_value_symbolic = is_memory_value_symbolic;
+		mem_read_result.is_mem_read_symbolic = is_memory_value_symbolic;
 		state->mem_reads_map.emplace(curr_instr_addr, mem_read_result);
 	}
 	else {
 		state->mem_reads_map.at(curr_instr_addr).memory_values.emplace_back(memory_read_value);
-		state->mem_reads_map.at(curr_instr_addr).is_value_symbolic |= is_memory_value_symbolic;
+		state->mem_reads_map.at(curr_instr_addr).is_mem_read_symbolic |= is_memory_value_symbolic;
 	}
 	state->propagate_taint_of_mem_read_instr_and_continue(curr_instr_addr);
 	return;
@@ -1887,6 +1919,9 @@ static void hook_intr(uc_engine *uc, uint32_t intno, void *user_data) {
 
 				uc_err err = uc_mem_write(uc, tx_bytes, &count, 4);
 				if (tx_bytes != 0) state->handle_write(tx_bytes, 4, true);
+				if (state->stopped) {
+					return;
+				}
 				state->transmit_records.push_back({dup_buf, count});
 				int result = 0;
 				uc_reg_write(uc, UC_X86_REG_EAX, &result);

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -105,9 +105,11 @@ struct memory_value_t {
 	uint64_t address;
     uint8_t value[MAX_MEM_ACCESS_SIZE];
     uint64_t size;
+	bool is_value_symbolic;
 
 	bool operator==(const memory_value_t &other_mem_value) const {
-		if ((address != other_mem_value.address) || (size != other_mem_value.size)) {
+		if ((address != other_mem_value.address) || (size != other_mem_value.size) ||
+			(is_value_symbolic != other_mem_value.is_value_symbolic)) {
 			return false;
 		}
 		return (memcmp(value, other_mem_value.value, size) == 0);
@@ -122,7 +124,7 @@ struct memory_value_t {
 
 struct mem_read_result_t {
 	std::vector<memory_value_t> memory_values;
-	bool is_value_symbolic;
+	bool is_mem_read_symbolic;
 };
 
 struct register_value_t {
@@ -161,6 +163,7 @@ struct block_details_t {
 	uint64_t block_size;
 	std::vector<instr_details_t> symbolic_instrs;
 	std::vector<register_value_t> register_values;
+	std::vector<std::pair<address_t, uint64_t>> symbolic_mem_deps;
 	bool vex_lift_failed;
 
 	void reset() {

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -602,7 +602,7 @@ class State {
 
 		uc_err start(address_t pc, uint64_t step = 1);
 
-		void stop(stop_t reason);
+		void stop(stop_t reason, bool do_commit=false);
 
 		void step(address_t current_address, int32_t size, bool check_stop_points=true);
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -41,3 +41,9 @@ def do_trace(proj, test_name, input_data, **kwargs):
     with open(fname, 'wb') as f:
         pickle.dump((r, TRACE_VERSION), f, -1)
     return r
+
+def load_cgc_pov(pov_file: str) -> tracer.TracerPoV:
+    if tracer is None:
+        raise Exception("Cannot load PoV because tracer is not installed")
+
+    return tracer.TracerPoV(pov_file)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -5,12 +5,7 @@ import logging
 import nose
 import angr
 
-try:
-    import tracer
-except ImportError:
-    tracer = None
-
-from common import bin_location, do_trace, slow_test
+from common import bin_location, do_trace, load_cgc_pov, slow_test
 
 def tracer_cgc(filename, test_name, stdin, copy_states=False):
     p = angr.Project(filename)
@@ -29,11 +24,8 @@ def tracer_cgc(filename, test_name, stdin, copy_states=False):
 
 
 def trace_cgc_with_pov_file(binary: str, test_name: str, pov_file: str, output_initial_bytes: bytes, copy_states=False):
-    if tracer is None:
-        raise Exception(f"Tracer is not installed and so cannot run test {test_name}")
-
     nose.tools.assert_true(os.path.isfile(pov_file))
-    pov = tracer.TracerPoV(pov_file)
+    pov = load_cgc_pov(pov_file)
     trace_result = tracer_cgc(binary, test_name, b''.join(pov.writes), copy_states)
     simgr = trace_result[0]
     simgr.run()


### PR DESCRIPTION
This is similar to #2449 but a different root cause: symbolic values will be overwritten during concrete execution and that would lead to issues when any of those values are dependencies of instructions yet to be executed. This PR adds support for detecting such cases and stop concrete execution if that happens. I've also added two test cases: one for this change and one for the changes in #2449.

Also, I'm not sure why the last CI run on the branch failed: the last commit should not cause any issues and the failing test passes in a local setup of the CI.