### PR TITLE
[WIP] Migrate static analyses to the new mixin-based memory model.

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/const_resolver.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/const_resolver.py
@@ -1,5 +1,6 @@
 import logging
 
+import claripy
 import pyvex
 
 from .resolver import IndirectJumpResolver
@@ -71,7 +72,8 @@ class ConstantResolver(IndirectJumpResolver):
                 if exists_in_replacements(replacements, block_loc, tmp_var):
                     resolved_tmp = replacements[block_loc][tmp_var]
 
-                    if isinstance(resolved_tmp, int) and self._is_target_valid(cfg, resolved_tmp):
-                        return True, [resolved_tmp]
+                    if isinstance(resolved_tmp, claripy.ast.Base) and resolved_tmp.op == "BVV" \
+                            and self._is_target_valid(cfg, resolved_tmp.args[0]):
+                        return True, [resolved_tmp.args[0]]
 
         return False, [ ]

--- a/angr/analyses/propagator/engine_base.py
+++ b/angr/analyses/propagator/engine_base.py
@@ -1,7 +1,5 @@
 import logging
 
-import claripy
-
 from ...engines.light import SimEngineLight
 from ...errors import SimEngineError
 

--- a/angr/analyses/propagator/engine_base.py
+++ b/angr/analyses/propagator/engine_base.py
@@ -1,5 +1,6 @@
-
 import logging
+
+import claripy
 
 from ...engines.light import SimEngineLight
 from ...errors import SimEngineError

--- a/angr/analyses/propagator/engine_vex.py
+++ b/angr/analyses/propagator/engine_vex.py
@@ -58,15 +58,10 @@ class SimEnginePropagatorVEX(
 
     def _load_data(self, addr, size, endness):
         if isinstance(addr, claripy.ast.Base):
-            if 'SpOffset' in addr.variables:
+            sp_offset = self.state.extract_offset_to_sp(addr)
+            if sp_offset is not None:
                 # Local variable
-                if addr.op == "BVS":
-                    offset = 0
-                elif addr.op == '__add__' and isinstance(addr.args[1], claripy.ast.Base) and addr.args[1].op == "BVV":
-                    offset = addr.args[1].args[0]
-                else:
-                    return None
-                v = self.state.load_local_variable(offset, size, endness)
+                v = self.state.load_local_variable(sp_offset, size, endness)
                 return v
             elif addr.op == "BVV":
                 addr = addr.args[0]
@@ -129,15 +124,10 @@ class SimEnginePropagatorVEX(
     def _store_data(self, addr, data, size, endness):
         # pylint: disable=unused-argument,no-self-use
         if isinstance(addr, claripy.ast.Base):
-            if 'SpOffset' in addr.variables:
+            sp_offset = self.state.extract_offset_to_sp(addr)
+            if sp_offset is not None:
                 # Local variables
-                if addr.op == "BVS":
-                    offset = 0
-                elif addr.op == '__add__' and isinstance(addr.args[1], claripy.ast.Base) and addr.args[1].op == "BVV":
-                    offset = addr.args[1].args[0]
-                else:
-                    return
-                self.state.store_local_variable(offset, size, data, endness)
+                self.state.store_local_variable(sp_offset, size, data, endness)
             elif addr.op == "BVV":
                 # a memory address
                 addr = addr.args[0]

--- a/angr/analyses/propagator/top_checker_mixin.py
+++ b/angr/analyses/propagator/top_checker_mixin.py
@@ -1,0 +1,13 @@
+import claripy
+
+from ...engines.light.engine import SimEngineLightMixin
+
+
+class TopCheckerMixin(SimEngineLightMixin):
+    def _is_top(self, expr) -> bool:
+        if isinstance(expr, claripy.ast.Base) and expr.op == "BVS" and expr.args[0] == 'TOP':
+            return True
+        return False
+
+    def _top(self, size: int):
+        return self.state.top(size)

--- a/angr/code_location.py
+++ b/angr/code_location.py
@@ -9,7 +9,7 @@ class CodeLocation:
 
     __slots__ = ('block_addr', 'stmt_idx', 'sim_procedure', 'ins_addr', 'context', 'info', 'block_idx', )
 
-    def __init__(self, block_addr: int, stmt_idx: int, sim_procedure=None, ins_addr: Optional[int]=None,
+    def __init__(self, block_addr: int, stmt_idx: Optional[int], sim_procedure=None, ins_addr: Optional[int]=None,
                  context: Optional[Tuple[int]]=None, block_idx: int=None, **kwargs):
         """
         Constructor.

--- a/angr/storage/memory_mixins/__init__.py
+++ b/angr/storage/memory_mixins/__init__.py
@@ -155,7 +155,7 @@ from .underconstrained_mixin import UnderconstrainedMixin
 from .unwrapper_mixin import UnwrapperMixin
 
 from .paged_memory.page_backer_mixins import ClemoryBackerMixin, DictBackerMixin
-from .paged_memory.paged_memory_mixin import PagedMemoryMixin, ListPagesMixin, UltraPagesMixin
+from .paged_memory.paged_memory_mixin import PagedMemoryMixin, ListPagesMixin, UltraPagesMixin, ListPagesWithLabelsMixin
 from .paged_memory.privileged_mixin import PrivilegedPagingMixin
 from .paged_memory.stack_allocation_mixin import StackAllocationMixin
 from .paged_memory.pages import *
@@ -287,7 +287,7 @@ class RegionedMemory(
 
 
 class LabeledMemory(
-    ListPagesMixin,
+    ListPagesWithLabelsMixin,
     DefaultFillerMixin,
     TopMergerMixin,
     PagedMemoryMixin,

--- a/angr/storage/memory_mixins/__init__.py
+++ b/angr/storage/memory_mixins/__init__.py
@@ -15,7 +15,7 @@ class MemoryMixin(SimStatePlugin):
         self.id = memory_id
         self.endness = endness
 
-    def copy(self, memo):
+    def copy(self, memo=None):
         o = type(self)()
         o.id = self.id
         o.endness = self.endness
@@ -150,6 +150,7 @@ from .simple_interface_mixin import SimpleInterfaceMixin
 from .size_resolution_mixin import SizeNormalizationMixin, SizeConcretizationMixin
 from .smart_find_mixin import SmartFindMixin
 from .symbolic_merger_mixin import SymbolicMergerMixin
+from .top_merger_mixin import TopMergerMixin
 from .underconstrained_mixin import UnderconstrainedMixin
 from .unwrapper_mixin import UnwrapperMixin
 
@@ -283,6 +284,29 @@ class RegionedMemory(
     PagedMemoryMixin,
 ):
     pass
+
+
+class LabeledMemory(
+    ListPagesMixin,
+    DefaultFillerMixin,
+    TopMergerMixin,
+    PagedMemoryMixin,
+):
+    """
+    LabeledMemory is used in static analysis. It allows storing objects with labels, such as `Definition`s.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _default_value(self, addr, size, **kwargs):
+        if kwargs.get("name", "").startswith("merge_uc_"):
+            # this is a hack. when this condition is satisfied, _default_value() is called inside Listpage.merge() to
+            # create temporary values. we simply return a TOP value here.
+            return self.state.top(size * self.state.arch.byte_width)
+
+        # we never fill default values for non-existent loads
+        kwargs['fill_missing'] = False
+        return super()._default_value(addr, size, **kwargs)
 
 
 class KeyValueMemory(

--- a/angr/storage/memory_mixins/convenient_mappings_mixin.py
+++ b/angr/storage/memory_mixins/convenient_mappings_mixin.py
@@ -5,9 +5,8 @@ import logging
 import claripy
 
 from angr import sim_options as options
-from ...errors import SimMemoryError
+from ...errors import SimMemoryError, SimMemoryMissingError
 from . import MemoryMixin
-from .default_filler_mixin import MemoryMissingException
 
 l = logging.getLogger(name=__name__)
 
@@ -62,7 +61,7 @@ class ConvenientMappingsMixin(MemoryMixin):
                     if len(self._hash_mapping[h]) == 0:
                         self._hash_mapping.pop(h, None)
                         self._updated_mappings.remove((h, id(self._hash_mapping)))
-        except MemoryMissingException:
+        except SimMemoryMissingError:
             pass
 
         if options.REVERSE_MEMORY_NAME_MAP in self.state.options:

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -3,11 +3,9 @@ import logging
 from . import MemoryMixin
 from ... import sim_options as options
 from ...misc.ux import once
+from ...errors import SimMemoryMissingError
 
 l = logging.getLogger(__name__)
-
-class MemoryMissingException(Exception):
-    pass
 
 
 class DefaultFillerMixin(MemoryMixin):
@@ -16,7 +14,7 @@ class DefaultFillerMixin(MemoryMixin):
         if self.state.project and self.state.project.concrete_target:
             return self.state.project.concrete_target.read_memory(addr, size)
         if fill_missing is False:
-            raise MemoryMissingException(addr, size)
+            raise SimMemoryMissingError(addr, size)
 
         bits = size * self.state.arch.byte_width
 

--- a/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
@@ -1,12 +1,12 @@
 import cffi
-from typing import Tuple, Type, Dict, Optional, Iterable, List, Any, Set
+from typing import Tuple, Type, Dict, Optional, Iterable, Set, Any
 import logging
 from collections import defaultdict
 
 import claripy
 
 from angr.storage.memory_mixins import MemoryMixin
-from angr.storage.memory_mixins.paged_memory.pages import PageType, ListPage, UltraPage
+from angr.storage.memory_mixins.paged_memory.pages import PageType, ListPage, ListPageWithLabels, UltraPage
 from ....errors import SimMemoryError
 
 # yeet
@@ -540,6 +540,45 @@ class PagedMemoryMixin(MemoryMixin):
 
 class ListPagesMixin(PagedMemoryMixin):
     PAGE_TYPE = ListPage
+
+
+class ListPagesWithLabelsMixin(PagedMemoryMixin):
+    PAGE_TYPE = ListPageWithLabels
+
+    def load_with_labels(self, addr: int, size: int=None, endness=None, **kwargs) -> Tuple[claripy.ast.Base,Tuple[Any]]:
+        if endness is None:
+            endness = self.endness
+
+        if type(size) is not int:
+            raise TypeError("Need size to be resolved to an int by this point")
+
+        if type(addr) is not int:
+            raise TypeError("Need addr to be resolved to an int by this point")
+
+        pageno, pageoff = self._divide_addr(addr)
+        vals = []
+
+        # fasttrack basic case
+        if pageoff + size <= self.page_size:
+            page = self._get_page(pageno, False, **kwargs)
+            vals.append(page.load(pageoff, size=size, endness=endness, page_addr=pageno*self.page_size, memory=self, cooperate=True, **kwargs))
+
+        else:
+            max_pageno = (1 << self.state.arch.bits) // self.page_size
+            bytes_done = 0
+            while bytes_done < size:
+                page = self._get_page(pageno, False, **kwargs)
+                sub_size = min(self.page_size-pageoff, size-bytes_done)
+                vals.append(page.load(pageoff, size=sub_size, endness=endness, page_addr=pageno*self.page_size, memory=self, cooperate=True, **kwargs))
+
+                bytes_done += sub_size
+                pageno = (pageno + 1) % max_pageno
+                pageoff = 0
+
+        out = self.PAGE_TYPE._compose_objects(vals, size, endness, memory=self, **kwargs)
+        labels = tuple(v[0][1].label for v in vals)
+        l.debug("%s.load_with_labels(%#x, %d, %s) = %s", self.id, addr, size, endness, out)
+        return out, labels
 
 
 class UltraPagesMixin(PagedMemoryMixin):

--- a/angr/storage/memory_mixins/paged_memory/pages/__init__.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/__init__.py
@@ -25,5 +25,5 @@ class PageBase(RefcountMixin, CooperationBase, ISPOMixin, PermissionsMixin, Memo
 
 PageType = typing.TypeVar('PageType', bound=PageBase)
 
-from .list_page import ListPage
+from .list_page import ListPage, ListPageWithLabels
 from .ultra_page import UltraPage

--- a/angr/storage/memory_mixins/paged_memory/pages/list_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/list_page.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Optional, List, Set, Tuple
 
-import claripy
-
 from . import PageBase
 from angr.storage.memory_object import SimMemoryObject
 from .cooperation import MemoryObjectMixin

--- a/angr/storage/memory_mixins/paged_memory/pages/list_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/list_page.py
@@ -1,5 +1,7 @@
 import logging
-from typing import Optional, List, Set, Tuple
+from typing import Optional, List, Set, Tuple, Any
+
+import claripy
 
 from . import PageBase
 from angr.storage.memory_object import SimMemoryObject
@@ -254,3 +256,10 @@ class ListPage(MemoryObjectMixin, PageBase):
         if mo.includes(start + page_addr):
             return mo
         return None
+
+
+class ListPageWithLabels(
+    ListPage
+):
+    # TODO: Maybe this class is moot
+    pass

--- a/angr/storage/memory_mixins/top_merger_mixin.py
+++ b/angr/storage/memory_mixins/top_merger_mixin.py
@@ -1,0 +1,19 @@
+from typing import Iterable, Tuple, Any, Callable
+
+from . import MemoryMixin
+
+
+class TopMergerMixin(MemoryMixin):
+    def __init__(self, *args, top_func=None, **kwargs):
+        self._top_func: Callable = top_func
+
+        super().__init__(*args, **kwargs)
+
+    def _merge_values(self, values: Iterable[Tuple[Any,Any]], merged_size: int):
+        merged_val = self._top_func(merged_size * self.state.arch.byte_width)
+        return merged_val
+
+    def copy(self, memo=None):
+        copied = super().copy(memo)
+        copied._top_func = self._top_func
+        return copied

--- a/angr/storage/memory_object.py
+++ b/angr/storage/memory_object.py
@@ -131,6 +131,15 @@ class SimMemoryObject:
         return "MO(%s)" % self.object
 
 
+class SimLabeledMemoryObject(SimMemoryObject):
+
+    __slots__ = ('label', )
+
+    def __init__(self, obj, base, endness, length=None, byte_width=8, label=None):
+        super().__init__(obj, base, endness, length=length, byte_width=byte_width)
+        self.label = label
+
+
 def bv_slice(value, offset, size, rev, bw):
     """
     Extremely cute utility to pretend you've serialized a value to stored bytes, sliced it a la python slicing, and then

--- a/angr/storage/memory_object.py
+++ b/angr/storage/memory_object.py
@@ -12,9 +12,12 @@ def obj_bit_size(o):
 
 class SimMemoryObject:
     """
-    A MemoryObjectRef instance is a reference to a byte or several bytes in
-    a specific object in memory. It should be used only by the bottom layer of memory.
+    A SimMemoryObject is a reference to a byte or several bytes in a specific object in memory. It should be used only
+    by the bottom layer of memory.
     """
+
+    __slots__ = ('is_bytes', '_byte_width', 'base', 'object', 'length', 'endness', )
+
     def __init__(self, obj, base, endness, length=None, byte_width=8):
         if type(obj) is bytes:
             assert byte_width == 8
@@ -22,7 +25,7 @@ class SimMemoryObject:
         elif not isinstance(obj, claripy.ast.Base):
             raise SimMemoryError('memory can only store claripy Expression')
 
-        self.is_bytes = type(obj) == bytes
+        self.is_bytes = type(obj) is bytes
         if self.is_bytes and endness != 'Iend_BE':
             raise SimMemoryError('bytes can only be stored big-endian')
         self._byte_width = byte_width
@@ -126,6 +129,7 @@ class SimMemoryObject:
 
     def __repr__(self):
         return "MO(%s)" % self.object
+
 
 def bv_slice(value, offset, size, rev, bw):
     """


### PR DESCRIPTION
Still work-in-progress.

TODOs:

- [ ] Migrate RDA (`live_definitions` and such) to `SimLabeledMemory`.
- [ ] Migrate `VariableManagerInternal` to `SimLabeledMemory`.
- [ ] Drop `KeyedRegion`.
- [ ] Drop `SpOffset` (we use a claripy BVS `SpOffset` instead).
- [ ] Clean up the code.