### PR TITLE
fix the argument order for `pycparser.CParser.parse`

### DIFF
--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -13,6 +13,7 @@ from ..errors import AngrAnalysisError
 
 if TYPE_CHECKING:
     from ..knowledge_base import KnowledgeBase
+    import angr
 
 l = logging.getLogger(name=__name__)
 

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -1784,7 +1784,7 @@ def _accepts_scope_stack():
     """
     pycparser hack to include scope_stack as parameter in CParser parse method
     """
-    def parse(self, text, scope_stack=None, filename='', debuglevel=0):
+    def parse(self,text, filename='', debug=False, scope_stack=None):
         self.clex.filename = filename
         self.clex.reset_lineno()
         self._scope_stack = [dict()] if scope_stack is None else scope_stack
@@ -1792,7 +1792,7 @@ def _accepts_scope_stack():
         return self.cparser.parse(
             input=text,
             lexer=self.clex,
-            debug=debuglevel)
+            debug=debug)
     setattr(pycparser.CParser, 'parse', parse)
 
 


### PR DESCRIPTION
This function was invoked in `pycparser` by `parser.parse(text, filename)` at [here](https://github.com/eliben/pycparser/blob/7999dde25706e8a2b4bc63634b058d79bdb6417f/pycparser/__init__.py#L90)

the old function will take `filename` as `scope_stack` and broken the library when `angr` was just imported 