### PR TITLE
Fix CGC allocate to not return memory used by loader as part of newly allocated memory

### DIFF
--- a/angr/procedures/cgc/allocate.py
+++ b/angr/procedures/cgc/allocate.py
@@ -46,6 +46,13 @@ class allocate(angr.SimProcedure):
                     self.state.cgc.add_sinkhole(cgc_flag_page_start_addr + 0x1000, sinkhole_size)
 
                 chosen = self.state.solver.BVV(cgc_flag_page_start_addr - aligned_length, self.state.arch.bits)
+            elif chosen_conc <= self.state.project.loader.max_addr < allocation_base_conc:
+                # Chosen memory overlaps with some loaded object
+                sinkhole_size = allocation_base_conc - self.state.project.loader.max_addr
+                if sinkhole_size != 0:
+                    self.state.cgc.add_sinkhole(self.state.project.loader.max_addr, sinkhole_size)
+
+                chosen = self.state.solver.BVV(self.state.project.loader.min_addr - aligned_length, self.state.arch.bits)
 
             self.state.cgc.allocation_base = chosen
 

--- a/angr/procedures/cgc/allocate.py
+++ b/angr/procedures/cgc/allocate.py
@@ -52,11 +52,13 @@ class allocate(angr.SimProcedure):
                 if sinkhole_size != 0:
                     self.state.cgc.add_sinkhole(self.state.project.loader.max_addr, sinkhole_size)
 
-                chosen = self.state.solver.BVV(self.state.project.loader.min_addr - aligned_length, self.state.arch.bits)
+                chosen = self.state.solver.BVV(self.state.project.loader.min_addr - aligned_length,
+                                               self.state.arch.bits)
 
             self.state.cgc.allocation_base = chosen
 
-        self.state.memory.store(addr, chosen, size=self.state.arch.bytes, condition=self.state.solver.And(addr != 0), endness='Iend_LE')
+        self.state.memory.store(addr, chosen, size=self.state.arch.bytes, condition=self.state.solver.And(addr != 0),
+                                endness='Iend_LE')
 
         # PROT_READ | PROT_WRITE default
         permissions = self.state.solver.BVV(1 | 2, 3)


### PR DESCRIPTION
This PR fixes CGC allocate syscall to treat memory pages used by loader as unavailable and thus, not use them as part of dynamically allocated memory.