### PR TITLE
Use str.format() instead of "%X" % (args) in engines/successors.py

### DIFF
--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -57,11 +57,11 @@ class SimSuccessors:
         if self.processed:
             successor_strings = [ ]
             if len(self.flat_successors) != 0:
-                successor_strings.append("%d sat" % len(self.flat_successors))
+                successor_strings.append("{} sat".format(len(self.flat_successors)))
             if len(self.unsat_successors) != 0:
-                successor_strings.append("%d unsat" % len(self.unsat_successors))
+                successor_strings.append("{} unsat".format(len(self.unsat_successors)))
             if len(self.unconstrained_successors) != 0:
-                successor_strings.append("%d unconstrained" % len(self.unconstrained_successors))
+                successor_strings.append("{} unconstrained".format(len(self.unconstrained_successors)))
 
             if len(successor_strings) == 0:
                 result = 'empty'
@@ -70,8 +70,8 @@ class SimSuccessors:
         else:
             result = 'failure'
         if isinstance(self.initial_state.arch, ArchSoot):
-            return '<%s from %s: %s>' % (self.description, self.addr, result)
-        return '<%s from %#x: %s>' % (self.description, self.addr, result)
+            return '<{} from {}: {}>'.format(self.description, self.addr, result)
+        return '<{} from {}: {}>'.format(self.description, self.addr, result)
 
     @property
     def is_empty(self):

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -69,11 +69,11 @@ class SimSuccessors:
                 result = ' '.join(successor_strings)
         else:
             result = 'failure'
-        addr_display = hex(self.addr) if isinstance(self.addr, int) else self.addr
-        if isinstance(self.initial_state.arch, ArchSoot):
-            return '<{} from {}: {}>'.format(self.description, addr_display, result)
-        return '<{} from {}: {}>'.format(self.description, addr_display, result)
 
+        if isinstance(self.addr, int):
+            return f'<{self.description} from {addr_display:#x}: {result}>'
+        else:
+            return f'<{self.description} from {addr_display}: {result}>'
     @property
     def is_empty(self):
         return not self.all_successors and not self.flat_successors and not self.unsat_successors and \

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -69,9 +69,10 @@ class SimSuccessors:
                 result = ' '.join(successor_strings)
         else:
             result = 'failure'
+        addr_display = hex(self.addr) if isinstance(self.addr, int) else self.addr
         if isinstance(self.initial_state.arch, ArchSoot):
-            return '<{} from {}: {}>'.format(self.description, self.addr, result)
-        return '<{} from {}: {}>'.format(self.description, self.addr, result)
+            return '<{} from {}: {}>'.format(self.description, addr_display, result)
+        return '<{} from {}: {}>'.format(self.description, addr_display, result)
 
     @property
     def is_empty(self):

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -57,11 +57,11 @@ class SimSuccessors:
         if self.processed:
             successor_strings = [ ]
             if len(self.flat_successors) != 0:
-                successor_strings.append("{} sat".format(len(self.flat_successors)))
+                successor_strings.append(f"{len(self.flat_successors)} sat")
             if len(self.unsat_successors) != 0:
-                successor_strings.append("{} unsat".format(len(self.unsat_successors)))
+                successor_strings.append(f"{len(self.unsat_successors)} unsat")
             if len(self.unconstrained_successors) != 0:
-                successor_strings.append("{} unconstrained".format(len(self.unconstrained_successors)))
+                successor_strings.append(f"{len(self.unconstrained_successors)} unconstrained")
 
             if len(successor_strings) == 0:
                 result = 'empty'


### PR DESCRIPTION
Currently, engines/successors.py is using the percentage-style string format (which looks like this: `"%d" % (17)`).

This commit changes that.

The reason being, I am testing some analysis on angr, and I want to return some types which are different from the ones angr is expecting. Everything works, apart from SimSuccessors.\_\_repr\_\_, which because of the percentage-style formats is very strict.