### PR TITLE
More fixes for qemu unicorn trace desync checks

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -637,11 +637,7 @@ class Tracer(ExplorationTechnique):
         for last_contain_index in range(trace_match_idx, trace_curr_idx + 1):
             if self._trace[last_contain_index] < big_block_start or self._trace[last_contain_index] > big_block_end:
                 # This qemu block is not contained in the bigger block
-                break
-
-        if last_contain_index != trace_curr_idx:
-            # Current block in trace is not in the big block
-            return (False, -1)
+                return (False, -1)
 
         # Check for future blocks in trace contained in big block
         for next_contain_index in range(trace_curr_idx + 1, len(self._trace)):

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -642,8 +642,8 @@ class Tracer(ExplorationTechnique):
                 # Found last block
                 big_block_end = curr_block.addr + curr_block.size
                 break
-            else:
-                curr_block_addr = curr_block.addr + curr_block.size
+
+            curr_block_addr = curr_block.addr + curr_block.size
 
         for last_contain_index in range(trace_match_idx, trace_curr_idx + 1):
             if self._trace[last_contain_index] < big_block_start or self._trace[last_contain_index] > big_block_end:
@@ -717,8 +717,8 @@ class Tracer(ExplorationTechnique):
                 # Found last block
                 angr_big_block_end_addr = curr_block.addr + curr_block.size
                 break
-            else:
-                curr_block_addr = curr_block.addr + curr_block.size
+
+            curr_block_addr = curr_block.addr + curr_block.size
 
         # Let's find the address of the last bytes of the big basic block from the trace
         big_block_end_addr = None

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -722,7 +722,7 @@ class Tracer(ExplorationTechnique):
 
         # Let's find the address of the last bytes of the big basic block from the trace
         big_block_end_addr = None
-        for trace_block_idx in range(trace_curr_idx + 1, len(self._trace)):
+        for trace_block_idx in range(trace_curr_idx, len(self._trace)):
             trace_block = state.project.factory.block(self._translate_trace_addr(self._trace[trace_block_idx]))
             trace_block_last_insn = trace_block.capstone.insns[-1]
             for insn_type in control_flow_insn_types:


### PR DESCRIPTION
This PR fixes some bugs in two tracer resync checks: qemu unicorn different block split check and qemu block contained in unicorn check. In the former check, we need to perform additional validation of the end address of the reconstructed block to ensure we found the correct end address. In the latter, we need to find the correct block end in case the block is split into multiple parts by pyvex. There are existing test cases for the former checks. For the latter fix, there is a possible test case(using KPRCA_00023) but tracing the binary doesn't complete in a reasonable time so I am not creating a test case now. Maybe we can add one later on if tracing time improves.