### PR TITLE
Fix exits discovery in libc_start_main for certain ARMHF binaries.

### DIFF
--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -154,7 +154,7 @@ class __libc_start_main(angr.SimProcedure):
         # Execute each block
         state = blank_state
         for b in blocks:
-            irsb = self.project.factory.default_engine.process(state, b, force_addr=b.addr)
+            irsb = self.project.factory.default_engine.process(state, irsb=b, force_addr=b.addr)
             if irsb.successors:
                 state = irsb.successors[0]
             else:


### PR DESCRIPTION
When passed as a positional argument, `b` is ignored, which leads to re-lifting of each block. Re-lifted blocks in certain ARMHF binaries may disable `arm_allow_optimizing_lookback` , and then lead to incorrect execution result. Passing in `b` as a keyword argument can prevent angr from re-lifting the block.