### PR TITLE
Fix SimTypeBottom's __repr__

### DIFF
--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -221,8 +221,11 @@ class SimTypeBottom(SimType):
 
     _base_name = 'bot'
 
-    def __repr__(self, label=None):
-        return 'BOT'
+    def __init__(self, label=None):
+        super().__init__(label)
+
+    def __repr__(self):
+        return self.label or 'BOT'
 
     def _init_str(self):
         return "%s(%s)" % (


### PR DESCRIPTION
I think this is the intended behavior, so that it can be properly printed (no matter what [fruit juice packs say](https://www.flickr.com/photos/duncan/2084134925)).