### PR TITLE
Save only required concrete memory values instead of all values

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -74,6 +74,7 @@ class MemoryValue(ctypes.Structure):
     _fields_ = [
         ('address', ctypes.c_uint64),
         ('value', ctypes.c_uint8),
+        ('is_value_set', ctypes.c_bool),
         ('is_value_symbolic', ctypes.c_bool)
     ]
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1898,7 +1898,12 @@ void State::propagate_taint_of_mem_read_instr_and_continue(address_t read_addres
 	for (auto i = 0; i < read_size; i++) {
 		memory_value_t memory_value;
 		memory_value.address = read_address + i;
-		memory_value.is_value_symbolic = (find_tainted(read_address + i, 1) != -1);
+		if (!is_mem_read_symbolic) {
+			memory_value.is_value_symbolic = false;
+		}
+		else {
+			memory_value.is_value_symbolic = (find_tainted(read_address + i, 1) != -1);
+		}
 		memory_read_values.emplace_back(memory_value);
 	}
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -1965,7 +1965,7 @@ void State::propagate_taint_of_mem_read_instr_and_continue(address_t read_addres
 								if (!value.is_value_symbolic) {
 									auto entry = block_mem_read_addr_details.find(value.address);
 									if (entry == block_mem_read_addr_details.end()) {
-										block_mem_read_addr_details.emplace(value.address, std::unordered_set<int64_t>(vex_stmt_taint_entry_it->second.sink.stmt_idx));
+										block_mem_read_addr_details.emplace(value.address, std::unordered_set<int64_t>({vex_stmt_taint_entry_it->second.sink.stmt_idx}));
 									}
 									else {
 										entry->second.emplace(vex_stmt_taint_entry_it->second.sink.stmt_idx);
@@ -1981,7 +1981,7 @@ void State::propagate_taint_of_mem_read_instr_and_continue(address_t read_addres
 								if (!value.is_value_symbolic) {
 									auto entry = block_mem_read_addr_details.find(value.address);
 									if (entry == block_mem_read_addr_details.end()) {
-										block_mem_read_addr_details.emplace(value.address, std::unordered_set<int64_t>(vex_stmt_taint_entry_it->second.sink.stmt_idx));
+										block_mem_read_addr_details.emplace(value.address, std::unordered_set<int64_t>({vex_stmt_taint_entry_it->second.sink.stmt_idx}));
 									}
 									else {
 										entry->second.emplace(vex_stmt_taint_entry_it->second.sink.stmt_idx);


### PR DESCRIPTION
Currently, values of all concrete memory reads are saved during execution in case required for re-execution later on, which slows things down in some cases. While #3583 implements a reasonable speedup, there is no need to save all values: it is sufficient to save just the value needed for re-execution. This PR reduces the number of concrete memory values saved in native interface: unless any concrete values are overwritten by the block(in which case, the value is saved before the write is performed), only required values are saved after the entire block has executed.