### PR TITLE
Skip re-execution of certain symbolic memory writes

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -76,8 +76,8 @@ class SimEngineUnicorn(SuccessorsMixin):
 
     @staticmethod
     def __reset_countdowns(state, next_state):
-        next_state.unicorn.countdown_symbolic_stop = state.unicorn.countdown_symbolic_stop
-        next_state.unicorn.countdown_unsupported_stop = state.unicorn.countdown_unsupported_stop
+        next_state.unicorn.countdown_symbolic_stop = 0
+        next_state.unicorn.countdown_unsupported_stop = 0
         next_state.unicorn.countdown_nonunicorn_blocks = state.unicorn.countdown_nonunicorn_blocks
         next_state.unicorn.countdown_stop_point = state.unicorn.countdown_stop_point
 

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -66,7 +66,7 @@ class RegisterValue(ctypes.Structure): # register_value_t
         ('offset', ctypes.c_uint64),
         ('value', ctypes.c_uint8 * _MAX_REGISTER_BYTE_SIZE)
     ]
-class InstrDetails(ctypes.Structure): # instr_details_t
+class InstrDetails(ctypes.Structure): # sym_instr_details_t
     _fields_ = [
         ('instr_addr', ctypes.c_uint64),
         ('has_memory_dep', ctypes.c_bool),
@@ -74,7 +74,7 @@ class InstrDetails(ctypes.Structure): # instr_details_t
         ('memory_values_count', ctypes.c_uint64),
     ]
 
-class BlockDetails(ctypes.Structure): # block_details_ret_t
+class BlockDetails(ctypes.Structure): # sym_block_details_ret_t
     _fields_ = [
         ('block_addr', ctypes.c_uint64),
         ('block_size', ctypes.c_uint64),

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -664,6 +664,9 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 						// Currrent write fully overwrites the previous written symbolic value and so the symbolic write
 						// instruction need not be re-executed
 						// TODO: How to handle partial overwrite?
+						// TODO: If this block is not fully executed in unicorn before control returns to python land,
+						// the state will be inconsistent until this concrete memory write is executed. If this happens,
+						// the symbolic memory write should be removed from list of instructions to re-execute in commit.
 						instrs_to_erase_it.emplace_back(sym_instr_it);
 					}
 				}

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -409,7 +409,7 @@ mem_update_t *State::sync() {
 
 void State::set_stops(uint64_t count, address_t *stops) {
 	stop_points.clear();
-	for (int i = 0; i < count; i++) {
+	for (uint64_t i = 0; i < count; i++) {
 		stop_points.insert(stops[i]);
 	}
 }
@@ -581,7 +581,6 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 	int start = address & 0xFFF;
 	int end = (address + size - 1) & 0xFFF;
 	short clean;
-	address_t instr_addr;
 	bool is_dst_symbolic;
 
 	if (!bitmap) {
@@ -1246,7 +1245,7 @@ taint_status_result_t State::get_final_taint_status(const std::unordered_set<tai
 				try {
 					mem_read_result = mem_reads_map.at(taint_source.instr_addr);
 				}
-				catch (std::out_of_range) {
+				catch (std::out_of_range const&) {
 					assert(false && "[sim_unicorn] Taint sink depends on a read not executed yet! This should not happen!");
 				}
 				is_symbolic = mem_read_result.is_mem_read_symbolic;
@@ -1281,7 +1280,7 @@ void State::mark_register_symbolic(vex_reg_offset_t reg_offset, bool do_block_le
 			symbolic_registers.emplace(reg_offset);
 		}
 		else {
-			for (int i = 0; i < reg_size_map.at(reg_offset); i++) {
+			for (uint64_t i = 0; i < reg_size_map.at(reg_offset); i++) {
 				symbolic_registers.emplace(reg_offset + i);
 			}
 		}
@@ -1309,7 +1308,7 @@ void State::mark_register_concrete(vex_reg_offset_t reg_offset, bool do_block_le
 			symbolic_registers.erase(reg_offset);
 		}
 		else {
-			for (int i = 0; i < reg_size_map.at(reg_offset); i++) {
+			for (uint64_t i = 0; i < reg_size_map.at(reg_offset); i++) {
 				symbolic_registers.erase(reg_offset + i);
 			}
 		}
@@ -1337,14 +1336,14 @@ bool State::is_symbolic_register(vex_reg_offset_t reg_offset) const {
 	}
 	reg_offset = get_full_register_offset(reg_offset);
 	// The register is not a CPU flag and so we check every byte of the register
-	for (auto i = 0; i < reg_size_map.at(reg_offset); i++) {
+	for (uint64_t i = 0; i < reg_size_map.at(reg_offset); i++) {
 		// If any of the register's bytes are symbolic, we deem the register to be symbolic
 		if (block_symbolic_registers.count(reg_offset + i) > 0) {
 			return true;
 		}
 	}
 	bool is_concrete = true;
-	for (auto i = 0; i < reg_size_map.at(reg_offset); i++) {
+	for (uint64_t i = 0; i < reg_size_map.at(reg_offset); i++) {
 		if (block_concrete_registers.count(reg_offset) == 0) {
 			is_concrete = false;
 			break;
@@ -1356,7 +1355,7 @@ bool State::is_symbolic_register(vex_reg_offset_t reg_offset) const {
 	}
 	// If we reach here, it means that the register is not marked symbolic or concrete in the block
 	// level taint status tracker. We check the state's symbolic register list.
-	for (auto i = 0; i < reg_size_map.at(reg_offset); i++) {
+	for (uint64_t i = 0; i < reg_size_map.at(reg_offset); i++) {
 		if (symbolic_registers.count(reg_offset + i) > 0) {
 			return true;
 		}
@@ -1775,7 +1774,7 @@ bool State::check_symbolic_stack_mem_dependencies_liveness() const {
 
 address_t State::get_instruction_pointer() const {
 	address_t out = 0;
-	unsigned int reg = arch_pc_reg();
+	int reg = arch_pc_reg();
 	if (reg == -1) {
 		out = 0;
 	} else {
@@ -1787,7 +1786,7 @@ address_t State::get_instruction_pointer() const {
 
 address_t State::get_stack_pointer() const {
 	address_t out = 0;
-	unsigned int reg = arch_sp_reg();
+	int reg = arch_sp_reg();
 	if (reg == -1) {
 		out = 0;
 	} else {
@@ -2118,7 +2117,7 @@ extern "C"
 void simunicorn_symbolic_register_data(State *state, uint64_t count, uint64_t *offsets)
 {
 	state->symbolic_registers.clear();
-	for (int i = 0; i < count; i++)
+	for (uint64_t i = 0; i < count; i++)
 	{
 		state->symbolic_registers.insert(offsets[i]);
 	}
@@ -2225,7 +2224,7 @@ void simunicorn_set_map_callback(State *state, uc_cb_eventmem_t cb) {
 extern "C"
 void simunicorn_set_artificial_registers(State *state, uint64_t *offsets, uint64_t count) {
 	state->artificial_vex_registers.clear();
-	for (int i = 0; i < count; i++) {
+	for (uint64_t i = 0; i < count; i++) {
 		state->artificial_vex_registers.emplace(offsets[i]);
 	}
 	return;
@@ -2235,7 +2234,7 @@ void simunicorn_set_artificial_registers(State *state, uint64_t *offsets, uint64
 extern "C"
 void simunicorn_set_vex_offset_to_register_size_mapping(State *state, uint64_t *vex_offsets, uint64_t *reg_sizes, uint64_t count) {
 	state->reg_size_map.clear();
-	for (int i = 0; i < count; i++) {
+	for (uint64_t i = 0; i < count; i++) {
 		state->reg_size_map.emplace(vex_offsets[i], reg_sizes[i]);
 	}
 	return;
@@ -2245,7 +2244,7 @@ void simunicorn_set_vex_offset_to_register_size_mapping(State *state, uint64_t *
 extern "C"
 void simunicorn_set_vex_to_unicorn_reg_mappings(State *state, uint64_t *vex_offsets, uint64_t *unicorn_ids, uint64_t count) {
 	state->vex_to_unicorn_map.clear();
-	for (int i = 0; i < count; i++) {
+	for (uint64_t i = 0; i < count; i++) {
 		state->vex_to_unicorn_map.emplace(vex_offsets[i], unicorn_ids[i]);
 	}
 	return;
@@ -2255,7 +2254,7 @@ void simunicorn_set_vex_to_unicorn_reg_mappings(State *state, uint64_t *vex_offs
 extern "C"
 void simunicorn_set_vex_sub_reg_to_reg_mappings(State *state, uint64_t *vex_sub_reg_offsets, uint64_t *vex_reg_offsets, uint64_t count) {
 	state->vex_sub_reg_map.clear();
-	for (int i = 0; i < count; i++) {
+	for (uint64_t i = 0; i < count; i++) {
 		state->vex_sub_reg_map.emplace(vex_sub_reg_offsets[i], vex_reg_offsets[i]);
 	}
 	return;
@@ -2265,7 +2264,7 @@ void simunicorn_set_vex_sub_reg_to_reg_mappings(State *state, uint64_t *vex_sub_
 extern "C"
 void simunicorn_set_cpu_flags_details(State *state, uint64_t *flag_vex_id, uint64_t *bitmasks, uint64_t count) {
 	state->cpu_flags.clear();
-	for (int i = 0; i < count; i++) {
+	for (uint64_t i = 0; i < count; i++) {
 		state->cpu_flags.emplace(flag_vex_id[i], bitmasks[i]);
 	}
 	return;
@@ -2281,7 +2280,7 @@ void simunicorn_set_unicorn_flags_register_id(State *state, int64_t reg_id) {
 extern "C"
 void simunicorn_set_register_blacklist(State *state, uint64_t *reg_list, uint64_t count) {
 	state->blacklisted_registers.clear();
-	for (int i = 0; i < count; i++) {
+	for (uint64_t i = 0; i < count; i++) {
 		state->blacklisted_registers.emplace(reg_list[i]);
 	}
 	return;
@@ -2296,7 +2295,7 @@ uint64_t simunicorn_get_count_of_blocks_with_symbolic_instrs(State *state) {
 
 extern "C"
 void simunicorn_get_details_of_blocks_with_symbolic_instrs(State *state, sym_block_details_ret_t *ret_block_details) {
-	for (auto i = 0; i < state->block_details_to_return.size(); i++) {
+	for (size_t i = 0; i < state->block_details_to_return.size(); i++) {
 		ret_block_details[i].block_addr = state->block_details_to_return[i].block_addr;
 		ret_block_details[i].block_size = state->block_details_to_return[i].block_size;
 		ret_block_details[i].symbolic_instrs = &(state->block_details_to_return[i].symbolic_instrs[0]);

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -130,6 +130,24 @@ struct mem_read_result_t {
 struct register_value_t {
 	uint64_t offset;
 	uint8_t value[MAX_REGISTER_BYTE_SIZE];
+
+	bool operator==(const register_value_t &reg_value) const {
+		if (offset != reg_value.offset) {
+			return false;
+		}
+		return (memcmp(value, reg_value.value, MAX_REGISTER_BYTE_SIZE) == 0);
+	}
+
+	std::size_t operator()(const register_value_t &reg_value) const {
+		return std::hash<uint64_t>()(reg_value.offset);
+	}
+};
+
+template <>
+struct std::hash<register_value_t> {
+	std::size_t operator()(const register_value_t &value) const {
+		return value.operator()(value);
+	}
 };
 
 struct instr_details_t {
@@ -138,17 +156,21 @@ struct instr_details_t {
 	bool has_symbolic_memory_dep;
 	memory_value_t *memory_values;
 	uint64_t memory_values_count;
+	std::vector<instr_details_t> instr_deps;
+	std::unordered_set<register_value_t> reg_deps;
+
+	instr_details_t() {
+		has_concrete_memory_dep = false;
+		has_symbolic_memory_dep = false;
+		instr_deps.clear();
+		reg_deps.clear();
+	}
 
 	bool operator==(const instr_details_t &other_instr) const {
 		if ((instr_addr != other_instr.instr_addr) || (has_concrete_memory_dep != other_instr.has_concrete_memory_dep) ||
-			(has_symbolic_memory_dep != other_instr.has_symbolic_memory_dep) ||
-			(memory_values_count != other_instr.memory_values_count)) {
+			(has_symbolic_memory_dep != other_instr.has_symbolic_memory_dep) || (instr_deps != other_instr.instr_deps) ||
+			(reg_deps != other_instr.reg_deps)) {
 				return false;
-		}
-		for (uint64_t counter = 0; counter < memory_values_count; counter++) {
-			if (!(memory_values[counter] == other_instr.memory_values[counter])) {
-				return false;
-			}
 		}
 		return true;
 	}
@@ -162,14 +184,52 @@ struct block_details_t {
 	address_t block_addr;
 	uint64_t block_size;
 	std::vector<instr_details_t> symbolic_instrs;
-	std::vector<register_value_t> register_values;
 	std::vector<std::pair<address_t, uint64_t>> symbolic_mem_deps;
 	bool vex_lift_failed;
 
 	void reset() {
 		block_addr = 0;
 		block_size = 0;
+		symbolic_instrs.clear();
+		symbolic_mem_deps.clear();
 		vex_lift_failed = false;
+	}
+};
+
+// sym_block_details_t and sym_instr_details_t are used to store data, references to which are returned to state plugin
+struct sym_instr_details_t {
+	address_t instr_addr;
+	bool has_memory_dep;
+	memory_value_t *memory_values;
+	uint64_t memory_values_count;
+
+	bool operator==(const sym_instr_details_t &other_instr) const {
+		if ((instr_addr != other_instr.instr_addr) || (has_memory_dep != other_instr.has_memory_dep) ||
+			(memory_values_count != other_instr.memory_values_count)) {
+				return false;
+		}
+		for (uint64_t counter = 0; counter < memory_values_count; counter++) {
+			if (!(memory_values[counter] == other_instr.memory_values[counter])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool operator<(const sym_instr_details_t &other_instr) const {
+		return (instr_addr < other_instr.instr_addr);
+	}
+};
+
+struct sym_block_details_t {
+	address_t block_addr;
+	uint64_t block_size;
+	std::vector<sym_instr_details_t> symbolic_instrs;
+	std::vector<register_value_t> register_values;
+
+	void reset() {
+		block_addr = 0;
+		block_size = 0;
 		symbolic_instrs.clear();
 		register_values.clear();
 	}
@@ -177,10 +237,10 @@ struct block_details_t {
 
 // This struct is used only to return data to the state plugin since ctypes doesn't natively handle
 // C++ STL containers
-struct block_details_ret_t {
+struct sym_block_details_ret_t {
 	uint64_t block_addr;
     uint64_t block_size;
-    instr_details_t *symbolic_instrs;
+    sym_instr_details_t *symbolic_instrs;
     uint64_t symbolic_instrs_count;
     register_value_t *register_values;
     uint64_t register_values_count;
@@ -374,9 +434,6 @@ class State {
 	// separately for easy rollback in case of errors.
 	block_details_t block_details;
 
-	// List of registers which are concrete dependencies of a block's instructions executed symbolically
-	std::unordered_set<vex_reg_offset_t> block_concrete_dependencies;
-
 	// List of register values at start of block
 	std::unordered_map<vex_reg_offset_t, register_value_t> block_start_reg_values;
 
@@ -385,6 +442,9 @@ class State {
 	// a symbolic address
 	RegisterSet block_symbolic_registers, block_concrete_registers;
 	TempSet block_symbolic_temps;
+
+	// List of instructions that should be executed symbolically
+	std::vector<block_details_t> blocks_with_symbolic_instrs;
 
 	// the latter part of the pair is a pointer to the page data if the page is direct-mapped, otherwise NULL
 	std::map<address_t, std::pair<taint_t *, uint8_t *>> active_pages;
@@ -412,6 +472,8 @@ class State {
 	void compute_slice_of_instrs(address_t instr_addr, const instruction_taint_entry_t &instr_taint_entry);
 	instr_details_t compute_instr_details(address_t instr_addr, const instruction_taint_entry_t &instr_taint_entry);
 	void get_register_value(uint64_t vex_reg_offset, uint8_t *out_reg_value) const;
+	// Return list of all dependent instructions including dependencies of those dependent instructions
+	std::set<instr_details_t> get_list_of_dep_instrs(const instr_details_t &instr) const;
 
 	// Returns a pair (taint sources, list of taint entities in ITE condition expression)
 	processed_vex_expr_t process_vex_expr(IRExpr *expr, address_t instr_addr, bool is_exit_stmt);
@@ -439,6 +501,10 @@ class State {
 	void propagate_taints();
 	void propagate_taint_of_one_instr(address_t instr_addr, const instruction_taint_entry_t &instr_taint_entry);
 
+	// Save values of concrete memory reads performed by an instruction and it's dependencies
+	void save_concrete_memory_deps(instr_details_t &instr);
+	// Find address and size of all symbolic memory reads performed by an instruction and it's dependencies
+	std::vector<std::pair<address_t, uint64_t>> find_symbolic_mem_deps(instr_details_t &instr) const;
 	void update_register_slice(address_t instr_addr, const instruction_taint_entry_t &curr_instr_taint_entry);
 
 	// Inline functions
@@ -572,8 +638,8 @@ class State {
 		// Result of all memory reads executed. Instruction address -> memory read result
 		std::unordered_map<address_t, mem_read_result_t> mem_reads_map;
 
-		// List of instructions that should be executed symbolically
-		std::vector<block_details_t> blocks_with_symbolic_instrs;
+		// List of instructions that should be executed symbolically; used to store data to return
+		std::vector<sym_block_details_t> block_details_to_return;
 
 		bool track_bbls;
 		bool track_stack;

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -548,7 +548,7 @@ class State {
 		}
 	}
 
-	inline unsigned int arch_pc_reg() const {
+	inline int arch_pc_reg() const {
 		switch (arch) {
 			case UC_ARCH_X86:
 				return mode == UC_MODE_64 ? UC_X86_REG_RIP : UC_X86_REG_EIP;
@@ -563,7 +563,7 @@ class State {
 		}
 	}
 
-	inline unsigned int arch_sp_reg() const {
+	inline int arch_sp_reg() const {
 		switch (arch) {
 			case UC_ARCH_X86:
 				return mode == UC_MODE_64 ? UC_X86_REG_RSP : UC_X86_REG_ESP;
@@ -598,7 +598,7 @@ class State {
 		// register to determine if we are executing in ARM or THUMB mode.
 		uint32_t cpsr_reg_val;
 		uc_reg_read(uc, UC_ARM_REG_CPSR, &cpsr_reg_val);
-		return (cpsr_reg_val & 32 == 0);
+		return ((cpsr_reg_val & 32) == 0);
 	}
 
 	public:

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -158,12 +158,14 @@ struct instr_details_t {
 	uint64_t memory_values_count;
 	std::vector<instr_details_t> instr_deps;
 	std::unordered_set<register_value_t> reg_deps;
+	std::vector<std::pair<address_t, uint64_t>> symbolic_mem_deps;
 
 	instr_details_t() {
 		has_concrete_memory_dep = false;
 		has_symbolic_memory_dep = false;
 		instr_deps.clear();
 		reg_deps.clear();
+		symbolic_mem_deps.clear();
 	}
 
 	bool operator==(const instr_details_t &other_instr) const {
@@ -184,14 +186,12 @@ struct block_details_t {
 	address_t block_addr;
 	uint64_t block_size;
 	std::vector<instr_details_t> symbolic_instrs;
-	std::vector<std::pair<address_t, uint64_t>> symbolic_mem_deps;
 	bool vex_lift_failed;
 
 	void reset() {
 		block_addr = 0;
 		block_size = 0;
 		symbolic_instrs.clear();
-		symbolic_mem_deps.clear();
 		vex_lift_failed = false;
 	}
 };

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -602,7 +602,7 @@ class State {
 		// register to determine if we are executing in ARM or THUMB mode.
 		uint32_t cpsr_reg_val;
 		uc_reg_read(uc, UC_ARM_REG_CPSR, &cpsr_reg_val);
-		return ((cpsr_reg_val & 32) == 0);
+		return ((cpsr_reg_val & 32) == 1);
 	}
 
 	public:

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -152,6 +152,8 @@ struct std::hash<register_value_t> {
 
 struct instr_details_t {
 	address_t instr_addr;
+	int64_t mem_write_addr;
+	int64_t mem_write_size;
 	bool has_concrete_memory_dep;
 	bool has_symbolic_memory_dep;
 	memory_value_t *memory_values;
@@ -164,6 +166,8 @@ struct instr_details_t {
 		has_concrete_memory_dep = false;
 		has_symbolic_memory_dep = false;
 		instr_deps.clear();
+		mem_write_addr = -1;
+		mem_write_size = -1;
 		reg_deps.clear();
 		symbolic_mem_deps.clear();
 	}

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -432,7 +432,7 @@ class State {
 	std::unordered_map<address_t, instr_slice_details_t> instr_slice_details_map;
 	// List of instructions in a block that should be executed symbolically. These are stored
 	// separately for easy rollback in case of errors.
-	block_details_t block_details;
+	block_details_t curr_block_details;
 
 	// List of register values at start of block
 	std::unordered_map<vex_reg_offset_t, register_value_t> block_start_reg_values;
@@ -744,7 +744,7 @@ class State {
 		}
 
 		inline bool is_symbolic_taint_propagation_disabled() const {
-			return (is_symbolic_tracking_disabled() || block_details.vex_lift_failed);
+			return (is_symbolic_tracking_disabled() || curr_block_details.vex_lift_failed);
 		}
 
 		inline address_t get_taint_engine_stop_mem_read_instr_addr() const {

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -182,6 +182,34 @@ def test_fauxware():
     nose.tools.assert_true('traced' in simgr.stashes)
 
 
+def test_skip_some_symbolic_memory_writes():
+    # Test symbolic memory write skipping in SimEngineUnicorn during tracing
+    # This test doesn't actually check if instruction was skipped. It checks if tracing is successful
+    binary = os.path.join(bin_location, "tests", "cgc", "CROMU_00023")
+    pov_file = os.path.join(bin_location, "tests_data", "cgc_povs", "CROMU_00023_POV_00000.xml")
+    output_initial_bytes = [b"", b"C - Change Diver Info", b"L - Log a New Dive", b"D - Download Dive Data",
+                            b"E - Edit Dives", b"P - Print Dive Logs", b"R - Remove Dives", b"S - Diver Statistics",
+                            b"X - Exit Application", b":", b"", b"Dive Log is empty", b"", b"C - Change Diver Info",
+                            b"L - Log a New Dive", b"D - Download Dive Data", b"E - Edit Dives",
+                            b"P - Print Dive Logs", b"R - Remove Dives", b"S - Diver Statistics",
+                            b"X - Exit Application", b":", b"", b"Dive Log is empty", b"", b"C - Change Diver Info",
+                            b"L - Log a New Dive", b"D - Download Dive Data", b"E - Edit Dives", b"P - Print Dive Logs",
+                            b"R - Remove Dives", b"S - Diver Statistics", b"X - Exit Application", b":",
+                            (b"Dive Site: Date: Time: Location (area/city): Max Depth in ft: Avg Depth in ft: "
+                             b"Dive Duration (mins): O2 Percentage: Pressure In (psi): Pressure Out (psi): "),
+                            b"C - Change Diver Info", b"L - Log a New Dive", b"D - Download Dive Data", b"E - Edit Dives",
+                            b"P - Print Dive Logs", b"R - Remove Dives", b"S - Diver Statistics", b"X - Exit Application", b":",
+                            (b"Dive Site: Date: Time: Location (area/city): Max Depth in ft: Avg Depth in ft: "
+                             b"Dive Duration (mins): O2 Percentage: Pressure In (psi): Pressure Out (psi): "),
+                            b"C - Change Diver Info", b"L - Log a New Dive", b"D - Download Dive Data",
+                            b"E - Edit Dives", b"P - Print Dive Logs", b"R - Remove Dives", b"S - Diver Statistics",
+                            b"X - Exit Application", b":",
+                            (b"First Name: Last Name: Street: City: State: Zip Code: Phone Number: PADI Diver Number: "
+                             b"PADI Cert Date: "),
+                            b"     Name: "]
+    trace_cgc_with_pov_file(binary, "tracer_skip_some_symbolic_memory_writes", pov_file, b'\n'.join(output_initial_bytes))
+
+
 def test_symbolic_memory_dependencies_liveness():
     # Tests for liveness of symbolic memory dependencies when re-executing symbolic instructions in SimEngineUnicorn
     # NRFIN_00036


### PR DESCRIPTION
Under some specific cases when the value of a symbolic memory write is never used before it's overwritten, it is possible to safely skip re-executing those memory writes. This PR adds support for this along with a test case for this. Also included are some unrelated code refactors and fixes for compiler warnings.