### PR TITLE
Optimize state copying

### DIFF
--- a/angr/state_plugins/callstack.py
+++ b/angr/state_plugins/callstack.py
@@ -16,7 +16,7 @@ class CallStack(SimStatePlugin):
     """
     def __init__(self, call_site_addr=0, func_addr=0, stack_ptr=0, ret_addr=0, jumpkind='Ijk_Call', next_frame: Optional['CallStack'] = None,
                  invoke_return_variable=None):
-        super(CallStack, self).__init__()
+        super().__init__()
         self.state = None
         self.call_site_addr = call_site_addr
         self.func_addr = func_addr
@@ -35,7 +35,7 @@ class CallStack(SimStatePlugin):
     #
 
     @SimStatePlugin.memo
-    def copy(self, memo, with_tail=True): # pylint: disable=unused-argument
+    def copy(self, memo, with_tail=True): # pylint: disable=unused-argument,arguments-differ
         o = super().copy(memo)
         o.call_site_addr = self.call_site_addr
         o.func_addr = self.func_addr
@@ -51,7 +51,7 @@ class CallStack(SimStatePlugin):
         return o
 
     def set_state(self, state):
-        super(CallStack, self).set_state(state)
+        super().set_state(state)
         # make the stack pointer as large as possible as soon as we know how large that actually is
         if self.stack_ptr == 0:
             try:
@@ -206,8 +206,8 @@ class CallStack(SimStatePlugin):
         try:
             return dropwhile(lambda x: lst[x] != item,
                              next(reversed(range(len(lst)))))
-        except Exception:
-            raise ValueError("%s not in the list" % item)
+        except Exception as e:
+            raise ValueError("%s not in the list" % item) from e
 
     @property
     def top(self):
@@ -358,7 +358,7 @@ class CallStack(SimStatePlugin):
                 return i
         return None
 
-class CallStackAction(object):
+class CallStackAction:
     """
     Used in callstack backtrace, which is a history of callstacks along a path, to record individual actions occurred
     each time the callstack is changed.
@@ -377,7 +377,7 @@ class CallStackAction(object):
         if action == 'push' and self.callframe is None:
             raise AngrError('callframe must be specified when action is "push".')
 
-        elif action == 'pop' and self.callframe is not None:
+        if action == 'pop' and self.callframe is not None:
             raise AngrError('callframe must not be specified when action is "pop".')
 
     def __repr__(self):

--- a/angr/state_plugins/callstack.py
+++ b/angr/state_plugins/callstack.py
@@ -30,37 +30,25 @@ class CallStack(SimStatePlugin):
         self.procedure_data = None
         self.locals = {}
 
-    # deprecated as SHIT
-    @property
-    def call_target(self):
-        raise Exception("FIX ME")
-
-    @property
-    def return_target(self):
-        raise Exception("FIX ME")
-
-    @property
-    def stack_pointer(self):
-        raise Exception("FIX ME")
-
     #
     # Public methods
     #
 
     @SimStatePlugin.memo
-    def copy(self, memo, with_tail=True): # pylint: disable=unused-argument,arguments-differ
-        n = CallStack(
-                call_site_addr=self.call_site_addr,
-                func_addr=self.func_addr,
-                stack_ptr=self.stack_ptr,
-                ret_addr=self.ret_addr,
-                jumpkind=self.jumpkind,
-                next_frame=self.next if with_tail else None,
-                invoke_return_variable=self.invoke_return_variable)
-        n.block_counter = collections.Counter(self.block_counter)
-        n.procedure_data = self.procedure_data
-        n.locals = dict(self.locals)
-        return n
+    def copy(self, memo, with_tail=True): # pylint: disable=unused-argument
+        o = super().copy(memo)
+        o.call_site_addr = self.call_site_addr
+        o.func_addr = self.func_addr
+        o.stack_ptr = self.stack_ptr
+        o.ret_addr = self.ret_addr
+        o.jumpkind = self.jumpkind
+        o.next = self.next if with_tail else None
+        o.invoke_return_variable = self.invoke_return_variable
+
+        o.block_counter = collections.Counter(self.block_counter)
+        o.procedure_data = self.procedure_data
+        o.locals = dict(self.locals)
+        return o
 
     def set_state(self, state):
         super(CallStack, self).set_state(state)

--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -48,6 +48,18 @@ class SimFilesystem(SimStatePlugin): # pretends links don't exist
         for fname in files:
             self.insert(fname, files[fname])
 
+    @SimStatePlugin.memo
+    def copy(self, memo):
+        o = super().copy(memo)
+
+        o.pathsep=self.pathsep
+        o.cwd=self.cwd
+        o._unlinks = list(self._unlinks)
+        o._files={k: v.copy(memo) for k, v in self._files.items()}
+        o._mountpoints={k: v.copy(memo) for k, v in self._mountpoints.items()}
+
+        return o
+
     @property
     def unlinks(self):
         for _, f in self._unlinks:
@@ -60,17 +72,6 @@ class SimFilesystem(SimStatePlugin): # pretends links don't exist
             self._files[fname].set_state(state)
         for fname in self._mountpoints:
             self._mountpoints[fname].set_state(state)
-
-    @SimStatePlugin.memo
-    def copy(self, memo):
-        o = SimFilesystem(
-                files={k: v.copy(memo) for k, v in self._files.items()},
-                pathsep=self.pathsep,
-                cwd=self.cwd,
-                mountpoints={k: v.copy(memo) for k, v in self._mountpoints.items()}
-            )
-        o._unlinks = list(self._unlinks)
-        return o
 
     def merge(self, others, merge_conditions, common_ancestor=None):
         for o in others:

--- a/angr/state_plugins/heap/heap_base.py
+++ b/angr/state_plugins/heap/heap_base.py
@@ -24,11 +24,18 @@ class SimHeapBase(SimStatePlugin):
     """
 
     def __init__(self, heap_base=None, heap_size=None):
-        SimStatePlugin.__init__(self)
+        super().__init__()
 
         self.heap_base = heap_base if heap_base is not None else DEFAULT_HEAP_LOCATION
         self.heap_size = heap_size if heap_size is not None else DEFAULT_HEAP_SIZE
         self.mmap_base = self.heap_base + self.heap_size * 2
+
+    def copy(self, memo):
+        o = super().copy(memo)
+        o.heap_base = self.heap_base
+        o.heap_size = self.heap_size
+        o.mmap_base = self.mmap_base
+        return o
 
     def _conc_alloc_size(self, sim_size):
         """

--- a/angr/state_plugins/heap/heap_brk.py
+++ b/angr/state_plugins/heap/heap_brk.py
@@ -28,6 +28,12 @@ class SimHeapBrk(SimHeapBase):
         super(SimHeapBrk, self).__init__(heap_base, heap_size)
         self.heap_location = self.heap_base
 
+    @SimStatePlugin.memo
+    def copy(self, memo):
+        o = super().copy(memo)
+        o.heap_location = self.heap_location
+        return o
+
     def allocate(self, sim_size):
         """
         The actual allocation primitive for this heap implementation. Increases the position of the break to allocate
@@ -106,13 +112,6 @@ class SimHeapBrk(SimHeapBase):
             self.state.memory.store(addr, v)
 
         return addr
-
-    @SimStatePlugin.memo
-    def copy(self, memo):# pylint: disable=unused-argument
-        c = SimHeapBrk(heap_base=self.heap_base, heap_size=self.heap_size)
-        c.heap_location = self.heap_location
-        c.mmap_base = self.mmap_base
-        return c
 
     def _combine(self, others):
         new_heap_location = max(o.heap_location for o in others)

--- a/angr/state_plugins/libc.py
+++ b/angr/state_plugins/libc.py
@@ -215,28 +215,27 @@ class SimStateLibc(SimStatePlugin):
 
     @SimStatePlugin.memo
     def copy(self, memo): # pylint: disable=unused-argument
-        c = SimStateLibc()
-        c.buf_symbolic_bytes = self.buf_symbolic_bytes
-        c.max_symbolic_strstr = self.max_symbolic_strstr
-        c.max_symbolic_strchr = self.max_symbolic_strchr
-        c.max_variable_size = self.max_variable_size
-        c.max_str_len = self.max_str_len
-        c.max_buffer_size = self.max_buffer_size
-        c.max_strtol_len = self.max_strtol_len
-        c.max_memcpy_size = self.max_memcpy_size
-        c.max_packet_size = self.max_packet_size
-        c.strtok_heap = self.strtok_heap[:]
-        c.simple_strtok = self.simple_strtok
-        c.strtok_token_size = self.strtok_token_size
-        c.strdup_stack = self.strdup_stack[:]
-        c.ppc64_abiv = self.ppc64_abiv
-        c.ctype_b_loc_table_ptr = self.ctype_b_loc_table_ptr
-        c.ctype_tolower_loc_table_ptr = self.ctype_tolower_loc_table_ptr
-        c.ctype_toupper_loc_table_ptr = self.ctype_toupper_loc_table_ptr
-        c.errno_location = self.errno_location
-        #c.aa = self.aa
+        o = super().copy(memo)
+        o.buf_symbolic_bytes = self.buf_symbolic_bytes
+        o.max_symbolic_strstr = self.max_symbolic_strstr
+        o.max_symbolic_strchr = self.max_symbolic_strchr
+        o.max_variable_size = self.max_variable_size
+        o.max_str_len = self.max_str_len
+        o.max_buffer_size = self.max_buffer_size
+        o.max_strtol_len = self.max_strtol_len
+        o.max_memcpy_size = self.max_memcpy_size
+        o.max_packet_size = self.max_packet_size
+        o.strtok_heap = self.strtok_heap[:]
+        o.simple_strtok = self.simple_strtok
+        o.strtok_token_size = self.strtok_token_size
+        o.strdup_stack = self.strdup_stack[:]
+        o.ppc64_abiv = self.ppc64_abiv
+        o.ctype_b_loc_table_ptr = self.ctype_b_loc_table_ptr
+        o.ctype_tolower_loc_table_ptr = self.ctype_tolower_loc_table_ptr
+        o.ctype_toupper_loc_table_ptr = self.ctype_toupper_loc_table_ptr
+        o.errno_location = self.errno_location
 
-        return c
+        return o
 
     def merge(self, others, merge_conditions, common_ancestor=None): # pylint: disable=unused-argument
         return False

--- a/angr/state_plugins/plugin.py
+++ b/angr/state_plugins/plugin.py
@@ -41,10 +41,13 @@ class SimStatePlugin:
         In order to simplify using the memo, you should annotate implementations of this function with
         ``SimStatePlugin.memo``
 
+        The base implementation of this function constructs a new instance of the plugin's class without calling its
+        initializer. If you super-call down to it, make sure you instanciate all the fields in your copy method!
+
         :param memo:    A dictionary mapping object identifiers (id(obj)) to their copied instance.  Use this to avoid
                         infinite recursion and diverged copies.
         """
-        raise NotImplementedError("copy() not implement for %s" % self.__class__.__name__)
+        return type(self).__new__(type(self))
 
     @staticmethod
     def memo(f):

--- a/angr/state_plugins/plugin.py
+++ b/angr/state_plugins/plugin.py
@@ -47,7 +47,9 @@ class SimStatePlugin:
         :param memo:    A dictionary mapping object identifiers (id(obj)) to their copied instance.  Use this to avoid
                         infinite recursion and diverged copies.
         """
-        return type(self).__new__(type(self))
+        o = type(self).__new__(type(self))
+        o.state = None
+        return o
 
     @staticmethod
     def memo(f):

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -190,7 +190,7 @@ class SimSystemPosix(SimStatePlugin):
     @SimStatePlugin.memo
     def copy(self, memo):
         o = super().copy(memo)
-        
+
         o.sigmask_bits = self.sigmask_bits
         o.maximum_symbolic_syscalls = self.maximum_symbolic_syscalls
         o.max_length = self.max_length

--- a/angr/state_plugins/posix.py
+++ b/angr/state_plugins/posix.py
@@ -190,6 +190,10 @@ class SimSystemPosix(SimStatePlugin):
     @SimStatePlugin.memo
     def copy(self, memo):
         o = super().copy(memo)
+        
+        o.sigmask_bits = self.sigmask_bits
+        o.maximum_symbolic_syscalls = self.maximum_symbolic_syscalls
+        o.max_length = self.max_length
         o.stdin = self.stdin.copy(memo)
         o.stdout = self.stdout.copy(memo)
         o.stderr = self.stderr.copy(memo)
@@ -211,6 +215,7 @@ class SimSystemPosix(SimStatePlugin):
         o.dev_fs = self.dev_fs.copy(memo)
         o.proc_fs = self.proc_fs.copy(memo)
         o._closed_fds = list(self._closed_fds)
+
         return o
 
     @property

--- a/angr/state_plugins/scratch.py
+++ b/angr/state_plugins/scratch.py
@@ -7,7 +7,7 @@ from .plugin import SimStatePlugin
 
 class SimStateScratch(SimStatePlugin):
     def __init__(self, scratch=None):
-        SimStatePlugin.__init__(self)
+        super().__init__()
 
         # info on the current run
         self.irsb = None

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -181,8 +181,8 @@ class SimSolver(SimStatePlugin):
     Any top-level variable of the claripy module can be accessed as a property of this object.
     """
     def __init__(self, solver=None, all_variables=None, temporal_tracked_variables=None, eternal_tracked_variables=None): #pylint:disable=redefined-outer-name
-        l.debug("Creating SimSolverClaripy.")
-        SimStatePlugin.__init__(self)
+        super().__init__()
+
         self._stored_solver = solver
         self.all_variables = [] if all_variables is None else all_variables
         self.temporal_tracked_variables = {} if temporal_tracked_variables is None else temporal_tracked_variables
@@ -415,7 +415,14 @@ class SimSolver(SimStatePlugin):
 
     @SimStatePlugin.memo
     def copy(self, memo): # pylint: disable=unused-argument
-        return type(self)(solver=self._solver.branch(), all_variables=self.all_variables, temporal_tracked_variables=self.temporal_tracked_variables, eternal_tracked_variables=self.eternal_tracked_variables)
+        o = super().copy(memo)
+
+        o._stored_solver = self._solver.branch()
+        o.all_variables = self.all_variables
+        o.temporal_tracked_variables = self.temporal_tracked_variables
+        o.eternal_tracked_variables = self.eternal_tracked_variables
+
+        return o
 
     @error_converter
     def merge(self, others, merge_conditions, common_ancestor=None): # pylint: disable=W0613

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -11,7 +11,7 @@ from .sim_action_object import ast_stripping_decorator, SimActionObject
 
 l = logging.getLogger(name=__name__)
 
-#pylint:disable=unidiomatic-typecheck
+#pylint:disable=unidiomatic-typecheck,isinstance-second-argument-not-valid-type
 
 #
 # Timing stuff
@@ -252,6 +252,8 @@ class SimSolver(SimStatePlugin):
         """
         Given an AST, iterate over all the keys of all the BVS leaves in the tree which are registered.
         """
+        # pylint: disable=stop-iteration-return
+        # ??? wtf pylint
         reverse_mapping = {next(iter(var.variables)): k for k, var in self.eternal_tracked_variables.items()}
         reverse_mapping.update({next(iter(var.variables)): k for k, var in self.temporal_tracked_variables.items() if k[-1] is not None})
 
@@ -407,7 +409,7 @@ class SimSolver(SimStatePlugin):
             return f
 
     def __dir__(self):
-        return sorted(set(dir(super(SimSolver, self)) + dir(claripy._all_operations) + dir(self.__class__)))
+        return sorted(set(dir(super()) + dir(claripy._all_operations) + dir(self.__class__)))
 
     #
     # Branching stuff
@@ -415,14 +417,14 @@ class SimSolver(SimStatePlugin):
 
     @SimStatePlugin.memo
     def copy(self, memo): # pylint: disable=unused-argument
-        o = super().copy(memo)
+        c = super().copy(memo)
 
-        o._stored_solver = self._solver.branch()
-        o.all_variables = self.all_variables
-        o.temporal_tracked_variables = self.temporal_tracked_variables
-        o.eternal_tracked_variables = self.eternal_tracked_variables
+        c._stored_solver = self._solver.branch()
+        c.all_variables = self.all_variables
+        c.temporal_tracked_variables = self.temporal_tracked_variables
+        c.eternal_tracked_variables = self.eternal_tracked_variables
 
-        return o
+        return c
 
     @error_converter
     def merge(self, others, merge_conditions, common_ancestor=None): # pylint: disable=W0613

--- a/angr/storage/file.py
+++ b/angr/storage/file.py
@@ -140,7 +140,7 @@ class SimFileBase(SimStatePlugin):
 
     @DefaultMemory.memo
     def copy(self, memo):
-        o = super().copy()
+        o = super().copy(memo)
         o.ident = self.ident
         o.name = self.name
         o.ident = self.ident

--- a/angr/storage/memory_mixins/__init__.py
+++ b/angr/storage/memory_mixins/__init__.py
@@ -16,7 +16,7 @@ class MemoryMixin(SimStatePlugin):
         self.endness = endness
 
     def copy(self, memo):
-        o = type(self)()
+        o = type(self).__new__(type(self))
         o.id = self.id
         o.endness = self.endness
         return o

--- a/angr/storage/memory_mixins/convenient_mappings_mixin.py
+++ b/angr/storage/memory_mixins/convenient_mappings_mixin.py
@@ -41,6 +41,7 @@ class ConvenientMappingsMixin(MemoryMixin):
         o._symbolic_addrs = set(self._symbolic_addrs)
         o._name_mapping = self._name_mapping.copy()
         o._hash_mapping = self._hash_mapping.copy()
+        o._updated_mappings = set()
         return o
 
     def store(self, addr, data, size=None, **kwargs):

--- a/angr/storage/memory_mixins/paged_memory/pages/refcount_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/refcount_mixin.py
@@ -7,8 +7,16 @@ class RefcountMixin(MemoryMixin):
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self._init()
+
+    def _init(self):
         self.refcount = 1
         self.lock = PicklableLock()
+
+    def copy(self, memo):
+        o = super().copy(memo)
+        o._init()
+        return o
 
     def acquire_unique(self):
         """

--- a/angr/storage/memory_mixins/regioned_memory/region_meta_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/region_meta_mixin.py
@@ -18,6 +18,14 @@ class MemoryRegionMetaMixin(MemoryMixin):
 
         self._is_stack = None
 
+    @MemoryMixin.memo
+    def copy(self, memo):
+        r: 'MemoryRegionMetaMixin' = super().copy(memo)
+        r.alocs = copy.deepcopy(self.alocs)
+        r._related_function_addr = self._related_function_addr
+        r._is_stack = self._is_stack
+        return r
+
     @property
     def is_stack(self):
         if self.id is None:
@@ -50,13 +58,6 @@ class MemoryRegionMetaMixin(MemoryMixin):
                     break
 
         return ret
-
-    @MemoryMixin.memo
-    def copy(self, memo):
-        r: 'MemoryRegionMetaMixin' = super().copy(memo)
-        r._alocs = copy.deepcopy(self.alocs)
-        r._related_function_addr = self._related_function_addr
-        return r
 
     def store(self, addr, data, bbl_addr=None, stmt_id=None, ins_addr=None, endness=None, **kwargs):
         if ins_addr is not None:

--- a/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
@@ -67,6 +67,25 @@ class RegionedMemoryMixin(MemoryMixin):
         self._write_targets_limit = write_targets_limit
         self._read_targets_limit = read_targets_limit
 
+    @MemoryMixin.memo
+    def copy(self, memo):
+        o: 'RegionedMemoryMixin' = super().copy(memo)
+        o._write_targets_limit = self._write_targets_limit
+        o._read_targets_limit = self._read_targets_limit
+        o._stack_size = self._stack_size
+        o._endness = self.endness
+        o._stack_region_map = self._stack_region_map
+        o._generic_region_map = self._generic_region_map
+        o._cle_memory_backer = self._cle_memory_backer
+        o._dict_memory_backer = self._dict_memory_backer
+        o._regioned_memory_cls = self._regioned_memory_cls
+
+        o._regions = {}
+        for region_id, region in self._regions.items():
+            o._regions[region_id] = region.copy(memo)
+
+        return o
+
     def load(self, addr, size: Optional[Union[BV,int]]=None, endness=None, condition: Optional[Bool]=None, **kwargs):
 
         if isinstance(size, BV) and isinstance(size._model_vsa, ValueSet):
@@ -132,24 +151,6 @@ class RegionedMemoryMixin(MemoryMixin):
                     self._regions[region_id] = region
                     r = True
         return r
-
-    @MemoryMixin.memo
-    def copy(self, memo):
-        o: 'RegionedMemoryMixin' = super().copy(memo)
-        o._write_targets_limit = self._write_targets_limit
-        o._read_targets_limit = self._read_targets_limit
-        o._stack_size = self._stack_size
-        o._endness = self.endness
-        o._stack_region_map = self._stack_region_map
-        o._generic_region_map = self._generic_region_map
-        o._cle_memory_backer = self._cle_memory_backer
-        o._dict_memory_backer = self._dict_memory_backer
-        o._regioned_memory_cls = self._regioned_memory_cls
-
-        for region_id, region in self._regions.items():
-            o._regions[region_id] = region.copy(memo)
-
-        return o
 
     def find(self, addr: Union[int,Bits], data, max_search, **kwargs):
         # FIXME: Attempt find() on more than one region

--- a/angr/storage/memory_mixins/size_resolution_mixin.py
+++ b/angr/storage/memory_mixins/size_resolution_mixin.py
@@ -64,6 +64,17 @@ class SizeConcretizationMixin(MemoryMixin):
         self._raise_memory_limit_error = raise_memory_limit_error
         self._size_limit = size_limit
 
+    def copy(self, memo):
+        o = super().copy(memo)
+
+        o._concretize_symbolic_write_size = self._concretize_symbolic_write_size
+        o._max_concretize_count = self._max_concretize_count
+        o._max_symbolic_size = self._max_symbolic_size
+        o._raise_memory_limit_error = self._raise_memory_limit_error
+        o._size_limit = self._size_limit
+
+        return o
+
     def load(self, addr, size=None, **kwargs):
         if getattr(size, 'op', 'BVV') == 'BVV':
             return super().load(addr, size=size, **kwargs)

--- a/tests/perf_concrete_execution.py
+++ b/tests/perf_concrete_execution.py
@@ -21,7 +21,7 @@ class SkinnyEngine(angr.engines.SimEngineFailure, angr.engines.SimEngineSyscall,
 def test_tight_loop(arch):
     b = angr.Project(os.path.join(test_location, arch, "perf_tight_loops"), auto_load_libs=False)
     state = b.factory.full_init_state(plugins={'registers': angr.state_plugins.SimLightRegisters()},
-                                      remove_options={angr.sim_options.COPY_STATES})
+            )#remove_options={angr.sim_options.COPY_STATES})
     simgr = b.factory.simgr(state)
     engine = SkinnyEngine(b)
 
@@ -33,7 +33,6 @@ def test_tight_loop(arch):
 
     print("Elapsed %f sec" % elapsed)
     #print(simgr)
-    b.loader.close()
 
 
 if __name__ == "__main__":

--- a/tests/perf_concrete_execution.py
+++ b/tests/perf_concrete_execution.py
@@ -1,9 +1,9 @@
-
 # Performance tests on concrete code execution without invoking Unicorn engine
+# uses a stripped-down SimEngine to only test the essential pieces
+# TODO also use a stripped-down memory
 
 import os
 import time
-import logging
 
 import angr
 import claripy
@@ -21,10 +21,11 @@ class SkinnyEngine(angr.engines.SimEngineFailure, angr.engines.SimEngineSyscall,
 def test_tight_loop(arch):
     b = angr.Project(os.path.join(test_location, arch, "perf_tight_loops"), auto_load_libs=False)
     state = b.factory.full_init_state(plugins={'registers': angr.state_plugins.SimLightRegisters()},
-            )#remove_options={angr.sim_options.COPY_STATES})
+                                               remove_options={angr.sim_options.COPY_STATES})
     simgr = b.factory.simgr(state)
     engine = SkinnyEngine(b)
 
+    # import logging
     # logging.getLogger('angr.sim_manager').setLevel(logging.INFO)
 
     start = time.time()

--- a/tests/perf_state_copy.py
+++ b/tests/perf_state_copy.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import time
+
+import angr
+import claripy
+
+bvs = claripy.BVS('foo', 8)
+
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
+
+def cycle(state):
+    state = state.copy()
+    state.memory.store(0x400000, bvs)
+    return state
+
+def main():
+    state = angr.Project(os.path.join(test_location, 'x86_64', 'fauxware'), main_opts={'base_addr': 0x400000}, auto_load_libs=True).factory.full_init_state(add_options={angr.options.REVERSE_MEMORY_NAME_MAP})
+    for _ in range(20000):
+        state = cycle(state)
+
+if __name__ == '__main__':
+    tstart = time.time()
+    main()
+    tend = time.time()
+    print('Elapsed: %f sec' % (tend - tstart))


### PR DESCRIPTION
Today's work.

- Adds a ChainMapCOW which brings copy-on-write to the ConvenientMappingsMixin
- Makes plugins not call `__init__` during copy, since it's going to overwrite the values anyway

The former gets some pretty solid dividends - 10-50% reduction in state copy time depending on which plugins are loaded. The latter only gets marginal improvements but I consider it to be better code hygiene. I uncovered a few bugs where the copy method wasn't copying a field correctly while implementing this.