### PR TITLE
Make BlockSimplifier sig backwards compat and add types

### DIFF
--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional, Union, Type, Iterable, Tuple, Set, TYPE_CHECKING
 
 from ailment.statement import Statement, Assignment, Call
-from ailment.expression import Expression, Tmp, Register, Load
+from ailment.expression import Expression, Tmp, Load
 
 from ...engines.light.data import SpOffset
 from ...knowledge_plugins.key_definitions.constants import OP_AFTER
@@ -27,8 +27,10 @@ class BlockSimplifier(Analysis):
     """
     Simplify an AIL block.
     """
-    def __init__(self, block: Optional['Block'], func_addr: Optional[int] = None, remove_dead_memdefs=False, stack_pointer_tracker=None,
-                 peephole_optimizations: Optional[Iterable[Union[Type[PeepholeOptimizationStmtBase],Type[PeepholeOptimizationExprBase]]]]=None,
+    def __init__(self, block: Optional['Block'], func_addr: Optional[int] = None,
+                 remove_dead_memdefs=False, stack_pointer_tracker=None,
+                 peephole_optimizations: Optional[Iterable[Union[Type[PeepholeOptimizationStmtBase],
+                                                                 Type[PeepholeOptimizationExprBase]]]]=None,
                  stack_arg_offsets: Optional[Set[Tuple[int, int]]] = None,
                  ):
         """

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -27,7 +27,7 @@ class BlockSimplifier(Analysis):
     """
     Simplify an AIL block.
     """
-    def __init__(self, block: Optional['Block'], func_addr: int, remove_dead_memdefs=False, stack_pointer_tracker=None,
+    def __init__(self, block: Optional['Block'], func_addr: Optional[int] = None, remove_dead_memdefs=False, stack_pointer_tracker=None,
                  peephole_optimizations: Optional[Iterable[Union[Type[PeepholeOptimizationStmtBase],Type[PeepholeOptimizationExprBase]]]]=None,
                  stack_arg_offsets: Optional[Set[Tuple[int, int]]] = None,
                  ):

--- a/angr/analyses/decompiler/peephole_optimizations/__init__.py
+++ b/angr/analyses/decompiler/peephole_optimizations/__init__.py
@@ -1,3 +1,5 @@
+from typing import List, Type
+
 from .coalesce_same_cascading_ifs import CoalesceSameCascadingIfs
 from .constant_derefs import ConstantDereferences
 from .extended_byte_and_mask import ExtendedByteAndMask
@@ -23,8 +25,8 @@ from .rewrite_mips_gp_loads import RewriteMipsGpLoads
 from .base import PeepholeOptimizationExprBase, PeepholeOptimizationStmtBase
 
 
-STMT_OPTS = [ ]
-EXPR_OPTS = [ ]
+STMT_OPTS: List[Type[PeepholeOptimizationStmtBase]] = []
+EXPR_OPTS: List[Type[PeepholeOptimizationExprBase]] = []
 
 _g = globals().copy()
 for v in _g.values():

--- a/angr/analyses/decompiler/peephole_optimizations/base.py
+++ b/angr/analyses/decompiler/peephole_optimizations/base.py
@@ -1,16 +1,23 @@
+from typing import Optional
+
 import archinfo
 from ailment.expression import BinaryOp, UnaryOp
+from angr.project import Project
+from angr.knowledge_base import KnowledgeBase
 
 
 class PeepholeOptimizationStmtBase:
 
     __slots__ = ('project', 'kb', 'func_addr', )
+    project: Project
+    kb: KnowledgeBase
+    func_addr: Optional[int]
 
     name = "Peephole Optimization - Statement"
     description = "Peephole Optimization - Statement"
     stmt_classes = None
 
-    def __init__(self, project, kb, func_addr):
+    def __init__(self, project: Project, kb: KnowledgeBase, func_addr: Optional[int]):
         self.project = project
         self.kb = kb
         self.func_addr = func_addr
@@ -22,12 +29,15 @@ class PeepholeOptimizationStmtBase:
 class PeepholeOptimizationExprBase:
 
     __slots__ = ('project', 'kb', 'func_addr', )
+    project: Project
+    kb: KnowledgeBase
+    func_addr: Optional[int]
 
     name = "Peephole Optimization - Expression"
     description = "Peephole Optimization - Expression"
     expr_classes = None
 
-    def __init__(self, project, kb, func_addr):
+    def __init__(self, project: Project, kb: KnowledgeBase, func_addr: Optional[int]):
         self.project = project
         self.kb = kb
         self.func_addr = func_addr

--- a/angr/analyses/decompiler/peephole_optimizations/base.py
+++ b/angr/analyses/decompiler/peephole_optimizations/base.py
@@ -17,7 +17,7 @@ class PeepholeOptimizationStmtBase:
     description = "Peephole Optimization - Statement"
     stmt_classes = None
 
-    def __init__(self, project: Project, kb: KnowledgeBase, func_addr: Optional[int]):
+    def __init__(self, project: Project, kb: KnowledgeBase, func_addr: Optional[int] = None):
         self.project = project
         self.kb = kb
         self.func_addr = func_addr
@@ -37,7 +37,7 @@ class PeepholeOptimizationExprBase:
     description = "Peephole Optimization - Expression"
     expr_classes = None
 
-    def __init__(self, project: Project, kb: KnowledgeBase, func_addr: Optional[int]):
+    def __init__(self, project: Project, kb: KnowledgeBase, func_addr: Optional[int] = None):
         self.project = project
         self.kb = kb
         self.func_addr = func_addr


### PR DESCRIPTION
As mentioned on Slack.
The `func_addr` is only required for the MIPS optimizations, and making it a positional arg would require all other uses of this analysis to change the parameters.

Also add some extra type information, especially to the PeepholeOptimization constructors and classes to make it explicit that `func_addr` is optional  