### PR TITLE
Correctly save values of sub-registers that do not start at byte 0 of the full register

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -388,7 +388,8 @@ def _load_native():
         _setup_prototype(h, 'executed_pages', ctypes.c_uint64, state_t)
         _setup_prototype(h, 'in_cache', ctypes.c_bool, state_t, ctypes.c_uint64)
         _setup_prototype(h, 'set_map_callback', None, state_t, unicorn.unicorn.UC_HOOK_MEM_INVALID_CB)
-        _setup_prototype(h, 'set_vex_to_unicorn_reg_mappings', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
+        _setup_prototype(h, 'set_vex_to_unicorn_reg_mappings', None, state_t, ctypes.POINTER(ctypes.c_uint64),
+                         ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'set_artificial_registers', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'get_count_of_blocks_with_symbolic_instrs', ctypes.c_uint64, state_t)
         _setup_prototype(h, 'get_details_of_blocks_with_symbolic_instrs', None, state_t, ctypes.POINTER(BlockDetails))
@@ -1102,13 +1103,17 @@ class Unicorn(SimStatePlugin):
         # Initialize VEX register offset to unicorn register ID mappings and VEX register offset to name map
         vex_reg_offsets = []
         unicorn_reg_ids = []
-        for vex_reg_offset, unicorn_reg_id in self.state.arch.vex_to_unicorn_map.items():
+        reg_sizes = []
+        for vex_reg_offset, (unicorn_reg_id, reg_size) in self.state.arch.vex_to_unicorn_map.items():
             vex_reg_offsets.append(vex_reg_offset)
             unicorn_reg_ids.append(unicorn_reg_id)
+            reg_sizes.append(reg_size)
 
         vex_reg_offsets_array = (ctypes.c_uint64 * len(vex_reg_offsets))(*map(ctypes.c_uint64, vex_reg_offsets))
         unicorn_reg_ids_array = (ctypes.c_uint64 * len(unicorn_reg_ids))(*map(ctypes.c_uint64, unicorn_reg_ids))
-        _UC_NATIVE.set_vex_to_unicorn_reg_mappings(self._uc_state, vex_reg_offsets_array, unicorn_reg_ids_array, len(vex_reg_offsets))
+        reg_sizes_array = (ctypes.c_uint64 * len(reg_sizes))(*map(ctypes.c_uint64, reg_sizes))
+        _UC_NATIVE.set_vex_to_unicorn_reg_mappings(self._uc_state, vex_reg_offsets_array, unicorn_reg_ids_array,
+                                                   reg_sizes_array, len(vex_reg_offsets))
 
         # Initial VEX to unicorn mappings for flag register
         if self.state.arch.unicorn_flag_register:

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -156,6 +156,12 @@ struct register_value_t {
 	uint8_t value[MAX_REGISTER_BYTE_SIZE];
 	int64_t size;
 
+	register_value_t() {
+		offset = 0;
+		size = -1;
+		memset(value, 0, MAX_REGISTER_BYTE_SIZE);
+	}
+
 	bool operator==(const register_value_t &reg_value) const {
 		if (offset != reg_value.offset) {
 			return false;
@@ -444,7 +450,6 @@ typedef std::unordered_map<address_t, block_taint_entry_t> BlockTaintCache;
 std::map<uint64_t, caches_t> global_cache;
 
 typedef std::unordered_set<vex_reg_offset_t> RegisterSet;
-typedef std::unordered_map<vex_reg_offset_t, unicorn_reg_id_t> RegisterMap;
 typedef std::unordered_set<vex_tmp_id_t> TempSet;
 
 struct fd_data {
@@ -517,7 +522,7 @@ class State {
 	block_details_t curr_block_details;
 
 	// List of register values at start of block
-	std::unordered_map<vex_reg_offset_t, register_value_t> block_start_reg_values;
+	std::map<vex_reg_offset_t, register_value_t> block_start_reg_values;
 
 	// Similar to memory reads in a block, we track the state of registers and VEX temps when
 	// propagating taint in a block for easy rollback if we need to abort due to read from/write to
@@ -694,7 +699,8 @@ class State {
 		VexArchInfo vex_archinfo;
 		RegisterSet symbolic_registers; // tracking of symbolic registers
 		RegisterSet blacklisted_registers;  // Registers which shouldn't be saved as a concrete dependency
-		RegisterMap vex_to_unicorn_map; // Mapping of VEX offsets to unicorn registers
+		// Mapping of VEX offsets to unicorn register IDs and register sizes
+		std::unordered_map<vex_reg_offset_t, std::pair<unicorn_reg_id_t, uint64_t>> vex_to_unicorn_map;
 		RegisterSet artificial_vex_registers; // Artificial VEX registers
 		std::unordered_map<vex_reg_offset_t, uint64_t> cpu_flags;	// VEX register offset and bitmask for CPU flags
 		int64_t cpu_flags_register;


### PR DESCRIPTION
In the native interface, values of sub-registers that do not start at byte 0 of the full register were not correctly saved for later re-execution. This PR fixes this. I have a possible test case using NRFIN_00021 CGC binary for this. However, that requires some more features to be implemented in angr. Hence, I am deferring adding that test case and not including it in this PR.

This PR also depends on angr/archinfo#105. The test case failures are because of this dependency. I ran all CI tests locally with the changes in the two PRs and did not find any failing tests.