### PR TITLE
Handle cpuid instruction in native interface

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -118,6 +118,7 @@ class STOP:  # stop_t
     STOP_SYMBOLIC_MEM_DEP_NOT_LIVE = 29
     STOP_SYSCALL_ARM    = 30
     STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK = 31
+    STOP_CPUID = 32
 
     stop_message = {}
     stop_message[STOP_NORMAL]        = "Reached maximum steps"
@@ -152,11 +153,12 @@ class STOP:  # stop_t
     stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE] = "A symbolic memory dependency on stack is no longer in scope"
     stop_message[STOP_SYSCALL_ARM]   = "ARM syscalls are currently not supported by SimEngineUnicorn"
     stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK] = "An instruction in current block overwrites a symbolic value needed for re-executing some instruction in same block"
+    stop_message[STOP_CPUID] = "Block executes cpuid which should be handled in VEX engine"
 
     symbolic_stop_reasons = [STOP_SYMBOLIC_CONDITION, STOP_SYMBOLIC_PC, STOP_SYMBOLIC_READ_ADDR,
         STOP_SYMBOLIC_READ_SYMBOLIC_TRACKING_DISABLED, STOP_SYMBOLIC_WRITE_ADDR,
         STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET, STOP_SYSCALL_ARM,
-        STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK]
+        STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK, STOP_CPUID]
 
     unsupported_reasons = [STOP_UNSUPPORTED_STMT_PUTI, STOP_UNSUPPORTED_STMT_STOREG, STOP_UNSUPPORTED_STMT_LOADG,
         STOP_UNSUPPORTED_STMT_CAS, STOP_UNSUPPORTED_STMT_LLSC, STOP_UNSUPPORTED_STMT_DIRTY,

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -118,7 +118,7 @@ class STOP:  # stop_t
     STOP_SYMBOLIC_MEM_DEP_NOT_LIVE = 29
     STOP_SYSCALL_ARM    = 30
     STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK = 31
-    STOP_CPUID = 32
+    STOP_X86_CPUID = 32
 
     stop_message = {}
     stop_message[STOP_NORMAL]        = "Reached maximum steps"
@@ -153,12 +153,12 @@ class STOP:  # stop_t
     stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE] = "A symbolic memory dependency on stack is no longer in scope"
     stop_message[STOP_SYSCALL_ARM]   = "ARM syscalls are currently not supported by SimEngineUnicorn"
     stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK] = "An instruction in current block overwrites a symbolic value needed for re-executing some instruction in same block"
-    stop_message[STOP_CPUID] = "Block executes cpuid which should be handled in VEX engine"
+    stop_message[STOP_X86_CPUID] = "Block executes cpuid which should be handled in VEX engine"
 
     symbolic_stop_reasons = [STOP_SYMBOLIC_CONDITION, STOP_SYMBOLIC_PC, STOP_SYMBOLIC_READ_ADDR,
         STOP_SYMBOLIC_READ_SYMBOLIC_TRACKING_DISABLED, STOP_SYMBOLIC_WRITE_ADDR,
         STOP_SYMBOLIC_BLOCK_EXIT_CONDITION, STOP_SYMBOLIC_BLOCK_EXIT_TARGET, STOP_SYSCALL_ARM,
-        STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK, STOP_CPUID]
+        STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK, STOP_X86_CPUID]
 
     unsupported_reasons = [STOP_UNSUPPORTED_STMT_PUTI, STOP_UNSUPPORTED_STMT_STOREG, STOP_UNSUPPORTED_STMT_LOADG,
         STOP_UNSUPPORTED_STMT_CAS, STOP_UNSUPPORTED_STMT_LLSC, STOP_UNSUPPORTED_STMT_DIRTY,

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -990,6 +990,9 @@ void State::process_vex_block(IRSB *vex_block, address_t address) {
 				// TODO
 				block_taint_entry.has_unsupported_stmt_or_expr_type = true;
 				block_taint_entry.unsupported_stmt_stop_reason = STOP_UNSUPPORTED_STMT_DIRTY;
+				if (strcasestr(stmt->Ist.Dirty.details->cee->name, "cpuid")) {
+					block_taint_entry.has_cpuid_instr = true;
+				}
 				break;
 			}
 			case Ist_MBE:
@@ -1427,6 +1430,55 @@ int32_t State::get_vex_expr_result_size(IRExpr *expr, IRTypeEnv* tyenv) const {
 		return 0;
 	}
 	return sizeofIRType(expr_type);
+}
+
+bool State::is_cpuid_in_block(address_t block_address, int32_t block_size) {
+	bool found_cpuid_bytes = false;
+	bool has_cpuid_instr = false;
+	int32_t real_size;
+	int32_t i;
+	const uint8_t cpuid_bytes[] = {0xf, 0xa2};
+
+	// Assume block size is MAX_BB_SIZE if block size is report as 0.
+	// See State::step
+	real_size = block_size == 0 ? MAX_BB_SIZE : block_size;
+	std::unique_ptr<uint8_t[]> instructions(new uint8_t[real_size]);
+	uc_mem_read(this->uc, block_address, instructions.get(), real_size);
+	// Test 1: Look for bytes corresponding to the cpuid instruction(0fa2) in the block. Naive linear search for two
+	// byte pattern
+	i = 0;
+	while (i < real_size) {
+		if (instructions[i] == cpuid_bytes[0]) {
+			if (instructions[i + 1] == cpuid_bytes[1]) {
+				found_cpuid_bytes = true;
+				break;
+			}
+			i ++;
+		}
+		i++;
+	}
+	if (!found_cpuid_bytes) {
+		return false;
+	}
+	// Test 2: Verify using VEX statements of the block
+	auto block_entry = block_taint_cache.find(block_address);
+	if (block_entry == block_taint_cache.end()) {
+		// Process VEX block
+		auto vex_lift_result = lift_block(block_address, real_size);
+		if ((vex_lift_result == NULL) || (vex_lift_result->size == 0)) {
+			// Since VEX lift failed, we cannot verify if cpuid is present. Assume it could exit and stop emulation.
+			stop(STOP_VEX_LIFT_FAILED);
+			return true;
+		}
+		process_vex_block(vex_lift_result->irsb, block_address);
+		block_entry = block_taint_cache.find(block_address);
+	}
+	has_cpuid_instr = block_entry->second.has_cpuid_instr;
+	if (block_size == 0) {
+		// Remove block from block taint cache since size reported by unicorn is 0
+		block_taint_cache.erase(block_entry);
+	}
+	return has_cpuid_instr;
 }
 
 VEXLiftResult* State::lift_block(address_t block_address, int32_t block_size) {
@@ -1923,6 +1975,13 @@ void State::start_propagating_taint(address_t block_address, int32_t block_size)
 			stop(STOP_SYSCALL_ARM);
 			return;
 		}
+	}
+	if ((arch == UC_ARCH_X86) && is_cpuid_in_block(block_address, block_size)) {
+		// Check if emulation was stopped; could be if VEX lift failed
+		if (!stopped) {
+			stop(STOP_CPUID);
+		}
+		return;
 	}
 	block_symbolic_temps.clear();
 	block_start_reg_values.clear();

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1976,12 +1976,15 @@ void State::start_propagating_taint(address_t block_address, int32_t block_size)
 			return;
 		}
 	}
-	if ((arch == UC_ARCH_X86) && is_cpuid_in_block(block_address, block_size)) {
-		// Check if emulation was stopped; could be if VEX lift failed
-		if (!stopped) {
-			stop(STOP_X86_CPUID);
+	if ((arch == UC_ARCH_X86) && block_taint_cache.find(block_address) != block_taint_cache.end()) {
+		// This is a block not previously executed so it could be execute cpuid instruction
+		if (is_cpuid_in_block(block_address, block_size)) {
+			// Check if emulation was stopped; could be if VEX lift failed
+			if (!stopped) {
+				stop(STOP_X86_CPUID);
+			}
+			return;
 		}
-		return;
 	}
 	block_symbolic_temps.clear();
 	block_start_reg_values.clear();

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1979,7 +1979,7 @@ void State::start_propagating_taint(address_t block_address, int32_t block_size)
 	if ((arch == UC_ARCH_X86) && is_cpuid_in_block(block_address, block_size)) {
 		// Check if emulation was stopped; could be if VEX lift failed
 		if (!stopped) {
-			stop(STOP_CPUID);
+			stop(STOP_X86_CPUID);
 		}
 		return;
 	}

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -307,7 +307,7 @@ enum stop_t {
 	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE,
 	STOP_SYSCALL_ARM,
 	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK,
-	STOP_CPUID,
+	STOP_X86_CPUID,
 };
 
 typedef std::vector<std::pair<taint_entity_t, std::unordered_set<taint_entity_t>>> taint_vector_t;

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -307,6 +307,7 @@ enum stop_t {
 	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE,
 	STOP_SYSCALL_ARM,
 	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK,
+	STOP_CPUID,
 };
 
 typedef std::vector<std::pair<taint_entity_t, std::unordered_set<taint_entity_t>>> taint_vector_t;
@@ -363,13 +364,24 @@ struct block_taint_entry_t {
 	// Track instruction that sets a VEX temp and list of VEX temps on which its value depends on
 	std::unordered_map<taint_entity_t, std::pair<address_t, std::unordered_set<taint_entity_t>>> vex_temp_deps;
 	address_t exit_stmt_instr_addr;
+	bool has_cpuid_instr;
 	bool has_unsupported_stmt_or_expr_type;
 	stop_t unsupported_stmt_stop_reason;
 	std::unordered_set<taint_entity_t> block_next_entities;
 
+	block_taint_entry_t() {
+		block_instrs_taint_data_map.clear();
+		exit_stmt_guard_expr_deps.clear();
+		exit_stmt_instr_addr = 0;
+		vex_temp_deps.clear();
+		has_cpuid_instr = false;
+		has_unsupported_stmt_or_expr_type = false;
+		block_next_entities.clear();
+	}
+
 	bool operator==(const block_taint_entry_t &other_entry) const {
 		return (block_instrs_taint_data_map == other_entry.block_instrs_taint_data_map) &&
-			   (vex_temp_deps == other_entry.vex_temp_deps) &&
+			   (vex_temp_deps == other_entry.vex_temp_deps) && (has_cpuid_instr == other_entry.has_cpuid_instr) &&
 			   (exit_stmt_instr_addr == other_entry.exit_stmt_instr_addr) &&
 			   (exit_stmt_guard_expr_deps == other_entry.exit_stmt_guard_expr_deps) &&
 			   (block_next_entities == other_entry.block_next_entities);
@@ -532,6 +544,7 @@ class State {
 	bool is_symbolic_register(vex_reg_offset_t reg_offset, int64_t reg_size) const;
 	bool is_symbolic_temp(vex_tmp_id_t temp_id) const;
 
+	bool is_cpuid_in_block(address_t block_address, int32_t block_size);
 	VEXLiftResult* lift_block(address_t block_address, int32_t block_size);
 
 	void mark_register_symbolic(vex_reg_offset_t reg_offset, int64_t reg_size);

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -36,11 +36,11 @@ def trace_cgc_with_pov_file(binary: str, test_name: str, pov_file: str, output_i
     nose.tools.assert_true(stdout_dump.startswith(output_initial_bytes))
 
 
-def tracer_linux(filename, test_name, stdin):
+def tracer_linux(filename, test_name, stdin, add_options=None, remove_options=None):
     p = angr.Project(filename)
 
     trace, _, crash_mode, crash_addr = do_trace(p, test_name, stdin, ld_linux=p.loader.linux_loader_object.binary, library_path=set(os.path.dirname(obj.binary) for obj in p.loader.all_elf_objects), record_stdout=True)
-    s = p.factory.full_init_state(mode='tracing', stdin=angr.SimFileStream)
+    s = p.factory.full_init_state(mode='tracing', stdin=angr.SimFileStream, add_options=add_options, remove_options=remove_options)
     s.preconstrainer.preconstrain_file(stdin, s.posix.stdin, True)
 
     simgr = p.factory.simulation_manager(s, hierarchy=False, save_unconstrained=crash_mode)
@@ -177,7 +177,7 @@ def test_fauxware():
         raise nose.SkipTest()
 
     b = os.path.join(bin_location, "tests", "x86_64", "fauxware")
-    simgr, _ = tracer_linux(b, 'tracer_fauxware', b'A'*18)
+    simgr, _ = tracer_linux(b, 'tracer_fauxware', b'A'*18, remove_options={angr.options.CPUID_SYMBOLIC})
     simgr.run()
 
     nose.tools.assert_true('traced' in simgr.stashes)


### PR DESCRIPTION
This PR adds support for handling cpuid instruction correctly in native interface: detect if it's present in the block to be executed and switch to VEX engine. As a consequence, the fauxware tracer test case has been modified to disable symbolic cpuid.