### PR TITLE
StructuredCodeGen: Output variable for Call.ret_expr when available.

### DIFF
--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -1655,7 +1655,10 @@ class StructuredCodeGenerator(Analysis):
 
         ret_expr = None
         if stmt.ret_expr is not None:
-            ret_expr = self._handle(stmt.ret_expr)
+            if stmt.ret_expr.variable is not None:
+                ret_expr = self._cvariable(stmt.ret_expr.variable, offset=stmt.ret_expr.variable_offset)
+            else:
+                ret_expr = self._handle(stmt.ret_expr)
 
         return CFunctionCall(target, target_func, args,
                              returning=target_func.returning if target_func is not None else True,


### PR DESCRIPTION
Before:

```
reg_16<8> = foo();
```

After:

```
s_0 = foo(); // s_0 is a variable
```