### PR TITLE
Exempt assigned issues from stalebot, increase operations per run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
             This issue has been closed due to inactivity.
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: 'pinned'
+          exempt-issue-labels: 'pinned,feature,enhancement,help wanted'
           exempt-pr-labels: 'pinned'
           exempt-all-issue-assignees: true
           operations-per-run: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,3 +23,5 @@ jobs:
           stale-pr-label: stale
           exempt-issue-labels: 'pinned'
           exempt-pr-labels: 'pinned'
+          exempt-all-issue-assignees: true
+          operations-per-run: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
+          days-before-stale: 120
           stale-issue-message: >
             This issue has been marked as `stale` because it has no recent activity.
             Please comment or add the `pinned` tag to prevent this issue from being closed.


### PR DESCRIPTION
This will change the stale bot to ignore issues (but not PRs) that have been assigned to anyone. It also increases the operations per day because it appears to have slowed down since the beginning.