### PR TITLE
[MIPS] Don't set gp if the value isn't resolved

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -4375,7 +4375,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
                     gp_value = caller_gp  # fallback
                 if gp_value is None:
                     gp_value = self._gp_value  # fallback to a previously found value
-                func.info['gp'] = gp_value
+                if gp_value is not None:
+                    func.info['gp'] = gp_value
 
         elif self.project.arch.name == "X86":
             # detect __x86.get_pc_thunk.bx


### PR DESCRIPTION
This can be triggered if the first function analyzed doesn't set the value of gp in it's first block.
i.e. many libraries and some statically linked binaries.
[console.zip](https://github.com/angr/angr/files/9978392/console.zip)
