### PR TITLE
Skip tests if a dependency is missing rather than failing them

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -92,7 +92,7 @@ def do_trace(proj, test_name, input_data, **kwargs):
     return r
 
 
-@skipUnless(tracer, "tracker is not installed")
+@skipUnless(tracer, "tracer is not installed")
 def load_cgc_pov(pov_file: str) -> "tracer.TracerPoV":
     return tracer.TracerPoV(pov_file)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import Optional, Sequence
 from tempfile import NamedTemporaryFile
 
-from unittest import skipIf, skipUnless, skip
+from unittest import skipIf, skipUnless, skip, SkipTest
 
 l = logging.getLogger("angr.tests.common")
 
@@ -64,7 +64,6 @@ def skip_if_not_linux(func):
 TRACE_VERSION = 1
 
 
-@skipUnless(tracer, "Tracer is not installed and cached data is not present")
 def do_trace(proj, test_name, input_data, **kwargs):
     """
     trace, magic, crash_mode, crash_addr = load_cached_trace(proj, "test_blurble")
@@ -84,6 +83,9 @@ def do_trace(proj, test_name, input_data, **kwargs):
                     return r[0]
         except (pickle.UnpicklingError, UnicodeDecodeError):
             print("Can't unpickle trace - rerunning")
+
+    if tracer is None:
+        raise SkipTest("Tracer is not installed and cached data is not present")
 
     runner = tracer.QEMURunner(project=proj, input=input_data, **kwargs)
     r = (runner.trace, runner.magic, runner.crash_mode, runner.crash_addr)

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -1,8 +1,13 @@
-from unittest import TestCase, main
+from unittest import TestCase, skipUnless, main
 import os
 
 import angr
 import archinfo
+
+try:
+    import pypcode
+except:
+    pypcode = None
 
 
 test_location = os.path.join(
@@ -12,6 +17,7 @@ test_location = os.path.join(
 
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
+@skipUnless(pypcode, "pypcode not available")
 class TestPcodeEngine(TestCase):
 
     def test_shellcode(self):

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -1,12 +1,12 @@
 from unittest import TestCase, skipUnless, main
 import os
 
-import angr
 import archinfo
+import angr
 
 try:
     import pypcode
-except:
+except ModuleNotFoundError:
     pypcode = None
 
 
@@ -51,7 +51,7 @@ class TestPcodeEngine(TestCase):
         s = p.factory.call_state(base_address, prototype=prototype)
         simgr = p.factory.simulation_manager(s)
         simgr.run()
-        assert sum(map(len, simgr.stashes.values())) == 2
+        assert sum(len(i) for i in simgr.stashes.values()) == 2
         assert {s.solver.eval(s.regs.rax) for s in simgr.deadended} == {0x1234, 0x5678}
 
         # Execute concretely
@@ -68,7 +68,7 @@ class TestPcodeEngine(TestCase):
         simgr = p.factory.simgr()
         simgr.run()
 
-        assert sum(map(len, simgr.stashes.values())) == len(simgr.deadended) == 3
+        assert sum(len(i) for i in simgr.stashes.values()) == len(simgr.deadended) == 3
 
         grant_paths = [s for s in simgr.deadended if b'trusted' in s.posix.dumps(1)]
         assert len(grant_paths) == 2

--- a/tests/test_cfgfast_soot.py
+++ b/tests/test_cfgfast_soot.py
@@ -3,11 +3,17 @@ import unittest
 
 import angr
 
+try:
+    import pysoot
+except ModuleNotFoundError:
+    pysoot = None
+
 test_location = os.path.join(os.path.dirname(os.path.realpath(str(__file__))), '..', '..', 'binaries', 'tests')
 
 
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
+@unittest.skipUnless(pysoot, "pysoot not available")
 class TestCfgfastSoot(unittest.TestCase):
     def test_simple1(self):
         binary_path = os.path.join(test_location, "java", "simple1.jar")

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -1,5 +1,6 @@
 
 import os
+import unittest
 
 import angr
 from angr.storage.memory_mixins import JavaVmMemory, DefaultMemory, KeyValueMemory
@@ -10,10 +11,16 @@ from archinfo.arch_soot import (ArchSoot, SootAddressDescriptor, SootMethodDescr
                                 SootArgument, SootAddressTerminator)
 from claripy.backends.backend_smtlib_solvers import z3str_popen  # pylint:disable=unused-import
 
+try:
+    import pysoot
+except ModuleNotFoundError:
+    pysoot = None
+
 file_dir = os.path.dirname(os.path.realpath(__file__))
 test_location = os.path.join(file_dir, "..", "..", "binaries", "tests", "java")
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_fauxware():
     # create project
     binary_path = os.path.join(test_location, "fauxware_java_jni", "fauxware.jar")
@@ -66,6 +73,7 @@ def test_apk_loading():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_cmd_line_args():
     project = create_project("cmd_line_args", load_native_libs=False)
     entry = project.factory.entry_state()
@@ -91,6 +99,7 @@ def test_cmd_line_args():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_jni_version_information():
     project = create_project("jni_version_information")
 
@@ -104,6 +113,7 @@ def test_jni_version_information():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_jni_global_and_local_refs():
     project = create_project("jni_global_and_local_refs")
 
@@ -194,6 +204,7 @@ def test_jni_field_access():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_jni_method_calls():
     project = create_project("jni_method_calls")
 
@@ -231,6 +242,7 @@ def test_jni_method_calls():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_jni_primitive_datatypes():
     project = create_project("jni_primitive_datatypes")
 
@@ -259,6 +271,7 @@ def test_jni_primitive_datatypes():
                assert_locals={'l1': 0xffffffffffffffff, 'l3': 1})
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_jni_object_arrays():
     project = create_project("jni_object_array_operations")
 
@@ -276,6 +289,7 @@ def test_jni_object_arrays():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_jni_array_operations():
     project = create_project("jni_array_operations")
 
@@ -355,6 +369,7 @@ def test_jni_array_operations():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_method_calls():
     project = create_project("method_calls", load_native_libs=False)
 
@@ -384,6 +399,7 @@ def test_method_calls():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_array_operations():
     project = create_project("array_operations", load_native_libs=False)
 
@@ -473,6 +489,7 @@ def test_array_operations():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_multiarray_operations():
     project = create_project("multiarray_operations", load_native_libs=False)
 
@@ -486,6 +503,7 @@ def test_multiarray_operations():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_loading():
     # Test1: test loading with load path
     native_libs_ld_path = os.path.join(
@@ -518,6 +536,7 @@ def test_loading():
 #
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_toggling_of_simstate():
     binary_dir = os.path.join(test_location, "misc", "simstates")
     project = create_project(binary_dir)
@@ -554,6 +573,7 @@ def test_toggling_of_simstate():
     assert isinstance(state_copy.registers, DefaultMemory)
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def test_object_tracking():
     binary_dir = os.path.join(test_location, "object_tracking")
     project = create_project(binary_dir, load_native_libs=False)
@@ -634,6 +654,7 @@ def run_method(project, method, assert_locals=None, assertions=None):
 #     print
 
 
+@unittest.skipUnless(pysoot, "pysoot not available")
 def create_project(binary_dir, load_native_libs=True):
     jar_path = os.path.join(test_location, binary_dir, "mixedjava.jar")
     if load_native_libs:

--- a/tests/test_jumptables.py
+++ b/tests/test_jumptables.py
@@ -1,8 +1,6 @@
 from typing import Set, Sequence, Optional, Mapping, Any, TYPE_CHECKING
-from tempfile import NamedTemporaryFile
 import logging
 import unittest
-import subprocess
 import os
 
 from common import compile_c, has_32_bit_compiler_support

--- a/tests/test_reassembler.py
+++ b/tests/test_reassembler.py
@@ -6,6 +6,8 @@ import tempfile
 import subprocess
 import shutil
 
+from common import compile_c, has_32_bit_compiler_support
+
 import angr
 
 
@@ -257,7 +259,7 @@ def test_partial_pie_ls_x86():
     r.remove_unnecessary_stuff()
     assembly = r.assembly(comments=True, symbolized=True)
 
-    if is_linux():
+    if is_linux() and has_32_bit_compiler_support():
         # we should be able to compile it and run it ... if we are running on x64 Linux
         tempdir = tempfile.mkdtemp(prefix="angr_test_reassembler_")
         asm_filename = "ls.s"

--- a/tests/test_reassembler.py
+++ b/tests/test_reassembler.py
@@ -6,7 +6,7 @@ import tempfile
 import subprocess
 import shutil
 
-from common import compile_c, has_32_bit_compiler_support
+from common import has_32_bit_compiler_support
 
 import angr
 


### PR DESCRIPTION
This skips both if python imports are missing, and skips tests that require non-supported actions (such as tests that require compiling 32-bit code when no viable compiler/header pair exist).