### PR TITLE
More type annotations to clean up mypy issues

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -17,7 +17,7 @@ from ...knowledge_plugins.functions import FunctionManager, Function
 from ...knowledge_plugins.cfg import IndirectJump, CFGNode, CFGENode, CFGModel  # pylint:disable=unused-import
 from ...misc.ux import deprecated
 from ...utils.constants import DEFAULT_STATEMENT
-from ... import SIM_PROCEDURES
+from ...procedures.procedure_dict import SIM_PROCEDURES
 from ...errors import SimTranslationError, SimMemoryError, SimIRSBError, SimEngineError, AngrUnsupportedSyscallError, \
     SimError
 from ...codenode import HookNode, BlockNode

--- a/angr/analyses/decompiler/graph_region.py
+++ b/angr/analyses/decompiler/graph_region.py
@@ -23,7 +23,7 @@ class GraphRegion:
 
     __slots__ = ('head', 'graph', 'successors', 'graph_with_successors', 'cyclic', )
 
-    def __init__(self, head, graph, successors: Optional[set], graph_with_successors: networkx.DiGraph, cyclic):
+    def __init__(self, head, graph, successors: Optional[list], graph_with_successors: networkx.DiGraph, cyclic):
         self.head = head
         self.graph = graph
         self.successors = successors

--- a/angr/analyses/forward_analysis/job_info.py
+++ b/angr/analyses/forward_analysis/job_info.py
@@ -1,15 +1,11 @@
-from typing import Generic, TypeVar
+from angr.analyses.cfg.cfg_job_base import BlockID, CFGJobBase
 
-# from angr.analyses.forward_analysis.forward_analysis import JobType, JobKey
 
-JobType = TypeVar("JobType")
-JobKey = TypeVar("JobKey")
-
-class JobInfo(Generic[JobKey, JobType]):
+class JobInfo:
     """
     Stores information of each job.
     """
-    def __init__(self, key: "JobKey", job: "JobType"):
+    def __init__(self, key: BlockID, job: CFGJobBase):
         self.key = key
         self.jobs = [(job, '')]
 
@@ -27,7 +23,7 @@ class JobInfo(Generic[JobKey, JobType]):
         return s
 
     @property
-    def job(self) -> "JobType":
+    def job(self) -> CFGJobBase:
         """
         Get the latest available job.
 

--- a/angr/analyses/girlscout.py
+++ b/angr/analyses/girlscout.py
@@ -16,7 +16,7 @@ import pyvex
 from . import Analysis
 
 from angr.analyses.cfg.cfg_fast import SegmentList
-from .. import options as o
+from .. import sim_options as o
 from ..annocfg import AnnotatedCFG
 from ..errors import SimMemoryError, SimEngineError, AngrError, SimValueError, SimIRSBError, SimSolverModeError, \
     SimError

--- a/angr/analyses/reaching_definitions/dep_graph.py
+++ b/angr/analyses/reaching_definitions/dep_graph.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Set, Iterable, Union
+from typing import Optional, Dict, Set, Iterable, Union, List
 from functools import reduce
 
 import networkx
@@ -10,7 +10,7 @@ from ...code_location import CodeLocation
 from ...knowledge_plugins.key_definitions.atoms import Atom, MemoryLocation
 from ...knowledge_plugins.key_definitions.definition import Definition
 from ...knowledge_plugins.key_definitions.undefined import UNDEFINED
-from ..cfg.cfg_base import CFGBase
+from ...knowledge_plugins.cfg import CFGModel
 from .external_codeloc import ExternalCodeLocation
 
 
@@ -57,7 +57,8 @@ class DepGraph:
         """
         self._graph.add_edge(source, destination, **labels)
 
-    def nodes(self) -> networkx.classes.reportviews.NodeView: return self._graph.nodes()
+    def nodes(self) -> networkx.classes.reportviews.NodeView:
+        return self._graph.nodes()
 
     def predecessors(self, node: Definition) -> networkx.classes.reportviews.NodeView:
         """
@@ -127,7 +128,7 @@ class DepGraph:
     def add_dependencies_for_concrete_pointers_of(self,
                                                   values: Iterable[Union[claripy.ast.Base,int]],
                                                   definition: Definition,
-                                                  cfg: CFGBase,
+                                                  cfg: CFGModel,
                                                   loader: Loader):
         """
         When a given definition holds concrete pointers, make sure the <MemoryLocation>s they point to are present in
@@ -140,8 +141,8 @@ class DepGraph:
         """
         assert definition in self.nodes(), 'The given Definition must be present in the given graph.'
 
-        known_predecessor_addresses = list(map(
-            lambda definition: definition.atom.addr,
+        known_predecessor_addresses: List[Union[int, claripy.ast.Base]] = list(map(
+            lambda definition: definition.atom.addr, # type: ignore # Needs https://github.com/python/mypy/issues/6847
             filter(
                 lambda p: isinstance(p.atom, MemoryLocation),
                 self.predecessors(definition)
@@ -168,7 +169,8 @@ class DepGraph:
         for address in unknown_concrete_addresses:
             data_at_address = cfg.memory_data.get(address, None) if cfg is not None else None
 
-            if data_at_address is None or data_at_address.sort not in ['string', 'unknown']: continue
+            if data_at_address is None or data_at_address.sort not in ['string', 'unknown']:
+                continue
 
             section = loader.main_object.find_section_containing(address)
             read_only = False if section is None else not section.is_writable

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -1067,6 +1067,7 @@ class SimEngineRDVEX(
         # - add uses for arguments
         # - kill return value registers
         # - caller-saving registers
+        atom: Atom
         if proto and proto.args:
             code_loc = self._codeloc()
             for arg in cc.arg_locs(proto):

--- a/angr/analyses/reaching_definitions/heap_allocator.py
+++ b/angr/analyses/reaching_definitions/heap_allocator.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Set, Union
+from typing import Union, List
 
 from ...knowledge_plugins.key_definitions.heap_address import HeapAddress
 from ...knowledge_plugins.key_definitions.unknown_size import UnknownSize
@@ -25,7 +25,7 @@ class HeapAllocator:
         :param canonical_size: The concrete size an <UNKNOWN_SIZE> defaults to.
         """
         self._next_heap_address: HeapAddress = HeapAddress(0)
-        self._allocated_addresses: Set[HeapAddress] = [self._next_heap_address]
+        self._allocated_addresses: List[HeapAddress] = [self._next_heap_address]
         self._canonical_size: int = canonical_size
 
     def allocate(self, size: Union[int, UnknownSize]) -> HeapAddress:

--- a/angr/analyses/reaching_definitions/subject.py
+++ b/angr/analyses/reaching_definitions/subject.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 import ailment
 
@@ -14,6 +15,7 @@ class SubjectType(Enum):
 
 
 class Subject:
+    _visitor: Union[FunctionGraphVisitor, SingleNodeGraphVisitor]
     def __init__(self, content, func_graph=None, cc=None):
         """
         The thing being analysed, and the way (visitor) to analyse it.
@@ -58,5 +60,5 @@ class Subject:
         return self._type
 
     @property
-    def visitor(self):
+    def visitor(self) -> Union[FunctionGraphVisitor, SingleNodeGraphVisitor]:
         return self._visitor

--- a/angr/knowledge_plugins/key_definitions/constants.py
+++ b/angr/knowledge_plugins/key_definitions/constants.py
@@ -1,7 +1,22 @@
+import enum
+
 DEBUG = False
 
 #
 # Observation point types
 #
-OP_BEFORE = 0
-OP_AFTER = 1
+
+
+class ObservationPointType(enum.IntEnum):
+    """
+    Enum to replace the previously generic constants
+    This makes it possible to annotate where they are expected by typing something as ObservationPointType
+    instead of Literal[0,1]
+    """
+    OP_BEFORE = 0
+    OP_AFTER = 1
+
+
+# For backwards compatibility
+OP_BEFORE = ObservationPointType.OP_BEFORE
+OP_AFTER = ObservationPointType.OP_AFTER

--- a/angr/knowledge_plugins/key_definitions/definition.py
+++ b/angr/knowledge_plugins/key_definitions/definition.py
@@ -36,6 +36,14 @@ class Definition:
         else:
             return '<Definition {Tags:%s, Atom:%s, Codeloc:%s}%s>' % (repr(self.tags), self.atom, self.codeloc,
                                                                     "" if not self.dummy else " dummy")
+
+    def __str__(self):
+        pretty_tags = "\n".join([str(tag) for tag in self.tags])
+        return f"Definition:\n" \
+               f"Atom: {self.atom}\n" \
+               f"CodeLoc: {self.codeloc}\n" \
+               f"Tags: {pretty_tags}"
+
     def __hash__(self):
         return hash((self.atom, self.codeloc))
 

--- a/angr/knowledge_plugins/key_definitions/environment.py
+++ b/angr/knowledge_plugins/key_definitions/environment.py
@@ -52,7 +52,7 @@ class Environment:
     def __repr__(self):
         return "Environment: %s" % self._environment
 
-    def __eq__(self, other: 'Environment') -> bool:
+    def __eq__(self, other: object) -> bool:
         assert isinstance(other, Environment), "Cannot compare Environment with %s" % type(other).__name__
         return self._environment == other._environment
 

--- a/angr/knowledge_plugins/key_definitions/key_definition_manager.py
+++ b/angr/knowledge_plugins/key_definitions/key_definition_manager.py
@@ -38,7 +38,7 @@ class KeyDefinitionManager(KnowledgeBasePlugin):
     """
     def __init__(self, kb: 'KnowledgeBase'):
         self.kb = kb
-        self.model_by_funcaddr: Dict[int,ReachingDefinitionsModel] = {}
+        self.model_by_funcaddr: Dict[int, ReachingDefinitionsModel] = {}
 
     def has_model(self, func_addr: int):
         return func_addr in self.model_by_funcaddr

--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -49,10 +49,14 @@ class DefinitionAnnotation(Annotation):
     def __hash__(self):
         return hash((self.definition, self.relocatable, self.eliminatable))
 
-    def __eq__(self, other: 'DefinitionAnnotation'):
-        return  self.definition == other.definition \
-            and self.relocatable == other.relocatable \
-            and self.eliminatable == other.eliminatable
+    def __eq__(self, other: 'object'):
+        if isinstance(other, DefinitionAnnotation):
+            return  self.definition == other.definition \
+                and self.relocatable == other.relocatable \
+                and self.eliminatable == other.eliminatable
+        else:
+            raise ValueError("DefinitionAnnotation can only check equality with other DefinitionAnnotation")
+
 
 # pylint: disable=W1116
 class LiveDefinitions:

--- a/angr/knowledge_plugins/key_definitions/rd_model.py
+++ b/angr/knowledge_plugins/key_definitions/rd_model.py
@@ -17,3 +17,10 @@ class ReachingDefinitionsModel:
             "[func %#x]" if self.func_addr is not None else "",
             len(self.observed_results),
         )
+
+    def copy(self) -> "ReachingDefinitionsModel":
+        new = ReachingDefinitionsModel(self.func_addr)
+        new.observed_results = self.observed_results.copy()
+        new.all_definitions = self.all_definitions.copy()
+        new.all_uses = self.all_uses.copy()
+        return new

--- a/angr/procedures/java_jni/__init__.py
+++ b/angr/procedures/java_jni/__init__.py
@@ -21,7 +21,7 @@ class JNISimProcedure(SimProcedure):
     """
 
     # Java type of return value
-    return_ty = None # type: Optional[str]
+    return_ty: Optional[str] = None
 
     # jboolean constants
     JNI_TRUE = 1

--- a/angr/procedures/java_jni/array_operations.py
+++ b/angr/procedures/java_jni/array_operations.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from . import JNISimProcedure
 from ...engines.soot.expressions import SimSootExpr_NewArray
@@ -28,7 +29,7 @@ class GetArrayLength(JNISimProcedure):
 
 class NewArray(JNISimProcedure):
 
-    element_type = None
+    element_type: Optional[str] = None
     return_ty = 'reference'
 
     def run(self, ptr_env, length_):

--- a/angr/procedures/java_jni/field_access.py
+++ b/angr/procedures/java_jni/field_access.py
@@ -10,7 +10,7 @@ from ...engines.soot.values import (SimSootValue_InstanceFieldRef,
 
 l = logging.getLogger('angr.procedures.java_jni.field_access')
 
-# pylint: disable=arguments-differ,unused-argument
+# pylint: disable=arguments-differ,unused-argument, missing-class-docstring
 
 #
 # GetFieldID / GetStaticFieldID
@@ -41,9 +41,6 @@ class GetFieldID(JNISimProcedure):
 #
 
 class GetStaticField(JNISimProcedure):
-
-    return_ty = None
-
     def run(self, ptr_env, _, field_id_):
         # get field reference
         field_id = self.state.jni_references.lookup(field_id_)
@@ -95,8 +92,6 @@ class SetStaticField(JNISimProcedure):
 #
 
 class GetField(JNISimProcedure):
-
-    return_ty = None
 
     def run(self, ptr_env, obj_, field_id_):
         # get field reference

--- a/angr/procedures/java_jni/method_calls.py
+++ b/angr/procedures/java_jni/method_calls.py
@@ -1,5 +1,6 @@
 
 import logging
+from typing import Optional
 
 from archinfo.arch_soot import (ArchSoot, SootAddressDescriptor, SootArgument,
                                 SootMethodDescriptor)
@@ -39,7 +40,7 @@ class GetMethodID(JNISimProcedure):
 
 class CallMethodBase(JNISimProcedure):
 
-    return_ty = None
+    return_ty: Optional[str] = None
 
     def _invoke(self, method_id, obj=None, dynamic_dispatch=True, args_in_array=None):
         # get invoke target

--- a/angr/project.py
+++ b/angr/project.py
@@ -6,11 +6,12 @@ import pickle
 import string
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 import archinfo
 from archinfo.arch_soot import SootAddressDescriptor, ArchSoot
 import cle
+from .sim_procedure import SimProcedure
 
 from .misc.ux import deprecated
 from .errors import AngrNoPluginError
@@ -458,7 +459,7 @@ class Project:
 
         self._sim_procedures[addr] = hook
 
-    def is_hooked(self, addr):
+    def is_hooked(self, addr) -> bool:
         """
         Returns True if `addr` is hooked.
 
@@ -467,7 +468,7 @@ class Project:
         """
         return addr in self._sim_procedures
 
-    def hooked_by(self, addr):
+    def hooked_by(self, addr) -> Optional[SimProcedure]:
         """
         Returns the current hook for `addr`.
 

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -2,7 +2,7 @@ import inspect
 import copy
 import itertools
 import logging
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Tuple
 
 from cle import SymbolType
 from archinfo.arch_soot import SootAddressDescriptor
@@ -10,7 +10,7 @@ from archinfo.arch_soot import SootAddressDescriptor
 if TYPE_CHECKING:
     import angr
     import archinfo
-    from angr import SimState
+    from angr.sim_state import SimState
 
 l = logging.getLogger(name=__name__)
 symbolic_count = itertools.count()
@@ -287,7 +287,7 @@ class SimProcedure:
     IS_FUNCTION = True
     ARGS_MISMATCH = False
     ALT_NAMES = None  # alternative names
-    local_vars = ()
+    local_vars: Tuple[str, ...] = ()
 
     def run(self, *args, **kwargs): # pylint: disable=unused-argument
         """


### PR DESCRIPTION
Cleans up more type errors related to https://github.com/angr/angr/pull/3023

Now running mypy with the following (quite lenient!) config passes
```
[mypy]

files = angr/angr/analyses/reaching_definitions, angr/angr/analyses/forward_analysis/, angr/angr/analyses/girlscout.py, angr/angr/knowledge_plugins/key_definitions/, angr/angr/project.py,angr/angr/sim_procedure.py, angr/angr/procedures/java_jni/

follow_imports = skip


disable_error_code = import, misc, no-redef, var-annotated

show_none_errors = false
```

especially `follow_imports = skip` ignores a ton of errors because mypy only checks the `files` defined in the config and doesn't descent into imports, but at least this ensures that the files themselves are sane.