### PR TITLE
Fix some bugs in native interface

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -138,6 +138,11 @@ uc_err State::start(address_t pc, uint64_t step) {
 }
 
 void State::stop(stop_t reason, bool do_commit) {
+	if (stopped) {
+		// Do not stop if already stopped. Sometimes, python lands initiates a stop even though native interface has
+		// already stopped leading to multiple issues.
+		return;
+	}
 	stopped = true;
 	stop_details.stop_reason = reason;
 	stop_details.block_addr = curr_block_details.block_addr;

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2512,7 +2512,6 @@ void State::perform_cgc_receive() {
 	if (rx_bytes != 0) {
 		handle_write(rx_bytes, 4, true);
 		if (stopped) {
-			free(tmp_buf);
 			return;
 		}
 		uc_mem_write(uc, rx_bytes, &actual_count, 4);


### PR DESCRIPTION
This PR fixes two bugs in the native interface:

- Double free: A `free` in `receive` implementation can occasionally cause a double free.
- Double stop: In some specific circumstances, a python land syscall hook stops execution in the native interface despite execution having been previously stopped in native interface itself. This results in incorrect stop information being saved leading to further issues.