### PR TITLE
Some engine cleanup

### DIFF
--- a/angr/engines/engine.py
+++ b/angr/engines/engine.py
@@ -11,7 +11,7 @@ l = logging.getLogger(name=__name__)
 class SimEngineBase:
     """
     Even more basey of a base class for SimEngine. Used as a base by mixins which want access to the project but for
-    which process doesn't make sense.
+    which having method `process` (contained in `SimEngine`) doesn't make sense
     """
     def __init__(self, project=None, **kwargs):
         if kwargs:

--- a/angr/engines/engine.py
+++ b/angr/engines/engine.py
@@ -8,11 +8,13 @@ from archinfo.arch_soot import SootAddressDescriptor
 
 l = logging.getLogger(name=__name__)
 
+
 class SimEngineBase:
     """
     Even more basey of a base class for SimEngine. Used as a base by mixins which want access to the project but for
     which having method `process` (contained in `SimEngine`) doesn't make sense
     """
+
     def __init__(self, project=None, **kwargs):
         if kwargs:
             raise TypeError("Unused initializer args: " + ", ".join(kwargs.keys()))
@@ -34,10 +36,12 @@ class SimEngineBase:
     def _is_false(self, v):
         return v is False
 
+
 class SimEngine(SimEngineBase):
     """
     A SimEngine is a class which understands how to perform execution on a state. This is a base class.
     """
+
     def process(self, state, **kwargs):
         """
         The main entry point for an engine. Should take a state and return a result.
@@ -47,6 +51,7 @@ class SimEngine(SimEngineBase):
         """
         raise NotImplementedError
 
+
 class TLSMixin:
     """
     Mix this class into any class that defines __tls to make all of the attributes named in that list into
@@ -54,6 +59,7 @@ class TLSMixin:
 
     MAGIC MAGIC MAGIC
     """
+
     def __new__(cls, *args, **kwargs):
         obj = super().__new__(cls, *args, **kwargs)
         obj.__local = threading.local()
@@ -72,6 +78,7 @@ class TLSMixin:
                         raise Exception("Programming error: %s is both in __tls and __class__" % attr)
                 else:
                     setattr(cls, attr, TLSProperty(attr))
+
 
 class TLSProperty:
     def __init__(self, name):
@@ -143,7 +150,8 @@ class SuccessorsMixin(SimEngine):
 
         self.successors = SimSuccessors(addr, old_state)
 
-        new_state._inspect('engine_process', when=BP_BEFORE, sim_engine=self, sim_successors=self.successors, address=addr)
+        new_state._inspect('engine_process', when=BP_BEFORE, sim_engine=self, sim_successors=self.successors,
+                           address=addr)
         self.successors = new_state._inspect_getattr('sim_successors', self.successors)
         try:
             self.process_successors(self.successors, **kwargs)
@@ -159,7 +167,7 @@ class SuccessorsMixin(SimEngine):
         if new_state.supports_inspect:
             new_state.inspect.downsize()
         # if not TRACK, clear actions on OLD state
-        #if o.TRACK_ACTION_HISTORY not in old_state.options:
+        # if o.TRACK_ACTION_HISTORY not in old_state.options:
         #    old_state.history.recent_events = []
 
         # fix up the descriptions...
@@ -189,7 +197,7 @@ class SuccessorsMixin(SimEngine):
         :param successors:      The successors object to fill out
         :param kwargs:          Any extra arguments. Do not fail if you are passed unexpected arguments.
         """
-        successors.processed = False        # mark failure
+        successors.processed = False  # mark failure
 
 
 from .. import sim_options as o

--- a/angr/engines/engine.py
+++ b/angr/engines/engine.py
@@ -1,3 +1,4 @@
+import abc
 import sys
 import logging
 import threading
@@ -37,11 +38,12 @@ class SimEngineBase:
         return v is False
 
 
-class SimEngine(SimEngineBase):
+class SimEngine(SimEngineBase, metaclass=abc.ABCMeta):
     """
     A SimEngine is a class which understands how to perform execution on a state. This is a base class.
     """
 
+    @abc.abstractmethod
     def process(self, state, **kwargs):
         """
         The main entry point for an engine. Should take a state and return a result.
@@ -49,7 +51,6 @@ class SimEngine(SimEngineBase):
         :param state:   The state to proceed from
         :return:        The result. Whatever you want ;)
         """
-        raise NotImplementedError
 
 
 class TLSMixin:


### PR DESCRIPTION
- improve comment for `SimEngineBase`
- reformat file to conform to `PEP 8: E302 expected 2 blank lines, found 1` warning
- make more explicit that `SimEngine` class is an abstract base class
