### PR TITLE
fix add_use_by_def type MemoryLocation

### DIFF
--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -289,7 +289,7 @@ class ReachingDefinitionsState:
                         self.dep_graph.add_edge(used, definition)
                         self.dep_graph.add_dependencies_for_concrete_pointers_of(
                             used,
-                            self.analysis.project.kb.cfgs['CFGFast'],
+                            self.analysis.project.kb.cfgs.get_most_accurate(),
                             self.analysis.project.loader
                         )
 

--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -175,7 +175,7 @@ class LiveDefinitions:
                 self._add_stack_use_by_def(definition, code_loc)
             elif isinstance(definition.atom.addr, HeapAddress):
                 self._add_heap_use_by_def(definition, code_loc)
-            elif isinstance(definition.atom.addr, MemoryLocation):
+            elif isinstance(definition.atom.addr, int):
                 self._add_memory_use_by_def(definition, code_loc)
             else:
                 # ignore RegisterOffset


### PR DESCRIPTION
Hi @Pamplemousse ,

I'm working with RDA currently. As creating `add_use_by_def`, I found that an `elif` statement should be changed to create a correct MemoryLocation use.
```
def add_use_by_def(self, definition: Definition, code_loc: CodeLocation) -> None:
        if isinstance(definition.atom, Register):
            self._add_register_use_by_def(definition, code_loc)
        elif isinstance(definition.atom, MemoryLocation):
            if isinstance(definition.atom.addr, SpOffset):
                self._add_stack_use_by_def(definition, code_loc)
            elif isinstance(definition.atom.addr, HeapAddress):
                self._add_heap_use_by_def(definition, code_loc)
            elif isinstance(definition.atom.addr, MemoryLocation):      // should change to isinstance(addr, int)
                self._add_memory_use_by_def(definition, code_loc) 
```

As the type of definition.atom.addr is in `[SpOffset, HeapAddress, int]`.