### PR TITLE
CFGFast: Do not duplicate indirect jump resolvers.

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/default_resolvers.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/default_resolvers.py
@@ -41,7 +41,7 @@ def default_indirect_jump_resolvers(obj, project):
     resolvers = [ ]
     for k, lst in arch_specific.items():
         if isinstance(obj, k):
-            resolvers = lst
+            resolvers = list(lst)
             break
 
     resolvers += DEFAULT_RESOLVERS['ALL']


### PR DESCRIPTION
This PR fixes the bug that CFGFast runs slower and slower when running within the same process multiple times.