### PR TITLE
Make siminspect work reentrantly

### DIFF
--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -254,6 +254,9 @@ class SimProcedure:
         state._inspect(
             'simprocedure',
             BP_AFTER,
+            simprocedure_name=inst.display_name,
+            simprocedure_addr=self.addr,
+            simprocedure=inst,
             simprocedure_result=r
         )
         r = state._inspect_getattr('simprocedure_result', r)

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -387,7 +387,7 @@ class SimState(PluginHub):
     T = TypeVar("T")
     def _inspect_getattr(self, attr: str, default_value: T):
         if self.supports_inspect:
-            if self.inspect.action_attrs_set and hasattr(self.inspect, attr):
+            if hasattr(self.inspect, attr):
                 return getattr(self.inspect, attr)
 
         return default_value

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -267,23 +267,21 @@ class SimInspector(SimStatePlugin):
 
     def action(self, event_type, when, **kwargs):
         """
-        Called from within SimuVEX when events happens. This function checks all breakpoints registered for that event
-        and fires the ones whose conditions match.
+        Called from within the engine when events happens. This function checks all breakpoints registered for that
+        event and fires the ones whose conditions match.
         """
-        # l.debug("Event %s (%s) firing...", event_type, when)
-        self.action_attrs_set = False
+
+        self._set_inspect_attrs(**kwargs)
+        self.action_attrs_set = True
 
         for bp in self._breakpoints[event_type]:
-            # l.debug("... checking bp %r", bp)
             if not self.action_attrs_set:
-                # setup attributes upon the first use
                 self._set_inspect_attrs(**kwargs)
                 self.action_attrs_set = True
             if bp.check(self.state, when):
-                # l.debug("... FIRE")
-                saved_set = self.action_attrs_set
                 bp.fire(self.state)
-                self.action_attrs_set = saved_set  # restore attrs-set status in case bp triggers more bps
+
+        self.action_attrs_set = False
 
     def make_breakpoint(self, event_type, *args, **kwargs):
         """

--- a/angr/storage/memory_mixins/clouseau_mixin.py
+++ b/angr/storage/memory_mixins/clouseau_mixin.py
@@ -45,8 +45,22 @@ class InspectMixinHigh(MemoryMixin):
             inspect=inspect,
             **kwargs)
 
-        if self.category == 'reg': self.state._inspect('reg_write', BP_AFTER)
-        elif self.category == 'mem': self.state._inspect('mem_write', BP_AFTER)
+        if self.category == 'reg':
+            self.state._inspect('reg_write', BP_AFTER,
+                reg_write_offset=addr,
+                reg_write_length=size,
+                reg_write_expr=data,
+                reg_write_condition=condition,
+                reg_write_endness=endness,
+            )
+        elif self.category == 'mem':
+            self.state._inspect('mem_write', BP_AFTER,
+                mem_write_address=addr,
+                mem_write_length=size,
+                mem_write_expr=data,
+                mem_write_condition=condition,
+                mem_write_endness=endness,
+            )
 
     def load(self, addr, size=None, condition=None, endness=None, inspect=True, **kwargs):
         if not inspect or not self.state.supports_inspect:
@@ -86,11 +100,19 @@ class InspectMixinHigh(MemoryMixin):
             **kwargs)
 
         if self.category == 'mem':
-            self.state._inspect('mem_read', BP_AFTER, mem_read_expr=r)
+            self.state._inspect('mem_read', BP_AFTER, mem_read_expr=r,
+                mem_read_address = addr,
+                mem_read_length = size,
+                mem_read_condition = condition,
+                mem_read_endness = endness)
             r = self.state._inspect_getattr("mem_read_expr", r)
 
         elif self.category == 'reg':
-            self.state._inspect('reg_read', BP_AFTER, reg_read_expr=r)
+            self.state._inspect('reg_read', BP_AFTER, reg_read_expr=r,
+                reg_read_offset = addr,
+                reg_read_length = size,
+                reg_read_condition = condition,
+                reg_read_endness = endness)
             r = self.state._inspect_getattr("reg_read_expr", r)
 
         return r


### PR DESCRIPTION
Performance impact of this change:

![siminspect_nop](https://user-images.githubusercontent.com/2498805/172061261-daf37aa8-a6e7-4055-abe8-dbd3f29ed17b.png)

A bit of a hit, but it will make behavior more intuitive and closes #2768 