### PR TITLE
Use return value from malloc to store data in getdelim

### DIFF
--- a/angr/procedures/libc/getdelim.py
+++ b/angr/procedures/libc/getdelim.py
@@ -86,7 +86,7 @@ class __getdelim(angr.SimProcedure):
 
             malloc = angr.SIM_PROCEDURES['libc']['malloc']
 
-            dst = self.inline_call(malloc,real_size)
+            dst = self.inline_call(malloc,real_size).ret_expr
 
             self.state.memory.store(dst, data, size=real_size)
             self.state.memory.store(dst+real_size, b'\0')


### PR DESCRIPTION
This PR fixes getdelim `SimProcedure` to use the return value of the inline malloc call for further processing instead of the `SimProcedure` instance return by `inline_call`.