### PR TITLE
Fix `is_syscall` in `CFGNodes.get_all_nodes()`

### DIFF
--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -274,11 +274,7 @@ class CFGModel(Serializable):
                                          cfg_node.size is not None and
                                          cfg_node.addr <= addr < (cfg_node.addr + cfg_node.size)
                                          ):
-                if is_syscall and cfg_node.is_syscall:
-                    results.append(cfg_node)
-                elif is_syscall is False and not cfg_node.is_syscall:
-                    results.append(cfg_node)
-                else:
+                if is_syscall is None or is_syscall == cfg_node.is_syscall:
                     results.append(cfg_node)
 
         return results


### PR DESCRIPTION
The param `is_syscall` doesn't work and always return all nodes.