### PR TITLE
cache clinic objects (vars and graph) for use in AIL graph

### DIFF
--- a/angr/analyses/decompiler/decompilation_cache.py
+++ b/angr/analyses/decompiler/decompilation_cache.py
@@ -1,5 +1,6 @@
 from typing import Optional, Set, Dict, TYPE_CHECKING
 
+from .clinic import Clinic
 from .structured_codegen import BaseStructuredCodeGenerator
 
 
@@ -11,3 +12,4 @@ class DecompilationCache:
         self.type_constraints: Optional[Set] = None
         self.var_to_typevar: Optional[Dict] = None
         self.codegen: Optional[BaseStructuredCodeGenerator] = None
+        self.clinic: Optional[Clinic] = None

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -128,6 +128,7 @@ class Decompiler(Analysis):
 
         self.codegen = codegen
         self.cache.codegen = codegen
+        self.clinic = clinic
 
     def _set_global_variables(self):
 


### PR DESCRIPTION
Linked to: https://github.com/angr/angr-management/pull/591. 

Makes clinic object cached on each decompilation call to both speeds up AIL graph construction in angr-management and to make it more accurate (decompiler optimizations are run on this graph). 