### PR TITLE
SimMemoryMixin: Introduce erase().

### DIFF
--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -147,23 +147,14 @@ class SimEngineRDAIL(
         false_target = self._expr(stmt.false_target)  # pylint:disable=unused-variable
 
         ip = Register(self.arch.ip_offset, self.arch.bytes)
-        codeloc = self._codeloc()
-
-        # Use the same annotated data for kill_definitions() to avoid creating ASTs multiple times
-        # Note that the cached dummy definition is always the IP register. This is intentional.
-        top_v = self.state.top(self.arch.bits)
-        dummy_def = Definition(Register(self.arch.ip_offset, self.arch.bytes), codeloc, dummy=True)
-        top_v = self.state.annotate_with_def(top_v, dummy_def)
-        top_mv = MultiValues(offset_to_values={0: {top_v}})
-
-        self.state.kill_definitions(ip, codeloc, data=top_mv, annotated=True)
+        self.state.kill_definitions(ip)
 
         # kill all cc_ops
         if 'cc_op' in self.arch.registers:
-            self.state.kill_definitions(Register(*self.arch.registers['cc_op']), codeloc, data=top_mv, annotated=True)
-            self.state.kill_definitions(Register(*self.arch.registers['cc_dep1']), codeloc, data=top_mv, annotated=True)
-            self.state.kill_definitions(Register(*self.arch.registers['cc_dep2']), codeloc, data=top_mv, annotated=True)
-            self.state.kill_definitions(Register(*self.arch.registers['cc_ndep']), codeloc, data=top_mv, annotated=True)
+            self.state.kill_definitions(Register(*self.arch.registers['cc_op']))
+            self.state.kill_definitions(Register(*self.arch.registers['cc_dep1']))
+            self.state.kill_definitions(Register(*self.arch.registers['cc_dep2']))
+            self.state.kill_definitions(Register(*self.arch.registers['cc_ndep']))
 
     def _ail_handle_Call(self, stmt: ailment.Stmt.Call):
         self._handle_Call_base(stmt, is_expr=False)
@@ -172,15 +163,8 @@ class SimEngineRDAIL(
         target = self._expr(stmt.target)  # pylint:disable=unused-variable
         codeloc = self._codeloc()
 
-        # Use the same annotated data for kill_definitions() to avoid creating ASTs multiple times
-        # Note that the cached dummy definition is always the IP register. This is intentional.
-        top_v = self.state.top(self.arch.bits)
-        dummy_def = Definition(Register(self.arch.ip_offset, self.arch.bytes), codeloc, dummy=True)
-        top_v = self.state.annotate_with_def(top_v, dummy_def)
-        top_mv = MultiValues(offset_to_values={0: {top_v}})
-
         ip = Register(self.arch.ip_offset, self.arch.bytes)
-        self.state.kill_definitions(ip, codeloc, data=top_mv, annotated=True)
+        self.state.kill_definitions(ip)
 
         # When stmt.args are available, used registers/stack variables are decided by stmt.args. Otherwise we fall-back
         # to using all argument registers.
@@ -233,21 +217,21 @@ class SimEngineRDAIL(
             elif cc.RETURN_VAL is not None:
                 # Return value is redefined here, so it is not a dummy value
                 return_reg_offset, return_reg_size = self.arch.registers[cc.RETURN_VAL.reg_name]
-                self.state.kill_definitions(Register(return_reg_offset, return_reg_size), codeloc, dummy=False)
+                self.state.kill_definitions(Register(return_reg_offset, return_reg_size))
 
         # Kill those ones that should be killed
         for var in killed_vars:
             if var.reg_offset == return_reg_offset:
                 # Skip the return variable
                 continue
-            self.state.kill_definitions(var, codeloc, data=top_mv, annotated=True)
+            self.state.kill_definitions(var)
 
         # kill all cc_ops
         if 'cc_op' in self.arch.registers:
-            self.state.kill_definitions(Register(*self.arch.registers['cc_op']), codeloc, data=top_mv, annotated=True)
-            self.state.kill_definitions(Register(*self.arch.registers['cc_dep1']), codeloc, data=top_mv, annotated=True)
-            self.state.kill_definitions(Register(*self.arch.registers['cc_dep2']), codeloc, data=top_mv, annotated=True)
-            self.state.kill_definitions(Register(*self.arch.registers['cc_ndep']), codeloc, data=top_mv, annotated=True)
+            self.state.kill_definitions(Register(*self.arch.registers['cc_op']))
+            self.state.kill_definitions(Register(*self.arch.registers['cc_dep1']))
+            self.state.kill_definitions(Register(*self.arch.registers['cc_dep2']))
+            self.state.kill_definitions(Register(*self.arch.registers['cc_ndep']))
 
     def _ail_handle_Return(self, stmt: ailment.Stmt.Return):  # pylint:disable=unused-argument
 

--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -313,8 +313,7 @@ class ReachingDefinitionsState:
             self.current_codeloc = code_loc
             self.codeloc_uses = set()
 
-    def kill_definitions(self, atom: Atom, code_loc: CodeLocation, data: Optional[MultiValues]=None, dummy=True,
-                         tags: Set[Tag]=None, annotated: bool=False) -> None:
+    def kill_definitions(self, atom: Atom) -> None:
         """
         Overwrite existing definitions w.r.t 'atom' with a dummy definition instance. A dummy definition will not be
         removed during simplification.
@@ -325,10 +324,7 @@ class ReachingDefinitionsState:
         :return: None
         """
 
-        if data is None:
-            data = MultiValues(offset_to_values={0: {self.top(atom.size * self.arch.byte_width)}})
-
-        self.kill_and_add_definition(atom, code_loc, data, dummy=dummy, tags=tags, annotated=annotated)
+        self.live_definitions.kill_definitions(atom)
 
     def kill_and_add_definition(self, atom: Atom, code_loc: CodeLocation, data: MultiValues,
                                 dummy=False, tags: Set[Tag]=None, endness=None,

--- a/angr/storage/memory_mixins/__init__.py
+++ b/angr/storage/memory_mixins/__init__.py
@@ -93,6 +93,17 @@ class MemoryMixin(SimStatePlugin):
         """
         raise NotImplementedError()
 
+    def erase(self, addr, size=None, **kwargs) -> None:
+        """
+        Set [addr:addr+size) to uninitialized. In many cases this will be faster than overwriting those locations with
+        new values. This is commonly used during static data flow analysis.
+
+        :param addr:    The address to start erasing.
+        :param size:    The number of bytes for erasing.
+        :return:        None
+        """
+        raise NotImplementedError()
+
     def _default_value(self, addr, size, name='mem', inspect=True, events=True, key=None, **kwargs):
         """
         Override this method to provide default values for a variety of edge cases and base cases.

--- a/angr/storage/memory_mixins/paged_memory/pages/list_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/list_page.py
@@ -87,6 +87,10 @@ class ListPage(MemoryObjectMixin, PageBase):
                 self.content[subaddr] = data
                 self.stored_offset.add(subaddr)
 
+    def erase(self, addr, size=None, **kwargs) -> None:
+        for off in range(size):
+            self.content[addr + off] = None
+
     def merge(self, others: List['ListPage'], merge_conditions, common_ancestor=None, page_addr: int=None,
               memory=None, changed_offsets: Optional[Set[int]]=None):
 

--- a/angr/storage/memory_mixins/paged_memory/pages/mv_list_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/mv_list_page.py
@@ -116,6 +116,10 @@ class MVListPage(
                         self.content[subaddr] = {self.content[subaddr]} | data
                     self.stored_offset.add(subaddr)
 
+    def erase(self, addr, size=None, **kwargs) -> None:
+        for off in range(size):
+            self.content[addr + off] = None
+
     def merge(self, others: List['MVListPage'], merge_conditions, common_ancestor=None, page_addr: int = None,
               memory=None, changed_offsets: Optional[Set[int]]=None):
 
@@ -268,11 +272,13 @@ class MVListPage(
                 differences.add(c)
             else:
                 if self.content[c] is None:
-                    self.content[c] = SimMemoryObject(self.sinkhole.bytes_at(page_addr + c, 1), page_addr + c,
-                                                      byte_width=byte_width, endness='Iend_BE')
+                    if self.sinkhole is not None:
+                        self.content[c] = SimMemoryObject(self.sinkhole.bytes_at(page_addr + c, 1), page_addr + c,
+                                                          byte_width=byte_width, endness='Iend_BE')
                 if other.content[c] is None:
-                    other.content[c] = SimMemoryObject(other.sinkhole.bytes_at(page_addr + c, 1), page_addr + c,
-                                                       byte_width=byte_width, endness='Iend_BE')
+                    if other.sinkhole is not None:
+                        other.content[c] = SimMemoryObject(other.sinkhole.bytes_at(page_addr + c, 1), page_addr + c,
+                                                           byte_width=byte_width, endness='Iend_BE')
                 if s_contains and self.content[c] != other.content[c]:
                     same = None
                     if self._mo_cmp is not None:


### PR DESCRIPTION
Removing data from memory is faster than overwriting it with a new BitVector. This is useful for improving the speed of static analysis.