### PR TITLE
Clean `RDA` `atoms`

### DIFF
--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -10,7 +10,7 @@ from ...calling_conventions import DEFAULT_CC, SimRegArg, SimStackArg, SimCC
 from ...utils.constants import DEFAULT_STATEMENT
 from ...knowledge_plugins.key_definitions.definition import Definition
 from ...knowledge_plugins.key_definitions.tag import LocalVariableTag, ParameterTag, ReturnValueTag, Tag
-from ...knowledge_plugins.key_definitions.atoms import Atom, Register, MemoryLocation, Parameter, Tmp
+from ...knowledge_plugins.key_definitions.atoms import Atom, Register, MemoryLocation, Tmp
 from ...knowledge_plugins.key_definitions.constants import OP_BEFORE, OP_AFTER
 from ...knowledge_plugins.key_definitions.dataset import DataSet
 from ...knowledge_plugins.key_definitions.heap_address import HeapAddress
@@ -393,13 +393,10 @@ class SimEngineRDVEX(
             elif isinstance(a, int):
                 mask = 2 ** bits - 1
                 a &= mask
-            elif type(a) is Parameter:
-                if type(a.value) is Register:
-                    a.value.size = bits // 8
-                elif type(a.value) is SpOffset:
-                    a.value.bits = bits
-                else:
-                    l.warning('Unsupported type Parameter->%s for conversion.', type(a.value).__name__)
+            elif isinstance(a, Register):
+                a.size = bits // 8
+            elif isinstance(a, SpOffset):
+                a.bits = bits
             else:
                 l.warning('Unsupported type %s for conversion.', type(a).__name__)
             data.add(a)

--- a/angr/knowledge_plugins/key_definitions/atoms.py
+++ b/angr/knowledge_plugins/key_definitions/atoms.py
@@ -8,7 +8,7 @@ class Atom:
     """
     This class represents a data storage location manipulated by IR instructions.
 
-    It could either be a Tmp (temporary variable), a Register, a MemoryLocation, or a Parameter.
+    It could either be a Tmp (temporary variable), a Register, a MemoryLocation.
     """
     def __repr__(self):
         raise NotImplementedError()
@@ -163,39 +163,3 @@ class MemoryLocation(Atom):
 
     def __hash__(self):
         return hash(('mem', self.addr, self.size))
-
-
-class Parameter(Atom):
-    """
-    Represents a function parameter.
-
-    Can either be a <angr.engines.light.data.SpOffset> if the parameter was passed on the stack, or a <Register>, depending on the calling
-    convention.
-    """
-    __slots__ = ('value', '_size', 'type_', 'meta')
-
-    def __init__(self, value, size=None, type_=None, meta=None):
-        super(Parameter, self).__init__()
-
-        self.value = value
-        self._size = size
-        self.type_ = type_
-        self.meta = meta
-
-    @property
-    def size(self) -> int:
-        return self._size
-
-    def __repr__(self):
-        type_ = ', type=%s' % self.type_ if self.type_ is not None else ''
-        meta = ', meta=%s' % self.meta if self.meta is not None else ''
-        return '<Param %s%s%s>' % (self.value, type_, meta)
-
-    def __eq__(self, other):
-        return type(other) is Parameter and \
-               self.value == other.value and \
-               self.type_ == other.type_ and \
-               self.meta == other.meta
-
-    def __hash__(self):
-        return hash(('par', self.value, self.type_, self.meta))


### PR DESCRIPTION
The `Parameter` atom is:
  * barely used / supported
  * redundant with `Register` and `SpOffset` depending on the calling convention

I find it confusing: atoms are meant to "represent" things that are manipulated by the IR.
Literally, the docstring:
> This class represents a data storage location manipulated by IR instructions.

But a `Parameter` is a "higher level" concept (technically `Union[SpOffset,Register]` resolved by knowing the architecture...).

@ltfish; @degrigis (I think I saw you use `Parameter`); @mahaloz, @AOS002 (I think you guys use RDA):
What are your opinions on removing this?

Signed-off-by: Pamplemousse <xav.maso@gmail.com>