### PR TITLE
Suppress false errors when dissecting ARM IT instructions

### DIFF
--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -2,6 +2,8 @@ import logging
 from collections import defaultdict
 from typing import Union, Optional, Sequence, Tuple, Any
 
+import archinfo
+
 import pyvex
 from angr.knowledge_plugins import Function
 
@@ -284,11 +286,15 @@ class Instruction(DisassemblyPiece):
             return
 
         if len(self.operands) != len(self.insn.operands):
-            l.error("Operand parsing failed for instruction %s. %d operands are parsed, while %d are expected.",
-                    str(self.insn),
-                    len(self.operands),
-                    len(self.insn.operands)
-                    )
+            if isinstance(self.arch, archinfo.ArchARM) and self.insn.mnemonic[:2] == "it":
+                # ARM IT instructions have op_str, but they are not considered operands by Capstone
+                pass
+            else:
+                l.error("Operand parsing failed for instruction %s. %d operands are parsed, while %d are expected.",
+                        str(self.insn),
+                        len(self.operands),
+                        len(self.insn.operands)
+                        )
             self.operands = [ ]
             return
 


### PR DESCRIPTION
I am getting these errors when disassembling some Thumb binaries:
`ERROR   | 2022-11-19 13:44:09,796 | angr.analyses.disassembly | Operand parsing failed for instruction 0x34:    ittt    ne. 1 operands are parsed, while 0 are expected.`
`ERROR   | 2022-11-19 13:44:09,797 | angr.analyses.disassembly | Operand parsing failed for instruction 0x42:    itt     ne. 1 operands are parsed, while 0 are expected.`
`ERROR   | 2022-11-19 13:44:09,799 | angr.analyses.disassembly | Operand parsing failed for instruction 0x70:    ite     eq. 1 operands are parsed, while 0 are expected.`
`ERROR   | 2022-11-19 13:44:09,801 | angr.analyses.disassembly | Operand parsing failed for instruction 0x9a:    it      eq. 1 operands are parsed, while 0 are expected.`

However they are false positives. Although `op_str` exist for IT instructions, which are the conditions such as `ne` or `eq`, Capstone do not consider them operands. They are parsed as operands by angr, which leads to the false errors.