### PR TITLE
implement microsoft fastcall cc

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1061,6 +1061,13 @@ class SimCCCdecl(SimCC):
 class SimCCStdcall(SimCCCdecl):
     CALLEE_CLEANUP = True
 
+class SimCCMicrosoftFastcall(SimCC):
+    ARG_REGS = ['ecx', 'edx'] # Remaining arguments are passed in stack
+    STACKARG_SP_DIFF = 4 # Return address is pushed on to stack by call
+    RETURN_VAL = SimRegArg('eax', 4)
+    RETURN_ADDR = SimStackArg(0, 4)
+    ARCH = archinfo.ArchX86
+
 class SimCCMicrosoftAMD64(SimCC):
     ARG_REGS = ['rcx', 'rdx', 'r8', 'r9']
     FP_ARG_REGS = ['xmm0', 'xmm1', 'xmm2', 'xmm3']

--- a/tests/test_cc.py
+++ b/tests/test_cc.py
@@ -9,11 +9,12 @@ def test_calling_conventions():
     # SimProcedures
     #
 
-    from angr.calling_conventions import SimCCCdecl
+    from angr.calling_conventions import SimCCCdecl, SimCCMicrosoftFastcall
 
     args = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 1000, 100000, 1000000, 2000000, 14, 15, 16 ]
     arches = [
         ('X86', SimCCCdecl),
+        ('X86', SimCCMicrosoftFastcall),
         ('AMD64', None),
         ('ARMEL', None),
         ('MIPS32', None),


### PR DESCRIPTION
## Description

Implements Microsoft's __fastcall calling convention. Since __fastcall is not completely standard across all compilers, this change only applies to Microsoft's implementation.

I used the following documents as references:
 * https://docs.microsoft.com/en-us/cpp/cpp/fastcall?view=msvc-160
 * https://en.wikipedia.org/wiki/X86_calling_conventions#Microsoft_fastcall
 * https://en.wikibooks.org/wiki/X86_Disassembly/Calling_Conventions#FASTCALL