### PR TITLE
Avoid updating recent_actions when using state.regs.ip

### DIFF
--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -157,7 +157,7 @@ class SimProcedure:
         provide arguments to the function.
         """
         # fill out all the fun stuff we don't want to frontload
-        if self.addr is None and not state.regs.ip.symbolic:
+        if self.addr is None and not state.regs._ip.symbolic:
             self.addr = state.addr
         if self.arch is None:
             self.arch = state.arch


### PR DESCRIPTION
Using `state.regs.ip` causes the actions to be updated, which should not happen in this case as the `sim_procedure` is not actually reading from rip.