### PR TITLE
Propagator: AILEngine: Always replace StackBaseOffsets.

### DIFF
--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -460,7 +460,7 @@ class PropagatorAILState(PropagatorState):
             self._prop_count[new] += 1
             prop_count = self._prop_count[new]
 
-        if prop_count <= 1:
+        if prop_count <= 1 or isinstance(new, ailment.Expr.StackBaseOffset):
             # we can propagate this expression
             super().add_replacement(codeloc, old, new)
         else:


### PR DESCRIPTION
This allows us to get rid of sp-replacement registers in certain architectures, such as ARM THUMB mode:

```
ADD             R7, SP, #0
```

In this case, `R7` is the sp-replacement register. This PR will allow the replacement of `R7` with `StackPointerOffset` across the entire function, then in a later optimization iteration, the assignment to `R7` will be removed.