### PR TITLE
CC: deal with the case when the successor block only contains a jump instruction.

### DIFF
--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -303,7 +303,7 @@ class CallingConventionAnalysis(Analysis):
 
             # If there is only one 'IMark' statement in vex --> the target block contains only direct jump
             if len(dst_bb.vex.statements) == 1 and dst_bb.vex.statements[0].tag == 'Ist_IMark'\
-                    and len(func.graph.out_edges(dst)) == 1:
+                    and func.graph.out_degree(dst) == 1:
                 for _, jmp_dst, jmp_data in func.graph.out_edges(dst, data=True):
                     subgraph.add_edge(dst, jmp_dst, **jmp_data)
 

--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -299,7 +299,7 @@ class CallingConventionAnalysis(Analysis):
             dst_insns = func.get_block(dst.addr).capstone.insns
             if len(dst_insns) == 1 and dst_insns[0].mnemonic == 'jmp':
                 for _, jmp_dst, jmp_data in func.graph.out_edges(dst, data=True):
-                    subgraph.add_edge(dst, jmp_dst, **data)
+                    subgraph.add_edge(dst, jmp_dst, **jmp_data)
 
         return subgraph
 

--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -295,6 +295,12 @@ class CallingConventionAnalysis(Analysis):
         for _, dst, data in func.graph.out_edges(the_block, data=True):
             subgraph.add_edge(the_block, dst, **data)
 
+            # If the dst bb only contains a jump instruction, add the jump target as well.
+            dst_insns = func.get_block(dst.addr).capstone.insns
+            if len(dst_insns) == 1 and dst_insns[0].mnemonic == 'jmp':
+                for _, jmp_dst, jmp_data in func.graph.out_edges(dst, data=True):
+                    subgraph.add_edge(dst, jmp_dst, **data)
+
         return subgraph
 
     def _analyze_callsite(self, caller_block_addr: int,

--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -302,7 +302,8 @@ class CallingConventionAnalysis(Analysis):
             dst_bb = self.project.factory.block(dst.addr, func.get_block(dst.addr).size, opt_level=1)
 
             # If there is only one 'IMark' statement in vex --> the target block contains only direct jump
-            if len(dst_bb.vex.statements) == 1 and len(func.graph.out_edges(dst)) == 1:
+            if len(dst_bb.vex.statements) == 1 and dst_bb.vex.statements[0].tag == 'Ist_IMark'\
+                    and len(func.graph.out_edges(dst)) == 1:
                 for _, jmp_dst, jmp_data in func.graph.out_edges(dst, data=True):
                     subgraph.add_edge(dst, jmp_dst, **jmp_data)
 

--- a/tests/test_calling_convention_analysis.py
+++ b/tests/test_calling_convention_analysis.py
@@ -240,6 +240,16 @@ class TestCallingConventionAnalysis(unittest.TestCase):
         cca = proj.analyses.CallingConvention(func)
         assert len(cca.prototype.args) == 6
 
+    def test_x64_return_value_used(self):
+        binary_path = os.path.join(test_location, "tests", "x86_64", "cwebp-0.3.1-feh-original")
+        proj = angr.Project(binary_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True, force_complete_scan=False)
+        func = proj.kb.functions.get_by_addr(0x4046e0)
+        cca = proj.analyses.CallingConvention(func=func, cfg=cfg, analyze_callsites=True)
+
+        assert cca.prototype is not None
+        assert cca.prototype.returnty is not None
+
 
 if __name__ == "__main__":
     # logging.getLogger("angr.analyses.variable_recovery.variable_recovery_fast").setLevel(logging.DEBUG)


### PR DESCRIPTION
### Description
When doing `CallingConventionAnalysis`, the logic is to generate a subgraph that only contains the basic block that does the call and the basic block after the call, and uses this subgraph for the `ReachingDefinitionsAnalysis`. However, there are cases when the basic block after the call contains barely a jump instruction to another block, without doing anything within this jump basic block. In this case, even if the return value of the target call was used (not in the jump block, but in the jump target block), the result of `_analyze_callsite_return_value_uses()` will say "No, the `return_def` is not used because the `uses` is empty in the subgraph", leading to incorrect prototype result.
### Example
Target call: ReadJPEG
Source code:
```
if (pic->width == 0 || pic->height == 0) {
    // If no size specified, try to decode it as PNG/JPEG (as appropriate).
    const InputFileFormat format = GetImageType(in_file);
    if (format == PNG_) {
      ok = ReadPNG(in_file, pic, keep_alpha, metadata);
    } else if (format == JPEG_) {
      ok = ReadJPEG(in_file, pic, metadata);
    } else if (format == TIFF_) {
      ok = ReadTIFF(filename, pic, keep_alpha, metadata);
    }
  } else {
    // If image size is specified, infer it as YUV format.
    ok = ReadYUV(in_file, pic);
  }
  if (!ok) {
    fprintf(stderr, "Error! Could not process file %s\n", filename);
  }
```
Assembly code in Ghidra:
```
                             LAB_00403549                                    XREF[1]:     00402cb4(j)  
        00403549 48 8d b4        LEA        argv=>picture,[RSP + 0x260]
                 24 60 02 
                 00 00
        00403551 48 89 da        MOV        RDX,RBX
        00403554 4c 89 ef        MOV        argc,R13
        00403557 e8 84 11        CALL       ReadJPEG                                         int ReadJPEG(FILE * in_file, Web
                 00 00
        0040355c e9 7d f7        JMP        LAB_00402cde
                 ff ff
...
...
...
                             LAB_00402cde                                    XREF[3]:     0040355c(j), 00403578(j), 
                                                                                          0040360a(j)  
        00402cde 85 c0           TEST       EAX,EAX
        00402ce0 0f 85 e5        JNZ        LAB_00401fcb
                 f2 ff ff
        00402ce6 e9 4e ec        JMP        LAB_00401939
                 ff ff

```
### Fix
In `_generate_callsite_subgraph()`, when adding an edge, check whether the destination block only contains a jump or not. If yes, add the jump target block into the subgraph as well.

### Notes
If you agree that this bug needs to be fixed, I will add the binary as well as a test case later.

The fix seems ugly now, your advice will be really appreciated!