### PR TITLE
Added parameter to control bytes read by CGC receive

### DIFF
--- a/angr/procedures/cgc/receive.py
+++ b/angr/procedures/cgc/receive.py
@@ -42,6 +42,9 @@ class receive(angr.SimProcedure):
 
         if CGC_NO_SYMBOLIC_RECEIVE_LENGTH in self.state.options:
             count = self.state.solver.eval(count)
+            if self.state.cgc.max_receive_size > 0:
+                count = min(count, self.state.cgc.max_receive_size)
+
             read_length = simfd.read(buf, count, short_reads=False)
             if type(read_length) is int:
                 read_length = self.state.solver.BVV(read_length, 32)

--- a/angr/simos/cgc.py
+++ b/angr/simos/cgc.py
@@ -48,6 +48,9 @@ class SimCGC(SimUserland):
         # Create the CGC plugin
         s.get_plugin('cgc')
 
+        # Set maximum bytes a single receive syscall should read
+        s.cgc.max_receive_size = kwargs.get("cgc_max_recv_size", 0)
+
         # Set up the flag page
         if flag_page is None:
             flag_page = [s.solver.BVS("cgc-flag-byte-%d" % i, 8, key=('flag', i), eternal=True) for i in range(0x1000)]

--- a/angr/state_plugins/cgc.py
+++ b/angr/state_plugins/cgc.py
@@ -35,6 +35,8 @@ class SimStateCGC(SimStatePlugin):
 
         self.flag_bytes = None
 
+        self.max_receive_size = 0
+
     @SimStatePlugin.memo
     def copy(self, memo): # pylint: disable=unused-argument
         c = super().copy(memo)
@@ -46,6 +48,7 @@ class SimStateCGC(SimStatePlugin):
         c.input_size = self.input_size
         c.sinkholes = set(self.sinkholes)
         c.flag_bytes = self.flag_bytes
+        c.max_receive_size = self.max_receive_size
 
         return c
 


### PR DESCRIPTION
In order to keep in sync with trace from archr, sometimes receives need to be completed in multiple steps just like how the QEMU tracer does it. This PR introduces support for this by adding a field in the CGC state plugin that can control the maximum number of bytes read in a single invocation of CGC receive syscall. This field is optional and unless specified, reading all bytes is still the default behaviour in angr's CGC receive syscall implementation.