### PR TITLE
Type annotations for RDA and other analysis related code

### DIFF
--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -31,14 +31,14 @@ class UnmatchedStatementsException(Exception):
 
 
 # statement difference classes
-class Difference(object):
+class Difference:
     def __init__(self, diff_type, value_a, value_b):
         self.type = diff_type
         self.value_a = value_a
         self.value_b = value_b
 
 
-class ConstantChange(object):
+class ConstantChange:
     def __init__(self, offset, value_a, value_b):
         self.offset = offset
         self.value_a = value_a
@@ -249,7 +249,7 @@ def compare_statement_dict(statement_1, statement_2):
     return differences
 
 
-class NormalizedBlock(object):
+class NormalizedBlock:
     # block may span multiple calls
     def __init__(self, block, function):
         addresses = [block.addr]
@@ -288,7 +288,7 @@ class NormalizedBlock(object):
         return '<Normalized Block for %#x, %d bytes>' % (self.addr, size)
 
 
-class NormalizedFunction(object):
+class NormalizedFunction:
     # a more normalized function
     def __init__(self, function: "Function"):
         # start by copying the graph
@@ -344,7 +344,7 @@ class NormalizedFunction(object):
                 self.call_sites[n] = call_targets
 
 
-class FunctionDiff(object):
+class FunctionDiff:
     """
     This class computes the a diff between two functions.
     """

--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -5,6 +5,11 @@ import types
 from collections import deque, defaultdict
 
 import networkx
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from angr.knowledge_plugins import Function
+
 from . import Analysis
 
 from ..errors import SimEngineError, SimMemoryError
@@ -285,9 +290,9 @@ class NormalizedBlock(object):
 
 class NormalizedFunction(object):
     # a more normalized function
-    def __init__(self, function):
+    def __init__(self, function: "Function"):
         # start by copying the graph
-        self.graph = function.graph.copy()
+        self.graph: networkx.DiGraph = function.graph.copy()
         self.project = function._function_manager._kb._project
         self.call_sites = dict()
         self.startpoint = function.startpoint
@@ -343,7 +348,7 @@ class FunctionDiff(object):
     """
     This class computes the a diff between two functions.
     """
-    def __init__(self, function_a, function_b, bindiff=None):
+    def __init__(self, function_a: "Function", function_b: "Function", bindiff=None):
         """
         :param function_a: The first angr Function object to diff.
         :param function_b: The second angr Function object.
@@ -564,7 +569,7 @@ class FunctionDiff(object):
         return diff_constants
 
     @staticmethod
-    def _compute_block_attributes(function):
+    def _compute_block_attributes(function: NormalizedFunction):
         """
         :param function:    A normalized function object.
         :returns:           A dictionary of basic block addresses to tuples of attributes.
@@ -590,7 +595,7 @@ class FunctionDiff(object):
         return attributes
 
     @staticmethod
-    def _distances_from_function_start(function):
+    def _distances_from_function_start(function: NormalizedFunction):
         """
         :param function:    A normalized Function object.
         :returns:           A dictionary of basic block addresses and their distance to the start of the function.
@@ -599,12 +604,12 @@ class FunctionDiff(object):
                                                            function.startpoint)
 
     @staticmethod
-    def _distances_from_function_exit(function):
+    def _distances_from_function_exit(function: NormalizedFunction):
         """
         :param function:    A normalized Function object.
         :returns:           A dictionary of basic block addresses and their distance to the exit of the function.
         """
-        reverse_graph = function.graph.reverse()
+        reverse_graph: networkx.DiGraph = function.graph.reverse()
         # we aren't guaranteed to have an exit from the function so explicitly add the node
         reverse_graph.add_node("start")
         found_exits = False

--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import logging
 
 import networkx
@@ -27,9 +29,9 @@ class CDG(Analysis):
 
         self._ancestor = None
         self._semi = None
-        self._post_dom = None
+        self._post_dom: Optional[networkx.DiGraph] = None
 
-        self._graph = None
+        self._graph: Optional[networkx.DiGraph] = None
         self._normalized_cfg = None
 
         if not no_construct:
@@ -103,7 +105,7 @@ class CDG(Analysis):
         # Construct post-dominator tree
         self._pd_construct()
 
-        self._graph = networkx.DiGraph()
+        self._graph: networkx.DiGraph  = networkx.DiGraph()
 
         # Construct the reversed dominance frontier mapping
         rdf = compute_dominance_frontier(self._normalized_cfg, self._post_dom)

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -48,17 +48,18 @@ class CFGBase(Analysis):
         :param cle.backends.Backend binary:         The binary to recover CFG on. By default the main binary is used.
         :param bool force_segment:                  Force CFGFast to rely on binary segments instead of sections.
         :param angr.SimState base_state:            A state to use as a backer for all memory loads.
-        :param bool resolve_indirect_jumps:         Whether to try to resolve indirect jumps. This is necessary to resolve jump
-                                                    targets from jump tables, etc.
-        :param list indirect_jump_resolvers:        A custom list of indirect jump resolvers. If this list is None or empty,
-                                                    default indirect jump resolvers specific to this architecture and binary
-                                                    types will be loaded.
+        :param bool resolve_indirect_jumps:         Whether to try to resolve indirect jumps.
+                                                    This is necessary to resolve jump targets from jump tables, etc.
+        :param list indirect_jump_resolvers:        A custom list of indirect jump resolvers.
+                                                    If this list is None or empty, default indirect jump resolvers
+                                                    specific to this architecture and binary types will be loaded.
         :param int indirect_jump_target_limit:      Maximum indirect jump targets to be recovered.
         :param bool detect_tail_calls:              Aggressive tail-call optimization detection. This option is only
                                                     respected in make_functions().
-        :param bool sp_tracking_track_memory:       Whether or not to track memory writes when tracking the stack pointer. This
-                                                    increases the accuracy of stack pointer tracking, especially for architectures
-                                                    without a base pointer. Only used if detect_tail_calls is enabled.
+        :param bool sp_tracking_track_memory:       Whether or not to track memory writes if tracking the stack pointer.
+                                                    This increases the accuracy of stack pointer tracking,
+                                                    especially for architectures without a base pointer.
+                                                    Only used if detect_tail_calls is enabled.
         :param None or CFGModel model:              The CFGModel instance to write to. A new CFGModel instance will be
                                                     created and registered with the knowledge base if `model` is None.
 
@@ -1036,7 +1037,12 @@ class CFGBase(Analysis):
 
         self._normalized = True
 
-    def _normalize_core(self, graph: networkx.DiGraph, callstack_key, smallest_node, other_nodes, smallest_nodes, end_addresses_to_nodes):
+    def _normalize_core(self, graph: networkx.DiGraph,
+                        callstack_key,
+                        smallest_node,
+                        other_nodes,
+                        smallest_nodes,
+                        end_addresses_to_nodes):
 
         # Break other nodes
         for n in other_nodes:
@@ -1350,7 +1356,7 @@ class CFGBase(Analysis):
                 self._release_gil(i, 20)
 
             if self._show_progressbar or self._progress_callback:
-                progress = min_stage_2_progress + (max_stage_2_progress - min_stage_2_progress) * (i * 1.0 / nodes_count)
+                progress = min_stage_2_progress + (max_stage_2_progress - min_stage_2_progress) * (i * 1. / nodes_count)
                 self._update_progress(progress)
 
             self._graph_bfs_custom(self.graph, [ fn ], self._graph_traversal_handler, blockaddr_to_function,
@@ -1382,7 +1388,7 @@ class CFGBase(Analysis):
         for i, fn in enumerate(sorted(secondary_function_nodes, key=lambda n: n.addr)):
 
             if self._show_progressbar or self._progress_callback:
-                progress = min_stage_3_progress + (max_stage_3_progress - min_stage_3_progress) * (i * 1.0 / nodes_count)
+                progress = min_stage_3_progress + (max_stage_3_progress - min_stage_3_progress) * (i * 1. / nodes_count)
                 self._update_progress(progress)
 
             self._graph_bfs_custom(self.graph, [fn], self._graph_traversal_handler, blockaddr_to_function,
@@ -1784,7 +1790,8 @@ class CFGBase(Analysis):
             is_syscall = self.project.simos.is_syscall_addr(addr)
 
             n = self.model.get_any_node(addr, is_syscall=is_syscall)
-            if n is None: node = addr
+            if n is None:
+                node = addr
             else: node = self._to_snippet(n)
 
             if isinstance(addr, SootAddressDescriptor):
@@ -1939,8 +1946,10 @@ class CFGBase(Analysis):
 
         if src_addr not in src_function.block_addrs_set:
             n = self.model.get_any_node(src_addr)
-            if n is None: node = src_addr
-            else: node = self._to_snippet(n)
+            if n is None:
+                node = src_addr
+            else:
+                node = self._to_snippet(n)
             self.kb.functions._add_node(src_function.addr, node)
 
         if data is None:
@@ -1951,8 +1960,10 @@ class CFGBase(Analysis):
 
         if jumpkind == 'Ijk_Ret':
             n = self.model.get_any_node(src_addr)
-            if n is None: from_node = src_addr
-            else: from_node = self._to_snippet(n)
+            if n is None:
+                from_node = src_addr
+            else:
+                from_node = self._to_snippet(n)
             self.kb.functions._add_return_from(src_function.addr, from_node, None)
 
         if dst is None:
@@ -1972,7 +1983,8 @@ class CFGBase(Analysis):
             dst_function = self._addr_to_function(dst_addr, blockaddr_to_function, known_functions)
 
             n = self.model.get_any_node(src_addr)
-            if n is None: src_snippet = self._to_snippet(addr=src_addr, base_state=self._base_state)
+            if n is None:
+                src_snippet = self._to_snippet(addr=src_addr, base_state=self._base_state)
             else:
                 src_snippet = self._to_snippet(cfg_node=n)
 
@@ -1993,8 +2005,8 @@ class CFGBase(Analysis):
             if isinstance(dst_addr, SootAddressDescriptor):
                 dst_addr = dst_addr.method
 
-            self.kb.functions._add_call_to(src_function.addr, src_snippet, dst_addr, fakeret_snippet, syscall=is_syscall,
-                                           ins_addr=ins_addr, stmt_idx=stmt_idx)
+            self.kb.functions._add_call_to(src_function.addr, src_snippet, dst_addr, fakeret_snippet,
+                                           syscall=is_syscall, ins_addr=ins_addr, stmt_idx=stmt_idx)
 
             if dst_function.returning:
                 returning_target = src.addr + src.size
@@ -2025,12 +2037,16 @@ class CFGBase(Analysis):
 
             # convert src_addr and dst_addr to CodeNodes
             n = self.model.get_any_node(src_addr)
-            if n is None: src_node = src_addr
-            else: src_node = self._to_snippet(cfg_node=n)
+            if n is None:
+                src_node = src_addr
+            else:
+                src_node = self._to_snippet(cfg_node=n)
 
             n = self.model.get_any_node(dst_addr)
-            if n is None: dst_node = dst_addr
-            else: dst_node = self._to_snippet(cfg_node=n)
+            if n is None:
+                dst_node = dst_addr
+            else:
+                dst_node = self._to_snippet(cfg_node=n)
 
             # pre-check: if source and destination do not belong to the same section, it must be jumping to another
             # function

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -320,7 +320,7 @@ class CFGBase(Analysis):
         return self._model.get_exit_stmt_idx(src_block, dst_block)
 
     @property
-    def graph(self):
+    def graph(self) -> networkx.DiGraph:
         raise NotImplementedError()
 
     def remove_edge(self, block_from, block_to):
@@ -1036,7 +1036,7 @@ class CFGBase(Analysis):
 
         self._normalized = True
 
-    def _normalize_core(self, graph, callstack_key, smallest_node, other_nodes, smallest_nodes, end_addresses_to_nodes):
+    def _normalize_core(self, graph: networkx.DiGraph, callstack_key, smallest_node, other_nodes, smallest_nodes, end_addresses_to_nodes):
 
         # Break other nodes
         for n in other_nodes:

--- a/angr/analyses/cfg/indirect_jump_resolvers/resolver.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/resolver.py
@@ -1,10 +1,13 @@
+import typing
 
 from ....errors import SimMemoryError
 
+if typing.TYPE_CHECKING:
+    from .... import Project
 
 class IndirectJumpResolver:
     def __init__(self, project, timeless=False, base_state=None):
-        self.project = project
+        self.project: "Project" = project
         self.timeless = timeless
         self.base_state = base_state
 

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -74,7 +74,7 @@ class ConditionProcessor:
         else:
             _g = region.graph
         end_nodes = {n for n in _g.nodes() if _g.out_degree(n) == 0}
-        inverted_graph = shallow_reverse(_g)
+        inverted_graph: networkx.DiGraph = shallow_reverse(_g)
         if end_nodes:
             if len(end_nodes) > 1:
                 # make sure there is only one end node

--- a/angr/analyses/decompiler/graph_region.py
+++ b/angr/analyses/decompiler/graph_region.py
@@ -23,7 +23,7 @@ class GraphRegion:
 
     __slots__ = ('head', 'graph', 'successors', 'graph_with_successors', 'cyclic', )
 
-    def __init__(self, head, graph, successors: Optional[set], graph_with_successors, cyclic):
+    def __init__(self, head, graph, successors: Optional[set], graph_with_successors: networkx.DiGraph, cyclic):
         self.head = head
         self.graph = graph
         self.successors = successors
@@ -31,7 +31,7 @@ class GraphRegion:
         # successors inside graph_with_successors are *not* deep copied. therefore, you should never modify any
         # successor node in graph_with_successors. to avoid potential programming errors, just treat
         # graph_with_successors as read-only.
-        self.graph_with_successors = graph_with_successors
+        self.graph_with_successors: networkx.DiGraph = graph_with_successors
         self.cyclic = cyclic
 
     def __repr__(self):
@@ -66,7 +66,7 @@ class GraphRegion:
         return GraphRegion(nodes_map[self.head], new_graph, successors, new_graph_with_successors, self.cyclic)
 
     @staticmethod
-    def _recursive_copy(old_graph, nodes_map, ignored_nodes=None):
+    def _recursive_copy(old_graph, nodes_map, ignored_nodes=None) -> networkx.DiGraph:
         new_graph = networkx.DiGraph()
 
         # make copy of each node and add the mapping from old nodes to new nodes into nodes_map
@@ -143,7 +143,7 @@ class GraphRegion:
             self._replace_node_in_graph(self.graph_with_successors, sub_region, replace_with)
 
     @staticmethod
-    def _replace_node_in_graph(graph, node, replace_with):
+    def _replace_node_in_graph(graph: networkx.DiGraph, node, replace_with):
 
         in_edges = list(graph.in_edges(node))
         out_edges = list(graph.out_edges(node))

--- a/angr/analyses/decompiler/optimization_passes/eager_returns.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_returns.py
@@ -77,7 +77,7 @@ class EagerReturnsSimplifier(OptimizationPass):
         if graph_updated:
             self.out_graph = graph_copy
 
-    def _analyze_core(self, graph):
+    def _analyze_core(self, graph: networkx.DiGraph):
 
         endnodes = [ node for node in graph.nodes() if graph.out_degree[node] == 0 ]
         graph_changed = False

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -587,7 +587,12 @@ class RegionIdentifier(Analysis):
         else:
             return None
 
-    def _abstract_acyclic_region(self, graph: networkx.DiGraph, region, frontier, dummy_endnode=None, secondary_graph=None):
+    def _abstract_acyclic_region(self,
+                                 graph: networkx.DiGraph,
+                                 region,
+                                 frontier,
+                                 dummy_endnode=None,
+                                 secondary_graph=None):
 
         in_edges = self._region_in_edges(graph, region, data=True)
         out_edges = self._region_out_edges(graph, region, data=True)
@@ -617,7 +622,8 @@ class RegionIdentifier(Analysis):
             self._abstract_acyclic_region(secondary_graph, region, { })
 
     @staticmethod
-    def _abstract_cyclic_region(graph: networkx.DiGraph, loop_nodes, head, normal_entries, abnormal_entries, normal_exit_node,
+    def _abstract_cyclic_region(graph: networkx.DiGraph, loop_nodes, head, normal_entries, abnormal_entries,
+                                normal_exit_node,
                                 abnormal_exit_nodes):
         region = GraphRegion(head, None, None, None, True)
 

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -71,7 +71,7 @@ class RegionIdentifier(Analysis):
 
         self.region = self._make_regions(graph)
 
-    def _get_start_node(self, graph):
+    def _get_start_node(self, graph: networkx.DiGraph):
         try:
             return next(n for n in graph.nodes() if graph.in_degree(n) == 0)
         except StopIteration:
@@ -111,7 +111,7 @@ class RegionIdentifier(Analysis):
 
         return False
 
-    def _make_supergraph(self, graph):
+    def _make_supergraph(self, graph: networkx.DiGraph):
 
         while True:
             for src, dst, data in graph.edges(data=True):
@@ -126,17 +126,17 @@ class RegionIdentifier(Analysis):
             else:
                 break
 
-    def _find_loop_headers(self, graph):
+    def _find_loop_headers(self, graph: networkx.DiGraph):
         return OrderedSet(sorted((t for _,t in dfs_back_edges(graph, self._start_node)), key=lambda x: x.addr))
 
-    def _find_initial_loop_nodes(self, graph, head):
+    def _find_initial_loop_nodes(self, graph: networkx.DiGraph, head):
         # TODO optimize
         latching_nodes = { s for s,t in dfs_back_edges(graph, self._start_node) if t == head }
         loop_subgraph = self.slice_graph(graph, head, latching_nodes, include_frontier=True)
         nodes = set(loop_subgraph.nodes())
         return nodes
 
-    def _refine_loop(self, graph, head, initial_loop_nodes, initial_exit_nodes):
+    def _refine_loop(self, graph: networkx.DiGraph, head, initial_loop_nodes, initial_exit_nodes):
         refined_loop_nodes = initial_loop_nodes.copy()
         refined_exit_nodes = initial_exit_nodes.copy()
 
@@ -157,7 +157,7 @@ class RegionIdentifier(Analysis):
 
         return refined_loop_nodes, refined_exit_nodes
 
-    def _remove_self_loop(self, graph):
+    def _remove_self_loop(self, graph: networkx.DiGraph):
 
         r = False
 
@@ -173,7 +173,7 @@ class RegionIdentifier(Analysis):
 
         return r
 
-    def _merge_single_entry_node(self, graph):
+    def _merge_single_entry_node(self, graph: networkx.DiGraph):
 
         r = False
 
@@ -190,7 +190,7 @@ class RegionIdentifier(Analysis):
 
         return r
 
-    def _make_regions(self, graph):
+    def _make_regions(self, graph: networkx.DiGraph):
 
         structured_loop_headers = set()
         new_regions = [ ]
@@ -251,7 +251,7 @@ class RegionIdentifier(Analysis):
     # Cyclic regions
     #
 
-    def _make_cyclic_region(self, head, graph):
+    def _make_cyclic_region(self, head, graph: networkx.DiGraph):
 
         l.debug("Found cyclic region at %#08x", head.addr)
         initial_loop_nodes = self._find_initial_loop_nodes(graph, head)
@@ -301,7 +301,7 @@ class RegionIdentifier(Analysis):
 
         return region
 
-    def _refine_loop_successors(self, region, graph):
+    def _refine_loop_successors(self, region, graph: networkx.DiGraph):
         """
         If there are multiple successors of a loop, convert them into conditional gotos. Eventually there should be
         only one loop successor.
@@ -402,7 +402,7 @@ class RegionIdentifier(Analysis):
     # Acyclic regions
     #
 
-    def _make_acyclic_region(self, head, graph, secondary_graph, failed_region_attempts, cyclic):
+    def _make_acyclic_region(self, head, graph: networkx.DiGraph, secondary_graph, failed_region_attempts, cyclic):
         # pre-processing
 
         # we need to create a copy of the original graph if
@@ -587,7 +587,7 @@ class RegionIdentifier(Analysis):
         else:
             return None
 
-    def _abstract_acyclic_region(self, graph, region, frontier, dummy_endnode=None, secondary_graph=None):
+    def _abstract_acyclic_region(self, graph: networkx.DiGraph, region, frontier, dummy_endnode=None, secondary_graph=None):
 
         in_edges = self._region_in_edges(graph, region, data=True)
         out_edges = self._region_out_edges(graph, region, data=True)
@@ -617,7 +617,7 @@ class RegionIdentifier(Analysis):
             self._abstract_acyclic_region(secondary_graph, region, { })
 
     @staticmethod
-    def _abstract_cyclic_region(graph, loop_nodes, head, normal_entries, abnormal_entries, normal_exit_node,
+    def _abstract_cyclic_region(graph: networkx.DiGraph, loop_nodes, head, normal_entries, abnormal_entries, normal_exit_node,
                                 abnormal_exit_nodes):
         region = GraphRegion(head, None, None, None, True)
 
@@ -691,7 +691,7 @@ class RegionIdentifier(Analysis):
                 out_edges.append((region, dst, data_))
         return out_edges
 
-    def _remove_node(self, graph, node):  # pylint:disable=no-self-use
+    def _remove_node(self, graph: networkx.DiGraph, node):  # pylint:disable=no-self-use
 
         in_edges = [ (src, dst, data) for (src, dst, data) in graph.in_edges(node, data=True) if not src is node ]
         out_edges = [ (src, dst, data) for (src, dst, data) in graph.out_edges(node, data=True) if not dst is node ]
@@ -712,7 +712,7 @@ class RegionIdentifier(Analysis):
             for _, dst, data in out_edges:
                 graph.add_edge(new_node, dst, **data)
 
-    def _merge_nodes(self, graph, node_a, node_b, force_multinode=False):  # pylint:disable=no-self-use
+    def _merge_nodes(self, graph: networkx.DiGraph, node_a, node_b, force_multinode=False):  # pylint:disable=no-self-use
 
         in_edges = list(graph.in_edges(node_a, data=True))
         out_edges = list(graph.out_edges(node_b, data=True))
@@ -743,7 +743,7 @@ class RegionIdentifier(Analysis):
         assert not node_a in graph
         assert not node_b in graph
 
-    def _absorb_node(self, graph, node_mommy, node_kiddie, force_multinode=False):  # pylint:disable=no-self-use
+    def _absorb_node(self, graph: networkx.DiGraph, node_mommy, node_kiddie, force_multinode=False):  # pylint:disable=no-self-use
 
         in_edges_mommy = graph.in_edges(node_mommy, data=True)
         out_edges_mommy = graph.out_edges(node_mommy, data=True)

--- a/angr/analyses/find_objects_static.py
+++ b/angr/analyses/find_objects_static.py
@@ -152,7 +152,6 @@ class NewFunctionHandler(FunctionHandler):
         executed_rda = True
         return executed_rda, state, visited_blocks, dep_graph
 
-
 class StaticObjectFinder(Analysis):
     """
     This analysis tries to find objects on the heap based on calls to new(), and subsequent calls to constructors with

--- a/angr/analyses/forward_analysis/forward_analysis.py
+++ b/angr/analyses/forward_analysis/forward_analysis.py
@@ -1,18 +1,22 @@
 from collections import defaultdict
-from typing import Dict, Any, List, Callable, Optional, Generic, TypeVar, Tuple, Set
+from typing import Dict, List, Callable, Optional, Generic, TypeVar, Tuple, Set, TYPE_CHECKING
 
 import networkx
 
-from .visitors.graph import GraphVisitor, NodeType
+from .visitors.graph import NodeType
 from ...errors import AngrForwardAnalysisError
 from ...errors import AngrSkipJobNotice, AngrDelayJobNotice, AngrJobMergingFailureNotice, AngrJobWideningFailureNotice
 from ...utils.algo import binary_insert
 from .job_info import JobInfo
 
+if TYPE_CHECKING:
+    from .visitors.graph import GraphVisitor
+
 AnalysisState = TypeVar("AnalysisState")
 NodeKey = TypeVar("NodeKey")
 JobType = TypeVar("JobType")
 JobKey = TypeVar("JobKey")
+
 
 class ForwardAnalysis(Generic[AnalysisState]):
     """

--- a/angr/analyses/forward_analysis/forward_analysis.py
+++ b/angr/analyses/forward_analysis/forward_analysis.py
@@ -1,15 +1,20 @@
 from collections import defaultdict
-from typing import Dict, Any, List, Callable
+from typing import Dict, Any, List, Callable, Optional, Generic, TypeVar, Tuple, Set
 
 import networkx
 
+from .visitors.graph import GraphVisitor, NodeType
 from ...errors import AngrForwardAnalysisError
 from ...errors import AngrSkipJobNotice, AngrDelayJobNotice, AngrJobMergingFailureNotice, AngrJobWideningFailureNotice
 from ...utils.algo import binary_insert
 from .job_info import JobInfo
 
+AnalysisState = TypeVar("AnalysisState")
+NodeKey = TypeVar("NodeKey")
+JobType = TypeVar("JobType")
+JobKey = TypeVar("JobKey")
 
-class ForwardAnalysis:
+class ForwardAnalysis(Generic[AnalysisState]):
     """
     This is my very first attempt to build a static forward analysis framework that can serve as the base of multiple
     static analyses in angr, including CFG analysis, VFG analysis, DDG, etc.
@@ -30,7 +35,7 @@ class ForwardAnalysis:
     """
 
     def __init__(self, order_jobs=False, allow_merging=False, allow_widening=False, status_callback=None,
-                 graph_visitor=None
+                 graph_visitor: "Optional[GraphVisitor[NodeType]]" = None
                  ):
         """
         Constructor
@@ -57,15 +62,15 @@ class ForwardAnalysis:
         self._should_abort = False
 
         # All remaining jobs
-        self._job_info_queue = [ ]
+        self._job_info_queue: List[JobType] = []
 
         # A map between job key to job. Jobs with the same key will be merged by calling _merge_jobs()
-        self._job_map = { }
+        self._job_map: Dict[JobKey, JobType] = {}
 
         # A mapping between node and its input states
-        self._input_states: Dict[Any,List[Any]] = defaultdict(list)
+        self._input_states: Dict[NodeKey, List[AnalysisState]] = defaultdict(list)
         # A mapping between node and its output state
-        self._output_state: Dict[Any,Any] = {}
+        self._output_state: Dict[NodeKey, AnalysisState] = {}
 
         # The graph!
         # Analysis results (nodes) are stored here
@@ -85,7 +90,7 @@ class ForwardAnalysis:
         return self._should_abort
 
     @property
-    def graph(self):
+    def graph(self) -> networkx.DiGraph:
         return self._graph
 
     @property
@@ -105,7 +110,7 @@ class ForwardAnalysis:
 
         self._should_abort = True
 
-    def has_job(self, job):
+    def has_job(self, job: JobType) -> bool:
         """
         Checks whether there exists another job which has the same job key.
         :param job: The job to check.
@@ -125,43 +130,43 @@ class ForwardAnalysis:
 
     # Common interfaces
 
-    def _pre_analysis(self):
+    def _pre_analysis(self) -> None:
         raise NotImplementedError('_pre_analysis() is not implemented.')
 
-    def _intra_analysis(self):
+    def _intra_analysis(self) -> None:
         raise NotImplementedError('_intra_analysis() is not implemented.')
 
-    def _post_analysis(self):
+    def _post_analysis(self) -> None:
         raise NotImplementedError('_post_analysis() is not implemented.')
 
-    def _job_key(self, job):
+    def _job_key(self, job: JobType) -> JobKey:
         raise NotImplementedError('_job_key() is not implemented.')
 
-    def _get_successors(self, job):
+    def _get_successors(self, job: JobType) -> List[JobType]:
         raise NotImplementedError('_get_successors() is not implemented.')
 
-    def _pre_job_handling(self, job):
+    def _pre_job_handling(self, job: JobType) -> None:
         raise NotImplementedError('_pre_job_handling() is not implemented.')
 
-    def _post_job_handling(self, job, new_jobs, successors):
+    def _post_job_handling(self, job: JobType, new_jobs, successors):
         raise NotImplementedError('_post_job_handling() is not implemented.')
 
-    def _handle_successor(self, job, successor, successors):
+    def _handle_successor(self, job: JobType, successor: JobType, successors: List[JobType]) -> List[JobType]:
         raise NotImplementedError('_handle_successor() is not implemented.')
 
-    def _job_queue_empty(self):
+    def _job_queue_empty(self) -> None:
         raise NotImplementedError('_job_queue_empty() is not implemented.')
 
-    def _initial_abstract_state(self, node):
+    def _initial_abstract_state(self, node: NodeType) -> AnalysisState:
         raise NotImplementedError('_initial_abstract_state() is not implemented.')
 
-    def _node_key(self, node) -> Any:  # pylint:disable=no-self-use
+    def _node_key(self, node: NodeType) -> NodeKey:  # pylint:disable=no-self-use
         """
         Override this method if hash(node) is slow for the type of node that are in use.
         """
         return node
 
-    def _run_on_node(self, node, state):
+    def _run_on_node(self, node: NodeType, state: AnalysisState) -> Tuple[bool, AnalysisState]:
         """
         The analysis routine that runs on each node in the graph.
 
@@ -179,7 +184,7 @@ class ForwardAnalysis:
 
         raise NotImplementedError('_run_on_node() is not implemented.')
 
-    def _merge_states(self, node, *states):
+    def _merge_states(self, node: NodeType, *states: AnalysisState) -> Tuple[AnalysisState, bool]:
         """
         Merge multiple abstract states into one.
 
@@ -191,28 +196,28 @@ class ForwardAnalysis:
 
         raise NotImplementedError('_merge_states() is not implemented.')
 
-    def _widen_states(self, *states):
+    def _widen_states(self, *states: AnalysisState) -> AnalysisState:
         raise NotImplementedError('_widen_states() is not implemented.')
 
     # Special interfaces for non-graph-traversal mode
 
-    def _merge_jobs(self, *jobs):
+    def _merge_jobs(self, *jobs: JobType):
         raise NotImplementedError('_merge_jobs() is not implemented.')
 
-    def _should_widen_jobs(self, *jobs):
+    def _should_widen_jobs(self, *jobs: JobType):
         raise NotImplementedError('_should_widen_jobs() is not implemented.')
 
-    def _widen_jobs(self, *jobs):
+    def _widen_jobs(self, *jobs: JobType):
         raise NotImplementedError('_widen_jobs() is not implemented.')
 
-    def _job_sorting_key(self, job):
+    def _job_sorting_key(self, job: JobType) -> int:
         raise NotImplementedError('_job_sorting_key() is not implemented.')
 
     #
     # Private methods
     #
 
-    def _analyze(self):
+    def _analyze(self) -> None:
         """
         The main analysis routine.
 
@@ -235,13 +240,13 @@ class ForwardAnalysis:
 
         self._post_analysis()
 
-    def _analysis_core_graph(self):
+    def _analysis_core_graph(self) -> None:
 
         while not self.should_abort:
 
             self._intra_analysis()
 
-            n = self._graph_visitor.next_node()
+            n: NodeType = self._graph_visitor.next_node()
 
             if n is None:
                 break
@@ -281,13 +286,12 @@ class ForwardAnalysis:
                     for succ in successors_to_visit:
                         self._graph_visitor.revisit_node(succ)
 
-    def _add_input_state(self, node, input_state):
+    def _add_input_state(self, node: NodeType, input_state: AnalysisState) -> Set[NodeType]:
         """
         Add the input state to all successors of the given node.
 
         :param node:        The node whose successors' input states will be touched.
         :param input_state: The state that will be added to successors of the node.
-        :return:            None
         """
 
         successors = set(self._graph_visitor.successors(node))
@@ -304,7 +308,7 @@ class ForwardAnalysis:
 
         return successors
 
-    def _get_and_update_input_state(self, node):
+    def _get_and_update_input_state(self, node: NodeType) -> Optional[AnalysisState]:
         """
         Get the input abstract state for this node, and remove it from the state map.
 
@@ -314,11 +318,11 @@ class ForwardAnalysis:
 
         if self._node_key(node) in self._input_states:
             input_state = self._get_input_state(node)
-            self._input_states[self._node_key(node)] = [ input_state ]
+            self._input_states[self._node_key(node)] = [input_state]
             return input_state
         return None
 
-    def _get_input_state(self, node):
+    def _get_input_state(self, node: NodeType) -> Optional[AnalysisState]:
         """
         Get the input abstract state for this node.
 
@@ -335,7 +339,7 @@ class ForwardAnalysis:
         merged_state, _ = self._merge_states(node, *all_input_states)
         return merged_state
 
-    def _analysis_core_baremetal(self):
+    def _analysis_core_baremetal(self) -> None:
 
         if not self._job_info_queue:
             self._job_queue_empty()
@@ -382,7 +386,7 @@ class ForwardAnalysis:
 
             self._intra_analysis()
 
-    def _process_job_and_get_successors(self, job_info):
+    def _process_job_and_get_successors(self, job_info: JobInfo[JobKey, JobType]) -> None:
         """
         Process a job, get all successors of this job, and call _handle_successor() to handle each successor.
 
@@ -407,7 +411,7 @@ class ForwardAnalysis:
 
         self._post_job_handling(job, all_new_jobs, successors)
 
-    def _insert_job(self, job):
+    def _insert_job(self, job: JobType) -> None:
         """
         Insert a new job into the job queue. If the job queue is ordered, this job will be inserted at the correct
         position.
@@ -466,7 +470,7 @@ class ForwardAnalysis:
         else:
             self._job_info_queue.append(job_info)
 
-    def _peek_job(self, pos):
+    def _peek_job(self, pos: int) -> JobType:
         """
         Return the job currently at position `pos`, but still keep it in the job queue. An IndexError will be raised
         if that position does not currently exist in the job list.

--- a/angr/analyses/forward_analysis/job_info.py
+++ b/angr/analyses/forward_analysis/job_info.py
@@ -1,8 +1,15 @@
-class JobInfo:
+from typing import Generic, TypeVar
+
+# from angr.analyses.forward_analysis.forward_analysis import JobType, JobKey
+
+JobType = TypeVar("JobType")
+JobKey = TypeVar("JobKey")
+
+class JobInfo(Generic[JobKey, JobType]):
     """
     Stores information of each job.
     """
-    def __init__(self, key, job):
+    def __init__(self, key: "JobKey", job: "JobType"):
         self.key = key
         self.jobs = [(job, '')]
 
@@ -20,7 +27,7 @@ class JobInfo:
         return s
 
     @property
-    def job(self):
+    def job(self) -> "JobType":
         """
         Get the latest available job.
 
@@ -56,3 +63,5 @@ class JobInfo:
         elif widened:
             job_type = 'widened'
         self.jobs.append((job, job_type))
+
+

--- a/angr/analyses/forward_analysis/job_info.py
+++ b/angr/analyses/forward_analysis/job_info.py
@@ -63,5 +63,3 @@ class JobInfo(Generic[JobKey, JobType]):
         elif widened:
             job_type = 'widened'
         self.jobs.append((job, job_type))
-
-

--- a/angr/analyses/forward_analysis/visitors/graph.py
+++ b/angr/analyses/forward_analysis/visitors/graph.py
@@ -1,8 +1,12 @@
+from typing import TypeVar, Generic, List, Collection, Optional, Iterator, Set, Dict
+
 from ....misc.ux import deprecated
 from ....utils.algo import binary_insert
 
+NodeType = TypeVar("NodeType")
 
-class GraphVisitor:
+
+class GraphVisitor(Generic[NodeType]):
     """
     A graph visitor takes a node in the graph and returns its successors. Typically it visits a control flow graph, and
     returns successors of a CFGNode each time. This is the base class of all graph visitors.
@@ -11,16 +15,16 @@ class GraphVisitor:
     __slots__ = ('_sorted_nodes', '_nodes_set', '_node_to_index', '_reached_fixedpoint', )
 
     def __init__(self):
-        self._sorted_nodes = [ ]
-        self._nodes_set = set()
-        self._node_to_index = { }
-        self._reached_fixedpoint = set()
+        self._sorted_nodes: List[NodeType] = [ ]
+        self._nodes_set: Set[NodeType] = set()
+        self._node_to_index: Dict[NodeType, int] = { }
+        self._reached_fixedpoint: Set[NodeType] = set()
 
     #
     # Interfaces
     #
 
-    def successors(self, node):
+    def successors(self, node: NodeType) -> List[NodeType]:
         """
         Get successors of a node. The node should be in the graph.
 
@@ -31,7 +35,7 @@ class GraphVisitor:
 
         raise NotImplementedError()
 
-    def predecessors(self, node):
+    def predecessors(self, node: NodeType) -> List[NodeType]:
         """
         Get predecessors of a node. The node should be in the graph.
 
@@ -42,7 +46,7 @@ class GraphVisitor:
 
         raise NotImplementedError()
 
-    def sort_nodes(self, nodes=None):
+    def sort_nodes(self, nodes: Optional[Collection[NodeType]] = None) -> List[NodeType]:
         """
         Get a list of all nodes sorted in an optimal traversal order.
 
@@ -57,7 +61,7 @@ class GraphVisitor:
     # Public methods
     #
 
-    def nodes(self):
+    def nodes(self) -> Iterator[NodeType]:
         """
         Return an iterator of nodes following an optimal traversal order.
 
@@ -94,7 +98,7 @@ class GraphVisitor:
             binary_insert(self._sorted_nodes, n, lambda elem: self._node_to_index[elem])
             self._nodes_set.add(n)
 
-    def next_node(self):
+    def next_node(self) -> Optional[NodeType]:
         """
         Get the next node to visit.
 
@@ -108,7 +112,7 @@ class GraphVisitor:
         self._nodes_set.remove(node)
         return node
 
-    def all_successors(self, node, skip_reached_fixedpoint=False):
+    def all_successors(self, node: NodeType, skip_reached_fixedpoint=False) -> Set[NodeType]:
         """
         Returns all successors to the specific node.
 
@@ -130,7 +134,7 @@ class GraphVisitor:
 
         return successors
 
-    def revisit_successors(self, node, include_self=True):
+    def revisit_successors(self, node: NodeType, include_self=True) -> None:
         """
         Revisit a node in the future. As a result, the successors to this node will be revisited as well.
 
@@ -150,7 +154,7 @@ class GraphVisitor:
                 binary_insert(self._sorted_nodes, succ, lambda elem: self._node_to_index[elem])
                 self._nodes_set.add(succ)
 
-    def revisit_node(self, node):
+    def revisit_node(self, node: NodeType) -> None:
         """
         Revisit a node in the future. Do not include its successors immediately.
 
@@ -162,7 +166,7 @@ class GraphVisitor:
             binary_insert(self._sorted_nodes, node, lambda elem: self._node_to_index[elem])
             self._nodes_set.add(node)
 
-    def reached_fixedpoint(self, node):
+    def reached_fixedpoint(self, node: NodeType) -> None:
         """
         Mark a node as reached fixed-point. This node as well as all its successors will not be visited in the future.
 

--- a/angr/analyses/girlscout.py
+++ b/angr/analyses/girlscout.py
@@ -78,7 +78,7 @@ class GirlScout(Analysis):
         self._reconnoiter()
 
     @property
-    def call_map(self):
+    def call_map(self) -> networkx.DiGraph:
         return self.call_map
 
     def _get_next_addr_to_search(self, alignment=None):

--- a/angr/analyses/loop_analysis.py
+++ b/angr/analyses/loop_analysis.py
@@ -19,7 +19,7 @@ class VariableTypes:
 
 class AnnotatedVariable:
 
-    __slots__ = [ 'variable', 'type' ]
+    __slots__ = ['variable', 'type']
 
     def __init__(self, variable, type_):
         self.variable = variable
@@ -71,7 +71,7 @@ class SootBlockProcessor:
             raise AngrLoopAnalysisError("Got an unexpected type of block %s." % type(self.block))
 
         if not self.block.stmts:
-            return
+            return None
 
         for stmt in self.block.stmts:
 

--- a/angr/analyses/loopfinder.py
+++ b/angr/analyses/loopfinder.py
@@ -58,7 +58,7 @@ class LoopFinder(Analysis):
         if not found_any:
             l.error("No knowledge of functions is present. Did you forget to construct a CFG?")
 
-    def _parse_loop_graph(self, subg, bigg):
+    def _parse_loop_graph(self, subg: networkx.DiGraph, bigg: networkx.DiGraph):
         """
         Create a Loop object for a strongly connected graph, and any strongly
         connected subgraphs, if possible.
@@ -150,7 +150,7 @@ class LoopFinder(Analysis):
              tops[:])
         return me, [me] + alls
 
-    def _parse_loops_from_graph(self, graph):
+    def _parse_loops_from_graph(self, graph: networkx.DiGraph):
         """
         Return all Loop instances that can be extracted from a graph.
 
@@ -160,6 +160,7 @@ class LoopFinder(Analysis):
         """
         outtop = []
         outall = []
+        subg: networkx.DiGraph
         for subg in ( networkx.induced_subgraph(graph, nodes).copy() for nodes in networkx.strongly_connected_components(graph)):
             if len(subg.nodes()) == 1:
                 if len(list(subg.successors(list(subg.nodes())[0]))) == 0:

--- a/angr/analyses/reaching_definitions/dep_graph.py
+++ b/angr/analyses/reaching_definitions/dep_graph.py
@@ -35,7 +35,7 @@ class DepGraph:
         if graph and not all(map(_is_definition, graph.nodes)):
             raise TypeError("In a DepGraph, nodes need to be <%s>s." % Definition.__name__)
 
-        self._graph = graph if graph is not None else networkx.DiGraph()
+        self._graph: networkx.DiGraph = graph if graph is not None else networkx.DiGraph()
 
     @property
     def graph(self) -> networkx.DiGraph:

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -583,13 +583,15 @@ class SimEngineRDAIL(
             # each value in expr0 >> expr1_v
             if len(expr0.values) == 1 and 0 in expr0.values:
                 if all(v.concrete for v in expr0.values[0]):
-                    vs = {(claripy.LShR(v, expr1_v._model_concrete.value) if v.concrete else self.state.top(bits)) for v in expr0.values[0]}
+                    vs = {(claripy.LShR(v, expr1_v._model_concrete.value) if v.concrete else self.state.top(bits))
+                          for v in expr0.values[0]}
                     r = MultiValues(offset_to_values={0: vs})
         elif expr0_v is not None and expr1_v is None:
             # expr0_v >> each value in expr1
             if len(expr1.values) == 1 and 0 in expr1.values:
                 if all(v.concrete for v in expr1.values[0]):
-                    vs = {(claripy.LShR(expr0_v, v._model_concrete.value) if v.concrete else self.state.top(bits)) for v in expr1.values[0]}
+                    vs = {(claripy.LShR(expr0_v, v._model_concrete.value) if v.concrete else self.state.top(bits))
+                          for v in expr1.values[0]}
                     r = MultiValues(offset_to_values={0: vs})
         else:
             if expr0_v.concrete and expr1_v.concrete:
@@ -615,13 +617,15 @@ class SimEngineRDAIL(
             # each value in expr0 >> expr1_v
             if len(expr0.values) == 1 and 0 in expr0.values:
                 if all(v.concrete for v in expr0.values[0]):
-                    vs = {(claripy.LShR(v, expr1_v._model_concrete.value) if v.concrete else self.state.top(bits)) for v in expr0.values[0]}
+                    vs = {(claripy.LShR(v, expr1_v._model_concrete.value) if v.concrete else self.state.top(bits))
+                          for v in expr0.values[0]}
                     r = MultiValues(offset_to_values={0: vs})
         elif expr0_v is not None and expr1_v is None:
             # expr0_v >> each value in expr1
             if len(expr1.values) == 1 and 0 in expr1.values:
                 if all(v.concrete for v in expr1.values[0]):
-                    vs = {(claripy.LShR(expr0_v, v._model_concrete.value) if v.concrete else self.state.top(bits)) for v in expr1.values[0]}
+                    vs = {(claripy.LShR(expr0_v, v._model_concrete.value) if v.concrete else self.state.top(bits))
+                          for v in expr1.values[0]}
                     r = MultiValues(offset_to_values={0: vs})
         else:
             if expr0_v.concrete and expr1_v.concrete:
@@ -647,13 +651,15 @@ class SimEngineRDAIL(
             # each value in expr0 << expr1_v
             if len(expr0.values) == 1 and 0 in expr0.values:
                 if all(v.concrete for v in expr0.values[0]):
-                    vs = {((v << expr1_v._model_concrete.value) if v.concrete else self.state.top(bits)) for v in expr0.values[0]}
+                    vs = {((v << expr1_v._model_concrete.value) if v.concrete else self.state.top(bits))
+                          for v in expr0.values[0]}
                     r = MultiValues(offset_to_values={0: vs})
         elif expr0_v is not None and expr1_v is None:
             # expr0_v >> each value in expr1
             if len(expr1.values) == 1 and 0 in expr1.values:
                 if all(v.concrete for v in expr1.values[0]):
-                    vs = {((expr0_v << v._model_concrete.value) if v.concrete else self.state.top(bits)) for v in expr1.values[0]}
+                    vs = {((expr0_v << v._model_concrete.value) if v.concrete else self.state.top(bits))
+                          for v in expr1.values[0]}
                     r = MultiValues(offset_to_values={0: vs})
         else:
             if expr0_v.concrete and expr1_v.concrete:
@@ -836,7 +842,9 @@ class SimEngineRDAIL(
         stack_addr = self.state.stack_address(expr.offset)
         return MultiValues(offset_to_values={0: {stack_addr}})
 
-    def _ail_handle_DirtyExpression(self, expr: ailment.Expr.DirtyExpression) -> MultiValues:  # pylint:disable=no-self-use
+    def _ail_handle_DirtyExpression(self,
+                                    expr: ailment.Expr.DirtyExpression
+                                    ) -> MultiValues:  # pylint:disable=no-self-use
         # FIXME: DirtyExpression needs .bits
         top = self.state.top(expr.bits)
         return MultiValues(offset_to_values={0: {top}})

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -18,6 +18,7 @@ from ...knowledge_plugins.key_definitions.live_definitions import Definition
 from .subject import SubjectType
 from .external_codeloc import ExternalCodeLocation
 from .rd_state import ReachingDefinitionsState
+from .function_handler import FunctionHandler
 
 l = logging.getLogger(name=__name__)
 
@@ -30,7 +31,8 @@ class SimEngineRDAIL(
     arch: archinfo.Arch
     state: ReachingDefinitionsState
 
-    def __init__(self, project, call_stack, maximum_local_call_depth, function_handler=None):
+    def __init__(self, project, call_stack, maximum_local_call_depth,
+                 function_handler: Optional[FunctionHandler] = None):
         super().__init__()
         self.project = project
         self._call_stack = call_stack
@@ -884,7 +886,7 @@ class SimEngineRDAIL(
         elif is_internal is True:
             handler_name = 'handle_local_function'
             if hasattr(self._function_handler, handler_name):
-                is_updated, state, visited_blocks, dep_graph = getattr(self._function_handler, handler_name)(
+                is_updated, state, visited_blocks, dep_graph = self._function_handler.handle_local_function(
                     self.state,
                     ip_addr,
                     self._call_stack,

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -1148,7 +1148,8 @@ class SimEngineRDVEX(
                 atom = Register(reg_offset, reg_size)
                 self.state.kill_and_add_definition(atom,
                                                    self._codeloc(),
-                                                   MultiValues(offset_to_values={0: {self.state.top(reg_size * self.arch.byte_width)}}),
+                                                   MultiValues(offset_to_values=
+                                                               {0: {self.state.top(reg_size * self.arch.byte_width)}}),
                                                    )
 
         if self.arch.call_pushes_ret is True:

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -24,6 +24,7 @@ from .external_codeloc import ExternalCodeLocation
 
 if TYPE_CHECKING:
     from ...knowledge_plugins import FunctionManager
+    from .function_handler import FunctionHandler
 
 
 l = logging.getLogger(name=__name__)
@@ -44,7 +45,7 @@ class SimEngineRDVEX(
         self._call_stack = call_stack
         self._maximum_local_call_depth = maximum_local_call_depth
         self.functions: Optional['FunctionManager'] = functions
-        self._function_handler = function_handler
+        self._function_handler: "FunctionHandler" = function_handler
         self._visited_blocks = None
         self._dep_graph = None
 
@@ -1044,7 +1045,7 @@ class SimEngineRDVEX(
             handler_name = 'handle_local_function'
             if hasattr(self._function_handler, handler_name):
                 codeloc = CodeLocation(func_addr_int, 0, None, func_addr_int, context=self._context)
-                executed_rda, state, visited_blocks, dep_graph = getattr(self._function_handler, handler_name)(
+                executed_rda, state, visited_blocks, dep_graph = self._function_handler.handle_local_function(
                     self.state,
                     func_addr_int,
                     self._call_stack,

--- a/angr/analyses/reaching_definitions/function_handler.py
+++ b/angr/analyses/reaching_definitions/function_handler.py
@@ -1,19 +1,18 @@
 from typing import TYPE_CHECKING, List, Set, Optional, Tuple, Union
 from abc import ABC, abstractmethod
+import logging
 
+from cle import Symbol
+
+l = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from angr.code_location import CodeLocation
     from angr.analyses.reaching_definitions.dep_graph import DepGraph
     from angr.analyses.reaching_definitions.rd_state import ReachingDefinitionsState
-    from angr.analyses.ddg import LiveDefinitions
-    from angr import Block
-    from angr.codenode import CodeNode
-    from angr.knowledge_plugins.cfg import CFGNode
-    from ailment import Block as AILBlock
 
 
-class FunctionHandler(ABC):
+class FunctionHandler:
     """
     An abstract base class for function handlers.
 
@@ -22,24 +21,26 @@ class FunctionHandler(ABC):
       - Provide a `handle_local_function` method.
     """
 
-    @abstractmethod
-    def hook(self, analysis):
+    def hook(self, analysis) -> "FunctionHandler":
         """
         A <FunctionHandler> needs information about the context in which it is executed.
         A <ReachingDefinitionsAnalysis> would "hook" into a handler by calling: `<FunctionHandler>.hook(self)`.
 
-        :param angr.analyses.ReachingDefinitionsAnalysis analysis: A <ReachingDefinitionsAnalysis> using this <FunctionHandler>.
+        :param angr.analyses.ReachingDefinitionsAnalysis analysis: A RDA using this <FunctionHandler>.
 
         :return FunctionHandler:
         """
-        raise NotImplementedError()
+        return self
 
-    @abstractmethod
-    def handle_local_function(self, state: 'ReachingDefinitionsState', function_address: int, call_stack: Optional[List],
-                              maximum_local_call_depth: int, visited_blocks: Set[int], dep_graph: 'DepGraph',
+    def handle_local_function(self,
+                              state: 'ReachingDefinitionsState',
+                              function_address: int, call_stack: Optional[List],
+                              maximum_local_call_depth: int,
+                              visited_blocks: Set[int],
+                              dep_graph: 'DepGraph',
                               src_ins_addr: Optional[int] = None,
-                              codeloc: Optional['CodeLocation'] = None) -> Tuple[
-        bool, "ReachingDefinitionsState", "Set[int]", "DepGraph"]:
+                              codeloc: Optional['CodeLocation'] = None
+                              ) -> Tuple[bool, "ReachingDefinitionsState", "Set[int]", "DepGraph"]:
         """
         :param state: The state at the entry of the function, i.e. the function's input state.
         :param function_address: The address of the function to handle.
@@ -49,4 +50,83 @@ class FunctionHandler(ABC):
         :param dep_graph: A definition-use graph, where nodes represent definitions, and edges represent uses.
         :param codeloc: The code location of the call to the analysed function.
         """
-        raise NotImplementedError()
+        l.warning('Please implement the local function handler with your own logic.')
+        return False, state, visited_blocks, dep_graph
+
+    def handle_unknown_call(self,
+                            state: 'ReachingDefinitionsState',
+                            src_codeloc: Optional['CodeLocation'] = None
+                            ) -> Tuple[bool, 'ReachingDefinitionsState']:
+        """
+        Called when the RDA encounters a function call to somewhere really weird.
+        E.g. the function address was invalid (not even TOP),
+        or the address of the function is outside of the main object, but also not a known symbol
+        :param state:
+        :param src_codeloc:
+        :return:
+        """
+        l.error('Encountered unknown call. Implement the unknown function handler with your own logic.')
+        return False, state
+
+    def handle_indirect_call(self,
+                             state: 'ReachingDefinitionsState',
+                             src_codeloc: Optional['CodeLocation'] = None
+                             ) -> Tuple[bool, 'ReachingDefinitionsState']:
+        """
+        The RDA encountered a function call with multiple possible values, or TOP as a target
+        :param state:
+        :param src_codeloc:
+        :return:
+        """
+        l.warning('Please implement the indirect function handler with your own logic.')
+        return False, state
+
+    def handle_external_function_fallback(self,
+                                          state: 'ReachingDefinitionsState',
+                                          src_codeloc: Optional['CodeLocation'] = None
+                                          ) -> Tuple[bool, 'ReachingDefinitionsState']:
+        """
+        Fallback for a call to an external function, that has no specific implementation
+        :param state:
+        :param src_codeloc:
+        :return:
+        """
+        return False, state
+
+    def handle_external_function_symbol(self,
+                                 state: 'ReachingDefinitionsState',
+                                 symbol: Symbol,
+                                 src_codeloc: Optional['CodeLocation'] = None,
+                                 ) -> Tuple[bool, 'ReachingDefinitionsState']:
+        """
+        The generic handler for external functions with a known symbol
+        This is different from
+        The default behavior using hasattr/getattr supports existing code,
+        but you can also implement the check if the external function is supported in another way,
+        e.g. similar to SimProcedures
+        :param state:
+        :param symbol:
+        :param src_codeloc:
+        :return:
+        """
+        if symbol.name:
+            self.handle_external_function_name(state, symbol.name, src_codeloc)
+            return self.handle_external_function_name(state, symbol.name, src_codeloc)
+        else:
+            l.warning('Symbol for external function has no name, falling back to generic handler',
+            l.warning('Symbol %s for external function has no name, falling back to generic handler',
+                      symbol)
+            return self.handle_external_function_fallback(state, src_codeloc)
+
+    def handle_external_function_name(self,
+                                      state: 'ReachingDefinitionsState',
+                                      ext_func_name: str,
+                                      src_codeloc: Optional['CodeLocation'] = None,
+                                      ) -> Tuple[bool, 'ReachingDefinitionsState']:
+        handler_name = 'handle_%s' % ext_func_name
+        if ext_func_name and hasattr(self, handler_name):
+            return getattr(self, handler_name)(state, src_codeloc)
+        else:
+            l.warning('No handler for external function %s(), falling back to generic handler',
+                      ext_func_name)
+            return self.handle_external_function_fallback(state, src_codeloc)

--- a/angr/analyses/reaching_definitions/function_handler.py
+++ b/angr/analyses/reaching_definitions/function_handler.py
@@ -1,10 +1,16 @@
-from typing import TYPE_CHECKING, List, Set, Optional
+from typing import TYPE_CHECKING, List, Set, Optional, Tuple, Union
 from abc import ABC, abstractmethod
+
 
 if TYPE_CHECKING:
     from angr.code_location import CodeLocation
     from angr.analyses.reaching_definitions.dep_graph import DepGraph
     from angr.analyses.reaching_definitions.rd_state import ReachingDefinitionsState
+    from angr.analyses.ddg import LiveDefinitions
+    from angr import Block
+    from angr.codenode import CodeNode
+    from angr.knowledge_plugins.cfg import CFGNode
+    from ailment import Block as AILBlock
 
 
 class FunctionHandler(ABC):
@@ -29,10 +35,11 @@ class FunctionHandler(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def handle_local_function(self, state: 'ReachingDefinitionsState', function_address: int, call_stack: List,
+    def handle_local_function(self, state: 'ReachingDefinitionsState', function_address: int, call_stack: Optional[List],
                               maximum_local_call_depth: int, visited_blocks: Set[int], dep_graph: 'DepGraph',
-                              src_ins_addr: Optional[int]=None,
-                              codeloc: Optional['CodeLocation']=None):
+                              src_ins_addr: Optional[int] = None,
+                              codeloc: Optional['CodeLocation'] = None) -> Tuple[
+        bool, "ReachingDefinitionsState", "Set[int]", "DepGraph"]:
         """
         :param state: The state at the entry of the function, i.e. the function's input state.
         :param function_address: The address of the function to handle.
@@ -41,7 +48,5 @@ class FunctionHandler(ABC):
         :param visited_blocks: A set of the addresses of the previously visited blocks.
         :param dep_graph: A definition-use graph, where nodes represent definitions, and edges represent uses.
         :param codeloc: The code location of the call to the analysed function.
-
-        :return Tuple[Boolean,LiveDefinitions,List<ailment.Block|Block|CodeNode|CFGNode>,DepGraph]:
         """
         raise NotImplementedError()

--- a/angr/analyses/reaching_definitions/function_handler.py
+++ b/angr/analyses/reaching_definitions/function_handler.py
@@ -1,5 +1,4 @@
-from typing import TYPE_CHECKING, List, Set, Optional, Tuple, Union
-from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, List, Set, Optional, Tuple
 import logging
 
 from cle import Symbol
@@ -12,6 +11,7 @@ if TYPE_CHECKING:
     from angr.analyses.reaching_definitions.rd_state import ReachingDefinitionsState
 
 
+# pylint: disable=unused-argument, no-self-use
 class FunctionHandler:
     """
     An abstract base class for function handlers.
@@ -110,10 +110,8 @@ class FunctionHandler:
         :return:
         """
         if symbol.name:
-            self.handle_external_function_name(state, symbol.name, src_codeloc)
             return self.handle_external_function_name(state, symbol.name, src_codeloc)
         else:
-            l.warning('Symbol for external function has no name, falling back to generic handler',
             l.warning('Symbol %s for external function has no name, falling back to generic handler',
                       symbol)
             return self.handle_external_function_fallback(state, src_codeloc)

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -1,7 +1,7 @@
 
 import logging
 from typing import Optional, DefaultDict, Dict, List, Tuple, Set, Any, Union, TYPE_CHECKING
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 
 import ailment
 import pyvex
@@ -30,7 +30,8 @@ if TYPE_CHECKING:
 l = logging.getLogger(name=__name__)
 
 
-class ReachingDefinitionsAnalysis(ForwardAnalysis[ReachingDefinitionsState], Analysis):  # pylint:disable=abstract-method
+class ReachingDefinitionsAnalysis(ForwardAnalysis[ReachingDefinitionsState],
+                                  Analysis):  # pylint:disable=abstract-method
     """
     ReachingDefinitionsAnalysis is a text-book implementation of a static data-flow analysis that works on either a
     function or a block. It supports both VEX and AIL. By registering observers to observation points, users may use
@@ -311,7 +312,7 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis[ReachingDefinitionsState], Ana
     def _pre_analysis(self):
         pass
 
-    def _initial_abstract_state(self, node) -> ReachingDefinitionsState:
+    def _initial_abstract_state(self, _node) -> ReachingDefinitionsState:
         if self._init_state is not None:
             return self._init_state
         else:
@@ -320,7 +321,8 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis[ReachingDefinitionsState], Ana
                 track_consts=self._track_consts, analysis=self, canonical_size=self._canonical_size,
             )
 
-    def _merge_states(self, node, *states: ReachingDefinitionsState):
+    # pylint: disable=no-self-use
+    def _merge_states(self, _node, *states: ReachingDefinitionsState):
         merged_state, merge_occurred = states[0].merge(*states[1:])
         return merged_state, not merge_occurred
 

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -20,9 +20,10 @@ from .engine_ail import SimEngineRDAIL
 from .engine_vex import SimEngineRDVEX
 from .rd_state import ReachingDefinitionsState
 from .subject import Subject, SubjectType
+from .function_handler import FunctionHandler
+
 if TYPE_CHECKING:
     from .dep_graph import DepGraph
-    from .function_handler import FunctionHandler
     from typing import Literal, Iterable
     ObservationPoint = Tuple[Literal['insn', 'node'], int, Literal[0, 1]]
 
@@ -116,7 +117,7 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis[ReachingDefinitionsState], Ana
         self._dep_graph = dep_graph
 
         if function_handler is None:
-            self._function_handler = function_handler
+            self._function_handler = FunctionHandler().hook(self)
         else:
             self._function_handler = function_handler.hook(self)
 

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -1,7 +1,7 @@
 
 import logging
 from typing import Optional, DefaultDict, Dict, List, Tuple, Set, Any, Union, TYPE_CHECKING
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 
 import ailment
 import pyvex
@@ -22,12 +22,14 @@ from .rd_state import ReachingDefinitionsState
 from .subject import Subject, SubjectType
 if TYPE_CHECKING:
     from .dep_graph import DepGraph
-
+    from .function_handler import FunctionHandler
+    from typing import Literal, Iterable
+    ObservationPoint = Tuple[Literal['insn', 'node'], int, Literal[0, 1]]
 
 l = logging.getLogger(name=__name__)
 
 
-class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-method
+class ReachingDefinitionsAnalysis(ForwardAnalysis[ReachingDefinitionsState], Analysis):  # pylint:disable=abstract-method
     """
     ReachingDefinitionsAnalysis is a text-book implementation of a static data-flow analysis that works on either a
     function or a block. It supports both VEX and AIL. By registering observers to observation points, users may use
@@ -49,10 +51,10 @@ class ReachingDefinitionsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=
             track_tmps=False,
             track_calls=None,
             track_consts=False,
-            observation_points=None,
+            observation_points: "Iterable[ObservationPoint]" =None,
             init_state: ReachingDefinitionsState=None,
             cc=None,
-            function_handler=None,
+            function_handler: "Optional[FunctionHandler]" = None,
             call_stack: Optional[List[int]]=None,
             maximum_local_call_depth=5,
             observe_all=False,

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -127,6 +127,7 @@ class SimEngineLight(
                             )
 
 
+# noinspection PyPep8Naming
 class SimEngineLightVEXMixin(SimEngineLightMixin):
 
     def _process(self, state, successors, *args, block, whitelist=None, **kwargs):  # pylint:disable=arguments-differ
@@ -705,27 +706,27 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
 
         return expr_0 > expr_1
 
-    def _handle_CmpEQ_v(self, expr, vector_size, vector_count):
+    def _handle_CmpEQ_v(self, expr, _vector_size, _vector_count):
         _, _ = self._binop_get_args(expr)
         return self._top(expr.result_size(self.tyenv))
 
-    def _handle_CmpNE_v(self, expr, vector_size, vector_count):
+    def _handle_CmpNE_v(self, expr, _vector_size, _vector_count):
         _, _ = self._binop_get_args(expr)
         return self._top(expr.result_size(self.tyenv))
 
-    def _handle_CmpLE_v(self, expr, vector_size, vector_count):
+    def _handle_CmpLE_v(self, expr, _vector_size, _vector_count):
         _, _ = self._binop_get_args(expr)
         return self._top(expr.result_size(self.tyenv))
 
-    def _handle_CmpGE_v(self, expr, vector_size, vector_count):
+    def _handle_CmpGE_v(self, expr, _vector_size, _vector_count):
         _, _ = self._binop_get_args(expr)
         return self._top(expr.result_size(self.tyenv))
 
-    def _handle_CmpLT_v(self, expr, vector_size, vector_count):
+    def _handle_CmpLT_v(self, expr, _vector_size, _vector_count):
         _, _ = self._binop_get_args(expr)
         return self._top(expr.result_size(self.tyenv))
 
-    def _handle_CmpGT_v(self, expr, vector_size, vector_count):
+    def _handle_CmpGT_v(self, expr, _vector_size, _vector_count):
         _, _ = self._binop_get_args(expr)
         return self._top(expr.result_size(self.tyenv))
 
@@ -753,6 +754,7 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
         return self._top(expr.result_size(self.tyenv))
 
 
+# noinspection PyPep8Naming
 class SimEngineLightAILMixin(SimEngineLightMixin):
 
     def _process(self, state, successors, *args, block=None, whitelist=None, **kwargs):  # pylint:disable=arguments-differ

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -874,7 +874,10 @@ class SimEngineLightAILMixin(SimEngineLightMixin):
     def _ail_handle_Reinterpret(self, expr: ailment.Expr.Reinterpret):
         arg = self._expr(expr.operand)
 
-        if isinstance(arg, int) and expr.from_bits == 32 and expr.from_type == "I" and expr.to_bits == 32 and expr.to_type == "F":
+        if isinstance(arg, int) and (expr.from_bits == 32
+                                     and expr.from_type == "I"
+                                     and expr.to_bits == 32
+                                     and expr.to_type == "F"):
             # int -> float
             b = struct.pack("<I", arg)
             f = struct.unpack("<f", b)[0]

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -18,7 +18,7 @@ from ..engine import SimEngine
 
 class SimEngineLightMixin:
     def __init__(self, *args, logger=None, **kwargs):
-        self.arch: archinfo.Arch = None
+        self.arch: Optional[archinfo.Arch] = None
         self.l = logger
         super().__init__(*args, **kwargs)
 
@@ -234,6 +234,10 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
             self.l.error('Unsupported expression type %s.', type(expr).__name__)
         return None
 
+    def _handle_Triop(self, expr: pyvex.IRExpr.Triop):
+        self.l.error('Unsupported Triop %s.', expr.op)
+        return None
+
     def _handle_RdTmp(self, expr):
         tmp = expr.tmp
 
@@ -292,7 +296,7 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
             self.l.error('Unsupported Unop %s.', expr.op)
             return None
 
-    def _handle_Binop(self, expr):
+    def _handle_Binop(self, expr: pyvex.IRExpr.Binop):
         handler = None
         if expr.op.startswith('Iop_And'):
             handler = '_handle_And'
@@ -730,7 +734,7 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
         _, _ = self._binop_get_args(expr)
         return self._top(expr.result_size(self.tyenv))
 
-    def _handle_MBE(self, expr):
+    def _handle_MBE(self, _expr: pyvex.IRStmt.MBE):
         # Yeah.... no.
         return None
 
@@ -811,7 +815,9 @@ class SimEngineLightAILMixin(SimEngineLightMixin):
     #
 
     def _codeloc(self):
-        return CodeLocation(self.block.addr, self.stmt_idx, ins_addr=self.ins_addr, context=self._context,
+        # noinspection PyUnresolvedReferences
+        return CodeLocation(self.block.addr, self.stmt_idx, ins_addr=self.ins_addr,
+                            context=self._context,
                             block_idx=self.block.idx)
 
     #

--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -356,7 +356,10 @@ class CFGModel(Serializable):
                 predecessors.append(pred)
         return predecessors
 
-    def get_successors(self, node, excluding_fakeret=True, jumpkind=None):
+    def get_successors(self, node: CFGNode,
+                       excluding_fakeret: bool = True,
+                       jumpkind: Optional[str] = None
+                       ) -> List[CFGNode]:
         """
         Get successors of a node in the control flow graph.
 

--- a/angr/knowledge_plugins/key_definitions/uses.py
+++ b/angr/knowledge_plugins/key_definitions/uses.py
@@ -15,7 +15,7 @@ class Uses:
         self._uses_by_definition: Dict['Definition',Set[CodeLocation]] = defaultdict(set)
         self._uses_by_location: Dict[CodeLocation, Set['Definition']] = defaultdict(set)
 
-    def add_use(self, definition, codeloc: CodeLocation):
+    def add_use(self, definition: "Definition", codeloc: CodeLocation):
         """
         Add a use for a given definition.
 
@@ -25,7 +25,7 @@ class Uses:
         self._uses_by_definition[definition].add(codeloc)
         self._uses_by_location[codeloc].add(definition)
 
-    def get_uses(self, definition: 'Definition'):
+    def get_uses(self, definition: 'Definition') -> Set[CodeLocation]:
         """
         Retrieve the uses of a given definition.
 

--- a/angr/project.py
+++ b/angr/project.py
@@ -89,7 +89,8 @@ class Project:
     :ivar storage:      Dictionary of things that should be loaded/stored with the Project.
     :type storage:      defaultdict(list)
     """
-
+    analyses: "AnalysesHub"
+    arch: archinfo.Arch
     def __init__(self, thing,
                  default_analysis_mode=None,
                  ignore_functions=None,

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -1,15 +1,16 @@
 import inspect
-import typing
 import copy
 import itertools
 import logging
 from typing import TYPE_CHECKING
+
 from cle import SymbolType
 from archinfo.arch_soot import SootAddressDescriptor
 
 if TYPE_CHECKING:
     import angr
     import archinfo
+    from angr import SimState
 
 l = logging.getLogger(name=__name__)
 symbolic_count = itertools.count()
@@ -94,6 +95,7 @@ class SimProcedure:
                             you want to extract variadic args.
 
     """
+    state: "SimState"
     def __init__(
         self, project=None, cc=None, prototype=None, symbolic_return=None,
         returns=None, is_syscall=False, is_stub=False,

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -2,7 +2,7 @@ import inspect
 import copy
 import itertools
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from cle import SymbolType
 from archinfo.arch_soot import SootAddressDescriptor
@@ -148,7 +148,7 @@ class SimProcedure:
         self.ret_expr = None
         self.call_ret_expr = None
         self.inhibit_autoret = None
-        self.arg_session: typing.Union[None, ArgSession, int] = None
+        self.arg_session: Union[None, ArgSession, int] = None
 
     def __repr__(self):
         return "<SimProcedure %s%s%s%s%s>" % self._describe_me()
@@ -526,8 +526,8 @@ class SimProcedure:
 
 
 from . import sim_options as o
-from angr.errors import SimProcedureError, SimProcedureArgumentError, SimShadowStackError
+from angr.errors import SimProcedureError, SimShadowStackError
 from angr.state_plugins.sim_action import SimActionExit
-from angr.calling_conventions import DEFAULT_CC, SimTypeFloat, SimTypeFunction, SimTypePointer, SimTypeChar, ArgSession
+from angr.calling_conventions import DEFAULT_CC, SimTypeFunction, SimTypePointer, SimTypeChar, ArgSession
 from .state_plugins import BP_AFTER, BP_BEFORE, NO_OVERRIDE
 from .sim_type import parse_signature, parse_type

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -70,6 +70,7 @@ class SimState(PluginHub):
     mem: "SimMemView"
     history: 'SimStateHistory'
     inspect: 'SimInspector'
+    jni_references: "SimStateJNIReferences"
     def __init__(
             self,
             project=None,
@@ -983,3 +984,4 @@ if TYPE_CHECKING:
     from .state_plugins.view import SimRegNameView, SimMemView
     from .state_plugins.callstack import CallStack
     from .state_plugins.inspect import SimInspector
+    from .state_plugins import SimStateJNIReferences

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -5,7 +5,7 @@ import logging
 import networkx
 
 
-def shallow_reverse(g):
+def shallow_reverse(g) -> networkx.DiGraph:
     """
     Make a shallow copy of a directional graph and reverse the edges. This is a workaround to solve the issue that one
     cannot easily make a shallow reversed copy of a graph in NetworkX 2, since networkx.reverse(copy=False) now returns
@@ -229,6 +229,7 @@ class ContainerNode:
 
 
 class Dominators:
+    dom: networkx.DiGraph
 
     def __init__(self, graph, entry_node, successors_func=None, reverse=False):
 
@@ -243,7 +244,7 @@ class Dominators:
         self._label = None
 
         # Output
-        self.dom = None
+        self.dom = None  # type: ignore # this is guaranteed to be not null after the __init__ returns
         self.prepared_graph = None
 
         self._construct(graph, entry_node)
@@ -463,5 +464,5 @@ class PostDominators(Dominators):
         super().__init__(graph, entry_node, successors_func=successors_func, reverse=True)
 
     @property
-    def post_dom(self):
+    def post_dom(self) -> networkx.DiGraph:
         return self.dom

--- a/tests/analyses/reaching_definitions/test_reachingdefinitions.py
+++ b/tests/analyses/reaching_definitions/test_reachingdefinitions.py
@@ -363,7 +363,8 @@ class TestReachingDefinitions(TestCase):
         cfg = project.analyses.CFGFast()
         main = cfg.functions['main']
 
-        # build a def-use graph for main() of /bin/true without tmps. check that the only dependency of the first block's
+        # build a def-use graph for main() of /bin/true without tmps.
+        # check that the only dependency of the first block's
         # guard is the four cc registers
         rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=False, dep_graph=DepGraph())
         guard_use = list(filter(
@@ -406,7 +407,9 @@ class TestReachingDefinitions(TestCase):
         cfg = project.analyses.CFGFast()
         main = cfg.functions['authenticate']
 
-        rda: ReachingDefinitionsAnalysis = project.analyses.ReachingDefinitions(subject=main, track_tmps=False, dep_graph=DepGraph())
+        rda: ReachingDefinitionsAnalysis = project.analyses.ReachingDefinitions(subject=main,
+                                                                                track_tmps=False,
+                                                                                dep_graph=DepGraph())
         dep_graph = rda.dep_graph
         open_rdi = next(iter(filter(
             lambda def_: isinstance(def_.atom, Register) and def_.atom.reg_offset == arch.registers['rdi'][0]

--- a/tests/analyses/reaching_definitions/test_reachingdefinitions.py
+++ b/tests/analyses/reaching_definitions/test_reachingdefinitions.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 
 import ailment
 import angr
+from angr.analyses import ReachingDefinitionsAnalysis
 from angr.code_location import CodeLocation
 from angr.analyses.reaching_definitions.external_codeloc import ExternalCodeLocation
 from angr.analyses.reaching_definitions.rd_state import ReachingDefinitionsState
@@ -405,7 +406,7 @@ class TestReachingDefinitions(TestCase):
         cfg = project.analyses.CFGFast()
         main = cfg.functions['authenticate']
 
-        rda = project.analyses.ReachingDefinitions(subject=main, track_tmps=False, dep_graph=DepGraph())
+        rda: ReachingDefinitionsAnalysis = project.analyses.ReachingDefinitions(subject=main, track_tmps=False, dep_graph=DepGraph())
         dep_graph = rda.dep_graph
         open_rdi = next(iter(filter(
             lambda def_: isinstance(def_.atom, Register) and def_.atom.reg_offset == arch.registers['rdi'][0]


### PR DESCRIPTION
Lots of type annotations and fixups for various analysis related concepts and specifically the RDA.

Some of the annotations like https://github.com/angr/angr/commit/5a3b2cdb192de63cf9cf0d079b69733fe95e4f80 might seem nearly useless, but they allow the IDE to infer that some access to this plugin is definitely of the type `SimStateJNIReferences` and methods/attributes that are the same as another class don't show up when searching for references to that member for the other class. All the annotations of `networkx.DiGraph` usage also serve this purpose, because often angr classes will have some member called `successors` which has a totally different meaning than `DiGraph.successors`.
Without annotations PyCharm can't realize that `graph.successors` is not a case where `SimProcedure.successors` is used, because `graph` might technically be of the type `SimProcedure`. 

I am not sure how large the performance impact is to use exception based handling for the function handler. Instead of using `hasattr`. The massive issue with the `hasattr`/`getattr` approach is that it completely destroys the IDE analysis, and now it is at least possible to find every usage of `FunctionHandler.handle_external_function` and reason about the problem, instead of having to search the entire codebase for the string `"handle_external_function"`