### PR TITLE
Use cross platform strstr in native interface instead of strcasestr

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -990,7 +990,7 @@ void State::process_vex_block(IRSB *vex_block, address_t address) {
 				// TODO
 				block_taint_entry.has_unsupported_stmt_or_expr_type = true;
 				block_taint_entry.unsupported_stmt_stop_reason = STOP_UNSUPPORTED_STMT_DIRTY;
-				if (strcasestr(stmt->Ist.Dirty.details->cee->name, "cpuid")) {
+				if (strstr(stmt->Ist.Dirty.details->cee->name, "CPUID")) {
 					block_taint_entry.has_cpuid_instr = true;
 				}
 				break;


### PR DESCRIPTION
This PR replaces use of `strcasestr` in native interface with cross-platform compatible `strstr`