### PR TITLE
Update realloc call to be a defined function

### DIFF
--- a/angr/procedures/win32/heap.py
+++ b/angr/procedures/win32/heap.py
@@ -31,7 +31,7 @@ class HeapAlloc(angr.SimProcedure):
 
 class HeapReAlloc(angr.SimProcedure):
     def run(self, hHeap, dwFlags, lpMem, dwBytes): #pylint:disable=arguments-differ, unused-argument
-        return self.state.heap.realloc(lpMem, dwBytes)
+        return self.state.heap._realloc(lpMem, dwBytes)
 
 
 class GlobalAlloc(HeapAlloc):


### PR DESCRIPTION
The realloc function is defined with an underscore in the SimHeapBrk class. This pull request just fixes it in the win32 sim procedure. https://github.com/angr/angr/blob/579c50afb11463fba656392e2c2944db6a279d18/angr/state_plugins/heap/heap_brk.py#L92