### PR TITLE
Decompiler: Fix duplication of arguments in variable lists.

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -176,7 +176,7 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
                 # Skip all memory variables
                 continue
 
-            if cvar.unified_variable in arg_set:
+            if var in arg_set or cvar.unified_variable in arg_set:
                 continue
 
             unified_var = self.variable_manager.unified_variable(var)

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -409,6 +409,27 @@ def test_decompiling_libsoap():
         assert False
 
 
+def test_decompiling_no_arguments_in_variable_list():
+
+    # function arguments should never appear in the variable list
+    bin_path = os.path.join(test_location, "x86_64", "test_arrays")
+    p = angr.Project(bin_path, auto_load_libs=False)
+
+    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    _ = p.analyses.CompleteCallingConventions(recover_variables=True)
+
+    func = cfg.functions['main']
+
+    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    code = dec.codegen.text
+    print(code)
+
+    argc_name = " a0"  # update this variable once the decompiler picks up argument names from the common definition of
+                       # main()
+    assert argc_name in code
+    assert code.count(argc_name) == 1  # it should only appear once
+
+
 def test_decompiling_strings_local_strlen():
     bin_path = os.path.join(test_location, "x86_64", "types", "strings")
     p = angr.Project(bin_path, auto_load_libs=False)


### PR DESCRIPTION
This PR fixes https://github.com/angr/angr-management/issues/346.