### PR TITLE
Save and restore VEX CC op if any CC dep is symbolic when syncing registers

### DIFF
--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -334,6 +334,25 @@ def test_single_step():
     nose.tools.assert_equal(len(successors2), 1)
     nose.tools.assert_equal(successors2[0].addr, step5)
 
+
+def test_symbolic_flags_preserved_on_stop():
+    """
+    Test if symbolic flags are preserved when unicorn engine stops. This is needed for cases where compare is performed
+    in one block and conditional jump in another.
+    """
+
+    p = angr.Project(os.path.join(test_location, "binaries", "tests", "x86_64", "test_symbolic_flags_in_unicorn"))
+    init_state = p.factory.full_init_state(add_options=angr.options.unicorn)
+    simgr = p.factory.simgr(init_state)
+    simgr.run()
+    result = None
+    for final_state in simgr.deadended:
+        if b"Congrats" in final_state.posix.dumps(1):
+            result = final_state.posix.dumps(0)
+            break
+
+    nose.tools.assert_equal(result, b'FLAG{l00ps_4r3_t00_34sy_r1gh7??}')
+
 if __name__ == '__main__':
     import logging
     logging.getLogger('angr.state_plugins.unicorn_engine').setLevel('DEBUG')


### PR DESCRIPTION
When syncing flags registers from native interface, `cc_op` is set to 0. This causes issues if result of conditional compare will be used in next block executed by VEX engine since the operation to perform will no longer be correct. This PR fixes this by marking the `cc_op` register as symbolic if any of the CC dep registers are symbolic so that its value would be preserved after syncing all registers. I believe saving `cc_op` would not be required if all dep registers are concrete since execution would never switch to VEX engine in that case.