### PR TITLE
Fix function name in module definition file to match the source

### DIFF
--- a/native/angr_native.def
+++ b/native/angr_native.def
@@ -44,4 +44,4 @@ EXPORTS
   simunicorn_set_vex_cc_reg_data
   simunicorn_get_count_of_writes_to_reexecute
   simunicorn_get_concrete_writes_to_reexecute
-  simunicorn_set_fp_ops_vex_codes
+  simunicorn_set_fp_regs_fp_ops_vex_codes


### PR DESCRIPTION
This PR fixes a bug introduced in #3622: the function name in the module definition file does not match the one in the source.