### PR TITLE
Add MultiWriteAnnotation to fgets

### DIFF
--- a/angr/procedures/libc/fgets.py
+++ b/angr/procedures/libc/fgets.py
@@ -1,6 +1,8 @@
 import angr
 from angr.storage.file import SimFile
 from angr.sim_type import SimTypeFd, SimTypeChar, SimTypeArray, SimTypeLength
+from angr.storage.memory_mixins.address_concretization_mixin import MultiwriteAnnotation
+
 
 from cle.backends.externs.simdata.io_file import io_file_data_for_arch
 
@@ -54,10 +56,11 @@ class fgets(angr.SimProcedure):
                         simfd.eof(),                 # - the file is at EOF, or
                         byte == b'\n'                # - it is a newline
                     )))
-
-            self.state.memory.store(dst, data, size=real_size)
-            self.state.memory.store(dst+real_size, b'\0')
-
+            self.state.memory.store(dst, data, size=real_size, multiwrite=True)
+            end_address = dst+real_size
+            end_address = end_address.annotate(MultiwriteAnnotation())
+            self.state.memory.store(end_address, b'\0', multiwrite=True)
+            
             return real_size
 
 fgets_unlocked = fgets

--- a/angr/procedures/libc/fgets.py
+++ b/angr/procedures/libc/fgets.py
@@ -1,6 +1,4 @@
 import angr
-from angr.storage.file import SimFile
-from angr.sim_type import SimTypeFd, SimTypeChar, SimTypeArray, SimTypeLength
 from angr.storage.memory_mixins.address_concretization_mixin import MultiwriteAnnotation
 
 
@@ -60,7 +58,7 @@ class fgets(angr.SimProcedure):
             end_address = dst + real_size
             end_address = end_address.annotate(MultiwriteAnnotation())
             self.state.memory.store(end_address, b'\0')
-            print(self.state.solver.constraints)
+
             return real_size
 
 fgets_unlocked = fgets

--- a/angr/procedures/libc/fgets.py
+++ b/angr/procedures/libc/fgets.py
@@ -56,11 +56,11 @@ class fgets(angr.SimProcedure):
                         simfd.eof(),                 # - the file is at EOF, or
                         byte == b'\n'                # - it is a newline
                     )))
-            self.state.memory.store(dst, data, size=real_size, multiwrite=True)
+            self.state.memory.store(dst, data, size=real_size)
             end_address = dst+real_size
             end_address = end_address.annotate(MultiwriteAnnotation())
-            self.state.memory.store(end_address, b'\0', multiwrite=True)
-            
+            self.state.memory.store(end_address, b'\0')
+            print(self.state.solver.constraints)
             return real_size
 
 fgets_unlocked = fgets

--- a/angr/procedures/libc/fgets.py
+++ b/angr/procedures/libc/fgets.py
@@ -57,7 +57,7 @@ class fgets(angr.SimProcedure):
                         byte == b'\n'                # - it is a newline
                     )))
             self.state.memory.store(dst, data, size=real_size)
-            end_address = dst+real_size
+            end_address = dst + real_size
             end_address = end_address.annotate(MultiwriteAnnotation())
             self.state.memory.store(end_address, b'\0')
             print(self.state.solver.constraints)

--- a/angr/storage/file.py
+++ b/angr/storage/file.py
@@ -435,7 +435,11 @@ class SimPackets(SimFileBase):
         """
         lengths = [self.state.solver.eval(x[1], **kwargs) for x in self.content]
         kwargs['cast_to'] = bytes
-        return [b'' if i == 0 else self.state.solver.eval(x[0][i*self.state.arch.byte_width-1:], **kwargs) for i, x in zip(lengths, self.content)]
+        sizes = [x[0].size() for x in self.content]
+        return [b'' if i == 0
+                    else self.state.solver.eval(
+                            x[0][:size-i*self.state.arch.byte_width], **kwargs)
+                    for i, size, x in zip(lengths, sizes, self.content)]
 
     def read(self, pos, size, **kwargs):
         """

--- a/tests/test_fgets.py
+++ b/tests/test_fgets.py
@@ -1,0 +1,47 @@
+import nose
+import logging
+
+import angr
+
+TARGET_APP = "../../binaries/tests/x86_64/fgets"
+
+l = logging.getLogger('angr.tests.libc.fgets')
+
+p = angr.Project("{}".format(TARGET_APP))
+
+find_normal = p.loader.find_symbol('find_normal').rebased_addr
+find_exact = p.loader.find_symbol('find_exact').rebased_addr
+find_eof = p.loader.find_symbol('find_eof').rebased_addr
+find_impossible = p.loader.find_symbol('find_impossible').rebased_addr
+
+def _testfind(addr, failmsg):
+    e = p.factory.entry_state()
+    e.options.add(angr.sim_options.SHORT_READS)
+    e.options.add(angr.sim_options.SYMBOL_FILL_UNCONSTRAINED_MEMORY)
+    s = p.factory.simgr(e)
+    r = s.explore(find=addr)
+    nose.tools.ok_(len(r.found) > 0, failmsg)
+    with open("./out.txt", "a") as outfile:
+        print(r.found[0].posix.dumps(0), file=outfile)
+    return r.found[0].posix.dumps(0)
+
+def _testnotfind(addr, failmsg):
+    e = p.factory.entry_state()
+    e.options.add(angr.sim_options.SHORT_READS)
+    e.options.add(angr.sim_options.SYMBOL_FILL_UNCONSTRAINED_MEMORY)
+    s = p.factory.simgr(e)
+    r= s.explore(find=addr)
+    nose.tools.ok_(len(r.found) == 0, failmsg)
+
+def test_normal():
+    answer = _testfind(find_normal, "Normal Failure!")
+    nose.tools.ok_(answer == b'normal\n')
+
+def test_exact():
+    _testfind(find_exact, "Exact Failure!")
+
+def test_eof():
+    _testfind(find_eof, "EOF Failure!")
+
+def test_impossible():
+    _testnotfind(find_impossible, "Impossible Failure!")

--- a/tests/test_fgets.py
+++ b/tests/test_fgets.py
@@ -1,9 +1,10 @@
 import nose
 import logging
-
+import os
 import angr
 
-TARGET_APP = "../../binaries/tests/x86_64/fgets"
+TARGET_APP = os.path.join(os.path.dirname(os.path.realpath(str(__file__))),
+    "../../binaries/tests/x86_64/fgets")
 
 l = logging.getLogger('angr.tests.libc.fgets')
 

--- a/tests/test_fgets.py
+++ b/tests/test_fgets.py
@@ -21,8 +21,6 @@ def _testfind(addr, failmsg):
     s = p.factory.simgr(e)
     r = s.explore(find=addr)
     nose.tools.ok_(len(r.found) > 0, failmsg)
-    with open("./out.txt", "a") as outfile:
-        print(r.found[0].posix.dumps(0), file=outfile)
     return r.found[0].posix.dumps(0)
 
 def _testnotfind(addr, failmsg):
@@ -38,10 +36,8 @@ def test_normal():
     nose.tools.ok_(answer == b'normal\n')
 
 def test_exact():
-    _testfind(find_exact, "Exact Failure!")
-
-def test_eof():
-    _testfind(find_eof, "EOF Failure!")
+    answer = _testfind(find_exact, "Exact Failure!")
+    nose.tools.ok_(answer.endswith(b'0123456789'))
 
 def test_impossible():
     _testnotfind(find_impossible, "Impossible Failure!")

--- a/tests/test_fgets.py
+++ b/tests/test_fgets.py
@@ -1,6 +1,7 @@
 import nose
 import logging
 import os
+
 import angr
 
 TARGET_APP = os.path.join(os.path.dirname(os.path.realpath(str(__file__))),


### PR DESCRIPTION
`fgets` incorrectly asserts after the final memory operation (even with `SHORT_READS` enabled) the following constraint

```
<Bool 0x7fffffffffeff50 + packetsize_0_stdin_40_64 == 0x7fffffffffeff59>
```

This is a *hard* assignment to packetsize_0_stdin_40_64, even though `fgets` can return a variable length.

By marking the store destination with a MultiWriteAnnotation, we correctly generate all possible expressions of `0x7fffffffffeff50 + packetsize_0_stdin_40_64`. (However, it probably should generate '0x7fffffffffeff50 + packetsize_0_stdin_40_64 <=0x7fffffffffeff59 ' rather than an OR'd expression of all possibiltiies).

Sample binary

```
#include <stdio.h>
#include <string.h>

int main() {
    char bob[20];
    fgets(bob, 10, stdin);
    if (strcmp("bob\n", bob) == 0) {
        printf("That's it!");
    }
}
```

Sample test

```
import angr

p = angr.Project("{}".format(TARGET_APP))
e = p.factory.entry_state()
e.options.add(angr.sim_options.SHORT_READS)
e.options.add(angr.sim_options.SYMBOL_FILL_UNCONSTRAINED_MEMORY)
s = p.factory.simgr(e)
r= s.explore(find=0x00400679)
r= s.explore(find=0x00400681)
print(r)
```