### PR TITLE
Fix: deduplicate Multivalues with same Definition when doing RDA

### DIFF
--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -46,6 +46,14 @@ class DefinitionAnnotation(Annotation):
     def eliminatable(self):
         return False
 
+    def __hash__(self):
+        return hash((self.definition, self.relocatable, self.eliminatable))
+
+    def __eq__(self, other: 'DefinitionAnnotation'):
+        return  self.definition == other.definition \
+            and self.relocatable == other.relocatable \
+            and self.eliminatable == other.eliminatable
+
 # pylint: disable=W1116
 class LiveDefinitions:
     """


### PR DESCRIPTION
specify __hash__ and __eq__ for DefintionAnnotation, otherwise deduplication through set() does not work.