### PR TITLE
tracer exploration: Fix qemu block contained in unicorn block check

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -672,8 +672,8 @@ class Tracer(ExplorationTechnique):
 
             curr_block_addr = curr_block.addr + curr_block.size
 
-        for last_contain_index in range(trace_match_idx, trace_curr_idx + 1):
-            if self._trace[last_contain_index] < big_block_start or self._trace[last_contain_index] > big_block_end:
+        for last_contain_index in range(trace_match_idx + 1, trace_curr_idx + 1):
+            if self._trace[last_contain_index] <= big_block_start or self._trace[last_contain_index] > big_block_end:
                 # This qemu block is not contained in the bigger block
                 return (False, -1)
 


### PR DESCRIPTION
This PR implements the following fixes to the qemu block contained in unicorn block check(introduced in #2588):

1. We do not need to compare the block at `last_match_index` in trace and `big_block_start` since they are the same.
2. All checks should check for strict containment: the block in qemu trace should not overlap with `big_block_start`(since the block at `last_match_index` already does). This prevents some trace desyncs being incorrectly deemed as not a desync.

I am not sure why worker 2 timed out in CI run for the branch: AFAIK there is no test case that exercises this code(the only CGC binary where I know this happens is KPRCA_00046, which angr takes a long time to trace).