### PR TITLE
fix(requirement)should update to latest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     progressbar2 >= 3
     rpyc
     cffi >= 1.14.0
-    unicorn >= 1.0.2rc4
+    unicorn == 1.0.3
     archinfo == 9.2.7.dev0
     claripy == 9.2.7.dev0
     cle == 9.2.7.dev0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     progressbar2 >= 3
     rpyc
     cffi >= 1.14.0
-    unicorn == 1.0.2rc4
+    unicorn >= 1.0.2rc4
     archinfo == 9.2.7.dev0
     claripy == 9.2.7.dev0
     cle == 9.2.7.dev0


### PR DESCRIPTION
version should not FREEZE for common use.
```shell
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.                                                                                        
angr 9.2.4 requires unicorn==1.0.2rc4, but you have unicorn 1.0.3 which is incompatible.
```