### PR TITLE
Fix incorrect pypcode version due to moving to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ packages = find:
 
 [options.extras_require]
 AngrDB = sqlalchemy
-pcode = pypcode == 1.0.2
+pcode = pypcode == 1.0.5
 
 [options.package_data]
 angr =


### PR DESCRIPTION
I noticed there was a commit to upgrade the pinned pypcode version to 1.0.5.

https://github.com/angr/angr/commit/2abde0d6eae34f88e87f7dff7e4daf120b96af87

Currently, it is 1.0.2 in setup.cfg. I think it's a mistake when moving to setup.cfg. You can check it here.

https://github.com/angr/angr/commit/1c055cf1e29315bbdde0ba82fa3528edcfcf7f97

cc @twizmwazin 