### PR TITLE
CGC syscall enhancements

### DIFF
--- a/angr/procedures/cgc/allocate.py
+++ b/angr/procedures/cgc/allocate.py
@@ -1,13 +1,14 @@
+import logging
+
 import claripy
 import angr
-import logging
 
 l = logging.getLogger(name=__name__)
 
 cgc_flag_page_start_addr = 0x4347c000
 
 class allocate(angr.SimProcedure):
-    #pylint:disable=arguments-differ
+    #pylint:disable=arguments-differ,missing-class-docstring
 
     def run(self, length, is_x, addr): #pylint:disable=unused-argument
         if self.state.solver.symbolic(length):

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -48,6 +48,7 @@ class TRANSMIT_RECORD(ctypes.Structure):
     """
 
     _fields_ = [
+        ('fd', ctypes.c_uint32),
         ('data', ctypes.c_void_p),
         ('count', ctypes.c_uint32)
     ]
@@ -1310,6 +1311,7 @@ class Unicorn(SimStatePlugin):
         # process the concrete transmits
         i = 0
         stdout = state.posix.get_fd(1)
+        stderr = state.posix.get_fd(2)
 
         while True:
             record = _UC_NATIVE.process_transmit(self._uc_state, i)
@@ -1317,7 +1319,10 @@ class Unicorn(SimStatePlugin):
                 break
 
             string = ctypes.string_at(record.contents.data, record.contents.count)
-            stdout.write_data(string)
+            if record.contents.fd == 1:
+                stdout.write_data(string)
+            elif record.contents.fd == 2:
+                stderr.write_data(string)
             i += 1
 
         # Re-execute concrete writes

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2425,6 +2425,7 @@ void State::perform_cgc_receive() {
 	uc_reg_read(uc, UC_X86_REG_EBX, &fd);
 	if (fd > 2) {
 		// Ignore any fds > 2
+		interrupt_handled = true;
 		return;
 	}
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2555,6 +2555,11 @@ void State::perform_cgc_transmit() {
 				return;
 			}
 		}
+		else {
+			// Read failed due to some other error. Abort.
+			free(dup_buf);
+			return;
+		}
 
 		if (!handle_symbolic_syscalls && (find_tainted(buf, count) != -1)) {
 			//printf("... symbolic data\n");

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2555,7 +2555,7 @@ void State::perform_cgc_transmit() {
 				return;
 			}
 		}
-		else {
+		else if (err != UC_ERR_OK) {
 			// Read failed due to some other error. Abort.
 			free(dup_buf);
 			return;

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2526,11 +2526,8 @@ void State::perform_cgc_transmit() {
 	uint32_t fd, buf, count, tx_bytes;
 
 	uc_reg_read(uc, UC_X86_REG_EBX, &fd);
-	if (fd == 2) {
-		// we won't try to handle fd 2 prints here, they are uncommon.
-		return;
-	}
-	else if (fd == 0 || fd == 1) {
+	if (fd < 3) {
+		// Process transmits to fd 0, 1 or 2 only.
 		uc_reg_read(uc, UC_X86_REG_ECX, &buf);
 		uc_reg_read(uc, UC_X86_REG_EDX, &count);
 		uc_reg_read(uc, UC_X86_REG_ESI, &tx_bytes);
@@ -2577,17 +2574,17 @@ void State::perform_cgc_transmit() {
 			return;
 		}
 
-		transmit_records.push_back({dup_buf, count});
+		transmit_records.push_back({fd, dup_buf, count});
 		int result = 0;
 		uc_reg_write(uc, UC_X86_REG_EAX, &result);
 		symbolic_registers.erase(8);
 		symbolic_registers.erase(9);
 		symbolic_registers.erase(10);
 		symbolic_registers.erase(11);
-		interrupt_handled = true;
 		syscall_count++;
-		return;
 	}
+	interrupt_handled = true;
+	return;
 }
 
 static void hook_mem_read(uc_engine *uc, uc_mem_type type, uint64_t address, int size, int64_t value, void *user_data) {

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2429,6 +2429,11 @@ void State::perform_cgc_receive() {
 		return;
 	}
 
+	if (fd == 1) {
+		// Python land maps 1 to 0 so do the same here for receives run on stdout.
+		fd = 0;
+	}
+
 	if (fd_details.count(fd) == 0) {
 		// fd stream has not been initialized in native interface. Can't perform receive.
 		return;

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -509,6 +509,7 @@ struct mem_update_t {
 };
 
 struct transmit_record_t {
+	uint32_t fd;
 	void *data;
 	uint32_t count;
 };


### PR DESCRIPTION
This PR implements some enhancements and fixes to CGC syscalls:

1. Handle transmits to stderr in native interface.
2. Mark transmits to fd > 3 as handled in native interface to prevent switching to python land.
3. If page containing buf for transmit is not mapped into native interface, map the page in instead of switching to python land.
4. Flag page should not be part of memory region returned by allocate.