### PR TITLE
Remove blocks with no symbolic instructions from re-execute list

### DIFF
--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -523,6 +523,9 @@ class State {
 	// separately for easy rollback in case of errors.
 	block_details_t curr_block_details;
 
+	// List of symbolic instructions in processed basic blocks that need not be re-executed. Will be removed on commit.
+	std::unordered_map<uint32_t, std::unordered_set<uint32_t>> symbolic_instrs_to_erase;
+
 	// List of register values at start of block
 	std::map<vex_reg_offset_t, register_value_t> block_start_reg_values;
 


### PR DESCRIPTION
`handle_write` occasionally marks some symbolic instructions as not requiring re-execution. In some cases, this results in a block with no instructions to re-execute. This PR removes such blocks from list of blocks with instructions touching symbolic data. The instruction/block remove logic has also been moved to `commit` to avoid any possible state inconsistencies if a rollback occurs after `handle_write` for any reason.