### PR TITLE
Fix taint save/restore for use in rollback

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -145,6 +145,11 @@ void State::stop(stop_t reason, bool do_commit) {
 	if ((reason == STOP_SYSCALL) || do_commit) {
 		commit();
 	}
+	else if ((reason != STOP_NORMAL) && (reason != STOP_STOPPOINT)) {
+		// Stop reason is not NORMAL, STOPPOINT or SYSCALL. Rollback.
+		// EXECNONE, ZEROPAGE, NOSTART, ZERO_DIV, NODECODE and HLT are never passed to this function.
+		rollback();
+	}
 	uc_emu_stop(uc);
 	// Prepare details of blocks with symbolic instructions to re-execute for returning to state plugin
 	for (auto &block: blocks_with_symbolic_instrs) {

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -273,31 +273,11 @@ void State::rollback() {
 		}
 		auto page = page_lookup(rit->address);
 		taint_t *bitmap = page.first;
-		uint8_t *data = page.second;
 
-		if (data == NULL) {
-			if (rit->clean) {
-				// should untaint some bits
-				address_t start = rit->address & 0xFFF;
-				int size = rit->size;
-				int clean = rit->clean;
-				for (auto i = 0; i < size; i++) {
-					if ((clean >> i) & 1) {
-						// this byte is untouched before this memory action
-						// in the rollback, we already failed to execute, so
-						// we don't care about symoblic address, just mark
-						// it's clean.
-						bitmap[start + i] = TAINT_NONE;
-					}
-				}
-			}
-		} else {
-			uint64_t start = rit->address & 0xFFF;
-			int size = rit->size;
-			int clean = rit->clean;
-			for (auto i = 0; i < size; i++) {
-				bitmap[start + i] = (clean & (1 << i)) != 0 ? TAINT_NONE : TAINT_SYMBOLIC;
-			}
+		uint64_t start = rit->address & 0xFFF;
+		int size = rit->size;
+		for (auto i = 0; i < size; i++) {
+			bitmap[start + i] = rit->previous_taint[i];
 		}
 	}
 	mem_writes.clear();
@@ -560,7 +540,7 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 
 	// From here, we are definitely only dealing with one page
 
-	mem_access_t record;
+	mem_write_t record;
 	record.address = address;
 	record.size = size;
 	uc_err err = uc_mem_read(uc, address, record.value, size);
@@ -677,6 +657,7 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 	}
 	if (data == NULL) {
 		for (auto i = start; i <= end; i++) {
+			record.previous_taint.push_back(bitmap[i]);
 			if (is_dst_symbolic) {
 				// Don't mark as TAINT_DIRTY since we don't want to sync it back to angr
 				// Also, no need to set clean: rollback will set it to TAINT_NONE which
@@ -685,13 +666,13 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 				bitmap[i] = TAINT_SYMBOLIC;
 			}
 			else if (bitmap[i] != TAINT_DIRTY) {
-				clean |= 1 << i; // this bit should not be marked as taint if we undo this action
 				bitmap[i] = TAINT_DIRTY;
 			}
 		}
 	}
 	else {
 		for (auto i = start; i <= end; i++) {
+			record.previous_taint.push_back(bitmap[i]);
 			if (is_dst_symbolic) {
 				// Don't mark as TAINT_DIRTY since we don't want to sync it back to angr
 				// Also, no need to set clean: rollback will set it to TAINT_NONE which
@@ -699,15 +680,11 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 				// due to an error encountered
 				bitmap[i] = TAINT_SYMBOLIC;
 			}
-			else if (bitmap[i] == TAINT_NONE) {
-				clean |= 1 << (i - start);
-			} else {
+			else if (bitmap[i] != TAINT_NONE) {
 				bitmap[i] = TAINT_NONE;
 			}
 		}
 	}
-
-	record.clean = clean;
 	mem_writes.push_back(record);
 }
 

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -400,13 +400,12 @@ typedef std::unordered_set<vex_reg_offset_t> RegisterSet;
 typedef std::unordered_map<vex_reg_offset_t, unicorn_reg_id_t> RegisterMap;
 typedef std::unordered_set<vex_tmp_id_t> TempSet;
 
-struct mem_access_t {
+struct mem_write_t {
 	address_t address;
 	uint8_t value[MAX_MEM_ACCESS_SIZE]; // assume size of any memory write is no more than 8
 	int size;
-	int clean; // save current page bitmap
-	bool is_symbolic;
-}; // actually it should be `mem_write_t` :)
+	std::vector<taint_t> previous_taint;
+};
 
 struct mem_update_t {
 	address_t address;
@@ -435,7 +434,7 @@ class State {
 
 	uc_context *saved_regs;
 
-	std::vector<mem_access_t> mem_writes;
+	std::vector<mem_write_t> mem_writes;
 	// List of all memory writes and their taint status
 	// Memory write instruction address -> is_symbolic
 	// TODO: Need to modify memory write taint handling for architectures that perform multiple

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -183,6 +183,22 @@ def test_fauxware():
     nose.tools.assert_true('traced' in simgr.stashes)
 
 
+def test_rollback_on_symbolic_conditional_exit():
+    # Test if state is correctly rolled back to before start of block in case block cannot be executed in unicorn engine
+    # because exit condition is symbolic
+    binary = os.path.join(bin_location, "tests", "cgc", "CROMU_00043")
+    pov_file = os.path.join(bin_location, "tests_data", "cgc_povs", "CROMU_00043_POV_00000.xml")
+    output_initial_bytes = [b"Network type: Broadcast", b"Source Address: 0x962B175B", b"Network type: Endpoint",
+                            b"Source Address: 0x321B00B0", b"Destination Address: 0xACF70019", b"Final Statistics:",
+                            b"\tTotal Packets: 6", b"\tStart Time: 0x5552C470", b"\tEnd Time: 0x54CAF0B0",
+                            b"\tLargest Packet: 0", b"\tSmallest Packet: 0", b"\tNumber of malformed packets: 0",
+                            b"\tNumber of packets shown 6", b"Option Headers:",
+                            b"This content has not been modified from the original",
+                            b"Capturing Authority: Network Provider", b"Capture Date: bKQcAXJJEqCSPmrIlRy",
+                            b"Capturing Authority: Employer\n"]
+    trace_cgc_with_pov_file(binary, "tracer_rollback_on_symbolic_conditional_exit", pov_file, b'\n'.join(output_initial_bytes))
+
+
 def test_skip_some_symbolic_memory_writes():
     # Test symbolic memory write skipping in SimEngineUnicorn during tracing
     # This test doesn't actually check if instruction was skipped. It checks if tracing is successful


### PR DESCRIPTION
Taint status of memory locations is not saved/restored correctly in case of rollbacks. This PR fixes this. Also, state needs to be rolled back to that at start of the block in case of stop reasons where the block is not executed in unicorn completely. There is one failing test case which requires the files included in [this PR to binaries repo](https://github.com/angr/binaries/pull/70)