### PR TITLE
Allow AnalysesHub to be used while preserving type annotations

### DIFF
--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -1,19 +1,23 @@
+import functools
 import sys
 import contextlib
 from collections import defaultdict
 from inspect import Signature
+from typing import TYPE_CHECKING, TypeVar, Type, Generic, Callable, Optional
+
 import progressbar
 import logging
 import time
-from typing import TYPE_CHECKING
 
 from ..misc.plugins import PluginVendor, VendorPreset
 from ..misc.ux import deprecated
-from ..errors import AngrAnalysisError
 
 if TYPE_CHECKING:
     from ..knowledge_base import KnowledgeBase
     import angr
+    from ..project import Project
+    from typing_extensions import ParamSpec
+    AnalysisParams = ParamSpec("AnalysisParams")
 
 l = logging.getLogger(name=__name__)
 
@@ -58,6 +62,7 @@ class AnalysisLogEntry:
             return '<AnalysisLogEntry %s with %s: %s>' % (msg_str, self.exc_type.__name__, self.exc_value)
 
 
+A = TypeVar("A", bound="Analysis")
 class AnalysesHub(PluginVendor):
     """
     This class contains functions for all the registered and runnable analyses,
@@ -70,7 +75,7 @@ class AnalysesHub(PluginVendor):
     def reload_analyses(self): # pylint: disable=no-self-use
         return
 
-    def _init_plugin(self, plugin_cls):
+    def _init_plugin(self, plugin_cls: Type[A]) -> "AnalysisFactory[A]":
         return AnalysisFactory(self.project, plugin_cls)
 
     def __getstate__(self):
@@ -81,9 +86,12 @@ class AnalysesHub(PluginVendor):
         s, self.project = sd
         super(AnalysesHub, self).__setstate__(s)
 
+    def __getitem__(self, plugin_cls: "Type[A]") -> "AnalysisFactory[A]":
+        return AnalysisFactory(self.project, plugin_cls)
 
-class AnalysisFactory:
-    def __init__(self, project, analysis_cls):
+
+class AnalysisFactory(Generic[A]):
+    def __init__(self, project: "Project", analysis_cls: Type[A]):
         self._project = project
         self._analysis_cls = analysis_cls
         self.__doc__ = ''
@@ -91,30 +99,43 @@ class AnalysisFactory:
         self.__doc__ += analysis_cls.__init__.__doc__ or ''
         self.__call__.__func__.__signature__ = Signature.from_callable(analysis_cls.__init__)
 
+    def prep(self,
+              fail_fast=False,
+              kb: Optional["KnowledgeBase"] = None,
+              progress_callback: Optional[Callable] = None,
+              show_progressbar: bool = False) -> Type[A]:
+
+        @functools.wraps(self._analysis_cls.__init__)
+        def wrapper(*args, **kwargs):
+            oself = object.__new__(self._analysis_cls)
+            oself.named_errors = {}
+            oself.errors = []
+            oself.log = []
+
+            oself._fail_fast = fail_fast
+            oself._name = self._analysis_cls.__name__
+            oself.project = self._project
+            oself.kb = kb or self._project.kb
+            oself._progress_callback = progress_callback
+
+            oself._show_progressbar = show_progressbar
+            oself.__init__(*args, **kwargs)
+            return oself
+
+        return wrapper # type: ignore
+
     def __call__(self, *args, **kwargs):
         fail_fast = kwargs.pop('fail_fast', False)
         kb = kwargs.pop('kb', self._project.kb)
         progress_callback = kwargs.pop('progress_callback', None)
         show_progressbar = kwargs.pop('show_progressbar', False)
 
-        oself = object.__new__(self._analysis_cls)
-        oself.named_errors = {}
-        oself.errors = []
-        oself.log = []
+        w = self.prep(fail_fast=fail_fast,
+                  kb=kb,
+                  progress_callback=progress_callback,
+                  show_progressbar=show_progressbar)
 
-        oself._fail_fast = fail_fast
-        oself._name = self._analysis_cls.__name__
-        oself.project = self._project
-        oself.kb = kb
-        oself._progress_callback = progress_callback
-
-        if oself._progress_callback is not None:
-            if not hasattr(oself._progress_callback, '__call__'):
-                raise AngrAnalysisError('The "progress_callback" parameter must be a None or a callable.')
-
-        oself._show_progressbar = show_progressbar
-        oself.__init__(*args, **kwargs)
-        return oself
+        return w(*args, **kwargs)
 
 
 class Analysis:

--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -153,7 +153,7 @@ class Analysis:
     :ivar progressbar.ProgressBar _progressbar: The progress bar object.
     """
 
-    project = None # type: 'angr.Project'
+    project: "Project" = None
     kb: 'KnowledgeBase' = None
     _fail_fast = None
     _name = None

--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -3,7 +3,7 @@ import logging
 import re
 from collections import defaultdict
 
-from . import Analysis
+from . import Analysis, CFGEmulated, DDG
 
 from ..knowledge_base import KnowledgeBase
 from .. import SIM_PROCEDURES
@@ -178,7 +178,7 @@ class BinaryOptimizer(Analysis):
         #    14 | PUT(eip) = 0x0804828b
         # there is no write to or read from eax
 
-        cfg = self.project.analyses.CFGEmulated(kb=func_kb,
+        cfg = self.project.analyses[CFGEmulated].prep(kb=func_kb)(
                                                 call_depth=1,
                                                 base_graph=function.graph,
                                                 keep_state=True,
@@ -186,9 +186,7 @@ class BinaryOptimizer(Analysis):
                                                 iropt_level=0,
                                                 )
 
-        ddg = self.project.analyses.DDG(kb=func_kb,
-                                        cfg=cfg
-                                        )
+        ddg = self.project.analyses[DDG].prep(kb=func_kb)(cfg=cfg)
 
         if 'constant_propagation' in self._techniques:
             self._constant_propagation(function, ddg.simplified_data_graph)

--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from angr.knowledge_plugins import Function
 
-from . import Analysis
+from . import Analysis, CFGEmulated
 
 from ..errors import SimEngineError, SimMemoryError
 
@@ -853,12 +853,12 @@ class BinDiff(Analysis):
         if cfg_a is None:
             #self.cfg_a = self.project.analyses.CFG(resolve_indirect_jumps=True)
             #self.cfg_b = other_project.analyses.CFG(resolve_indirect_jumps=True)
-            self.cfg_a = self.project.analyses.CFGEmulated(context_sensitivity_level=1,
+            self.cfg_a = self.project.analyses[CFGEmulated].prep()(context_sensitivity_level=1,
                                                             keep_state = True,
                                                             enable_symbolic_back_traversal = back_traversal,
                                                             enable_advanced_backward_slicing = enable_advanced_backward_slicing)
 
-            self.cfg_b = other_project.analyses.CFGEmulated(context_sensitivity_level=1,
+            self.cfg_b = other_project.analyses[CFGEmulated].prep()(context_sensitivity_level=1,
                                                             keep_state = True,
                                                             enable_symbolic_back_traversal = back_traversal,
                                                             enable_advanced_backward_slicing = enable_advanced_backward_slicing)

--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -16,8 +16,8 @@ from ..knowledge_plugins.variables.variable_access import VariableAccessSort
 from ..utils.constants import DEFAULT_STATEMENT
 from .reaching_definitions import get_all_definitions
 from .reaching_definitions.external_codeloc import ExternalCodeLocation
+from . import Analysis, register_analysis, ReachingDefinitionsAnalysis
 from .reaching_definitions.function_handler import FunctionHandler
-from . import Analysis, register_analysis
 
 if TYPE_CHECKING:
     from ..knowledge_plugins.functions import Function
@@ -265,7 +265,7 @@ class CallingConventionAnalysis(Analysis):
                 func = self.kb.functions[caller.addr]
                 subgraph = self._generate_callsite_subgraph(func, caller_block_addr)
 
-                rda = self.project.analyses.ReachingDefinitions(
+                rda = self.project.analyses[ReachingDefinitionsAnalysis].prep()(
                     func,
                     func_graph=subgraph,
                     observation_points=[

--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -36,7 +36,10 @@ class CDG(Analysis):
 
         if not no_construct:
             if self._cfg is None:
-                self._cfg = self.project.analyses.CFGEmulated()
+                # This leads to import cycles otherwise
+                # pylint: disable=import-outside-toplevel
+                from angr.analyses.cfg.cfg_emulated import CFGEmulated
+                self._cfg = self.project.analyses[CFGEmulated].prep()()
 
             # FIXME: We should not use get_any_irsb in such a real setting...
             self._entry = self._cfg.model.get_any_node(self._start)
@@ -191,7 +194,6 @@ class CDG(Analysis):
                     self._post_dom.add_edge(b1, b2)
                 else:
                     _l.debug("%s is not in post dominator dict.", b2)
-
 
 from angr.analyses import AnalysesHub
 AnalysesHub.register_default('CDG', CDG)

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -13,7 +13,8 @@ import archinfo
 from archinfo.arch_soot import SootAddressDescriptor
 from archinfo.arch_arm import is_arm_arch, get_real_address_if_arm
 
-from ...knowledge_plugins.functions import FunctionManager, Function
+from ...knowledge_plugins.functions.function_manager import FunctionManager
+from ...knowledge_plugins.functions.function import Function
 from ...knowledge_plugins.cfg import IndirectJump, CFGNode, CFGENode, CFGModel  # pylint:disable=unused-import
 from ...misc.ux import deprecated
 from ...utils.constants import DEFAULT_STATEMENT
@@ -23,6 +24,7 @@ from ...errors import SimTranslationError, SimMemoryError, SimIRSBError, SimEngi
 from ...codenode import HookNode, BlockNode
 from ...engines.vex.lifter import VEX_IRSB_MAX_SIZE, VEX_IRSB_MAX_INST
 from .. import Analysis
+from ..stack_pointer_tracker import StackPointerTracker
 from .indirect_jump_resolvers.default_resolvers import default_indirect_jump_resolvers
 
 l = logging.getLogger(name=__name__)
@@ -1925,9 +1927,9 @@ class CFGBase(Analysis):
                 regs = {self.project.arch.sp_offset}
                 if hasattr(self.project.arch, 'bp_offset') and self.project.arch.bp_offset is not None:
                     regs.add(self.project.arch.bp_offset)
-                sptracker = self.project.analyses.StackPointerTracker(src_function, regs,
-                                                                      track_memory=self._sp_tracking_track_memory)
-
+                sptracker = self.project.analyses[StackPointerTracker]                    .prep()(
+    src_function, re                    =self._sp_tracking_track_memory
+                )
                 sp_delta = sptracker.offset_after_block(src_addr, self.project.arch.sp_offset)
                 if sp_delta == 0:
                     return True

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -35,7 +35,7 @@ class CFGBase(Analysis):
     The base class for control flow graphs.
     """
 
-    tag = None
+    tag: Optional[str] = None
     _cle_pseudo_objects = (ExternObject, KernelObject, TLSObject)
 
     def __init__(self, sort, context_sensitivity_level, normalize=False, binary=None, force_segment=False,
@@ -1927,9 +1927,8 @@ class CFGBase(Analysis):
                 regs = {self.project.arch.sp_offset}
                 if hasattr(self.project.arch, 'bp_offset') and self.project.arch.bp_offset is not None:
                     regs.add(self.project.arch.bp_offset)
-                sptracker = self.project.analyses[StackPointerTracker]                    .prep()(
-    src_function, re                    =self._sp_tracking_track_memory
-                )
+                sptracker = self.project.analyses[StackPointerTracker].prep()(src_function, regs,
+                                                                            track_memory=self._sp_tracking_track_memory)
                 sp_delta = sptracker.offset_after_block(src_addr, self.project.arch.sp_offset)
                 if sp_delta == 0:
                     return True

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from collections import defaultdict
 from functools import reduce
-from typing import Dict
+from typing import Dict, List
 
 import angr
 import claripy
@@ -13,6 +13,7 @@ from archinfo import ArchARM
 
 from ... import BP, BP_BEFORE, BP_AFTER, SIM_PROCEDURES, procedures
 from ... import options as o
+from ...codenode import BlockNode
 from ...engines.procedure import ProcedureEngine
 from ...exploration_techniques.loop_seer import LoopSeer
 from ...exploration_techniques.slicecutor import Slicecutor
@@ -33,7 +34,7 @@ from .cfg_utils import CFGUtils
 from ..cdg import CDG
 from ..ddg import DDG
 from ..backward_slice import BackwardSlice
-from ..loopfinder import LoopFinder
+from ..loopfinder import LoopFinder, Loop
 
 l = logging.getLogger(name=__name__)
 
@@ -78,9 +79,7 @@ class CFGJob(CFGJobBase):
 
 
 class PendingJob:
-    def __init__(self, caller_func_addr, returning_source, state, src_block_id, src_exit_stmt_idx, src_exit_ins_addr,
-                 call_stack):
-        """
+    """
         A PendingJob is whatever will be put into our pending_exit list. A pending exit is an entry that created by the
         returning of a call or syscall. It is "pending" since we cannot immediately figure out whether this entry will
         be executed or not. If the corresponding call/syscall intentially doesn't return, then the pending exit will be
@@ -88,7 +87,10 @@ class PendingJob:
         entry is created from the returning and will be analyzed later). If the corresponding call/syscall might
         return, but for some reason (for example, an unsupported instruction is met during the analysis) our analysis
         does not return properly, then the pending exit will be picked up and put into remaining_jobs list.
-
+    """
+    def __init__(self, caller_func_addr, returning_source, state, src_block_id, src_exit_stmt_idx, src_exit_ins_addr,
+                 call_stack):
+        """
         :param returning_source:    Address of the callee function. It might be None if address of the callee is not
                                     resolvable.
         :param state:               The state after returning from the callee function. Of course there is no way to get
@@ -314,18 +316,17 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
     # Public methods
     #
 
-    def copy(self):
+    def copy(self) -> "CFGEmulated":
         """
         Make a copy of the CFG.
 
         :return: A copy of the CFG instance.
-        :rtype: angr.analyses[CFG].prep()
         """
         new_cfg = CFGEmulated.__new__(CFGEmulated)
         super(CFGEmulated, self).make_copy(new_cfg)
 
         new_cfg._indirect_jump_target_limit = self._indirect_jump_target_limit
-        new_cfg.named_errors = dict(self.named_errors)
+        new_cfg.named_errors = defaultdict(list, self.named_errors)
         new_cfg.errors = list(self.errors)
         new_cfg._fail_fast = self._fail_fast
         new_cfg._max_steps = self._max_steps
@@ -415,19 +416,19 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             raise AngrCFGError('Max loop unrolling times must be set to an integer greater than or equal to 0 if ' +
                                'loop unrolling is enabled.')
 
-        def _unroll(graph, loop):
+        def _unroll(graph: networkx.DiGraph, loop: Loop):
             """
             The loop callback method where loops are unrolled.
 
-            :param networkx.DiGraph graph: The control flow graph.
-            :param angr.analyses.loopfinder.Loop loop: The loop instance.
+            :param graph: The control flow graph.
+            :param loop: The loop instance.
             :return: None
             """
 
             for back_edge in loop.continue_edges:
                 loop_body_addrs = {n.addr for n in loop.body_nodes}
-                src_blocknode = back_edge[0]  # type: angr.knowledge.codenode.BlockNode
-                dst_blocknode = back_edge[1]  # type: angr.knowledge.codenode.BlockNode
+                src_blocknode: BlockNode = back_edge[0]
+                dst_blocknode: BlockNode = back_edge[1]
 
                 for src in self.get_all_nodes(src_blocknode.addr):
                     for dst in graph.successors(src):
@@ -1437,7 +1438,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         return successors
 
-    def _post_job_handling(self, job, new_jobs, successors):
+    def _post_job_handling(self, job: CFGJob, _new_jobs, successors: List[SimState]): # type: ignore[override]
         """
 
         :param CFGJob job:
@@ -1496,7 +1497,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
         return successors, extra_info
 
-    def _post_handle_job_debug(self, job, successors):
+    def _post_handle_job_debug(self, job: CFGJob, successors: List[SimState]) -> None:
         """
         Post job handling: print debugging information regarding the current job.
 
@@ -1653,7 +1654,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         if jumpkind == "Ijk_Call":
             extra_info['last_call_exit_target'] = target_addr
 
-    def _handle_successor(self, job, successor, successors):
+    def _handle_successor(self, job, successor: SimState, successors):
         """
         Returns a new CFGJob instance for further analysis, or None if there is no immediate state to perform the
         analysis on.
@@ -1661,7 +1662,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         :param CFGJob job: The current job.
         """
 
-        state = successor
+        state: SimState = successor
         all_successor_states = successors
         addr = job.addr
 
@@ -2452,7 +2453,8 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         next_node = next_nodes[0]
 
         # Get the weakly-connected subgraph that contains `next_node`
-        all_subgraphs = ( networkx.induced_subgraph(taint_graph, nodes) for nodes in networkx.weakly_connected_components(taint_graph))
+        all_subgraphs = ( networkx.induced_subgraph(taint_graph, nodes)
+                          for nodes in networkx.weakly_connected_components(taint_graph))
         starts = set()
         for subgraph in all_subgraphs:
             if next_node in subgraph:
@@ -2917,7 +2919,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
             inst = SIM_PROCEDURES["stubs"]["PathTerminator"]()
             sim_successors = ProcedureEngine().process(state, procedure=inst)
 
-        except AngrExitError as ex:
+        except AngrExitError:
             exception_info = sys.exc_info()
             l.debug("Caught a AngrExitError during CFG recovery. Don't panic, this is usually expected.", exc_info=True)
             # Generate a PathTerminator to terminate the current path

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1241,7 +1241,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
     def _intra_analysis(self):
         pass
 
-    def _get_successors(self, job):  # pylint:disable=arguments-differ
+    def _get_successors(self, job: CFGJob) -> List[CFGJob]:  # type: ignore[override] # pylint:disable=arguments-differ
 
         # current_function_addr = job.func_addr
         # addr = job.addr
@@ -1598,7 +1598,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
     # Basic block scanning
 
-    def _scan_block(self, cfg_job):
+    def _scan_block(self, cfg_job: CFGJob) -> List[CFGJob]:
         """
         Scan a basic block starting at a specific address
 
@@ -1625,7 +1625,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         return entries
 
-    def _scan_procedure(self, cfg_job, current_func_addr):
+    def _scan_procedure(self, cfg_job, current_func_addr) -> List[CFGJob]:
         """
         Checks the hooking procedure for this address searching for new static
         exit points to add to successors (generating entries for them)
@@ -1678,7 +1678,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             # Mark the address as traced
             self._traced_addresses.add(addr)
 
-        entries = [ ]
+        entries: List[CFGJob] = [ ]
 
         if procedure.ADDS_EXITS:
             # Get two blocks ahead
@@ -1721,7 +1721,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         return entries
 
-    def _scan_irsb(self, cfg_job, current_func_addr):
+    def _scan_irsb(self, cfg_job, current_func_addr) -> List[CFGJob]:
         """
         Generate a list of successors (generating them each as entries) to IRSB.
         Updates previous CFG nodes with edges.
@@ -1870,13 +1870,14 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         return entries
 
-    def _create_jobs(self, target, jumpkind, current_function_addr, irsb, addr, cfg_node, ins_addr,
-                     stmt_idx) -> List[CFGJob]:
+    def _create_jobs(self,
+                     target, jumpkind, current_function_addr, irsb, addr, cfg_node, ins_addr, stmt_idx
+                     ) -> List[CFGJob]:
         """
         Given a node and details of a successor, makes a list of CFGJobs
         and if it is a call or exit marks it appropriately so in the CFG
 
-        :param int target:          Destination of the resultant job
+        :param target:              Destination of the resultant job
         :param str jumpkind:        The jumpkind of the edge going to this node
         :param int current_function_addr: Address of the current function
         :param pyvex.IRSB irsb:     IRSB of the predecessor node
@@ -1886,7 +1887,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :param int stmt_idx:        ID of the source statement.
         :return:                    a list of CFGJobs
         """
-
+        target_addr: Optional[int]
         if type(target) is pyvex.IRExpr.Const:  # pylint: disable=unidiomatic-typecheck
             target_addr = target.con.value
         elif type(target) in (pyvex.IRConst.U8, pyvex.IRConst.U16, pyvex.IRConst.U32, pyvex.IRConst.U64):  # pylint: disable=unidiomatic-typecheck
@@ -1906,7 +1907,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             else:
                 raise AngrCFGError("This shouldn't be possible")
 
-        jobs = [ ]
+        jobs: List[CFGJob] = []
         is_syscall = jumpkind.startswith("Ijk_Sys")
 
         # Special handling:
@@ -2046,7 +2047,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         return jobs
 
     def _create_job_call(self, addr, irsb, cfg_node, stmt_idx, ins_addr, current_function_addr, target_addr, jumpkind,
-                         is_syscall=False):
+                         is_syscall=False) -> List[CFGJob]:
         """
         Generate a CFGJob for target address, also adding to _pending_entries
         if returning to succeeding position (if irsb arg is populated)
@@ -2064,7 +2065,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
         :rtype:                     list
         """
 
-        jobs = [ ]
+        jobs: List[CFGJob] = [ ]
 
         if is_syscall:
             # Fix the target_addr for syscalls

--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -2,6 +2,8 @@
 import logging
 
 from collections import defaultdict
+from typing import List
+
 from sortedcontainers import  SortedDict
 from copy import copy
 
@@ -377,7 +379,7 @@ class CFGFastSoot(CFGFast):
 
         return stmts_count
 
-    def _scan_block(self, cfg_job):
+    def _scan_block(self, cfg_job) -> List[CFGJob]:
         """
         Scan a basic block starting at a specific address
 

--- a/angr/analyses/class_identifier.py
+++ b/angr/analyses/class_identifier.py
@@ -1,7 +1,6 @@
 from ..sim_type import SimCppClass, SimTypeCppFunction
 from ..analyses import AnalysesHub
-from . import Analysis
-
+from . import Analysis, CFGFast, VtableFinder
 
 
 class ClassIdentifier(Analysis):
@@ -17,9 +16,9 @@ class ClassIdentifier(Analysis):
 
     def __init__(self):
         if "CFGFast" not in self.project.kb.cfgs:
-            self.project.analyses.CFGFast(cross_references=True)
+            self.project.analyses[CFGFast].prep()(cross_references=True)
         self.classes = {}
-        vtable_analysis = self.project.analyses.VtableFinder()
+        vtable_analysis = self.project.analyses[VtableFinder].prep()()
         self.vtables_list = vtable_analysis.vtables_list
         self._analyze()
 

--- a/angr/analyses/complete_calling_conventions.py
+++ b/angr/analyses/complete_calling_conventions.py
@@ -5,7 +5,7 @@ import claripy
 
 from ..knowledge_plugins.cfg import CFGModel
 from ..analyses.cfg import CFGUtils
-from . import Analysis, register_analysis
+from . import Analysis, register_analysis, VariableRecoveryFast, CallingConventionAnalysis
 
 _l = logging.getLogger(name=__name__)
 
@@ -89,7 +89,7 @@ class CompleteCallingConventionsAnalysis(Analysis):
                 if self._recover_variables and self.function_needs_variable_recovery(func):
                     _l.info("Performing variable recovery on %r...", func)
                     try:
-                        _ = self.project.analyses.VariableRecoveryFast(func, kb=self.kb, low_priority=self._low_priority)
+                        _ = self.project.analyses[VariableRecoveryFast].prep(kb=self.kb)(func, low_priority=self._low_priority)
                     except claripy.ClaripyError:
                         _l.warning("An claripy exception occurred during variable recovery analysis on function %#x.",
                                    func.addr,
@@ -98,7 +98,7 @@ class CompleteCallingConventionsAnalysis(Analysis):
                         continue
 
                 # determine the calling convention of each function
-                cc_analysis = self.project.analyses.CallingConvention(func, cfg=self._cfg, kb=self.kb,
+                cc_analysis = self.project.analyses[CallingConventionAnalysis].prep(kb=self.kb)(func, cfg=self._cfg,
                                                                       analyze_callsites=self._analyze_callsites)
                 if cc_analysis.cc is not None:
                     _l.info("Determined calling convention and prototype for %r.", func)

--- a/angr/analyses/forward_analysis/forward_analysis.py
+++ b/angr/analyses/forward_analysis/forward_analysis.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
-from typing import Dict, List, Callable, Optional, Generic, TypeVar, Tuple, Set, TYPE_CHECKING
+from typing import Dict, List, Callable, Optional, Generic, TypeVar, Tuple, Set, TYPE_CHECKING, Union
 
 import networkx
 
 from .visitors.graph import NodeType
 from ..cfg.cfg_job_base import CFGJobBase, BlockID
+from ...sim_state import SimState
 from ...errors import AngrForwardAnalysisError
 from ...errors import AngrSkipJobNotice, AngrDelayJobNotice, AngrJobMergingFailureNotice, AngrJobWideningFailureNotice
 from ...utils.algo import binary_insert
@@ -143,16 +144,16 @@ class ForwardAnalysis(Generic[AnalysisState, NodeType]):
     def _job_key(self, job: CFGJobBase) -> BlockID:
         raise NotImplementedError('_job_key() is not implemented.')
 
-    def _get_successors(self, job: CFGJobBase) -> List[CFGJobBase]:
+    def _get_successors(self, job: CFGJobBase) -> Union[List[SimState], List[CFGJobBase]]:
         raise NotImplementedError('_get_successors() is not implemented.')
 
     def _pre_job_handling(self, job: CFGJobBase) -> None:
         raise NotImplementedError('_pre_job_handling() is not implemented.')
 
-    def _post_job_handling(self, job: CFGJobBase, new_jobs, successors):
+    def _post_job_handling(self, job: CFGJobBase, new_jobs, successors: List[SimState]) -> None:
         raise NotImplementedError('_post_job_handling() is not implemented.')
 
-    def _handle_successor(self, job: CFGJobBase, successor: CFGJobBase, successors: List[CFGJobBase])->List[CFGJobBase]:
+    def _handle_successor(self, job: CFGJobBase, successor: SimState, successors: List[SimState]) -> List[CFGJobBase]:
         raise NotImplementedError('_handle_successor() is not implemented.')
 
     def _job_queue_empty(self) -> None:

--- a/angr/analyses/init_finder.py
+++ b/angr/analyses/init_finder.py
@@ -7,7 +7,7 @@ import pyvex
 import claripy
 
 from ..engines.light import SimEngineLight, SimEngineLightVEXMixin
-from . import register_analysis
+from . import register_analysis, PropagatorAnalysis
 from .analysis import Analysis
 from .forward_analysis import FunctionGraphVisitor, SingleNodeGraphVisitor, ForwardAnalysis
 from .propagator.vex_vars import VEXTmp
@@ -174,14 +174,14 @@ class InitializationFinder(ForwardAnalysis, Analysis):  # pylint:disable=abstrac
             # traversing a function
             graph_visitor = FunctionGraphVisitor(func, func_graph)
             if replacements is None:
-                prop = self.project.analyses.Propagator(func=func, func_graph=func_graph,
+                prop = self.project.analyses[PropagatorAnalysis].prep()(func=func, func_graph=func_graph,
                                                         base_state=self.project.factory.blank_state())
                 replacements = prop.replacements
         elif block is not None:
             # traversing a block
             graph_visitor = SingleNodeGraphVisitor(block)
             if replacements is None:
-                prop = self.project.analyses.Propagator(block=block,
+                prop = self.project.analyses[PropagatorAnalysis].prep()(block=block,
                                                         base_state=self.project.factory.blank_state())
                 replacements = prop.replacements
         else:

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -398,13 +398,13 @@ class SimEngineRDAIL(
                 continue
             if addr.concrete:
                 # a concrete address
-                addr = addr._model_concrete.value
+                concrete_addr: int = addr._model_concrete.value
                 try:
-                    vs: MultiValues = self.state.memory_definitions.load(addr, size=size, endness=expr.endness)
+                    vs: MultiValues = self.state.memory_definitions.load(concrete_addr, size=size, endness=expr.endness)
                 except SimMemoryMissingError:
                     continue
 
-                memory_location = MemoryLocation(addr, size, endness=expr.endness)
+                memory_location = MemoryLocation(concrete_addr, size, endness=expr.endness)
                 self.state.add_use(memory_location, self._codeloc())
                 result = result.merge(vs) if result is not None else vs
             elif self.state.is_stack_address(addr):

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -5,7 +5,7 @@ import archinfo
 from archinfo.arch_arm import is_arm_arch
 import claripy
 import networkx
-from . import Analysis
+from . import Analysis, CFGEmulated
 
 from .cfg.cfg_job_base import BlockID, FunctionKey, CFGJobBase
 from .cfg.cfg_utils import CFGUtils
@@ -462,7 +462,8 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
             l.debug("Generating a CFG, since none was given...")
             # TODO: can we use a fast CFG instead? note that fast CFG does not care of context sensitivity at all, but
             # TODO: for state merging, we also don't really care about context sensitivity.
-            self._cfg = self.project.analyses.CFGEmulated(context_sensitivity_level=self._context_sensitivity_level,
+            self._cfg = self.project.analyses[CFGEmulated].prep()(
+                context_sensitivity_level=self._context_sensitivity_level,
                 starts=(self._start,)
             )
 

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -911,7 +911,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
 
         return new_jobs
 
-    def _post_job_handling(self, job, new_jobs, successors):  # pylint:disable=unused-argument
+    def _post_job_handling(self, job: VFGJob, new_jobs, successors):  # pylint:disable=unused-argument
 
         # Debugging output
         if l.level == logging.DEBUG:
@@ -1562,7 +1562,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
                 l.debug("Removed (%s) from FakeExits dict.",
                         ",".join([hex(i) if i is not None else 'None' for i in tpl]))
 
-    def _post_job_handling_debug(self, job, successors):
+    def _post_job_handling_debug(self, job: VFGJob, successors):
         """
         Print out debugging information after handling a VFGJob and generating the succeeding jobs.
 

--- a/angr/analyses/vsa_ddg.py
+++ b/angr/analyses/vsa_ddg.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 
 import networkx
-from . import Analysis
+from . import Analysis, VFG
 
 from ..code_location import CodeLocation
 from ..errors import AngrDDGError
@@ -61,7 +61,7 @@ class VSA_DDG(Analysis):
         if vfg is not None:
             self._vfg = vfg
         else:
-            self._vfg = self.project.analyses.VFG(function_start=start_addr,
+            self._vfg = self.project.analyses[VFG].prep()(function_start=start_addr,
                                              interfunction_level=interfunction_level,
                                              context_sensitivity_level=context_sensitivity_level)
 

--- a/angr/analyses/vtable.py
+++ b/angr/analyses/vtable.py
@@ -1,7 +1,7 @@
 import logging
 
 from ..analyses import AnalysesHub
-from . import Analysis
+from . import Analysis, CFGFast
 
 l = logging.getLogger(name=__name__)
 
@@ -26,7 +26,7 @@ class VtableFinder(Analysis):
     def __init__(self):
         if "CFGFast" not in self.project.kb.cfgs:
             # populate knowledge base
-            self.project.analyses.CFGFast(cross_references=True)
+            self.project.analyses[CFGFast].prep()(cross_references=True)
 
         skip_analysis = True
         # check if the sections exist

--- a/angr/analyses/xrefs.py
+++ b/angr/analyses/xrefs.py
@@ -8,7 +8,7 @@ from ..knowledge_plugins.xrefs import XRef, XRefType
 from ..engines.light import SimEngineLight, SimEngineLightVEXMixin
 from .propagator.vex_vars import VEXTmp
 from .propagator.values import Top
-from . import register_analysis
+from . import register_analysis, PropagatorAnalysis
 from .analysis import Analysis
 from .forward_analysis import FunctionGraphVisitor, SingleNodeGraphVisitor, ForwardAnalysis
 
@@ -182,13 +182,13 @@ class XRefsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-metho
             # traversing a function
             graph_visitor = FunctionGraphVisitor(func, func_graph)
             if replacements is None:
-                prop = self.project.analyses.Propagator(func=func, func_graph=func_graph)
+                prop = self.project.analyses[PropagatorAnalysis].prep()(func=func, func_graph=func_graph)
                 replacements = prop.replacements
         elif block is not None:
             # traversing a block
             graph_visitor = SingleNodeGraphVisitor(block)
             if replacements is None:
-                prop = self.project.analyses.Propagator(block=block)
+                prop = self.project.analyses[PropagatorAnalysis].prep()(block=block)
                 replacements = prop.replacements
         else:
             raise ValueError('Unsupported analysis target.')

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -626,7 +626,7 @@ class SimCC:
         """
         return self.RETURN_ADDR
 
-    def next_arg(self, session, arg_type):
+    def next_arg(self, session: ArgSession, arg_type: SimType):
         if isinstance(arg_type, (SimStruct, SimUnion, SimTypeFixedSizeArray)):
             raise TypeError(f"{self} doesn't know how to store aggregate types. Consider overriding next_arg to "
                             "implement its ABI logic")

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -20,6 +20,7 @@ from .misc.plugins import PluginHub, PluginPreset
 from .sim_state_options import SimStateOptions
 from .state_plugins import SimStatePlugin
 
+
 def arch_overrideable(f):
     @functools.wraps(f)
     def wrapped_f(self, *args, **kwargs):
@@ -71,6 +72,7 @@ class SimState(PluginHub):
     history: 'SimStateHistory'
     inspect: 'SimInspector'
     jni_references: "SimStateJNIReferences"
+    scratch: "SimStateScratch"
     def __init__(
             self,
             project=None,
@@ -984,4 +986,5 @@ if TYPE_CHECKING:
     from .state_plugins.view import SimRegNameView, SimMemView
     from .state_plugins.callstack import CallStack
     from .state_plugins.inspect import SimInspector
-    from .state_plugins import SimStateJNIReferences
+    from .state_plugins.jni_references import SimStateJNIReferences
+    from .state_plugins.scratch import SimStateScratch

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -1,7 +1,8 @@
 import re
 import os
 import angr
-
+from angr.analyses import VariableRecoveryFast, CallingConventionAnalysis,\
+    CompleteCallingConventionsAnalysis, CFGFast, Decompiler
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
@@ -9,12 +10,12 @@ def test_decompiling_all_x86_64():
     bin_path = os.path.join(test_location, "x86_64", "all")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
     for f in cfg.functions.values():
         if f.is_simprocedure:
             print("Skipping SimProcedure %s." % repr(f))
             continue
-        dec = p.analyses.Decompiler(f, cfg=cfg.model)
+        dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
         if dec.codegen is not None:
             print(dec.codegen.text)
         else:
@@ -25,14 +26,14 @@ def test_decompiling_babypwn_i386():
     bin_path = os.path.join(test_location, "i386", "decompiler", "codegate2017_babypwn")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
     for f in cfg.functions.values():
         if f.is_simprocedure:
             print("Skipping SimProcedure %s." % repr(f))
             continue
         if f.addr not in (0x8048a71, 0x8048c6b):
             continue
-        dec = p.analyses.Decompiler(f, cfg=cfg.model)
+        dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
         if dec.codegen is not None:
             print(dec.codegen.text)
         else:
@@ -43,9 +44,9 @@ def test_decompiling_loop_x86_64():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "loop")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
     f = cfg.functions['loop']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is not None:
 
         # it should be properly structured to a while loop without conditional breaks
@@ -60,10 +61,10 @@ def test_decompiling_all_i386():
     bin_path = os.path.join(test_location, "i386", "all")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     f = cfg.functions['main']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is not None:
         print(dec.codegen.text)
     else:
@@ -78,10 +79,10 @@ def test_decompiling_aes_armel():
     # It is incorrectly linked. We override this here
     p = angr.Project(bin_path, arch='ARMEL', auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     f = cfg.functions['main']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is not None:
         print(dec.codegen.text)
     else:
@@ -92,10 +93,10 @@ def test_decompiling_mips_allcmps():
     bin_path = os.path.join(test_location, "mips", "allcmps")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(collect_data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(collect_data_references=True, normalize=True)
 
     f = cfg.functions['main']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is not None:
         print(dec.codegen.text)
     else:
@@ -106,10 +107,10 @@ def test_decompiling_linked_list():
     bin_path = os.path.join(test_location, "x86_64", "linked_list")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     f = cfg.functions['sum']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is not None:
         print(dec.codegen.text)
     else:
@@ -121,10 +122,10 @@ def test_decompiling_dir_gcc_O0_free_ent():
     bin_path = os.path.join(test_location, "x86_64", "dir_gcc_-O0")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True)
 
     f = cfg.functions['free_ent']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is not None:
         print(dec.codegen.text)
     else:
@@ -138,10 +139,10 @@ def test_decompiling_dir_gcc_O0_main():
     bin_path = os.path.join(test_location, "x86_64", "dir_gcc_-O0")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True)
 
     f = cfg.functions['main']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is not None:
         print(dec.codegen.text)
     else:
@@ -153,10 +154,10 @@ def test_decompiling_dir_gcc_O0_emit_ancillary_info():
     bin_path = os.path.join(test_location, "x86_64", "dir_gcc_-O0")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True)
 
     f = cfg.functions['emit_ancillary_info']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is not None:
         print(dec.codegen.text)
     else:
@@ -169,10 +170,10 @@ def test_decompiling_switch0_x86_64():
     bin_path = os.path.join(test_location, "x86_64", "switch_0")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     f = cfg.functions['main']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
 
     if dec.codegen is not None:
         code = dec.codegen.text
@@ -197,7 +198,7 @@ def test_decompiling_switch1_x86_64():
     bin_path = os.path.join(test_location, "x86_64", "switch_1")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     # disable eager returns simplifier
     all_optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes("AMD64",
@@ -206,7 +207,7 @@ def test_decompiling_switch1_x86_64():
                                 if p is not angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier ]
 
     f = cfg.functions['main']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
     if dec.codegen is not None:
         code = dec.codegen.text
         assert "switch" in code
@@ -231,7 +232,7 @@ def test_decompiling_switch2_x86_64():
     bin_path = os.path.join(test_location, "x86_64", "switch_2")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     # disable eager returns simplifier
     all_optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes("AMD64",
@@ -240,7 +241,7 @@ def test_decompiling_switch2_x86_64():
                                 if p is not angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier ]
 
     f = cfg.functions['main']
-    dec = p.analyses.Decompiler(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
     if dec.codegen is not None:
         code = dec.codegen.text
         assert "switch" in code
@@ -270,7 +271,7 @@ def test_decompiling_true_x86_64_0():
     bin_path = os.path.join(test_location, "x86_64", "true_ubuntu_2004")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     # disable eager returns simplifier
     all_optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes("AMD64",
@@ -279,7 +280,7 @@ def test_decompiling_true_x86_64_0():
                                if p is not angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier]
 
     f = cfg.functions[0x4048c0]
-    dec = p.analyses.Decompiler(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
     print(dec.codegen.text)
     if dec.codegen is not None:
         code = dec.codegen.text
@@ -294,7 +295,7 @@ def test_decompiling_true_x86_64_1():
     bin_path = os.path.join(test_location, "x86_64", "true_ubuntu_2004")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     # disable eager returns simplifier
     all_optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes("AMD64",
@@ -303,7 +304,7 @@ def test_decompiling_true_x86_64_1():
                                if p is not angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier]
 
     f = cfg.functions[0x404dc0]
-    dec = p.analyses.Decompiler(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
     print(dec.codegen.text)
     code: str = dec.codegen.text
 
@@ -320,7 +321,7 @@ def test_decompiling_true_a_x86_64_0():
     bin_path = os.path.join(test_location, "x86_64", "true_a")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     # disable eager returns simplifier
     all_optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes("AMD64",
@@ -329,7 +330,7 @@ def test_decompiling_true_a_x86_64_0():
                                if p is not angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier]
 
     f = cfg.functions[0x401e60]
-    dec = p.analyses.Decompiler(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
     print(dec.codegen.text)
 
 
@@ -338,7 +339,7 @@ def test_decompiling_true_a_x86_64_1():
     bin_path = os.path.join(test_location, "x86_64", "true_a")
     p = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     # disable eager returns simplifier
     all_optimization_passes = angr.analyses.decompiler.optimization_passes.get_default_optimization_passes("AMD64",
@@ -347,7 +348,7 @@ def test_decompiling_true_a_x86_64_1():
                                if p is not angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier]
 
     f = cfg.functions[0x404410]
-    dec = p.analyses.Decompiler(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model, optimization_passes=all_optimization_passes)
     print(dec.codegen.text)
 
 
@@ -370,16 +371,16 @@ def test_decompiling_1after909_verify_password():
     bin_path = os.path.join(test_location, "x86_64", "1after909")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
 
     # verify_password
     f = cfg.functions['verify_password']
     # recover calling convention
-    p.analyses.VariableRecoveryFast(f)
-    cca = p.analyses.CallingConvention(f)
+    p.analyses[VariableRecoveryFast].prep()(f)
+    cca = p.analyses[CallingConventionAnalysis].prep()(f)
     f.calling_convention = cca.cc
     f.prototype = cca.prototype
-    dec = p.analyses.Decompiler(f, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model)
     if dec.codegen is None:
         print("Failed to decompile function %r." % f)
         assert False
@@ -404,8 +405,8 @@ def test_decompiling_1after909_doit():
     bin_path = os.path.join(test_location, "x86_64", "1after909")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(normalize=True, data_references=True)
-    p.analyses.CompleteCallingConventions(recover_variables=True)
+    cfg = p.analyses[CFGFast].prep()(normalize=True, data_references=True)
+    p.analyses[CompleteCallingConventionsAnalysis].prep()(recover_variables=True)
 
     # doit
     f = cfg.functions['doit']
@@ -416,7 +417,7 @@ def test_decompiling_1after909_doit():
         optimization_passes += [
             angr.analyses.decompiler.optimization_passes.EagerReturnsSimplifier,
     ]
-    dec = p.analyses.Decompiler(f, cfg=cfg.model, optimization_passes=optimization_passes)
+    dec = p.analyses[Decompiler].prep()(f, cfg=cfg.model, optimization_passes=optimization_passes)
     if dec.codegen is None:
         print("Failed to decompile function %r." % f)
         assert False
@@ -449,10 +450,10 @@ def test_decompiling_libsoap():
     bin_path = os.path.join(test_location, "armel", "libsoap.so")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     func = cfg.functions[0x41d000]
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     if dec.codegen is not None:
         code = dec.codegen.text
         print(code)
@@ -468,12 +469,12 @@ def test_decompiling_no_arguments_in_variable_list():
     bin_path = os.path.join(test_location, "x86_64", "test_arrays")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
-    _ = p.analyses.CompleteCallingConventions(recover_variables=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
+    _ = p.analyses[CompleteCallingConventionsAnalysis].prep()(recover_variables=True)
 
     func = cfg.functions['main']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
 
@@ -495,15 +496,15 @@ def test_decompiling_strings_local_strlen():
     bin_path = os.path.join(test_location, "x86_64", "types", "strings")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
     func = cfg.functions['local_strlen']
 
-    _ = p.analyses.VariableRecoveryFast(func)
-    cca = p.analyses.CallingConvention(func, cfg=cfg.model)
+    _ = p.analyses[VariableRecoveryFast].prep()(func)
+    cca = p.analyses[CallingConventionAnalysis].prep()(func, cfg=cfg.model)
     func.calling_convention = cca.cc
     func.prototype = cca.prototype
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     assert dec.codegen is not None, "Failed to decompile function %r." % func
 
     code = dec.codegen.text
@@ -517,15 +518,15 @@ def test_decompiling_strings_local_strcat():
     bin_path = os.path.join(test_location, "x86_64", "types", "strings")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
     func = cfg.functions['local_strcat']
 
-    _ = p.analyses.VariableRecoveryFast(func)
-    cca = p.analyses.CallingConvention(func, cfg=cfg.model)
+    _ = p.analyses[VariableRecoveryFast].prep()(func)
+    cca = p.analyses[CallingConventionAnalysis].prep()(func, cfg=cfg.model)
     func.calling_convention = cca.cc
     func.prototype = cca.prototype
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     assert dec.codegen is not None, "Failed to decompile function %r." % func
 
     code = dec.codegen.text
@@ -540,22 +541,22 @@ def test_decompiling_strings_local_strcat_with_local_strlen():
     bin_path = os.path.join(test_location, "x86_64", "types", "strings")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
     func_strlen = cfg.functions['local_strlen']
-    _ = p.analyses.VariableRecoveryFast(func_strlen)
-    cca = p.analyses.CallingConvention(func_strlen, cfg=cfg.model)
+    _ = p.analyses[VariableRecoveryFast].prep()(func_strlen)
+    cca = p.analyses[CallingConventionAnalysis].prep()(func_strlen, cfg=cfg.model)
     func_strlen.calling_convention = cca.cc
     func_strlen.prototype = cca.prototype
-    p.analyses.Decompiler(func_strlen, cfg=cfg.model)
+    p.analyses[Decompiler].prep()(func_strlen, cfg=cfg.model)
 
     func = cfg.functions['local_strcat']
 
-    _ = p.analyses.VariableRecoveryFast(func)
-    cca = p.analyses.CallingConvention(func, cfg=cfg.model)
+    _ = p.analyses[VariableRecoveryFast].prep()(func)
+    cca = p.analyses[CallingConventionAnalysis].prep()(func, cfg=cfg.model)
     func.calling_convention = cca.cc
     func.prototype = cca.prototype
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     assert dec.codegen is not None, "Failed to decompile function %r." % func
 
     code = dec.codegen.text
@@ -570,11 +571,11 @@ def test_decompilation_call_expr_folding():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "call_expr_folding")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     func_0 = cfg.functions['strlen_should_fold']
     opt = [ o for o in angr.analyses.decompiler.decompilation_options.options if o.param == "remove_dead_memdefs" ][0]
-    dec = p.analyses.Decompiler(func_0, cfg=cfg.model, options=[(opt, True)])
+    dec = p.analyses[Decompiler].prep()(func_0, cfg=cfg.model, options=[(opt, True)])
     code = dec.codegen.text
     print(code)
     m = re.search(r"v(\d+) = \(int\)strlen\(&v(\d+)\);", code)  # e.g., s_428 = (int)strlen(&s_418);
@@ -583,13 +584,13 @@ def test_decompilation_call_expr_folding():
     assert m.group(1) != m.group(2)
 
     func_1 = cfg.functions['strlen_should_not_fold']
-    dec = p.analyses.Decompiler(func_1, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func_1, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
     assert code.count("strlen(") == 1
 
     func_2 = cfg.functions['strlen_should_not_fold_into_loop']
-    dec = p.analyses.Decompiler(func_2, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func_2, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
     assert code.count("strlen(") == 1
@@ -599,11 +600,11 @@ def test_decompilation_excessive_condition_removal():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "bf")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     func = cfg.functions[0x100003890]
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
 
@@ -616,11 +617,11 @@ def test_decompilation_excessive_goto_removal():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "bf")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     func = cfg.functions[0x100003890]
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
 
@@ -633,10 +634,10 @@ def test_decompilation_switch_case_structuring_with_removed_nodes():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "union")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     func = cfg.functions["build_date"]
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
 
@@ -650,12 +651,12 @@ def test_decompilation_x86_64_stack_arguments():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "union")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     func = cfg.functions["build_date"]
 
     # no dead memdef removal
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
 
@@ -675,7 +676,7 @@ def test_decompilation_x86_64_stack_arguments():
     # kill the cache since variables to statements won't match any more - variables are re-discovered with the new
     # option.
     p.kb.structured_code.cached.clear()
-    dec = p.analyses.Decompiler(func, cfg=cfg.model, options=[(opt, True)])
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model, options=[(opt, True)])
     code = dec.codegen.text
     print(code)
 
@@ -695,11 +696,11 @@ def test_decompiling_amp_challenge03_arm():
     bin_path = os.path.join(test_location, "armhf", "decompiler", "challenge_03")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
-    p.analyses.CompleteCallingConventions(recover_variables=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
+    p.analyses[CompleteCallingConventionsAnalysis].prep()(recover_variables=True)
     func = cfg.functions['main']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
 
@@ -713,10 +714,10 @@ def test_decompiling_fauxware_mipsel():
     bin_path = os.path.join(test_location, "mipsel", "fauxware")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
     func = cfg.functions['main']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
 
@@ -735,10 +736,10 @@ def test_stack_canary_removal_x8664_extra_exits():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "babyheap_level1_teaching1")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
     func = cfg.functions['main']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
     print(code)
 
@@ -752,10 +753,10 @@ def test_ifelseif_x8664():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "babyheap_level1_teaching1")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
     func = cfg.functions['main']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
 
     print(code)
@@ -766,10 +767,10 @@ def test_decompiling_missing_function_call():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "adams")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
     func = cfg.functions['main']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
 
     print(code)
@@ -787,12 +788,12 @@ def test_decompiling_morton_my_message_callback():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "morton")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
-    p.analyses.CompleteCallingConventions(recover_variables=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
+    p.analyses[CompleteCallingConventionsAnalysis].prep()(recover_variables=True)
 
     func = cfg.functions['my_message_callback']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
 
     print(code)
@@ -808,12 +809,12 @@ def test_decompiling_morton_lib_handle__suback():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "morton.libmosquitto.so.1")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
-    p.analyses.CompleteCallingConventions(recover_variables=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
+    p.analyses[CompleteCallingConventionsAnalysis].prep()(recover_variables=True)
 
     func = cfg.functions.function(name='handle__suback', plt=False)
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
 
     print(code)
@@ -824,11 +825,11 @@ def test_decompiling_newburry_main():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "newbury")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     func = cfg.functions['main']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
 
     print(code)
@@ -840,11 +841,11 @@ def test_single_instruction_loop():
     bin_path = os.path.join(test_location, "x86_64", "decompiler", "level_12_teaching")
     p = angr.Project(bin_path, auto_load_libs=False)
 
-    cfg = p.analyses.CFG(data_references=True, normalize=True)
+    cfg = p.analyses[CFGFast].prep()(data_references=True, normalize=True)
 
     func = cfg.functions['main']
 
-    dec = p.analyses.Decompiler(func, cfg=cfg.model)
+    dec = p.analyses[Decompiler].prep()(func, cfg=cfg.model)
     code = dec.codegen.text
 
     print(code)


### PR DESCRIPTION
This is a generic attempt to deal with the type information black hole `AnalysesHub`.
I think the "proper" way to do this would be some smart usage of the [PEP 612: Parameter Specification Variables](https://www.python.org/dev/peps/pep-0612/), but for now this should be a simple enough workaround. We technically lie and pretend that `Type[Analysis]` is returned instead of a callable that just wraps , but I think this should be okay. The only issue would be if someone tries using the returned "Type" in a way that isn't directly constructing the class from it, and I don't really see a reason why they would even get the idea to pass this through the analysis hub first.

One potential caveat is that this bypasses the plugin registry, but I think that should be fine? 

An issue that might creep up during refactoring of existing code is that the specific Analysis class (e.g. CFGFast) now needs to imported to be used in this way. This could maybe lead to import cycles in some circumstances, but in those cases there is still the fallback of using the old approach or only importing the class right before it is used.

Core Advantages:

```python
# mypy/PyCharm can now infer that the variable `cdg` has the type `CDG` and what the parameters of the analysis are (e.g. `cfg`)
cdg = self.project.analyses[CDG].prep(fail_fast=self._fail_fast)(cfg=self)
```

