### PR TITLE
Lazy import sympy.

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -4,16 +4,19 @@ import operator
 import logging
 
 import networkx
-import sympy
 
 import claripy
 import ailment
 
+from ...utils.lazy_import import lazy_import
 from ...utils.graph import dominates, shallow_reverse
 from ...block import Block, BlockNode
 from ..cfg.cfg_utils import CFGUtils
 from .structurer_nodes import (EmptyBlockNotice, SequenceNode, CodeNode, SwitchCaseNode, BreakNode,
                                ConditionalBreakNode, LoopNode, ConditionNode, ContinueNode, CascadingConditionNode)
+
+sympy = lazy_import("sympy")
+
 
 l = logging.getLogger(__name__)
 

--- a/angr/utils/__init__.py
+++ b/angr/utils/__init__.py
@@ -3,6 +3,7 @@ from .timing import timethis
 from . import graph
 from . import constants
 from . import enums_conv
+from . import lazy_import
 
 
 def looks_like_sql(s: str) -> bool:

--- a/angr/utils/lazy_import.py
+++ b/angr/utils/lazy_import.py
@@ -1,0 +1,12 @@
+import importlib.util
+import sys
+
+
+def lazy_import(name):
+    spec = importlib.util.find_spec(name)
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module


### PR DESCRIPTION
Importing sympy takes a long time (about 300 ms on Linux). We make it lazy to speed up `import angr`.