### PR TITLE
don't change global angr.options in test_unicorn

### DIFF
--- a/tests/test_unicorn.py
+++ b/tests/test_unicorn.py
@@ -256,10 +256,8 @@ def test_partial_reads():
 
     p = angr.Project(os.path.join(test_location, "binaries", "tests", "x86_64",
                                   "test_partial_reads_handling_in_unicorn"), auto_load_libs=False)
-    add_options = angr.options.unicorn
     # Do not treat as uninitalized memory as symbolic. Prevents introducing undesired symbolic taint
-    add_options.add(angr.options.ZERO_FILL_UNCONSTRAINED_MEMORY)
-    init_state = p.factory.full_init_state(add_options=add_options)
+    init_state = p.factory.full_init_state(add_options=so.unicorn | {so.ZERO_FILL_UNCONSTRAINED_MEMORY})
     global_var_val = [init_state.solver.BVV(0x41414141, 32), init_state.solver.BVV(0x42424242, 32),
                       init_state.solver.BVS("symb_val_0", 32), init_state.solver.BVS("symb_val_1", 32)]
     global_var_symb = p.loader.find_symbol("global_var")


### PR DESCRIPTION
The problem is I can only pass `test_unicorn` using `python -m nose2 -v test_unicorn.test_stops` and others such as the former one. I cannot pass `test_unicorn` using `python -m nose2 -v test_unicorn` As a result, I have to spend much time to iterate these tests manually just like what is done in angr/ci-setting.

The real problem is `test_partial_reads` changes the global `angr.options` However, I think it's not intentionally. Other tests just make a copy to use. 

With this patch, `python -m nose2 -v test_unicorn` can pass normally.