### PR TITLE
Strchr: Ensure that the string is long enough to include the found character

### DIFF
--- a/angr/procedures/libc/strchr.py
+++ b/angr/procedures/libc/strchr.py
@@ -30,12 +30,13 @@ class strchr(angr.SimProcedure):
             a = a.annotate(MultiwriteAnnotation())
             self.state.add_constraints(*c)
 
-        if not self.state.solver.is_true(a == 0):
-            # If we found the character we are looking for, we need to
-            # ensure that the string length is long enough to include
-            # the character!
-            chrpos = a - s_addr
-            self.state.add_constraints(chrpos <= s_strlen.ret_expr)
+        # If we found the character we are looking for, we need to
+        # ensure that the string length is long enough to include
+        # the character!
+        chrpos = a - s_addr
+        self.state.add_constraints(self.state.solver.If(a != 0,
+                                                        chrpos <= s_strlen.ret_expr,
+                                                        True))
 
         return a
         #self.state.add_constraints(self.state.solver.ULT(a - s_addr, s_strlen.ret_expr))

--- a/angr/procedures/libc/strchr.py
+++ b/angr/procedures/libc/strchr.py
@@ -30,6 +30,13 @@ class strchr(angr.SimProcedure):
             a = a.annotate(MultiwriteAnnotation())
             self.state.add_constraints(*c)
 
+        if not self.state.solver.is_true(a == 0):
+            # If we found the character we are looking for, we need to
+            # ensure that the string length is long enough to include
+            # the character!
+            chrpos = a - s_addr
+            self.state.add_constraints(chrpos < s_strlen.ret_expr)
+
         return a
         #self.state.add_constraints(self.state.solver.ULT(a - s_addr, s_strlen.ret_expr))
         #self.max_chr_index = max(i)

--- a/angr/procedures/libc/strchr.py
+++ b/angr/procedures/libc/strchr.py
@@ -35,7 +35,7 @@ class strchr(angr.SimProcedure):
             # ensure that the string length is long enough to include
             # the character!
             chrpos = a - s_addr
-            self.state.add_constraints(chrpos < s_strlen.ret_expr)
+            self.state.add_constraints(chrpos <= s_strlen.ret_expr)
 
         return a
         #self.state.add_constraints(self.state.solver.ULT(a - s_addr, s_strlen.ret_expr))


### PR DESCRIPTION
If this constraint is not added, the characters before the found character can be NULL bytes.