### PR TITLE
Fix _op_generic_Perm

### DIFF
--- a/angr/engines/vex/claripy/irop.py
+++ b/angr/engines/vex/claripy/irop.py
@@ -1053,7 +1053,7 @@ class SimIROp:
         ordered_0 = list(reversed(args[0].chop(self._vector_size)))
         ordered_1 = list(reversed(args[1].chop(self._vector_size)))
         res = []
-        nbits = int(math.log2(self._vector_size))
+        nbits = int(math.log2(self._vector_count))
         for pword in ordered_1:
             switch = pword[nbits-1:0]
             kill = pword[self._vector_size - 1]


### PR DESCRIPTION
Sorry for the drive-by pull request; I figured it was easier than reporting a bug, since what this fixes is most likely just a typo. I won't be offended if you close this and just apply the change yourselves. :)

This change is necessary to fix AArch64's `tbl` instruction, which can select 8-bit elements out of a 128-bit vector. In this case, `_vector_size` is 8 and `_vector_count` is 16. (I imagine in most cases, `_vector_size` is the greater/equal, so the bug doesn't have any effect then.)