### PR TITLE
Fix a bug where the char argument of memset is passed in as a BV32 or…

### DIFF
--- a/angr/procedures/libc/memset.py
+++ b/angr/procedures/libc/memset.py
@@ -38,8 +38,8 @@ class memset(angr.SimProcedure):
         return r
 
     def run(self, dst_addr, char, num):
-        if char.size() != 8: # sizeof(char)
-            char = self.state.solver.Extract(7, 0, char)
+        if char.size() != self.state.arch.byte_width: # sizeof(char)
+            char = self.state.solver.Extract(self.state.arch.byte_width - 1, 0, char)
 
         if self.state.solver.symbolic(num):
             l.debug("symbolic length")

--- a/angr/procedures/libc/memset.py
+++ b/angr/procedures/libc/memset.py
@@ -38,6 +38,9 @@ class memset(angr.SimProcedure):
         return r
 
     def run(self, dst_addr, char, num):
+        if char.size() != 8: # sizeof(char)
+            char = self.state.solver.Extract(7, 0, char)
+
         if self.state.solver.symbolic(num):
             l.debug("symbolic length")
             max_size = self.state.solver.min_int(num) + self.state.libc.max_buffer_size


### PR DESCRIPTION
… BV64 resulting in writing 4 or 8 times too much data.

Basically what it sounds like, `write_bytes = self.state.solver.Concat(*([ char ] * max_size))` was causing a 4 or 8x over-write because the `char` argument was not actually 8 bits wide. This extracts the char if the size is off. This was happening on arm32, may also happen on other architectures.