### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: >
+            This issue has been marked as `stale` because it has no recent activity.
+            Please comment or add the `pinned` tag to prevent this issue from being closed.
+          stale-pr-message: >
+            This pull request has been marked as `stale` because it has no recent activity.
+            Please comment or add the `pinned` tag to prevent this issue from being closed.
+          close-issue-message: >
+            This issue has been closed due to inactivity.
+          close-pr-message: >
+            This issue has been closed due to inactivity.
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: 'pinned'
+          exempt-pr-labels: 'pinned'


### PR DESCRIPTION
This workflow will automatically mark issues and PRs as stale after 60 days of inactivity, and then close issues 7 days after that. Adding a `pinned` label will prevent an issue/PR from becoming stale. All values are configurable if we believe these periods are too short or long. There is a default maximum of 30 items per day to avoid hitting API limits, so this should take a few weeks to go through the existing backlog.