### PR TITLE
Cache RDA used in Clinic (AILSimplifier) for Analyses

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -19,6 +19,7 @@ from ...procedures.stubs.UnresolvableCallTarget import UnresolvableCallTarget
 from ...procedures.stubs.UnresolvableJumpTarget import UnresolvableJumpTarget
 from .. import Analysis, register_analysis
 from ..cfg.cfg_base import CFGBase
+from ..reaching_definitions import ReachingDefinitionsAnalysis
 from .ailgraph_walker import AILGraphWalker
 from .ailblock_walker import AILBlockWalker
 from .optimization_passes import get_default_optimization_passes, OptimizationPassStage
@@ -70,6 +71,7 @@ class Clinic(Analysis):
         self.peephole_optimizations = peephole_optimizations
         self._must_struct = must_struct
         self._reset_variable_names = reset_variable_names
+        self.reaching_definitions: Optional['ReachingDefinitionsAnalysis'] = None
         self._cache = cache
 
         # sanity checks
@@ -449,6 +451,9 @@ class Clinic(Analysis):
             stack_arg_offsets=stack_arg_offsets,
             ail_manager=self._ail_manager,
         )
+        # cache the simplifier's RDA analysis
+        self.reaching_definitions = simp._reaching_definitions
+
         # the function graph has been updated at this point
         return simp.simplified
 

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -71,7 +71,7 @@ class Clinic(Analysis):
         self.peephole_optimizations = peephole_optimizations
         self._must_struct = must_struct
         self._reset_variable_names = reset_variable_names
-        self.reaching_definitions: Optional['ReachingDefinitionsAnalysis'] = None
+        self.reaching_definitions: Optional[ReachingDefinitionsAnalysis] = None
         self._cache = cache
 
         # sanity checks

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -143,7 +143,7 @@ class Decompiler(Analysis):
         self.cache.clinic = self.clinic
 
     @timethis
-    def _run_region_simplification_passes(self, ail_graph, ri, reaching_defenitions):
+    def _run_region_simplification_passes(self, ail_graph, ri, reaching_definitions):
         """
         Runs optimizations that should be executed after a single region identification. This function will return
         two items: the new RegionIdentifier object and the new AIL Graph, which should probably be written
@@ -176,7 +176,7 @@ class Decompiler(Analysis):
 
             analysis = getattr(self.project.analyses, pass_.__name__)
             a = analysis(self.func, blocks_by_addr=addr_to_blocks, blocks_by_addr_and_idx=addr_and_idx_to_blocks,
-                         graph=ail_graph, region_identifier=ri, reaching_defenitions=reaching_defenitions)
+                         graph=ail_graph, region_identifier=ri, reaching_definitions=reaching_definitions)
 
             # should be None if no changes
             if a.out_graph:

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -116,7 +116,7 @@ class Decompiler(Analysis):
         # recover regions
         ri = self.project.analyses.RegionIdentifier(self.func, graph=clinic.graph, cond_proc=cond_proc, kb=self.kb)
         # run optimizations that may require re-RegionIdentification
-        self.clinic.graph, ri = self._run_region_simplification_passes(clinic.graph, ri)
+        self.clinic.graph, ri = self._run_region_simplification_passes(clinic.graph, ri, clinic.reaching_definitions)
         self._update_progress(75., text='Structuring code')
 
         # structure it
@@ -143,7 +143,7 @@ class Decompiler(Analysis):
         self.cache.clinic = self.clinic
 
     @timethis
-    def _run_region_simplification_passes(self, ail_graph, ri):
+    def _run_region_simplification_passes(self, ail_graph, ri, reaching_defenitions):
         """
         Runs optimizations that should be executed after a single region identification. This function will return
         two items: the new RegionIdentifier object and the new AIL Graph, which should probably be written
@@ -154,9 +154,9 @@ class Decompiler(Analysis):
 
         @param ail_graph:   DiGraph with AIL Statements
         @param ri:          RegionIdentifier
+        @param reaching_defenitions: ReachingDefenitionAnalysis
         @return:            The possibly new AIL DiGraph and RegionIdentifier
         """
-        cond_proc = ri.cond_proc
         addr_and_idx_to_blocks: Dict[Tuple[int, Optional[int]], ailment.Block] = {}
         addr_to_blocks: Dict[int, Set[ailment.Block]] = defaultdict(set)
 
@@ -176,12 +176,14 @@ class Decompiler(Analysis):
 
             analysis = getattr(self.project.analyses, pass_.__name__)
             a = analysis(self.func, blocks_by_addr=addr_to_blocks, blocks_by_addr_and_idx=addr_and_idx_to_blocks,
-                         graph=ail_graph, region_identifier=ri)
+                         graph=ail_graph, region_identifier=ri, reaching_defenitions=reaching_defenitions)
 
             # should be None if no changes
             if a.out_graph:
                 # use the new graph
                 ail_graph = a.out_graph
+
+                cond_proc = ConditionProcessor(self.project.arch)
                 # always update RI on graph change
                 ri = self.project.analyses.RegionIdentifier(self.func, graph=ail_graph, cond_proc=cond_proc,
                                                             kb=self.kb)

--- a/angr/analyses/decompiler/optimization_passes/eager_returns.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_returns.py
@@ -50,6 +50,7 @@ class EagerReturnsSimplifier(OptimizationPass):
         self.max_level = max_level
         self.min_indegree = min_indegree
         self.node_idx = count(start=node_idx_start)
+        self._ri = kwargs.get("region_identifier", None)
 
         self.analyze()
 

--- a/angr/analyses/decompiler/optimization_passes/eager_returns.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_returns.py
@@ -42,7 +42,8 @@ class EagerReturnsSimplifier(OptimizationPass):
                  # settings
                  max_level=2,
                  min_indegree=2,
-                 **kwargs):
+                 region_identifier=None,
+                 reaching_definitions=None):
 
         super().__init__(func, blocks_by_addr=blocks_by_addr, blocks_by_addr_and_idx=blocks_by_addr_and_idx,
                          graph=graph)
@@ -50,7 +51,8 @@ class EagerReturnsSimplifier(OptimizationPass):
         self.max_level = max_level
         self.min_indegree = min_indegree
         self.node_idx = count(start=node_idx_start)
-        self._ri = kwargs.get("region_identifier", None)
+        self._ri = region_identifier
+        self._rd = reaching_definitions
 
         self.analyze()
 

--- a/angr/analyses/decompiler/optimization_passes/eager_returns.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_returns.py
@@ -42,7 +42,7 @@ class EagerReturnsSimplifier(OptimizationPass):
                  # settings
                  max_level=2,
                  min_indegree=2,
-                 region_identifier=None):
+                 **kwargs):
 
         super().__init__(func, blocks_by_addr=blocks_by_addr, blocks_by_addr_and_idx=blocks_by_addr_and_idx,
                          graph=graph)
@@ -50,7 +50,6 @@ class EagerReturnsSimplifier(OptimizationPass):
         self.max_level = max_level
         self.min_indegree = min_indegree
         self.node_idx = count(start=node_idx_start)
-        self._ri = region_identifier
 
         self.analyze()
 


### PR DESCRIPTION
## Why?
This PR is actually related to #3334, since it is about opening up more of the internal API of RegionIdentifier and Clinic. While Clinic is running is it uses ReachingDefenition analysis through AILSimplifier. After the simplifier is in its last pass, it has the most up to date RDA computed. For analyses down the line, this can save a lot of time since RDA is costly. This PR grabs the final ReachingDefenitionsAnalysis computed in AILSimplifier and makes it a public property in Clinc, allowing optimizations to use it in the future. 