### PR TITLE
Use python's native warning system for deprecation warnings

### DIFF
--- a/angr/misc/ux.py
+++ b/angr/misc/ux.py
@@ -1,3 +1,6 @@
+import warnings
+
+
 once_set = set()
 
 def once(key):
@@ -15,9 +18,9 @@ def deprecated(replacement=None):
         def inner(*args, **kwargs):
             if func not in already_complained:
                 if replacement is None:
-                    print("\x1b[31;1mDeprecation warning: Don't use %s\x1b[0m" % (func.__name__))
+                    warnings.warn("Don't use %s" % (func.__name__), DeprecationWarning)
                 else:
-                    print("\x1b[31;1mDeprecation warning: Use %s instead of %s\x1b[0m" % (replacement, func.__name__))
+                    warnings.warn("Use %s instead of %s" % (replacement, func.__name__), DeprecationWarning)
                 already_complained.add(func)
             return func(*args, **kwargs)
         return inner


### PR DESCRIPTION
There is a behavior change with this, namely that python ignores `DeprecationWarnings` by default if they are not triggered directly by `__main__`, per [docs](https://docs.python.org/3/library/warnings.html#default-warning-filter). However, this improves standardization and user control by allowing it to be disabled.