### PR TITLE
Fix AttributeError in Suggestions ExplorationTechnique

### DIFF
--- a/angr/exploration_techniques/suggestions.py
+++ b/angr/exploration_techniques/suggestions.py
@@ -38,7 +38,7 @@ class Suggestions(ExplorationTechnique):
         self.lock = PicklableLock()
 
     def step(self, simgr, stash='active', **kwargs):
-        simgr = simgr.step(stash=stash, **kwargs)
+        simgr.step(stash=stash, **kwargs)
 
         for state in simgr.stashes.get('interrupted', []):
             if id(state) in self.suggested:


### PR DESCRIPTION
I met this error when using angr:
```
Traceback (most recent call last):
  File "xxx.py", line 61, in <module>
    sm.explore(find=FIND_ADDRESS,avoid=AVOID_ADDRESS,step_func=printConstraints)
  File "/home/xxx/.local/lib/python3.10/site-packages/angr/sim_manager.py", line 288, in explore
    self.run(stash=stash, n=n, **kwargs)
  File "/home/xxx/.local/lib/python3.10/site-packages/angr/sim_manager.py", line 318, in run
    self.step(stash=stash, **kwargs)
  File "/home/xxx/.local/lib/python3.10/site-packages/angr/misc/hookset.py", line 90, in __call__
    result = current_hook(self.func.__self__, *args, **kwargs)
  File "/home/xxx/.local/lib/python3.10/site-packages/angr/exploration_techniques/explorer.py", line 112, in step
    return simgr.step(stash=stash, extra_stop_points=base_extra_stop_points | self._extra_stop_points, **kwargs)
  File "/home/xxx/.local/lib/python3.10/site-packages/angr/misc/hookset.py", line 90, in __call__
    result = current_hook(self.func.__self__, *args, **kwargs)
  File "/home/xxx/.local/lib/python3.10/site-packages/angr/exploration_techniques/suggestions.py", line 44, in step
    for state in simgr.stashes.get('interrupted', []):
AttributeError: 'NoneType' object has no attribute 'stashes'
```

It seems that sometimes the `step` function does not have return value, so I removed the assignment statement.
