### PR TITLE
make gcc happy with template specialization

### DIFF
--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -162,12 +162,14 @@ struct register_value_t {
 	}
 };
 
-template <>
-struct std::hash<register_value_t> {
-	std::size_t operator()(const register_value_t &value) const {
-		return value.operator()(value);
-	}
-};
+namespace std{
+	template <>
+	struct hash<register_value_t> {
+		std::size_t operator()(const register_value_t &value) const {
+			return value.operator()(value);
+		}
+	};
+}
 
 struct instr_details_t {
 	address_t instr_addr;

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -162,7 +162,7 @@ struct register_value_t {
 	}
 };
 
-namespace std{
+namespace std {
 	template <>
 	struct hash<register_value_t> {
 		std::size_t operator()(const register_value_t &value) const {


### PR DESCRIPTION
Most likely, this issue only happens when using an "old" gcc version.

I installed angr on Ubuntu 18.04 (using `gcc (Ubuntu 5.5.0-12ubuntu1~16.04) 5.5.0 20171010`) with the following steps:
```
mkvirtualenv -p /usr/local/bin/python3.7 angr
workon angr
cd angr-dev
./extremely-simple-setup.sh
```
I got the error:
```
    In file included from sim_unicorn.cpp:24:0:
    sim_unicorn.hpp:166:13: error: specialization of ‘template<class _Tp> struct std::hash’ in different namespace [-fpermissive]
     struct std::hash<register_value_t> {
                 ^
    In file included from /usr/include/c++/5/bits/basic_string.h:5574:0,
                     from /usr/include/c++/5/string:52,
                     from /usr/include/c++/5/random:40,
                     from /usr/include/c++/5/bits/stl_algo.h:66,
                     from /usr/include/c++/5/algorithm:62,
                     from sim_unicorn.cpp:3:
    /usr/include/c++/5/bits/functional_hash.h:58:12: error:   from definition of ‘template<class _Tp> struct std::hash’ [-fpermissive]
         struct hash;
                ^
    Makefile:40: recipe for target 'angr_native.so' failed
    make: *** [angr_native.so] Error 1
```

This error seems related to this [https://programmersought.com/article/41522947014/](https://programmersought.com/article/41522947014)
My fix follows the solution presented in the linked post.

Template specialization is already used somewhere else in `sim_unicorn.hpp`
Specifically, here:
```
// Hash function for unordered_map. Needs to be defined this way in C++.
namespace std {
	template <>
	struct hash<taint_entity_t> {
		std::size_t operator()(const taint_entity_t &entity) const {
			return entity.operator()(entity);
		}
	};
}
```
In this case the code is already in the format gcc likes.






