### PR TITLE
Require setuptools >= 59

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=59"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Setuptools 59 exposed setuptools.errors to mirror old distutils errors.