### PR TITLE
VariableManager: Only reuse phi vars for variables created in the same block.

### DIFF
--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -324,13 +324,13 @@ class VariableManagerInternal(Serializable):
                 non_phis.add(var)
         if len(existing_phis) == 1:
             existing_phi = next(iter(existing_phis))
-            if non_phis.issubset(self.get_phi_subvariables(existing_phi)):
-                return existing_phi
-            else:
-                # Update phi variables
-                self._phi_variables[existing_phi] |= non_phis
+            if block_addr in self._phi_variables_by_block and existing_phi in self._phi_variables_by_block[block_addr]:
+                if not non_phis.issubset(self.get_phi_subvariables(existing_phi)):
+                    # Update the variables that this phi variable represents
+                    self._phi_variables[existing_phi] |= non_phis
                 return existing_phi
 
+        # allocate a new phi variable
         repre = next(iter(variables))
         repre_type = type(repre)
         if repre_type is SimRegisterVariable:


### PR DESCRIPTION
This commit solves the issue that unrelated and unaccessed variables may
be added to an existing cluster of variables (governed by the same phi
variable). By limiting the reuse of phi variables, when an unrelated
variable U is added to an existing cluster of variables that already
have a phi variable A, we will create a new phi node B that governs
both A and U. This way it allows us to track if B is accessed or not
(instead of only tracking if A is accessed).