### PR TITLE
make angr logger co-exist with other loggers

### DIFF
--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -55,7 +55,10 @@ class Loggers:
             logging.getLogger(name).setLevel(level)
 
 class CuteHandler(logging.StreamHandler):
-     def emit(self, record):
+    def emit(self, record):
+        if not record.name.startswith("angr"):
+            return
+
         color = zlib.adler32(record.name.encode()) % 7 + 31
         try:
             record.name = ("\x1b[%dm" % color) + record.name + "\x1b[0m"


### PR DESCRIPTION
currenlty, angr forcefully adds `CuteHandler` to root handler. if there are other loggers in the script, messages from the other loggers will be printed twice, which is annoying