### PR TITLE
Add eager_ifunc_resolution project param

### DIFF
--- a/angr/procedures/linux_loader/sim_loader.py
+++ b/angr/procedures/linux_loader/sim_loader.py
@@ -28,16 +28,20 @@ class IFuncResolver(angr.SimProcedure):
     local_vars = ('saved_regs',)
 
     # pylint: disable=arguments-differ,unused-argument
-    def run(self, funcaddr=None, gotaddr=None, funcname=None):
-        self.saved_regs = {reg.name: self.state.registers.load(reg.name) for reg in self.arch.register_list if reg.argument}
-        self.call(funcaddr, (), continue_at='after_call', cc=self.cc, prototype='void *x()')
+    def run(self, funcaddr=None):
+        resolved = self.state.globals.get(('ifunc_resolution', funcaddr), None)
+        if resolved is None:
+            self.saved_regs = {reg.name: self.state.registers.load(reg.name) for reg in self.arch.register_list if reg.argument}
+            self.call(funcaddr, (), continue_at='after_call', cc=self.cc, prototype='void *x()')
+        else:
+            self.jump(resolved)
 
-    def after_call(self, funcaddr=None, gotaddr=None, funcname=None):
+    def after_call(self, funcaddr=None):
         value = self.cc.return_val(angr.sim_type.SimTypePointer(angr.sim_type.SimTypeBottom())).get_value(self.state)
         for name, val in self.saved_regs.items():
             self.state.registers.store(name, val)
 
-        self.state.memory.store(gotaddr, value, endness=self.state.arch.memory_endness, priv=True)
+        self.state.globals[('ifunc_resolution', funcaddr)] = value
         self.jump(value)
 
     def __repr__(self):

--- a/angr/procedures/linux_loader/sim_loader.py
+++ b/angr/procedures/linux_loader/sim_loader.py
@@ -32,7 +32,7 @@ class IFuncResolver(angr.SimProcedure):
         resolved = self.state.globals.get(('ifunc_resolution', funcaddr), None)
         if resolved is None:
             self.saved_regs = {reg.name: self.state.registers.load(reg.name) for reg in self.arch.register_list if reg.argument}
-            self.call(funcaddr, (), continue_at='after_call', cc=self.cc, prototype='void *x()')
+            self.call(funcaddr, (), continue_at='after_call', cc=self.cc, prototype='void *x()', jumpkind='Ijk_NoHook')
         else:
             self.jump(resolved)
 
@@ -43,6 +43,3 @@ class IFuncResolver(angr.SimProcedure):
 
         self.state.globals[('ifunc_resolution', funcaddr)] = value
         self.jump(value)
-
-    def __repr__(self):
-        return '<IFuncResolver %s>' % self.kwargs.get('funcname', None)

--- a/angr/project.py
+++ b/angr/project.py
@@ -107,6 +107,7 @@ class Project:
                  load_function=None,
                  analyses_preset=None,
                  concrete_target=None,
+                 eager_ifunc_resolution=None,
                  **kwargs):
 
         # Step 1: Load the binary
@@ -178,6 +179,7 @@ class Project:
         self._ignore_functions = ignore_functions
         self._support_selfmodifying_code = support_selfmodifying_code
         self._translation_cache = translation_cache
+        self._eager_ifunc_resolution = eager_ifunc_resolution
         self._executing = False # this is a flag for the convenience API, exec() and terminate_execution() below
 
         if self._support_selfmodifying_code:

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -438,7 +438,7 @@ class SimProcedure:
         self.successors.add_successor(self.state, ret_addr, self.state.solver.true, 'Ijk_Ret')
 
 
-    def call(self, addr, args, continue_at, cc=None, prototype=None):
+    def call(self, addr, args, continue_at, cc=None, prototype=None, jumpkind='Ijk_Call'):
         """
         Add an exit representing calling another function via pointer.
 
@@ -477,7 +477,7 @@ class SimProcedure:
             call_state.regs.t9 = addr
 
         self._exit_action(call_state, addr)
-        self.successors.add_successor(call_state, addr, call_state.solver.true, 'Ijk_Call')
+        self.successors.add_successor(call_state, addr, call_state.solver.true, jumpkind)
 
         if o.DO_RET_EMULATION in self.state.options:
             # we need to set up the call because the continuation will try to tear it down
@@ -487,13 +487,13 @@ class SimProcedure:
             guard = ret_state.solver.true if o.TRUE_RET_EMULATION_GUARD in ret_state.options else ret_state.solver.false
             self.successors.add_successor(ret_state, ret_addr, guard, 'Ijk_FakeRet')
 
-    def jump(self, addr):
+    def jump(self, addr, jumpkind='Ijk_Boring'):
         """
         Add an exit representing jumping to an address.
         """
         self.inhibit_autoret = True
         self._exit_action(self.state, addr)
-        self.successors.add_successor(self.state, addr, self.state.solver.true, 'Ijk_Boring')
+        self.successors.add_successor(self.state, addr, self.state.solver.true, jumpkind)
 
     def exit(self, exit_code):
         """

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -150,7 +150,6 @@ class SimLinux(SimUserland):
                                 proc = P['linux_loader']['IFuncResolver'](
                                     display_name='IFuncResolver.' + reloc.symbol.name,
                                     funcaddr=gotvalue,
-                                    funcname=reloc.symbol.name,
                                 )
                                 self.project.hook(gotvalue, proc)
 

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -161,7 +161,7 @@ class SimLinux(SimUserland):
                                     display_name='IFuncResolver.' + reloc.symbol.name,
                                     funcaddr=gotvalue,
                                 )
-                                self.project.hook(gotvalue, proc)
+                                self.project.hook(gotvalue, proc, replace=True)
 
 
     def syscall_abi(self, state):


### PR DESCRIPTION
Closes #3503

This changes the way ifunc resolution works. Previously, it would do it in a very similar way to how libc does it, rewriting the GOT after being resolved. This caused issues (see linked issue) but the best solution to that issue would prevent concrete execution with unicorn from performing efficiently (would leave a hook permanently embedded in the control flow graph, causing execution to switch out of unicorn whenever it gets hit). This is a compromise by introducing a Project parameter which controls whether ifuncs are resolved lazily or eagerly. In lazy mode, the default, hooks work but in the unhooked case there will be a permanent hook performing the redirect to the resolver or the resolved function. In eager mode, resolution is performed on project creation and hooks will not work, but concrete execution will be very speedy.