### PR TITLE
fix cfg parameter "iropt_level" not working problem

### DIFF
--- a/angr/engines/vex/heavy/heavy.py
+++ b/angr/engines/vex/heavy/heavy.py
@@ -99,7 +99,8 @@ class HeavyVEXMixin(SuccessorsMixin, ClaripyDataMixin, SimStateStorageMixin, VEX
                     thumb=thumb,
                     size=size,
                     num_inst=num_inst,
-                    extra_stop_points=extra_stop_points)
+                    extra_stop_points=extra_stop_points,
+                    opt_level=kwargs['opt_level'])
 
             if irsb.size == 0:
                 if irsb.jumpkind == 'Ijk_NoDecode' and not self.state.project.is_hooked(irsb.addr):

--- a/angr/engines/vex/heavy/heavy.py
+++ b/angr/engines/vex/heavy/heavy.py
@@ -92,6 +92,10 @@ class HeavyVEXMixin(SuccessorsMixin, ClaripyDataMixin, SimStateStorageMixin, VEX
 
         while True:
             if irsb is None:
+                if 'opt_level' in kwargs:
+                    tmp_opt_level = kwargs['opt_level']
+                else:
+                    tmp_opt_level = None
                 irsb = self.lift_vex(
                     addr=addr,
                     state=self.state,
@@ -100,7 +104,7 @@ class HeavyVEXMixin(SuccessorsMixin, ClaripyDataMixin, SimStateStorageMixin, VEX
                     size=size,
                     num_inst=num_inst,
                     extra_stop_points=extra_stop_points,
-                    opt_level=kwargs['opt_level'])
+                    opt_level=tmp_opt_level)
 
             if irsb.size == 0:
                 if irsb.jumpkind == 'Ijk_NoDecode' and not self.state.project.is_hooked(irsb.addr):


### PR DESCRIPTION
Hi,

When I run the code
```
proj = angr.Project('./a.out',
                    load_options={'auto_load_libs': False},
                    use_sim_procedures=True,
                    default_analysis_mode='symbolic')
cfg = proj.analyses.CFGEmulated(context_sensitivity_level=2, keep_state=True,
                                state_add_options=angr.sim_options.refs,
                                iropt_level=0
                                )
```
I found that the Vex IR statements in any node of the cfg is just same as the result in the situation where iropt_level was set to 1(which is default). This parameter 'iropt_level' didn't make any effect. 

I fixed the issue in this commit


