### PR TITLE
Add an upper bound of known compatible unicorn releases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     progressbar2 >= 3
     rpyc
     cffi >= 1.14.0
-    unicorn >= 2.0.1
+    unicorn >= 2.0.1, <= 2.0.1.post1
     archinfo == 9.2.27.dev0
     claripy == 9.2.27.dev0
     cle == 9.2.27.dev0


### PR DESCRIPTION
Because unicorn updates have broken angr in the past, this adds an upper bound so that we only allow versions that have been tested first.