### PR TITLE
Add function, block pretty-printing

### DIFF
--- a/angr/__init__.py
+++ b/angr/__init__.py
@@ -1,4 +1,5 @@
 # pylint: disable=wildcard-import
+# pylint: disable=wrong-import-position
 
 __version__ = (9, 0, "gitrolling")
 
@@ -18,7 +19,11 @@ For more information, see here: https://docs.angr.io/appendix/migration
 Good luck!
 """)
 
-# first: let's set up some bootstrap logging
+from .utils.formatting import setup_terminal
+setup_terminal()
+del setup_terminal
+
+# let's set up some bootstrap logging
 import logging
 logging.getLogger("angr").addHandler(logging.NullHandler())
 from .misc.loggers import Loggers

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -1064,7 +1064,7 @@ class Disassembly(Analysis):
             else:
                 buf.append(item.render(formatting))
 
-        if self._graph is not None and show_edges and len(buf) > 0:
+        if self._graph is not None and show_edges and buf:
             edges_by_line = set()
             for edge in self._graph.edges.items():
                 from_block, to_block = edge[0]
@@ -1080,8 +1080,9 @@ class Disassembly(Analysis):
             # Render block edges, to a reference buffer for tracking and output buffer for display
             edge_buf = ['' for _ in buf]
             ref_buf = ['' for _ in buf]
+            edge_col = col('edge')
             for f, t in sorted(edges_by_line, key=lambda e: abs(e[0]-e[1])):
-                add_edge_to_buffer(edge_buf, ref_buf, f, t, lambda s: ansi_color(s, col('edge')), ascii_only=ascii_only)
+                add_edge_to_buffer(edge_buf, ref_buf, f, t, lambda s: ansi_color(s, edge_col), ascii_only=ascii_only)
                 add_edge_to_buffer(ref_buf, ref_buf, f, t, ascii_only=ascii_only)
             max_edge_depth = max(map(len, ref_buf))
 

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -964,13 +964,13 @@ class Disassembly(Analysis):
             b = self.project.factory.block(block.addr, size=block.size)
             self._add_block_ir_to_results(block, b.vex)
 
-    def render(self, formatting=None, show_edges: bool = True, show_addresses: bool = True, show_bytes: bool = True) -> str:
+    def render(self, formatting=None, show_edges: bool = True, show_addresses: bool = True, show_bytes: bool = False) -> str:
         """
         Render the disassembly to a string, with optional edges and addresses.
 
         Color will be added by default, if enabled. To disable color pass an empty formatting dict.
         """
-        max_bytes_per_line = 7
+        max_bytes_per_line = 5
         bytes_width = max_bytes_per_line*3+1
         a2ln = defaultdict(list)
         buf = []

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -60,8 +60,11 @@ class DisassemblyPiece:
 
     def highlight(self, string, formatting=None):
         try:
-            if formatting is not None and self in formatting['highlight']:
-                return self.color(string, 'highlight', formatting)
+            if formatting is not None:
+                if 'format_callback' in formatting:
+                    return formatting['format_callback'](self, string)
+                if self in formatting['highlight']:
+                    return self.color(string, 'highlight', formatting)
         except KeyError:
             pass
         return string

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -964,7 +964,8 @@ class Disassembly(Analysis):
             b = self.project.factory.block(block.addr, size=block.size)
             self._add_block_ir_to_results(block, b.vex)
 
-    def render(self, formatting=None, show_edges: bool = True, show_addresses: bool = True, show_bytes: bool = False) -> str:
+    def render(self, formatting=None, show_edges: bool = True, show_addresses: bool = True,
+               show_bytes: bool = False, ascii_only: Optional[bool] = None) -> str:
         """
         Render the disassembly to a string, with optional edges and addresses.
 
@@ -1080,8 +1081,8 @@ class Disassembly(Analysis):
             edge_buf = ['' for _ in buf]
             ref_buf = ['' for _ in buf]
             for f, t in sorted(edges_by_line, key=lambda e: abs(e[0]-e[1])):
-                add_edge_to_buffer(edge_buf, ref_buf, f, t, lambda s: ansi_color(s, col('edge')))
-                add_edge_to_buffer(ref_buf, ref_buf, f, t)
+                add_edge_to_buffer(edge_buf, ref_buf, f, t, lambda s: ansi_color(s, col('edge')), ascii_only=ascii_only)
+                add_edge_to_buffer(ref_buf, ref_buf, f, t, ascii_only=ascii_only)
             max_edge_depth = max(map(len, ref_buf))
 
             # Justify edge and combine with disassembly

--- a/angr/block.py
+++ b/angr/block.py
@@ -239,8 +239,11 @@ class Block(Serializable):
     def __ne__(self, other):
         return not self == other
 
-    def pp(self):
-        return self.disassembly.pp()
+    def pp(self, **kwargs):
+        if self._project is not None:
+            print(self._project.analyses.Disassembly(ranges=[(self.addr, self.addr + self.size)]).render(**kwargs))
+        else:
+            self.disassembly.pp()
 
     @property
     def _vex_engine(self):

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -27,7 +27,7 @@ l = logging.getLogger(name=__name__)
 from ...sim_type import SimTypeFunction, parse_defns
 from ...calling_conventions import SimCC
 from ...project import Project
-from ...utils.formatting import ansi_color, add_edge_to_buffer
+from ...utils.formatting import ansi_color_enabled, ansi_color, add_edge_to_buffer
 
 
 class Function(Serializable):
@@ -1538,12 +1538,15 @@ class Function(Serializable):
 
         return func
 
-    def pp(self, color: bool = True, show_edges: bool = True, show_address: bool = True):
+    def pp(self, color: Optional[bool] = None, show_edges: bool = True, show_address: bool = True):
         """
         Pretty-print the function disassembly, with color and block edges.
         """
         # Lazily imported to prevent circular dependency
         from ...analyses.disassembly import Label, ConstantOperand, MemoryOperand, Instruction, BlockStart, Comment  # pylint:disable=import-outside-toplevel
+
+        if color is None:
+            color = ansi_color_enabled
 
         dis = self.project.analyses.Disassembly(self)
         a2ln = defaultdict(list)

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -27,6 +27,7 @@ l = logging.getLogger(name=__name__)
 from ...sim_type import SimTypeFunction, parse_defns
 from ...calling_conventions import SimCC
 from ...project import Project
+from ...utils.formatting import ansi_color, add_edge_to_buffer
 
 
 class Function(Serializable):
@@ -1536,3 +1537,90 @@ class Function(Serializable):
         func.tags = self.tags
 
         return func
+
+    def pp(self, color: bool = True, show_edges: bool = True, show_address: bool = True):
+        """
+        Pretty-print the function disassembly, with color and block edges.
+        """
+        # Lazily imported to prevent circular dependency
+        from ...analyses.disassembly import Label, ConstantOperand, MemoryOperand, Instruction, BlockStart, Comment  # pylint:disable=import-outside-toplevel
+
+        dis = self.project.analyses.Disassembly(self)
+        a2ln = defaultdict(list)
+        buf = []
+        colors = {
+            'address':       'gray',
+            'edge':          'yellow',
+            Label:           'bright_yellow',
+            ConstantOperand: 'cyan',
+            MemoryOperand:   'yellow',
+            Comment:         'gray',
+        } if color else {}
+
+        formatting = {
+            'format_callback': lambda item, s: ansi_color(s, colors.get(type(item), None))
+        }
+
+        # Format disassembly
+        addr_width = len(f'{self.addr:x}') if show_address else 0
+        comment = None
+
+        for item in dis.raw_result:
+            if isinstance(item, BlockStart):
+                if len(buf) > 0:
+                    buf.append('')
+            elif isinstance(item, Label):
+                addr = ' '*(addr_width + 2) if show_address else ''
+                buf.append(addr + ansi_color(item.render()[0], colors.get(type(item), None)))
+            elif isinstance(item, Comment):
+                comment = item
+            elif isinstance(item, Instruction):
+                a2ln[item.addr].append(len(buf))
+                item.disect_instruction()
+
+                s_plain = item.render()[0]
+                s = item.render(formatting)[0]
+
+                if show_address:
+                    a = f'{item.addr:x}'
+                    s_plain = a + '  ' + s_plain
+                    s = ansi_color(a, colors.get('address', None)) + '  ' + s
+
+                if comment is not None:
+                    comment_column = len(s_plain)
+                    s += ansi_color(' ; ' + comment.text[0], colors.get(Comment, None))
+
+                buf.append(s)
+
+                if comment is not None and len(comment.text) > 1:
+                    for line in comment.text[1:]:
+                        buf.append(' '*comment_column + ansi_color(' ; ' + line, colors.get(Comment, None)))
+                comment = None
+
+        if show_edges:
+            edges_by_line = set()
+            for edge in self.graph.edges.items():
+                from_block, to_block = edge[0]
+                if to_block.addr != from_block.addr + from_block.size:
+                    from_addr = edge[1]['ins_addr']
+                    to_addr = to_block.addr
+                    if not (from_addr in a2ln and to_addr in a2ln):
+                        continue
+                    for f in a2ln[from_addr]:
+                        for t in a2ln[to_addr]:
+                            edges_by_line.add((f, t))
+
+            # Render block edges, to a reference buffer for tracking and output buffer for display
+            edge_buf = ['' for _ in buf]
+            ref_buf = ['' for _ in buf]
+            for f, t in sorted(edges_by_line, key=lambda e: abs(e[0]-e[1])):
+                add_edge_to_buffer(edge_buf, ref_buf, f, t, lambda s: ansi_color(s, colors.get('edge', None)))
+                add_edge_to_buffer(ref_buf, ref_buf, f, t)
+            max_edge_depth = max(map(len, ref_buf))
+
+            # Justify edge and combine with disassembly
+            for i, line in enumerate(buf):
+                buf[i] = ' ' * (max_edge_depth - len(ref_buf[i])) + edge_buf[i] + line
+
+        for line in buf:
+            print(line)

--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -1,6 +1,8 @@
 import logging
 import zlib
 from .testing import is_testing
+from ..utils.formatting import ansi_color_enabled
+
 
 class Loggers:
     """
@@ -15,7 +17,7 @@ class Loggers:
         self.load_all_loggers()
         self.profiling_enabled = False
 
-        self.handler = CuteHandler()
+        self.handler = CuteHandler() if ansi_color_enabled else logging.StreamHandler()
         self.handler.setFormatter(logging.Formatter('%(levelname)-7s | %(asctime)-23s | %(name)-8s | %(message)s'))
 
         if not is_testing and len(logging.root.handlers) == 0:

--- a/angr/utils/formatting.py
+++ b/angr/utils/formatting.py
@@ -61,7 +61,7 @@ def ansi_color(s: str, color: Optional[str]) -> str:
 
 def add_edge_to_buffer(buf: Sequence[str], ref: Sequence[str], start: int, end: int,
                        formatter: Optional[Callable[[str], str]] = None,
-                       dashed: bool = False):
+                       dashed: bool = False, ascii_only: bool = False):
     """
     Draw an edge by adding Unicode box and arrow glyphs to beginning of each line in a list of lines.
 
@@ -78,15 +78,26 @@ def add_edge_to_buffer(buf: Sequence[str], ref: Sequence[str], start: int, end: 
     max_depth  = max(map(len, ref[abs_start:abs_end+1]))
     descending = start < end
 
-    chars = {
-        'start_cap'    : '╴',
-        'start_corner' : '╭' if descending else '╰',
-        'end_cap'      : '⏵',
-        'end_corner'   : '╰' if descending else '╭',
-        'horizontal'   : '╌' if dashed else '─',
-        'vertical'     : '╎' if dashed else '│',
-        'spin'         : '⟳ ',
-    }
+    if ascii_only:
+        chars = {
+            'start_cap'    : '-',
+            'start_corner' : '+',
+            'end_cap'      : '>',
+            'end_corner'   : '+',
+            'horizontal'   : '+' if dashed else '-',
+            'vertical'     : '+' if dashed else '|',
+            'spin'         : '@ ',
+        }
+    else:
+        chars = {
+            'start_cap'    : '╴',
+            'start_corner' : '╭' if descending else '╰',
+            'end_cap'      : '⧽',
+            'end_corner'   : '╰' if descending else '╭',
+            'horizontal'   : '╌' if dashed else '─',
+            'vertical'     : '╎' if dashed else '│',
+            'spin'         : '⟳ ',
+        }
 
     def handle_line(i, edge_str):
         if formatter is not None:

--- a/angr/utils/formatting.py
+++ b/angr/utils/formatting.py
@@ -11,10 +11,8 @@ ansi_color_enabled: bool = False
 
 def setup_terminal():
     """
-    Check if we are running in a TTY. If so, make sure the terminal supports
-    ANSI escape sequences. If not, disable colorized output. Sets global
-    `ansi_color_enabled` to True if colorized output should be enabled by
-    default.
+    Check if we are running in a TTY. If so, make sure the terminal supports ANSI escape sequences. If not, disable
+    colorized output. Sets global `ansi_color_enabled` to True if colorized output should be enabled by default.
     """
     isatty = (hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
                and hasattr(sys.stderr, 'isatty') and sys.stderr.isatty())
@@ -30,9 +28,8 @@ def ansi_color(s: str, color: Optional[str]) -> str:
     """
     Colorize string `s` by wrapping in ANSI escape sequence for given `color`.
 
-    This function does not consider whether escape sequences are functional or
-    not; it is up to the caller to determine if its appropriate. Check global
-    `ansi_color_enabled` value in this module.
+    This function does not consider whether escape sequences are functional or not; it is up to the caller to determine
+    if its appropriate. Check global `ansi_color_enabled` value in this module.
     """
     if color is None:
         return s

--- a/angr/utils/formatting.py
+++ b/angr/utils/formatting.py
@@ -36,22 +36,22 @@ def ansi_color(s: str, color: Optional[str]) -> str:
 
     codes = {
         'black':          '30m',
-        'bright_black':   '30;1m',
-        'gray':           '30;1m',  # alias 'bright black'
+        'bright_black':   '90m',
+        'gray':           '90m',  # alias 'bright black'
         'blue':           '34m',
-        'bright_blue':    '34;1m',
+        'bright_blue':    '94m',
         'cyan':           '36m',
-        'bright_cyan':    '36;1m',
+        'bright_cyan':    '96m',
         'green':          '32m',
-        'bright_green':   '32;1m',
+        'bright_green':   '92m',
         'magenta':        '35m',
-        'bright_magenta': '35;1m',
+        'bright_magenta': '95m',
         'red':            '31m',
-        'bright_red':     '31;1m',
+        'bright_red':     '91m',
         'white':          '37m',
-        'bright_white':   '37;1m',
+        'bright_white':   '97m',
         'yellow':         '33m',
-        'bright_yellow':  '33;1m',
+        'bright_yellow':  '93m',
     }
     return '\u001b[' + codes[color] + s + '\u001b[0m'
 

--- a/angr/utils/formatting.py
+++ b/angr/utils/formatting.py
@@ -61,7 +61,7 @@ def ansi_color(s: str, color: Optional[str]) -> str:
 
 def add_edge_to_buffer(buf: Sequence[str], ref: Sequence[str], start: int, end: int,
                        formatter: Optional[Callable[[str], str]] = None,
-                       dashed: bool = False, ascii_only: bool = False):
+                       dashed: bool = False, ascii_only: Optional[bool] = None):
     """
     Draw an edge by adding Unicode box and arrow glyphs to beginning of each line in a list of lines.
 
@@ -71,12 +71,17 @@ def add_edge_to_buffer(buf: Sequence[str], ref: Sequence[str], start: int, end: 
     :param end: End line, where arrow points.
     :param formatter: Optional callback function used to format the edge before writing it to output buffer.
     :param dashed: Render edge line dashed instead of solid.
+    :param ascii_only: Render edge using ASCII characters only. If unspecified, guess by stdout encoding.
     :return:
     """
     abs_start  = min(start, end)
     abs_end    = max(start, end)
     max_depth  = max(map(len, ref[abs_start:abs_end+1]))
     descending = start < end
+
+    if ascii_only is None:
+        # Guess whether we should only use ASCII characters based on stdout encoding
+        ascii_only = getattr(sys.stdout, 'encoding', None) != 'utf-8'
 
     if ascii_only:
         chars = {

--- a/angr/utils/formatting.py
+++ b/angr/utils/formatting.py
@@ -1,9 +1,38 @@
+import sys
 from typing import Sequence, Optional, Callable
+
+
+if sys.platform == 'win32':
+    import colorama  # pylint:disable=import-error
+
+
+ansi_color_enabled: bool = False
+
+
+def setup_terminal():
+    """
+    Check if we are running in a TTY. If so, make sure the terminal supports
+    ANSI escape sequences. If not, disable colorized output. Sets global
+    `ansi_color_enabled` to True if colorized output should be enabled by
+    default.
+    """
+    isatty = (hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+               and hasattr(sys.stderr, 'isatty') and sys.stderr.isatty())
+    if sys.platform == 'win32' and isatty:
+        if not isinstance(sys.stdout, colorama.ansitowin32.StreamWrapper):
+            colorama.init()
+
+    global ansi_color_enabled  # pylint:disable=global-statement
+    ansi_color_enabled = isatty
 
 
 def ansi_color(s: str, color: Optional[str]) -> str:
     """
     Colorize string `s` by wrapping in ANSI escape sequence for given `color`.
+
+    This function does not consider whether escape sequences are functional or
+    not; it is up to the caller to determine if its appropriate. Check global
+    `ansi_color_enabled` value in this module.
     """
     if color is None:
         return s

--- a/angr/utils/formatting.py
+++ b/angr/utils/formatting.py
@@ -1,0 +1,77 @@
+from typing import Sequence, Optional, Callable
+
+
+def ansi_color(s: str, color: Optional[str]) -> str:
+    """
+    Colorize string `s` by wrapping in ANSI escape sequence for given `color`.
+    """
+    if color is None:
+        return s
+
+    codes = {
+        'black':          '30m',
+        'bright_black':   '30;1m',
+        'gray':           '30;1m',  # alias 'bright black'
+        'blue':           '34m',
+        'bright_blue':    '34;1m',
+        'cyan':           '36m',
+        'bright_cyan':    '36;1m',
+        'green':          '32m',
+        'bright_green':   '32;1m',
+        'magenta':        '35m',
+        'bright_magenta': '35;1m',
+        'red':            '31m',
+        'bright_red':     '31;1m',
+        'white':          '37m',
+        'bright_white':   '37;1m',
+        'yellow':         '33m',
+        'bright_yellow':  '33;1m',
+    }
+    return '\u001b[' + codes[color] + s + '\u001b[0m'
+
+
+def add_edge_to_buffer(buf: Sequence[str], ref: Sequence[str], start: int, end: int,
+                       formatter: Optional[Callable[[str], str]] = None,
+                       dashed: bool = False):
+    """
+    Draw an edge by adding Unicode box and arrow glyphs to beginning of each line in a list of lines.
+
+    :param buf: Output buffer, used to render formatted edges.
+    :param ref: Reference buffer, used to calculate edge depth.
+    :param start: Start line.
+    :param end: End line, where arrow points.
+    :param formatter: Optional callback function used to format the edge before writing it to output buffer.
+    :param dashed: Render edge line dashed instead of solid.
+    :return:
+    """
+    abs_start  = min(start, end)
+    abs_end    = max(start, end)
+    max_depth  = max(map(len, ref[abs_start:abs_end+1]))
+    descending = start < end
+
+    chars = {
+        'start_cap'    : '╴',
+        'start_corner' : '╭' if descending else '╰',
+        'end_cap'      : '⏵',
+        'end_corner'   : '╰' if descending else '╭',
+        'horizontal'   : '╌' if dashed else '─',
+        'vertical'     : '╎' if dashed else '│',
+        'spin'         : '⟳ ',
+    }
+
+    def handle_line(i, edge_str):
+        if formatter is not None:
+            edge_str = formatter(edge_str)
+        buf[i] = edge_str + buf[i]
+
+    if start == end:
+        handle_line(start, chars['spin'])
+    else:
+        handle_line(start, (chars['start_corner']
+                            + chars['horizontal'] * (max_depth - len(ref[start]))
+                            + chars['start_cap']))
+        handle_line(end, (chars['end_corner']
+                          + chars['horizontal'] * (max_depth - len(ref[end]))
+                          + chars['end_cap']))
+        for i in range(abs_start + 1, abs_end):
+            handle_line(i, chars['vertical'] + ' ' * (1 + max_depth - len(ref[i])))

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ setup(
     extras_require={
         'AngrDB': ['sqlalchemy'],
         'pcode': ['pypcode==1.0.2'],
+        ':sys_platform == "win32"': ['colorama'],
     },
     cmdclass=cmdclass,
     include_package_data=True,


### PR DESCRIPTION
Adds `Function::pp()` to output a nice function disassembly, with edges and color.

![image](https://user-images.githubusercontent.com/8210/140837253-e99d589c-7df7-4f28-aad4-56998135bb80.png)

Updates `Block:pp()` to print block disassembly with edges and color too.

![image](https://user-images.githubusercontent.com/8210/140837303-bf0fff8e-41ee-4198-aeb7-e1e2286d66bb.png)

Also adds option to disassemble ranges of code:

![image](https://user-images.githubusercontent.com/8210/140837416-39ce6824-8b39-4fff-9e0d-176b0940c587.png)

If you want you can show instruction bytes, pass the `show_bytes=True` argument:

![image](https://user-images.githubusercontent.com/8210/140837504-c57b0916-0c53-4f08-80ac-19e6b7557386.png)

Other options to control rendering:
* `show_edges=False`
* `show_addresses=False`
* `ascii_only=True`, or 
* define custom `formatting`.

Color is disabled by default if not writing to a TTY. Logging is also fixed so it does not emit color sequences in this case.

Tested working on Windows with newly added colorama initialization.

On Windows you will get the best experience using the new console. This will work with the classic console, but depending on the configured font, your terminal may not render all glyphs correctly, in which case you can just use the `ascii_only` option.

Ideas for future improvements:
* Showing non-code in range disassembly (e.g. inline data as `.dd` like other disassemblers do, or show hex view)
* User color schemes / edge character sets
* Additional edge formatting (can easily show exception edges as dashed or differently colored, for example)
* Possibly updating CFG on demand when unexplored ranges are disassembled
* Adding edge rendering to other formatted code listings, like AIL

---

Needs https://github.com/angr/angr-doc/pull/382