### PR TITLE
Make SimInspector.action() faster.

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -1381,25 +1381,25 @@ class JumpTableResolver(IndirectJumpResolver):
             if sort == 'mem_write':
                 bp = BP(when=BP_BEFORE, enabled=True, action=StoreHook.hook,
                         condition=lambda _s, a=block_addr, idx=stmt_idx:
-                            _s.scratch.bbl_addr == a and _s.inspect.statement == idx
+                            _s.scratch.bbl_addr == a and _s.scratch.stmt_idx == idx
                         )
                 state.inspect.add_breakpoint('mem_write', bp)
             elif sort == 'mem_read':
                 hook = LoadHook()
                 bp0 = BP(when=BP_BEFORE, enabled=True, action=hook.hook_before,
                          condition=lambda _s, a=block_addr, idx=stmt_idx:
-                            _s.scratch.bbl_addr == a and _s.inspect.statement == idx
+                            _s.scratch.bbl_addr == a and _s.scratch.stmt_idx == idx
                          )
                 state.inspect.add_breakpoint('mem_read', bp0)
                 bp1 = BP(when=BP_AFTER, enabled=True, action=hook.hook_after,
                          condition=lambda _s, a=block_addr, idx=stmt_idx:
-                            _s.scratch.bbl_addr == a and _s.inspect.statement == idx
+                            _s.scratch.bbl_addr == a and _s.scratch.stmt_idx == idx
                          )
                 state.inspect.add_breakpoint('mem_read', bp1)
             elif sort == 'reg_write':
                 bp = BP(when=BP_BEFORE, enabled=True, action=PutHook.hook,
                         condition=lambda _s, a=block_addr, idx=stmt_idx:
-                            _s.scratch.bbl_addr == a and _s.inspect.statement == idx
+                            _s.scratch.bbl_addr == a and _s.scratch.stmt_idx == idx
                         )
                 state.inspect.add_breakpoint('reg_write', bp)
             else:

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -382,7 +382,7 @@ class SimState(PluginHub):
     T = TypeVar("T")
     def _inspect_getattr(self, attr: str, default_value: T):
         if self.supports_inspect:
-            if hasattr(self.inspect, attr):
+            if self.inspect.action_attrs_set and hasattr(self.inspect, attr):
                 return getattr(self.inspect, attr)
 
         return default_value

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -281,7 +281,9 @@ class SimInspector(SimStatePlugin):
                 self.action_attrs_set = True
             if bp.check(self.state, when):
                 # l.debug("... FIRE")
+                saved_set = self.action_attrs_set
                 bp.fire(self.state)
+                self.action_attrs_set = saved_set  # restore attrs-set status in case bp triggers more bps
 
     def make_breakpoint(self, event_type, *args, **kwargs):
         """

--- a/tests/perf_concrete_execution.py
+++ b/tests/perf_concrete_execution.py
@@ -14,7 +14,19 @@ if hasattr(claripy, "set_debug"):
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
-class SkinnyEngine(angr.engines.SimEngineFailure, angr.engines.SimEngineSyscall, angr.engines.HooksMixin, angr.engines.HeavyVEXMixin):
+
+class SkinnyEngine(angr.engines.SimEngineFailure,
+                   angr.engines.SimEngineSyscall,
+                   angr.engines.HooksMixin,
+                   angr.engines.HeavyVEXMixin):
+    pass
+
+
+class InspectorEngine(angr.engines.SimEngineFailure,
+                      angr.engines.SimEngineSyscall,
+                      angr.engines.HooksMixin,
+                      angr.engines.SimInspectMixin,
+                      angr.engines.HeavyVEXMixin):
     pass
 
 
@@ -34,6 +46,21 @@ def test_tight_loop(arch):
 
     print("Elapsed %f sec" % elapsed)
     #print(simgr)
+
+
+def test_tight_loop_with_inspector(arch):
+    b = angr.Project(os.path.join(test_location, arch, "perf_tight_loops"), auto_load_libs=False)
+    state = b.factory.full_init_state(plugins={'registers': angr.state_plugins.SimLightRegisters()},
+                                               remove_options={angr.sim_options.COPY_STATES})
+    state.supports_inspect = True  # force enable inspect without adding any breakpoints
+    simgr = b.factory.simgr(state)
+    engine = InspectorEngine(b)
+
+    start = time.time()
+    simgr.explore(engine=engine)
+    elapsed = time.time() - start
+
+    print("Elapsed %f sec" % elapsed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Running `test_tight_loop_with_inspector` as the performance benchmark.

Original: 30.8 seconds.

With this PR: 25.3 seconds.

`test_tight_loop`: 21 seconds.
