### PR TITLE
Fix testcase so that it fails when the variable is cast

### DIFF
--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -476,7 +476,7 @@ class TestDecompiler(unittest.TestCase):
         code = dec.codegen.text
 
         argc_name = "a0"  # update this variable once the decompiler picks up
-                           # argument names from the common definition of main()
+                          # argument names from the common definition of main()
 
         assert len(re.search(rf'({argc_name}),', code).groups()) == 1 #Should always appear as argument
         assert re.search(rf'({argc_name})\)*;', code) is None #Should never appear in variable list

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -475,10 +475,11 @@ class TestDecompiler(unittest.TestCase):
         l.debug("Decompiled function %s\n%s", repr(func), dec.codegen.text)
         code = dec.codegen.text
 
-        argc_name = " a0"  # update this variable once the decompiler picks up
+        argc_name = "a0"  # update this variable once the decompiler picks up
                            # argument names from the common definition of main()
-        assert argc_name in code
-        assert code.count(argc_name) == 1  # it should only appear once
+
+        assert len(re.search(rf'({argc_name}),', code).groups()) == 1 #Should always appear as argument
+        assert re.search(rf'({argc_name})\)*;', code) is None #Should never appear in variable list
 
     def test_decompiling_strings_c_representation(self):
 


### PR DESCRIPTION
The previous version of this test case missed the following snippet:

```
int main(unsigned long a0, unsigned long a1)
{
     unsigned long v0;  // [bp-0xc8]
     unsigned int v1;  // [bp-0xbc]
     unsigned int v2;  // [bp-0xb0]
     unsigned int v3;  // [bp-0xac]
     unsigned int v4;  // [bp-0xa0]
     char v5;  // [bp-0x38]
     char v6;  // [bp-0x30]
     char v7;  // [bp-0x1e]
 
     v1 = ((int)a0);
     v0 = a1;
     v3 = 65;
     for (v2 = 0; v2 <= 25; v3 += 1)
     {
         v4 = v3;
         v2 += 1;
     }
     for (v2 = 0; v2 <= 25; v2 += 1)
     {
         v6 = ((char)v4);
     }
     v7 = 0;
     return puts(&v5);
}
```

The cast was not picked up by `argc_name = " a0"` in the original testcase.
