### PR TITLE
Fix `unfuck` stash not found and add more whitelist functions for veritesting

### DIFF
--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -28,6 +28,11 @@ class CallTracingFilter(object):
         SIM_PROCEDURES['cgc']['receive'],
         SIM_PROCEDURES['cgc']['transmit'],
         SIM_PROCEDURES['posix']['read'],
+        SIM_PROCEDURES['libc']['fgetc'],
+        SIM_PROCEDURES["glibc"]["__ctype_b_loc"],
+        SIM_PROCEDURES["libc"]["strlen"],
+        SIM_PROCEDURES["libc"]["strcmp"],
+        SIM_PROCEDURES["libc"]["atoi"],
     }
 
     cfg_cache = { }

--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -310,8 +310,6 @@ class Veritesting(Analysis):
             manager.step(successor_func=self._get_successors)
 
             if self._terminator is not None and self._terminator(manager):
-                for p in manager.unfuck:
-                    self._unfuck(p)
                 break
 
             # Stash all paths that we do not see in our CFG


### PR DESCRIPTION
1. Fix `unfuck` stash not found, I found `_unfuck` was called later before return, so I believe it's safe to remove here.
https://github.com/angr/angr/blob/9ba2fb69a673f66a844fe9d648fc10f82c75f1d6/angr/analyses/veritesting.py#L352-L353

2. I add some functions to whitelist which are very common in loops, but I'm not sure if it safe to do so.
