### PR TITLE
Fix for multiple partial memory reads where concrete value is read after a symbolic value

### DIFF
--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -492,6 +492,7 @@ class State {
 
 	address_t taint_engine_next_instr_address, taint_engine_stop_mem_read_instruction;
 	uint32_t taint_engine_stop_mem_read_size;
+	bool symbolic_read_in_progress;
 
 	address_t unicorn_next_instr_addr;
 	address_t prev_stack_top_addr;


### PR DESCRIPTION
This PR fixes a bug introduced in #2724. unicorn splits some reads into multiple parts and triggers read hook for each of them. Currently, if there are no symbolic registers, we do not propagate taint if a concrete value is read from memory. However, this concrete read could be one part of a larger memory read whose some previous part read a symbolic value(we do not propagate taint until all bytes have been read). This PR adds support for detecting such cases and propagating taint after entire read is done. A possible test case for this is tracing KPRCA_00031 using one of it's PoVs. However, it takes a long time to finish(close to 15 mins on my machine) so I'm not adding a test case for now. Maybe we can add it later on if tracing it becomes faster.