### PR TITLE
Added support for subregister tainting in native interface

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -64,7 +64,8 @@ class RegisterValue(ctypes.Structure): # register_value_t
 
     _fields_ = [
         ('offset', ctypes.c_uint64),
-        ('value', ctypes.c_uint8 * _MAX_REGISTER_BYTE_SIZE)
+        ('value', ctypes.c_uint8 * _MAX_REGISTER_BYTE_SIZE),
+        ('size', ctypes.c_int64)
     ]
 class InstrDetails(ctypes.Structure): # sym_instr_details_t
     _fields_ = [
@@ -934,13 +935,13 @@ class Unicorn(SimStatePlugin):
         def _get_register_values(register_values):
             for register_value in register_values:
                 # Convert the register value in bytes to number of appropriate size and endianness
-                reg_name, reg_size = self.state.arch.vex_reg_offset_to_name[register_value.offset]
+                reg_name = self.state.arch.register_size_names[(register_value.offset, register_value.size)]
                 if self.state.arch.register_endness == archinfo.Endness.LE:
                     reg_value = int.from_bytes(register_value.value, "little")
                 else:
                     reg_value = int.from_bytes(register_value.value, "big")
 
-                reg_value = reg_value & (pow(2, reg_size * 8) - 1)
+                reg_value = reg_value & (pow(2, register_value.size * 8) - 1)
                 yield (reg_name, reg_value)
 
         def _get_memory_values(memory_values):

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -357,7 +357,6 @@ def _load_native():
         _setup_prototype(h, 'in_cache', ctypes.c_bool, state_t, ctypes.c_uint64)
         _setup_prototype(h, 'set_map_callback', None, state_t, unicorn.unicorn.UC_HOOK_MEM_INVALID_CB)
         _setup_prototype(h, 'set_vex_to_unicorn_reg_mappings', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
-        _setup_prototype(h, 'set_vex_sub_reg_to_reg_mappings', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'set_vex_offset_to_register_size_mapping', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'set_artificial_registers', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'get_count_of_blocks_with_symbolic_instrs', ctypes.c_uint64, state_t)
@@ -1059,16 +1058,6 @@ class Unicorn(SimStatePlugin):
         vex_reg_offsets_array = (ctypes.c_uint64 * len(vex_reg_offsets))(*map(ctypes.c_uint64, vex_reg_offsets))
         unicorn_reg_ids_array = (ctypes.c_uint64 * len(unicorn_reg_ids))(*map(ctypes.c_uint64, unicorn_reg_ids))
         _UC_NATIVE.set_vex_to_unicorn_reg_mappings(self._uc_state, vex_reg_offsets_array, unicorn_reg_ids_array, len(vex_reg_offsets))
-
-        vex_reg_offsets = []
-        vex_sub_reg_offsets = []
-        for vex_sub_reg_offset, vex_reg_offset in self.state.arch.vex_sub_reg_to_reg_map.items():
-            vex_reg_offsets.append(vex_reg_offset)
-            vex_sub_reg_offsets.append(vex_sub_reg_offset)
-
-        vex_reg_offsets_array = (ctypes.c_uint64 * len(vex_reg_offsets))(*map(ctypes.c_uint64, vex_reg_offsets))
-        vex_sub_reg_offsets_array = (ctypes.c_uint64 * len(vex_sub_reg_offsets))(*map(ctypes.c_uint64, vex_sub_reg_offsets))
-        _UC_NATIVE.set_vex_sub_reg_to_reg_mappings(self._uc_state, vex_sub_reg_offsets_array, vex_reg_offsets_array, len(vex_sub_reg_offsets_array))
 
         vex_reg_offsets = []
         vex_reg_sizes = []

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1013,13 +1013,13 @@ class Unicorn(SimStatePlugin):
 
         if options.UNICORN_SYM_REGS_SUPPORT in self.state.options and \
                 options.UNICORN_AGGRESSIVE_CONCRETIZATION not in self.state.options:
-            archinfo = copy.deepcopy(self.state.arch.vex_archinfo)
-            archinfo['hwcache_info']['caches'] = 0
-            archinfo['hwcache_info'] = _VexCacheInfo(**archinfo['hwcache_info'])
+            vex_archinfo = copy.deepcopy(self.state.arch.vex_archinfo)
+            vex_archinfo['hwcache_info']['caches'] = 0
+            vex_archinfo['hwcache_info'] = _VexCacheInfo(**vex_archinfo['hwcache_info'])
             _UC_NATIVE.enable_symbolic_reg_tracking(
                 self._uc_state,
                 getattr(pyvex.pvc, self.state.arch.vex_arch),
-                _VexArchInfo(**archinfo),
+                _VexArchInfo(**vex_archinfo),
             )
 
             if self._symbolic_offsets:

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -358,7 +358,6 @@ def _load_native():
         _setup_prototype(h, 'in_cache', ctypes.c_bool, state_t, ctypes.c_uint64)
         _setup_prototype(h, 'set_map_callback', None, state_t, unicorn.unicorn.UC_HOOK_MEM_INVALID_CB)
         _setup_prototype(h, 'set_vex_to_unicorn_reg_mappings', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
-        _setup_prototype(h, 'set_vex_offset_to_register_size_mapping', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'set_artificial_registers', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'get_count_of_blocks_with_symbolic_instrs', ctypes.c_uint64, state_t)
         _setup_prototype(h, 'get_details_of_blocks_with_symbolic_instrs', None, state_t, ctypes.POINTER(BlockDetails))
@@ -1059,16 +1058,6 @@ class Unicorn(SimStatePlugin):
         vex_reg_offsets_array = (ctypes.c_uint64 * len(vex_reg_offsets))(*map(ctypes.c_uint64, vex_reg_offsets))
         unicorn_reg_ids_array = (ctypes.c_uint64 * len(unicorn_reg_ids))(*map(ctypes.c_uint64, unicorn_reg_ids))
         _UC_NATIVE.set_vex_to_unicorn_reg_mappings(self._uc_state, vex_reg_offsets_array, unicorn_reg_ids_array, len(vex_reg_offsets))
-
-        vex_reg_offsets = []
-        vex_reg_sizes = []
-        for vex_reg_offset, vex_reg_size in self.state.arch.vex_reg_to_size_map.items():
-            vex_reg_offsets.append(vex_reg_offset)
-            vex_reg_sizes.append(vex_reg_size)
-
-        vex_reg_offsets_array = (ctypes.c_uint64 * len(vex_reg_offsets))(*map(ctypes.c_uint64, vex_reg_offsets))
-        vex_reg_sizes_array = (ctypes.c_uint64 * len(vex_reg_sizes))(*map(ctypes.c_uint64, vex_reg_sizes))
-        _UC_NATIVE.set_vex_offset_to_register_size_mapping(self._uc_state, vex_reg_offsets_array, vex_reg_sizes_array, len(vex_reg_offsets_array))
 
         # Initial VEX to unicorn mappings for flag register
         if self.state.arch.unicorn_flag_register:

--- a/native/angr_native.def
+++ b/native/angr_native.def
@@ -36,6 +36,4 @@ EXPORTS
   simunicorn_set_cpu_flags_details
   simunicorn_set_register_blacklist
   simunicorn_set_unicorn_flags_register_id
-  simunicorn_set_vex_offset_to_register_size_mapping
-  simunicorn_set_vex_sub_reg_to_reg_mappings
   simunicorn_set_vex_to_unicorn_reg_mappings

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2292,16 +2292,6 @@ void simunicorn_set_vex_to_unicorn_reg_mappings(State *state, uint64_t *vex_offs
 	return;
 }
 
-// VEX sub-registers to full register mapping
-extern "C"
-void simunicorn_set_vex_sub_reg_to_reg_mappings(State *state, uint64_t *vex_sub_reg_offsets, uint64_t *vex_reg_offsets, uint64_t count) {
-	state->vex_sub_reg_map.clear();
-	for (uint64_t i = 0; i < count; i++) {
-		state->vex_sub_reg_map.emplace(vex_sub_reg_offsets[i], vex_reg_offsets[i]);
-	}
-	return;
-}
-
 // Mapping details for flags registers
 extern "C"
 void simunicorn_set_cpu_flags_details(State *state, uint64_t *flag_vex_id, uint64_t *bitmasks, uint64_t count) {

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2311,16 +2311,6 @@ void simunicorn_set_artificial_registers(State *state, uint64_t *offsets, uint64
 	return;
 }
 
-// Register sizes mapping
-extern "C"
-void simunicorn_set_vex_offset_to_register_size_mapping(State *state, uint64_t *vex_offsets, uint64_t *reg_sizes, uint64_t count) {
-	state->reg_size_map.clear();
-	for (uint64_t i = 0; i < count; i++) {
-		state->reg_size_map.emplace(vex_offsets[i], reg_sizes[i]);
-	}
-	return;
-}
-
 // VEX register offsets to unicorn register ID mappings
 extern "C"
 void simunicorn_set_vex_to_unicorn_reg_mappings(State *state, uint64_t *vex_offsets, uint64_t *unicorn_ids, uint64_t count) {

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -498,8 +498,8 @@ class State {
 	bool is_symbolic_temp(vex_tmp_id_t temp_id) const;
 	bool is_symbolic_register_or_temp(const taint_entity_t &entity) const;
 
-	void mark_register_symbolic(vex_reg_offset_t reg_offset, bool do_block_level);
-	void mark_register_concrete(vex_reg_offset_t reg_offset, bool do_block_level);
+	void mark_register_symbolic(vex_reg_offset_t reg_offset);
+	void mark_register_concrete(vex_reg_offset_t reg_offset);
 	void mark_temp_symbolic(vex_tmp_id_t temp_id);
 
 	block_taint_entry_t process_vex_block(IRSB *vex_block, address_t address);

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -524,10 +524,6 @@ class State {
 	}
 
 	inline vex_reg_offset_t get_full_register_offset(vex_reg_offset_t reg_offset) const {
-		auto vex_sub_reg_mapping_entry = vex_sub_reg_map.find(reg_offset);
-		if (vex_sub_reg_mapping_entry != vex_sub_reg_map.end()) {
-			return vex_sub_reg_mapping_entry->second;
-		}
 		if (reg_size_map.find(reg_offset) != reg_size_map.end()) {
 			return reg_offset;
 		}
@@ -634,7 +630,6 @@ class State {
 		RegisterSet symbolic_registers; // tracking of symbolic registers
 		RegisterSet blacklisted_registers;  // Registers which shouldn't be saved as a concrete dependency
 		RegisterMap vex_to_unicorn_map; // Mapping of VEX offsets to unicorn registers
-		RegisterMap vex_sub_reg_map; // Mapping of VEX sub-registers to their main register
 		std::unordered_map<vex_reg_offset_t, uint64_t> reg_size_map;
 		RegisterSet artificial_vex_registers; // Artificial VEX registers
 		std::unordered_map<vex_reg_offset_t, uint64_t> cpu_flags;	// VEX register offset and bitmask for CPU flags

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -629,7 +629,6 @@ class State {
 		RegisterSet symbolic_registers; // tracking of symbolic registers
 		RegisterSet blacklisted_registers;  // Registers which shouldn't be saved as a concrete dependency
 		RegisterMap vex_to_unicorn_map; // Mapping of VEX offsets to unicorn registers
-		std::unordered_map<vex_reg_offset_t, uint64_t> reg_size_map;
 		RegisterSet artificial_vex_registers; // Artificial VEX registers
 		std::unordered_map<vex_reg_offset_t, uint64_t> cpu_flags;	// VEX register offset and bitmask for CPU flags
 		int64_t cpu_flags_register;

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -224,7 +224,7 @@ struct sym_instr_details_t {
 			(memory_values_count != other_instr.memory_values_count)) {
 				return false;
 		}
-		for (uint64_t counter = 0; counter < memory_values_count; counter++) {
+		for (auto counter = 0; counter < memory_values_count; counter++) {
 			if (!(memory_values[counter] == other_instr.memory_values[counter])) {
 				return false;
 			}

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -527,18 +527,6 @@ class State {
 		return (blacklisted_registers.count(reg_offset) > 0);
 	}
 
-	inline vex_reg_offset_t get_full_register_offset(vex_reg_offset_t reg_offset) const {
-		if (reg_size_map.find(reg_offset) != reg_size_map.end()) {
-			return reg_offset;
-		}
-		for (auto &entry: reg_size_map) {
-			if ((entry.first <= reg_offset) && (reg_offset <= entry.first + entry.second)) {
-				return entry.first;
-			}
-		}
-		return reg_offset;
-	}
-
 	inline unsigned int arch_pc_reg_vex_offset() const {
 		switch (arch) {
 			case UC_ARCH_X86:

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -494,7 +494,7 @@ class State {
 	std::set<instr_details_t> get_list_of_dep_instrs(const instr_details_t &instr) const;
 
 	// Returns a pair (taint sources, list of taint entities in ITE condition expression)
-	processed_vex_expr_t process_vex_expr(IRExpr *expr, IRSB *vex_block, address_t instr_addr, bool is_exit_stmt);
+	processed_vex_expr_t process_vex_expr(IRExpr *expr, IRTypeEnv *vex_block_tyenv, address_t instr_addr, bool is_exit_stmt);
 
 	// Determine cumulative result of taint statuses of a set of taint entities
 	// EG: This is useful to determine the taint status of a taint sink given it's taint sources
@@ -503,6 +503,8 @@ class State {
 	// A vector version of get_final_taint_status for checking mem_ref_entity_list which can't be an
 	// unordered_set
 	taint_status_result_t get_final_taint_status(const std::vector<taint_entity_t> &taint_sources) const;
+
+	int32_t get_vex_expr_result_size(IRExpr *expr, IRTypeEnv* tyenv) const;
 
 	bool is_block_exit_guard_symbolic() const;
 	bool is_block_next_target_symbolic() const;

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -210,6 +210,14 @@ def test_skip_some_symbolic_memory_writes():
     trace_cgc_with_pov_file(binary, "tracer_skip_some_symbolic_memory_writes", pov_file, b'\n'.join(output_initial_bytes))
 
 
+def test_subregister_tainting():
+    # Tests for subregister tainting: taint only bytes of subregister and not entire register
+    binary = os.path.join(bin_location, "tests", "cgc", "KPRCA_00028")
+    pov_file = os.path.join(bin_location, "tests_data", "cgc_povs", "KPRCA_00028_POV_00000.xml")
+    output_initial_bytes = b"Welcome to the SLUR REPL. Type an expression to evaluate it.\n> "
+    trace_cgc_with_pov_file(binary, "tracer_subregister_tainting", pov_file, output_initial_bytes)
+
+
 def test_symbolic_memory_dependencies_liveness():
     # Tests for liveness of symbolic memory dependencies when re-executing symbolic instructions in SimEngineUnicorn
     # NRFIN_00036


### PR DESCRIPTION
This PR implements support for correct tainting of subregisters in native interface. It also includes some linter fixes and code cleanup in native interface.