### PR TITLE
Propagate taint before writing to memory in CGC receive and transmit in native interface

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2328,6 +2328,9 @@ void State::perform_cgc_receive() {
 		// Requested to read 0 bytes. Set *rx_bytes and syscall return value to 0
 		if (rx_bytes != 0) {
 			handle_write(rx_bytes, 4, true);
+			if (stopped) {
+				return;
+			}
 			uc_mem_write(uc, rx_bytes, &count, 4);
 		}
 		uc_reg_write(uc, UC_X86_REG_EAX, &count);
@@ -2347,11 +2350,19 @@ void State::perform_cgc_receive() {
 	if (actual_count > 0) {
 		// Mark buf as symbolic
 		handle_write(buf, actual_count, true, true);
+		if (stopped) {
+			free(tmp_buf);
+			return;
+		}
 		uc_mem_write(uc, buf, tmp_buf, actual_count);
 	}
 	free(tmp_buf);
 	if (rx_bytes != 0) {
 		handle_write(rx_bytes, 4, true);
+		if (stopped) {
+			free(tmp_buf);
+			return;
+		}
 		uc_mem_write(uc, rx_bytes, &actual_count, 4);
 	}
 	count = 0;
@@ -2443,6 +2454,9 @@ void State::perform_cgc_transmit() {
 
 		if (tx_bytes != 0) {
 			handle_write(tx_bytes, 4, true);
+			if (stopped) {
+				return;
+			}
 			uc_mem_write(uc, tx_bytes, &count, 4);
 		}
 


### PR DESCRIPTION
In CGC receives and transmits in native interface, some memory writes are not performed correctly because the memory page corresponding to that address is not mapped into unicorn. This PR ensures that the page is mapped by executing `handle_write`(which maps the page into unicorn if not yet mapped in) before the memory write. I have a possible test case for this using CROMU_00012; I plan to add it later on since it requires some more features to be implemented.