### PR TITLE
Minor sim_type fixes

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -43,7 +43,7 @@ def test_cproto_conversion():
     pyproto_name, pyproto, the_str = convert_cproto_to_py(cproto_1)  # pylint:disable=unused-variable
 
     nose.tools.assert_equal(pyproto_name, "bad")
-    nose.tools.assert_is(pyproto, None)
+    nose.tools.assert_is_not(pyproto, None)
 
     # A even worse function declaration
     # Special thanks to @schieb, see GitHub PR #958


### PR DESCRIPTION
- Fix typo
- Add support for parsing function declarations without parameter types (found in the very old C syntax where you declare parameter types after the parameter list but before the function body)
- Fix bug with creating structs with redefined member information
- Allow `int` and similar types to be compared without a size attached
- Allow passing an include path to the preprocessor