### PR TITLE
in SimActionData._desc 'o.ast' needs to be checked if it's of type bytes, str or int otherwise an AttributeError is thrown

### DIFF
--- a/angr/state_plugins/sim_action.py
+++ b/angr/state_plugins/sim_action.py
@@ -269,6 +269,8 @@ class SimActionData(SimAction):
                 o = o.ast
             except AttributeError:
                 pass
+            if type(o) in {bytes, str, int}:
+                return o
             return o.shallow_repr()
         if self.type == 'reg':
             _size = self.size.ast if isinstance(self.size, SimActionObject) else self.size


### PR DESCRIPTION
Another _repr bug in SimActionData._desc.

![image](https://user-images.githubusercontent.com/18367903/117514191-49d02b80-af61-11eb-8496-93bef58f2b69.png)
