### PR TITLE
Fix an issue related to CFGEmulated generated using base graph, and add a test case.

### DIFF
--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1127,9 +1127,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
              len(job.call_stack) > self._call_depth and \
              (self._call_tracing_filter is None or self._call_tracing_filter(job.state, job.jumpkind)):
             should_skip = True
-        # Skip this job if there is another job in the _job_info_queue sharing the same block id
-        elif self._base_graph is not None and next((en for en in self._job_info_queue[1:] if en.job.block_id == block_id), None):
-            should_skip = True
 
         # SimInspect breakpoints support
         job.state._inspect('cfg_handle_job', BP_BEFORE)

--- a/tests/test_cfgemulated.py
+++ b/tests/test_cfgemulated.py
@@ -513,40 +513,40 @@ def test_abort_and_resume():
 
 def test_base_graph():
     path = os.path.join(test_location, "x86_64", "test_cfgemulated_base_graph")
-    
+
     func_addr = 0x401129
-    
+
     edges = {
         (0x401129, 0x401144),
         (0x401129, 0x40114d),
         (0x401144, 0x401154),
         (0x40114d, 0x401154),
     }
-    
+
     final_states_info = {
         0x401129: 2,
         0x40114d: 1,
         0x401144: 1,
         0x401154: 1,
     }
-    
+
     proj = angr.Project(path, load_options={'auto_load_libs': False})
-    
+
     cfg_fast = proj.analyses.CFGFast(normalize=True)
     target_function = cfg_fast.kb.functions[func_addr]
     target_function.normalize()
-    
-    target_function_cfg_emulated = proj.analyses.CFGEmulated(keep_state=True, 
+
+    target_function_cfg_emulated = proj.analyses.CFGEmulated(keep_state=True,
                                          state_add_options=angr.options.refs,
                                          base_graph = target_function.graph, starts=(func_addr,),
                                          normalize=True)
     for src, dst in edges:
         src_node = target_function_cfg_emulated.get_any_node(src)
         dst_node = target_function_cfg_emulated.get_any_node(dst)
-        nose.tools.assert_in(dst_node, src_node.successors, 
+        nose.tools.assert_in(dst_node, src_node.successors,
                              msg="CFG edge %s-%s is not found." % (src_node, dst_node)
                              )
-    
+
     for (node_addr,final_states_number) in final_states_info.items():
         node = target_function_cfg_emulated.get_any_node(node_addr)
         nose.tools.assert_equal(final_states_number, len(node.final_states),


### PR DESCRIPTION
### Problem
In one of my previous PR(#2469), I reused the ```should_skip``` flag to avoid processing duplicate CFG nodes. In that PR, I intended to **process the last block but skip those duplicate blocks before the last one**.
```
...
elif self._base_graph is not None and next((en for en in self._job_info_queue[1:] if en.job.block_id == block_id), None):
            should_skip = True
```
However, I didn't realize that the task of avoiding duplication has already been handled by another part of the code within ```_pre_job_handling()```, which **skips all the blocks that are traced more than ```_max_iterations_```(which is set to 1 initially)**:
``` 
if self._traced_addrs[job.call_stack_suffix][addr] >= self._max_iterations:
            should_skip = True
...
# Increment tracing count for this block
        self._traced_addrs[job.call_stack_suffix][addr] += 1
```
Therefore, if these two strategies are applied at the same time, **all the duplicate blocks will be skipped, without processing even once.**

### Solution
Since the task of avoiding processing duplicate CFG nodes has already been handled by the tracing count strategy, I can simply delete my added codes.
A test is also added for this issue. 

ci link: angr/angr-targets#12