### PR TITLE
ARM64 support in disassembly

### DIFF
--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -244,6 +244,7 @@ class Instruction(DisassemblyPiece):
                 return
         
         for operand in dummy_operands:
+            # FIXME: '\x00\x00\x01\x4E'    TBL     V0.16B, {V0.16B}, V1.16B
             opr_pieces = self.split_op_string(operand)
             cur_operand = []
             if opr_pieces[0][0].isalpha() and opr_pieces[0] in self.arch.registers:
@@ -270,6 +271,8 @@ class Instruction(DisassemblyPiece):
                         v = -v
                         cur_operand.pop()
                     cur_operand.append(Value(v, with_sign))
+                elif p[0].isalpha() and p in self.arch.registers:
+                    cur_operand.append(Register(p))
                 else:
                     cur_operand.append(p)
             self.operands.append(cur_operand)

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -172,6 +172,7 @@ class Instruction(DisassemblyPiece):
         self.arch = self.project.arch
         self.format = ''
         self.components = ()
+        self.opcode = None
         self.operands = [ ]
 
         # the following members will be filled in after disecting the instruction
@@ -215,9 +216,9 @@ class Instruction(DisassemblyPiece):
             # Check if this is a number or an identifier.
             ordc = ord(c[0])
             # pylint:disable=too-many-boolean-expressions
-            if (ordc >= 0x30 and ordc <= 0x39) or \
-               (ordc >= 0x41 and ordc <= 0x5a) or \
-               (ordc >= 0x61 and ordc <= 0x7a):
+            if 0x30 <= ordc <= 0x39 or \
+               0x41 <= ordc <= 0x5a or \
+               0x61 <= ordc <= 0x7a:
 
                 # perform some basic classification
                 intc = None
@@ -284,11 +285,12 @@ class Instruction(DisassemblyPiece):
             return
 
         if len(self.operands) != len(self.insn.operands):
-            l.error("Operand parsing failed for instruction %s. %d operands are parsed, while %d are expected.",
-                    str(self.insn),
-                    len(self.operands),
-                    len(self.insn.operands)
-                    )
+            l.error(
+                "Operand parsing failed for instruction %s. %d operands are parsed, while %d are expected.",
+                str(self.insn),
+                len(self.operands),
+                len(self.insn.operands)
+            )
             self.operands = [ ]
             return
 
@@ -311,9 +313,9 @@ class Instruction(DisassemblyPiece):
                 in_word = False
                 continue
             # pylint:disable=too-many-boolean-expressions
-            if (ordc >= 0x30 and ordc <= 0x39) or \
-               (ordc >= 0x41 and ordc <= 0x5a) or \
-               (ordc >= 0x61 and ordc <= 0x7a):
+            if 0x30 <= ordc <= 0x39 or \
+               0x41 <= ordc <= 0x5a or \
+               0x61 <= ordc <= 0x7a:
                 if in_word:
                     pieces[-1] += c
                 else:

--- a/tests/test_disassembly.py
+++ b/tests/test_disassembly.py
@@ -28,7 +28,7 @@ class TestDisassembly(TestCase):
             ranges=[(block.addr, block.addr + block.size)]
         )
 
-        insns = filter(lambda r: isinstance(r, Instruction), disasm.raw_result)
+        insns = [r for r in disasm.raw_result if isinstance(r, Instruction)]
         rendered_insns = [i.render()[0].lower() for i in insns]
         assert 'v0.2d' in rendered_insns[0]
         assert 'v2.b[5]' in rendered_insns[1]


### PR DESCRIPTION
Added aarch64-specific `disect_instruction_for_aarch64()` function. I think patching the existing `disect_instruction` can hardly help, instead it easily messes up the code.

Testcases are also added.

BTW, I have read some of the previous PRs and code in capstone-engine, I think condition code/shifter/extender should be treated as attributes of opcode/operands (at least for arm64).

And according to [wikipedia](https://en.wikipedia.org/wiki/Instruction_set_architecture):

> [Machine language](https://en.wikipedia.org/wiki/Machine_code) is built up from discrete statements or instructions. On the processing architecture, a given instruction may specify:
> - opcode (the instruction to be performed) e.g. add, copy, test
> - any explicit operands:
>   - [registers](https://en.wikipedia.org/wiki/Processor_register)
>   - literal/constant values
>   - [addressing modes](https://en.wikipedia.org/wiki/Addressing_mode) used to access memory

So I think it makes sense that capstone engine do not treat them as operands.


Also, let's just stop hackish workarounds and do different instruction disection for different architectures!