### PR TITLE
Added SimMemView.with_type() to pass a SimType

### DIFF
--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -218,6 +218,16 @@ class SimMemView(SimStatePlugin):
     def __cmp__(self, other):
         raise ValueError("Trying to compare SimMemView is not what you want to do")
 
+    def with_type(self, name: str):
+        """
+        Returns a copy of the SimMemView with a type.
+
+        :param name:    The name of the type.
+        :returns:       The typed SimMemView copy.
+        """
+        ty = SimMemView.types[name].with_arch(self.state.arch)
+        return self._deeper(ty=ty)
+
     @SimStatePlugin.memo
     def copy(self, memo): # pylint: disable=unused-argument
         return SimMemView()

--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -1,9 +1,13 @@
+from typing import TYPE_CHECKING
 import logging
 
 import claripy
 from archinfo.arch_soot import ArchSoot, SootAddressDescriptor
 from archinfo.arch_arm import is_arm_arch
 from .plugin import SimStatePlugin
+
+if TYPE_CHECKING:
+    from angr.sim_type import SimType
 
 
 l = logging.getLogger(name=__name__)
@@ -218,14 +222,14 @@ class SimMemView(SimStatePlugin):
     def __cmp__(self, other):
         raise ValueError("Trying to compare SimMemView is not what you want to do")
 
-    def with_type(self, name: str):
+    def with_type(self, sim_type: "SimType") -> "SimMemView":
         """
         Returns a copy of the SimMemView with a type.
 
-        :param name:    The name of the type.
-        :returns:       The typed SimMemView copy.
+        :param sim_type:    The new type.
+        :returns:           The typed SimMemView copy.
         """
-        ty = SimMemView.types[name].with_arch(self.state.arch)
+        ty = sim_type.with_arch(self.state.arch)
         return self._deeper(ty=ty)
 
     @SimStatePlugin.memo


### PR DESCRIPTION
This adds `with_type` to SimMemoryView.

```python
from angr.sim_type import ALL_TYPES
s.mem[0x404010].with_type(ALL_TYPES["unsigned int"])
```
This is needed for #2402.

Before, you could not specify the C type as a string, only like this:
```python
s.mem[0x404010].unsigned
```