### PR TITLE
Fix multiple issues in AILSimplifier.

### DIFF
--- a/angr/analyses/decompiler/peephole_optimizations/conv_a_sub0_shr_and.py
+++ b/angr/analyses/decompiler/peephole_optimizations/conv_a_sub0_shr_and.py
@@ -46,7 +46,7 @@ class ConvASub0ShrAnd(PeepholeOptimizationExprBase):
                             and real_expr.operands[1].value == 0:
                         real_expr = real_expr.operands[0]
 
-                    cvt = Convert(expr.idx, real_expr.bits, to_bits, True, real_expr, **expr.tags)
+                    cvt = Convert(expr.idx, real_expr.bits, to_bits, False, real_expr, **expr.tags)
                     cmp = BinaryOp(None, "CmpLT",
                                    (
                                        cvt,

--- a/angr/knowledge_plugins/key_definitions/uses.py
+++ b/angr/knowledge_plugins/key_definitions/uses.py
@@ -33,6 +33,21 @@ class Uses:
         """
         return self._uses_by_definition.get(definition, set())
 
+    def remove_use(self, definition: 'Definition', codeloc: 'CodeLocation') -> None:
+        """
+        Remove one use of a given definition.
+
+        :param definition:  The definition of which to remove the uses.
+        :param codeloc:     The code location where the use is.
+        :return:            None
+        """
+        if definition in self._uses_by_definition:
+            if codeloc in self._uses_by_definition[definition]:
+                self._uses_by_definition[definition].remove(codeloc)
+
+        if codeloc in self._uses_by_location:
+            self._uses_by_location[codeloc].remove(definition)
+
     def remove_uses(self, definition: 'Definition'):
         """
         Remove all uses of a given definition.


### PR DESCRIPTION
- Fix the bug that too many legitimate uses are removed.

- Fix the bug that _fold_call_exprs() may end up using old blocks
instead of new blocks.

- Fix the bug that new blocks may be used as keys in self.blocks,
leading to incorrectly optimized blocks.

- Fix the bug that expression replacement may fail due to Convert being
incorrectly set to signed.