### PR TITLE
Support JNI & Thread node, edge

### DIFF
--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -190,8 +190,6 @@ class CFGFastSoot(CFGFast):
                     succs = self._special_invoke_successors(stmt, addr, block)
                     if succs:
                         successors.extend(succs)
-                        has_default_exit = False
-                        break
 
                 succs = self._soot_create_invoke_successors(stmt, addr, invoke_expr)
                 if succs:
@@ -214,6 +212,10 @@ class CFGFastSoot(CFGFast):
                 expr = stmt.right_op
 
                 if isinstance(expr, SootInvokeExpr):
+                    succs = self._special_invoke_successors(stmt, addr, block)
+                    if succs:
+                        successors.extend(succs)
+
                     succs = self._soot_create_invoke_successors(stmt, addr, expr)
                     if succs:
                         successors.extend(succs)
@@ -242,7 +244,7 @@ class CFGFastSoot(CFGFast):
         return succs_native
 
     def _special_invoke_successors(self, stmt, addr, block):
-        invoke_expr = stmt.invoke_expr
+        invoke_expr = stmt.invoke_expr if isinstance(stmt, InvokeStmt) else stmt.right_op
         succs = None
 
         # add <clinit>

--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -247,7 +247,7 @@ class CFGFastSoot(CFGFast):
 
         # add <clinit>
         # many class using jni are loading the library in static method
-        if invoke_expr.method_name is '<init>':
+        if invoke_expr.method_name == '<init>':
             clinit_invoke_expr = copy(invoke_expr)
             clinit_invoke_expr.method_name = '<clinit>'
             succs = self._soot_create_invoke_successors(stmt, addr, clinit_invoke_expr)
@@ -274,7 +274,8 @@ class CFGFastSoot(CFGFast):
                 thread_class_name = None
                 args = []
                 for before_stmt in block.statements[:block.statements.index(stmt)]:
-                    args.extend(before_stmt.invoke_expr.args) if isinstance(before_stmt, InvokeStmt) else None
+                    if isinstance(before_stmt, InvokeStmt):
+                        args.extend(before_stmt.invoke_expr.args)
 
                 # match arg.name == base.name
                 for name in [arg.name for arg in args if isinstance(arg, SootLocal)]:


### PR DESCRIPTION
Implemented follows function.

- **Add support_jni flag** : needs for low overhead when don't care jni
- **Link edge <init> to <clinit>** : most of jni developer use loadlibrary in static method
- **Link edge System.Loadlibrary to [libname].JNI_Onload** : connect java to native level, know library name
- **Link edge of java invoke native method** :  it formatted nativemethod.<methodname> because of lack of library name
- **Link edge of Thread run** : only use on jni_support condition, else then may occur Nonetype "block"

Unfortunately, there is an issue, so make_function method have to disable when use supporting jni.
It is prototype. But I checked some samples working.(at least, [native-media](https://github.com/android/ndk-samples/tree/master/native-media))