### PR TITLE
Propagator: Enforce strict load/store ordering

### DIFF
--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -76,6 +76,8 @@ class SimEnginePropagatorAIL(
         addr = self._expr(stmt.addr)
         data = self._expr(stmt.data)
 
+        self.state.last_store = stmt
+
         # is it accessing the stack?
         sp_offset = self.extract_offset_to_sp(addr.one_expr) if addr.one_expr is not None else None
         if sp_offset is not None:

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -263,7 +263,7 @@ class PropagatorAILState(PropagatorState):
     Describes the state used in the AIL engine of Propagator.
     """
 
-    __slots__ = ('_registers', '_stack_variables', '_tmps', '_inside_call_stmt')
+    __slots__ = ('_registers', '_stack_variables', '_tmps', '_inside_call_stmt', 'last_store')
 
     def __init__(self, arch, project=None, replacements=None, only_consts=False, prop_count=None, equivalence=None,
                  stack_variables=None, registers=None):
@@ -282,6 +282,7 @@ class PropagatorAILState(PropagatorState):
 
         self._registers.set_state(self)
         self._stack_variables.set_state(self)
+        self.last_store = None
 
     def __repr__(self):
         return "<PropagatorAILState>"

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -666,7 +666,7 @@ def test_decompilation_x86_64_stack_arguments():
             # The line should look like this:
             #   v0 = (int)snprintf(v32[8], (v43 + 0x1) * 0x2 + 0x1a, "%s, %.2d %s %d %.2d:%.2d:%.2d GMT\r\n", &v34,
             #   ((long long)v35), &v33, ((long long)v36 + 1900), ((long long)v35), ((long long)v35), ((long long)v35));
-            assert "1900" in line, "There is a missing stack argument."
+            assert line.count(',') == 10, "There is a missing stack argument."
             break
     else:
         assert False, "The line with snprintf() is not found."
@@ -686,7 +686,7 @@ def test_decompilation_x86_64_stack_arguments():
             # The line should look like this:
             #   v0 = (int)snprintf(v32[8], (v43 + 0x1) * 0x2 + 0x1a, "%s, %.2d %s %d %.2d:%.2d:%.2d GMT\r\n", &v34,
             #   ((long long)v35), &v33, ((long long)v36 + 1900), ((long long)v35), ((long long)v35), ((long long)v35));
-            assert "1900" in line, "There is a missing stack argument."
+            assert line.count(',') == 10, "There is a missing stack argument."
             break
     else:
         assert False, "The line with snprintf() is not found."


### PR DESCRIPTION
Prevents propagating load expressions which become invalidated by a
store. This fixes some incorrect code generation, but may inhibit
legitimate optimizations which should be handled by RDA/SSA.

Depends on https://github.com/angr/binaries/pull/86 for test case.

Original Source:
```c
char *simple_strcpy(char *dst, const char *src)
{
    char *p = dst;
    while (( *p++ = *src++ ));
    return dst;
}
```

Disassembly:
```nasm
00000000000011a9 <simple_strcpy>:
    11a9:	f3 0f 1e fa          	endbr64 
    11ad:	55                   	push   rbp
    11ae:	48 89 e5             	mov    rbp,rsp
    11b1:	48 89 7d e8          	mov    QWORD PTR [rbp-0x18],rdi
    11b5:	48 89 75 e0          	mov    QWORD PTR [rbp-0x20],rsi
    11b9:	48 8b 45 e8          	mov    rax,QWORD PTR [rbp-0x18]
    11bd:	48 89 45 f8          	mov    QWORD PTR [rbp-0x8],rax
    11c1:	90                   	nop
    11c2:	48 8b 55 e0          	mov    rdx,QWORD PTR [rbp-0x20]
    11c6:	48 8d 42 01          	lea    rax,[rdx+0x1]
    11ca:	48 89 45 e0          	mov    QWORD PTR [rbp-0x20],rax
    11ce:	48 8b 45 f8          	mov    rax,QWORD PTR [rbp-0x8]
    11d2:	48 8d 48 01          	lea    rcx,[rax+0x1]
    11d6:	48 89 4d f8          	mov    QWORD PTR [rbp-0x8],rcx
    11da:	0f b6 12             	movzx  edx,BYTE PTR [rdx]
    11dd:	88 10                	mov    BYTE PTR [rax],dl
    11df:	0f b6 00             	movzx  eax,BYTE PTR [rax]
    11e2:	84 c0                	test   al,al
    11e4:	75 dc                	jne    11c2 <simple_strcpy+0x19>
    11e6:	48 8b 45 e8          	mov    rax,QWORD PTR [rbp-0x18]
    11ea:	5d                   	pop    rbp
    11eb:	c3                   	ret    
```

Before patch:
```c
int simple_strcpy(char *a0, char *a1)
{
    char * v0;  // [bp-0x28]
    char *v1;  // [bp-0x20]
    char * v2;  // [bp-0x10]

    v1 = a0;
    v0 = a1;
    v2 = a0;
    do
    {
        v0 += 1;
        v2 += 1;
        v2[0] = v0[0];
    }
    while (((long long)v2[0]) != 0);
    return v1;
}
```

After patch:
```c
int simple_strcpy(char *a0, char *a1)
{
    BOT tmp_22;  // tmp #22
    BOT tmp_14;  // tmp #14
    char * v0;  // [bp-0x28]
    char *v1;  // [bp-0x20]
    char * v2;  // [bp-0x10]

    v1 = a0;
    v0 = a1;
    v2 = a0;
    do
    {
        tmp_14 = v0;
        v0 += 1;
        tmp_22 = v2;
        v2 += 1;
        tmp_22[0] = tmp_14[0];
    }
    while (((long long)tmp_22[0]) != 0);
    return v1;
}
```

For reference:

Decomp from IDA 7.6.21052

```c
_BYTE *__fastcall simple_strcpy(_BYTE *a1, _BYTE *a2)
{
  _BYTE *v2; // rdx
  _BYTE *v3; // rax
  _BYTE *v6; // [rsp+18h] [rbp-8h]

  v6 = a1;
  do
  {
    v2 = a2++;
    v3 = v6++;
    *v3 = *v2;
  }
  while ( *v3 );
  return a1;
}
```

Decomp from Ghidra 10.1.2
```c
char * simple_strcpy(char *param_1,char *param_2)
{
  char cVar1;
  char *local_28;
  char *local_10;
  
  local_28 = param_2;
  local_10 = param_1;
  do {
    *local_10 = *local_28;
    cVar1 = *local_10;
    local_28 = local_28 + 1;
    local_10 = local_10 + 1;
  } while (cVar1 != '\0');
  return param_1;
}
```