### PR TITLE
Set taint engine state data when performing partial symbolic memory read so that it resumes correctly

### DIFF
--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1941,6 +1941,8 @@ void State::propagate_taint_of_mem_read_instr_and_continue(address_t read_addres
 		// Also, remember that a symbolic value has been partially read from memory so that even if the rest of the
 		// bytes to be read are concrete, taint will be propagated.
 		symbolic_read_in_progress = true;
+		taint_engine_stop_mem_read_instruction = curr_instr_addr;
+		taint_engine_next_stmt_idx = curr_stmt_idx;
 		return;
 	}
 	else if (mem_read_result.read_size > taint_engine_stop_mem_read_size) {


### PR DESCRIPTION
Sometimes unicorn triggers read hook multiple times for a single read in an instruction(eg: when reading 16 bytes from memory). If the first partial read is symbolic, then we map all values read so far to VEX statements in the current block where they are read and then wait until the remaining bytes have been read. However, we do not update some state data used by the taint engine to correctly resume taint propagation after a memory read is completed. This cause the second partial read hook to incorrectly assume this is first time symbolic bytes are being read from memory and it will attempt to remap all memory reads to the corresponding VEX statements in the current block(which was already done completed in the previous read hook). This PR fixes this by setting the required data so that the taint engine correctly resumes taint propagation from where it stopped previously.

I do not have a test case for this since the issue was discovered using some code that cannot be made public now. If needed, I could attempt creating a test case.