### PR TITLE
Correctly handle partial pending memory reads

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1785,6 +1785,11 @@ void State::propagate_taint_of_mem_read_instr_and_continue(address_t read_addres
 							block_mem_reads_map.emplace(instr_entry_it->first, mem_read_result);
 							break;
 						}
+						else if (block_mem_reads_data.size() == 0) {
+							// This entry is of a partial memory read for the instruction being processed.
+							block_mem_reads_map.emplace(instr_entry_it->first, mem_read_result);
+							break;
+						}
 					}
 					if (block_mem_reads_data.size() == 0) {
 						// All pending reads have been processed and inserted into the map
@@ -1792,11 +1797,6 @@ void State::propagate_taint_of_mem_read_instr_and_continue(address_t read_addres
 							// Update iterator since all reads for current instruction have been processed. We should
 							// start searching for next instruction with memory read from successor of this instruction.
 							instr_entry_it++;
-						}
-						else {
-							// There are still more reads pending for this instruction. Insert partial result value into the
-							// block's memory reads map
-							block_mem_reads_map.emplace(instr_entry_it->first, mem_read_result);
 						}
 						break;
 					}

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -1,9 +1,11 @@
-import angr
-import pickle
-import re
-from angr import options as so
 import gc
 import os
+import pickle
+import re
+
+import angr
+from angr import options as so
+
 from common import slow_test
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..")

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -246,6 +246,29 @@ def test_fauxware_aggressive():
     assert len(pg.deadended) == 1
 
 
+def test_partial_reads():
+    """
+    This test case if unicorn engine correctly handles case when symbolic taint is introduced by the second partial read
+    performed by unicorn. Unicorn triggers memory read hook twice when reading value greater than 8 bytes on x86-64.
+    """
+
+    p = angr.Project(os.path.join(test_location, "binaries", "tests", "x86_64", "test_partial_reads_handling_in_unicorn"))
+    add_options = angr.options.unicorn
+    # Do not treat as uninitalized memory as symbolic. Prevents introducing undesired symbolic taint
+    add_options.add(angr.options.ZERO_FILL_UNCONSTRAINED_MEMORY)
+    init_state = p.factory.full_init_state(add_options=add_options)
+    global_var_val = [init_state.solver.BVV(0x41414141, 32), init_state.solver.BVV(0x42424242, 32),
+                      init_state.solver.BVS("symb_val_0", 32), init_state.solver.BVS("symb_val_1", 32)]
+    global_var_symb = p.loader.find_symbol("global_var")
+    # Store every byte separately so that entire variable is not treated as symbolic
+    for count, val in enumerate(global_var_val):
+        init_state.memory.store(global_var_symb.rebased_addr + count * 4, val, endness=init_state.arch.memory_endness)
+
+    pg = p.factory.simulation_manager(init_state)
+    pg.run()
+    assert len(pg.deadended) == 1
+
+
 def run_similarity(binpath, depth, prehook=None):
     b = angr.Project(os.path.join(test_location, binpath), auto_load_libs=False)
     cc = b.analyses.CongruencyCheck(throw=True)

--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -252,7 +252,8 @@ def test_partial_reads():
     performed by unicorn. Unicorn triggers memory read hook twice when reading value greater than 8 bytes on x86-64.
     """
 
-    p = angr.Project(os.path.join(test_location, "binaries", "tests", "x86_64", "test_partial_reads_handling_in_unicorn"))
+    p = angr.Project(os.path.join(test_location, "binaries", "tests", "x86_64",
+                                  "test_partial_reads_handling_in_unicorn"), auto_load_libs=False)
     add_options = angr.options.unicorn
     # Do not treat as uninitalized memory as symbolic. Prevents introducing undesired symbolic taint
     add_options.add(angr.options.ZERO_FILL_UNCONSTRAINED_MEMORY)


### PR DESCRIPTION
Previously, we were handling partial pending reads not yet associated with a memory read instruction too late. This resulted in #3092 when checking if all reads at the last processed memory read instruction are done. This PR fixes #3092 by processing partial reads earlier.