### PR TITLE
Preallocate initial stack without creating symbols

### DIFF
--- a/angr/simos/__init__.py
+++ b/angr/simos/__init__.py
@@ -24,6 +24,7 @@ def register_simos(name, cls):
 for k, v in _DESCR_EI_OSABI.items():
     register_simos(v, SimLinux)
 
+register_simos('linux', SimLinux)
 register_simos('windows', SimWindows)
 register_simos('cgc', SimCGC)
 register_simos('javavm', SimJavaVM)

--- a/angr/simos/cgc.py
+++ b/angr/simos/cgc.py
@@ -37,7 +37,8 @@ class SimCGC(SimUserland):
         s = super(SimCGC, self).state_blank(**kwargs)  # pylint:disable=invalid-name
 
         # pre-grow the stack by 20 pages. unsure if this is strictly required or just a hack around a compiler bug
-        s.memory.allocate_stack_pages(kwargs['stack_end'] - 1, 20 * 0x1000)
+        if hasattr(s.memory, 'allocate_stack_pages'):
+            s.memory.allocate_stack_pages(kwargs['stack_end'] - 1, 20 * 0x1000)
 
         # Map the flag page
         if o.ABSTRACT_MEMORY not in s.options:

--- a/angr/simos/cgc.py
+++ b/angr/simos/cgc.py
@@ -37,7 +37,7 @@ class SimCGC(SimUserland):
         s = super(SimCGC, self).state_blank(**kwargs)  # pylint:disable=invalid-name
 
         # pre-grow the stack by 20 pages. unsure if this is strictly required or just a hack around a compiler bug
-        state.memory.allocate_stack_pages(state.solver.eval(state.regs.sp) - 1, 20 * 0x1000)
+        s.memory.allocate_stack_pages(kwargs['stack_end'] - 1, 20 * 0x1000)
 
         # Map the flag page
         if o.ABSTRACT_MEMORY not in s.options:

--- a/angr/simos/cgc.py
+++ b/angr/simos/cgc.py
@@ -37,8 +37,7 @@ class SimCGC(SimUserland):
         s = super(SimCGC, self).state_blank(**kwargs)  # pylint:disable=invalid-name
 
         # pre-grow the stack by 20 pages. unsure if this is strictly required or just a hack around a compiler bug
-        for i in range(20):
-            s.memory.load(kwargs['stack_end'] - 4 - i * 0x1000, size=4, endness='Iend_LE')
+        state.memory.allocate_stack_pages(state.solver.eval(state.regs.sp) - 1, 20 * 0x1000)
 
         # Map the flag page
         if o.ABSTRACT_MEMORY not in s.options:

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -178,7 +178,7 @@ class SimLinux(SimUserland):
         state = super().state_blank(thread_idx=thread_idx, **kwargs)
 
         # pre-grow the stack by 0x20 pages. unsure if this is strictly required or just a hack around a compiler bug
-        if hasattr(state.memory, 'allocate_stack_pages'):
+        if not self._is_core and hasattr(state.memory, 'allocate_stack_pages'):
             state.memory.allocate_stack_pages(state.solver.eval(state.regs.sp) - 1, 0x20 * 0x1000)
 
         tls_obj = self.project.loader.tls.threads[thread_idx if thread_idx is not None else 0]

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -178,7 +178,8 @@ class SimLinux(SimUserland):
         state = super().state_blank(thread_idx=thread_idx, **kwargs)
 
         # pre-grow the stack by 0x20 pages. unsure if this is strictly required or just a hack around a compiler bug
-        state.memory.allocate_stack_pages(state.solver.eval(state.regs.sp) - 1, 0x20 * 0x1000)
+        if hasattr(state.memory, 'allocate_stack_pages'):
+            state.memory.allocate_stack_pages(state.solver.eval(state.regs.sp) - 1, 0x20 * 0x1000)
 
         tls_obj = self.project.loader.tls.threads[thread_idx if thread_idx is not None else 0]
         if isinstance(state.arch, ArchAMD64):

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -15,6 +15,7 @@ from ..procedures import SIM_PROCEDURES as P, SIM_LIBRARIES as L
 from ..state_plugins import SimFilesystem, SimHostFilesystem
 from ..storage.file import SimFile, SimFileBase
 from ..errors import AngrSyscallError
+from .. import sim_options as o
 from .userland import SimUserland
 
 _l = logging.getLogger(name=__name__)
@@ -174,7 +175,10 @@ class SimLinux(SimUserland):
     # pylint: disable=arguments-differ
     def state_blank(self, fs=None, concrete_fs=False, chroot=None,
             cwd=None, pathsep=b'/', thread_idx=None, init_libc = False, **kwargs):
-        state = super(SimLinux, self).state_blank(thread_idx=thread_idx, **kwargs)
+        state = super().state_blank(thread_idx=thread_idx, **kwargs)
+
+        # pre-grow the stack by 0x20 pages. unsure if this is strictly required or just a hack around a compiler bug
+        state.memory.allocate_stack_pages(state.solver.eval(state.regs.sp) - 1, 0x20 * 0x1000)
 
         tls_obj = self.project.loader.tls.threads[thread_idx if thread_idx is not None else 0]
         if isinstance(state.arch, ArchAMD64):

--- a/angr/storage/memory_mixins/paged_memory/stack_allocation_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/stack_allocation_mixin.py
@@ -1,7 +1,7 @@
 import logging
 
 from .paged_memory_mixin import PagedMemoryMixin
-from ....errors import SimSegfaultException
+from ....errors import SimSegfaultException, SimMemoryError
 
 l = logging.getLogger(__name__)
 
@@ -24,22 +24,41 @@ class StackAllocationMixin(PagedMemoryMixin):
         o._stack_perms = self._stack_perms
         return o
 
+    def allocate_stack_pages(self, addr: int, size: int, **kwargs):
+        """
+        Pre-allocates pages for the stack without triggering any logic related to reading from them.
+
+        :param addr: The highest address that should be mapped
+        :param size: The number of bytes to be allocated. byte 1 is the one at addr, byte 2 is the one before that, and so on.
+        :return: A list of the new page objects
+        """
+        # weird off-by-ones here. we want to calculate the last byte requested, find its pageno, and then use that to determine what the last page allocated will be and then how many pages are touched
+        pageno = addr // self.page_size
+        if pageno != self._red_pageno:
+            raise SimMemoryError("Trying to allocate stack space in a place that isn't the top of the stack")
+        num = pageno - ((addr - size + 1) // self.page_size) + 1
+
+        result = []
+        for _ in range(num):
+            new_red_pageno = (self._red_pageno - 1) % ((1 << self.state.arch.bits) // self.page_size)
+            if new_red_pageno in self._pages:
+                raise SimSegfaultException(self._red_pageno * self.page_size, "stack collided with heap")
+
+            if self._remaining_stack is not None and self._remaining_stack < self.page_size:
+                raise SimSegfaultException(self._red_pageno * self.page_size, "exhausted stack quota")
+
+            l.debug("Allocating new stack page at %#x", self._red_pageno * self.page_size)
+            result.append(PagedMemoryMixin._initialize_default_page(self, self._red_pageno, permissions=self._stack_perms, **kwargs))
+            self._pages[self._red_pageno] = result[-1]
+
+            self._red_pageno = new_red_pageno
+            if self._remaining_stack is not None:
+                self._remaining_stack -= self.page_size
+
+        return result
+
     def _initialize_page(self, pageno: int, **kwargs):
         if pageno != self._red_pageno:
             return super()._initialize_page(pageno, **kwargs)
 
-        new_red_pageno = (pageno - 1) % ((1 << self.state.arch.bits) // self.page_size)
-        if new_red_pageno in self._pages:
-            raise SimSegfaultException(pageno * self.page_size, "stack collided with heap")
-
-        if self._remaining_stack is not None and self._remaining_stack < self.page_size:
-            raise SimSegfaultException(pageno * self.page_size, "exhausted stack quota")
-
-        self._red_pageno = new_red_pageno
-        if self._remaining_stack is not None:
-            self._remaining_stack -= self.page_size
-
-        l.debug("Allocating new stack page at %#x", pageno * self.page_size)
-
-        new_page = PagedMemoryMixin._initialize_default_page(self, pageno, permissions=self._stack_perms, **kwargs)
-        return new_page
+        return self.allocate_stack_pages((pageno + 1) * self.page_size - 1, self.page_size)[0]

--- a/tests/test_stack_alignment.py
+++ b/tests/test_stack_alignment.py
@@ -1,8 +1,9 @@
 import logging
 import nose
+import os
 
 from angr.calling_conventions import DEFAULT_CC, SimCCUnknown
-from angr import SimState
+from angr import SimState, sim_options as o, Project
 from archinfo import all_arches, ArchAMD64, ArchSoot
 
 l = logging.getLogger('angr.tests.test_stack_alignment')
@@ -42,6 +43,12 @@ def test_sys_v_abi_compliance():
     # ref: https://raw.githubusercontent.com/wiki/hjl-tools/x86-psABI/x86-64-psABI-1.0.pdf , page 18t
     nose.tools.assert_true(st.solver.is_true(((st.regs.rsp + 8) % 16 == 0)),
                            'System V ABI calling convention violated!')
+
+def test_initial_allocation():
+    # not strictly about alignment but it's about stack initialization so whatever
+    p = Project(os.path.join(os.path.dirname(__file__), '../../binaries/tests/x86_64/true'), auto_load_libs=False)
+    s = p.factory.entry_state(add_options={o.STRICT_PAGE_ACCESS})
+    s.memory.load(s.regs.sp - 0x10000, 4)
 
 if __name__ == "__main__":
     test_alignment()


### PR DESCRIPTION
For #2516. Unsure if it will solve the problem outright but this seems to be an improvement to me.