### PR TITLE
Fix an off-by-one error in trace replay

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -875,7 +875,7 @@ class Tracer(ExplorationTechnique):
         self._current_slide = self._aslr_slides[target_obj]
         target_addr += self._current_slide
         try:
-            target_idx = self._trace.index(target_addr, state.globals['trace_idx'] + 1)
+            target_idx = self._trace.index(target_addr, state.globals['trace_idx'])
         except ValueError as e:
             # if the user wants to catch desync caused by sim_procedure,
             # mark this state as a desync state and then end the tracing prematurely


### PR DESCRIPTION
This is sort of a bug report and PR in one.  When tracing static binaries on x86-64, the first address in the trace is hooked by LinuxLoader, and so we fast forward to LinuxLoader.  Unfortunately, fast forwarding only looks at subsequent indices in the trace.

So we get an exception like:
```
Traceback (most recent call last):
  File "/home/ed/Documents/angr-dev/angr/angr/exploration_techniques/tracer.py", line 863, in _fast_forward
    target_idx = self._trace.index(target_addr, state.globals['trace_idx'] + 1)
ValueError: 4201488 is not in list

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.6/pdb.py", line 1667, in main
    pdb._runscript(mainpyfile)
  File "/usr/lib/python3.6/pdb.py", line 1548, in _runscript
    self.run(statement)
  File "/usr/lib/python3.6/bdb.py", line 434, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/home/ed/Documents/Angry-CodeReuse/gentrace.py", line 1, in <module>
    import angr  # Angr adds a cool colorful log printer
  File "/home/ed/Documents/Angry-CodeReuse/gentrace.py", line 31, in main
    crashed_state = angry.utils.trace.get_trace(args)
  File "/home/ed/Documents/Angry-CodeReuse/angry/utils/trace.py", line 195, in get_trace
    crashed_state = trace_to_crash(proj, init_state, trace)
  File "/home/ed/Documents/Angry-CodeReuse/angry/utils/angry_logging.py", line 14, in wrapper
    return func(*args, **kwargs)
  File "/home/ed/Documents/Angry-CodeReuse/angry/utils/trace.py", line 140, in trace_to_crash
    simgr.run()
  File "/home/ed/Documents/angr-dev/angr/angr/sim_manager.py", line 280, in run
    self.step(stash=stash, **kwargs)
  File "/home/ed/Documents/angr-dev/angr/angr/misc/hookset.py", line 75, in __call__
    result = current_hook(self.func.__self__, *args, **kwargs)
  File "/home/ed/Documents/angr-dev/angr/angr/exploration_techniques/tracer.py", line 318, in step
    return simgr.step(stash=stash, **kwargs)
  File "/home/ed/Documents/angr-dev/angr/angr/misc/hookset.py", line 80, in __call__
    return self.func(*args, **kwargs)
  File "/home/ed/Documents/angr-dev/angr/angr/sim_manager.py", line 365, in step
    successors = self.step_state(state, successor_func=successor_func, **run_args)
  File "/home/ed/Documents/angr-dev/angr/angr/misc/hookset.py", line 75, in __call__
    result = current_hook(self.func.__self__, *args, **kwargs)
  File "/home/ed/Documents/angr-dev/angr/angr/exploration_techniques/tracer.py", line 357, in step_state
    self._update_state_tracking(sat_succs[0])
  File "/home/ed/Documents/angr-dev/angr/angr/exploration_techniques/tracer.py", line 572, in _update_state_tracking
    self._fast_forward(state)
  File "/home/ed/Documents/angr-dev/angr/angr/exploration_techniques/tracer.py", line 870, in _fast_forward
    raise AngrTracerError("Trace failed to synchronize during fast forward? You might want to unhook %s." % (self.project.hooked_by(state.history.addr).display_name)) from e
angr.errors.AngrTracerError: Trace failed to synchronize during fast forward? You might want to unhook LinuxLoader.
```

This PR simply allows fast forwarding to be a noop if we are already at the target address.  As far as I can tell, this doesn't break anything.