### PR TITLE
Use VEX block to determine address of write instruction instead of relying on unicorn engine

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -239,7 +239,7 @@ class SimEngineUnicorn(SuccessorsMixin):
                     break
 
         if (state.unicorn.stop_reason in (STOP.symbolic_stop_reasons + STOP.unsupported_reasons) or
-            state.unicorn.stop_reason in (STOP.STOP_UNKNOWN_MEMORY_WRITE, STOP.STOP_VEX_LIFT_FAILED)):
+            state.unicorn.stop_reason in (STOP.STOP_UNKNOWN_MEMORY_WRITE_SIZE, STOP.STOP_VEX_LIFT_FAILED)):
             l.info(state.unicorn.stop_message)
 
         if state.unicorn.jumpkind.startswith('Ijk_Sys'):

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -114,7 +114,7 @@ class STOP:  # stop_t
     STOP_UNSUPPORTED_EXPR_GETI    = 25
     STOP_UNSUPPORTED_STMT_UNKNOWN = 26
     STOP_UNSUPPORTED_EXPR_UNKNOWN = 27
-    STOP_UNKNOWN_MEMORY_WRITE     = 28
+    STOP_UNKNOWN_MEMORY_WRITE_SIZE = 28
     STOP_SYMBOLIC_MEM_DEP_NOT_LIVE = 29
     STOP_SYSCALL_ARM    = 30
     STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK = 31
@@ -149,7 +149,7 @@ class STOP:  # stop_t
     stop_message[STOP_UNSUPPORTED_EXPR_GETI]   = "Symbolic taint propagation for GetI expression not yet supported"
     stop_message[STOP_UNSUPPORTED_STMT_UNKNOWN]= "Canoo propagate symbolic taint for unsupported VEX statement type"
     stop_message[STOP_UNSUPPORTED_EXPR_UNKNOWN]= "Cannot propagate symbolic taint for unsupported VEX expression"
-    stop_message[STOP_UNKNOWN_MEMORY_WRITE]    = "Cannot find a memory write at instruction; likely because unicorn reported PC value incorrectly"
+    stop_message[STOP_UNKNOWN_MEMORY_WRITE_SIZE] = "Cannot determine size of memory write; likely because unicorn didn't"
     stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE] = "A symbolic memory dependency on stack is no longer in scope"
     stop_message[STOP_SYSCALL_ARM]   = "ARM syscalls are currently not supported by SimEngineUnicorn"
     stop_message[STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK] = "An instruction in current block overwrites a symbolic value needed for re-executing some instruction in same block"
@@ -1094,7 +1094,7 @@ class Unicorn(SimStatePlugin):
         self.stop_reason = self.stop_details.stop_reason
         self.stop_message = STOP.get_stop_msg(self.stop_reason)
         if self.stop_reason in (STOP.symbolic_stop_reasons + STOP.unsupported_reasons) or \
-          self.stop_reason in (STOP.STOP_UNKNOWN_MEMORY_WRITE, STOP.STOP_VEX_LIFT_FAILED):
+          self.stop_reason in (STOP.STOP_UNKNOWN_MEMORY_WRITE_SIZE, STOP.STOP_VEX_LIFT_FAILED):
             self.stop_message += f". Block 0x{self.stop_details.block_addr:02x}(size: {self.stop_details.block_size})."
 
         # figure out why we stopped
@@ -1150,8 +1150,8 @@ class Unicorn(SimStatePlugin):
         elif self.stop_reason in STOP.unsupported_reasons:
             self.countdown_nonunicorn_blocks = 0
             self.countdown_unsupported_stop = self.cooldown_unsupported_stop
-        elif self.stop_reason == STOP.STOP_UNKNOWN_MEMORY_WRITE:
-            # Skip one block in case of unknown memory write
+        elif self.stop_reason == STOP.STOP_UNKNOWN_MEMORY_WRITE_SIZE:
+            # Skip one block in case of unknown memory write size
             self.countdown_nonunicorn_blocks = 0
             self.countdown_unsupported_stop = 2
         else:

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -561,7 +561,7 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 	int start = address & 0xFFF;
 	int end = (address + size - 1) & 0xFFF;
 	short clean;
-	address_t curr_instr_addr;
+	address_t curr_instr_addr = 0;
 	bool is_dst_symbolic;
 
 	if (!bitmap) {
@@ -601,6 +601,13 @@ void State::handle_write(address_t address, int size, bool is_interrupt) {
 			}
 			auto &next_mem_write = block_mem_writes_taint_data.front();
 			is_dst_symbolic |= next_mem_write.is_symbolic;
+			if (curr_instr_addr == 0) {
+				curr_instr_addr = next_mem_write.instr_addr;
+			}
+			else if (curr_instr_addr != next_mem_write.instr_addr) {
+				printf("Memory writes from two instructions being processed as part of one instruction. This should not happen!\n");
+				abort();
+			}
 			if (size_of_writes_processed + next_mem_write.size > size) {
 				// Including current write entry exceeds size of current write reported by unicorn. Update size of write
 				// entry instead of erasing it completely

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -305,7 +305,7 @@ enum stop_t {
 	STOP_UNSUPPORTED_STMT_UNKNOWN,
 	STOP_UNSUPPORTED_EXPR_GETI,
 	STOP_UNSUPPORTED_EXPR_UNKNOWN,
-	STOP_UNKNOWN_MEMORY_WRITE,
+	STOP_UNKNOWN_MEMORY_WRITE_SIZE,
 	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE,
 	STOP_SYSCALL_ARM,
 	STOP_SYMBOLIC_MEM_DEP_NOT_LIVE_CURR_BLOCK,
@@ -448,6 +448,18 @@ struct mem_write_t {
 	std::vector<taint_t> previous_taint;
 };
 
+struct mem_write_taint_t {
+	address_t instr_addr;
+	bool is_symbolic;
+	uint32_t size;
+
+	mem_write_taint_t(address_t write_instr, bool symbolic, uint32_t write_size) {
+		instr_addr = write_instr;
+		is_symbolic = symbolic;
+		size = write_size;
+	}
+};
+
 struct mem_update_t {
 	address_t address;
 	uint64_t length;
@@ -480,7 +492,7 @@ class State {
 	// Memory write instruction address -> is_symbolic
 	// TODO: Need to modify memory write taint handling for architectures that perform multiple
 	// memory writes in a single instruction
-	std::unordered_map<address_t, bool> mem_writes_taint_map;
+	std::vector<mem_write_taint_t> block_mem_writes_taint_data;
 
 	// List of instructions in a block that should be executed symbolically. These are stored
 	// separately for easy rollback in case of errors.

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -335,13 +335,15 @@ struct instruction_taint_entry_t {
 	uint32_t mem_read_size;
 
 	bool has_memory_read;
-	bool has_memory_write;
+
+	// Count number of bytes written to memory by the instruction
+	uint32_t mem_write_size;
 
 	bool operator==(const instruction_taint_entry_t &other_instr_deps) const {
 		return (taint_sink_src_map == other_instr_deps.taint_sink_src_map) &&
 			   (dependencies == other_instr_deps.dependencies) &&
 			   (has_memory_read == other_instr_deps.has_memory_read) &&
-			   (has_memory_write == other_instr_deps.has_memory_write);
+			   (mem_write_size == other_instr_deps.mem_write_size);
 	}
 
 	void reset() {
@@ -353,8 +355,8 @@ struct instruction_taint_entry_t {
 		ite_cond_entity_list.clear();
 		taint_sink_src_map.clear();
 		has_memory_read = false;
-		has_memory_write = false;
 		mem_read_size = 0;
+		mem_write_size = 0;
 		unmodified_dep_regs.clear();
 		return;
 	}


### PR DESCRIPTION
Occasionally, the value of PC register reported by unicorn is incorrect, making it unreliable when propagating taint to memory. This PR fixes this by using the VEX block to determine the address of instruction writing to memory, similar to how address of instruction reading data from memory is determined.

Edit: Missed adding some more details. This effectively removes need for `STOP_UNKNOWN_MEMORY_WRITE` since we can reliably determine address of write instruction from VEX block. However, I chose to replace it with `STOP_UNKNOWN_MEMORY_WRITE_SIZE`(when we simply switch to VEX engine) just in case there are scenarios where unicorn does not correctly report the size of the write. I'm unsure if such a scenario will arise but left it in there anyway. If that's not needed, I can remove it.