### PR TITLE
Fix package description in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,7 @@ classifiers =
     Programming Language :: Python :: 3.6
 license = BSD 2 Clause
 license_files = LICENSE
-description = |
-    A multi-architecture binary analysis toolkit, with the ability to perform\
-    dynamic symbolic execution and various static analyses on binaries
+description = A multi-architecture binary analysis toolkit, with the ability to perform dynamic symbolic execution and various static analyses on binaries
 long_description = file: README.md
 long_description_content_type = text/markdown
 


### PR DESCRIPTION
YAML-style multi-line strings are not permitted in the format used by setup.cfg, so this just makes it a long line..