### PR TITLE
Support unicorn versions newer than 2.0.1 as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=59", "wheel", "pyvex==9.2.27.dev0", "unicorn==2.0.1"]
+requires = ["setuptools>=59", "wheel", "pyvex==9.2.27.dev0", "unicorn>=2.0.1"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     progressbar2 >= 3
     rpyc
     cffi >= 1.14.0
-    unicorn == 2.0.1
+    unicorn >= 2.0.1
     archinfo == 9.2.27.dev0
     claripy == 9.2.27.dev0
     cle == 9.2.27.dev0


### PR DESCRIPTION
A new version of unicorn(2.0.1post1) was released few days ago. All CI and CGC tracing tests seem to pass with the latest version so we could support for that too.