### PR TITLE
Print exceptions during logging

### DIFF
--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -1,3 +1,4 @@
+import traceback
 import logging
 import zlib
 
@@ -101,9 +102,13 @@ class CuteFormatter(logging.Formatter):
                 col = Color(c + Color.black.value)
                 message = color(col, False) + message + clear
                 name = color(col, False) + name + clear
+        # Finalize log message
         name = name.ljust(14 + len(name) - name_len)
         level = level.ljust(8 + len(level) - lvl_len)
-        return f"{level} | {self.formatTime(record, self.datefmt) : <23} | {name} | {message}"
+        body: str = f"{level} | {self.formatTime(record, self.datefmt) : <23} | {name} | {message}"
+        if record.exc_info:
+            body += "\n" + "".join(traceback.format_exception(record.exc_info[1]))[:-1]
+        return body
 
 
 def is_enabled_for(logger, level):

--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -107,8 +107,7 @@ class CuteFormatter(logging.Formatter):
         level = level.ljust(8 + len(level) - lvl_len)
         body: str = f"{level} | {self.formatTime(record, self.datefmt) : <23} | {name} | {message}"
         if record.exc_info:
-            # pylint: disable=no-value-for-parameter
-            body += "\n" + "".join(traceback.format_exception(record.exc_info[1]))[:-1]
+            body += "\n" + "".join(traceback.format_exception(*record.exc_info))[:-1]
         return body
 
 

--- a/angr/misc/loggers.py
+++ b/angr/misc/loggers.py
@@ -107,6 +107,7 @@ class CuteFormatter(logging.Formatter):
         level = level.ljust(8 + len(level) - lvl_len)
         body: str = f"{level} | {self.formatTime(record, self.datefmt) : <23} | {name} | {message}"
         if record.exc_info:
+            # pylint: disable=no-value-for-parameter
             body += "\n" + "".join(traceback.format_exception(record.exc_info[1]))[:-1]
         return body
 


### PR DESCRIPTION
Fixes: https://github.com/angr/angr/issues/3616

With this update:
```
>>> try:
...   raise Exception()
... except:
...   logging.root.exception("haha")
...
ERROR    | 2022-11-18 16:02:33,314 | root           | haha
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
Exception
```