### PR TITLE
Fix handling of float format strings for scanf functions

### DIFF
--- a/angr/procedures/libc/fscanf.py
+++ b/angr/procedures/libc/fscanf.py
@@ -1,8 +1,8 @@
-from angr.procedures.stubs.format_parser import FormatParser
+from angr.procedures.stubs.format_parser import ScanfFormatParser
 
 from cle.backends.externs.simdata.io_file import io_file_data_for_arch
 
-class fscanf(FormatParser):
+class fscanf(ScanfFormatParser):
     #pylint:disable=arguments-differ
 
     def run(self, file_ptr, fmt):  # pylint:disable=unused-argument

--- a/angr/procedures/libc/scanf.py
+++ b/angr/procedures/libc/scanf.py
@@ -1,10 +1,10 @@
 import logging
 
-from angr.procedures.stubs.format_parser import FormatParser
+from angr.procedures.stubs.format_parser import ScanfFormatParser
 
 l = logging.getLogger(name=__name__)
 
-class scanf(FormatParser):
+class scanf(ScanfFormatParser):
     #pylint:disable=arguments-differ,unused-argument
 
     def run(self, fmt):

--- a/angr/procedures/libc/sscanf.py
+++ b/angr/procedures/libc/sscanf.py
@@ -1,10 +1,10 @@
 import logging
 
-from angr.procedures.stubs.format_parser import FormatParser
+from angr.procedures.stubs.format_parser import ScanfFormatParser
 
 l = logging.getLogger(name=__name__)
 
-class sscanf(FormatParser):
+class sscanf(ScanfFormatParser):
     #pylint:disable=arguments-differ,unused-argument
     def run(self, data, fmt):
         fmt_str = self._parse(1)

--- a/angr/procedures/stubs/format_parser.py
+++ b/angr/procedures/stubs/format_parser.py
@@ -343,7 +343,7 @@ class FormatSpecifier:
 
 class FormatParser(SimProcedure):
     """
-    For SimProcedures relying on format strings.
+    For SimProcedures relying on printf-style format strings.
     """
 
     ARGS_MISMATCH = True
@@ -610,5 +610,54 @@ class FormatParser(SimProcedure):
         l.debug("Fmt: %r", fmt_str)
 
         return fmt_str
+
+
+class ScanfFormatParser(FormatParser):
+    """
+    For SimProcedures relying on scanf-style format strings.
+    """
+
+    basic_spec = {
+        b'd': sim_type.SimTypeInt(),  # 'int',
+        b'i': sim_type.SimTypeInt(),  # 'int',
+        b'o': sim_type.SimTypeInt(signed=False),  # 'unsigned int',
+        b'u': sim_type.SimTypeInt(signed=False),  # 'unsigned int',
+        b'x': sim_type.SimTypeInt(signed=False),  # 'unsigned int',
+        b'X': sim_type.SimTypeInt(signed=False),  # 'unsigned int',
+        b'e': sim_type.SimTypeFloat(),  # 'float',
+        b'E': sim_type.SimTypeFloat(),  # 'float',
+        b'f': sim_type.SimTypeFloat(),  # 'float',
+        b'F': sim_type.SimTypeFloat(),  # 'float',
+        b'g': sim_type.SimTypeFloat(),  # 'float',
+        b'G': sim_type.SimTypeFloat(),  # 'float',
+        b'a': sim_type.SimTypeFloat(),  # 'float',
+        b'A': sim_type.SimTypeFloat(),  # 'float',
+        b'c': sim_type.SimTypeChar(),  # 'char',
+        b's': sim_type.SimTypePointer(sim_type.SimTypeChar()),  # 'char*',
+        b'p': sim_type.SimTypePointer(sim_type.SimTypeInt(signed=False)),  # 'uintptr_t',
+        b'n': sim_type.SimTypePointer(sim_type.SimTypeInt(signed=False)),
+    }
+
+    # All float conversion specifiers
+    float_spec = [b'e', b'E', b'f', b'F', b'g', b'G', b'a', b'A']
+
+    # Length modifiers and how they apply to float conversion.
+    float_len_mod = {
+        b'l': sim_type.SimTypeDouble,  # 'double',
+        b'll': sim_type.SimTypeDouble,  # 'long double',
+    }
+
+    @property
+    def _mod_spec(self):
+        """
+        Modified length specifiers: mapping between length modifiers and conversion specifiers. This generates all the
+        possibilities, i.e. lf, etc.
+        """
+        mod_spec = super()._mod_spec
+        for mod, size in self.float_len_mod.items():
+            for conv in self.float_spec:
+                mod_spec[mod + conv] = size
+        return mod_spec
+
 
 from angr.errors import SimProcedureArgumentError, SimProcedureError, SimSolverError

--- a/angr/procedures/stubs/format_parser.py
+++ b/angr/procedures/stubs/format_parser.py
@@ -653,11 +653,15 @@ class ScanfFormatParser(FormatParser):
         Modified length specifiers: mapping between length modifiers and conversion specifiers. This generates all the
         possibilities, i.e. lf, etc.
         """
-        mod_spec = super()._mod_spec
-        for mod, size in self.float_len_mod.items():
-            for conv in self.float_spec:
-                mod_spec[mod + conv] = size
-        return mod_spec
+        if FormatParser._MOD_SPEC is None:
+            mod_spec = dict(super()._mod_spec.items())
+            for mod, size in self.float_len_mod.items():
+                for conv in self.float_spec:
+                    mod_spec[mod + conv] = size
+
+            FormatParser._MOD_SPEC = mod_spec
+
+        return FormatParser._MOD_SPEC
 
 
 from angr.errors import SimProcedureArgumentError, SimProcedureError, SimSolverError


### PR DESCRIPTION
The C standard specifies that `scanf`-style functions interpret format strings for floating point numbers differently than `printf`-style functions. In `scanf` the conversion specifiers a, A, e, E, f, F, g, and G are treated as `float` without a modifier and `double` with the `l` modifier. In `printf` the specifiers are treated as `double` without a modifier or with the `l` modifier. In both the `L` modifier is used to indicate `long double`.