### PR TITLE
Some bug fixes for getdelim SimProcedure

### DIFF
--- a/angr/procedures/libc/getdelim.py
+++ b/angr/procedures/libc/getdelim.py
@@ -31,7 +31,7 @@ class __getdelim(angr.SimProcedure):
         # case 1: the data is concrete. we should read it a byte at a time since we can't seek for
         # the newline and we don't have any notion of buffering in-memory
         if simfd.read_storage.concrete:
-            if self.state.solver.eval(simfd.eof()):
+            if self.state.solver.is_true(simfd.eof()):
                 # End-of-file reached
                 return -1
 

--- a/angr/procedures/libc/getdelim.py
+++ b/angr/procedures/libc/getdelim.py
@@ -54,6 +54,8 @@ class __getdelim(angr.SimProcedure):
                 if count == size:
                     size = count + size + 1
                     dst = self.inline_call(realloc, dst, size).ret_expr
+                if delim.size() > data.size():
+                    data = data.zero_extend(delim.size() - data.size())
                 if self.state.solver.is_true(data == delim):
                     break
 

--- a/angr/procedures/libc/getdelim.py
+++ b/angr/procedures/libc/getdelim.py
@@ -31,6 +31,10 @@ class __getdelim(angr.SimProcedure):
         # case 1: the data is concrete. we should read it a byte at a time since we can't seek for
         # the newline and we don't have any notion of buffering in-memory
         if simfd.read_storage.concrete:
+            if self.state.solver.eval(simfd.eof()):
+                # End-of-file reached
+                return -1
+
             realloc = angr.SIM_PROCEDURES['libc']['realloc']
 
             # #dereference the destination buffer


### PR DESCRIPTION
This PR fixes following bugs in getdelim SimProcedure.

1. Added missing EOF check when only concrete bytes are present: treated as failure by getdelim.
2. In concrete mode, file is read one byte at a time(i.e. `data` is always a BV8) but `delim` can be of a different size. In order to compare the two, `data` should be zero extended to the same size as `delim`.