### PR TITLE
Add subprocess initialization function

### DIFF
--- a/angr/analyses/complete_calling_conventions.py
+++ b/angr/analyses/complete_calling_conventions.py
@@ -154,7 +154,14 @@ class CompleteCallingConventionsAnalysis(Analysis):
 
             # spawn workers to perform the analysis
             with self._func_queue_lock:
-                procs = [_mp_context.Process(target=self._worker_routine, args=(Initializer.get(),), daemon=True) for _ in range(self._workers)]
+                procs = [
+                    _mp_context.Process(
+                        target=self._worker_routine,
+                        args=(Initializer.get(),),
+                        daemon=True
+                    )
+                    for _ in range(self._workers)
+                ]
                 for proc_idx, proc in enumerate(procs):
                     self._update_progress(0, text=f"Spawning worker {proc_idx}...")
                     proc.start()

--- a/angr/analyses/complete_calling_conventions.py
+++ b/angr/analyses/complete_calling_conventions.py
@@ -7,7 +7,7 @@ import logging
 
 import claripy
 
-from ..utils.mp import mp_context
+from ..utils.mp import mp_context, Initializer
 from ..knowledge_plugins.cfg import CFGModel
 from ..analyses.cfg import CFGUtils
 from . import Analysis, register_analysis, VariableRecoveryFast, CallingConventionAnalysis
@@ -154,7 +154,7 @@ class CompleteCallingConventionsAnalysis(Analysis):
 
             # spawn workers to perform the analysis
             with self._func_queue_lock:
-                procs = [_mp_context.Process(target=self._worker_routine, daemon=True) for _ in range(self._workers)]
+                procs = [_mp_context.Process(target=self._worker_routine, args=(Initializer.get(),), daemon=True) for _ in range(self._workers)]
                 for proc_idx, proc in enumerate(procs):
                     self._update_progress(0, text=f"Spawning worker {proc_idx}...")
                     proc.start()
@@ -189,7 +189,8 @@ class CompleteCallingConventionsAnalysis(Analysis):
             for proc in procs:
                 proc.join()
 
-    def _worker_routine(self):
+    def _worker_routine(self, initializer: Initializer):
+        initializer.initialize()
         idx = 0
         while not self._func_queue.empty():
             try:

--- a/angr/distributed/worker.py
+++ b/angr/distributed/worker.py
@@ -4,6 +4,7 @@ import multiprocessing
 import logging
 import sys
 
+from angr.utils.mp import Initializer
 from ..exploration_techniques import ExplorationTechnique, Bucketizer
 from ..vaults import VaultDirShelf
 
@@ -71,12 +72,11 @@ class Worker:
         self.remove_options = remove_options
 
     def start(self):
-        self._proc = multiprocessing.Process(
-            target=self.run,
-        )
+        self._proc = multiprocessing.Process(target=self.run, args=(Initializer.get(),))
         self._proc.start()
 
-    def run(self):
+    def run(self, initializer: Initializer):
+        initializer.initialize()
 
         from ..exploration_techniques.spiller import Spiller, PickledStatesDb  # pylint:disable=import-outside-toplevel
 

--- a/angr/utils/mp.py
+++ b/angr/utils/mp.py
@@ -1,5 +1,51 @@
+from typing import NamedTuple, Optional, Callable, List, Dict, Any
 import multiprocessing
 import platform
+
+
+class Closure(NamedTuple):
+    """
+    A pickle-able lambda; note that f, args, and kwargs must be pickleable
+    """
+    f: Callable[..., None]
+    args: List[Any]
+    kwargs: Dict[str, Any]
+
+
+class Initializer:
+    """
+    A singleton class with global state used to initialize a multiprocessing.Process
+    """
+    _single: Optional["Initializer"] = None
+
+    @classmethod
+    def get(cls) -> "Initializer":
+        """
+        A wrapper around init since this class is a singleton
+        """
+        if cls._single is None:
+            cls._single = cls(_manual = False)
+        return cls._single
+
+    def __init__(self, *, _manual: bool = True):
+        if _manual:
+            raise RuntimeError("This is a singleton; call .get() instead")
+        self.initializers: List[Closure] = []
+
+    def register(self, f: Callable[..., None], *args: Any, **kwargs: Any) -> None:
+        """
+        A shortcut for adding Closures as initializers
+        """
+        self.initializers.append(Closure(f, args, kwargs))
+
+    def initialize(self) -> None:
+        """
+        Initialize a multiprocessing.Process
+        Set the current global initalizer to the same state as this initalizer, then calls each initalizer
+        """
+        self._single = self
+        for i in self.initializers:
+            i.f(*i.args, **i.kwargs)
 
 
 def mp_context():


### PR DESCRIPTION
Allows `multiprocess.Process`'s to be initialized using data from the parent. All target functions of `multiprocessing.Process` should:
1. `from angr.utils.mp import Initializer` at the top of their file
2. Have their first argument be `initializer: Initializer`
3. Have their first line be `initializer.initialize()`