### PR TITLE
Structurer: Addresses multiple causes for non-determinism.

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -242,7 +242,7 @@ class ConditionProcessor:
             for n in node.nodes:
                 new_node = self.remove_claripy_bool_asts(n, memo=memo)
                 new_nodes.append(new_node)
-            new_seq_node = SequenceNode(new_nodes)
+            new_seq_node = SequenceNode(node.addr, new_nodes)
             return new_seq_node
 
         elif isinstance(node, MultiNode):

--- a/angr/analyses/decompiler/empty_node_remover.py
+++ b/angr/analyses/decompiler/empty_node_remover.py
@@ -39,11 +39,11 @@ class EmptyNodeRemover:
         self._walker = SequenceWalker(handlers=handlers)
         r = self._walker.walk(self.root)
         if r is None:
-            self.result = SequenceNode(nodes=[])
+            self.result = SequenceNode(None, nodes=[])
         else:
             # Make sure it's still a sequence node
             if not isinstance(r, SequenceNode):
-                r = SequenceNode(nodes=[r])
+                r = SequenceNode(node.addr, nodes=[r])
             self.result = r
 
     #
@@ -69,7 +69,7 @@ class EmptyNodeRemover:
             self.replaced_sequences[node] = new_nodes[0]
             return new_nodes[0]
 
-        sn = SequenceNode(nodes=new_nodes)
+        sn = SequenceNode(node.addr, nodes=new_nodes)
         self.replaced_sequences[node] = sn
         return sn
 

--- a/angr/analyses/decompiler/structurer.py
+++ b/angr/analyses/decompiler/structurer.py
@@ -497,10 +497,6 @@ class Structurer(Analysis):
 
         self._make_switch_cases(seq)
 
-        # remove conditional jumps of the current level
-        # seq = self._remove_conditional_jumps(seq, follow_seq=False)
-        # new_seq = EmptyNodeRemover(seq).result
-
         # this is hackish...
         # seq.nodes = new_seq.nodes
 
@@ -508,6 +504,8 @@ class Structurer(Analysis):
         self._structure_common_subexpression_conditions(seq)
         self._make_ites(seq)
         self._remove_redundant_jumps(seq)
+        # remove conditional jumps of the current level
+        seq = self._remove_conditional_jumps(seq, follow_seq=False)
 
         empty_node_remover = EmptyNodeRemover(seq)
         new_seq = empty_node_remover.result

--- a/angr/analyses/decompiler/structurer_nodes.py
+++ b/angr/analyses/decompiler/structurer_nodes.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Optional
 
 import claripy
 import ailment
@@ -83,9 +83,10 @@ class BaseNode:
 
 class SequenceNode(BaseNode):
 
-    __slots__ = ('nodes',)
+    __slots__ = ('addr', 'nodes',)
 
-    def __init__(self, nodes=None):
+    def __init__(self, addr: Optional[int], nodes=None):
+        self.addr = addr
         self.nodes = nodes if nodes is not None else [ ]
 
     def __repr__(self):
@@ -93,13 +94,6 @@ class SequenceNode(BaseNode):
             return "<SequenceNode, %d nodes>" % len(self.nodes)
         else:
             return "<SequenceNode %#x, %d nodes>" % (self.addr, len(self.nodes))
-
-    @property
-    def addr(self):
-        if self.nodes:
-            return self.nodes[0].addr
-        else:
-            return None
 
     def add_node(self, node):
         self.nodes.append(node)
@@ -114,7 +108,7 @@ class SequenceNode(BaseNode):
         return self.nodes.index(node)
 
     def copy(self):
-        return SequenceNode(nodes=self.nodes[::])
+        return SequenceNode(self.addr, nodes=self.nodes[::])
 
     def dbg_repr(self, indent=0):
         s = ""

--- a/angr/analyses/decompiler/structurer_nodes.py
+++ b/angr/analyses/decompiler/structurer_nodes.py
@@ -1,3 +1,4 @@
+# pylint:disable=missing-class-docstring
 from typing import List, Tuple, Any, Optional
 
 import claripy
@@ -269,7 +270,7 @@ class ConditionalBreakNode(BreakNode):
     __slots__ = ('condition',)
 
     def __init__(self, addr, condition, target):
-        super(ConditionalBreakNode, self).__init__(addr, target)
+        super().__init__(addr, target)
         self.condition = condition
 
     def __repr__(self):

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -151,23 +151,23 @@ def insert_node(parent, insert_idx, node, node_idx, label=None, insert_location=
         parent.nodes.insert(insert_idx, node)
     elif isinstance(parent, CodeNode):
         # Make a new sequence node
-        seq = SequenceNode(nodes=[parent.node, node])
+        seq = SequenceNode(parent.addr, nodes=[parent.node, node])
         parent.node = seq
     elif isinstance(parent, MultiNode):
         parent.nodes.insert(insert_idx, node)
     elif isinstance(parent, ConditionNode):
         if node_idx == 0:
             # true node
-            parent.true_node = SequenceNode(nodes=[parent.true_node])
+            parent.true_node = SequenceNode(parent.true_node.addr, nodes=[parent.true_node])
             insert_node(parent.true_node, insert_idx - node_idx, node, 0)
         else:
             # false node
-            parent.false_node = SequenceNode(nodes=[parent.false_node])
+            parent.false_node = SequenceNode(parent.false_node.addr, nodes=[parent.false_node])
             insert_node(parent.false_node, insert_idx - node_idx, node, 0)
     elif isinstance(parent, CascadingConditionNode):
         cond, child_node = parent.condition_and_nodes[node_idx]
         if not isinstance(child_node, SequenceNode):
-            child_node = SequenceNode(nodes=[child_node])
+            child_node = SequenceNode(child_node.addr, nodes=[child_node])
             parent.condition_and_nodes[node_idx] = (cond, child_node)
         insert_node(child_node, insert_idx - node_idx, node, 0)
     elif isinstance(parent, SwitchCaseNode):
@@ -183,7 +183,7 @@ def insert_node(parent, insert_idx, node, node_idx, label=None, insert_location=
                 new_nodes = [ node, parent.cases[node_idx] ]
             else:
                 raise TypeError("Unsupported 'insert_location' value %r." % insert_location)
-            seq = SequenceNode(nodes=new_nodes)
+            seq = SequenceNode(new_nodes[0].addr, nodes=new_nodes)
             parent.cases[node_idx] = seq
         elif label == 'default':
             if insert_location == 'after':
@@ -192,7 +192,7 @@ def insert_node(parent, insert_idx, node, node_idx, label=None, insert_location=
                 new_nodes = [ node, parent.default_node ]
             else:
                 raise TypeError("Unsupported 'insert_location' value %r." % insert_location)
-            seq = SequenceNode(nodes=new_nodes)
+            seq = SequenceNode(new_nodes[0].addr, nodes=new_nodes)
             parent.default_node = seq
     else:
         raise NotImplementedError()


### PR DESCRIPTION
- SequenceNodes should keep their addresses unchanged during
simplification.

- Structurer only removes conditional jumps after the entire region has
finished being structured.

- Sub nodes in each switch case should keep their order unchanged (stay
in topological order).

- If-then-else branches are always ordered by node addresses.

This PR requires https://github.com/angr/angr/pull/2891.