### PR TITLE
More unicorn engine native interface optimizations

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1221,7 +1221,9 @@ void State::get_register_value(uint64_t vex_reg_offset, uint8_t *out_reg_value) 
 		auto closest_reg_offset = vex_to_unicorn_map.lower_bound(vex_reg_offset);
 		uc_reg_read(uc, vex_to_unicorn_map.at(closest_reg_offset->first).first, reg_val);
 		if (closest_reg_offset->first != vex_reg_offset) {
-			// Dependency is a sub-register that starts in middle of larger register. Adjust offset to start copying from
+			// Dependency is a sub-register that starts in middle of larger register. Adjust offset to start copying
+			// from
+			closest_reg_offset--;
 			val_offset = vex_reg_offset - closest_reg_offset->first;
 		}
 		memcpy(out_reg_value, reg_val + val_offset, MAX_REGISTER_BYTE_SIZE - val_offset);

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -920,6 +920,7 @@ void State::compute_slice_of_stmt(vex_stmt_details_t &stmt) {
 				dep_reg_val.offset = source.reg_offset;
 				dep_reg_val.size = source.value_size;
 				get_register_value(dep_reg_val.offset, dep_reg_val.value);
+				stmt.reg_deps.insert(dep_reg_val);
 			}
 		}
 		else if (source.entity_type == TAINT_ENTITY_MEM) {

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -370,6 +370,7 @@ void State::commit() {
 	block_concrete_registers.clear();
 	block_stmt_concrete_regs.clear();
 	block_symbolic_mem_deps.clear();
+	block_symbolic_mem_writes.clear();
 	block_concrete_writes_to_reexecute.clear();
 	curr_block_details.reset();
 	block_mem_reads_data.clear();

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -549,9 +549,6 @@ class State {
 	// List of symbolic statements in processed basic blocks that need not be re-executed. Will be removed on commit.
 	std::unordered_map<uint32_t, std::unordered_set<uint32_t>> symbolic_stmts_to_erase;
 
-	// List of register values at start of block
-	std::map<vex_reg_offset_t, register_value_t> block_start_reg_values;
-
 	// Similar to memory reads in a block, we track the state of registers and VEX temps when
 	// propagating taint in a block for easy rollback if we need to abort due to read from/write to
 	// a symbolic address
@@ -753,7 +750,7 @@ class State {
 		RegisterSet symbolic_registers; // tracking of symbolic registers
 		RegisterSet blacklisted_registers;  // Registers which shouldn't be saved as a concrete dependency
 		// Mapping of VEX offsets to unicorn register IDs and register sizes
-		std::unordered_map<vex_reg_offset_t, std::pair<unicorn_reg_id_t, uint64_t>> vex_to_unicorn_map;
+		std::map<vex_reg_offset_t, std::pair<unicorn_reg_id_t, uint64_t>> vex_to_unicorn_map;
 		// VEX CC registers
 		std::unordered_map<vex_reg_offset_t, uint64_t> vex_cc_regs;
 		RegisterSet artificial_vex_registers; // Artificial VEX registers


### PR DESCRIPTION
This PR includes a bug fix and an optimization that seems to speed up execution in the native interface in some cases. The bug fix is simply clearing a block level info tracker that should have been cleared; I missed adding that earlier. The optimization is modifying how values of registers are saved for re-execution. Previously, values of all registers were saved at the start of each block and the relevant ones were copied during slice computation. However, it is sufficient to simply save only the values required when computing statements that need to be re-executed. Currently, this is achieved by restoring register context in unicorn object in commit. unicorn2 supports reading register values from a saved context. After this PR is merged, I'll modify the unicorn2 code to use the relevant unicorn engine APIs.