### PR TITLE
Do not compute concrete bytes of input fds in unicorn engine to pass to native interface

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -359,7 +359,8 @@ class SimEngineUnicorn(SuccessorsMixin):
         # initialize unicorn plugin
         try:
             syscall_data = kwargs["syscall_data"] if "syscall_data" in kwargs else None
-            state.unicorn.setup(syscall_data=syscall_data)
+            fd_bytes = kwargs["fd_bytes"] if "fd_bytes" in kwargs else None
+            state.unicorn.setup(syscall_data=syscall_data, fd_bytes=fd_bytes)
         except SimValueError:
             # it's trying to set a symbolic register somehow
             # fail out, force fallback to next engine

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1168,7 +1168,7 @@ class Unicorn(SimStatePlugin):
                 read_pos = self.state.solver.eval(self.state.posix.fd.get(fd_num).read_pos)
                 _UC_NATIVE.set_fd_bytes(self._uc_state, fd_num, fd_bytes_p, len(fd_data), read_pos)
         else:
-            l.warning("Input fds concrete data not specified. Handling some syscalls in native interface could fail.")
+            l.info("Input fds concrete data not specified. Handling some syscalls in native interface could fail.")
 
         # Initialize list of artificial VEX registers
         artificial_regs_list = self.state.arch.artificial_registers_offsets

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1167,6 +1167,8 @@ class Unicorn(SimStatePlugin):
                 fd_bytes_p = int(ffi.cast('uint64_t', ffi.from_buffer(memoryview(fd_data))))
                 read_pos = self.state.solver.eval(self.state.posix.fd.get(fd_num).read_pos)
                 _UC_NATIVE.set_fd_bytes(self._uc_state, fd_num, fd_bytes_p, len(fd_data), read_pos)
+        else:
+            l.warning("No concrete data specified for input fds. Some syscalls may not be handled in native interface if requested.")
 
         # Initialize list of artificial VEX registers
         artificial_regs_list = self.state.arch.artificial_registers_offsets

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -32,6 +32,9 @@ def tracer_cgc(filename, test_name, stdin, copy_states=False, follow_unsat=False
         follow_unsat=follow_unsat,
         syscall_data=syscall_data,
     )
+    if angr.options.UNICORN_HANDLE_CGC_RECEIVE_SYSCALL in add_options:
+        t.set_fd_data({0: stdin})
+
     simgr.use_technique(t)
     simgr.use_technique(angr.exploration_techniques.Oppologist())
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -32,7 +32,7 @@ def tracer_cgc(filename, test_name, stdin, copy_states=False, follow_unsat=False
         follow_unsat=follow_unsat,
         syscall_data=syscall_data,
     )
-    if angr.options.UNICORN_HANDLE_CGC_RECEIVE_SYSCALL in add_options:
+    if add_options is not None and angr.options.UNICORN_HANDLE_CGC_RECEIVE_SYSCALL in add_options:
         t.set_fd_data({0: stdin})
 
     simgr.use_technique(t)


### PR DESCRIPTION
Currently, the unicorn engine computes the concrete bytes of input fds by concretizing the preconstrained stdin each time so that syscalls can be handled in native interface. This concretization adds a lot of computation overhead that can be avoided since the concrete bytes are known at start and thus, can be simply passed directly to tracer.

I could use some feedback on the implementation. I could not find a way archr's QEMU tracer could access the concrete bytes(they seem to be passed as an action and not raw bytes?) and thus, pass it to tracer exploration technique directly. That's why I created a new function to set the concrete bytes. Does this seem intuitive? Can this be implemented in a better way?