### PR TITLE
CFGFast: Make sure project.entry is always the first in the list.

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1026,10 +1026,14 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         # Sort it
         starting_points = sorted(list(starting_points), reverse=False)
 
-        if self._start_at_entry and self.project.entry is not None and self._inside_regions(self.project.entry) and \
-                self.project.entry not in starting_points:
-            # make sure self.project.entry is inserted
-            starting_points = [ self.project.entry ] + starting_points
+        if self._start_at_entry and self.project.entry is not None and self._inside_regions(self.project.entry):
+            if self.project.entry not in starting_points:
+                # make sure self.project.entry is inserted
+                starting_points = [ self.project.entry ] + starting_points
+            else:
+                # make sure project.entry is the first item
+                starting_points.remove(self.project.entry)
+                starting_points = [ self.project.entry ] + starting_points
 
         # Create jobs for all starting points
         for sp in starting_points:

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -932,7 +932,7 @@ def test_starting_point_ordering():
 
     # if ordering is incorrect, edge to function 0x103D4 will not exist
     n = cfg.model.get_any_node(proj.entry)
-    nose.tools.assert_true(n != None)
+    nose.tools.assert_is_not_none(n)
     nose.tools.assert_true(len(n.successors) > 0)
     nose.tools.assert_true(len(n.successors[0].successors) > 0)
     nose.tools.assert_equal(len(n.successors[0].successors[0].successors), 3)
@@ -944,7 +944,6 @@ def test_starting_point_ordering():
     nose.tools.assert_true(len(n.successors) > 0)
     nose.tools.assert_true(len(n.successors[0].successors) > 0)
     nose.tools.assert_true(len(n.successors[0].successors[0].successors) > 0)
-    nose.tools.assert_equal(len(n.successors[0].successors[0].successors[0].addr) > 0x103D4)
     nose.tools.assert_equal(n.successors[0].successors[0].successors[0].addr, 0x103D4)
 
 

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -920,6 +920,33 @@ def test_load_from_shellcode():
 
     nose.tools.assert_equal(len(cfg.model.nodes()), 2)
 
+def test_starting_point_ordering():
+
+    # project entry should always be first
+    # so edge/path to unlabeled main function from _start
+    # is correctly generated
+
+    path = os.path.join(test_location, "armel", "start_ordering")
+    proj = angr.Project(path, auto_load_libs=False)
+    cfg = proj.analyses.CFGFast()
+
+    # if ordering is incorrect, edge to function 0x103D4 will not exist
+    n = cfg.model.get_any_node(proj.entry)
+    nose.tools.assert_true(n != None)
+    nose.tools.assert_true(len(n.successors) > 0)
+    nose.tools.assert_true(len(n.successors[0].successors) > 0)
+    nose.tools.assert_equal(len(n.successors[0].successors[0].successors), 3)
+
+    # now checking if path to the "real main" exists
+    nose.tools.assert_true(len(n.successors[0].successors[0].successors[1].successors) > 0)
+    n = n.successors[0].successors[0].successors[1].successors[0]
+
+    nose.tools.assert_true(len(n.successors) > 0)
+    nose.tools.assert_true(len(n.successors[0].successors) > 0)
+    nose.tools.assert_true(len(n.successors[0].successors[0].successors) > 0)
+    nose.tools.assert_equal(len(n.successors[0].successors[0].successors[0].addr) > 0x103D4)
+    nose.tools.assert_equal(n.successors[0].successors[0].successors[0].addr, 0x103D4)
+
 
 def run_all():
 
@@ -965,6 +992,7 @@ def run_all():
     test_generate_special_info()
     test_plt_stub_has_one_jumpout_site()
     test_load_from_shellcode()
+    test_starting_point_ordering()
 
 
 def main():


### PR DESCRIPTION
This commit solves the problem of missing edges between _start and
libc_start_main if libc_start_main is scanned before _start (and thus, a
CFGJob with src_node being None is used, which causes edges between
project.entry and libc_start_main not getting created).