### PR TITLE
Do not compute address of memory reads when re-executing them

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -103,8 +103,9 @@ class SimEngineUnicorn(SuccessorsMixin):
         self.state.scratch.set_tyenv(vex_block.tyenv)
         for instr_entry in block_details["instrs"]:
             self._instr_mem_reads = [n for n in instr_entry["mem_dep"]]  # pylint:disable=attribute-defined-outside-init
-            # Insert breakpoint to set the correct memory read address
-            self.state.inspect.b('mem_read', when=BP_BEFORE, action=self._set_correct_mem_read_addr)
+            if self._instr_mem_reads:
+                # Insert breakpoint to set the correct memory read address
+                self.state.inspect.b('mem_read', when=BP_BEFORE, action=self._set_correct_mem_read_addr)
 
             instr_vex_stmt_indices = vex_block_details["stmt_indices"][instr_entry["instr_addr"]]
             start_index = instr_vex_stmt_indices["start"]

--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -125,10 +125,6 @@ class SimEngineUnicorn(SuccessorsMixin):
             self.state.inspect._breakpoints["mem_read"] = copy.copy(saved_mem_read_breakpoints)
             del self._instr_mem_reads
 
-        # Restore breakpoints
-        for succ_state in self.successors.successors:
-            succ_state.inspect._breakpoints["mem_read"] = copy.copy(saved_mem_read_breakpoints)
-
         del self.stmt_idx
 
     def _execute_symbolic_instrs(self):

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -973,7 +973,8 @@ class Unicorn(SimStatePlugin):
 
         def _get_memory_values(memory_values):
             for memory_value in memory_values:
-                yield {"address": memory_value.address, "value": bytes(memory_value.value[:memory_value.size])}
+                yield {"address": memory_value.address, "value": bytes(memory_value.value[:memory_value.size]),
+                       "size": memory_value.size, "symbolic": memory_value.is_value_symbolic}
 
         def _get_instr_details(symbolic_instrs):
             for instr in symbolic_instrs:

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -973,16 +973,7 @@ class Unicorn(SimStatePlugin):
 
         def _get_memory_values(memory_values):
             for memory_value in memory_values:
-                mem_address = memory_value.address
-                mem_val_size = memory_value.size
-                # Convert the memory value in bytes to number of appropriate size and endianness
-                mem_val = memory_value.value[:mem_val_size]
-                if self.state.arch.memory_endness == archinfo.Endness.LE:
-                    mem_val = int.from_bytes(mem_val, "little")
-                else:
-                    mem_val = int.from_bytes(mem_val, "big")
-
-                yield {"address": mem_address, "value": mem_val, "size": mem_val_size}
+                yield {"address": memory_value.address, "value": bytes(memory_value.value[:memory_value.size])}
 
         def _get_instr_details(symbolic_instrs):
             for instr in symbolic_instrs:

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -336,7 +336,7 @@ _unicorn_tls.uc = None
 
 class _VexCacheInfo(ctypes.Structure):
     """
-    VexCacheInfo
+    VexCacheInfo struct from vex
     """
 
     _fields_ = [
@@ -348,7 +348,7 @@ class _VexCacheInfo(ctypes.Structure):
 
 class _VexArchInfo(ctypes.Structure):
     """
-    VexArchInfo
+    VexArchInfo struct from vex
     """
 
     _fields_ = [

--- a/angr/storage/memory_mixins/convenient_mappings_mixin.py
+++ b/angr/storage/memory_mixins/convenient_mappings_mixin.py
@@ -49,7 +49,7 @@ class ConvenientMappingsMixin(MemoryMixin):
         try:
             if options.REVERSE_MEMORY_NAME_MAP in self.state.options:
                 # remove this address for the old variables
-                old_obj = self.load(addr, size=size, fill_missing=False)
+                old_obj = self.load(addr, size=size, fill_missing=False, disable_actions=True, inspect=False)
 
                 obj_vars = old_obj.variables
                 for v in obj_vars:

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -814,7 +814,7 @@ void State::compute_slice_of_instr(instr_details_t &instr, bool is_instr_symboli
 			// Register was not concrete before instruction was executed. Do not compute slice.
 			continue;
 		}
-		if (!reg_dep.used_in_mem_addr || block_mem_reads_map.at(instr.instr_addr).is_mem_read_symbolic) {
+		if (!reg_dep.used_in_mem_addr) {
 			instrs_to_process.emplace(instr_taint_entry.dep_reg_modifier_addr.at(reg_dep.reg_offset));
 		}
 	}

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -252,7 +252,7 @@ void State::commit() {
 	}
 	if (curr_block_details.symbolic_instrs.size() > 0) {
 		for (auto &symbolic_instr: curr_block_details.symbolic_instrs) {
-			compute_slice_of_instr(symbolic_instr, true);
+			compute_slice_of_instr(symbolic_instr);
 			// Save all concrete memory dependencies of the block
 			save_concrete_memory_deps(symbolic_instr);
 		}
@@ -755,7 +755,7 @@ void State::handle_write(address_t address, int size, bool is_interrupt = false,
 	mem_writes.push_back(record);
 }
 
-void State::compute_slice_of_instr(instr_details_t &instr, bool is_instr_symbolic = false) {
+void State::compute_slice_of_instr(instr_details_t &instr) {
 	// Compute block slice of instruction needed to setup concrete registers needed by it and also save values of
 	// registers not changed from start of the block
 	std::unordered_set<address_t> instrs_to_process;
@@ -834,7 +834,7 @@ void State::compute_slice_of_instr(instr_details_t &instr, bool is_instr_symboli
 	for (auto &instr_to_process_addr: instrs_to_process) {
 		auto &instr_to_process_taint_entry = block_taint_entry.block_instrs_taint_data_map.at(instr_to_process_addr);
 		instr_details_t instr_details = compute_instr_details(instr_to_process_addr, instr_to_process_taint_entry);
-		compute_slice_of_instr(instr_details, false);
+		compute_slice_of_instr(instr_details);
 		instr.reg_deps.insert(instr_details.reg_deps.begin(), instr_details.reg_deps.end());
 		instr.instr_deps.insert(instr_details.instr_deps.begin(), instr_details.instr_deps.end());
 		instr_details.reg_deps.clear();

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -62,6 +62,7 @@ struct taint_entity_t {
 	// Instruction in which the entity is used. Used for taint sinks; ignored for taint sources.
 	address_t instr_addr;
 	int64_t value_size;
+	mutable bool used_in_mem_addr;
 
 	taint_entity_t() {
 		reg_offset = -1;
@@ -69,6 +70,7 @@ struct taint_entity_t {
 		mem_ref_entity_list.clear();
 		instr_addr = 0;
 		value_size = -1;
+		used_in_mem_addr = false;
 	}
 
 	bool operator==(const taint_entity_t &other_entity) const {
@@ -601,6 +603,9 @@ class State {
 	void mark_temp_symbolic(vex_tmp_id_t temp_id);
 
 	void process_vex_block(IRSB *vex_block, address_t address);
+
+	void set_deps_mem_addr_status(const taint_entity_t &entity, instruction_taint_entry_t &instr_taint_entry);
+	void update_deps_mem_addr_status(const taint_entity_t &entity, instruction_taint_entry_t &instr_taint_entry);
 
 	void propagate_taints();
 	void propagate_taint_of_one_instr(address_t instr_addr, const instruction_taint_entry_t &instr_taint_entry);

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -569,7 +569,7 @@ class State {
 
 	std::pair<taint_t *, uint8_t *> page_lookup(address_t address) const;
 
-	void compute_slice_of_instr(instr_details_t &instr);
+	void compute_slice_of_instr(instr_details_t &instr, bool is_instr_symbolic);
 	instr_details_t compute_instr_details(address_t instr_addr, const instruction_taint_entry_t &instr_taint_entry);
 	void get_register_value(uint64_t vex_reg_offset, uint8_t *out_reg_value) const;
 	// Return list of all dependent instructions including dependencies of those dependent instructions

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -571,7 +571,7 @@ class State {
 
 	std::pair<taint_t *, uint8_t *> page_lookup(address_t address) const;
 
-	void compute_slice_of_instr(instr_details_t &instr, bool is_instr_symbolic);
+	void compute_slice_of_instr(instr_details_t &instr);
 	instr_details_t compute_instr_details(address_t instr_addr, const instruction_taint_entry_t &instr_taint_entry);
 	void get_register_value(uint64_t vex_reg_offset, uint8_t *out_reg_value) const;
 	// Return list of all dependent instructions including dependencies of those dependent instructions


### PR DESCRIPTION
Currently, if any memory reads need to be re-executed in VEX engine, the slice re-executed also includes instructions that compute the address of memory read. These additional instructions sometimes have side effects that affects the consistency of the state. This PR avoids this side effects by using the read address and read size information from native interface to set the address of reads instead of computing the address. All CI tests seem to pass and the CGC tracing tests I ran also seem to work fine.

I also included lots of linter fixes in `SimEngineUnicorn` related files in this PR: linter has been complaining about those files often in the past so I decided to fix a lot of those issues. It would be good if those were reviewed as well. Most are in one commit; two minor changes were made in a later commit.