### PR TITLE
Clinic: Assign an idx to Call.ret_expr expressions.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -475,6 +475,7 @@ class Clinic(Analysis):
             csm = self.project.analyses.AILCallSiteMaker(block,
                                                          reaching_definitions=rd,
                                                          stack_pointer_tracker=stack_pointer_tracker,
+                                                         ail_manager=self._ail_manager,
                                                          )
             if csm.stack_arg_offsets is not None:
                 TempClass.stack_arg_offsets |= csm.stack_arg_offsets

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -514,7 +514,7 @@ class Clinic(Analysis):
                 if isinstance(ret_val, SimRegArg):
                     reg = self.project.arch.registers[ret_val.reg_name]
                     new_stmt.ret_exprs.append(ailment.Expr.Register(
-                        None,
+                        self._next_atom(),
                         None,
                         reg[0],
                         reg[1] * self.project.arch.byte_width,
@@ -803,6 +803,9 @@ class Clinic(Analysis):
                 graph.add_edge(src, dst, **data)
 
         return graph
+
+    def _next_atom(self) -> int:
+        return self._ail_manager.next_atom()
 
     @staticmethod
     def _make_callsites_rd_observe_callback(ob_type, **kwargs):

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -238,19 +238,26 @@ class SimEnginePropagatorAIL(
         new_expr = self.state.load_register(expr)
         if new_expr is not None:
             # check if this new_expr uses any expression that has been overwritten
+            replaced = False
             all_subexprs = list(new_expr.all_exprs())
-            if not any(self.is_using_outdated_def(subexpr) for subexpr in all_subexprs):
+            if all_subexprs and not any(self.is_using_outdated_def(subexpr) for subexpr in all_subexprs):
                 if len(all_subexprs) == 1:
                     # trivial case
                     subexpr = all_subexprs[0]
                     if subexpr.size == expr.size:
+                        replaced = True
                         l.debug("Add a replacement: %s with %s", expr, subexpr)
                         self.state.add_replacement(self._codeloc(), expr, subexpr)
                 else:
                     is_concatenation, result_expr = _test_concatenation(new_expr)
                     if is_concatenation:
+                        replaced = True
                         l.debug("Add a replacement: %s with %s", expr, result_expr)
                         self.state.add_replacement(self._codeloc(), expr, result_expr)
+
+            if not replaced:
+                l.debug("Add a replacement: %s with TOP", expr)
+                self.state.add_replacement(self._codeloc(), expr, self.state.top(expr.bits))
             return new_expr
 
         return PropValue.from_value_and_details(self.state.top(expr.bits), expr.size, expr, self._codeloc())

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -161,7 +161,7 @@ class SimEnginePropagatorAIL(
         if tmp is not None:
             # check if this new_expr uses any expression that has been overwritten
             all_subexprs = list(tmp.all_exprs())
-            if any(self.is_using_outdated_def(sub_expr) for sub_expr in all_subexprs):
+            if any(self.is_using_outdated_def(sub_expr, avoid=expr) for sub_expr in all_subexprs):
                 return PropValue.from_value_and_details(
                     self.state.top(expr.size * self.arch.byte_width), expr.size, expr, self._codeloc())
 

--- a/angr/analyses/propagator/outdated_definition_walker.py
+++ b/angr/analyses/propagator/outdated_definition_walker.py
@@ -19,12 +19,19 @@ class OutdatedDefinitionWalker(AILBlockWalker):
         self.avoid = avoid
         self.expr_handlers[Expr.Register] = self._handle_Register
         self.expr_handlers[Expr.Load] = self._handle_Load
+        self.expr_handlers[Expr.Tmp] = self._handle_Tmp
         self.out_dated = False
+
+    # pylint:disable=unused-argument
+    def _handle_Tmp(self, expr_idx: int, tmp_expr: Expr.Tmp, stmt_idx: int, stmt: Stmt.Assignment,
+                    block: Optional[Block]):
+        if self.avoid is not None and tmp_expr.likes(self.avoid):
+            self.out_dated = True
 
     # pylint:disable=unused-argument
     def _handle_Register(self, expr_idx: int, reg_expr: Expr.Register, stmt_idx: int, stmt: Stmt.Assignment,
                          block: Optional[Block]):
-        if self.avoid is not None and reg_expr == self.avoid:
+        if self.avoid is not None and reg_expr.likes(self.avoid):
             self.out_dated = True
         else:
             v = self.state.load_register(reg_expr)

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -308,8 +308,12 @@ def test_decompiling_true_x86_64_1():
     code: str = dec.codegen.text
 
     # constant propagation was failing. see https://github.com/angr/angr/issues/2659
-    assert code.count("32 <=") == 0
-    assert code.count("32") == 2
+    assert code.count("32 <=") == 0 and code.count("32 >") == 0 and \
+           code.count("((int)32) <=") == 0 and code.count("((int)32) >") == 0
+    if "*(&stack_base-56:32)" in code:
+        assert code.count("32") == 3
+    else:
+        assert code.count("32") == 2
 
 
 def test_decompiling_true_a_x86_64_0():


### PR DESCRIPTION
This fix addresses the issue where AIL simplifiers may replace more
expressions (in this case, replacing the return expression of a call
statement if one of its arguments is the same as, i.e., likes, its
return expression) than necessary.