### PR TITLE
Explicitly typed API for KB

### DIFF
--- a/tests/test_kb_plugins.py
+++ b/tests/test_kb_plugins.py
@@ -3,8 +3,6 @@ import networkx
 
 import os
 
-from angr import KnowledgeBase
-
 location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
@@ -43,8 +41,6 @@ def test_kb_plugins_typed():
                    angr.knowledge_plugins.Comments]:
         assert isinstance(p.kb.request_knowledge(plugin), plugin)
 
-
-
     # The default plugins should have been instantiated by `request_knowledge`, and should now be available
     for plugin in [angr.knowledge_plugins.Data,
               angr.knowledge_plugins.FunctionManager,
@@ -52,7 +48,6 @@ def test_kb_plugins_typed():
               angr.knowledge_plugins.Labels,
               angr.knowledge_plugins.Comments]:
         assert isinstance(p.kb.request_knowledge(plugin), plugin)
-
 
     # Check that explicitly creating and registering new kind of plugin also works
     class TestPlugin(angr.knowledge_plugins.KnowledgeBasePlugin):
@@ -66,7 +61,6 @@ def test_kb_plugins_typed():
     p.kb.register_plugin("test_plugin", t)
 
     assert p.kb.get_knowledge(TestPlugin) == t
-
 
 
 if __name__ == '__main__':

--- a/tests/test_kb_plugins.py
+++ b/tests/test_kb_plugins.py
@@ -2,6 +2,9 @@ import angr
 import networkx
 
 import os
+
+from angr import KnowledgeBase
+
 location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
@@ -21,6 +24,49 @@ def test_kb_plugins():
     assert dir(p.kb) is not None
     for plugin in ['data', 'functions', 'variables', 'labels', 'comments', 'callgraph', 'resolved_indirect_jumps', 'unresolved_indirect_jumps']:
         assert plugin in dir(p.kb)
+
+
+def test_kb_plugins_typed():
+    p = angr.Project(os.path.join(location, 'x86_64', 'fauxware'), auto_load_libs=False)
+
+    for plugin in [angr.knowledge_plugins.Data,
+                   angr.knowledge_plugins.FunctionManager,
+                   angr.knowledge_plugins.VariableManager,
+                   angr.knowledge_plugins.Labels,
+                   angr.knowledge_plugins.Comments]:
+        assert p.kb.get_knowledge(plugin) is None
+
+    for plugin in [angr.knowledge_plugins.Data,
+                   angr.knowledge_plugins.FunctionManager,
+                   angr.knowledge_plugins.VariableManager,
+                   angr.knowledge_plugins.Labels,
+                   angr.knowledge_plugins.Comments]:
+        assert isinstance(p.kb.request_knowledge(plugin), plugin)
+
+
+
+    # The default plugins should have been instantiated by `request_knowledge`, and should now be available
+    for plugin in [angr.knowledge_plugins.Data,
+              angr.knowledge_plugins.FunctionManager,
+              angr.knowledge_plugins.VariableManager,
+              angr.knowledge_plugins.Labels,
+              angr.knowledge_plugins.Comments]:
+        assert isinstance(p.kb.request_knowledge(plugin), plugin)
+
+
+    # Check that explicitly creating and registering new kind of plugin also works
+    class TestPlugin(angr.knowledge_plugins.KnowledgeBasePlugin):
+        def __init__(self, kb=None):
+            self._kb = kb
+
+    # Assert that unknown plugins return None when using "get_knowledge"
+    assert p.kb.get_knowledge(TestPlugin) is None
+
+    t = TestPlugin(p.kb)
+    p.kb.register_plugin("test_plugin", t)
+
+    assert p.kb.get_knowledge(TestPlugin) == t
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Same idea as the new type safe analysis API:
Make it possible to interact with the knowledge base in a way that preserves type information, especially when using Plugins that aren't included in angr by default. The old way will still be available and should not be affected in any way.

I'm not sure about the method names `get_knowledge` (only gets an already registered plugin) and `request_knowledge` (instantiates and registers the plugin if not available) so if someone has better ideas I'm open to suggestions. Because these are now explicit methods they are now straightforward to rename/refactor.