### PR TITLE
SimLinux: Fix uninitialized high 32 bits of the argc on stack.

### DIFF
--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -296,7 +296,11 @@ class SimLinux(SimUserland):
 
         # Put argc on stack and fix the stack pointer
         newsp = argv - state.arch.bytes
-        state.memory.store(newsp, argc, endness=state.arch.memory_endness)
+        if len(argc) < state.arch.bits:
+            argc_bvv = claripy.ZeroExt(state.arch.bits - len(argc), argc)
+        else:
+            argc_bvv = argc
+        state.memory.store(newsp, argc_bvv, endness=state.arch.memory_endness)
         state.regs.sp = newsp
 
         if state.arch.name in ('PPC32',):


### PR DESCRIPTION
This issue is causing value loading from `envp` to contain an unconstrained symbolic variable, which leads to several test cases ending up in infinite loops. It is only exposed by https://github.com/angr/claripy/pull/310 since unconstrained symbolic variables were frequently evaluated as 0 in the past (due to empty cached models) when `ModelCacheMixin` is enabled.

This PR fixes the hanging angr CI.