### PR TITLE
Add ran_cca flag to Function

### DIFF
--- a/angr/analyses/complete_calling_conventions.py
+++ b/angr/analyses/complete_calling_conventions.py
@@ -171,6 +171,7 @@ class CompleteCallingConventionsAnalysis(Analysis):
                 if varman is not None:
                     self.kb.variables.function_managers[func_addr] = varman
                     varman.set_manager(self.kb.variables)
+                func.ran_cca = True
 
                 if self._cc_callback is not None:
                     self._cc_callback(func_addr)
@@ -205,6 +206,9 @@ class CompleteCallingConventionsAnalysis(Analysis):
     def _analyze_core(self, func_addr: int) -> Tuple[Optional['SimCC'],Optional['SimTypeFunction'],
                                                      Optional['VariableManagerInternal']]:
         func = self.kb.functions.get_by_addr(func_addr)
+        if func.ran_cca:
+            return func.calling_convention, func.prototype, self.kb.variables.get_function_manager(func_addr)
+
         if self._recover_variables and self.function_needs_variable_recovery(func):
             _l.info("Performing variable recovery on %r...", func)
             try:

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -41,7 +41,7 @@ class Function(Serializable):
                  'bp_on_stack', 'retaddr_on_stack', 'sp_delta', 'calling_convention', 'prototype', '_returning',
                  'prepared_registers', 'prepared_stack_variables', 'registers_read_afterwards',
                  'startpoint', '_addr_to_block_node', '_block_sizes', '_block_cache', '_local_blocks',
-                 '_local_block_addrs', 'info', 'tags', 'alignment', 'is_prototype_guessed',
+                 '_local_block_addrs', 'info', 'tags', 'alignment', 'is_prototype_guessed', 'ran_cca',
                  )
 
     def __init__(self, function_manager, addr, name=None, syscall=None, is_simprocedure=None, binary_name=None,
@@ -121,6 +121,8 @@ class Function(Serializable):
         self._argument_stack_variables = []
 
         self._project = None  # type: Optional[Project] # will be initialized upon the first access to self.project
+
+        self.ran_cca = False  # this is set by CompleteCallingConventions to avoid reprocessing failed functions
 
         #
         # Initialize unspecified properties


### PR DESCRIPTION
I noticed a lot of duplicate time being spent in CCA when recovery fails in a bunch of functions and so it tries on every single function decompilation to rerun CCA on all these functions. This adds a flag to indicate you've already run CCA, so it doesn't bother trying.