### PR TITLE
Returning TOP in RDA for the whole register

### DIFF
--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -60,6 +60,19 @@ class DefinitionAnnotation(Annotation):
     def __repr__(self):
         return f"<{self.__class__.__name__}({repr(self.definition)})"
 
+
+class RegisterMultiValuedMemory(MultiValuedMemory):
+    def _default_value(self, addr, size, **kwargs):
+        # TODO: Make _default_value() a separate Mixin
+        reg_atom = Register(addr, size)
+        top = self.state.top(size * self.state.arch.byte_width)
+        top = self.state.annotate_with_def(top, Definition(reg_atom, angr.analyses.reaching_definitions.external_codeloc.ExternalCodeLocation()))
+        values = MultiValues({0: {top}})
+        # # write it to registers
+        self.state.kill_and_add_definition(reg_atom, angr.analyses.reaching_definitions.external_codeloc.ExternalCodeLocation(), values)
+        return top
+
+
 # pylint: disable=W1116
 class LiveDefinitions:
     """
@@ -87,7 +100,7 @@ class LiveDefinitions:
         self.track_tmps = track_tmps
         self._canonical_size: int = canonical_size  # TODO: Drop canonical_size
 
-        self.register_definitions = MultiValuedMemory(memory_id="reg",
+        self.register_definitions = RegisterMultiValuedMemory(memory_id="reg",
                                                       top_func=self.top,
                                                       skip_missing_values_during_merging=False,
                                                       page_kwargs={'mo_cmp': self._mo_cmp}) \


### PR DESCRIPTION
This fix is for the following issue during RDA.

- If a smaller part of a register is set first e.g. `PUT(AX) = 0x5`, then the whole register is retrieved later e.g. `t0 = GET(RAX)`, `t0 `will now have `TOP `of size `64 `instead of having `TOP `and the values `0x5 `of respective sizes.
- This happens because` register_definitions.load()` in `_handle_Get()` catches a `SimMemoryMissingError` which is raised in `default_filler_mixin.py` when it tries to fill the missing part because `fill_missing` is set to `False `always as a default. This exception is caught in `_handle_Get()` in RDA's vex engine, which creates a `TOP `of the size of the whole register instead of keeping the existing definitions for parts of the register.