### PR TITLE
Allow SimPackets.write() pos to be None

### DIFF
--- a/angr/storage/file.py
+++ b/angr/storage/file.py
@@ -537,6 +537,8 @@ class SimPackets(SimFileBase):
             size = self.state.solver.BVV(size, self.state.arch.bits)
 
         # sanity check on packet number and determine if data is already present
+        if pos is None:
+            pos = len(self.content)
         if pos < 0:
             raise SimFileError("SimPacket.write(%d): Negative packet number?" % pos)
         elif pos > len(self.content):


### PR DESCRIPTION
The docstring for `SimPackets.write()` claims that the `pos` argument "May be None to append to the stream", but this case isn't actually handled and just triggers an exception instead. `SimPackets.read()`, which has the same docstring note, has an extra couple lines to handle that case, so this was probably just a copypaste mistake.