### PR TITLE
Check if symbolic memory dependencies of instructions in current block are live

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -117,6 +117,7 @@ class STOP:  # stop_t
     STOP_UNKNOWN_MEMORY_WRITE     = 28
     STOP_SYMBOLIC_MEM_DEP_NOT_LIVE = 29
     STOP_SYSCALL_ARM    = 30
+    STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK = 31
 
     stop_message = {}
     stop_message[STOP_NORMAL]        = "Reached maximum steps"
@@ -150,10 +151,12 @@ class STOP:  # stop_t
     stop_message[STOP_UNKNOWN_MEMORY_WRITE]    = "Cannot find a memory write at instruction; likely because unicorn reported PC value incorrectly"
     stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE] = "A symbolic memory dependency on stack is no longer in scope"
     stop_message[STOP_SYSCALL_ARM]   = "ARM syscalls are currently not supported by SimEngineUnicorn"
+    stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK] = "An instruction in current block overwrites a symbolic value needed for re-executing some instruction in same block"
 
     symbolic_stop_reasons = [STOP_SYMBOLIC_CONDITION, STOP_SYMBOLIC_PC, STOP_SYMBOLIC_READ_ADDR,
         STOP_SYMBOLIC_READ_SYMBOLIC_TRACKING_DISABLED, STOP_SYMBOLIC_WRITE_ADDR,
-        STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET, STOP_SYSCALL_ARM]
+        STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET, STOP_SYSCALL_ARM,
+        STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK]
 
     unsupported_reasons = [STOP_UNSUPPORTED_STMT_PUTI, STOP_UNSUPPORTED_STMT_STOREG, STOP_UNSUPPORTED_STMT_LOADG,
         STOP_UNSUPPORTED_STMT_CAS, STOP_UNSUPPORTED_STMT_LLSC, STOP_UNSUPPORTED_STMT_DIRTY,

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -607,7 +607,7 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 			}
 		}
 	}
-	if (find_tainted(address, size) != -1) {
+	if ((find_tainted(address, size) != -1) & (!is_dst_symbolic)) {
 		// We are writing to a memory location that is currently symbolic. If the destination if a memory dependency
 		// of some instruction to be re-executed, we need to re-execute that instruction before continuing.
 		auto write_start_addr = address;
@@ -639,35 +639,33 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 				}
 			}
 		}
-		if (!is_dst_symbolic) {
-			// The destination is not a memory dependency of some instruction to be re-executed. We now check if any
-			// instructions to be re-executed write to this same location. If there is one, they need not be re-executed
-			// since this concrete write nullifies their effects.
-			auto curr_write_start_addr = address;
-			auto curr_write_end_addr = address + size;
-			std::vector<std::vector<instr_details_t>::iterator> instrs_to_erase_it;
-			for (auto &block: blocks_with_symbolic_instrs) {
-				instrs_to_erase_it.clear();
-				for (auto sym_instr_it = block.symbolic_instrs.begin(); sym_instr_it != block.symbolic_instrs.end(); sym_instr_it++) {
-					int64_t symbolic_write_start_addr = sym_instr_it->mem_write_addr;
-					if (symbolic_write_start_addr == -1) {
-						// Instruction does not write a symbolic write to memory. No need to check this.
-						continue;
-					}
-					int64_t symbolic_write_end_addr = sym_instr_it->mem_write_addr + sym_instr_it->mem_write_size;
-					if ((curr_write_start_addr <= symbolic_write_start_addr) && (symbolic_write_end_addr <= curr_write_end_addr)) {
-						// Currrent write fully overwrites the previous written symbolic value and so the symbolic write
-						// instruction need not be re-executed
-						// TODO: How to handle partial overwrite?
-						// TODO: If this block is not fully executed in unicorn before control returns to python land,
-						// the state will be inconsistent until this concrete memory write is executed. If this happens,
-						// the symbolic memory write should be removed from list of instructions to re-execute in commit.
-						instrs_to_erase_it.emplace_back(sym_instr_it);
-					}
+		// The destination is not a memory dependency of some instruction to be re-executed. We now check if any
+		// instructions to be re-executed write to this same location. If there is one, they need not be re-executed
+		// since this concrete write nullifies their effects.
+		auto curr_write_start_addr = address;
+		auto curr_write_end_addr = address + size;
+		std::vector<std::vector<instr_details_t>::iterator> instrs_to_erase_it;
+		for (auto &block: blocks_with_symbolic_instrs) {
+			instrs_to_erase_it.clear();
+			for (auto sym_instr_it = block.symbolic_instrs.begin(); sym_instr_it != block.symbolic_instrs.end(); sym_instr_it++) {
+				int64_t symbolic_write_start_addr = sym_instr_it->mem_write_addr;
+				if (symbolic_write_start_addr == -1) {
+					// Instruction does not write a symbolic write to memory. No need to check this.
+					continue;
 				}
-				for (auto &instr_to_erase_it: instrs_to_erase_it) {
-					block.symbolic_instrs.erase(instr_to_erase_it);
+				int64_t symbolic_write_end_addr = sym_instr_it->mem_write_addr + sym_instr_it->mem_write_size;
+				if ((curr_write_start_addr <= symbolic_write_start_addr) && (symbolic_write_end_addr <= curr_write_end_addr)) {
+					// Currrent write fully overwrites the previous written symbolic value and so the symbolic write
+					// instruction need not be re-executed
+					// TODO: How to handle partial overwrite?
+					// TODO: If this block is not fully executed in unicorn before control returns to python land,
+					// the state will be inconsistent until this concrete memory write is executed. If this happens,
+					// the symbolic memory write should be removed from list of instructions to re-execute in commit.
+					instrs_to_erase_it.emplace_back(sym_instr_it);
 				}
+			}
+			for (auto &instr_to_erase_it: instrs_to_erase_it) {
+				block.symbolic_instrs.erase(instr_to_erase_it);
 			}
 		}
 	}

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -295,6 +295,7 @@ enum stop_t {
 	STOP_UNKNOWN_MEMORY_WRITE,
 	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE,
 	STOP_SYSCALL_ARM,
+	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK,
 };
 
 typedef std::vector<std::pair<taint_entity_t, std::unordered_set<taint_entity_t>>> taint_vector_t;


### PR DESCRIPTION
Previously, we were checking if we were overwriting symbolic memory dependencies of instructions in blocks already processed but we were not checking if an instruction in current block overwrites dependency of a previous instruction in same block. This PR introduces a new stop type for such scenarios: we treat this condition as a symbolic stop and execute the entire block in VEX engine. Unfortunately, I don't have a test case that would be done in a reasonable time: tracing the binary takes too long.

This PR also introduces an optimization which restricts liveness checks of such dependencies only if a symbolic value is being overwritten with a concrete value(previously, we were checking for all overwrites). This will reduce the number of liveness checks as well as unicorn engine stoppage due to this check failing. For example, in CSAW 2015 wyvern challenge, this optimization reduced the number of stoppage due to liveness check failure from ~460 to less than 30. From what I checked, this optimization does not seem to break anything since all CI tests pass and the CGC binary tracing experiments I ran seem to be unaffected. Also, I'm still not sure why wyvern fails this check at some points: it was working fine even before the liveness check was introduced. That's something to look into later on.