### PR TITLE
Handle hooks in dissasembly analysis

### DIFF
--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -149,13 +149,9 @@ class BlockStart(DisassemblyPiece):
 
 
 class Hook(DisassemblyPiece):
-    def __init__(self, addr, parentblock):
-        self.addr = addr
-        self.parentblock = parentblock
-        if parentblock and parentblock.parentfunc:
-            simproc_name = str(parentblock.parentfunc.sim_procedure)
-        else:
-            simproc_name = "Unknown"
+    def __init__(self, block):
+        self.addr = block.addr
+        simproc_name = str(block.sim_procedure)
         self.name = simproc_name.split()[-1].strip("'<>")
         self.short_name = simproc_name.strip("'<>").split('.')[-1]
 
@@ -849,19 +845,22 @@ class Disassembly(Analysis):
                     assert start < end
 
                     # Grab all blocks that intersect target range
-                    blocks = sorted([n.block.codenode
-                                     for n in self._graph.nodes() if not (n.addr + n.size <= start or n.addr >= end)],
+                    blocks = sorted([n.to_codenode()
+                                     for n in self._graph.nodes() if not (n.addr + (n.size or 1) <= start or
+                                                                          n.addr >= end)],
                                     key=lambda node: (node.addr, not node.is_hook))
 
                     # Trim blocks that are not within range
                     for i, block in enumerate(blocks):
-                        if block.addr < start:
+                        if block.size and block.addr < start:
                             delta = start - block.addr
-                            blocks[i] = BlockNode(block.addr + delta, block.size - delta, block.bytestr[delta:])
+                            block_bytes = block.bytestr[delta:] if block.bytestr else None
+                            blocks[i] = BlockNode(block.addr + delta, block.size - delta, block_bytes)
                     for i, block in enumerate(blocks):
-                        if block.addr + block.size > end:
+                        if block.size and block.addr + block.size > end:
                             delta = block.addr + block.size - end
-                            blocks[i] = BlockNode(block.addr, block.size - delta, block.bytestr[0:-delta])
+                            block_bytes = block.bytestr[0:-delta] if block.bytestr else None
+                            blocks[i] = BlockNode(block.addr, block.size - delta, block_bytes)
 
                     for block in blocks:
                         self.parse_block(block)
@@ -928,7 +927,7 @@ class Disassembly(Analysis):
         self.raw_result.append(bs)
 
         if block.is_hook:
-            hook = Hook(block.addr, bs)
+            hook = Hook(block)
             self.raw_result.append(hook)
             self.raw_result_map['hooks'][block.addr] = hook
         elif self.project.arch.capstone_support:
@@ -989,6 +988,7 @@ class Disassembly(Analysis):
                     ConstantOperand: 'cyan',
                     MemoryOperand:   'yellow',
                     Comment:         'gray',
+                    Hook:            'green',
                 } if ansi_color_enabled else {},
                 'format_callback': lambda item, s: ansi_color(s, formatting['colors'].get(type(item), None))
             }
@@ -1026,6 +1026,9 @@ class Disassembly(Analysis):
                 buf.append(pad + item.render(formatting)[0])
             elif isinstance(item, Comment):
                 comment = item
+            elif isinstance(item, Hook):
+                a2ln[item.addr].append(len(buf))
+                buf.append(format_address(item.addr) + item.render(formatting)[0])
             elif isinstance(item, Instruction):
                 a2ln[item.addr].append(len(buf))
                 lines = []
@@ -1065,12 +1068,14 @@ class Disassembly(Analysis):
 
                 buf.extend(lines)
             else:
-                buf.append(item.render(formatting))
+                buf.append(''.join(item.render(formatting)))
 
         if self._graph is not None and show_edges and buf:
             edges_by_line = set()
             for edge in self._graph.edges.items():
                 from_block, to_block = edge[0]
+                if from_block.size is None:
+                    continue
                 if to_block.addr != from_block.addr + from_block.size:
                     from_addr = edge[1]['ins_addr']
                     to_addr = to_block.addr

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -844,7 +844,10 @@ class Disassembly(Analysis):
             else:
                 self._graph = cfg.graph
                 for start, end in ranges:
-                    assert(start < end)
+                    if start == end:
+                        continue
+                    assert start < end
+
                     # Grab all blocks that intersect target range
                     blocks = sorted([n.block.codenode
                                      for n in self._graph.nodes() if not (n.addr + n.size <= start or n.addr >= end)],


### PR DESCRIPTION
Handles hooks a little nicer

Looks like:

![image](https://user-images.githubusercontent.com/8210/145309424-5040074a-9156-4020-aad8-37e5f1a65503.png)

One thing to note is that hooking some bytes in a function will mark a new function at the hooked location, so pretty-printing a function with some part of that function hooked will only show the function contents without any blocks following the hook. -- I think this behavior should be changed such that it shows the entire hooked function, but it is left for future work.

Fixes #2991