### PR TITLE
enable mips for symbion

### DIFF
--- a/angr/project.py
+++ b/angr/project.py
@@ -167,7 +167,7 @@ class Project:
                        "you want to use a concrete target.")
             raise Exception("Incompatible options for the project")
 
-        if self.concrete_target and self.arch.name not in ['X86', 'AMD64', 'ARMHF']:
+        if self.concrete_target and self.arch.name not in ['X86', 'AMD64', 'ARMHF', 'MIPS32']:
             l.critical("Concrete execution does not support yet the selected architecture. Aborting.")
             raise Exception("Incompatible options for the project")
 

--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -133,7 +133,7 @@ class Concrete(SimStatePlugin):
 
         # now we have to register a SimInspect in order to synchronize the segments register
         # on demand when the symbolic execution accesses it
-        if self.state.project.arch.name != 'ARMHF' and not self.segment_registers_callback_initialized:
+        if self.state.project.arch.name in ['X86', 'AMD64'] and not self.segment_registers_callback_initialized:
             segment_register_name = self.state.project.simos.get_segment_register_name()
             if segment_register_name:
                 self.fs_register_bp = self.state.inspect.b('reg_read',


### PR DESCRIPTION
I've made some minor changes to symbion to allow analysis of MIPS architecture binaries, namely:

- Adding MIPS to the allowed list when creating a Project with a concrete_target
- Switching the logic for the concrete state_plugin such that it only deals with segment registers for the architectures which would currently support it through SimOS.

The couple of binaries I've used it on are quite simple so I'm hoping this PR acts as a starting point for whatever other changes may be needed.