### PR TITLE
Fine grained slicing in native interface

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -147,7 +147,7 @@ class SimEngineUnicorn(SuccessorsMixin):
         recent_bbl_addrs = None
         stop_details = None
 
-        for block_details in self.state.unicorn._get_details_of_blocks_with_symbolic_instrs():
+        for block_details in self.state.unicorn._get_details_of_blocks_with_symbolic_vex_stmts():
             self.state.scratch.guard = self.state.solver.true
             try:
                 if self.state.os_name == "CGC" and \
@@ -238,7 +238,7 @@ class SimEngineUnicorn(SuccessorsMixin):
     def _get_vex_block_details(self, block_addr, block_size):
         # Mostly based on the lifting code in HeavyVEXMixin
         # pylint:disable=no-member
-        irsb = super().lift_vex(addr=block_addr, state=self.state, size=block_size, cross_insn_opt=False)
+        irsb = super().lift_vex(addr=block_addr, state=self.state, size=block_size)
         if irsb.size == 0:
             if irsb.jumpkind == 'Ijk_NoDecode':
                 if not self.state.project.is_hooked(irsb.addr):

--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -98,8 +98,6 @@ class SimEngineUnicorn(SuccessorsMixin):
         else:
             vex_block = self.block_details_cache[block_details["block_addr"]]
 
-        self.vex_state_addr = block_details["block_addr"]
-
         # Save breakpoints for restoring later
         saved_mem_read_breakpoints = copy.copy(self.state.inspect._breakpoints["mem_read"])
         for reg_name, reg_value in block_details["registers"]:

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -408,7 +408,8 @@ def _load_native():
             getattr(handle, func).argtypes = argtypes
 
         #_setup_prototype_explicit(h, 'logSetLogLevel', None, ctypes.c_uint64)
-        _setup_prototype(h, 'alloc', state_t, uc_engine_t, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_bool, ctypes.c_bool)
+        _setup_prototype(h, 'alloc', state_t, uc_engine_t, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_bool,
+                         ctypes.c_bool)
         _setup_prototype(h, 'dealloc', None, state_t)
         _setup_prototype(h, 'hook', None, state_t)
         _setup_prototype(h, 'unhook', None, state_t)
@@ -443,7 +444,8 @@ def _load_native():
                          ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'set_artificial_registers', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'get_count_of_blocks_with_symbolic_vex_stmts', ctypes.c_uint64, state_t)
-        _setup_prototype(h, 'get_details_of_blocks_with_symbolic_vex_stmts', None, state_t, ctypes.POINTER(BlockDetails))
+        _setup_prototype(h, 'get_details_of_blocks_with_symbolic_vex_stmts', None, state_t,
+                         ctypes.POINTER(BlockDetails))
         _setup_prototype(h, 'get_stop_details', StopDetails, state_t)
         _setup_prototype(h, 'set_register_blacklist', None, state_t, ctypes.POINTER(ctypes.c_uint64), ctypes.c_uint64)
         _setup_prototype(h, 'set_cpu_flags_details', None, state_t, ctypes.POINTER(ctypes.c_uint64),

--- a/native/angr_native.def
+++ b/native/angr_native.def
@@ -29,8 +29,8 @@ EXPORTS
   simunicorn_set_tracking
   simunicorn_executed_pages
   simunicorn_in_cache
-  simunicorn_get_count_of_blocks_with_symbolic_instrs
-  simunicorn_get_details_of_blocks_with_symbolic_instrs
+  simunicorn_get_count_of_blocks_with_symbolic_vex_stmts
+  simunicorn_get_details_of_blocks_with_symbolic_vex_stmts
   simunicorn_get_stop_details
   simunicorn_set_artificial_registers
   simunicorn_set_cpu_flags_details

--- a/native/angr_native.def
+++ b/native/angr_native.def
@@ -41,3 +41,4 @@ EXPORTS
   simunicorn_process_transmit
   simunicorn_set_fd_bytes
   simunicorn_set_random_syscall_data
+  simunicorn_set_vex_cc_reg_data

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1220,7 +1220,7 @@ void State::get_register_value(uint64_t vex_reg_offset, uint8_t *out_reg_value) 
 		else {
 			// The flag is not 0 so we shift right until first non-zero bit is in LSB so that value of flag register
 			// will be set correctly when re-executing
-			for (int i = 1; i < MAX_REGISTER_BYTE_SIZE && (reg_value & 1 == 0); i++) {
+			for (int i = 1; i < MAX_REGISTER_BYTE_SIZE && ((reg_value & 1) == 0); i++) {
 				reg_value >>= i;
 			}
 			memcpy(out_reg_value, (uint8_t *)&reg_value, MAX_REGISTER_BYTE_SIZE);

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -811,7 +811,7 @@ void State::compute_slice_of_stmt(vex_stmt_details_t &stmt) {
 					stmt.reg_deps.insert(dep_reg_val);
 				}
 				else {
-					assert(false && "[sim_unicorn] Dependency register not saved at block start. Please create a bug with repro instructions.");
+					assert(false && "[sim_unicorn] Dependency register not saved at block start. Please report a bug with repro instructions.");
 				}
 			}
 		}

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -782,7 +782,7 @@ void State::compute_slice_of_stmt(vex_stmt_details_t &stmt) {
 
 	auto &stmt_taint_entry = block_taint_entry.block_stmts_taint_data.at(stmt.stmt_idx);
 	for (auto &source: stmt_taint_entry.sources) {
-		if (source.stmt_idx != -1) {
+		if (source.entity_type == TAINT_ENTITY_TMP) {
 			stmts_to_process.emplace_back(source.stmt_idx);
 		}
 		else if ((source.entity_type == TAINT_ENTITY_REG) && is_valid_dependency_register(source.reg_offset)) {

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -817,6 +817,15 @@ void State::compute_slice_of_stmt(vex_stmt_details_t &stmt) {
 		}
 	}
 
+	// If statement performs a memory store, compute slice to set up the write address correctly.
+	if (stmt_taint_entry.sink.entity_type == TAINT_ENTITY_MEM) {
+		for (auto &source: stmt_taint_entry.sink.mem_ref_entity_list) {
+			// TODO: Are addresses for memory writes always stored in VEX temps?
+			assert(source.entity_type == TAINT_ENTITY_TMP);
+			stmts_to_process.emplace_back(source.stmt_idx);
+		}
+	}
+
 	for (auto &dep_stmt_idx: stmts_to_process) {
 		auto &dep_stmt_taint_entry = block_taint_entry.block_stmts_taint_data.at(dep_stmt_idx);
 		vex_stmt_details_t dep_stmt_details = compute_vex_stmt_details(dep_stmt_taint_entry);

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1574,7 +1574,7 @@ void State::propagate_taints() {
 	// We continue propagating taint until we encounter 1) a memory read, 2) end of block or
 	// 3) a stop state for concrete execution
 	for (auto curr_stmt_idx = taint_engine_next_stmt_idx; curr_stmt_idx < total_stmt_count && !stopped; ++curr_stmt_idx) {
-		auto &curr_stmt_taint_data = block_taint_entry.block_stmts_taint_data.at(taint_engine_next_stmt_idx);
+		auto &curr_stmt_taint_data = block_taint_entry.block_stmts_taint_data.at(curr_stmt_idx);
 		address_t curr_instr_addr = curr_stmt_taint_data.sink.instr_addr;
 		if (curr_stmt_taint_data.has_memory_read) {
 			// Pause taint propagation to process the memory read and continue from instruction

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -815,6 +815,14 @@ void State::compute_slice_of_stmt(vex_stmt_details_t &stmt) {
 				}
 			}
 		}
+		else if (source.entity_type == TAINT_ENTITY_MEM) {
+			// Compute slice to set up the read address correctly
+			for (auto &mem_ref_entity: source.mem_ref_entity_list) {
+				// TODO: Are addresses for memory reads always stored in VEX temps?
+				assert(mem_ref_entity.entity_type == TAINT_ENTITY_TMP);
+				stmts_to_process.emplace_back(mem_ref_entity.stmt_idx);
+			}
+		}
 	}
 
 	// If statement performs a memory store, compute slice to set up the write address correctly.

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -178,7 +178,7 @@ void State::stop(stop_t reason, bool do_commit) {
 			sym_stmt.stmt_idx = stmt.stmt_idx;
 			sym_stmt.memory_values = stmt.memory_values;
 			sym_stmt.memory_values_count = stmt.memory_values_count;
-			sym_stmt.has_memory_dep = stmt.has_concrete_memory_dep || (stmt.has_symbolic_memory_dep && !stmt.has_read_from_symbolic_addr);
+			sym_stmt.has_memory_dep = stmt.has_concrete_memory_dep;
 			sym_block.symbolic_stmts.emplace_back(sym_stmt);
 		}
 		block_details_to_return.emplace_back(sym_block);

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -690,7 +690,7 @@ void State::handle_write(address_t address, int size, bool is_interrupt = false,
 	if (is_dst_symbolic && !is_interrupt) {
 		// Save the details of memory location written to in the statement details
 		for (auto &symbolic_stmt: curr_block_details.symbolic_stmts) {
-			if (symbolic_stmt.instr_addr == curr_instr_addr) {
+			if ((symbolic_stmt.instr_addr == curr_instr_addr) && symbolic_stmt.has_memory_write) {
 				symbolic_stmt.mem_write_addr = address;
 				symbolic_stmt.mem_write_size = size;
 				break;
@@ -1866,6 +1866,7 @@ void State::propagate_taint_of_one_stmt(const vex_stmt_taint_entry_t &vex_stmt_t
 	is_stmt_symbolic = false;
 	vex_stmt_details = compute_vex_stmt_details(vex_stmt_taint_entry);
 	if (taint_sink.entity_type == TAINT_ENTITY_MEM) {
+		vex_stmt_details.has_memory_write = true;
 		auto addr_taint_status = get_final_taint_status(taint_sink.mem_ref_entity_list);
 		// Check if address written to is symbolic or is read from memory
 		if (addr_taint_status != TAINT_STATUS_CONCRETE) {

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -786,7 +786,7 @@ void State::compute_slice_of_stmt(vex_stmt_details_t &stmt) {
 			stmts_to_process.emplace_back(source.stmt_idx);
 		}
 		else if ((source.entity_type == TAINT_ENTITY_REG) && is_valid_dependency_register(source.reg_offset) &&
-		  !is_symbolic_register(source.reg_offset, source.value_size, false)) {
+		  !is_symbolic_register(source.reg_offset, source.value_size)) {
 			// Source is a register dependency that is not modified from start of block till this instruction.
 			register_value_t dep_reg_val;
 			dep_reg_val.offset = source.reg_offset;
@@ -1531,50 +1531,44 @@ void State::mark_register_concrete(vex_reg_offset_t reg_offset, int64_t reg_size
 	return;
 }
 
-bool State::is_symbolic_register(vex_reg_offset_t reg_offset, int64_t reg_size, bool with_block_changes) const {
+bool State::is_symbolic_register(vex_reg_offset_t reg_offset, int64_t reg_size) const {
 	// We check if this register is symbolic or concrete in the block level taint statuses since
 	// those are more recent. If not found in either, check the state's symbolic register list.
 	// TODO: Is checking only first byte of artificial and blacklisted registers to determine if they are symbolic fine
 	// or should all be checked?
 	if ((cpu_flags.find(reg_offset) != cpu_flags.end()) || (artificial_vex_registers.count(reg_offset) > 0)
-	  || (blacklisted_registers.count(reg_offset) > 0)) {
-		if (with_block_changes) {
-			// Check if taint status changes when block is executed
-			if (block_symbolic_registers.count(reg_offset) > 0) {
-				return true;
-			}
-			else if (block_concrete_registers.count(reg_offset) > 0) {
-				return false;
-			}
+	    || (blacklisted_registers.count(reg_offset) > 0)) {
+		if (block_symbolic_registers.count(reg_offset) > 0) {
+			return true;
 		}
-		if (symbolic_registers.count(reg_offset) > 0) {
+		else if (block_concrete_registers.count(reg_offset) > 0) {
+			return false;
+		}
+		else if (symbolic_registers.count(reg_offset) > 0) {
 			return true;
 		}
 		return false;
 	}
 	// The register is not a CPU flag and so we check every byte of the register
-	if (with_block_changes) {
-		for (auto i = 0; i < reg_size; i++) {
-			// If any of the register's bytes are symbolic, we deem the register to be symbolic
-			if (block_symbolic_registers.count(reg_offset + i) > 0) {
-				return true;
-			}
-		}
-		bool is_concrete = true;
-		for (auto i = 0; i < reg_size; i++) {
-			if (block_concrete_registers.count(reg_offset) == 0) {
-				is_concrete = false;
-				break;
-			}
-		}
-		if (is_concrete) {
-			// All bytes of register are concrete and so the register is concrete
-			return false;
+	for (auto i = 0; i < reg_size; i++) {
+		// If any of the register's bytes are symbolic, we deem the register to be symbolic
+		if (block_symbolic_registers.count(reg_offset + i) > 0) {
+			return true;
 		}
 	}
-	// If we reach here, it means that either the register is not marked symbolic or concrete in the block
-	// level taint status tracker or any changes to taint when executing the block should be ignored. We check the
-	// state's symbolic register list.
+	bool is_concrete = true;
+	for (auto i = 0; i < reg_size; i++) {
+		if (block_concrete_registers.count(reg_offset) == 0) {
+			is_concrete = false;
+			break;
+		}
+	}
+	if (is_concrete) {
+		// All bytes of register are concrete and so the register is concrete
+		return false;
+	}
+	// If we reach here, it means that the register is not marked symbolic or concrete in the block
+	// level taint status tracker. We check the state's symbolic register list.
 	for (auto i = 0; i < reg_size; i++) {
 		if (symbolic_registers.count(reg_offset + i) > 0) {
 			return true;

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -785,7 +785,8 @@ void State::compute_slice_of_stmt(vex_stmt_details_t &stmt) {
 		if (source.entity_type == TAINT_ENTITY_TMP) {
 			stmts_to_process.emplace_back(source.stmt_idx);
 		}
-		else if ((source.entity_type == TAINT_ENTITY_REG) && is_valid_dependency_register(source.reg_offset)) {
+		else if ((source.entity_type == TAINT_ENTITY_REG) && is_valid_dependency_register(source.reg_offset) &&
+		  !is_symbolic_register(source.reg_offset, source.value_size)) {
 			// Source is a register dependency that is not modified from start of block till this instruction.
 			register_value_t dep_reg_val;
 			dep_reg_val.offset = source.reg_offset;

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2001,8 +2001,9 @@ void State::propagate_taint_of_one_stmt(const vex_stmt_taint_entry_t &vex_stmt_t
 				}
 			}
 		}
-		curr_block_details.symbolic_stmts.emplace_back(vex_stmt_details);
-	}
+		if ((taint_sink.entity_type == TAINT_ENTITY_REG) || (taint_sink.entity_type == TAINT_ENTITY_MEM)) {
+			curr_block_details.symbolic_stmts.emplace_back(vex_stmt_details);
+		}
 	return;
 }
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2029,13 +2029,22 @@ void State::propagate_taint_of_one_stmt(const vex_stmt_taint_entry_t &vex_stmt_t
 		// touch a VEX CC register as symbolic for correct re-execution
 		else {
 			curr_block_details.marks_vex_cc_reg_symbolic = true;
-			for (auto &stmt_detail: curr_block_details.vex_cc_reg_setter_details) {
-				auto sym_stmt_it = curr_block_details.symbolic_stmts.begin();
-				auto sym_stmt_it_end = curr_block_details.symbolic_stmts.end();
-				for (; sym_stmt_it != sym_stmt_it_end; sym_stmt_it++) {
-					if (stmt_detail.stmt_idx < sym_stmt_it->stmt_idx) {
-						curr_block_details.symbolic_stmts.insert(sym_stmt_it - 1, stmt_detail);
-						break;
+			if (curr_block_details.symbolic_stmts.size() == 0) {
+				// There are no symbolic statements. Simply insert all VEX CC register setters into list of symbolic
+				// statements.
+				curr_block_details.symbolic_stmts.insert(curr_block_details.symbolic_stmts.end(),
+					curr_block_details.vex_cc_reg_setter_details.begin(),
+					curr_block_details.vex_cc_reg_setter_details.end());
+			}
+			else {
+				for (auto &stmt_detail: curr_block_details.vex_cc_reg_setter_details) {
+					auto sym_stmt_it = curr_block_details.symbolic_stmts.begin();
+					auto sym_stmt_it_end = curr_block_details.symbolic_stmts.end();
+					for (; sym_stmt_it != sym_stmt_it_end; sym_stmt_it++) {
+						if (stmt_detail.stmt_idx < sym_stmt_it->stmt_idx) {
+							curr_block_details.symbolic_stmts.insert(sym_stmt_it - 1, stmt_detail);
+							break;
+						}
 					}
 				}
 			}

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -256,14 +256,6 @@ void State::commit() {
 	mem_writes.clear();
 	cur_steps++;
 
-	// Sync all block level taint statuses reads with state's taint statuses and block level
-	// symbolic instruction list with state's symbolic instruction list
-	for (auto &reg_offset: block_symbolic_registers) {
-		symbolic_registers.emplace(reg_offset);
-	}
-	for (auto &reg_offset: block_concrete_registers) {
-		symbolic_registers.erase(reg_offset);
-	}
 	// Remove instructions whose effects are overwritten by subsequent instructions from the re-execute list
 	std::vector<std::vector<block_details_t>::iterator> blocks_to_erase_it;
 	for (auto &stmts_to_erase_entry: symbolic_stmts_to_erase) {
@@ -296,6 +288,14 @@ void State::commit() {
 	}
 	if (curr_block_details.block_addr == trace_last_block_addr) {
 		trace_last_block_curr_count += 1;
+	}
+	// Sync all block level taint statuses reads with state's taint statuses and block level
+	// symbolic instruction list with state's symbolic instruction list
+	for (auto &reg_offset: block_symbolic_registers) {
+		symbolic_registers.emplace(reg_offset);
+	}
+	for (auto &reg_offset: block_concrete_registers) {
+		symbolic_registers.erase(reg_offset);
 	}
 	// Clear all block level taint status trackers and symbolic instruction list
 	block_symbolic_registers.clear();

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2120,26 +2120,26 @@ void State::continue_propagating_taint() {
 	return;
 }
 
-void State::save_concrete_memory_deps(vex_stmt_details_t &instr) {
-	if (instr.has_concrete_memory_dep || (instr.has_symbolic_memory_dep && !instr.has_read_from_symbolic_addr)) {
-		archived_memory_values.emplace_back(block_mem_reads_map.at(instr.stmt_idx).memory_values);
-		instr.memory_values = &(archived_memory_values.back()[0]);
-		instr.memory_values_count = archived_memory_values.back().size();
+void State::save_concrete_memory_deps(vex_stmt_details_t &vex_stmt_det) {
+	if (vex_stmt_det.has_concrete_memory_dep || (vex_stmt_det.has_symbolic_memory_dep && !vex_stmt_det.has_read_from_symbolic_addr)) {
+		archived_memory_values.emplace_back(block_mem_reads_map.at(vex_stmt_det.stmt_idx).memory_values);
+		vex_stmt_det.memory_values = &(archived_memory_values.back()[0]);
+		vex_stmt_det.memory_values_count = archived_memory_values.back().size();
 	}
-	std::queue<std::set<vex_stmt_details_t>::iterator> instrs_to_process;
-	for (auto it = instr.stmt_deps.begin(); it != instr.stmt_deps.end(); it++) {
-		instrs_to_process.push(it);
+	std::queue<std::set<vex_stmt_details_t>::iterator> vex_stmts_to_process;
+	for (auto it = vex_stmt_det.stmt_deps.begin(); it != vex_stmt_det.stmt_deps.end(); it++) {
+		vex_stmts_to_process.push(it);
 	}
-	while (!instrs_to_process.empty()) {
-		auto &curr_stmt = instrs_to_process.front();
+	while (!vex_stmts_to_process.empty()) {
+		auto &curr_stmt = vex_stmts_to_process.front();
 		if (curr_stmt->has_concrete_memory_dep) {
 			archived_memory_values.emplace_back(block_mem_reads_map.at(curr_stmt->stmt_idx).memory_values);
 			curr_stmt->memory_values = &(archived_memory_values.back()[0]);
 			curr_stmt->memory_values_count = archived_memory_values.back().size();
 		}
-		instrs_to_process.pop();
+		vex_stmts_to_process.pop();
 		for (auto it = curr_stmt->stmt_deps.begin(); it != curr_stmt->stmt_deps.end(); *it++) {
-			instrs_to_process.push(it);
+			vex_stmts_to_process.push(it);
 		}
 	}
 	return;

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -826,6 +826,13 @@ void State::compute_slice_of_stmt(vex_stmt_details_t &stmt) {
 		}
 	}
 
+	for (auto &entity: stmt_taint_entry.ite_cond_entity_list) {
+		// Compute slice for VEX temps used in condition of ITE expression
+		// TODO: Do ITE conditions contain only VEX temps?
+		assert(entity.entity_type == TAINT_ENTITY_TMP);
+		stmts_to_process.emplace_back(entity.stmt_idx);
+	}
+
 	// If statement performs a memory store, compute slice to set up the write address correctly.
 	if (stmt_taint_entry.sink.entity_type == TAINT_ENTITY_MEM) {
 		for (auto &source: stmt_taint_entry.sink.mem_ref_entity_list) {

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -379,7 +379,7 @@ struct vex_stmt_taint_entry_t {
 };
 
 struct block_taint_entry_t {
-	std::vector<vex_stmt_taint_entry_t> block_stmts_taint_data;
+	std::map<uint32_t, vex_stmt_taint_entry_t> block_stmts_taint_data;
 	std::unordered_set<taint_entity_t> exit_stmt_guard_expr_deps;
 	bool has_cpuid_instr;
 	bool has_unsupported_stmt_or_expr_type;

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -379,7 +379,7 @@ struct vex_stmt_taint_entry_t {
 };
 
 struct block_taint_entry_t {
-	std::map<uint32_t, vex_stmt_taint_entry_t> block_stmts_taint_data;
+	std::map<int64_t, vex_stmt_taint_entry_t> block_stmts_taint_data;
 	std::unordered_set<taint_entity_t> exit_stmt_guard_expr_deps;
 	bool has_cpuid_instr;
 	bool has_unsupported_stmt_or_expr_type;
@@ -540,7 +540,8 @@ class State {
 	int64_t trace_last_block_curr_count;
 	int64_t trace_last_block_tot_count;
 
-	address_t taint_engine_next_stmt_idx, taint_engine_stop_mem_read_instruction;
+	address_t taint_engine_stop_mem_read_instruction;
+	int64_t taint_engine_next_stmt_idx;
 	uint32_t taint_engine_stop_mem_read_size;
 	bool symbolic_read_in_progress;
 

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -215,17 +215,17 @@ struct vex_stmt_details_t {
 		reg_deps.clear();
 	}
 
-	bool operator==(const vex_stmt_details_t &other_instr) const {
-		if ((instr_addr != other_instr.instr_addr) || (has_concrete_memory_dep != other_instr.has_concrete_memory_dep) ||
-			(has_symbolic_memory_dep != other_instr.has_symbolic_memory_dep) || (stmt_deps != other_instr.stmt_deps) ||
-			(reg_deps != other_instr.reg_deps)) {
+	bool operator==(const vex_stmt_details_t &other_stmt) const {
+		if ((instr_addr != other_stmt.instr_addr) || (stmt_idx != other_stmt.stmt_idx) ||
+			(has_concrete_memory_dep != other_stmt.has_concrete_memory_dep) || (reg_deps != other_stmt.reg_deps) ||
+			(has_symbolic_memory_dep != other_stmt.has_symbolic_memory_dep) || (stmt_deps != other_stmt.stmt_deps)) {
 				return false;
 		}
 		return true;
 	}
 
-	bool operator<(const vex_stmt_details_t &other_instr) const {
-		return (instr_addr < other_instr.instr_addr);
+	bool operator<(const vex_stmt_details_t &other_stmt) const {
+		return (instr_addr < other_stmt.instr_addr) || (stmt_idx < other_stmt.stmt_idx);
 	}
 };
 

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -620,7 +620,7 @@ class State {
 
 	bool is_block_exit_guard_symbolic() const;
 	bool is_block_next_target_symbolic() const;
-	bool is_symbolic_register(vex_reg_offset_t reg_offset, int64_t reg_size) const;
+	bool is_symbolic_register(vex_reg_offset_t reg_offset, int64_t reg_size, bool with_block_changes = true) const;
 	bool is_symbolic_temp(vex_tmp_id_t temp_id) const;
 
 	bool is_cpuid_in_block(address_t block_address, int32_t block_size);

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -139,6 +139,10 @@ struct memory_value_t {
 		return (memcmp(value, other_mem_value.value, size) == 0);
 	}
 
+	memory_value_t() {
+		reset();
+	}
+
 	void reset() {
 		address = 0;
 		size = 0;
@@ -240,6 +244,10 @@ struct block_details_t {
 	// if they end in syscall. Remove it after syscalls are correctly setup on ARM in native interface itself.
 	VEXLiftResult *vex_lift_result;
 
+	block_details_t() {
+		reset();
+	}
+
 	void reset() {
 		block_addr = 0;
 		block_size = 0;
@@ -283,6 +291,10 @@ struct sym_block_details_t {
 	bool has_symbolic_exit;
 	std::vector<sym_vex_stmt_details_t> symbolic_stmts;
 	std::vector<register_value_t> register_values;
+
+	sym_block_details_t() {
+		reset();
+	}
 
 	void reset() {
 		block_addr = 0;
@@ -367,6 +379,10 @@ struct vex_stmt_taint_entry_t {
 			   (mem_write_size == other_stmt.mem_write_size);
 	}
 
+	vex_stmt_taint_entry_t() {
+		reset();
+	}
+
 	void reset() {
 		sink.reset();
 		sources.clear();
@@ -415,6 +431,10 @@ struct processed_vex_expr_t {
 	stop_t unsupported_expr_stop_reason;
 	uint32_t mem_read_size;
 	int64_t value_size;
+
+	processed_vex_expr_t() {
+		reset();
+	}
 
 	void reset() {
 		taint_sources.clear();

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -554,8 +554,8 @@ class State {
 	RegisterSet block_symbolic_registers, block_concrete_registers;
 	TempSet block_symbolic_temps;
 
-	// Set of register dependencies that were concrete before an instruction was executed
-	std::unordered_map<address_t, std::unordered_map<vex_reg_offset_t, int64_t>> block_instr_concrete_regs;
+	// Set of register dependencies that were concrete before a VEX statement was executed
+	std::unordered_map<int64_t, std::unordered_map<vex_reg_offset_t, int64_t>> block_stmt_concrete_regs;
 
 	// List of instructions that should be executed symbolically
 	std::vector<block_details_t> blocks_with_symbolic_stmts;

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -202,6 +202,7 @@ struct vex_stmt_details_t {
 	bool has_concrete_memory_dep;
 	bool has_symbolic_memory_dep;
 	bool has_read_from_symbolic_addr;
+	bool has_memory_write;
 	// Mark fields as mutable so that they can be updated after inserting into std::set
 	mutable memory_value_t *memory_values;
 	mutable uint64_t memory_values_count;
@@ -213,6 +214,7 @@ struct vex_stmt_details_t {
 		has_concrete_memory_dep = false;
 		has_symbolic_memory_dep = false;
 		has_read_from_symbolic_addr = false;
+		has_memory_write = false;
 		stmt_deps.clear();
 		mem_write_addr = -1;
 		mem_write_size = -1;

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -629,7 +629,7 @@ class State {
 
 	bool is_block_exit_guard_symbolic() const;
 	bool is_block_next_target_symbolic() const;
-	bool is_symbolic_register(vex_reg_offset_t reg_offset, int64_t reg_size, bool with_block_changes = true) const;
+	bool is_symbolic_register(vex_reg_offset_t reg_offset, int64_t reg_size) const;
 	bool is_symbolic_temp(vex_tmp_id_t temp_id) const;
 
 	bool is_cpuid_in_block(address_t block_address, int32_t block_size);

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -210,6 +210,7 @@ struct vex_stmt_details_t {
 	// Mark fields as mutable so that they can be updated after inserting into std::set
 	mutable memory_value_t *memory_values;
 	mutable uint64_t memory_values_count;
+	std::unordered_map<address_t, uint64_t> symbolic_mem_deps;
 	std::set<vex_stmt_details_t> stmt_deps;
 	std::unordered_set<register_value_t> reg_deps;
 
@@ -606,7 +607,12 @@ class State {
 	// Count of blocks executed in native interface
 	int64_t executed_blocks_count;
 
-	std::unordered_map<address_t, uint64_t> symbolic_mem_deps;
+	// Details of symbolic memory dependencies of all VEX statements to be re-executed. Stores address and size of
+	// memory location and number of VEX statements the location is a dependency of. Only dependencies of statements
+	// that will be re-executed are tracked.
+	std::unordered_map<address_t, std::pair<uint64_t, uint64_t>> symbolic_mem_deps;
+	// Symbolic memory dependencies of all symbolic VEX statements in current block.
+	std::unordered_map<address_t, uint64_t> block_symbolic_mem_deps;
 
 	// Private functions
 


### PR DESCRIPTION
This PR adds support for computing re-execution slice at VEX statement granularity instead of instruction granularity. This approach prevents write-write conflicts that occur when re-executing symbolic instructions. This fine grained slicing also allows us to re-execute only those statements that affect program state: memory and register writes.