### PR TITLE
Use blocks obtained from self.blocks directly in instruction_size

### DIFF
--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1183,8 +1183,7 @@ class Function(Serializable):
         :return int: Size of the instruction in bytes, or None if the instruction is not found.
         """
 
-        for b in self.blocks:
-            block = self.get_block(b.addr, size=b.size, byte_string=b.bytestr)
+        for block in self.blocks:
             if insn_addr in block.instruction_addrs:
                 index = block.instruction_addrs.index(insn_addr)
                 if index == len(block.instruction_addrs) - 1:

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -53,8 +53,23 @@ def test_function_instruction_addr_from_any_addr():
     nose.tools.assert_equal(func_main.addr_to_instruction_addr(0x400742), 0x400742)
     nose.tools.assert_equal(func_main.addr_to_instruction_addr(0x400743), 0x400742)
 
+def test_function_instruction_size():
+
+    p = angr.Project(os.path.join(test_location, 'x86_64', 'fauxware'), auto_load_libs=False)
+    cfg = p.analyses.CFG()
+
+    func_main = cfg.kb.functions['main']
+
+    nose.tools.assert_equal(func_main.instruction_size(0x40071d), 1)
+    nose.tools.assert_equal(func_main.instruction_size(0x40071e), 3)
+    nose.tools.assert_equal(func_main.instruction_size(0x400721), 4)
+    nose.tools.assert_equal(func_main.instruction_size(0x400725), 3)
+    nose.tools.assert_equal(func_main.instruction_size(0x400728), 4)
+    nose.tools.assert_equal(func_main.instruction_size(0x400739), 5)
+    nose.tools.assert_equal(func_main.instruction_size(0x400742), 5)
 
 if __name__ == "__main__":
     test_function_serialization()
     test_function_definition_application()
     test_function_instruction_addr_from_any_addr()
+    test_function_instruction_size()


### PR DESCRIPTION
The [self.blocks](https://github.com/angr/angr/blob/c93d36514b572f5df841304befa7c6804044d81d/angr/knowledge_plugins/functions/function.py#L1186) used in `instruction_size` yields blocks created by [self.get_block(...)](https://github.com/angr/angr/blob/c93d36514b572f5df841304befa7c6804044d81d/angr/knowledge_plugins/functions/function.py#L239).
Therefore, it should not be necessary to use [self.get_block](https://github.com/angr/angr/blob/c93d36514b572f5df841304befa7c6804044d81d/angr/knowledge_plugins/functions/function.py#L1187) again in `instruction_size`.

This is a possible fix to Issue #2827, since this removes the reference to the invalid attribute `b.bytestr` for `Block` `b`. 