### PR TITLE
Updated MemoryValue fields to match the native interface struct

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -56,7 +56,8 @@ class MemoryValue(ctypes.Structure): # memory_value_t
     _fields_ = [
         ('address', ctypes.c_uint64),
         ('value', ctypes.c_uint8 * _MAX_MEM_ACCESS_SIZE),
-        ('size', ctypes.c_uint64)
+        ('size', ctypes.c_uint64),
+        ('is_value_symbolic', ctypes.c_bool)
     ]
 
 class RegisterValue(ctypes.Structure): # register_value_t


### PR DESCRIPTION
This PR adds the missing `is_value_symbolic` field to `MemoryValue` class in the unicorn state plugin. The field was added to the `memory_value_t` struct in the native interface in #2477 but the `MemoryValue` class was not updated. I feel it is easier to add this field to `MemoryValue` class(even though it's not used in state plugin) than introduce a new struct to copy only the fields needed over FFI. The boolean field does introduce the overhead of copying an additional unsigned integer(https://docs.python.org/3/library/ctypes.html#ctypes.c_bool) across FFI but copying fields to a new struct in native interface is probably going to incur a similar amount of overhead.