### PR TITLE
CCodeGen: Support compound assignment operators

### DIFF
--- a/angr/analyses/decompiler/decompilation_options.py
+++ b/angr/analyses/decompiler/decompilation_options.py
@@ -61,6 +61,16 @@ options = [
         category="Display",
         default_value=True,
         clears_cache=False,
+    ),
+    O(
+        "Use compound assignment operators",
+        'Reduce statements "a = a + b" to "a += b".',
+        bool,
+        "codegen",
+        "use_compound_assignments",
+        category="Display",
+        default_value=True,
+        clears_cache=False,
     )
 ]
 

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -610,7 +610,7 @@ def test_decompilation_excessive_condition_removal():
 
     code = code.replace(" ", "").replace("\n", "")
     # s_1a += 1 should not be wrapped inside any if-statements. it is always reachable.
-    assert "}v4=v4+1;}" in code or "}v4=v4+0x1;}" in code
+    assert "}v4+=1;}" in code or "}v4+=0x1;}" in code
 
 
 def test_decompilation_excessive_goto_removal():


### PR DESCRIPTION
Support optionally using compound assignment operators, transforming `a = a + b` to `a += b`.
