### PR TITLE
Rewrote VEX CPU flag registers handling to support flag-style values from more than one register

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -395,8 +395,8 @@ def _load_native():
         _setup_prototype(h, 'get_details_of_blocks_with_symbolic_instrs', None, state_t, ctypes.POINTER(BlockDetails))
         _setup_prototype(h, 'get_stop_details', StopDetails, state_t)
         _setup_prototype(h, 'set_register_blacklist', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
-        _setup_prototype(h, 'set_cpu_flags_details', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
-        _setup_prototype(h, 'set_unicorn_flags_register_id', None, state_t, ctypes.c_int64)
+        _setup_prototype(h, 'set_cpu_flags_details', None, state_t, ctypes.POINTER(ctypes.c_uint64),
+                         ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'set_fd_bytes', state_t, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint64)
 
         l.info('native plugin is enabled')
@@ -1115,19 +1115,21 @@ class Unicorn(SimStatePlugin):
         _UC_NATIVE.set_vex_to_unicorn_reg_mappings(self._uc_state, vex_reg_offsets_array, unicorn_reg_ids_array,
                                                    reg_sizes_array, len(vex_reg_offsets))
 
-        # Initial VEX to unicorn mappings for flag register
-        if self.state.arch.unicorn_flag_register:
-            _UC_NATIVE.set_unicorn_flags_register_id(self._uc_state, self.state.arch.unicorn_flag_register)
-            cpu_flag_vex_offsets = []
-            cpu_flag_bitmasks = []
-            for cpu_flag_reg_offset, cpu_flag_reg_bitmask in self.state.arch.cpu_flag_register_offsets_and_bitmasks_map.items():
-                cpu_flag_vex_offsets.append(cpu_flag_reg_offset)
-                cpu_flag_bitmasks.append(cpu_flag_reg_bitmask)
+        # VEX to unicorn mappings for VEX flag registers
+        if self.state.arch.cpu_flag_register_offsets_and_bitmasks_map:
+            flag_vex_offsets = []
+            flag_bitmasks = []
+            flag_uc_regs = []
+            for flag_vex_offset, (uc_reg, flag_bitmask) in self.state.arch.cpu_flag_register_offsets_and_bitmasks_map.items():
+                flag_vex_offsets.append(flag_vex_offset)
+                flag_bitmasks.append(flag_bitmask)
+                flag_uc_regs.append(uc_reg)
 
-            if len(cpu_flag_vex_offsets) > 0:
-                cpu_flag_vex_offsets_array = (ctypes.c_uint64 * len(cpu_flag_vex_offsets))(*map(ctypes.c_uint64, cpu_flag_vex_offsets))
-                cpu_flag_bitmasks_array = (ctypes.c_uint64 * len(cpu_flag_bitmasks))(*map(ctypes.c_uint64, cpu_flag_bitmasks))
-                _UC_NATIVE.set_cpu_flags_details(self._uc_state, cpu_flag_vex_offsets_array, cpu_flag_bitmasks_array,len(cpu_flag_vex_offsets))
+            flag_vex_offsets_array = (ctypes.c_uint64 * len(flag_vex_offsets))(*map(ctypes.c_uint64, flag_vex_offsets))
+            flag_bitmasks_array = (ctypes.c_uint64 * len(flag_bitmasks))(*map(ctypes.c_uint64, flag_bitmasks))
+            flag_uc_regs_array = (ctypes.c_uint64 * len(flag_uc_regs))(*map(ctypes.c_uint64, flag_uc_regs))
+            _UC_NATIVE.set_cpu_flags_details(self._uc_state, flag_vex_offsets_array, flag_uc_regs_array,
+                                             flag_bitmasks_array, len(flag_vex_offsets))
         elif self.state.arch.name.startswith("ARM"):
             l.warning("Flag registers for %s not set in native unicorn interface.", self.state.arch.name)
 

--- a/native/angr_native.def
+++ b/native/angr_native.def
@@ -36,5 +36,4 @@ EXPORTS
   simunicorn_set_artificial_registers
   simunicorn_set_cpu_flags_details
   simunicorn_set_register_blacklist
-  simunicorn_set_unicorn_flags_register_id
   simunicorn_set_vex_to_unicorn_reg_mappings

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -702,8 +702,8 @@ class State {
 		// Mapping of VEX offsets to unicorn register IDs and register sizes
 		std::unordered_map<vex_reg_offset_t, std::pair<unicorn_reg_id_t, uint64_t>> vex_to_unicorn_map;
 		RegisterSet artificial_vex_registers; // Artificial VEX registers
-		std::unordered_map<vex_reg_offset_t, uint64_t> cpu_flags;	// VEX register offset and bitmask for CPU flags
-		int64_t cpu_flags_register;
+		// VEX flag register offset, corresponding unicorn register ID and bitmask for CPU flags
+		std::unordered_map<vex_reg_offset_t, std::pair<uint64_t, uint64_t>> cpu_flags;
 		stop_details_t stop_details;
 
 		// List of all values read from memory in current block


### PR DESCRIPTION
This PR modifies the VEX CPU flag registers handling in native interface to support multiple values from different registers. Currently, only VEX register `sseround` has been added; more can be easily introduced by modifying archinfo appropriately. I have a possible test case using NRFIN_00021 CGC binary. However, that requires some more features to be implemented in angr. Hence, I am deferring adding that test case and not including it in this PR. 

This PR also fixes a bug which prevented saving VEX CPU flag registers from being saved correctly. It was introduced in #3131.

This PR also depends on angr/archinfo#106. The test case failures are because of this dependency. I ran all CI tests locally with the changes in the two PRs and did not find any failing tests.