### PR TITLE
Do not treat unsat states as potential successors in tracer exploration technique

### DIFF
--- a/tests/test_driller_core.py
+++ b/tests/test_driller_core.py
@@ -10,7 +10,7 @@ from test_tracer import tracer_cgc
 
 def test_cgc():
     binary = os.path.join(bin_location, 'tests', 'cgc', 'sc1_0b32aa01_01')
-    simgr, tracer = tracer_cgc(binary, 'driller_core_cgc', b'AAAA', copy_states=True)
+    simgr, tracer = tracer_cgc(binary, 'driller_core_cgc', b'AAAA', copy_states=True, follow_unsat=True)
     simgr.use_technique(angr.exploration_techniques.DrillerCore(tracer._trace))
     simgr.run()
 
@@ -21,7 +21,7 @@ def test_simprocs():
     binary = os.path.join(bin_location, 'tests', 'i386', 'driller_simproc')
     memcmp = angr.SIM_PROCEDURES['libc']['memcmp']()
 
-    simgr, tracer = tracer_cgc(binary, 'driller_core_simprocs', b'A'*128, copy_states=True)
+    simgr, tracer = tracer_cgc(binary, 'driller_core_simprocs', b'A'*128, copy_states=True, follow_unsat=True)
     p = simgr._project
     p.hook(0x8048200, memcmp)
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -7,7 +7,7 @@ import angr
 
 from common import bin_location, do_trace, load_cgc_pov, slow_test
 
-def tracer_cgc(filename, test_name, stdin, copy_states=False):
+def tracer_cgc(filename, test_name, stdin, copy_states=False, follow_unsat=False):
     p = angr.Project(filename)
     p.simos.syscall_library.update(angr.SIM_LIBRARIES['cgcabi_tracer'])
 
@@ -16,7 +16,8 @@ def tracer_cgc(filename, test_name, stdin, copy_states=False):
     s.preconstrainer.preconstrain_file(stdin, s.posix.stdin, True)
 
     simgr = p.factory.simulation_manager(s, hierarchy=False, save_unconstrained=crash_mode)
-    t = angr.exploration_techniques.Tracer(trace, crash_addr=crash_addr, keep_predecessors=1, copy_states=copy_states)
+    t = angr.exploration_techniques.Tracer(trace, crash_addr=crash_addr, keep_predecessors=1, copy_states=copy_states,
+                                           follow_unsat=follow_unsat)
     simgr.use_technique(t)
     simgr.use_technique(angr.exploration_techniques.Oppologist())
 


### PR DESCRIPTION
The tracer exploration technique treats unsatisfiable states as potential successors in strict tracing mode. This can lead to incorrect states being deemed as correct successors when tracing. This PR fixes this and adds a driller specific exploration technique where unsat states should be treated as potential successors. The failing test cases are driller repo test cases, which have been fixed in [this PR](https://github.com/shellphish/driller/pull/89).