### PR TITLE
Fix bit order for bytes in read/write fds in CGC fdwait syscall

### DIFF
--- a/angr/procedures/cgc/fdwait.py
+++ b/angr/procedures/cgc/fdwait.py
@@ -12,28 +12,34 @@ class fdwait(angr.SimProcedure):
         total_ready = self.state.solver.BVV(0, self.state.arch.bits)
 
         read_fds = [ ]
-        for fd in range(32):
-            if angr.options.CGC_NON_BLOCKING_FDS in self.state.options:
-                sym_bit = self.state.solver.BVV(1, 1)
-            else:
-                sym_bit = self.state.solver.Unconstrained('fdwait_read_%d_%d'%(run_count,fd), 1, key=('syscall', 'fdwait', fd, 'read_ready'))
-            fd = self.state.solver.BVV(fd, self.state.arch.bits)
-            sym_newbit = self.state.solver.If(self.state.solver.ULT(fd, nfds), sym_bit, 0)
-            total_ready += sym_newbit.zero_extend(self.state.arch.bits - 1)
-            read_fds.append(sym_newbit)
+        for fd_set in range(0, 32, 8):
+            sym_newbits = []
+            for fd in range(fd_set, fd_set + 8):
+                if angr.options.CGC_NON_BLOCKING_FDS in self.state.options:
+                    sym_bit = self.state.solver.BVV(1, 1)
+                else:
+                    sym_bit = self.state.solver.Unconstrained('fdwait_read_%d_%d'%(run_count,fd), 1, key=('syscall', 'fdwait', fd, 'read_ready'))
+                fd = self.state.solver.BVV(fd, self.state.arch.bits)
+                sym_newbit = self.state.solver.If(self.state.solver.ULT(fd, nfds), sym_bit, 0)
+                total_ready += sym_newbit.zero_extend(self.state.arch.bits - 1)
+                sym_newbits.append(sym_newbit)
+            read_fds.extend(reversed(sym_newbits))
         self.state.memory.store(readfds, self.state.solver.Concat(*read_fds), condition=readfds != 0)
 
         write_fds = [ ]
-        for fd in range(32):
-            if angr.options.CGC_NON_BLOCKING_FDS in self.state.options:
-                sym_bit = self.state.solver.BVV(1, 1)
-            else:
-                sym_bit = self.state.solver.Unconstrained('fdwait_write_%d_%d' % (run_count, fd), 1, key=('syscall', 'fdwait', fd, 'write_ready'))
+        for fd_set in range(0, 32, 8):
+            sym_newbits = []
+            for fd in range(fd_set, fd_set + 8):
+                if angr.options.CGC_NON_BLOCKING_FDS in self.state.options:
+                    sym_bit = self.state.solver.BVV(1, 1)
+                else:
+                    sym_bit = self.state.solver.Unconstrained('fdwait_write_%d_%d' % (run_count, fd), 1, key=('syscall', 'fdwait', fd, 'write_ready'))
 
-            fd = self.state.solver.BVV(fd, self.state.arch.bits)
-            sym_newbit = self.state.solver.If(self.state.solver.ULT(fd, nfds), sym_bit, 0)
-            total_ready += sym_newbit.zero_extend(self.state.arch.bits - 1)
-            write_fds.append(sym_newbit)
+                fd = self.state.solver.BVV(fd, self.state.arch.bits)
+                sym_newbit = self.state.solver.If(self.state.solver.ULT(fd, nfds), sym_bit, 0)
+                total_ready += sym_newbit.zero_extend(self.state.arch.bits - 1)
+                sym_newbits.append(sym_newbit)
+            write_fds.extend(reversed(sym_newbits))
         self.state.memory.store(writefds, self.state.solver.Concat(*write_fds), condition=writefds != 0)
 
         self.state.memory.store(readyfds, total_ready, endness='Iend_LE', condition=readyfds != 0)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -206,6 +206,14 @@ def test_floating_point_memory_reads():
     output = b'\x00' * 36
     trace_cgc_with_pov_file(binary, "tracer_floating_point_memory_reads", pov_file, output)
 
+def test_fdwait_fds():
+    # Test fdwait working with appropriate bit order for read/write fds
+    binary = os.path.join(bin_location, "tests", "cgc", "CROMU_00029")
+    pov_file = os.path.join(bin_location, "tests_data", "cgc_povs", "CROMU_00029_POV_00000.xml")
+    output = [b"For what material would you like to run this simulation?", b"  1. Air", b"  2. Aluminum",
+              b"  3. Copper", b"  4. Custom\nSelection: "]
+    trace_cgc_with_pov_file(binary, "tracer_floating_point_memory_reads", pov_file, b'\n'.join(output))
+
 def test_skip_some_symbolic_memory_writes():
     # Test symbolic memory write skipping in SimEngineUnicorn during tracing
     # This test doesn't actually check if instruction was skipped. It checks if tracing is successful


### PR DESCRIPTION
It seems the bit order of the bytes in read and write fds in the CGC fdwait syscall should be reverse of how it's currently stored. This PR fixes this and also includes a test case. The test case `test_rex.test_reconstraining` failed on the CI run on the branch. I'm not sure why: it runs fine locally. I also noticed this test case failed in(edit: CI run on) another branch I'm working on(implementing something entirely different) so perhaps the failure is not due to these changes.