### PR TITLE
Fix - SimProcedure passed in syscall breakpoint

### DIFF
--- a/angr/engines/procedure.py
+++ b/angr/engines/procedure.py
@@ -42,7 +42,7 @@ class ProcedureMixin:
             state.options.discard(o.AUTO_REFS)
 
         if procedure.is_syscall:
-            state._inspect('syscall', BP_AFTER, syscall_name=procedure.display_name)
+            state._inspect('syscall', BP_AFTER, syscall_name=procedure.display_name, simprocedure=inst)
 
         successors.description = 'SimProcedure ' + procedure.display_name
         if procedure.is_syscall:


### PR DESCRIPTION
Prior to this commit simprocedure object was not passed to 'syscall' breakpoints.