### PR TITLE
Fix incorrect ailment expression construction in propogator

### DIFF
--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -493,7 +493,7 @@ class PropagatorAILState(PropagatorState):
         if start == 0:
             return ailment.Expr.Convert(None, expr.bits, bits, False, expr)
         else:
-            a = ailment.Expr.BinaryOp(None, "Shr", (expr, bits), False)
+            a = ailment.Expr.BinaryOp(None, "Shr", (expr, ailment.Expr.Const(None, None, bits, expr.bits)), False)
             return ailment.Expr.Convert(None, a.bits, bits, False, a)
 
     @staticmethod


### PR DESCRIPTION
Required for `login_handler` of `dorchester` to decompile correctly.