### PR TITLE
Speed up loading by delaying loading of win32api definitions.

### DIFF
--- a/angr/misc/autoimport.py
+++ b/angr/misc/autoimport.py
@@ -1,6 +1,8 @@
 import os
 import importlib
 import logging
+from typing import Optional, Callable
+
 
 l = logging.getLogger(name=__name__)
 
@@ -28,13 +30,16 @@ def auto_import_packages(base_module, base_path, ignore_dirs=(), ignore_files=()
                         setattr(package, name, mod)
             yield lib_module_name, package
 
-def auto_import_modules(base_module, base_path, ignore_files=()):
+
+def auto_import_modules(base_module, base_path, ignore_files=(), filter_func: Optional[Callable]=None):
     for proc_file_name in os.listdir(base_path):
         if not proc_file_name.endswith('.py'):
             continue
         if proc_file_name in ignore_files or proc_file_name == '__init__.py':
             continue
         proc_module_name = proc_file_name[:-3]
+        if filter_func is not None and not filter_func(proc_module_name):
+            continue
 
         try:
             proc_module = importlib.import_module(".%s" % proc_module_name, base_module)

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -18,6 +18,7 @@ from ..errors import (
 from .. import sim_options as o
 from ..tablespecs import StringTableSpec
 from ..procedures import SIM_LIBRARIES as L
+from ..procedures.definitions import load_win32api_definitions
 from .simos import SimOS
 
 _l = logging.getLogger(name=__name__)
@@ -40,10 +41,12 @@ class SecurityCookieInit(enum.Enum):
 
 class SimWindows(SimOS):
     """
-    Environemnt for the Windows Win32 subsystem. Does not support syscalls currently.
+    Environment for the Windows Win32 subsystem. Does not support syscalls currently.
     """
     def __init__(self, project):
         super(SimWindows, self).__init__(project, name='Win32')
+
+        load_win32api_definitions()
 
         self._exception_handler = None
         self.fmode_ptr = None


### PR DESCRIPTION
Re: #3036 

```
$ time python -c "import angr"

real	0m1.222s
user	0m1.146s
sys	0m0.386s
$ time python -c "import angr; angr.procedures.definitions.load_win32api_definitions()"

real	0m3.117s
user	0m2.859s
sys	0m0.569s
```