### PR TITLE
tracer: Access last history object without generate entire list when picking right successor

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -448,7 +448,7 @@ class Tracer(ExplorationTechnique):
                 if self._compare_addr(self._trace[idx + 1], succ.addr):
                     res.append(succ)
                 else:
-                    *_, last_description = succ.history.descriptions
+                    last_description = succ.history.descriptions[-1]
                     if 'Unicorn' in last_description:
                         # A new state was created in SimEngineUnicorn. Check every recent basic block to see if any
                         # match the next expected index


### PR DESCRIPTION
Tracer exploration generates a list of all descriptions from state's history in order to check just the last one. This PR fixes this by using negative indexing support in the descriptions iterator to retrieve just the last one.