### PR TITLE
Pin setuptools to <=63.4.3 because >=64.0.0 breaks editable builds.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=59", "wheel", "pyvex==9.2.14.dev0", "unicorn==1.0.2rc4"]
+requires = ["setuptools>=59, <=63.4.3", "wheel", "pyvex==9.2.14.dev0", "unicorn==1.0.2rc4"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Re: https://github.com/pypa/setuptools/issues/3501

We should investigate when we are not in deadline mode.