### PR TITLE
Fix test_strtol slow marker, refactor for unittest

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -42,7 +42,7 @@ def do_trace(proj, test_name, input_data, **kwargs):
         pickle.dump((r, TRACE_VERSION), f, -1)
     return r
 
-def load_cgc_pov(pov_file: str) -> tracer.TracerPoV:
+def load_cgc_pov(pov_file: str) -> "tracer.TracerPoV":
     if tracer is None:
         raise Exception("Cannot load PoV because tracer is not installed")
 

--- a/tests/test_strtol.py
+++ b/tests/test_strtol.py
@@ -1,76 +1,61 @@
+import os
 import subprocess
 import sys
-import os
-
-import nose
-from nose.plugins.attrib import attr
-
-import logging
-l = logging.getLogger('angr.tests.strtol')
+import unittest
 
 import angr
-
-test_location = os.path.dirname(os.path.realpath(__file__))
-
-
-def run_strtol(threads):
-    if not sys.platform.startswith('linux'):
-        raise nose.SkipTest()
-
-    test_bin = os.path.join(test_location, "..", "..", "binaries", "tests", "x86_64", "strtol_test")
-    b = angr.Project(test_bin)
-
-    initial_state = b.factory.entry_state(remove_options={angr.options.LAZY_SOLVES})
-    pg = b.factory.simulation_manager(thing=initial_state, threads=threads)
-
-    # find the end of main
-    expected_outputs = {b"base 8 worked\n", b"base +8 worked\n", b"0x worked\n", b"+0x worked\n", b"base +10 worked\n",
-                        b"base 10 worked\n", b"base -8 worked\n", b"-0x worked\n", b"base -10 worked\n", b"Nope\n"}
-    pg.explore(find=0x400804, num_find=len(expected_outputs))
-    nose.tools.assert_equal(len(pg.found), len(expected_outputs))
-
-    # check the outputs
-    pipe = subprocess.PIPE
-    for f in pg.found:
-        test_input = f.posix.dumps(0)
-        test_output = f.posix.dumps(1)
-        expected_outputs.remove(test_output)
-
-        # check the output works as expected
-        p = subprocess.Popen(test_bin, stdout=pipe, stderr=pipe, stdin=pipe)
-        ret = p.communicate(test_input)[0]
-        nose.tools.assert_equal(ret, test_output)
-
-    # check that all of the outputs were seen
-    nose.tools.assert_equal(len(expected_outputs), 0)
+from common import slow_test, bin_location
 
 
-@attr(speed='slow')
-def test_strtol():
-    yield run_strtol, None
-    # yield run_strtol, 8
+class TestStrtol(unittest.TestCase):
+    @slow_test
+    @unittest.skipUnless(sys.platform.startswith("linux"), "linux-only")
+    def test_strtol(self, threads=None):
+        test_bin = os.path.join(bin_location, "tests", "x86_64", "strtol_test")
+        b = angr.Project(test_bin)
 
+        initial_state = b.factory.entry_state(remove_options={angr.options.LAZY_SOLVES})
+        pg = b.factory.simulation_manager(thing=initial_state, threads=threads)
 
-def test_strtol_long_string():
+        # find the end of main
+        expected_outputs = {b"base 8 worked\n", b"base +8 worked\n", b"0x worked\n", b"+0x worked\n", b"base +10 worked\n",
+                            b"base 10 worked\n", b"base -8 worked\n", b"-0x worked\n", b"base -10 worked\n", b"Nope\n"}
+        pg.explore(find=0x400804, num_find=len(expected_outputs))
+        assert len(pg.found) == len(expected_outputs)
 
-    # convert a 11-digit long string to a number.
-    # there was an off-by-one error before.
+        # check the outputs
+        pipe = subprocess.PIPE
+        for f in pg.found:
+            test_input = f.posix.dumps(0)
+            test_output = f.posix.dumps(1)
+            expected_outputs.remove(test_output)
 
-    b = angr.load_shellcode(b"\x90\x90", "AMD64")
-    state = b.factory.blank_state()
-    state.memory.store(0x500000, b"98831114236\x00")
+            # check the output works as expected
+            p = subprocess.Popen(test_bin, stdout=pipe, stderr=pipe, stdin=pipe)
+            ret = p.communicate(test_input)[0]
+            assert ret == test_output
 
-    state.libc.max_strtol_len = 11
+        # check that all of the outputs were seen
+        assert len(expected_outputs) == 0
 
-    strtol = angr.SIM_LIBRARIES['libc.so.6'].get('strtol', arch=b.arch)
-    strtol.state = state.copy()
-    ret = strtol.run(0x500000, 0, 0)
+    def test_strtol_long_string(self):
+        # convert a 11-digit long string to a number.
+        # there was an off-by-one error before.
 
-    nose.tools.assert_true(strtol.state.satisfiable())
-    nose.tools.assert_equal(len(strtol.state.solver.eval_upto(ret, 2)), 1)
-    nose.tools.assert_equal(strtol.state.solver.eval_one(ret), 98831114236)
+        b = angr.load_shellcode(b"\x90\x90", "AMD64")
+        state = b.factory.blank_state()
+        state.memory.store(0x500000, b"98831114236\x00")
+
+        state.libc.max_strtol_len = 11
+
+        strtol = angr.SIM_LIBRARIES['libc.so.6'].get('strtol', arch=b.arch)
+        strtol.state = state.copy()
+        ret = strtol.run(0x500000, 0, 0)
+
+        assert strtol.state.satisfiable()
+        assert len(strtol.state.solver.eval_upto(ret, 2)) == 1
+        assert strtol.state.solver.eval_one(ret) == 98831114236
 
 
 if __name__ == "__main__":
-    test_strtol_long_string()
-    run_strtol(None)
+    unittest.main()

--- a/tests/test_strtol.py
+++ b/tests/test_strtol.py
@@ -8,6 +8,8 @@ from common import slow_test, bin_location
 
 
 class TestStrtol(unittest.TestCase):
+    # pylint: disable=no-self-use
+
     @slow_test
     @unittest.skipUnless(sys.platform.startswith("linux"), "linux-only")
     def test_strtol(self, threads=None):
@@ -31,8 +33,8 @@ class TestStrtol(unittest.TestCase):
             expected_outputs.remove(test_output)
 
             # check the output works as expected
-            p = subprocess.Popen(test_bin, stdout=pipe, stderr=pipe, stdin=pipe)
-            ret = p.communicate(test_input)[0]
+            with subprocess.Popen(test_bin, stdout=pipe, stderr=pipe, stdin=pipe) as p:
+                ret = p.communicate(test_input)[0]
             assert ret == test_output
 
         # check that all of the outputs were seen


### PR DESCRIPTION
Came across this test while testing the CI. The slow test marker was incorrect, so I corrected it and converted it to unittest while I was here.