### PR TITLE
Remove python2 __div__ and __rdiv__

### DIFF
--- a/angr/analyses/propagator/values.py
+++ b/angr/analyses/propagator/values.py
@@ -40,9 +40,6 @@ class Top:
     def __rmul__(self, other):
         return self
 
-    def __rdiv__(self, other):
-        return self
-
     def __floordiv__(self, other):
         return self
 

--- a/angr/engines/vex/claripy/irop.py
+++ b/angr/engines/vex/claripy/irop.py
@@ -134,7 +134,7 @@ arithmetic_operation_map = {
     'Add': '__add__',
     'Sub': '__sub__',
     'Mul': '__mul__',
-    'Div': '__div__',
+    'Div': '__truediv__',
     'Neg': 'Neg',
     'Abs': 'Abs',
     'Mod': '__mod__',
@@ -430,7 +430,7 @@ class SimIROp:
         else:
             raise SimOperationError("op_mapped called with invalid mapping, for %s" % self.name)
 
-        if o == '__div__' and self.is_signed:
+        if o == '__truediv__' and self.is_signed:
             # yikes!!!!!!!
             return claripy.SDiv(*sized_args)
 

--- a/angr/engines/vex/claripy/irop.py
+++ b/angr/engines/vex/claripy/irop.py
@@ -134,7 +134,7 @@ arithmetic_operation_map = {
     'Add': '__add__',
     'Sub': '__sub__',
     'Mul': '__mul__',
-    'Div': '__truediv__',
+    'Div': '__floordiv__',
     'Neg': 'Neg',
     'Abs': 'Abs',
     'Mod': '__mod__',
@@ -430,7 +430,7 @@ class SimIROp:
         else:
             raise SimOperationError("op_mapped called with invalid mapping, for %s" % self.name)
 
-        if o == '__truediv__' and self.is_signed:
+        if o == '__floordiv__' and self.is_signed:
             # yikes!!!!!!!
             return claripy.SDiv(*sized_args)
 

--- a/angr/knowledge_plugins/key_definitions/dataset.py
+++ b/angr/knowledge_plugins/key_definitions/dataset.py
@@ -138,9 +138,6 @@ class DataSet:
     def __mul__(self, other):
         return self._bin_op(other, operator.mul)
 
-    def __div__(self, other):
-        return self._bin_op(other, operator.floordiv)
-
     def __lshift__(self, other):
         return self._bin_op(other, operator.lshift)
 

--- a/angr/knowledge_plugins/key_definitions/unknown_size.py
+++ b/angr/knowledge_plugins/key_definitions/unknown_size.py
@@ -15,9 +15,6 @@ class UnknownSize:
     def __rsub__(self, other):
         return self
 
-    def __div__(self, other):
-        return self
-
     def __floordiv__(self, other):
         return self
 


### PR DESCRIPTION
This is related to the PR in claripy: https://github.com/angr/claripy/pull/205

`__div__` and `__rdiv__` are python2 functions; we are python3 now so we should remove them.

The two things that should be checked extra carefully are:
1. I chose to use floordiv in lieu of div, as opposed to truediv.
2. In `angr/engines/vex/claripy/irop.py`:
```
 433         if o == '__truediv__' and self.is_signed:
 434             # yikes!!!!!!!
 435             return claripy.SDiv(*sized_args)
```

I changed `__div__` to `__floordiv__`, but it should be noted that the `yikes` comment was there before. That said, I am fairly certain that the `__` div functions are all unsigned in claripy. Should line `435` be just invoking `Div` instead of `SDiv`, or is that why the yikes remains?