### PR TITLE
Propagator: AIL engine's memory model is now aware of partially zeroed register and memory bytes.

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1297,14 +1297,20 @@ class CTypeCast(CExpression):
         return self._type
 
     def c_repr_chunks(self, indent=0, asexpr=False):
+        leading_paren = False
+        paren = CClosingObject("(")
         if self.codegen.show_casts:
-            paren = CClosingObject("(")
-            yield "(", paren
+            # look ahead to detect if a leading paren is required
+            if isinstance(self.expr, CFunctionCall):
+                leading_paren = False
+            else:
+                leading_paren = True
+                yield "(", paren
             yield "(", paren
             yield "{}".format(self.dst_type), self
             yield ")", paren
         yield from CExpression._try_c_repr_chunks(self.expr)
-        if self.codegen.show_casts:
+        if self.codegen.show_casts and leading_paren:
             yield ")", paren
 
 

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1300,9 +1300,12 @@ class CTypeCast(CExpression):
         if self.codegen.show_casts:
             paren = CClosingObject("(")
             yield "(", paren
+            yield "(", paren
             yield "{}".format(self.dst_type), self
             yield ")", paren
         yield from CExpression._try_c_repr_chunks(self.expr)
+        if self.codegen.show_casts:
+            yield ")", paren
 
 
 class CConstant(CExpression):

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -101,7 +101,7 @@ class SimEnginePropagatorAIL(
 
     def _ail_handle_Jump(self, stmt):
         target = self._expr(stmt.target)
-        if target.one_expr == stmt.target:
+        if target is None or  target.one_expr == stmt.target:
             return
 
         if target.one_expr is not None:

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -119,14 +119,17 @@ class SimEnginePropagatorAIL(
                 _ = self._expr(arg)
 
         if expr_stmt.ret_expr is not None:
-            # it has a return expression. awesome - treat it as an assignment
-            v = PropValue.from_value_and_details(
-                self.state.top(expr_stmt.ret_expr.size * self.arch.byte_width),
-                expr_stmt.ret_expr.size, expr_stmt.ret_expr, self._codeloc()
-            )
-            self.state.store_register(expr_stmt.ret_expr.offset, v)
-            # set equivalence
-            self.state.add_equivalence(self._codeloc(), expr_stmt.ret_expr, expr_stmt)
+            if isinstance(expr_stmt.ret_expr, Expr.Register):
+                # it has a return expression. awesome - treat it as an assignment
+                v = PropValue.from_value_and_details(
+                    self.state.top(expr_stmt.ret_expr.size * self.arch.byte_width),
+                    expr_stmt.ret_expr.size, expr_stmt.ret_expr, self._codeloc()
+                )
+                self.state.store_register(expr_stmt.ret_expr, v)
+                # set equivalence
+                self.state.add_equivalence(self._codeloc(), expr_stmt.ret_expr, expr_stmt)
+            else:
+                l.warning("Unsupported ret_expr type %s.", expr_stmt.ret_expr.__class__)
 
     def _ail_handle_ConditionalJump(self, stmt):
         _ = self._expr(stmt.condition)

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -9,6 +9,7 @@ from ...utils.constants import is_alignment_mask
 from ...engines.light import SimEngineLightAILMixin
 from ...sim_variable import SimStackVariable
 from .engine_base import SimEnginePropagatorBase
+from .prop_value import PropValue, Detail
 
 if TYPE_CHECKING:
     from .propagator import PropagatorAILState
@@ -51,17 +52,21 @@ class SimEnginePropagatorAIL(
         dst = stmt.dst
 
         if type(dst) is Expr.Tmp:
-            self.state.store_variable(dst, src, self._codeloc())
+            self.state.store_temp(dst.tmp_idx, src)
 
         elif type(dst) is Expr.Register:
-            self.state.store_variable(dst, src, self._codeloc())
+            if src.needs_details:
+                # provide details
+                src = src.with_details(dst.size, dst, self._codeloc())
+
+            self.state.store_register(dst, src)
             if isinstance(stmt.src, (Expr.Register, Stmt.Call)):
                 # set equivalence
                 self.state.add_equivalence(self._codeloc(), dst, stmt.src)
         else:
             l.warning('Unsupported type of Assignment dst %s.', type(dst).__name__)
 
-    def _ail_handle_Store(self, stmt):
+    def _ail_handle_Store(self, stmt: Stmt.Store):
 
         self.state: 'PropagatorAILState'
 
@@ -69,29 +74,26 @@ class SimEnginePropagatorAIL(
         data = self._expr(stmt.data)
 
         # is it accessing the stack?
-        sp_offset = self.extract_offset_to_sp(addr)
+        sp_offset = self.extract_offset_to_sp(addr.value)
         if sp_offset is not None:
-            if isinstance(data, Expr.StackBaseOffset):
+            if isinstance(data.one_expr, Expr.StackBaseOffset):
                 # convert it to a BV
-                expr = data
-                data_v = self.sp_offset(data.offset)
+                expr = data.one_expr
+                data_v = self.sp_offset(data.one_expr.offset)
                 size = data_v.size() // self.arch.byte_width
-            elif isinstance(data, claripy.ast.BV):
-                expr = stmt.data
-                data_v = data
+                to_store = PropValue.from_value_and_details(data_v, size, expr, self._codeloc())
+            elif isinstance(data.value, claripy.ast.BV):
+                expr = data.one_expr if data.one_expr is not None else stmt.data
+                data_v = data.value
                 size = data_v.size() // self.arch.byte_width
+                to_store = PropValue.from_value_and_details(data_v, size, expr, self._codeloc())
             else:
-                expr = data
-                data_v = self.state.top(data.bits)
-                size = data.bits // self.arch.byte_width
+                size = stmt.size
+                to_store = data.with_details(stmt.size, data.one_expr if data.one_expr is not None else stmt.data,
+                                             self._codeloc())
 
-            if data_v is not None:
-                # Storing data to a stack variable
-                self.state.store_stack_variable(sp_offset, size, data_v,
-                                                expr=expr,
-                                                def_at=self._codeloc(),
-                                                endness=stmt.endness,
-                                                )
+            # Storing data to a stack variable
+            self.state.store_stack_variable(sp_offset, to_store, endness=stmt.endness)
 
             # set equivalence
             var = SimStackVariable(sp_offset, size)
@@ -99,11 +101,11 @@ class SimEnginePropagatorAIL(
 
     def _ail_handle_Jump(self, stmt):
         target = self._expr(stmt.target)
-        if target == stmt.target:
+        if target.one_expr == stmt.target:
             return
 
-        if not self.state.is_top(target):
-            new_jump_stmt = Stmt.Jump(stmt.idx, target, **stmt.tags)
+        if target.one_expr is not None:
+            new_jump_stmt = Stmt.Jump(stmt.idx, target.one_expr, **stmt.tags)
             self.state.add_replacement(self._codeloc(),
                                        stmt,
                                        new_jump_stmt,
@@ -116,12 +118,13 @@ class SimEnginePropagatorAIL(
             for arg in expr_stmt.args:
                 _ = self._expr(arg)
 
-        if expr_stmt.ret_expr:
+        if expr_stmt.ret_expr is not None:
             # it has a return expression. awesome - treat it as an assignment
-            self.state.store_variable(expr_stmt.ret_expr,
-                                      self.state.top(expr_stmt.ret_expr.size * self.arch.byte_width),
-                                      self._codeloc(),
-                                      )
+            v = PropValue.from_value_and_details(
+                self.state.top(expr_stmt.ret_expr.size * self.arch.byte_width),
+                expr_stmt.ret_expr.size, expr_stmt.ret_expr, self._codeloc()
+            )
+            self.state.store_register(expr_stmt.ret_expr.offset, v)
             # set equivalence
             self.state.add_equivalence(self._codeloc(), expr_stmt.ret_expr, expr_stmt)
 
@@ -139,26 +142,40 @@ class SimEnginePropagatorAIL(
     # AIL expression handlers
     #
 
-    def _ail_handle_Tmp(self, expr: Expr.Tmp):
-        new_expr = self.state.get_variable(expr)
+    def _expr(self, expr) -> Optional[PropValue]:
+        return super()._expr(expr)
 
-        if new_expr is not None:
+    def _ail_handle_Tmp(self, expr: Expr.Tmp) -> PropValue:
+        tmp = self.state.load_tmp(expr.tmp_idx)
+
+        if tmp is not None:
             # check if this new_expr uses any expression that has been overwritten
-            if self.is_using_outdated_def(new_expr):
-                return self.state.top(expr.size * self.arch.byte_width)
+            all_subexprs = list(tmp.all_exprs())
+            if any(self.is_using_outdated_def(sub_expr) for sub_expr in all_subexprs):
+                return PropValue.from_value_and_details(
+                    self.state.top(expr.size * self.arch.byte_width), expr.size, expr, self._codeloc())
 
-            l.debug("Add a replacement: %s with %s", expr, new_expr)
-            self.state.add_replacement(self._codeloc(), expr, new_expr)
-            # if isinstance(new_expr, (Expr.Register, Expr.Const, Expr.Convert, Expr.BasePointerOffset)):
-            return new_expr
+            if len(all_subexprs) == 1 and 0 in tmp.offset_and_details and tmp.offset_and_details[0].size == expr.size:
+                subexpr = all_subexprs[0]
+                l.debug("Add a replacement: %s with %s", expr, subexpr)
+                self.state.add_replacement(self._codeloc(), expr, subexpr)
+            elif tmp.offset_and_details and 0 in tmp.offset_and_details:
+                non_zero_subexprs = list(tmp.non_zero_exprs())
+                if len(non_zero_subexprs) == 1 and non_zero_subexprs[0] is tmp.offset_and_details[0].expr:
+                    # we will use the zero-extended version as the replacement
+                    subexpr = non_zero_subexprs[0]
+                    subexpr = Expr.Convert(subexpr.idx, subexpr.bits, expr.bits, False, subexpr)
+                    l.debug("Add a replacement: %s with %s", expr, subexpr)
+                    self.state.add_replacement(self._codeloc(), expr, subexpr)
+            return tmp
 
         if not self._propagate_tmps:
             # we should not propagate any tmps. as a result, we return None for reading attempts to a tmp.
-            return self.state.top(expr.size * self.arch.byte_width)
+            return PropValue(self.state.top(expr.size * self.arch.byte_width))
 
-        return self.state.top(expr.size * self.arch.byte_width)
+        return PropValue(self.state.top(expr.size * self.arch.byte_width))
 
-    def _ail_handle_Register(self, expr):
+    def _ail_handle_Register(self, expr: Expr.Register) -> Optional[PropValue]:
 
         self.state: 'PropagatorAILState'
 
@@ -169,38 +186,47 @@ class SimEnginePropagatorAIL(
                 if sb_offset is not None:
                     new_expr = Expr.StackBaseOffset(None, self.arch.bits, sb_offset)
                     self.state.add_replacement(self._codeloc(), expr, new_expr)
-                    return new_expr
+                    return PropValue.from_value_and_details(
+                        self.sp_offset(sb_offset), expr.size, new_expr, self._codeloc()
+                    )
             elif expr.reg_offset == self.arch.bp_offset:
                 sb_offset = self._stack_pointer_tracker.offset_before(self.ins_addr, self.arch.bp_offset)
                 if sb_offset is not None:
                     new_expr = Expr.StackBaseOffset(None, self.arch.bits, sb_offset)
                     self.state.add_replacement(self._codeloc(), expr, new_expr)
-                    return new_expr
+                    return PropValue.from_value_and_details(
+                        self.sp_offset(sb_offset), expr.size, new_expr, self._codeloc()
+                    )
 
-        new_expr = self.state.get_variable(expr)
+        new_expr = self.state.load_register(expr)
         if new_expr is not None:
             # check if this new_expr uses any expression that has been overwritten
-            if not self.is_using_outdated_def(new_expr):
-                l.debug("Add a replacement: %s with %s", expr, new_expr)
-                self.state.add_replacement(self._codeloc(), expr, new_expr)
-                expr = new_expr
+            all_subexprs = list(new_expr.all_exprs())
+            if not any(self.is_using_outdated_def(subexpr) for subexpr in all_subexprs) and \
+                    len(all_subexprs) == 1:
+                subexpr = all_subexprs[0]
+                l.debug("Add a replacement: %s with %s", expr, subexpr)
+                self.state.add_replacement(self._codeloc(), expr, subexpr)
+            return new_expr
 
-        return expr
+        return PropValue.from_value_and_details(self.state.top(expr.bits), expr.size, expr, self._codeloc())
 
-    def _ail_handle_Load(self, expr: Expr.Load):
+    def _ail_handle_Load(self, expr: Expr.Load) -> Optional[PropValue]:
 
         self.state: 'PropagatorAILState'
 
         addr = self._expr(expr.addr)
 
-        if self.state.is_top(addr):
-            return self.state.top(expr.size * self.arch.byte_width)
+        if self.state.is_top(addr.value):
+            return PropValue.from_value_and_details(
+                self.state.top(expr.size * self.arch.byte_width), expr.size, expr, self._codeloc()
+            )
 
-        sp_offset = self.extract_offset_to_sp(addr)
+        sp_offset = self.extract_offset_to_sp(addr.value)
         if sp_offset is not None:
             # Stack variable.
-            var = self.state.get_stack_variable(sp_offset, expr.size, endness=expr.endness)
-            if var is not None and not self.state.is_top(var):
+            var = self.state.load_stack_variable(sp_offset, expr.size, endness=expr.endness)
+            if var is not None and not self.state.is_top(var.value):
                 # We do not add replacements here since in AIL function and block simplifiers we explicitly forbid
                 # replacing stack variables.
                 #
@@ -209,54 +235,141 @@ class SimEnginePropagatorAIL(
                 #    self.state.add_replacement(self._codeloc(), expr, var)
                 return var
 
-        if addr is not expr.addr:
-            return Expr.Load(expr.idx, addr, expr.size, expr.endness, **expr.tags)
-        return expr
+        addr_expr = addr.one_expr
+        if addr_expr is not None and addr_expr is not expr.addr:
+            new_expr = Expr.Load(expr.idx, addr_expr, expr.size, expr.endness, **expr.tags)
+        else:
+            new_expr = expr
+        prop_value = PropValue.from_value_and_details(
+            self.state.top(expr.size * self.arch.byte_width), expr.size, new_expr, self._codeloc()
+        )
+        return prop_value
 
-    def _ail_handle_Convert(self, expr: Expr.Convert):
-        operand_expr = self._expr(expr.operand)
+    def _ail_handle_Convert(self, expr: Expr.Convert) -> PropValue:
+        o_value = self._expr(expr.operand)
 
-        if self.state.is_top(operand_expr):
-            return self.state.top(expr.to_bits)
-
-        if type(operand_expr) is Expr.Convert:
-            if expr.from_bits == operand_expr.to_bits and expr.to_bits == operand_expr.from_bits:
-                # eliminate the redundant Convert
-                return operand_expr.operand
+        if o_value is None or self.state.is_top(o_value.value):
+            new_value = self.state.top(expr.to_bits)
+        else:
+            if expr.from_bits < expr.to_bits:
+                if expr.is_signed:
+                    new_value = claripy.SignExt(expr.to_bits - expr.from_bits, o_value.value)
+                else:
+                    new_value = claripy.ZeroExt(expr.to_bits - expr.from_bits, o_value.value)
+            elif expr.from_bits > expr.to_bits:
+                new_value = claripy.Extract(expr.to_bits - 1, 0, o_value.value)
             else:
-                return Expr.Convert(expr.idx, operand_expr.from_bits, expr.to_bits, expr.is_signed, operand_expr.operand)
-        elif type(operand_expr) is Expr.Const:
-            # do the conversion right away
-            value = operand_expr.value
-            mask = (2 ** expr.to_bits) - 1
-            value &= mask
-            return Expr.Const(expr.idx, operand_expr.variable, value, expr.to_bits)
+                new_value = o_value.value
 
-        converted = Expr.Convert(expr.idx, expr.from_bits, expr.to_bits, expr.is_signed, operand_expr, **expr.tags)
-        return converted
+        o_expr = o_value.one_expr
+        o_defat = o_value.one_defat
+        if o_expr is not None:
+            # easy cases
+            if type(o_expr) is Expr.Convert:
+                if expr.from_bits == o_expr.to_bits and expr.to_bits == o_expr.from_bits:
+                    # eliminate the redundant Convert
+                    new_expr = o_expr.operand
+                else:
+                    new_expr = Expr.Convert(expr.idx, o_expr.from_bits, expr.to_bits, expr.is_signed, o_expr.operand)
+            elif type(o_expr) is Expr.Const:
+                # do the conversion right away
+                value = o_expr.value
+                mask = (2 ** expr.to_bits) - 1
+                value &= mask
+                new_expr = Expr.Const(expr.idx, o_expr.variable, value, expr.to_bits)
+            else:
+                new_expr = Expr.Convert(expr.idx, expr.from_bits, expr.to_bits, expr.is_signed, o_expr, **expr.tags)
 
-    def _ail_handle_Const(self, expr):
-        return expr
+            if isinstance(new_expr, Expr.Convert) and not new_expr.is_signed \
+                    and new_expr.to_bits > new_expr.from_bits and new_expr.from_bits % self.arch.byte_width == 0:
+                # special handling for zero-extension: it simplifies the code if we explicitly model zeros
+                new_size = new_expr.from_bits // self.arch.byte_width
+                offset_and_details = {
+                    0: Detail(new_size, new_expr.operand, o_defat),
+                    new_size: Detail(
+                        new_expr.size - new_size,
+                        Expr.Const(expr.idx, None, 0, new_expr.to_bits - new_expr.from_bits),
+                        self._codeloc()),
+                }
+            else:
+                offset_and_details = {0: Detail(expr.size, new_expr, self._codeloc())}
 
-    def _ail_handle_DirtyExpression(self, expr):  # pylint:disable=no-self-use
-        return expr
+            return PropValue(new_value, offset_and_details=offset_and_details)
 
-    def _ail_handle_ITE(self, expr: Expr.ITE):
-        cond = self._expr(expr.cond)  # pylint:disable=unused-variable
-        iftrue = self._expr(expr.iftrue)  # pylint:disable=unused-variable
-        iffalse = self._expr(expr.iffalse)  # pylint:disable=unused-variable
+        elif o_value.offset_and_details:
+            # hard cases... we will keep certain labels and eliminate other labels
+            start_offset = 0
+            end_offset = expr.to_bits // self.arch.byte_width
+            offset_and_details = {}
+            for offset_, detail_ in o_value.offset_and_details.items():
+                if offset_ < start_offset and offset_ + detail_.size > start_offset:
+                    # we start here
+                    off = 0
+                    siz = min(end_offset, offset_ + detail_.size) - start_offset
+                    expr_ = self._extract_ail_expression(
+                        (start_offset - offset_) * self.arch.byte_width,
+                        siz * self.arch.byte_width,
+                        detail_.expr
+                    )
+                    offset_and_details[off] = Detail(siz, expr_, detail_.def_at)
+                elif offset_ >= start_offset and offset_ + detail_.size <= end_offset:
+                    # we include the whole thing
+                    off = offset_ - start_offset
+                    siz = detail_.size
+                    offset_and_details[off] = Detail(siz, detail_.expr, detail_.def_at)
+                elif offset_ < end_offset and offset_ + detail_.size >= end_offset:
+                    # we include all the way until end_offset
+                    if offset_ < start_offset:
+                        off = 0
+                        siz = end_offset - start_offset
+                    else:
+                        off = offset_ - start_offset
+                        siz = end_offset - offset_
+                    expr_ = self._extract_ail_expression(0, siz * self.arch.byte_width, detail_.expr)
+                    offset_and_details[off] = Detail(siz, expr_, detail_.def_at)
 
-        return expr
+            return PropValue(
+                new_value,
+                offset_and_details=offset_and_details
+            )
+        else:
+            # it's empty... no expression is available for whatever reason
+            return PropValue.from_value_and_details(new_value, expr.size, expr, self._codeloc())
 
-    def _ail_handle_Reinterpret(self, expr: Expr.Reinterpret):
+    def _ail_handle_Const(self, expr: Expr.Const) -> PropValue:
+        return PropValue.from_value_and_details(claripy.BVV(expr.value, expr.bits), expr.size, expr, self._codeloc())
+
+    def _ail_handle_DirtyExpression(self, expr: Expr.DirtyExpression) -> Optional[PropValue]:  # pylint:disable=no-self-use
+        return PropValue.from_value_and_details(
+            self.state.top(expr.bits),expr.size, expr, self._codeloc()
+        )
+
+    def _ail_handle_ITE(self, expr: Expr.ITE) -> Optional[PropValue]:
+        # pylint:disable=unused-variable
+        cond = self._expr(expr.cond)
+        iftrue = self._expr(expr.iftrue)
+        iffalse = self._expr(expr.iffalse)
+
+        return PropValue.from_value_and_details(
+            self.state.top(expr.bits),
+            expr.size, expr, self._codeloc()
+        )
+
+    def _ail_handle_Reinterpret(self, expr: Expr.Reinterpret) -> Optional[PropValue]:
         arg = self._expr(expr.operand)
 
-        if self.state.is_top(arg):
-            arg = expr.operand
+        if self.state.is_top(arg.value):
+            one_expr = arg.one_expr
+            if one_expr is not None:
+                expr = Expr.Reinterpret(expr.idx, expr.from_bits, expr.from_type, expr.to_bits, expr.to_type, one_expr,
+                                        **expr.tags)
 
-        return Expr.Reinterpret(expr.idx, expr.from_bits, expr.from_type, expr.to_bits, expr.to_type, arg, **expr.tags)
+        return PropValue.from_value_and_details(
+            arg.value,
+            expr.size, expr, self._codeloc()
+        )
 
-    def _ail_handle_CallExpr(self, expr_stmt: Stmt.Call):  # pylint:disable=useless-return
+    def _ail_handle_CallExpr(self, expr_stmt: Stmt.Call) -> Optional[PropValue]:
         _ = self._expr(expr_stmt.target)
 
         if expr_stmt.args:
@@ -264,22 +377,33 @@ class SimEnginePropagatorAIL(
                 _ = self._expr(arg)
 
         # ignore ret_expr
-        return expr_stmt
+        return PropValue.from_value_and_details(
+            self.state.top(expr_stmt.bits),
+            expr_stmt.size, expr_stmt, self._codeloc()
+        )
 
-    def _ail_handle_Cmp(self, expr: Expr.BinaryOp):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+    def _ail_handle_Cmp(self, expr: Expr.BinaryOp) -> PropValue:
+        operand_0_value = self._expr(expr.operands[0])
+        operand_1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            operand_0 = expr.operands[0]
-        if self.state.is_top(operand_1):
-            operand_1 = expr.operands[1]
+        if operand_0_value is not None and operand_1_value is not None:
+            operand_0_oneexpr = operand_0_value.one_expr
+            operand_1_oneexpr = operand_1_value.one_expr
+            if operand_0_oneexpr is expr.operands[0] and operand_1_oneexpr is expr.operands[1]:
+                # nothing changed
+                return PropValue.from_value_and_details(self.state.top(expr.bits), expr.size, expr, self._codeloc())
+            else:
+                operand_0 = operand_0_oneexpr if operand_0_oneexpr is not None else expr.operands[0]
+                operand_1 = operand_1_oneexpr if operand_1_oneexpr is not None else expr.operands[1]
 
-        if operand_0 is expr.operands[0] and operand_1 is expr.operands[1]:
-            # nothing changed
-            return expr
+            new_expr = Expr.BinaryOp(expr.idx, expr.op, [operand_0, operand_1], expr.signed, **expr.tags)
+        else:
+            new_expr = expr
 
-        return Expr.BinaryOp(expr.idx, expr.op, [operand_0, operand_1], expr.signed, **expr.tags)
+        return PropValue.from_value_and_details(
+            self.state.top(expr.bits),
+            expr.size, new_expr, self._codeloc()
+        )
 
     _ail_handle_CmpF = _ail_handle_Cmp
     _ail_handle_CmpLE = _ail_handle_Cmp
@@ -293,171 +417,269 @@ class SimEnginePropagatorAIL(
     _ail_handle_CmpEQ = _ail_handle_Cmp
     _ail_handle_CmpNE = _ail_handle_Cmp
 
-    def _ail_handle_Add(self, expr: Expr.BinaryOp):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+    def _ail_handle_Add(self, expr: Expr.BinaryOp) -> PropValue:
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+            value = self.state.top(expr.bits)
+        else:
+            if o0_value.value.concrete and o1_value.value.concrete:
+                value = o0_value.value + o1_value.value
+            else:
+                value = self.state.top(expr.bits)
 
-        if isinstance(operand_0, Expr.Const) and isinstance(operand_1, Expr.Const):
-            return Expr.Const(expr.idx, None, operand_0.value + operand_1.value, expr.bits)
-        elif isinstance(operand_0, Expr.BasePointerOffset) and isinstance(operand_1, Expr.Const):
-            r = operand_0.copy()
-            r.offset += operand_1.value
-            return r
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            if isinstance(o0_expr, Expr.BasePointerOffset) and isinstance(o1_expr, Expr.Const):
+                new_expr = o0_value.one_expr.copy()
+                new_expr.offset += o1_expr.value
+            else:
+                new_expr = Expr.BinaryOp(expr.idx,
+                                         'Add',
+                                         [o0_expr if o0_expr is not None else expr.operands[0],
+                                          o1_expr if o1_expr is not None else expr.operands[1],],
+                                         expr.signed,
+                                         **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
-        return Expr.BinaryOp(expr.idx, 'Add', [operand_0 if operand_0 is not None else expr.operands[0],
-                                               operand_1 if operand_1 is not None else expr.operands[1]
-                                               ],
-                             expr.signed,
-                             **expr.tags)
+    def _ail_handle_Sub(self, expr: Expr.BinaryOp) -> PropValue:
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-    def _ail_handle_Sub(self, expr: Expr.BinaryOp):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+            value = self.state.top(expr.bits)
+        else:
+            if o0_value.value.concrete and o1_value.value.concrete:
+                value = o0_value.value - o1_value.value
+            else:
+                value = self.state.top(expr.bits)
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            if isinstance(o0_expr, Expr.BasePointerOffset) and isinstance(o1_expr, Expr.Const):
+                new_expr = o0_value.one_expr.copy()
+                new_expr.offset -= o1_expr.value
+            else:
+                new_expr = Expr.BinaryOp(expr.idx,
+                                         'Sub',
+                                         [o0_expr if o0_expr is not None else expr.operands[0],
+                                          o1_expr if o1_expr is not None else expr.operands[1],],
+                                         expr.signed,
+                                         **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
-        if isinstance(operand_0, Expr.Const) and isinstance(operand_1, Expr.Const):
-            return Expr.Const(expr.idx, None, operand_0.value - operand_1.value, expr.bits)
-        elif isinstance(operand_0, Expr.BasePointerOffset) and isinstance(operand_1, Expr.Const):
-            r = operand_0.copy()
-            r.offset -= operand_1.value
-            return r
-
-        return Expr.BinaryOp(expr.idx, 'Sub', [ operand_0 if operand_0 is not None else expr.operands[0],
-                                                operand_1 if operand_1 is not None else expr.operands[1]
-                                                ],
-                             expr.signed,
-                             **expr.tags)
-
-    def _ail_handle_StackBaseOffset(self, expr: Expr.StackBaseOffset) -> Expr.StackBaseOffset:  # pylint:disable=no-self-use
-        return expr
+    def _ail_handle_StackBaseOffset(self, expr: Expr.StackBaseOffset) -> PropValue:  # pylint:disable=no-self-use
+        return PropValue.from_value_and_details(self.state.top(expr.bits), expr.size, expr, self._codeloc())
 
     def _ail_handle_And(self, expr: Expr.BinaryOp):
 
-        self.state: 'PropagatorAILState'
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        # Special logic for stack pointer alignment
-        sp_offset = self.extract_offset_to_sp(operand_0)
-        if sp_offset is not None and type(operand_1) is Expr.Const and is_alignment_mask(operand_1.value):
-            return operand_0
-
-        return Expr.BinaryOp(expr.idx, 'And', [ operand_0, operand_1 ], expr.signed, **expr.tags)
+            # Special logic for stack pointer alignment
+            sp_offset = self.extract_offset_to_sp(o0_value.value)
+            if sp_offset is not None and type(o1_expr) is Expr.Const and is_alignment_mask(o1_expr.value):
+                value = o0_value.value
+                new_expr = o0_expr
+            else:
+                value = self.state.top(expr.bits)
+                new_expr = Expr.BinaryOp(expr.idx,
+                                         'And',
+                                         [o0_expr if o0_expr is not None else expr.operands[0],
+                                          o1_expr if o1_expr is not None else expr.operands[1],],
+                                         expr.signed,
+                                         **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_Or(self, expr: Expr.BinaryOp):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        return Expr.BinaryOp(expr.idx, 'Or', [ operand_0, operand_1 ], expr.signed, **expr.tags)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Or',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1],],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_Xor(self, expr: Expr.BinaryOp):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        return Expr.BinaryOp(expr.idx, 'Xor', [ operand_0, operand_1 ], expr.signed, **expr.tags)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Xor',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1],],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_Shl(self, expr: Expr.BinaryOp):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        return Expr.BinaryOp(expr.idx, 'Shl', [ operand_0, operand_1 ], expr.signed, **expr.tags)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Shl',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1], ],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_Shr(self, expr: Expr.BinaryOp):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Shr',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1],],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
-        return Expr.BinaryOp(expr.idx, 'Shr', [ operand_0, operand_1 ], expr.signed, **expr.tags)
+    def _ail_handle_Sar(self, expr: Expr.BinaryOp):
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
+
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Sar',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1],],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_Mul(self, expr):
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
-
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        return Expr.BinaryOp(expr.idx, 'Mul', [operand_0, operand_1, ], expr.signed, bits=expr.bits, **expr.tags)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Mul',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1],],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_Mull(self, expr):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        return Expr.BinaryOp(expr.idx, 'Mull', [operand_0, operand_1, ], expr.signed, bits=expr.bits, **expr.tags)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Mull',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1],],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_Div(self, expr):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        return Expr.BinaryOp(expr.idx, 'Div', [ operand_0, operand_1, ], expr.signed, **expr.tags)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Div',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1],],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_DivMod(self, expr):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        return Expr.BinaryOp(expr.idx, 'DivMod', [operand_0, operand_1, ], expr.signed, **expr.tags)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'DivMod',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1],],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     def _ail_handle_Concat(self, expr):
-        operand_0 = self._expr(expr.operands[0])
-        operand_1 = self._expr(expr.operands[1])
+        o0_value = self._expr(expr.operands[0])
+        o1_value = self._expr(expr.operands[1])
 
-        if self.state.is_top(operand_0):
-            return self.state.top(expr.bits)
-        elif self.state.is_top(operand_1):
-            return self.state.top(expr.bits)
-
-        return Expr.BinaryOp(expr.idx, 'Concat', [operand_0, operand_1, ], expr.signed, **expr.tags)
+        value = self.state.top(expr.bits)
+        if o0_value is None or o1_value is None:
+            new_expr = expr
+        else:
+            o0_expr = o0_value.one_expr
+            o1_expr = o1_value.one_expr
+            new_expr = Expr.BinaryOp(expr.idx,
+                                     'Concat',
+                                     [o0_expr if o0_expr is not None else expr.operands[0],
+                                      o1_expr if o1_expr is not None else expr.operands[1], ],
+                                     expr.signed,
+                                     **expr.tags)
+        return PropValue.from_value_and_details(value, expr.size, new_expr, self._codeloc())
 
     #
     # Util methods
@@ -477,7 +699,7 @@ class SimEnginePropagatorAIL(
             # pylint:disable=unused-argument
             def _handle_Register(self, expr_idx: int, reg_expr: Expr.Register, stmt_idx: int, stmt: Stmt.Assignment,
                                  block: Optional[Block]):
-                v = self.state.get_variable(reg_expr)
+                v = self.state.load_register(reg_expr)
                 if v is not None:
                     if not expr.likes(v):
                         self.out_dated = True
@@ -487,3 +709,15 @@ class SimEnginePropagatorAIL(
         walker = OutdatedDefinitionWalker(self.state)
         walker.walk_expression(expr)
         return walker.out_dated
+
+    @staticmethod
+    def _extract_ail_expression(start: int, bits: int, expr: Expr.Expression) -> Optional[Expr.Expression]:
+        if start == 0:
+            return Expr.Convert(None, expr.bits, bits, False, expr)
+        else:
+            a = Expr.BinaryOp(None, "Shr", (expr, Expr.Const(None, None, bits, expr.bits)), False)
+            return Expr.Convert(None, a.bits, bits, False, a)
+
+    @staticmethod
+    def _extend_ail_expression(bits: int, expr: Expr.Expression) -> Optional[Expr.Expression]:
+        return Expr.Convert(None, expr.bits, bits + expr.bits, False, expr)

--- a/angr/analyses/propagator/prop_value.py
+++ b/angr/analyses/propagator/prop_value.py
@@ -1,0 +1,141 @@
+from typing import Dict, Any, Tuple, Iterable, Generator, Optional, TYPE_CHECKING
+
+import claripy
+import ailment
+
+if TYPE_CHECKING:
+    from ...code_location import CodeLocation
+
+
+class Detail:
+    """
+    A companion class used together with PropValue. It describes stored information at each offset (in bytes).
+    """
+
+    __slots__ = ('size', 'expr', 'def_at')
+
+    def __init__(self, size: int, expr: ailment.Expression, def_at: 'CodeLocation'):
+        self.size = size
+        self.expr = expr
+        self.def_at = def_at
+
+    def __repr__(self) -> str:
+        return f"{self.size:x}: {self.expr}@{self.def_at}"
+
+
+# The base value
+
+class PropValue:
+    """
+    Describes immutable basic value type that is used in Propagator.
+    """
+
+    __slots__ = ('value', 'offset_and_details',)
+
+    def __init__(self,
+                 value: claripy.ast.Bits,
+                 offset_and_details: Optional[Dict[int,Detail]] = None):
+        self.value = value
+        self.offset_and_details = offset_and_details
+
+    @property
+    def needs_details(self):
+        return not bool(self.offset_and_details)
+
+    @property
+    def one_expr(self) -> Optional[ailment.Expression]:
+        """
+        Get the expression that starts at offset 0 and covers the entire PropValue. Returns None if there are no
+        expressions or multiple expressions.
+        """
+        if self.offset_and_details and len(self.offset_and_details) == 1:
+            if 0 in self.offset_and_details:
+                detail = self.offset_and_details[0]
+                if detail.size == self.value.size() // 8:
+                    return detail.expr
+        return None
+
+    @property
+    def one_defat(self) -> Optional['CodeLocation']:
+        """
+        Get the definition location of the expression that starts at offset 0 and covers the entire PropValue. Returns
+        None if there are no expressions or multiple expressions.
+        """
+        if self.offset_and_details and len(self.offset_and_details) == 1:
+            if 0 in self.offset_and_details:
+                detail = self.offset_and_details[0]
+                if detail.size == self.value.size() // 8:
+                    return detail.def_at
+        return None
+
+    def to_label(self):
+        raise NotImplementedError()
+
+    def with_details(self, size: int, expr: ailment.Expression, def_at: 'CodeLocation') -> 'PropValue':
+        return PropValue(self.value, offset_and_details={0: Detail(size, expr, def_at)})
+
+    def all_exprs(self) -> Generator[ailment.Expression,None,None]:
+        if not self.offset_and_details:
+            return
+        for detail in self.offset_and_details.values():
+            yield detail.expr
+
+    def non_zero_exprs(self) -> Generator[ailment.Expression,None,None]:
+        if not self.offset_and_details:
+            return
+        for detail in self.offset_and_details.values():
+            if isinstance(detail.expr, ailment.Expr.Const) and detail.expr.value == 0:
+                continue
+            yield detail.expr
+
+    @staticmethod
+    def chop_value(value: claripy.ast.Bits, begin_offset, end_offset) -> claripy.ast.Bits:
+        chop_start = value.size() - begin_offset * 8 - 1
+        chop_end = value.size() - end_offset * 8
+        return value[chop_start : chop_end]
+
+    def value_and_labels(self) -> Generator[Tuple[int,claripy.ast.Bits,int,Optional[Dict]],None,None]:
+        keys = list(sorted(self.offset_and_details.keys()))
+        if keys[0] != 0:
+            # missing details at 0
+            yield 0, self.chop_value(self.value, 0, keys[0]), keys[0], None
+
+        end_offset = 0
+        for idx, offset in enumerate(keys):
+            detail = self.offset_and_details[offset]
+            end_offset = offset + detail.size
+            label = {
+                'expr': detail.expr,
+                'def_at': detail.def_at
+            }
+            yield offset, self.chop_value(self.value, offset, end_offset), end_offset - offset, label
+
+            # gap detection
+            if idx != len(keys) - 1:
+                next_offset = keys[idx + 1]
+                if end_offset != next_offset:
+                    yield end_offset, self.chop_value(self.value, end_offset, next_offset), next_offset - end_offset, \
+                          None
+
+        # final gap detection
+        if end_offset < self.value.size() // 8:
+            yield end_offset, self.chop_value(self.value, end_offset, self.value.size() // 8), \
+                self.value.size() // 8 - end_offset, None
+
+    @staticmethod
+    def from_value_and_labels(value: claripy.ast.Bits,
+                              labels: Iterable[Tuple[int,int,Dict[str,Any]]]) -> 'PropValue':
+        offset_and_details = {}
+        for offset, size, label in labels:
+            offset_and_details[offset] = Detail(size, label['expr'], label['def_at'])
+        if 0 not in offset_and_details:
+            raise RuntimeError("Details at offset 0 is not provided in labels")
+        return PropValue(value, offset_and_details=offset_and_details)
+
+    @staticmethod
+    def from_value_and_details(value: claripy.ast.Bits,
+                               size: int,
+                               expr: ailment.Expression,
+                               def_at: 'CodeLocation'):
+        d = Detail(size, expr, def_at)
+        return PropValue(value, offset_and_details={0: d})

--- a/angr/analyses/propagator/prop_value.py
+++ b/angr/analyses/propagator/prop_value.py
@@ -130,7 +130,7 @@ class PropValue:
         offset_and_details = {}
         for offset, offset_in_expr, size, label in labels:
             expr = label['expr']
-            if offset_in_expr is not 0:
+            if offset_in_expr != 0:
                 expr = PropValue.extract_ail_expression(offset_in_expr * 8, size * 8, expr)
             elif size < expr.size:
                 expr = PropValue.extract_ail_expression(0, size * 8, expr)

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -17,6 +17,7 @@ from ..analysis import Analysis
 from ..forward_analysis import ForwardAnalysis, FunctionGraphVisitor, SingleNodeGraphVisitor
 from .engine_vex import SimEnginePropagatorVEX
 from .engine_ail import SimEnginePropagatorAIL
+from .prop_value import PropValue
 
 if TYPE_CHECKING:
     from angr.storage import SimMemoryObject
@@ -286,114 +287,38 @@ class PropagatorAILState(PropagatorState):
 
         return state, merge_occurred
 
-    def store_variable(self, variable, value, def_at) -> None:
-        if variable is None or value is None:
+    def store_temp(self, tmp_idx: int, value: PropValue):
+        self._tmps[tmp_idx] = value
+
+    def load_tmp(self, tmp_idx: int) -> Optional[PropValue]:
+        return self._tmps.get(tmp_idx, None)
+
+    def store_register(self, reg: ailment.Expr.Register, value: PropValue) -> None:
+        if isinstance(value, ailment.Expr.Expression) and value.has_atom(reg, identity=False):
             return
-        if isinstance(value, ailment.Expr.Expression) and value.has_atom(variable, identity=False):
-            return
 
-        if isinstance(variable, ailment.Expr.Tmp):
-            self._tmps[variable.tmp_idx] = value
-        elif isinstance(variable, ailment.Expr.Register):
-            if isinstance(value, claripy.ast.Base):
-                # We directly store the value in memory
-                expr = None
-            elif isinstance(value, ailment.Expr.Const):
-                # convert the const expression to a claripy AST
-                expr = value
-                value = claripy.BVV(value.value, value.bits)
-            elif isinstance(value, ailment.Expr.Expression):
-                # the value is an expression. the actual value will be TOP.
-                expr = value
-                value = self.top(expr.bits)
-            else:
-                raise TypeError("Unsupported value type %s" % type(value))
+        for offset, chopped_value, size, label in value.value_and_labels():
+            self._registers.store(reg.reg_offset + offset, chopped_value, size=size, label=label)
 
-            label = {
-                'expr': expr,
-                'def_at': def_at,
-            }
-
-            self._registers.store(variable.reg_offset, value, size=variable.size, label=label)
-        else:
-            _l.warning("Unsupported old variable type %s.", type(variable))
-
-    def store_stack_variable(self, sp_offset: int, size, new, expr=None, def_at=None, endness=None) -> None:  # pylint:disable=unused-argument
+    def store_stack_variable(self, sp_offset: int, new: PropValue, endness=None) -> None:  # pylint:disable=unused-argument
         # normalize sp_offset to handle negative offsets
         sp_offset += 0x65536
         sp_offset &= (1 << self.arch.bits) - 1
 
-        label = {
-            'expr': expr,
-            'def_at': def_at,
-        }
+        for offset, value, size, label in new.value_and_labels():
+            self._stack_variables.store(sp_offset + offset, value, size=size, endness=endness, label=label)
 
-        self._stack_variables.store(sp_offset, new, size=size, endness=endness, label=label)
+    def load_register(self, reg: ailment.Expr.Register) -> Optional[PropValue]:
+        try:
+            value, labels = self._registers.load_with_labels(reg.reg_offset, size=reg.size)
+        except SimMemoryMissingError:
+            # value does not exist
+            return None
 
-    def get_variable(self, variable) -> Any:
-        if isinstance(variable, ailment.Expr.Tmp):
-            return self._tmps.get(variable.tmp_idx, None)
-        elif isinstance(variable, ailment.Expr.Register):
-            try:
-                value, labels = self._registers.load_with_labels(variable.reg_offset, size=variable.size)
-            except SimMemoryMissingError:
-                # value does not exist
-                return None
+        prop_value = PropValue.from_value_and_labels(value, labels)
+        return prop_value
 
-            if len(labels) == 1:
-                # extract labels
-                offset, size, label = labels[0]
-                if value.size() // self.arch.byte_width == size:
-                    # the label covers the entire expression
-                    expr: Optional[ailment.Expr.Expression] = label['expr']
-                    def_at = label['def_at']
-                    if expr is not None:
-                        if expr.bits > size * self.arch.byte_width:
-                            # we are loading a chunk of the original expression
-                            expr = self._extract_ail_expression(
-                                offset * self.arch.byte_width,
-                                size * self.arch.byte_width,
-                                expr,
-                            )
-                        if expr.bits < variable.size * self.arch.byte_width:
-                            # we are loading more than the expression has - extend the size of the expression
-                            expr = self._extend_ail_expression(
-                                variable.size * self.arch.byte_width - expr.bits,
-                                expr,
-                            )
-                else:
-                    expr = None
-                    def_at = None
-            else:
-                # Multiple definitions and expressions
-                expr = None
-                def_at = None
-
-            if self.is_top(value):
-                # return a non-const expression if there is one, or return a Top
-                if expr is not None:
-                    if isinstance(expr, ailment.Expr.Expression) and not isinstance(expr, ailment.Expr.Const):
-                        copied_expr = expr.copy()
-                        copied_expr.tags['def_at'] = def_at
-                        return copied_expr
-                    else:
-                        return value
-                if value.size() != variable.bits:
-                    return self.top(variable.bits)
-                return value
-
-            # value is not TOP
-            if value.size() != variable.bits:
-                raise TypeError("Incorrect sized read. Expect %d bits." % variable.bits)
-
-            if expr is None:
-                return value
-            else:
-                return expr
-
-        return None
-
-    def get_stack_variable(self, sp_offset: int, size, endness=None) -> Optional[Any]:
+    def load_stack_variable(self, sp_offset: int, size, endness=None) -> Optional[PropValue]:
         # normalize sp_offset to handle negative offsets
         sp_offset += 0x65536
         sp_offset &= (1 << self.arch.bits) - 1
@@ -403,46 +328,8 @@ class PropagatorAILState(PropagatorState):
             # the stack variable does not exist
             return None
 
-        if len(labels) == 1:
-            # extract labels
-            offset, size, label = labels[0]
-            expr: Optional[ailment.Expr.Expression] = label['expr']
-            def_at = label['def_at']
-            if expr is not None and expr.depth <= 3:
-                if expr.bits > size * self.arch.byte_width:
-                    # we are loading a chunk of the original expression
-                    expr = self._extract_ail_expression(
-                        offset * self.arch.byte_width,
-                        size * self.arch.byte_width,
-                        expr,
-                    )
-                if expr.bits < size * self.arch.byte_width:
-                    # we are loading more than the expression has - extend the size of the expression
-                    expr = self._extend_ail_expression(
-                        size * self.arch.byte_width - expr.bits,
-                        expr,
-                    )
-            else:
-                expr = None
-        else:
-            # Multiple definitions and expressions
-            expr = None
-            def_at = None
-
-        if self.is_top(value):
-            # return a non-const expression if there is one, or return a Top
-            if expr is not None:
-                if isinstance(expr, ailment.Expr.Expression) and not isinstance(expr, ailment.Expr.Const):
-                    copied_expr = expr.copy()
-                    copied_expr.tags['def_at'] = def_at
-                    return copied_expr
-                else:
-                    return value
-            if value.size() != size * self.arch.byte_width:
-                return self.top(size * self.arch.byte_width)
-            return value
-
-        return expr if expr is not None else value
+        prop_value = PropValue.from_value_and_labels(value, labels)
+        return prop_value
 
     def add_replacement(self, codeloc, old, new):
 
@@ -487,18 +374,6 @@ class PropagatorAILState(PropagatorState):
     def add_equivalence(self, codeloc, old, new):
         eq = Equivalence(codeloc, old, new)
         self._equivalence.add(eq)
-
-    @staticmethod
-    def _extract_ail_expression(start: int, bits: int, expr: ailment.Expr.Expression) -> Optional[ailment.Expr.Expression]:
-        if start == 0:
-            return ailment.Expr.Convert(None, expr.bits, bits, False, expr)
-        else:
-            a = ailment.Expr.BinaryOp(None, "Shr", (expr, ailment.Expr.Const(None, None, bits, expr.bits)), False)
-            return ailment.Expr.Convert(None, a.bits, bits, False, a)
-
-    @staticmethod
-    def _extend_ail_expression(bits: int, expr: ailment.Expr.Expression) -> Optional[ailment.Expr.Expression]:
-        return ailment.Expr.Convert(None, expr.bits, bits + expr.bits, False, expr)
 
 
 class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-method

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -26,9 +26,10 @@ if TYPE_CHECKING:
 _l = logging.getLogger(name=__name__)
 
 
-# The base state
-
 class PropagatorState:
+    """
+    Describes the base state used in Propagator.
+    """
 
     __slots__ = ('arch', 'gpr_size', '_prop_count', '_only_consts', '_replacements', '_equivalence', 'project',
                  '_store_tops', '__weakref__', )
@@ -154,6 +155,9 @@ class PropagatorState:
 # VEX state
 
 class PropagatorVEXState(PropagatorState):
+    """
+    Describes the state used in the VEX engine of Propagator.
+    """
 
     __slots__ = ('_registers', '_stack_variables', 'do_binops', )
 
@@ -162,8 +166,16 @@ class PropagatorVEXState(PropagatorState):
         super().__init__(arch, project=project, replacements=replacements, only_consts=only_consts,
                          prop_count=prop_count, store_tops=store_tops)
         self.do_binops = do_binops
-        self._registers = LabeledMemory(memory_id='reg', top_func=self.top, page_kwargs={'mo_cmp': self._mo_cmp}) if registers is None else registers
-        self._stack_variables = LabeledMemory(memory_id='mem', top_func=self.top, page_kwargs={'mo_cmp': self._mo_cmp}) if local_variables is None else local_variables
+        self._registers = LabeledMemory(
+            memory_id='reg',
+            top_func=self.top,
+            page_kwargs={'mo_cmp': self._mo_cmp}) \
+            if registers is None else registers
+        self._stack_variables = LabeledMemory(
+            memory_id='mem',
+            top_func=self.top,
+            page_kwargs={'mo_cmp': self._mo_cmp}) \
+            if local_variables is None else local_variables
 
         self._registers.set_state(self)
         self._stack_variables.set_state(self)
@@ -222,6 +234,10 @@ class PropagatorVEXState(PropagatorState):
 
 
 class Equivalence:
+    """
+    Describes an equivalence relationship between two atoms.
+    """
+
     __slots__ = ('codeloc', 'atom0', 'atom1',)
 
     def __init__(self, codeloc, atom0, atom1):
@@ -243,15 +259,21 @@ class Equivalence:
 
 
 class PropagatorAILState(PropagatorState):
+    """
+    Describes the state used in the AIL engine of Propagator.
+    """
 
     __slots__ = ('_registers', '_stack_variables', '_tmps', )
 
     def __init__(self, arch, project=None, replacements=None, only_consts=False, prop_count=None, equivalence=None,
                  stack_variables=None, registers=None):
-        super().__init__(arch, project=project, replacements=replacements, only_consts=only_consts, prop_count=prop_count,
+        super().__init__(arch, project=project, replacements=replacements, only_consts=only_consts,
+                         prop_count=prop_count,
                          equivalence=equivalence)
 
-        self._stack_variables = LabeledMemory(memory_id='mem', top_func=self.top, page_kwargs={'mo_cmp': self._mo_cmp}) \
+        self._stack_variables = LabeledMemory(memory_id='mem',
+                                              top_func=self.top,
+                                              page_kwargs={'mo_cmp': self._mo_cmp}) \
             if stack_variables is None else stack_variables
         self._registers = LabeledMemory(memory_id='reg', top_func=self.top, page_kwargs={'mo_cmp': self._mo_cmp}) \
             if registers is None else registers

--- a/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
@@ -74,12 +74,14 @@ class MemoryObjectMixin(CooperationBase):
         else:
             # we need to extract labels for SimLabeledMemoryObjects
             elements = [ ]
+            offset = 0
             for i, (a, o) in enumerate(c_objects):
                 length: int = ((c_objects[i+1][0] - a) & mask) if i != len(c_objects)-1 else ((c_objects[0][0] + size - a) & mask)
                 byts = o.bytes_at(a, length, endness=endness)
                 elements.append(byts)
                 if isinstance(o, SimLabeledMemoryObject):
-                    labels.append((a - o.base, length, o.label))
+                    labels.append((a - o.base + offset, length, o.label))
+                offset += length
         if len(elements) == 0:
             # nothing is read out
             return claripy.BVV(0, 0)

--- a/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
@@ -80,7 +80,7 @@ class MemoryObjectMixin(CooperationBase):
                 byts = o.bytes_at(a, length, endness=endness)
                 elements.append(byts)
                 if isinstance(o, SimLabeledMemoryObject):
-                    labels.append((a - o.base + offset, length, o.label))
+                    labels.append((offset, a - o.base, length, o.label))
                 offset += length
         if len(elements) == 0:
             # nothing is read out

--- a/tests/test_block_simplifier.py
+++ b/tests/test_block_simplifier.py
@@ -62,7 +62,7 @@ def test_simplify_dead_assign_0():
             ),
             ailment.Stmt.Jump(
                 next(n),
-                0x3333,
+                ailment.Expr.Const(None, None, 0x3333, 64),
                 ins_addr=0x1338
             ),
         ]


### PR DESCRIPTION
Before:

```
int sub_400cc5(char *a0[5], char *a1[7])
{
    BOT tmp_99;  // tmp #99
    BOT tmp_186;  // tmp #186
    BOT tmp_98;  // tmp #98
    BOT tmp_187;  // tmp #187
    BOT tmp_100;  // tmp #100
    BOT tmp_20;  // tmp #20
    BOT tmp_188;  // tmp #188
    BOT tmp_110;  // tmp #110
    BOT tmp_189;  // tmp #189
    BOT tmp_111;  // tmp #111
    BOT tmp_113;  // tmp #113
    BOT tmp_190;  // tmp #190
    BOT tmp_112;  // tmp #112
    BOT tmp_191;  // tmp #191
    BOT tmp_114;  // tmp #114
    BOT tmp_24;  // tmp #24
    BOT tmp_192;  // tmp #192
    BOT tmp_118;  // tmp #118
    BOT tmp_121;  // tmp #121
    BOT tmp_140;  // tmp #140
    BOT tmp_197;  // tmp #197
    BOT tmp_139;  // tmp #139
    BOT tmp_40;  // tmp #40
    BOT tmp_198;  // tmp #198
    BOT tmp_142;  // tmp #142
    BOT tmp_145;  // tmp #145
    BOT v0;  // [bp-0x20]
    char v1;  // [bp-0xc]
    char v10;  // al
    unsigned short v11;  // dx
    unsigned long long v12;  // rdx
    unsigned long long v2;  // [bp-0xb]
    unsigned long long v3;  // [bp-0xa]
    unsigned long long v5;  // rax
    unsigned long long v6;  // rax
    unsigned long long v7;  // rax
    unsigned short v8;  // ax
    unsigned long long v9;  // rax

    v0 = a0;
    v1 = (char)a1[5];
    v6 = (long long)a0[2];
    v8 = (short)a0[2];
    v12 = (long long)a0[3];
    v11 = (short)a0[3];
    tmp_99 = rdx<8>;
    tmp_186 = (int)tmp_99;
    tmp_98 = tmp_186;
    tmp_187 = (long long)tmp_98;
    tmp_100 = tmp_187;
    tmp_20 = tmp_100 * 256;
    tmp_188 = (int)tmp_20;
    tmp_110 = tmp_188;
    tmp_189 = (long long)tmp_110;
    tmp_111 = tmp_189;
    tmp_113 = rax<8>;
    tmp_190 = (int)tmp_113;
    tmp_112 = tmp_190;
    tmp_191 = (int)tmp_111;
    tmp_114 = tmp_191;
    tmp_24 = tmp_112 + tmp_114;
    tmp_192 = (long long)tmp_24;
    tmp_118 = tmp_192;
    v7 = tmp_118;
    tmp_121 = v7;
    v3 = tmp_121;
    v5 = (long long)a0[4];
    v10 = (char)(long long)a0[4] >> 2;
    tmp_140 = rax<8>;
    tmp_197 = (int)tmp_140;
    tmp_139 = tmp_197;
    tmp_40 = tmp_139 & 3;
    tmp_198 = (long long)tmp_40;
    tmp_142 = tmp_198;
    v9 = tmp_142;
    tmp_145 = v9;
    v2 = tmp_145;
    a1[5] = (char)tmp_145 != 0;
    if ((long long)a1[5] == 0)
    {
        a1[6] = 0;
        a1[4] = 0;
        return v0;
    }
    else if (v3 == 0)
    {
        return v0;
    }
    else if ((long long)a1[4] == 0)
    {
        a1[6] = 1;
        return v0;
    }
    else
    {
        return v0;
    }
}
```

After (without eager return simplifier):

```
int sub_400cc5(char a0[5], char a1[7])
{
    char v0[7];  // [bp-0x28]
    char v1[5];  // [bp-0x20]
    char v2;  // [bp-0xc]
    char v3;  // [bp-0xb]
    unsigned short v4;  // [bp-0xa]

    v1 = a0;
    v0 = a1;
    v2 = v0[5];
    v4 = ((short)((int)v1[2]) + ((int)((long long)v1[3]) * 256));
    v3 = ((char)((int)((long long)v1[4]) >> 2) & 3);
    v0[5] = ((char)v3 != 0);
    if (((long long)v0[5]) == 0)
    {
        v0[6] = 0;
        v0[4] = 0;
    }
    else if (v4 != 0 && ((long long)v0[4]) == 0)
    {
        v0[6] = 1;
    }
    return v1;
}

```