### PR TITLE
Fix default values in CCs to match type signature (and fix bugs)

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -349,12 +349,12 @@ class SimCC:
     # Here are all the things a subclass needs to specify!
     #
 
-    ARG_REGS: List[str] = None                                  # A list of all the registers used for integral args, in order (names or offsets)
-    FP_ARG_REGS: List[str] = None                               # A list of all the registers used for floating point args, in order
+    ARG_REGS: List[str] = []                                    # A list of all the registers used for integral args, in order (names or offsets)
+    FP_ARG_REGS: List[str] = []                                 # A list of all the registers used for floating point args, in order
     STACKARG_SP_BUFF = 0                                        # The amount of stack space reserved between the saved return address
                                                                 # (if applicable) and the arguments. Probably zero.
     STACKARG_SP_DIFF = 0                                        # The amount of stack space reserved for the return address
-    CALLER_SAVED_REGS: List[str] = None                         # Caller-saved registers
+    CALLER_SAVED_REGS: List[str] = []                           # Caller-saved registers
     RETURN_ADDR: SimFunctionArgument = None                     # The location where the return address is stored, as a SimFunctionArgument
     RETURN_VAL: SimFunctionArgument = None                      # The location where the return value is stored, as a SimFunctionArgument
     OVERFLOW_RETURN_VAL: Optional[SimFunctionArgument] = None   # The second half of the location where a double-length return value is stored


### PR DESCRIPTION
https://github.com/angr/angr/blob/8c4f21e3e7a561f9ebabcd301ed801b8e76866d4/angr/analyses/reaching_definitions/engine_ail.py#L210 crashes with CCs like `SimCCAArch64` because it doesn't override `CALLER_SAVED_REGS` with an empty list, so `CALLER_SAVED_REGS` is `None` and it crashes because you can't iterate over `None`.
The type annotation of `CALLER_SAVED_REGS` states that this is a `List[str]`, so it has to be set to a default of an empty list to conform. To make this consistent I am doing the same for `ARG_REGS` and `FP_ARG_REGS`.

`RETURN_ADDR` and `RETURN_VAL` are technically problematic too, but at that point you need to consider removing all the actual values and just leaving the type annotations for the class variables themselves, which is possible since Python 3.6. Then every SimCC needs to specify all of those values, which would be more effort to fix for now.