### PR TITLE
Avoid doing lazy import when pyinstaller is in-place.

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -9,13 +9,18 @@ import claripy
 import ailment
 
 from ...utils.lazy_import import lazy_import
+from ...utils import is_pyinstaller
 from ...utils.graph import dominates, shallow_reverse
 from ...block import Block, BlockNode
 from ..cfg.cfg_utils import CFGUtils
 from .structurer_nodes import (EmptyBlockNotice, SequenceNode, CodeNode, SwitchCaseNode, BreakNode,
                                ConditionalBreakNode, LoopNode, ConditionNode, ContinueNode, CascadingConditionNode)
 
-sympy = lazy_import("sympy")
+if is_pyinstaller():
+    # PyInstaller is not happy with lazy import
+    import sympy
+else:
+    sympy = lazy_import("sympy")
 
 
 l = logging.getLogger(__name__)

--- a/angr/utils/__init__.py
+++ b/angr/utils/__init__.py
@@ -4,6 +4,7 @@ from . import graph
 from . import constants
 from . import enums_conv
 from . import lazy_import
+from .env import is_pyinstaller
 
 
 def looks_like_sql(s: str) -> bool:

--- a/angr/utils/env.py
+++ b/angr/utils/env.py
@@ -1,0 +1,9 @@
+import sys
+
+def is_pyinstaller() -> bool:
+    """
+    Detect if we are currently running as a PyInstaller-packaged program.
+    :return:    True if we are running as a PyInstaller-packaged program. False if we are running in Python directly
+                (e.g., development mode).
+    """
+    return getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')


### PR DESCRIPTION
This PR fixes the broken standalone angr management releases.