### PR TITLE
Do not save any memory info for reads from symbolic addresses

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -148,6 +148,7 @@ class SimEngineUnicorn(SuccessorsMixin):
         stop_details = None
 
         for block_details in self.state.unicorn._get_details_of_blocks_with_symbolic_instrs():
+            self.state.scratch.guard = self.state.solver.true
             try:
                 if self.state.os_name == "CGC" and \
                   block_details["block_addr"] in {self.state.unicorn.cgc_random_addr,
@@ -211,7 +212,6 @@ class SimEngineUnicorn(SuccessorsMixin):
                             self.successors.flat_successors.remove(self.state)
                             self.successors.all_successors.remove(self.state)
                             self.successors.successors.remove(self.state)
-                            self.state.scratch.guard = self.state.solver.true
                         else:
                             # There are multiple satisfiable states. Use the state's record of basic blocks executed
                             # and block where native interface stopped to determine which state followed the path traced
@@ -228,7 +228,6 @@ class SimEngineUnicorn(SuccessorsMixin):
                                     self.state = succ
                                     self.successors.flat_successors.remove(succ)
                                     self.successors.successors.remove(succ)
-                                    self.state.scratch.guard = self.state.solver.true
                                     break
                             else:
                                 raise Exception("Multiple valid successor states found but none followed the trace!")

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -191,6 +191,7 @@ struct instr_details_t {
 	int64_t mem_write_size;
 	bool has_concrete_memory_dep;
 	bool has_symbolic_memory_dep;
+	bool has_read_from_symbolic_addr;
 	// Mark fields as mutable so that they can be updated after inserting into std::set
 	mutable memory_value_t *memory_values;
 	mutable uint64_t memory_values_count;
@@ -200,6 +201,7 @@ struct instr_details_t {
 	instr_details_t() {
 		has_concrete_memory_dep = false;
 		has_symbolic_memory_dep = false;
+		has_read_from_symbolic_addr = false;
 		instr_deps.clear();
 		mem_write_addr = -1;
 		mem_write_size = -1;


### PR DESCRIPTION
Previously, information about memory reads from symbolic addresses were also saved for re-executing later on when performing tracing. This resulted in some constraints not being added to solver, thus slowing some constraint solving/concretization. This PR fixes this issue by not saving any information about such reads.