### PR TITLE
tracer exploration: Treat only last occurrence of last block in trace as a stop point

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -169,6 +169,7 @@ class SimEngineUnicorn(SuccessorsMixin):
             return super().process_successors(successors, **kwargs)
 
         extra_stop_points = kwargs.get('extra_stop_points', None)
+        last_block_details = kwargs.get('last_block_details', None)
         step = kwargs.get('step', None)
         if extra_stop_points is None:
             extra_stop_points = set(self.project._sim_procedures)
@@ -210,6 +211,8 @@ class SimEngineUnicorn(SuccessorsMixin):
 
         try:
             state.unicorn.set_stops(extra_stop_points)
+            if last_block_details is not None:
+                state.unicorn.set_last_block_details(last_block_details)
             state.unicorn.set_tracking(track_bbls=o.UNICORN_TRACK_BBL_ADDRS in state.options,
                                        track_stack=o.UNICORN_TRACK_STACK_POINTERS in state.options)
             state.unicorn.hook()

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -173,6 +173,10 @@ class Tracer(ExplorationTechnique):
         # whether we should follow the trace
         self._no_follow = self._trace is None
 
+        # Keep track of count of termination point
+        self._last_block_total_count = self._trace.count(self._trace[-1])
+        self._last_block_seen_count = 0
+
         # sanity check: copy_states must be enabled in Permissive mode since we may need to backtrack from a previous
         # state.
         if self._mode == TracingMode.Permissive and not self._copy_states:
@@ -343,8 +347,17 @@ class Tracer(ExplorationTechnique):
                 self.project.hook(state.addr, RepHook(insn.mnemonic.split(" ")[1]).run, length=insn.size)
 
         # perform the step. ask qemu to stop at the termination point.
-        stops = set(kwargs.pop('extra_stop_points', ())) | {self._trace[-1]}
-        succs_dict = simgr.step_state(state, extra_stop_points=stops, **kwargs)
+        # if termination point occurs multiple times in trace, pass details to SimEngineUnicorn's native interface so
+        # that it can stop at last block
+        if self._last_block_total_count > 1:
+            stops = set(kwargs.pop('extra_stop_points', ()))
+            last_block_details = {"addr": self._trace[-1], "tot_count": self._last_block_total_count,
+                                  "curr_count": self._last_block_seen_count}
+        else:
+            stops = set(kwargs.pop('extra_stop_points', ())) | {self._trace[-1]}
+            last_block_details = None
+
+        succs_dict = simgr.step_state(state, extra_stop_points=stops, last_block_details=last_block_details, **kwargs)
         if None not in succs_dict and simgr.errored:
             raise simgr.errored[-1].error
         sat_succs = succs_dict[None]  # satisfiable states
@@ -472,6 +485,8 @@ class Tracer(ExplorationTechnique):
         idx = state.globals['trace_idx']
         sync = state.globals['sync_idx']
         timer = state.globals['sync_timer']
+
+        self._last_block_seen_count += state.history.recent_bbl_addrs.count(self._trace[-1])
 
         if state.history.recent_block_count > 1:
             # multiple blocks were executed this step. they should follow the trace *perfectly*

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -364,6 +364,7 @@ def _load_native():
         _setup_prototype(h, 'syscall_count', ctypes.c_uint64, state_t)
         _setup_prototype(h, 'step', ctypes.c_uint64, state_t)
         _setup_prototype(h, 'activate_page', None, state_t, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p)
+        _setup_prototype(h, 'set_last_block_details', None, state_t, ctypes.c_uint64, ctypes.c_int64, ctypes.c_int64)
         _setup_prototype(h, 'set_stops', None, state_t, ctypes.c_uint64, ctypes.POINTER(ctypes.c_uint64))
         _setup_prototype(h, 'cache_page', ctypes.c_bool, state_t, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_char_p, ctypes.c_uint64)
         _setup_prototype(h, 'uncache_pages_touching_region', None, state_t, ctypes.c_uint64, ctypes.c_uint64)
@@ -674,6 +675,9 @@ class Unicorn(SimStatePlugin):
     def _setup_unicorn(self):
         if self.state.arch.uc_mode is None:
             raise SimUnicornUnsupport("unsupported architecture %r" % self.state.arch)
+
+    def set_last_block_details(self, details):
+        _UC_NATIVE.set_last_block_details(self._uc_state, details["addr"], details["curr_count"], details["tot_count"])
 
     def set_stops(self, stop_points):
         _UC_NATIVE.set_stops(self._uc_state,

--- a/native/angr_native.def
+++ b/native/angr_native.def
@@ -14,6 +14,7 @@ EXPORTS
   simunicorn_syscall_count
   simunicorn_step
   simunicorn_activate_page
+  simunicorn_set_last_block_details
   simunicorn_set_stops
   simunicorn_set_map_callback
   simunicorn_cache_page

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -518,6 +518,10 @@ class State {
 	//std::map<uint64_t, taint_t *> active_pages;
 	std::set<uint64_t> stop_points;
 
+	address_t trace_last_block_addr;
+	int64_t trace_last_block_curr_count;
+	int64_t trace_last_block_tot_count;
+
 	address_t taint_engine_next_instr_address, taint_engine_stop_mem_read_instruction;
 	uint32_t taint_engine_stop_mem_read_size;
 	bool symbolic_read_in_progress;
@@ -733,6 +737,11 @@ class State {
 		 * record consecutive dirty bit range, return a linked list of ranges
 		 */
 		mem_update_t *sync();
+
+		/*
+		 * set details of the last block of trace
+		 */
+		void set_last_block_details(address_t block_addr, int64_t curr_count, int64_t tot_count);
 
 		/*
 		 * set a list of stops to stop execution at


### PR DESCRIPTION
The tracer exploration technique inserts the last block as a stop point for unicorn engine and thus, the unicorn engine will stop every time the block is executed and not just the last instance. If the block is frequently executed in the program, the frequent stopping would slow down tracing greatly. This PR adds support for conditionally stopping if the last block is executed multiple times.

- If the last block in trace is executed only once, there is no change in behaviour: it is simply added as a stop point every time.

- If the last block is executed multiple times, the tracer exploration technique tracks the number of times the block is executed and passes some information to the unicorn engine. The unicorn engine uses this information to stop only if it is the last execution of the last block in trace. This check and stop has to be done in the native interface since it is impossible to predict when the last instance of the last block will be executed. 

The CI tests all seem to pass and I am seeing some performance improvements in 2-3 CGC binaries(2-3x improvement). There are two other binaries where an unrelated bug is revealed; very likely because execution went further due to reduce stopping(I feel those should be fixed separately in a different PR). I don't see any performance hits for the CGC binaries that are related to these changes.