### PR TITLE
Show memory operand prefixes by default

### DIFF
--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -670,7 +670,7 @@ class MemoryOperand(Operand):
             return super(MemoryOperand, self)._render(formatting)
         else:
             values_style = "square"
-            show_prefix = False
+            show_prefix = True
             custom_values_str = None
 
             if formatting is not None:
@@ -679,8 +679,8 @@ class MemoryOperand(Operand):
 
                 try:
                     show_prefix_str = formatting['show_prefix'][self.ident]
-                    if show_prefix_str in ('true', 'True'):
-                        show_prefix = True
+                    if show_prefix_str in ('false', 'False'):
+                        show_prefix = False
                 except KeyError:
                     pass
 


### PR DESCRIPTION
DisassemblyAnalysis does not currently show memory operand prefixes in disassembly listings by default. This patch changes the default to prefer displaying operand prefixes, so the reader can understand the type,size of the dereferences.

For example:
```nasm
804e74c  fld     [esp+0x4]
```
becomes:
```nasm
804e74c  fld     qword  ptr  [esp+0x4]
```

Fixes https://github.com/angr/angr-management/issues/492
