### PR TITLE
Update p-code engine to match new pypcode API

### DIFF
--- a/angr/engines/pcode/behavior.py
+++ b/angr/engines/pcode/behavior.py
@@ -53,7 +53,7 @@ class OpBehaviorCopy(OpBehavior):
     """
     Behavior for the COPY operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.COPY, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
@@ -64,7 +64,7 @@ class OpBehaviorEqual(OpBehavior):
     """
     Behavior for the INT_EQUAL operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_EQUAL, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -75,7 +75,7 @@ class OpBehaviorNotEqual(OpBehavior):
     """
     Behavior for the INT_NOTEQUAL operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_NOTEQUAL, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -86,7 +86,7 @@ class OpBehaviorIntSless(OpBehavior):
     """
     Behavior for the INT_SLESS operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SLESS, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -97,7 +97,7 @@ class OpBehaviorIntSlessEqual(OpBehavior):
     """
     Behavior for the INT_SLESSEQUAL operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SLESSEQUAL, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -108,7 +108,7 @@ class OpBehaviorIntLess(OpBehavior):
     """
     Behavior for the INT_LESS operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_LESS, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -119,7 +119,7 @@ class OpBehaviorIntLessEqual(OpBehavior):
     """
     Behavior for the INT_LESSEQUAL operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_LESSEQUAL, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -130,7 +130,7 @@ class OpBehaviorIntZext(OpBehavior):
     """
     Behavior for the INT_ZEXT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_ZEXT, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
@@ -141,7 +141,7 @@ class OpBehaviorIntSext(OpBehavior):
     """
     Behavior for the INT_SEXT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SEXT, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
@@ -152,7 +152,7 @@ class OpBehaviorIntAdd(OpBehavior):
     """
     Behavior for the INT_ADD operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_ADD, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -163,7 +163,7 @@ class OpBehaviorIntSub(OpBehavior):
     """
     Behavior for the INT_SUB operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SUB, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -174,7 +174,7 @@ class OpBehaviorIntCarry(OpBehavior):
     """
     Behavior for the INT_CARRY operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_CARRY, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -187,7 +187,7 @@ class OpBehaviorIntScarry(OpBehavior):
     """
     Behavior for the INT_SCARRY operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SCARRY, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -209,7 +209,7 @@ class OpBehaviorIntSborrow(OpBehavior):
     """
     Behavior for the INT_SBORROW operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SBORROW, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -230,7 +230,7 @@ class OpBehaviorInt2Comp(OpBehavior):
     """
     Behavior for the INT_2COMP operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_2COMP, True)
 
     # uintb OpBehaviorInt2Comp::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -245,7 +245,7 @@ class OpBehaviorIntNegate(OpBehavior):
     """
     Behavior for the INT_NEGATE operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_NEGATE, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
@@ -256,7 +256,7 @@ class OpBehaviorIntXor(OpBehavior):
     """
     Behavior for the INT_XOR operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_XOR, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -267,7 +267,7 @@ class OpBehaviorIntAnd(OpBehavior):
     """
     Behavior for the INT_AND operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_AND, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -278,7 +278,7 @@ class OpBehaviorIntOr(OpBehavior):
     """
     Behavior for the INT_OR operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_OR, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -289,7 +289,7 @@ class OpBehaviorIntLeft(OpBehavior):
     """
     Behavior for the INT_LEFT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_LEFT, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -301,7 +301,7 @@ class OpBehaviorIntRight(OpBehavior):
     """
     Behavior for the INT_RIGHT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_RIGHT, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -313,7 +313,7 @@ class OpBehaviorIntSright(OpBehavior):
     """
     Behavior for the INT_SRIGHT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SRIGHT, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -325,7 +325,7 @@ class OpBehaviorIntMult(OpBehavior):
     """
     Behavior for the INT_MULT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_MULT, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -336,7 +336,7 @@ class OpBehaviorIntDiv(OpBehavior):
     """
     Behavior for the INT_DIV operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_DIV, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -347,7 +347,7 @@ class OpBehaviorIntSdiv(OpBehavior):
     """
     Behavior for the INT_SDIV operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SDIV, False)
 
     # uintb OpBehaviorIntSdiv::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -369,7 +369,7 @@ class OpBehaviorIntRem(OpBehavior):
     """
     Behavior for the INT_REM operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_REM, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -380,7 +380,7 @@ class OpBehaviorIntSrem(OpBehavior):
     """
     Behavior for the INT_SREM operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.INT_SREM, False)
 
     # uintb OpBehaviorIntSrem::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -402,7 +402,7 @@ class OpBehaviorBoolNegate(OpBehavior):
     """
     Behavior for the BOOL_NEGATE operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.BOOL_NEGATE, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
@@ -413,7 +413,7 @@ class OpBehaviorBoolXor(OpBehavior):
     """
     Behavior for the BOOL_XOR operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.BOOL_XOR, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -424,7 +424,7 @@ class OpBehaviorBoolAnd(OpBehavior):
     """
     Behavior for the BOOL_AND operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.BOOL_AND, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -435,7 +435,7 @@ class OpBehaviorBoolOr(OpBehavior):
     """
     Behavior for the BOOL_OR operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.BOOL_OR, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -446,7 +446,7 @@ class OpBehaviorFloatEqual(OpBehavior):
     """
     Behavior for the FLOAT_EQUAL operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_EQUAL, False)
 
     # uintb OpBehaviorFloatEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -464,7 +464,7 @@ class OpBehaviorFloatNotEqual(OpBehavior):
     """
     Behavior for the FLOAT_NOTEQUAL operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_NOTEQUAL, False)
 
     # uintb OpBehaviorFloatNotEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -482,7 +482,7 @@ class OpBehaviorFloatLess(OpBehavior):
     """
     Behavior for the FLOAT_LESS operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_LESS, False)
 
     # uintb OpBehaviorFloatLess::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -500,7 +500,7 @@ class OpBehaviorFloatLessEqual(OpBehavior):
     """
     Behavior for the FLOAT_LESSEQUAL operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_LESSEQUAL, False)
 
     # uintb OpBehaviorFloatLessEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -518,7 +518,7 @@ class OpBehaviorFloatNan(OpBehavior):
     """
     Behavior for the FLOAT_NAN operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_NAN, True)
 
     # uintb OpBehaviorFloatNan::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -536,7 +536,7 @@ class OpBehaviorFloatAdd(OpBehavior):
     """
     Behavior for the FLOAT_ADD operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_ADD, False)
 
     # uintb OpBehaviorFloatAdd::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -554,7 +554,7 @@ class OpBehaviorFloatDiv(OpBehavior):
     """
     Behavior for the FLOAT_DIV operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_DIV, False)
 
     # uintb OpBehaviorFloatDiv::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -572,7 +572,7 @@ class OpBehaviorFloatMult(OpBehavior):
     """
     Behavior for the FLOAT_MULT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_MULT, False)
 
     # uintb OpBehaviorFloatMult::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -590,7 +590,7 @@ class OpBehaviorFloatSub(OpBehavior):
     """
     Behavior for the FLOAT_SUB operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_SUB, False)
 
     # uintb OpBehaviorFloatSub::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -608,7 +608,7 @@ class OpBehaviorFloatNeg(OpBehavior):
     """
     Behavior for the FLOAT_NEG operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_NEG, True)
 
     # uintb OpBehaviorFloatNeg::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -626,7 +626,7 @@ class OpBehaviorFloatAbs(OpBehavior):
     """
     Behavior for the FLOAT_ABS operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_ABS, True)
 
     # uintb OpBehaviorFloatAbs::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -644,7 +644,7 @@ class OpBehaviorFloatSqrt(OpBehavior):
     """
     Behavior for the FLOAT_SQRT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_SQRT, True)
 
     # uintb OpBehaviorFloatSqrt::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -662,7 +662,7 @@ class OpBehaviorFloatInt2Float(OpBehavior):
     """
     Behavior for the FLOAT_INT2FLOAT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_INT2FLOAT, True)
 
     # uintb OpBehaviorFloatInt2Float::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -680,7 +680,7 @@ class OpBehaviorFloatFloat2Float(OpBehavior):
     """
     Behavior for the FLOAT_FLOAT2FLOAT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_FLOAT2FLOAT, True)
 
     # uintb OpBehaviorFloatFloat2Float::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -701,7 +701,7 @@ class OpBehaviorFloatTrunc(OpBehavior):
     """
     Behavior for the FLOAT_TRUNC operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_TRUNC, True)
 
     # uintb OpBehaviorFloatTrunc::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -719,7 +719,7 @@ class OpBehaviorFloatCeil(OpBehavior):
     """
     Behavior for the FLOAT_CEIL operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_CEIL, True)
 
     # uintb OpBehaviorFloatCeil::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -737,7 +737,7 @@ class OpBehaviorFloatFloor(OpBehavior):
     """
     Behavior for the FLOAT_FLOOR operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_FLOOR, True)
 
     # uintb OpBehaviorFloatFloor::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -755,7 +755,7 @@ class OpBehaviorFloatRound(OpBehavior):
     """
     Behavior for the FLOAT_ROUND operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.FLOAT_ROUND, True)
 
     # uintb OpBehaviorFloatRound::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
@@ -773,7 +773,7 @@ class OpBehaviorPiece(OpBehavior):
     """
     Behavior for the PIECE operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.PIECE, False)
 
     # uintb OpBehaviorPiece::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
@@ -788,7 +788,7 @@ class OpBehaviorSubpiece(OpBehavior):
     """
     Behavior for the SUBPIECE operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.SUBPIECE, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
@@ -801,7 +801,7 @@ class OpBehaviorPopcount(OpBehavior):
     """
     Behavior for the POPCOUNT operation.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(OpCode.POPCOUNT, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
@@ -815,7 +815,7 @@ class BehaviorFactory:
     """
     Returns the behavior object for a given opcode.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         self._behaviors = {}
         self._register_behaviors()
 

--- a/angr/engines/pcode/behavior.py
+++ b/angr/engines/pcode/behavior.py
@@ -1,7 +1,7 @@
 import operator
 from typing import Callable, Iterable, Tuple
 
-from pypcode import OpCode, Sleigh
+from pypcode import OpCode
 import claripy
 from claripy.ast.bv import BV
 
@@ -54,7 +54,7 @@ class OpBehaviorCopy(OpBehavior):
     Behavior for the COPY operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_COPY, True)
+        super().__init__(OpCode.COPY, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
         return in1
@@ -65,7 +65,7 @@ class OpBehaviorEqual(OpBehavior):
     Behavior for the INT_EQUAL operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_EQUAL, False)
+        super().__init__(OpCode.INT_EQUAL, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return self.generic_compare((in1, in2), operator.eq)
@@ -76,7 +76,7 @@ class OpBehaviorNotEqual(OpBehavior):
     Behavior for the INT_NOTEQUAL operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_NOTEQUAL, False)
+        super().__init__(OpCode.INT_NOTEQUAL, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return self.generic_compare((in1, in2), operator.ne)
@@ -87,7 +87,7 @@ class OpBehaviorIntSless(OpBehavior):
     Behavior for the INT_SLESS operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SLESS, False)
+        super().__init__(OpCode.INT_SLESS, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return self.generic_compare((in1, in2), claripy.SLT)
@@ -98,7 +98,7 @@ class OpBehaviorIntSlessEqual(OpBehavior):
     Behavior for the INT_SLESSEQUAL operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SLESSEQUAL, False)
+        super().__init__(OpCode.INT_SLESSEQUAL, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return self.generic_compare((in1, in2), claripy.SLE)
@@ -109,7 +109,7 @@ class OpBehaviorIntLess(OpBehavior):
     Behavior for the INT_LESS operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_LESS, False)
+        super().__init__(OpCode.INT_LESS, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return self.generic_compare((in1, in2), claripy.ULT)
@@ -120,7 +120,7 @@ class OpBehaviorIntLessEqual(OpBehavior):
     Behavior for the INT_LESSEQUAL operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_LESSEQUAL, False)
+        super().__init__(OpCode.INT_LESSEQUAL, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return self.generic_compare((in1, in2), claripy.ULE)
@@ -131,7 +131,7 @@ class OpBehaviorIntZext(OpBehavior):
     Behavior for the INT_ZEXT operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_ZEXT, True)
+        super().__init__(OpCode.INT_ZEXT, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
         return in1.zero_extend((size_out-size_in)*8)
@@ -142,7 +142,7 @@ class OpBehaviorIntSext(OpBehavior):
     Behavior for the INT_SEXT operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SEXT, True)
+        super().__init__(OpCode.INT_SEXT, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
         return in1.sign_extend((size_out-size_in)*8)
@@ -153,7 +153,7 @@ class OpBehaviorIntAdd(OpBehavior):
     Behavior for the INT_ADD operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_ADD, False)
+        super().__init__(OpCode.INT_ADD, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 + in2
@@ -164,7 +164,7 @@ class OpBehaviorIntSub(OpBehavior):
     Behavior for the INT_SUB operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SUB, False)
+        super().__init__(OpCode.INT_SUB, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 - in2
@@ -175,7 +175,7 @@ class OpBehaviorIntCarry(OpBehavior):
     Behavior for the INT_CARRY operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_CARRY, False)
+        super().__init__(OpCode.INT_CARRY, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         # origin: ccall.py pc_actions_ADD
@@ -188,7 +188,7 @@ class OpBehaviorIntScarry(OpBehavior):
     Behavior for the INT_SCARRY operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SCARRY, False)
+        super().__init__(OpCode.INT_SCARRY, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         res = in1 + in2
@@ -210,7 +210,7 @@ class OpBehaviorIntSborrow(OpBehavior):
     Behavior for the INT_SBORROW operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SBORROW, False)
+        super().__init__(OpCode.INT_SBORROW, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         res = in1 - in2
@@ -231,7 +231,7 @@ class OpBehaviorInt2Comp(OpBehavior):
     Behavior for the INT_2COMP operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_2COMP, True)
+        super().__init__(OpCode.INT_2COMP, True)
 
     # uintb OpBehaviorInt2Comp::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -246,7 +246,7 @@ class OpBehaviorIntNegate(OpBehavior):
     Behavior for the INT_NEGATE operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_NEGATE, True)
+        super().__init__(OpCode.INT_NEGATE, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
         return ~in1
@@ -257,7 +257,7 @@ class OpBehaviorIntXor(OpBehavior):
     Behavior for the INT_XOR operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_XOR, False)
+        super().__init__(OpCode.INT_XOR, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 ^ in2
@@ -268,7 +268,7 @@ class OpBehaviorIntAnd(OpBehavior):
     Behavior for the INT_AND operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_AND, False)
+        super().__init__(OpCode.INT_AND, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 & in2
@@ -279,7 +279,7 @@ class OpBehaviorIntOr(OpBehavior):
     Behavior for the INT_OR operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_OR, False)
+        super().__init__(OpCode.INT_OR, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 | in2
@@ -290,7 +290,7 @@ class OpBehaviorIntLeft(OpBehavior):
     Behavior for the INT_LEFT operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_LEFT, False)
+        super().__init__(OpCode.INT_LEFT, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         in1, in2 = make_bv_sizes_equal(in1, in2)
@@ -302,7 +302,7 @@ class OpBehaviorIntRight(OpBehavior):
     Behavior for the INT_RIGHT operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_RIGHT, False)
+        super().__init__(OpCode.INT_RIGHT, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         in1, in2 = make_bv_sizes_equal(in1, in2)
@@ -314,7 +314,7 @@ class OpBehaviorIntSright(OpBehavior):
     Behavior for the INT_SRIGHT operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SRIGHT, False)
+        super().__init__(OpCode.INT_SRIGHT, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         in1, in2 = make_bv_sizes_equal(in1, in2)
@@ -326,7 +326,7 @@ class OpBehaviorIntMult(OpBehavior):
     Behavior for the INT_MULT operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_MULT, False)
+        super().__init__(OpCode.INT_MULT, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 * in2
@@ -337,7 +337,7 @@ class OpBehaviorIntDiv(OpBehavior):
     Behavior for the INT_DIV operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_DIV, False)
+        super().__init__(OpCode.INT_DIV, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 / in2
@@ -348,7 +348,7 @@ class OpBehaviorIntSdiv(OpBehavior):
     Behavior for the INT_SDIV operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SDIV, False)
+        super().__init__(OpCode.INT_SDIV, False)
 
     # uintb OpBehaviorIntSdiv::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -370,7 +370,7 @@ class OpBehaviorIntRem(OpBehavior):
     Behavior for the INT_REM operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_REM, False)
+        super().__init__(OpCode.INT_REM, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 % in2
@@ -381,7 +381,7 @@ class OpBehaviorIntSrem(OpBehavior):
     Behavior for the INT_SREM operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_INT_SREM, False)
+        super().__init__(OpCode.INT_SREM, False)
 
     # uintb OpBehaviorIntSrem::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -403,7 +403,7 @@ class OpBehaviorBoolNegate(OpBehavior):
     Behavior for the BOOL_NEGATE operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_BOOL_NEGATE, True)
+        super().__init__(OpCode.BOOL_NEGATE, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
         return in1 ^ 1
@@ -414,7 +414,7 @@ class OpBehaviorBoolXor(OpBehavior):
     Behavior for the BOOL_XOR operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_BOOL_XOR, False)
+        super().__init__(OpCode.BOOL_XOR, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 ^ in2
@@ -425,7 +425,7 @@ class OpBehaviorBoolAnd(OpBehavior):
     Behavior for the BOOL_AND operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_BOOL_AND, False)
+        super().__init__(OpCode.BOOL_AND, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 & in2
@@ -436,7 +436,7 @@ class OpBehaviorBoolOr(OpBehavior):
     Behavior for the BOOL_OR operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_BOOL_OR, False)
+        super().__init__(OpCode.BOOL_OR, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         return in1 | in2
@@ -446,13 +446,8 @@ class OpBehaviorFloatEqual(OpBehavior):
     """
     Behavior for the FLOAT_EQUAL operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_EQUAL, False)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_EQUAL, False)
 
     # uintb OpBehaviorFloatEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -469,13 +464,8 @@ class OpBehaviorFloatNotEqual(OpBehavior):
     """
     Behavior for the FLOAT_NOTEQUAL operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_NOTEQUAL, False)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_NOTEQUAL, False)
 
     # uintb OpBehaviorFloatNotEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -492,13 +482,8 @@ class OpBehaviorFloatLess(OpBehavior):
     """
     Behavior for the FLOAT_LESS operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_LESS, False)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_LESS, False)
 
     # uintb OpBehaviorFloatLess::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -515,13 +500,8 @@ class OpBehaviorFloatLessEqual(OpBehavior):
     """
     Behavior for the FLOAT_LESSEQUAL operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_LESSEQUAL, False)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_LESSEQUAL, False)
 
     # uintb OpBehaviorFloatLessEqual::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -538,13 +518,8 @@ class OpBehaviorFloatNan(OpBehavior):
     """
     Behavior for the FLOAT_NAN operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_NAN, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_NAN, True)
 
     # uintb OpBehaviorFloatNan::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -561,13 +536,8 @@ class OpBehaviorFloatAdd(OpBehavior):
     """
     Behavior for the FLOAT_ADD operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_ADD, False)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_ADD, False)
 
     # uintb OpBehaviorFloatAdd::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -584,13 +554,8 @@ class OpBehaviorFloatDiv(OpBehavior):
     """
     Behavior for the FLOAT_DIV operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_DIV, False)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_DIV, False)
 
     # uintb OpBehaviorFloatDiv::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -607,13 +572,8 @@ class OpBehaviorFloatMult(OpBehavior):
     """
     Behavior for the FLOAT_MULT operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_MULT, False)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_MULT, False)
 
     # uintb OpBehaviorFloatMult::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -630,13 +590,8 @@ class OpBehaviorFloatSub(OpBehavior):
     """
     Behavior for the FLOAT_SUB operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_SUB, False)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_SUB, False)
 
     # uintb OpBehaviorFloatSub::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -653,13 +608,8 @@ class OpBehaviorFloatNeg(OpBehavior):
     """
     Behavior for the FLOAT_NEG operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_NEG, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_NEG, True)
 
     # uintb OpBehaviorFloatNeg::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -676,13 +626,8 @@ class OpBehaviorFloatAbs(OpBehavior):
     """
     Behavior for the FLOAT_ABS operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_ABS, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_ABS, True)
 
     # uintb OpBehaviorFloatAbs::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -699,13 +644,8 @@ class OpBehaviorFloatSqrt(OpBehavior):
     """
     Behavior for the FLOAT_SQRT operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_SQRT, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_SQRT, True)
 
     # uintb OpBehaviorFloatSqrt::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -722,13 +662,8 @@ class OpBehaviorFloatInt2Float(OpBehavior):
     """
     Behavior for the FLOAT_INT2FLOAT operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_INT2FLOAT, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_INT2FLOAT, True)
 
     # uintb OpBehaviorFloatInt2Float::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -745,13 +680,8 @@ class OpBehaviorFloatFloat2Float(OpBehavior):
     """
     Behavior for the FLOAT_FLOAT2FLOAT operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_FLOAT2FLOAT, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_FLOAT2FLOAT, True)
 
     # uintb OpBehaviorFloatFloat2Float::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -771,13 +701,8 @@ class OpBehaviorFloatTrunc(OpBehavior):
     """
     Behavior for the FLOAT_TRUNC operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_TRUNC, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_TRUNC, True)
 
     # uintb OpBehaviorFloatTrunc::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -794,13 +719,8 @@ class OpBehaviorFloatCeil(OpBehavior):
     """
     Behavior for the FLOAT_CEIL operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_CEIL, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_CEIL, True)
 
     # uintb OpBehaviorFloatCeil::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -817,13 +737,8 @@ class OpBehaviorFloatFloor(OpBehavior):
     """
     Behavior for the FLOAT_FLOOR operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_FLOOR, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_FLOOR, True)
 
     # uintb OpBehaviorFloatFloor::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -840,13 +755,8 @@ class OpBehaviorFloatRound(OpBehavior):
     """
     Behavior for the FLOAT_ROUND operation.
     """
-
-    __slots__ = ("opcode", "is_unary", "is_special", "_translate")
-    _translate: Sleigh
-
-    def __init__(self, trans: Sleigh) -> None:
-        self._translate = trans
-        super().__init__(OpCode.CPUI_FLOAT_ROUND, True)
+    def __init__(self) -> None:
+        super().__init__(OpCode.FLOAT_ROUND, True)
 
     # uintb OpBehaviorFloatRound::evaluateUnary(int4 size_out,int4 size_in,uintb in1) const
     #
@@ -864,7 +774,7 @@ class OpBehaviorPiece(OpBehavior):
     Behavior for the PIECE operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_PIECE, False)
+        super().__init__(OpCode.PIECE, False)
 
     # uintb OpBehaviorPiece::evaluateBinary(int4 size_out,int4 size_in,uintb in1,uintb in2) const
     #
@@ -879,7 +789,7 @@ class OpBehaviorSubpiece(OpBehavior):
     Behavior for the SUBPIECE operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_SUBPIECE, False)
+        super().__init__(OpCode.SUBPIECE, False)
 
     def evaluate_binary(self, size_out: int, size_in: int, in1: BV, in2: BV) -> BV:
         if in2.size() < in1.size():
@@ -892,7 +802,7 @@ class OpBehaviorPopcount(OpBehavior):
     Behavior for the POPCOUNT operation.
     """
     def __init__(self) -> None:
-        super().__init__(OpCode.CPUI_POPCOUNT, True)
+        super().__init__(OpCode.POPCOUNT, True)
 
     def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
         expr = claripy.BVV(0, size_out*8)
@@ -905,8 +815,7 @@ class BehaviorFactory:
     """
     Returns the behavior object for a given opcode.
     """
-    def __init__(self, trans: Sleigh = None) -> None:
-        self._trans = trans
+    def __init__(self) -> None:
         self._behaviors = {}
         self._register_behaviors()
 
@@ -915,75 +824,75 @@ class BehaviorFactory:
 
     def _register_behaviors(self) -> None:
         self._behaviors.update({
-            OpCode.CPUI_COPY: OpBehaviorCopy(),
-            OpCode.CPUI_LOAD: OpBehavior(OpCode.CPUI_LOAD, False, True),
-            OpCode.CPUI_STORE: OpBehavior(OpCode.CPUI_STORE, False, True),
-            OpCode.CPUI_BRANCH: OpBehavior(OpCode.CPUI_BRANCH, False, True),
-            OpCode.CPUI_CBRANCH: OpBehavior(OpCode.CPUI_CBRANCH, False, True),
-            OpCode.CPUI_BRANCHIND: OpBehavior(OpCode.CPUI_BRANCHIND, False, True),
-            OpCode.CPUI_CALL: OpBehavior(OpCode.CPUI_CALL, False, True),
-            OpCode.CPUI_CALLIND: OpBehavior(OpCode.CPUI_CALLIND, False, True),
-            OpCode.CPUI_CALLOTHER: OpBehavior(OpCode.CPUI_CALLOTHER, False, True),
-            OpCode.CPUI_RETURN: OpBehavior(OpCode.CPUI_RETURN, False, True),
-            OpCode.CPUI_MULTIEQUAL: OpBehavior(OpCode.CPUI_MULTIEQUAL, False, True),
-            OpCode.CPUI_INDIRECT: OpBehavior(OpCode.CPUI_INDIRECT, False, True),
-            OpCode.CPUI_PIECE: OpBehaviorPiece(),
-            OpCode.CPUI_SUBPIECE: OpBehaviorSubpiece(),
-            OpCode.CPUI_INT_EQUAL: OpBehaviorEqual(),
-            OpCode.CPUI_INT_NOTEQUAL: OpBehaviorNotEqual(),
-            OpCode.CPUI_INT_SLESS: OpBehaviorIntSless(),
-            OpCode.CPUI_INT_SLESSEQUAL: OpBehaviorIntSlessEqual(),
-            OpCode.CPUI_INT_LESS: OpBehaviorIntLess(),
-            OpCode.CPUI_INT_LESSEQUAL: OpBehaviorIntLessEqual(),
-            OpCode.CPUI_INT_ZEXT: OpBehaviorIntZext(),
-            OpCode.CPUI_INT_SEXT: OpBehaviorIntSext(),
-            OpCode.CPUI_INT_ADD: OpBehaviorIntAdd(),
-            OpCode.CPUI_INT_SUB: OpBehaviorIntSub(),
-            OpCode.CPUI_INT_CARRY: OpBehaviorIntCarry(),
-            OpCode.CPUI_INT_SCARRY: OpBehaviorIntScarry(),
-            OpCode.CPUI_INT_SBORROW: OpBehaviorIntSborrow(),
-            OpCode.CPUI_INT_2COMP: OpBehaviorInt2Comp(),
-            OpCode.CPUI_INT_NEGATE: OpBehaviorIntNegate(),
-            OpCode.CPUI_INT_XOR: OpBehaviorIntXor(),
-            OpCode.CPUI_INT_AND: OpBehaviorIntAnd(),
-            OpCode.CPUI_INT_OR: OpBehaviorIntOr(),
-            OpCode.CPUI_INT_LEFT: OpBehaviorIntLeft(),
-            OpCode.CPUI_INT_RIGHT: OpBehaviorIntRight(),
-            OpCode.CPUI_INT_SRIGHT: OpBehaviorIntSright(),
-            OpCode.CPUI_INT_MULT: OpBehaviorIntMult(),
-            OpCode.CPUI_INT_DIV: OpBehaviorIntDiv(),
-            OpCode.CPUI_INT_SDIV: OpBehaviorIntSdiv(),
-            OpCode.CPUI_INT_REM: OpBehaviorIntRem(),
-            OpCode.CPUI_INT_SREM: OpBehaviorIntSrem(),
-            OpCode.CPUI_BOOL_NEGATE: OpBehaviorBoolNegate(),
-            OpCode.CPUI_BOOL_XOR: OpBehaviorBoolXor(),
-            OpCode.CPUI_BOOL_AND: OpBehaviorBoolAnd(),
-            OpCode.CPUI_BOOL_OR: OpBehaviorBoolOr(),
-            OpCode.CPUI_CAST: OpBehavior(OpCode.CPUI_CAST, False, True),
-            OpCode.CPUI_PTRADD: OpBehavior(OpCode.CPUI_PTRADD, False, True),
-            OpCode.CPUI_PTRSUB: OpBehavior(OpCode.CPUI_PTRSUB, False, True),
-            OpCode.CPUI_FLOAT_EQUAL: OpBehaviorFloatEqual(self._trans),
-            OpCode.CPUI_FLOAT_NOTEQUAL: OpBehaviorFloatNotEqual(self._trans),
-            OpCode.CPUI_FLOAT_LESS: OpBehaviorFloatLess(self._trans),
-            OpCode.CPUI_FLOAT_LESSEQUAL: OpBehaviorFloatLessEqual(self._trans),
-            OpCode.CPUI_FLOAT_NAN: OpBehaviorFloatNan(self._trans),
-            OpCode.CPUI_FLOAT_ADD: OpBehaviorFloatAdd(self._trans),
-            OpCode.CPUI_FLOAT_DIV: OpBehaviorFloatDiv(self._trans),
-            OpCode.CPUI_FLOAT_MULT: OpBehaviorFloatMult(self._trans),
-            OpCode.CPUI_FLOAT_SUB: OpBehaviorFloatSub(self._trans),
-            OpCode.CPUI_FLOAT_NEG: OpBehaviorFloatNeg(self._trans),
-            OpCode.CPUI_FLOAT_ABS: OpBehaviorFloatAbs(self._trans),
-            OpCode.CPUI_FLOAT_SQRT: OpBehaviorFloatSqrt(self._trans),
-            OpCode.CPUI_FLOAT_INT2FLOAT: OpBehaviorFloatInt2Float(self._trans),
-            OpCode.CPUI_FLOAT_FLOAT2FLOAT: OpBehaviorFloatFloat2Float(self._trans),
-            OpCode.CPUI_FLOAT_TRUNC: OpBehaviorFloatTrunc(self._trans),
-            OpCode.CPUI_FLOAT_CEIL: OpBehaviorFloatCeil(self._trans),
-            OpCode.CPUI_FLOAT_FLOOR: OpBehaviorFloatFloor(self._trans),
-            OpCode.CPUI_FLOAT_ROUND: OpBehaviorFloatRound(self._trans),
-            OpCode.CPUI_SEGMENTOP: OpBehavior(OpCode.CPUI_SEGMENTOP, False, True),
-            OpCode.CPUI_CPOOLREF: OpBehavior(OpCode.CPUI_CPOOLREF, False, True),
-            OpCode.CPUI_NEW: OpBehavior(OpCode.CPUI_NEW, False, True),
-            OpCode.CPUI_INSERT: OpBehavior(OpCode.CPUI_INSERT, False, True),
-            OpCode.CPUI_EXTRACT: OpBehavior(OpCode.CPUI_EXTRACT, False, True),
-            OpCode.CPUI_POPCOUNT: OpBehaviorPopcount(),
+            OpCode.COPY              : OpBehaviorCopy(),
+            OpCode.LOAD              : OpBehavior(OpCode.LOAD, False, True),
+            OpCode.STORE             : OpBehavior(OpCode.STORE, False, True),
+            OpCode.BRANCH            : OpBehavior(OpCode.BRANCH, False, True),
+            OpCode.CBRANCH           : OpBehavior(OpCode.CBRANCH, False, True),
+            OpCode.BRANCHIND         : OpBehavior(OpCode.BRANCHIND, False, True),
+            OpCode.CALL              : OpBehavior(OpCode.CALL, False, True),
+            OpCode.CALLIND           : OpBehavior(OpCode.CALLIND, False, True),
+            OpCode.CALLOTHER         : OpBehavior(OpCode.CALLOTHER, False, True),
+            OpCode.RETURN            : OpBehavior(OpCode.RETURN, False, True),
+            OpCode.MULTIEQUAL        : OpBehavior(OpCode.MULTIEQUAL, False, True),
+            OpCode.INDIRECT          : OpBehavior(OpCode.INDIRECT, False, True),
+            OpCode.PIECE             : OpBehaviorPiece(),
+            OpCode.SUBPIECE          : OpBehaviorSubpiece(),
+            OpCode.INT_EQUAL         : OpBehaviorEqual(),
+            OpCode.INT_NOTEQUAL      : OpBehaviorNotEqual(),
+            OpCode.INT_SLESS         : OpBehaviorIntSless(),
+            OpCode.INT_SLESSEQUAL    : OpBehaviorIntSlessEqual(),
+            OpCode.INT_LESS          : OpBehaviorIntLess(),
+            OpCode.INT_LESSEQUAL     : OpBehaviorIntLessEqual(),
+            OpCode.INT_ZEXT          : OpBehaviorIntZext(),
+            OpCode.INT_SEXT          : OpBehaviorIntSext(),
+            OpCode.INT_ADD           : OpBehaviorIntAdd(),
+            OpCode.INT_SUB           : OpBehaviorIntSub(),
+            OpCode.INT_CARRY         : OpBehaviorIntCarry(),
+            OpCode.INT_SCARRY        : OpBehaviorIntScarry(),
+            OpCode.INT_SBORROW       : OpBehaviorIntSborrow(),
+            OpCode.INT_2COMP         : OpBehaviorInt2Comp(),
+            OpCode.INT_NEGATE        : OpBehaviorIntNegate(),
+            OpCode.INT_XOR           : OpBehaviorIntXor(),
+            OpCode.INT_AND           : OpBehaviorIntAnd(),
+            OpCode.INT_OR            : OpBehaviorIntOr(),
+            OpCode.INT_LEFT          : OpBehaviorIntLeft(),
+            OpCode.INT_RIGHT         : OpBehaviorIntRight(),
+            OpCode.INT_SRIGHT        : OpBehaviorIntSright(),
+            OpCode.INT_MULT          : OpBehaviorIntMult(),
+            OpCode.INT_DIV           : OpBehaviorIntDiv(),
+            OpCode.INT_SDIV          : OpBehaviorIntSdiv(),
+            OpCode.INT_REM           : OpBehaviorIntRem(),
+            OpCode.INT_SREM          : OpBehaviorIntSrem(),
+            OpCode.BOOL_NEGATE       : OpBehaviorBoolNegate(),
+            OpCode.BOOL_XOR          : OpBehaviorBoolXor(),
+            OpCode.BOOL_AND          : OpBehaviorBoolAnd(),
+            OpCode.BOOL_OR           : OpBehaviorBoolOr(),
+            OpCode.CAST              : OpBehavior(OpCode.CAST, False, True),
+            OpCode.PTRADD            : OpBehavior(OpCode.PTRADD, False, True),
+            OpCode.PTRSUB            : OpBehavior(OpCode.PTRSUB, False, True),
+            OpCode.FLOAT_EQUAL       : OpBehaviorFloatEqual(),
+            OpCode.FLOAT_NOTEQUAL    : OpBehaviorFloatNotEqual(),
+            OpCode.FLOAT_LESS        : OpBehaviorFloatLess(),
+            OpCode.FLOAT_LESSEQUAL   : OpBehaviorFloatLessEqual(),
+            OpCode.FLOAT_NAN         : OpBehaviorFloatNan(),
+            OpCode.FLOAT_ADD         : OpBehaviorFloatAdd(),
+            OpCode.FLOAT_DIV         : OpBehaviorFloatDiv(),
+            OpCode.FLOAT_MULT        : OpBehaviorFloatMult(),
+            OpCode.FLOAT_SUB         : OpBehaviorFloatSub(),
+            OpCode.FLOAT_NEG         : OpBehaviorFloatNeg(),
+            OpCode.FLOAT_ABS         : OpBehaviorFloatAbs(),
+            OpCode.FLOAT_SQRT        : OpBehaviorFloatSqrt(),
+            OpCode.FLOAT_INT2FLOAT   : OpBehaviorFloatInt2Float(),
+            OpCode.FLOAT_FLOAT2FLOAT : OpBehaviorFloatFloat2Float(),
+            OpCode.FLOAT_TRUNC       : OpBehaviorFloatTrunc(),
+            OpCode.FLOAT_CEIL        : OpBehaviorFloatCeil(),
+            OpCode.FLOAT_FLOOR       : OpBehaviorFloatFloor(),
+            OpCode.FLOAT_ROUND       : OpBehaviorFloatRound(),
+            OpCode.SEGMENTOP         : OpBehavior(OpCode.SEGMENTOP, False, True),
+            OpCode.CPOOLREF          : OpBehavior(OpCode.CPOOLREF, False, True),
+            OpCode.NEW               : OpBehavior(OpCode.NEW, False, True),
+            OpCode.INSERT            : OpBehavior(OpCode.INSERT, False, True),
+            OpCode.EXTRACT           : OpBehavior(OpCode.EXTRACT, False, True),
+            OpCode.POPCOUNT          : OpBehaviorPopcount(),
             })

--- a/angr/engines/pcode/emulate.py
+++ b/angr/engines/pcode/emulate.py
@@ -1,25 +1,24 @@
 import logging
 from typing import Union
 
-import pypcode
-from pypcode import OpCode, VarnodeData, PcodeOpRaw
+from pypcode import OpCode, Varnode, PcodeOp, Translation
 import claripy
 from claripy.ast.bv import BV
 
 from ..engine import SimEngineBase
 from ...utils.constants import DEFAULT_STATEMENT
-from .lifter import IRSB, PcodeInstruction
+from .lifter import IRSB
 from .behavior import OpBehavior
 
 l = logging.getLogger(__name__)
 
 class PcodeEmulatorMixin(SimEngineBase):
     """
-    Mixin for P-Code execution.
+    Mixin for p-code execution.
     """
 
-    _current_ins:      Union[PcodeInstruction, None]
-    _current_op:       Union[PcodeOpRaw, None]
+    _current_ins:      Union[Translation, None]
+    _current_op:       Union[PcodeOp, None]
     _current_behavior: Union[OpBehavior, None]
 
     def __init__(self, *args, **kwargs):
@@ -28,27 +27,27 @@ class PcodeEmulatorMixin(SimEngineBase):
         self._current_op = None
         self._current_behavior = None
         self._special_op_handlers = {
-            OpCode.CPUI_LOAD:       self._execute_load,
-            OpCode.CPUI_STORE:      self._execute_store,
-            OpCode.CPUI_BRANCH:     self._execute_branch,
-            OpCode.CPUI_CBRANCH:    self._execute_cbranch,
-            OpCode.CPUI_BRANCHIND:  self._execute_branchind,
-            OpCode.CPUI_CALL:       self._execute_call,
-            OpCode.CPUI_CALLIND:    self._execute_callind,
-            OpCode.CPUI_CALLOTHER:  self._execute_callother,
-            OpCode.CPUI_RETURN:     self._execute_ret,
-            OpCode.CPUI_MULTIEQUAL: self._execute_multiequal,
-            OpCode.CPUI_INDIRECT:   self._execute_indirect,
-            OpCode.CPUI_SEGMENTOP:  self._execute_segment_op,
-            OpCode.CPUI_CPOOLREF:   self._execute_cpool_ref,
-            OpCode.CPUI_NEW:        self._execute_new,
+            OpCode.LOAD:       self._execute_load,
+            OpCode.STORE:      self._execute_store,
+            OpCode.BRANCH:     self._execute_branch,
+            OpCode.CBRANCH:    self._execute_cbranch,
+            OpCode.BRANCHIND:  self._execute_branchind,
+            OpCode.CALL:       self._execute_call,
+            OpCode.CALLIND:    self._execute_callind,
+            OpCode.CALLOTHER:  self._execute_callother,
+            OpCode.RETURN:     self._execute_ret,
+            OpCode.MULTIEQUAL: self._execute_multiequal,
+            OpCode.INDIRECT:   self._execute_indirect,
+            OpCode.SEGMENTOP:  self._execute_segment_op,
+            OpCode.CPOOLREF:   self._execute_cpool_ref,
+            OpCode.NEW:        self._execute_new,
         }
 
     def handle_pcode_block(self, irsb: IRSB) -> None:
         """
         Execute a single IRSB.
 
-        :param irsb: The block to be executed.
+        :param irsb: Block to be executed.
         """
         self.irsb = irsb
         # Hack on a handler here to track whether exit has been handled or not
@@ -58,24 +57,24 @@ class PcodeEmulatorMixin(SimEngineBase):
 
         fallthru_addr = None
         for i, ins in enumerate(irsb._instructions):
-            l.debug("Executing machine instruction @ %#x (%d of %d)", ins.addr.getOffset(), i+1, len(irsb._instructions))
+            l.debug("Executing machine instruction @ %#x (%d of %d)", ins.address.offset, i+1, len(irsb._instructions))
 
             # Execute a single instruction of the emulated machine
             self._current_ins = ins
-            self.state.scratch.ins_addr = self._current_ins.addr.getOffset()
+            self.state.scratch.ins_addr = self._current_ins.address.offset
 
             # FIXME: Hacking this on here but ideally should use "scratch".
             self._pcode_tmps = {}  # FIXME: Consider alignment requirements
 
             for op in self._current_ins.ops:
                 self._current_op = op
-                self._current_behavior = irsb.behaviors.get_behavior_for_opcode(self._current_op.getOpcode())
-                l.debug("Executing p-code op: %s", self._current_ins.pp_op_str(self._current_op))
+                self._current_behavior = irsb.behaviors.get_behavior_for_opcode(self._current_op.opcode)
+                l.debug("Executing p-code op: %s", self._current_op)
                 self._execute_current_op()
 
             self._current_op = None
             self._current_behavior = None
-            fallthru_addr = ins.addr.getOffset() + ins.length
+            fallthru_addr = ins.address.offset + ins.length
 
         if not self.state.scratch.exit_handled:
             self.successors.add_successor(
@@ -100,22 +99,21 @@ class PcodeEmulatorMixin(SimEngineBase):
         else:
             self._execute_binary()
 
-    def _map_register_name(self, var_data: VarnodeData) -> int:
+    def _map_register_name(self, varnode: Varnode) -> int:
         """
         Map SLEIGH register offset to ArchInfo register offset based on name.
 
-        :param var_data: The varnode to translate.
-        :return:         The register file offset.
+        :param varnode: Varnode to translate.
+        :return:        Register file offset.
         """
         # FIXME: Will need performance optimization
         # FIXME: Should not get trans object this way. Moreover, should have a faster mapping method than going through trans
-        trans = self.irsb._instructions[0].trans
-        reg_name = trans.getRegisterName(var_data.space, var_data.offset, var_data.size)
+        reg_name = varnode.get_register_name()
         try:
             reg_offset = self.state.project.arch.get_register_offset(reg_name.lower())
             l.debug("Mapped register '%s' to offset %x", reg_name, reg_offset)
         except ValueError:
-            reg_offset = var_data.offset + 0x100000
+            reg_offset = varnode.offset + 0x100000
             l.debug("Could not map register '%s' from archinfo. Mapping to %x", reg_name, reg_offset)
         return reg_offset
 
@@ -143,63 +141,63 @@ class PcodeEmulatorMixin(SimEngineBase):
         else:
             return v_in
 
-    def _set_value(self, var_data: VarnodeData, value: BV) -> None:
+    def _set_value(self, varnode: Varnode, value: BV) -> None:
         """
         Store a value for a given varnode.
 
         This method stores to the appropriate register, or unique space,
         depending on the space indicated by the varnode.
 
-        :param var_data: The varnode to store into.
-        :param value:    The value to store.
+        :param varnode: Varnode to store into.
+        :param value:   Value to store.
         """
-        space_name = var_data.space.getName()
+        space_name = varnode.space.name
 
         # FIXME: Consider moving into behavior.py
-        value = self._adjust_value_size(var_data.size*8, value)
-        assert var_data.size*8 == value.size()
+        value = self._adjust_value_size(varnode.size*8, value)
+        assert varnode.size*8 == value.size()
 
-        l.debug("Storing %s %x %s %d", space_name, var_data.offset, value, var_data.size)
+        l.debug("Storing %s %x %s %d", space_name, varnode.offset, value, varnode.size)
         if space_name == "register":
             self.state.registers.store(
-                self._map_register_name(var_data), value, size=var_data.size
+                self._map_register_name(varnode), value, size=varnode.size
             )
 
         elif space_name == "unique":
-            self._pcode_tmps[var_data.offset] = value
+            self._pcode_tmps[varnode.offset] = value
 
         elif space_name in ("ram", "mem"):
-            l.debug("Storing %s to offset %s", value, var_data.offset)
-            self.state.memory.store(var_data.offset, value, endness=self.project.arch.memory_endness)
+            l.debug("Storing %s to offset %s", value, varnode.offset)
+            self.state.memory.store(varnode.offset, value, endness=self.project.arch.memory_endness)
 
         else:
             raise NotImplementedError()
 
-    def _get_value(self, var_data: VarnodeData) -> BV:
+    def _get_value(self, varnode: Varnode) -> BV:
         """
         Get a value for a given varnode.
 
         This method loads from the appropriate const, register, unique, or RAM
         space, depending on the space indicated by the varnode.
 
-        :param var_data: The varnode to load from.
-        :return:         The value loaded.
+        :param varnode: Varnode to load from.
+        :return:        Value loaded.
         """
-        space_name = var_data.space.getName()
-        size = var_data.size
-        l.debug("Loading %s - %x x %d", space_name, var_data.offset, size)
+        space_name = varnode.space.name
+        size = varnode.size
+        l.debug("Loading %s - %x x %d", space_name, varnode.offset, size)
         if space_name == "const":
-            return claripy.BVV(var_data.offset, size*8)
+            return claripy.BVV(varnode.offset, size*8)
         elif space_name == "register":
-            return self.state.registers.load(self._map_register_name(var_data), size=size)
+            return self.state.registers.load(self._map_register_name(varnode), size=size)
         elif space_name == "unique":
             # FIXME: Support loading data of different sizes. For now, assume
             # size of values read are same as size written.
-            assert self._pcode_tmps[var_data.offset].size() == size*8
-            return self._pcode_tmps[var_data.offset]
+            assert self._pcode_tmps[varnode.offset].size() == size*8
+            return self._pcode_tmps[varnode.offset]
         elif space_name in ("ram", "mem"):
-            val = self.state.memory.load(var_data.offset, endness=self.project.arch.memory_endness, size=size)
-            l.debug("Loaded %s from offset %s", val, var_data.offset)
+            val = self.state.memory.load(varnode.offset, endness=self.project.arch.memory_endness, size=size)
+            l.debug("Loaded %s from offset %s", val, varnode.offset)
             return val
         else:
             raise NotImplementedError()
@@ -208,36 +206,36 @@ class PcodeEmulatorMixin(SimEngineBase):
         """
         Execute the unary behavior of the current op.
         """
-        in1 = self._get_value(self._current_op.getInput(0))
+        in1 = self._get_value(self._current_op.inputs[0])
         l.debug("in1 = %s", in1)
         out = self._current_behavior.evaluate_unary(
-            self._current_op.getOutput().size, self._current_op.getInput(0).size, in1
+            self._current_op.output.size, self._current_op.inputs[0].size, in1
         )
         l.debug("out unary = %s", out)
-        self._set_value(self._current_op.getOutput(), out)
+        self._set_value(self._current_op.output, out)
 
     def _execute_binary(self) -> None:
         """
         Execute the binary behavior of the current op.
         """
-        in1 = self._get_value(self._current_op.getInput(0))
-        in2 = self._get_value(self._current_op.getInput(1))
+        in1 = self._get_value(self._current_op.inputs[0])
+        in2 = self._get_value(self._current_op.inputs[1])
         l.debug("in1 = %s", in1)
         l.debug("in2 = %s", in2)
         out = self._current_behavior.evaluate_binary(
-            self._current_op.getOutput().size, self._current_op.getInput(0).size, in1, in2
+            self._current_op.output.size, self._current_op.inputs[0].size, in1, in2
         )
         l.debug("out binary = %s", out)
-        self._set_value(self._current_op.getOutput(), out)
+        self._set_value(self._current_op.output, out)
 
     def _execute_load(self) -> None:
         """
         Execute a p-code load operation.
         """
-        spc = pypcode.Address.getSpaceFromConst(self._current_op.getInput(0).getAddr())
-        assert spc.getName() in ("ram", "mem")
-        off = self._get_value(self._current_op.getInput(1))
-        out = self._current_op.getOutput()
+        spc = self._current_op.inputs[0].get_space_from_const()
+        assert spc.name in ("ram", "mem")
+        off = self._get_value(self._current_op.inputs[1])
+        out = self._current_op.output
         res = self.state.memory.load(off, out.size, endness=self.project.arch.memory_endness)
         l.debug("Loaded %s from offset %s", res, off)
         self._set_value(out, res)
@@ -246,10 +244,10 @@ class PcodeEmulatorMixin(SimEngineBase):
         """
         Execute a p-code store operation.
         """
-        spc = pypcode.Address.getSpaceFromConst(self._current_op.getInput(0).getAddr())
-        assert spc.getName() in ("ram", "mem")
-        off = self._get_value(self._current_op.getInput(1))
-        data = self._get_value(self._current_op.getInput(2))
+        spc = self._current_op.inputs[0].get_space_from_const()
+        assert spc.name in ("ram", "mem")
+        off = self._get_value(self._current_op.inputs[1])
+        data = self._get_value(self._current_op.inputs[2])
         l.debug("Storing %s at offset %s", data, off)
         self.state.memory.store(off, data, endness=self.project.arch.memory_endness)
 
@@ -257,12 +255,12 @@ class PcodeEmulatorMixin(SimEngineBase):
         """
         Execute a p-code branch operation.
         """
-        dest_addr = self._current_op.getInput(0).getAddr()
-        if dest_addr.isConstant():
-            raise NotImplementedError("P-code relative branch not supported yet")
+        dest_addr = self._current_op.inputs[0].get_addr()
+        if dest_addr.is_constant:
+            raise NotImplementedError("p-code relative branch not supported yet")
 
         self.state.scratch.exit_handled = True
-        expr = dest_addr.getOffset()
+        expr = dest_addr.offset
         self.successors.add_successor(
             self.state,
             expr,
@@ -276,15 +274,15 @@ class PcodeEmulatorMixin(SimEngineBase):
         """
         Execute a p-code conditional branch operation.
         """
-        cond = self._get_value(self._current_op.getInput(1))
-        dest_addr = self._current_op.getInput(0).getAddr()
-        if dest_addr.isConstant():
-            raise NotImplementedError("P-code relative branch not supported yet")
+        cond = self._get_value(self._current_op.inputs[1])
+        dest_addr = self._current_op.inputs[0].get_addr()
+        if dest_addr.is_constant:
+            raise NotImplementedError("p-code relative branch not supported yet")
 
         exit_state = self.state.copy()
         self.successors.add_successor(
             exit_state,
-            dest_addr.getOffset(),
+            dest_addr.offset,
             cond != 0,
             "Ijk_Boring",
             exit_stmt_idx=DEFAULT_STATEMENT,
@@ -317,7 +315,7 @@ class PcodeEmulatorMixin(SimEngineBase):
         Execute a p-code indirect branch operation.
         """
         self.state.scratch.exit_handled = True
-        expr = self._get_value(self._current_op.getInput(0))
+        expr = self._get_value(self._current_op.inputs[0])
         self.successors.add_successor(
             self.state,
             expr,
@@ -332,7 +330,7 @@ class PcodeEmulatorMixin(SimEngineBase):
         Execute a p-code call operation.
         """
         self.state.scratch.exit_handled = True
-        expr = self._current_op.getInput(0).getAddr().getOffset()
+        expr = self._current_op.inputs[0].get_addr().offset
         self.successors.add_successor(
             self.state,
             expr,
@@ -347,7 +345,7 @@ class PcodeEmulatorMixin(SimEngineBase):
         Execute a p-code indirect call operation.
         """
         self.state.scratch.exit_handled = True
-        expr = self._get_value(self._current_op.getInput(0))
+        expr = self._get_value(self._current_op.inputs[0])
         self.successors.add_successor(
             self.state,
             expr,

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -497,7 +497,7 @@ class Lifter:
     arch: archinfo.Arch
     addr: int
 
-    def __init__(self, arch: archinfo.Arch, addr: int) -> None:
+    def __init__(self, arch: archinfo.Arch, addr: int):
         self.arch = arch
         self.addr = addr
         self.data = None
@@ -569,7 +569,7 @@ class Lifter:
 
 
 class Postprocessor:
-    def __init__(self, irsb: IRSB) -> None:
+    def __init__(self, irsb: IRSB):
         self.irsb = irsb
 
     def postprocess(self) -> None:
@@ -868,7 +868,7 @@ class PcodeBasicBlockLifter:
     context: pypcode.Context
     behaviors: BehaviorFactory
 
-    def __init__(self, arch: archinfo.Arch) -> None:
+    def __init__(self, arch: archinfo.Arch):
         archinfo_to_lang_map = {
             'X86':   'x86:LE:32:default',
             'AMD64': 'x86:LE:64:default'

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -7,8 +7,6 @@
 
 from collections import defaultdict
 import logging
-import os
-import sys
 from typing import Union, Optional, Iterable, Sequence, Tuple
 
 import archinfo
@@ -51,11 +49,13 @@ class ExitStatement:
         self.dst = dst
         self.jumpkind = jumpkind
 
+
 class PcodeDisassemblerBlock(DisassemblerBlock):
     """
     Helper class to represent a block of dissassembled target architecture
     instructions
     """
+
 
 class PcodeDisassemblerInsn(DisassemblerInsn):
     """
@@ -71,100 +71,15 @@ class PcodeDisassemblerInsn(DisassemblerInsn):
 
     @property
     def address(self) -> int:
-        return self.insn.addr.getOffset()
+        return self.insn.address.offset
 
     @property
     def mnemonic(self) -> str:
-        return self.insn.asm_mnemonic
+        return self.insn.asm_mnem
 
     @property
     def op_str(self) -> str:
-        return self.insn.asm_op_str
-
-
-class PcodeInstruction:
-    __slots__ = (
-        "addr",
-        "length",
-        "pcode",
-        "trans",
-        "asm_mnemonic",
-        "asm_op_str"
-    )
-
-    addr: pypcode.Address
-    length: int
-    pcode: pypcode.PcodeRawOutHelper
-    trans: pypcode.Sleigh
-    asm_mnemonic: str
-    asm_op_str: str
-
-    def __init__(self,
-                 addr: pypcode.Address,
-                 length: int,
-                 pcode: pypcode.PcodeRawOutHelper,
-                 trans: pypcode.Sleigh,
-                 asm: pypcode.AssemblyEmitCacher) -> None:
-        self.addr = addr
-        self.length = length
-        self.pcode = pcode
-        self.trans = trans
-        self.asm_mnemonic = asm.mnem
-        self.asm_op_str = asm.body
-
-    @property
-    def ops(self) -> pypcode.PcodeRawOutHelper:
-        return self.pcode.opcache
-
-    def pp_vardata(self, data: pypcode.VarnodeData) -> None:
-        space_name = data.space.getName()
-        if space_name == "register":
-            space_name = "reg"
-            regname = self.trans.getRegisterName(data.space, data.offset, data.size)
-            space_name += "{%s}" % regname
-        return "(%s, 0x%x, %d) " % (space_name, data.offset, data.size)
-
-    def pp(self) -> None:
-        for op in self.pcode.opcache:
-            out = op.getOutput()
-            if out:
-                sys.stdout.write("%-20s = " % (self.pp_vardata(out)))
-            else:
-                sys.stdout.write(" " * 23)
-            sys.stdout.write("%-12s " % pypcode.get_opname(op.getOpcode()))
-            for i in range(op.numInput()):
-                sys.stdout.write(self.pp_vardata(op.getInput(i)))
-            sys.stdout.write("\n")
-
-    def pp_op_str(self, op: pypcode.PcodeOpRaw) -> str:
-        s = ""
-        out = op.getOutput()
-        if out:
-            s += "%-20s = " % (self.pp_vardata(out))
-        else:
-            s += " " * 23
-        s += "%-12s " % pypcode.get_opname(op.getOpcode())
-
-        start = 0
-        if op.getOpcode() in [pypcode.OpCode.CPUI_LOAD, pypcode.OpCode.CPUI_STORE]:
-            s += "[%s] " % self.pp_space_from_constant_id(op)
-            start += 1
-
-        for i in range(start, op.numInput()):
-            s += "%-20s" % self.pp_vardata(op.getInput(i))
-
-        if op.getOpcode() == pypcode.OpCode.CPUI_CALLOTHER:
-            print(s)
-            assert False
-
-        return s
-
-    @staticmethod
-    def pp_space_from_constant_id(op: int) -> str:
-        # For these operations, input0 contains a constant id of the space which
-        # input1 is an offset into
-        assert op.getOpcode() in [pypcode.OpCode.CPUI_LOAD, pypcode.OpCode.CPUI_STORE]
-        return pypcode.Address.getSpaceFromConst(op.getInput(0).getAddr()).getName()
+        return self.insn.asm_body
 
 
 class IRSB:
@@ -206,7 +121,7 @@ class IRSB:
     _direct_next: Optional[bool]
     _exit_statements: Sequence[Tuple[int, int, ExitStatement]]
     _instruction_addresses: Sequence[int]
-    _instructions: Sequence[PcodeInstruction]
+    _instructions: Sequence[pypcode.Translation]
     _size: Optional[int]
     _statements: Iterable # Note: currently unused
     _disassembly: Optional[PcodeDisassemblerBlock]
@@ -396,7 +311,7 @@ class IRSB:
         """
         Addresses of instructions in this block.
         """
-        return [ins.addr.getOffset() for ins in self._instructions]
+        return [ins.address.offset for ins in self._instructions]
 
     @property
     def size(self) -> int:
@@ -453,10 +368,10 @@ class IRSB:
         for i, ins in enumerate(self._instructions):
             sa.append(
                 "   %02d | ------ %08x, %d ------"
-                % (i, ins.addr.getOffset(), ins.length)
+                % (i, ins.address.offset, ins.length)
             )
-            for j, op in enumerate(ins.ops):
-                sa.append("  +%02d | %s" % (j, ins.pp_op_str(op)))
+            for op in ins.ops:
+                sa.append("  +%02d | %s" % (op.seq.uniq, pypcode.PcodePrettyPrinter.fmt_op(op)))
 
         if isinstance(self.next, int):
             next_str = '%x' % self.next
@@ -488,7 +403,7 @@ class IRSB:
         jumpkind: Optional[str] = None,
         direct_next: Optional[bool] = None,
         size: Optional[int] = None,
-        instructions: Optional[Iterable[PcodeInstruction]] = None,
+        instructions: Optional[Iterable[pypcode.Translation]] = None,
         instruction_addresses: Optional[Iterable[int]] = None,
         exit_statements: Sequence[Tuple[int, int, ExitStatement]] = None,
         default_exit_target: Optional = None,
@@ -501,7 +416,7 @@ class IRSB:
         self._size = size
         self._instructions = instructions or []
         self._instruction_addresses = instruction_addresses
-        self._exit_statements = exit_statements
+        self._exit_statements = exit_statements or []
         self.default_exit_target = default_exit_target
 
     def _from_py(self, irsb: "IRSB") -> None:
@@ -950,48 +865,25 @@ def register(lifter: Lifter, arch_name: str) -> None:
 
 class PcodeBasicBlockLifter:
 
-    sleighfilename: str
-    docstorage: pypcode.DocumentStorage
-    doc: pypcode.Element
-    context: pypcode.ContextInternal
-    loader: pypcode.SimpleLoadImage
-    trans: pypcode.Sleigh
+    context: pypcode.Context
     behaviors: BehaviorFactory
-    data: Optional[bytearray]
 
     def __init__(self, arch: archinfo.Arch) -> None:
-        if arch.name == "X86":
-            sleigh_arch = "x86"
-        elif arch.name == "AMD64":
-            sleigh_arch = "x86-64"
-        else:
-            # FIXME: Add more architectures
+        archinfo_to_lang_map = {
+            'X86':   'x86:LE:32:default',
+            'AMD64': 'x86:LE:64:default'
+        }
+        if arch.name not in archinfo_to_lang_map:
             raise NotImplementedError()
 
-        self.sleighfilename = os.path.join(pypcode.SLEIGH_SPECFILES_PATH, sleigh_arch + ".sla")
-        if not os.path.exists(self.sleighfilename):
-            raise Exception("SLIEGH file not found for architecture %s" % sleigh_arch)
-        self.docstorage = pypcode.DocumentStorage()
-        self.doc = self.docstorage.openDocument(self.sleighfilename).getRoot()
-        self.docstorage.registerTag(self.doc)
-        self.context = pypcode.ContextInternal()
-        self.loader = pypcode.SimpleLoadImage(0, bytearray(b"\x00"), 1)
-        self.trans = pypcode.Sleigh(self.loader, self.context)
-        self.trans.initialize(self.docstorage)
-        self.behaviors = BehaviorFactory(self.trans)
-        self.data = None
+        langs = {l.id:l
+            for a in pypcode.Arch.enumerate()
+                for l in a.languages}
 
-        # FIXME: Load from corresponding *.pspec instead of hardcoding here
-        if arch.name == "X86":
-            self.context.setVariableDefault("addrsize", 1)  # Address size is 32-bit
-            self.context.setVariableDefault("opsize", 1)  # Operand size is 32-bit
-        elif arch.name == "AMD64":
-            self.context.setVariableDefault("addrsize", 2)  # Address size is 64-bit
-            self.context.setVariableDefault("opsize", 1)  # Operand size is 64-bit
-            self.context.setVariableDefault("bit64", 1)
-            self.context.setVariableDefault("rexprefix", 0)
-        else:
-            raise NotImplementedError()
+        lang = langs[archinfo_to_lang_map[arch.name]]
+
+        self.context = pypcode.Context(lang)
+        self.behaviors = BehaviorFactory()
 
     def lift(self,
              irsb: IRSB,
@@ -1000,111 +892,55 @@ class PcodeBasicBlockLifter:
              bytes_offset: int = 0,
              max_bytes: Optional[int] = None,
              max_inst: Optional[int] = None) -> None:
+
         if max_bytes is None or max_bytes > MAX_BYTES:
             max_bytes = min(len(data), MAX_BYTES)
         if max_inst is None or max_inst > MAX_INSTRUCTIONS:
             max_inst = MAX_INSTRUCTIONS
 
-        addr = pypcode.Address(self.trans.getDefaultSpace(), baseaddr + bytes_offset)
-        lastaddr = pypcode.Address(self.trans.getDefaultSpace(), baseaddr + max_bytes)
+        irsb.behaviors = self.behaviors # FIXME
 
-        # NOTE: It's important to retain this reference to the data or it
-        # may be garbage collected while processing!
-        self.data = bytearray(data)
-        self.loader.setData(baseaddr, self.data, len(data))
-        self.trans.reset(self.loader, self.context)
-        self.trans.initialize(self.docstorage)
-        irsb.behaviors = self.behaviors
+        # Translate
+        addr = baseaddr + bytes_offset
+        result = self.context.translate(data[bytes_offset:], addr, max_inst, max_bytes, True)
+        irsb._instructions = result.instructions
 
-        # Lift basic block to pcode
-        # FIXME: Move this to C++ eventually
-        irsb._exit_statements = []
-        end_basic_block = False
-        op_count = 0
+        # Post-process block to mark exits and next block
+        next_block = None
+        for insn in irsb._instructions:
+            for op in insn.ops:
+                if (op.opcode in [pypcode.OpCode.BRANCH, pypcode.OpCode.CBRANCH]
+                    and op.inputs[0].get_addr().is_constant):
+                        l.warning('Block contains relative p-code jump at '
+                                  'instruction %#x:%d, which is not emulated '
+                                  'yet.', op.seq.pc.offset, op.seq.uniq)
+                if op.opcode == pypcode.OpCode.CBRANCH:
+                    irsb._exit_statements.append((
+                        op.seq.pc.offset, op.seq.uniq,
+                        ExitStatement(op.inputs[0].offset, 'Ijk_Boring')))
+                elif op.opcode == pypcode.OpCode.BRANCH:
+                    next_block = (op.inputs[0].offset, 'Ijk_Boring')
+                elif op.opcode == pypcode.OpCode.BRANCHIND:
+                    next_block = (None, 'Ijk_Boring')
+                elif op.opcode == pypcode.OpCode.CALL:
+                    next_block = (op.inputs[0].offset, 'Ijk_Call')
+                elif op.opcode == pypcode.OpCode.CALLIND:
+                    next_block = (None, 'Ijk_Call')
+                elif op.opcode == pypcode.OpCode.RETURN:
+                    next_block = (None, 'Ijk_Ret')
 
-        irsb.next = addr.getOffset()
-        irsb.jumpkind = "Ijk_Boring"
+        if len(irsb._instructions) > 0:
+            last_insn = irsb._instructions[-1]
+            fallthru_addr = last_insn.address.offset + last_insn.length
+        else:
+            fallthru_addr = addr
 
-        asm = pypcode.AssemblyEmitCacher()
+        if result.error:
+            next_block = (fallthru_addr, 'Ijk_NoDecode')
+        elif next_block is None:
+            next_block = (fallthru_addr, 'Ijk_Boring')
 
-        while (not end_basic_block) and (addr < lastaddr) and (len(irsb._instructions) < max_inst):
-            has_internal_branch = False
-            has_external_branch = False
-            emit = pypcode.PcodeRawOutHelper(self.trans)
-            try:
-                self.trans.printAssembly(asm, addr)
-                length = self.trans.oneInstruction(emit, addr)
-            except: # pylint:disable=bare-except
-                # FIXME: Add nicer exception handling for failed translation
-                l.warning('Failed to decode instruction at %08x', addr.getOffset())
-                irsb.jumpkind = "Ijk_NoDecode"
-                break
-
-            if (addr+length) > lastaddr:
-                # Decoded past the acceptable limit. Stop here.
-                break
-
-            ins = PcodeInstruction(addr, length, emit, self.trans, asm)
-            irsb._instructions.append(ins)
-            irsb.next = addr.getOffset() + length
-
-            # print('P-code ops for instruction at address %x' % addr.getOffset())
-            # for op_idx, op in enumerate(ins.pcode.opcache):
-            #     print(ins.pp_op_str(op))
-
-            for op in ins.pcode.opcache:
-                opcode = op.getOpcode()
-
-                if opcode in [
-                    pypcode.OpCode.CPUI_BRANCH,
-                    pypcode.OpCode.CPUI_CBRANCH,
-                ]:
-                    if op.getInput(0).space.getIndex() == pypcode.AddrSpace.constant_space_index:
-                        has_internal_branch = True
-                        raise NotImplementedError("P-code relative branches are not supported yet")
-
-                    has_external_branch = True
-                    assert not end_basic_block
-                    end_basic_block = True
-                    if opcode == pypcode.OpCode.CPUI_CBRANCH:
-                        ins_addr = addr.getOffset()
-                        exit_stmt = op.getInput(0).getAddr().getOffset()
-                        irsb._exit_statements.append((ins_addr, op_count, ExitStatement(exit_stmt, "Ijk_Boring")))
-
-                    elif opcode == pypcode.OpCode.CPUI_BRANCH:
-                        irsb.next = op.getInput(0).getAddr().getOffset()
-                        irsb.jumpkind = "Ijk_Boring"
-
-                elif opcode == pypcode.OpCode.CPUI_BRANCHIND:
-                    assert not end_basic_block
-                    end_basic_block = True
-                    irsb.next = None
-                    irsb.jumpkind = "Ijk_Boring"
-
-                elif opcode == pypcode.OpCode.CPUI_CALL:
-                    assert not end_basic_block
-                    end_basic_block = True
-                    irsb.next = op.getInput(0).getAddr().getOffset()
-                    irsb.jumpkind = "Ijk_Call"
-
-                elif opcode == pypcode.OpCode.CPUI_CALLIND:
-                    assert not end_basic_block
-                    end_basic_block = True
-                    irsb.next = None
-                    irsb.jumpkind = "Ijk_Call"
-
-                elif opcode == pypcode.OpCode.CPUI_RETURN:
-                    assert not end_basic_block
-                    end_basic_block = True
-                    irsb.next = None
-                    irsb.jumpkind = "Ijk_Ret"
-
-                op_count += 1
-
-            addr += length
-
-            # Should be okay but want to check. Not sure if any instructions do this.
-            assert not (has_internal_branch and has_external_branch), "CHECKME"
+        irsb.next, irsb.jumpkind = next_block
 
 
 class PcodeLifter(Lifter):

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ setup(
     setup_requires=[_UNICORN, 'pyvex'],
     extras_require={
         'AngrDB': ['sqlalchemy'],
-        'pcode': ['pypcode==0.0.2'],
+        'pcode': ['pypcode==1.0.1'],
     },
     cmdclass=cmdclass,
     include_package_data=True,


### PR DESCRIPTION
* pypcode has migrated from cppyy to CFFI-based bindings, with some minor API changes to make things a little more pythonic.
* pypcode release version is now 1.0.1 on PyPI (wheels now included), and ships everything needed for translation.
* pypcode now runs on macOS/Windows platforms in addition to Linux (tested), so p-code lifter/execution engine also works on these platforms (also tested).
* An IR pretty-printer was added in pypcode to beautify IRSBs a bit.
* A couple notable changes in behavior:
  * pypcode now handles initialization of the translation context, which simplifies the lifter code a bit here. We just select an architecture "language" to create a context with and begin translating blocks.
  * Instead of calling into pypcode to translate a single instruction at a time, we now try to translate entire basic blocks at a time. 
  * Otherwise the engine is largely unchanged.
* The p-code execution engine is still noticeably slower than the VEX engine. Based on some quick profiling this appears mostly due to cost of executing CPU flag management IR. I do think there's room for improvement there, but it remains future work.
* Apart from the rudimentary smoke tests in the pypcode repo, there is also a distinct lack of test cases for the p-code engine. I will fix this with a follow-up PR as well.

ailment PR is also required for these updates: angr/ailment#60