### PR TITLE
Include ins_addr in CodeLocation

### DIFF
--- a/angr/code_location.py
+++ b/angr/code_location.py
@@ -80,11 +80,14 @@ class CodeLocation:
         return type(self) is type(other) and self.block_addr == other.block_addr and \
                 self.stmt_idx == other.stmt_idx and self.sim_procedure is other.sim_procedure and \
                 self.context == other.context and \
-                self.block_idx == other.block_idx
+                self.block_idx == other.block_idx and \
+                self.ins_addr
 
     def __lt__(self, other):
         if self.block_addr != other.block_addr:
             return self.block_addr < other.block_addr
+        if self.ins_addr != other.ins_addr:
+            return self.ins_addr < other.ins_addr
         if self.stmt_idx != other.stmt_idx:
             return self.stmt_idx < other.stmt_idx
         return False
@@ -93,7 +96,7 @@ class CodeLocation:
         """
         returns the hash value of self.
         """
-        return hash((self.block_addr, self.stmt_idx, self.sim_procedure, self.context, self.block_idx))
+        return hash((self.block_addr, self.stmt_idx, self.sim_procedure, self.ins_addr, self.context, self.block_idx))
 
     def _store_kwargs(self, **kwargs):
         if self.info is None:


### PR DESCRIPTION
- Not having `ins_addr` in code location results in the same hash value for two code locations with the same `stmt_idx` but different `ins_addr`.
- This situation arises when you are performing simplifications on a block that results in certain statements being removed, so the statement id now points to a different instruction.
- The reason this is a problem is that when a new AST is created, `claripy `has a cache, where it checks to see if the AST has already been created. But since `ins_addr `is not included in the hash of the annotation, there is a possibility that a new AST annotation with a different `ins_addr `but same `stmt_idx `already exists in the cache. So it returns this AST with the annotation that has the incorrect `ins_addr`