### PR TITLE
Save information about dependent registers of the last instruction in a basic block

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1099,6 +1099,16 @@ void State::process_vex_block(IRSB *vex_block, address_t address) {
 		instruction_taint_entry.mem_read_size += block_next_taint_sources.mem_read_size;
 		instruction_taint_entry.has_memory_read |= (block_next_taint_sources.mem_read_size != 0);
 	}
+	// Save register dependencies' info
+	for (auto &dep: instruction_taint_entry.dependencies.at(TAINT_ENTITY_REG)) {
+		auto entry = last_reg_modifier_instr.find(dep.reg_offset);
+		if (entry != last_reg_modifier_instr.end()) {
+			instruction_taint_entry.dep_reg_modifier_addr.emplace(dep.reg_offset, entry->second);
+		}
+		else {
+			instruction_taint_entry.unmodified_dep_regs.emplace(dep.reg_offset, dep.value_size);
+		}
+	}
 	// Save last instruction's entry
 	block_taint_entry.block_instrs_taint_data_map.emplace(curr_instr_addr, instruction_taint_entry);
 	block_taint_cache.emplace(address, block_taint_entry);


### PR DESCRIPTION
This PR fixes a problem related to saving information of dependencies of an instruction that needs to be re-execution. Currently, information about the register dependencies of the last instruction of a basic block is not saved in the native interface. This causes the instruction's slice to be  computed incorrectly, leading to issues during when re-executing the instruction. I have a potential test case for this using NRFIN_00026 CGC binary. However, that requires some more features to be implemented in angr and so adding the test case later on when is probably a better idea.

I am seeing some desyncs when tracing 2 other CGC binaries, which I believe don't happen without this feature. However, I think the root cause of the desync existed earlier but were not triggered until the changes in this PR were implemented(have not verified this). Since all CI test also pass, I think this PR can be merged in. Those issues will be fixed eventually and should anything important break, I can take a look and fix things.