### PR TITLE
fix over-filtering in arm_thumb_filter_jump_successors

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -483,6 +483,12 @@ class CFGBase(Analysis):
                             while itstate != 0:
                                 it_counter += 1
                                 itstate >>= 8
+                    elif val.tag == 'Iex_Const':
+                        it_counter = 0
+                        itstate = val.con.value
+                        while itstate != 0:
+                            it_counter += 1
+                            itstate >>= 8
 
         if it_counter != 0:
             l.debug('Basic block ends before calculated IT block (%#x)', irsb.addr)


### PR DESCRIPTION
Constant can be directly loaded in ```itstate``` register, but ```_arm_thumb_filter_jump_successors``` does not handle with this case (it only considers constant in tmp) and overly filter some successors. Therefore, angr fails to recover some blocks and edges for Arm thumb binary. 

I attach the pyvex IR and assembly/disassembly code (where constant is directly loaded) below:

![image](https://user-images.githubusercontent.com/12579777/132016371-f1508845-bcf5-4d64-afcb-3619c57c01ff.png)

![image](https://user-images.githubusercontent.com/12579777/132016563-401654b5-2996-4606-8b16-f5021ec3f636.png)

