### PR TITLE
Clinic: Set arch to function prototype.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -536,7 +536,7 @@ class Clinic(Analysis):
         else:
             returnty = SimTypeInt()
 
-        self.function.prototype = SimTypeFunction(func_args, returnty)
+        self.function.prototype = SimTypeFunction(func_args, returnty).with_arch(self.project.arch)
 
     @timethis
     def _recover_and_link_variables(self, ail_graph, arg_list):

--- a/angr/analyses/decompiler/structured_codegen.py
+++ b/angr/analyses/decompiler/structured_codegen.py
@@ -303,7 +303,7 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
                 yield str(variable), cvariable
             yield ";", None
 
-            loc_repr = variable.loc_repr(self.functy._arch)
+            loc_repr = variable.loc_repr(self.codegen.project.arch)
             yield "  // ", None
             yield loc_repr, None
             yield "\n", None


### PR DESCRIPTION
[Here](https://github.com/angr/angr/blob/9f3bbe6b085537e1d300774366f65381ca5f725e/angr/analyses/decompiler/structured_codegen.py#L306) accesses the `_arch` property of function prototype. However, the `_arch` of function prototypes may not be set. This PR fixes this issue.

@rhelmot is the linked line of code your intended use? You could have accessed `self.project.arch` instead.