### PR TITLE
Fix small bug in user controlled code handling in tracer

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -809,7 +809,7 @@ class Tracer(ExplorationTechnique):
         # first check: are we just executing user-controlled code?
         if not state.ip.symbolic and state.mem[state.ip].char.resolved.symbolic:
             l.debug("executing input-related code")
-            return state
+            return state, state
 
         state = state.copy()
         state.options.add(sim_options.COPY_STATES)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -253,6 +253,14 @@ def test_symbolic_memory_dependencies_liveness():
     trace_cgc_with_pov_file(binary, "tracer_symbolic_memory_dependencies_liveness", pov_file, output_initial_bytes)
 
 
+def test_user_controlled_code_execution():
+    # Test user controlled code execution where instruction pointer is concrete and code is symbolic
+    binary = os.path.join(bin_location, "tests", "cgc", "NRFIN_00034")
+    pov_file = os.path.join(bin_location, "tests_data", "cgc_povs", "NRFIN_00034_POV_00000.xml")
+    output_initial_bytes = b"\x00" * 8
+    trace_cgc_with_pov_file(binary, "tracer_user_controlled_code_execution", pov_file, output_initial_bytes)
+
+
 def run_all():
     def print_test_name(name):
         print('#' * (len(name) + 8))


### PR DESCRIPTION
Fixed a small bug in user controlled code handling in tracer and added a test case. The two failing test cases are likely unrelated to this change: one is an error in API docs and other is due to missing files needed by a test case added in a recently merged in PR(a PR on binaries repo already exists adding the files but it hasn't been approved yet).