### PR TITLE
Correct block printing for ARM Thumb

### DIFF
--- a/angr/block.py
+++ b/angr/block.py
@@ -256,7 +256,8 @@ class Block(Serializable):
 
     def pp(self, **kwargs):
         if self._project is not None:
-            print(self._project.analyses.Disassembly(ranges=[(self.addr, self.addr + self.size)]).render(**kwargs))
+            addr = self.addr - 1 if self.thumb else self.addr
+            print(self._project.analyses.Disassembly(ranges=[(addr, addr + self.size)]).render(**kwargs))
         else:
             self.disassembly.pp()
 


### PR DESCRIPTION
Addresses for thumb are increased by 1. This leads to printing functions decode the instructions at wrong addresses.

Correct the addresses if binary is Thumb.