### PR TITLE
added storage string for SimActionData objects of type 'tmp'

### DIFF
--- a/angr/state_plugins/sim_action.py
+++ b/angr/state_plugins/sim_action.py
@@ -274,6 +274,8 @@ class SimActionData(SimAction):
             _size = self.size.ast if isinstance(self.size, SimActionObject) else self.size
             assert isinstance(_size, int)
             storage = self.arch.register_size_names[(self.offset, _size // self.arch.byte_width)]
+        elif self.type == 'tmp':
+            storage = f'tmp_{self.tmp}'
         else:
             storage = self.addr
         direction = '<<----' if self.action == 'write' else '---->>'


### PR DESCRIPTION
Added storage string for SimActionData objects of type 'tmp' to resolve AttributeError: 'NoneType' object has no attribute 'shallow_repr' while printing the action.

When printing out the state.history.actions SimActionData objects cause the following error:

![image](https://user-images.githubusercontent.com/18367903/117505690-74ff4e80-af52-11eb-88b4-feb93f111e23.png)

I added a storage string for SimActionData objects of type 'tmp'. The string is a combination of `tmp_` and `SimActionData.tmp`. I think that value is an identifier. 

Here's an example output for 'tmp' action objects.
![image](https://user-images.githubusercontent.com/18367903/117507534-2acb9c80-af55-11eb-9176-5da384e08e92.png)
