### PR TITLE
Don't treat UnresolvedJumpTarget as a known successor target

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -17,6 +17,7 @@ from ...knowledge_plugins.functions.function_manager import FunctionManager
 from ...knowledge_plugins.functions.function import Function
 from ...knowledge_plugins.cfg import IndirectJump, CFGNode, CFGENode, CFGModel  # pylint:disable=unused-import
 from ...misc.ux import deprecated
+from ...procedures.stubs.UnresolvableJumpTarget import UnresolvableJumpTarget
 from ...utils.constants import DEFAULT_STATEMENT
 from ...procedures.procedure_dict import SIM_PROCEDURES
 from ...errors import SimTranslationError, SimMemoryError, SimIRSBError, SimEngineError, AngrUnsupportedSyscallError, \
@@ -880,7 +881,12 @@ class CFGBase(Analysis):
 
             # determine where it jumps/returns to
             goout_site_successors = goout_site.successors()
-            if not goout_site_successors:
+            # Filter out UnresolvableJumpTarget because those don't mean that we actually know where it jumps to
+            known_successors = list(
+                filter(lambda n: not (isinstance(n, HookNode) and n.sim_procedure == UnresolvableJumpTarget),
+                       goout_site_successors))
+
+            if not known_successors:
                 # not sure where it jumps to. bail out
                 bail_out = True
                 continue

--- a/angr/codenode.py
+++ b/angr/codenode.py
@@ -1,4 +1,6 @@
 import logging
+from typing import List
+
 l = logging.getLogger(name=__name__)
 
 
@@ -43,7 +45,7 @@ class CodeNode:
             self._hash = hash((self.addr, self.size))
         return self._hash
 
-    def successors(self):
+    def successors(self) -> List["CodeNode"]:
         if self._graph is None:
             raise ValueError("Cannot calculate successors for graphless node")
         return list(self._graph.successors(self))

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -68,13 +68,13 @@ class Function(Serializable):
         self.normalized = False
 
         # block nodes at whose ends the function returns
-        self._ret_sites = set()
+        self._ret_sites: Set[BlockNode] = set()
         # block nodes at whose ends the function jumps out to another function (jumps outside)
-        self._jumpout_sites = set()
+        self._jumpout_sites: Set[BlockNode] = set()
         # block nodes at whose ends the function calls out to another non-returning function
-        self._callout_sites = set()
+        self._callout_sites: Set[BlockNode] = set()
         # block nodes that ends the function by returning out to another function (returns outside). This is rare.
-        self._retout_sites = set()
+        self._retout_sites: Set[BlockNode] = set()
         # block nodes (basic block nodes) at whose ends the function terminates
         # in theory, if everything works fine, endpoints == ret_sites | jumpout_sites | callout_sites
         self._endpoints = defaultdict(set)


### PR DESCRIPTION
@rhelmot  This should be the most simple fix for the flakeyness encountered with the the return detection. A successor that is just a hook to the generic unresolved jump target simproc shouldn't be treated as a "known" successor for deriving whether a function returns or not.