### PR TITLE
Decompose large symbolic BVs to smaller sized BVs when storing to memory if possible

### DIFF
--- a/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
@@ -107,6 +107,17 @@ class MemoryObjectMixin(CooperationBase):
                                                    label=label)
         size = yield
         while True:
+            if data.symbolic and data.op == 'Concat' and data.size() > size * 8:
+                offset = cur_addr - addr
+                # Generate new memory object with only size bytes to speed up extracting bytes
+                cur_data = data.args[offset].concat(*data.args[offset + 1:offset + size])
+                if label is None:
+                    memory_object = SimMemoryObject(cur_data, cur_addr, endness,
+                                                    byte_width=memory.state.arch.byte_width if memory is not None else 8)
+                else:
+                    memory_object = SimLabeledMemoryObject(cur_data, cur_addr, endness,
+                                                           byte_width=memory.state.arch.byte_width if memory is not None else 8,
+                                                           label=label)
             cur_addr += size
             size = yield memory_object, memory_object.base, memory_object.length
 


### PR DESCRIPTION
Symbolic BVs larger than 1 page were stored as is in memory. This slows down extracting bytes from the BV for further processing. This PR adds support for decomposing large symbolic BVs into smaller ones before storing to memory so that bytes can be extracted faster. This speeds up tracing 2-3 CGC binaries by 1.5-3x with no noticeable slowdowns.  I added support only for BVs where operation is `Concat` since that's what I mainly encountered. Can something similar be done for other operations? Should support for those be added?