### PR TITLE
Add guard to bad log statement

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2065,7 +2065,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             else:
                 # TODO: Support more jumpkinds
                 l.debug("Unsupported jumpkind %s", jumpkind)
-                l.debug("Instruction address: %#x", ins_addr)
+                if isinstance(ins_addr, int):
+                    l.debug("Instruction address: %#x", ins_addr)
 
         return jobs
 


### PR DESCRIPTION
Fixes one `TypeError: %x format: an integer is required, not NoneType`

As for why the ins_addr is None, I think this is a block with no instructions (I'm analyzing a blob)