### PR TITLE
3593 log level colors

### DIFF
--- a/angr/misc/ansi.py
+++ b/angr/misc/ansi.py
@@ -1,6 +1,8 @@
 from typing import Optional, Union
 from enum import Enum, unique
 
+__all__ = ("clear", "Color", "BackgroundColor", "color")
+
 
 _ansi_prefix = "\x1b["
 
@@ -28,7 +30,7 @@ class Color(Enum):
     white = 37
 
 
-BackgroundColor = unique(Enum("BackgroundColor", { i.name:(i.value+10) for i in TextColor }))
+BackgroundColor = unique(Enum("BackgroundColor", { i.name:(i.value+10) for i in Color }))
 
 
 #
@@ -41,6 +43,6 @@ def color(color: Union[Color, BackgroundColor], bright: bool):
 	Return the ansi prefix using the given code
 	Bright may not be used with a BackgroundColor
 	"""
-	if isinstance(color, BackgroundColor):
+	if bright and isinstance(color, BackgroundColor):
 		raise ValueError("Backgrounds should not be bright")
-	return f"{_ansi_prefix}{colore.value};1m" if bright else f"{_ansi_prefix}{color.value}m"
+	return f"{_ansi_prefix}{color.value};1m" if bright else f"{_ansi_prefix}{color.value}m"

--- a/angr/misc/ansi.py
+++ b/angr/misc/ansi.py
@@ -1,8 +1,6 @@
 from typing import Union
 from enum import Enum, unique
 
-__all__ = ("clear", "Color", "BackgroundColor", "color")
-
 
 _ansi_prefix = "\x1b["
 

--- a/angr/misc/ansi.py
+++ b/angr/misc/ansi.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Union
 from enum import Enum, unique
 
 __all__ = ("clear", "Color", "BackgroundColor", "color")
@@ -38,11 +38,11 @@ BackgroundColor = unique(Enum("BackgroundColor", { i.name:(i.value+10) for i in 
 #
 
 
-def color(color: Union[Color, BackgroundColor], bright: bool):
-	"""
-	Return the ansi prefix using the given code
-	Bright may not be used with a BackgroundColor
-	"""
-	if bright and isinstance(color, BackgroundColor):
-		raise ValueError("Backgrounds should not be bright")
-	return f"{_ansi_prefix}{color.value};1m" if bright else f"{_ansi_prefix}{color.value}m"
+def color(c: Union[Color, BackgroundColor], bright: bool):
+    """
+    Return the ansi prefix using the given code
+    Bright may not be used with a BackgroundColor
+    """
+    if bright and isinstance(c, BackgroundColor):
+        raise ValueError("Backgrounds should not be bright")
+    return f"{_ansi_prefix}{c.value};1m" if bright else f"{_ansi_prefix}{c.value}m"

--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -1,7 +1,7 @@
 import logging
 import zlib
 
-from .ansi import color
+from .ansi import *
 
 from .testing import is_testing
 from ..utils.formatting import ansi_color_enabled
@@ -74,34 +74,35 @@ class CuteFormatter(logging.Formatter):
 
     __slots__ = ("_should_color",)
 
-    def __init__(self, color: bool):
+    def __init__(self, should_color: bool):
         super().__init__()
-        self._should_color: bool = color
+        self._should_color: bool = should_color
 
     def format(self, record: logging.LogRecord):
         name: str = record.name
-		level: str = record.levelname
+        level: str = record.levelname
         message: str = record.getMessage()
         name_len: int = len(name)
-        lvl_len: int = len(name)
+        lvl_len: int = len(level)
         if self._should_color:
-			# Color level
-			if record.levelno >= logging.CRITICAL:
-				level = ansi.color(ansi.Color.red, True) + level + ansi.clear
-				level = ansi.color(ansi.BackgroundColor.yellow, False) + level + ansi.clear
-			elif record.levelno >= logging.ERROR:
-				level = ansi.color(ansi.Color.red, False) + level + ansi.clear
-			elif record.levelno >= logging.WARNING:
-				level = ansi.color(ansi.Color.yellow, False) + level + ansi.clear
-			elif record.levelno >= logging.INFO:
-				level = ansi.color(ansi.Color.blue, False) + level + ansi.clear
-			# Color text
+            # Color level
+            if record.levelno >= logging.CRITICAL:
+                level = color(Color.red, True) + level + clear
+                level = color(BackgroundColor.yellow, False) + level + clear
+            elif record.levelno >= logging.ERROR:
+                level = color(Color.red, False) + level + clear
+            elif record.levelno >= logging.WARNING:
+                level = color(Color.yellow, False) + level + clear
+            elif record.levelno >= logging.INFO:
+                level = color(Color.blue, False) + level + clear
+            # Color text
             c: int = zlib.adler32(record.name.encode()) % 7
             if c != 0:  # Do not color black or white, allow 'uncolored'
-                message = color + ansi.color(ansi.Color(c), False) + message + ansi.clear
-                name = color + ansi.color(ansi.Color(c), False) + name + ansi.clear
+                col = Color(c + Color.black.value)
+                message = color(col, False) + message + clear
+                name = color(col, False) + name + clear
         name = name.ljust(14 + len(name) - name_len)
-		level = level.ljust(7 + len(level) - lvl_len)
+        level = level.ljust(8 + len(level) - lvl_len)
         return f"{level} | {self.formatTime(record, self.datefmt) : <23} | {name} | {message}"
 
 

--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -1,10 +1,11 @@
 import logging
 import zlib
 
-from .ansi import *
+from .ansi import Color, BackgroundColor, color, clear
 
 from .testing import is_testing
 from ..utils.formatting import ansi_color_enabled
+from .. import loggers
 
 
 class Loggers:
@@ -47,7 +48,7 @@ class Loggers:
             raise AttributeError(k)
 
     def __dir__(self):
-        return list(super(Loggers, self).__dir__()) + list(self._loggers.keys())
+        return list(super().__dir__()) + list(self._loggers.keys())
 
     def enable_root_logger(self):
         """
@@ -63,7 +64,7 @@ class Loggers:
 
     @staticmethod
     def setall(level):
-        for name in logging.Logger.manager.loggerDict.keys():
+        for name in logging.Logger.manager.loggerDict:
             logging.getLogger(name).setLevel(level)
 
 
@@ -108,7 +109,6 @@ class CuteFormatter(logging.Formatter):
 
 def is_enabled_for(logger, level):
     if level == 1:
-        from .. import loggers
         return loggers.profiling_enabled
     return originalIsEnabledFor(logger, level)
 

--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -90,6 +90,9 @@ class CuteFormatter(logging.Formatter):
         asctime: str = self.formatTime(record, self.datefmt)
         return f"{record.levelname : <7} | {asctime : <23} | {name} | {message}"
 
+def qqq():
+    for i in range(100):
+        logging.getLogger(str(i)).warning("abc")
 
 def is_enabled_for(logger, level):
     if level == 1:

--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -90,9 +90,6 @@ class CuteFormatter(logging.Formatter):
         asctime: str = self.formatTime(record, self.datefmt)
         return f"{record.levelname : <7} | {asctime : <23} | {name} | {message}"
 
-def qqq():
-    for i in range(100):
-        logging.getLogger(str(i)).warning("abc")
 
 def is_enabled_for(logger, level):
     if level == 1:

--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -5,7 +5,6 @@ from .ansi import Color, BackgroundColor, color, clear
 
 from .testing import is_testing
 from ..utils.formatting import ansi_color_enabled
-from .. import loggers
 
 
 class Loggers:
@@ -109,6 +108,7 @@ class CuteFormatter(logging.Formatter):
 
 def is_enabled_for(logger, level):
     if level == 1:
+        from .. import loggers
         return loggers.profiling_enabled
     return originalIsEnabledFor(logger, level)
 

--- a/ansi.py
+++ b/ansi.py
@@ -1,0 +1,46 @@
+from typing import Optional, Union
+from enum import Enum, unique
+
+
+_ansi_prefix = "\x1b["
+
+
+#
+# Ansi colors
+#
+
+
+clear: str = f"{_ansi_prefix}0m"
+
+
+@unique
+class Color(Enum):
+    """
+    The basic ansi colors
+    """
+    black = 30
+    red = 31
+    green = 32
+    yellow = 33
+    blue = 34
+    magenta = 35
+    cyan = 36
+    white = 37
+
+
+BackgroundColor = unique(Enum("BackgroundColor", { i.name:(i.value+10) for i in TextColor }))
+
+
+#
+# Functions
+#
+
+
+def color(color: Union[Color, BackgroundColor], bright: bool):
+	"""
+	Return the ansi prefix using the given code
+	Bright may not be used with a BackgroundColor
+	"""
+	if isinstance(color, BackgroundColor):
+		raise ValueError("Backgrounds should not be bright")
+	return f"{_ansi_prefix}{colore.value};1m" if bright else f"{_ansi_prefix}{color.value}m"


### PR DESCRIPTION
Implements: https://github.com/angr/angr/issues/3593

This PR colors log level names according to level severity while retaining different loggers coloring their own messages different colors. This should make scanning through logs easier- scanning on the left it is easy to pick out higher level log messages, scanning on the right it is easy what angr had before.
Colors can be changed in this PR, I went with these by default as I find them easy. `Critical` is the one that is most odd, but `Critical` should very much stand out in my opinion so that is the point.

Before merging:
- [x] Merge: https://github.com/angr/angr/pull/3592


With this PR, output looks like this:
<img width="445" alt="logs2" src="https://user-images.githubusercontent.com/20288064/199630501-ebee474c-96e3-4ca3-a58e-21f1b05bb3e5.png">