### PR TITLE
Basic support for ARM for function handling in Propagator

### DIFF
--- a/angr/analyses/propagator/engine_vex.py
+++ b/angr/analyses/propagator/engine_vex.py
@@ -93,7 +93,19 @@ class SimEnginePropagatorVEX(
                 #   ret
                 ebx_offset = self.arch.registers['ebx'][0]
                 self.state.store_register(ebx_offset, 4, self.block.addr + self.block.size)
-
+        elif self.arch.name == "ARMCortexM":
+                cc = None
+                if self._project.kb.functions.get(addr, None):
+                    cc = self._project.kb.functions[addr].calling_convention
+                if cc is None:
+                    cc = DEFAULT_CC.get(self.arch.name, None)(self.arch)
+                if cc.RETURN_VAL is not None:
+                    if isinstance(cc.RETURN_VAL, SimRegArg):
+                        r0_offset = self.arch.registers['r0'][0]
+                        self.state.store_register(r0_offset, 4, Top(1))
+        else:
+            _l.debug("Handling function not supported for arch {}, expect imprecisions".format(hex(self.arch.name)))
+            
     #
     # VEX statement handlers
     #


### PR DESCRIPTION
When propagating constants in Propagator, we need to define the return value as TOP if the function has a return value.
As for now, I'm handling only the ARMCortexM arch, but theoretically, we should re-organize better this code as we did for the `engine_vex` in ReachingDefinition (https://github.com/angr/angr/blob/master/angr/analyses/reaching_definitions/engine_vex.py#L530).

Also, what is the code above handling the "X86" case?