### PR TITLE
Fix thumb mode check in native interface part 2

### DIFF
--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -586,7 +586,7 @@ class State {
 		// register to determine if we are executing in ARM or THUMB mode.
 		uint32_t cpsr_reg_val;
 		uc_reg_read(uc, UC_ARM_REG_CPSR, &cpsr_reg_val);
-		return ((cpsr_reg_val & 32) == 1);
+		return ((cpsr_reg_val & 32) != 0);
 	}
 
 	public:


### PR DESCRIPTION
The check for ARM/Thumb mode in angr native was not correctly fixed in PR #2562 and is likely the reason for bug #2604. This PR fixes the check and fixes #2604.