### PR TITLE
indirect call resolution correctly propagates gp value from stack

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/mips_elf_fast.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/mips_elf_fast.py
@@ -20,6 +20,9 @@ l = logging.getLogger(name=__name__)
 
 
 class OverwriteTmpValueCallback:
+    """
+    Overwrites temporary values during resolution
+    """
     def __init__(self, gp_value):
         self.gp_value = gp_value
 
@@ -28,8 +31,11 @@ class OverwriteTmpValueCallback:
 
 
 class MipsElfFastResolver(IndirectJumpResolver):
+    """
+    Indirect Jump Resolver for MIPs
+    """
     def __init__(self, project):
-        super(MipsElfFastResolver, self).__init__(project, timeless=True)
+        super().__init__(project, timeless=True)
 
     def filter(self, cfg, addr, func_addr, block, jumpkind):
         if not isinstance(self.project.arch, (archinfo.ArchMIPS32, archinfo.ArchMIPS64, )):

--- a/angr/analyses/cfg/indirect_jump_resolvers/mips_elf_fast.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/mips_elf_fast.py
@@ -55,10 +55,6 @@ class MipsElfFastResolver(IndirectJumpResolver):
                 print("Resolved %x -> %s" % (addr, resolved_targets))
                 return resolved, resolved_targets
         return False, []
-        # resolved, resolved_targets = self._resolve(cfg, addr, func_addr, block, jumpkind)
-        # if resolved:
-        #     print("Resolved %x -> %s" % (addr, resolved_targets))
-        # return resolved, resolved_targets
 
     def _resolve(self, cfg, addr, func_addr, block, jumpkind, max_level):
         """
@@ -162,12 +158,12 @@ class MipsElfFastResolver(IndirectJumpResolver):
                             # found the load from stack
                             # we must make sure value of that temporary variable equals to the correct gp value
                             state.inspect.make_breakpoint('tmp_write', when=BP_BEFORE,
-                                                          condition=lambda s, bbl_addr_=block_addr_in_slice,
-                                                                           tmp_offset_=tmp_offset:
-                                                          s.scratch.bbl_addr == bbl_addr_ and s.inspect.tmp_write_num == tmp_offset_,
-                                                          action=OverwriteTmpValueCallback(
-                                                              gp_value).overwrite_tmp_value
-                                                          )
+                                        condition=lambda s, bbl_addr_=block_addr_in_slice,
+                                                        tmp_offset_=tmp_offset:
+                                        s.scratch.bbl_addr == bbl_addr_ and s.inspect.tmp_write_num == tmp_offset_,
+                                        action=OverwriteTmpValueCallback(
+                                        gp_value).overwrite_tmp_value
+                                        )
                             break
 
     @staticmethod


### PR DESCRIPTION
previously were only doing gp_value resolution for first block then breaking out of loop
now does for all blocks in slice. also added wrapper code so if resolution is possible on
smaller max_level in Blade() then it will return that instead (slight efficiency improvement)