### PR TITLE
Address CFGFast crashes of args' lengths must all be equal.

### DIFF
--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -521,6 +521,12 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
         if isinstance(expr_1, claripy.ast.Base) and expr_1.op == "BVV":
             # convert it to an int when possible
             expr_1 = expr_1.args[0]
+        else:
+            # make sure the sizes are the same - VEX does not care about it
+            if expr_1.size() < expr_0.size():
+                expr_1 = claripy.ZeroExt(expr_0.size() - expr_1.size(), expr_1)
+            elif expr_1.size() > expr_0.size():
+                expr_1 = claripy.Extract(expr_0.size() - 1, 0, expr_1)
 
         return expr_0 << expr_1
 
@@ -535,6 +541,12 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
         if isinstance(expr_1, claripy.ast.Base) and expr_1.op == "BVV":
             # convert it to an int when possible
             expr_1 = expr_1.args[0]
+        else:
+            # make sure the sizes are the same - VEX does not care about it
+            if expr_1.size() < expr_0.size():
+                expr_1 = claripy.ZeroExt(expr_0.size() - expr_1.size(), expr_1)
+            elif expr_1.size() > expr_0.size():
+                expr_1 = claripy.Extract(expr_0.size() - 1, 0, expr_1)
 
         return claripy.LShR(expr_0, expr_1)
 
@@ -550,6 +562,12 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
         if isinstance(expr_1, claripy.ast.Base) and expr_1.op == "BVV":
             # convert it to an int when possible
             expr_1 = expr_1.args[0]
+        else:
+            # make sure the sizes are the same - VEX does not care about it
+            if expr_1.size() < expr_0.size():
+                expr_1 = claripy.ZeroExt(expr_0.size() - expr_1.size(), expr_1)
+            elif expr_1.size() > expr_0.size():
+                expr_1 = claripy.Extract(expr_0.size() - 1, 0, expr_1)
 
         return expr_0 >> expr_1
 

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import sys
+import unittest
 
 from nose.plugins.attrib import attr
 import nose.tools
@@ -139,10 +140,10 @@ def test_busybox():
 def test_ntoskrnl():
     path = "C:\\Windows\\System32\\ntoskrnl.exe"  # we cannot distribute this file. as a result, this test case is manual
     if not os.path.isfile(path):
-        raise nose.SkipTest("ntoskrnl.exe does not exist on this system.")
+        raise unittest.skip("ntoskrnl.exe does not exist on this system.")
 
     proj = angr.Project(path, auto_load_libs=False)
-    cfg = proj.analyses.CFG(data_references=True, normalize=True, show_progressbar=True)
+    _ = proj.analyses.CFG(data_references=True, normalize=True, show_progressbar=True)
 
     # nothing should prevent us from finish creating the CFG
 

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -135,6 +135,18 @@ def test_busybox():
         yield cfg_fast_edges_check, arch, filename, edges_
 
 
+@attr(speed='slow')
+def test_ntoskrnl():
+    path = "C:\\Windows\\System32\\ntoskrnl.exe"  # we cannot distribute this file. as a result, this test case is manual
+    if not os.path.isfile(path):
+        raise nose.SkipTest("ntoskrnl.exe does not exist on this system.")
+
+    proj = angr.Project(path, auto_load_libs=False)
+    cfg = proj.analyses.CFG(data_references=True, normalize=True, show_progressbar=True)
+
+    # nothing should prevent us from finish creating the CFG
+
+
 def test_fauxware():
     filename = "fauxware"
     functions = {


### PR DESCRIPTION
This PR fixes angr/angr-management#236.