### PR TITLE
Handling for abi not in syscall abis

### DIFF
--- a/angr/simos/userland.py
+++ b/angr/simos/userland.py
@@ -148,7 +148,7 @@ class SimUserland(SimOS):
         else:
             proc = self.syscall_library.get(number, self.arch, abilist)
 
-        if proc.abi is not None:
+        if proc.abi is not None and proc.abi in self.syscall_abis:
             baseno, minno, _ = self.syscall_abis[proc.abi]
             mapno = number - minno + baseno
         else:


### PR DESCRIPTION
A user on reddit asked for help with an exception thrown by this library, I think that this PR should fix it, however maybe there is a better way to go about it that someone with more experience with the library would know about.

https://old.reddit.com/r/AskReverseEngineering/comments/ltr1km/problem_with_angr/
![](https://i.imgur.com/Zcg3xjJ.png)
![](https://i.imgur.com/isBPPnf.png)

Exception is `KeyError: ‘amd64’` at https://github.com/angr/angr/blob/63cf7e461af496471a6c9e6d4a8524ac3e508c39/angr/simos/userland.py#L152