### PR TITLE
Correctly handle symbolic branches in native interface

### DIFF
--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -154,6 +154,7 @@ class SimEngineUnicorn(SuccessorsMixin):
         # Restore breakpoints
         for succ_state in self.successors.successors:
             succ_state.inspect._breakpoints["mem_read"] = copy.copy(saved_mem_read_breakpoints)
+            succ_state.inspect._breakpoints["mem_write"] = copy.copy(saved_mem_read_breakpoints)
 
         del self.stmt_idx
 


### PR DESCRIPTION
This PR fixes how the native interface handles symbolic branches. Previously, we were checking if the branch condition was symbolic, which was sufficient because we were working at instruction granularity: the VEX exit statement would be automatically executed if instruction is symbolic. However, after switching to VEX statement granularity for re-execution, we need to explicitly mark the VEX exit statement as symbolic so that it would be executed during re-execution.