### PR TITLE
Recover variables in ITEs. Do not rebuild Assignment.dst.

### DIFF
--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -113,6 +113,12 @@ class BlockSimplifier(Analysis):
                         # special case: do not replace the ret_expr of a call statement to another call statement
                         r = False
                         new_stmt = None
+                    elif isinstance(stmt, Assignment):
+                        # special case: do not replace the dst
+                        new_stmt = None
+                        r, new_src = stmt.src.replace(old, new)
+                        if r:
+                            new_stmt = Assignment(stmt.idx, stmt.dst, new_src, **stmt.tags)
                     else:
                         r, new_stmt = stmt.replace(old, new)
 

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -685,6 +685,20 @@ class Clinic(Analysis):
         elif type(expr) is ailment.Expr.Convert:
             self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt, expr.operand)
 
+        elif type(expr) is ailment.Expr.ITE:
+            variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
+            if len(variables) == 1:
+                var, offset = next(iter(variables))
+                expr.variable = var
+                expr.variable_offset = offset
+            else:
+                self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt,
+                                             expr.cond)
+                self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt,
+                                             expr.iftrue)
+                self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt,
+                                             expr.iftrue)
+
         elif isinstance(expr, ailment.Expr.BasePointerOffset):
             variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr)
             if len(variables) == 1:

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -262,7 +262,7 @@ def test_decompiling_switch2_x86_64():
         assert False
 
 
-def test_decompiling_true_x86_64():
+def test_decompiling_true_x86_64_0():
 
     # in fact this test case tests if CFGBase._process_jump_table_targeted_functions successfully removes "function"
     # 0x402543, which is an artificial function that the compiler (GCC) created for identified "cold" functions.
@@ -288,6 +288,24 @@ def test_decompiling_true_x86_64():
     else:
         print("Failed to decompile function %r." % f)
         assert False
+
+
+def test_decompiling_true_a_x86_64():
+
+    bin_path = os.path.join(test_location, "x86_64", "true_a")
+    p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
+
+    cfg = p.analyses.CFG(normalize=True, data_references=True)
+
+    # disable eager returns simplifier
+    all_optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes("AMD64",
+                                                                                                           "linux")
+    all_optimization_passes = [p for p in all_optimization_passes
+                               if p is not angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier]
+
+    f = cfg.functions[0x404410]
+    dec = p.analyses.Decompiler(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
+    print(dec.codegen.text)
 
 
 def test_decompiling_1after909():


### PR DESCRIPTION
This PR addresses the first issue in #2643.