### PR TITLE
Remove _binary from CDG

### DIFF
--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -23,7 +23,6 @@ class CDG(Analysis):
         :param start:           The starting point to begin constructing the control dependence graph
         :param no_construct:    Skip the construction step. Only used in unit-testing.
         """
-        self._binary = self.project.loader.main_object
         self._start = start if start is not None else self.project.entry
         self._cfg = cfg
 


### PR DESCRIPTION
- It's presence prevents using it on e.g. shared libraries (looking at
  you libc, which does not contain a loader)
- It appears the last use of the `_binary` stems from https://github.com/angr/angr/blob/663e603184743d077b9056a1ff4a94db64f80b08/angr/cdg.py#L36, but was removed in https://github.com/angr/angr/commit/308a2e46c6785ad6e76c218ad06f910e3e5e182b