### PR TITLE
Prefer builtin constructors

### DIFF
--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -294,9 +294,9 @@ class NormalizedFunction:
         # start by copying the graph
         self.graph: networkx.DiGraph = function.graph.copy()
         self.project = function._function_manager._kb._project
-        self.call_sites = dict()
+        self.call_sites = {}
         self.startpoint = function.startpoint
-        self.merged_blocks = dict()
+        self.merged_blocks = {}
         self.orig_function = function
 
         # find nodes which end in call and combine them
@@ -360,8 +360,8 @@ class FunctionDiff:
         self._project_b = self._function_b.project
         self._bindiff = bindiff
 
-        self._attributes_a = dict()
-        self._attributes_a = dict()
+        self._attributes_a = {}
+        self._attributes_b = {}
 
         self._block_matches = set()
         self._unmatched_blocks_from_a = set()
@@ -409,7 +409,7 @@ class FunctionDiff:
         :return: A list of block matches which appear to differ
         """
         differing_blocks = []
-        diffs = dict()
+        diffs = {}
         for (block_a, block_b) in self._block_matches:
             if self.blocks_probably_identical(block_a, block_b) and \
                     not self.blocks_probably_identical(block_a, block_b, check_constants=True):
@@ -658,8 +658,8 @@ class FunctionDiff:
         processed_matches = set((x, y) for (x, y) in initial_matches)
 
         # Keep a dict of current matches, which will be updated if better matches are found
-        matched_a = dict()
-        matched_b = dict()
+        matched_a = {}
+        matched_b = {}
         for (x, y) in processed_matches:
             matched_a[x] = y
             matched_b[y] = x
@@ -870,10 +870,10 @@ class BinDiff(Analysis):
         l.debug("Done computing cfg's")
 
         self._p2 = other_project
-        self._attributes_a = dict()
-        self._attributes_a = dict()
+        self._attributes_a = {}
+        self._attributes_b = {}
 
-        self._function_diffs = dict()
+        self._function_diffs = {}
         self.function_matches = set()
         self._unmatched_functions_from_a = set()
         self._unmatched_functions_from_b = set()
@@ -954,7 +954,7 @@ class BinDiff(Analysis):
         """
         :return: A dict of block matches with differing constants to the tuple of constants
         """
-        diffs = dict()
+        diffs = {}
         for (func_a, func_b) in self.function_matches:
             diffs.update(self.get_function_diff(func_a, func_b).blocks_with_differing_constants)
         return diffs
@@ -984,7 +984,7 @@ class BinDiff(Analysis):
         :returns:    a dictionary of function addresses to tuples of attributes
         """
         # the attributes we use are the number of basic blocks, number of edges, and number of subfunction calls
-        attributes = dict()
+        attributes = {}
         all_funcs = set(cfg.kb.callgraph.nodes())
         for function_addr in cfg.kb.functions:
             # skip syscalls and functions which are None in the cfg
@@ -1038,8 +1038,8 @@ class BinDiff(Analysis):
                 plt_matches.append((addr, self._p2.loader.main_object.plt[name]))
 
         # in the case of sim procedures the actual sim procedure might be in the interfunction graph, not the plt entry
-        func_to_addr_a = dict()
-        func_to_addr_b = dict()
+        func_to_addr_a = {}
+        func_to_addr_b = {}
         for (k, hook) in self.project._sim_procedures.items():
             if "resolves" in hook.kwargs:
                 func_to_addr_a[hook.kwargs['resolves']] = k
@@ -1099,8 +1099,8 @@ class BinDiff(Analysis):
         processed_matches = set((x, y) for (x, y) in initial_matches)
 
         # Keep a dict of current matches, which will be updated if better matches are found
-        matched_a = dict()
-        matched_b = dict()
+        matched_a = {}
+        matched_b = {}
         for (x, y) in processed_matches:
             matched_a[x] = y
             matched_b[y] = x

--- a/angr/analyses/identifier/functions/__init__.py
+++ b/angr/analyses/identifier/functions/__init__.py
@@ -9,7 +9,7 @@ from ..func import Func
 
 # Import all classes under the current directory, and group them based on
 # lib names.
-Functions = dict()
+Functions = {}
 path = os.path.dirname(os.path.abspath(__file__))
 skip_dirs = ['__init__.py']
 skip_procs = ['__init__', 'func']

--- a/angr/analyses/identifier/identify.py
+++ b/angr/analyses/identifier/identify.py
@@ -62,12 +62,12 @@ class Identifier(Analysis):
         self._reg_list = a.default_symbolic_registers
         self._reg_list = [r for r in self._reg_list if r not in (self._sp_reg, self._ip_reg)]
 
-        self.matches = dict()
+        self.matches = {}
 
         self.callsites = None
         self.inv_callsites = None
-        self.func_info = dict()
-        self.block_to_func = dict()
+        self.func_info = {}
+        self.block_to_func = {}
 
         self.map_callsites()
 
@@ -277,7 +277,7 @@ class Identifier(Analysis):
             return False
 
     def map_callsites(self):
-        callsites = dict()
+        callsites = {}
         for f in self._cfg.functions.values():
             for callsite in f.get_call_sites():
                 if f.get_call_target(callsite) is None:
@@ -291,7 +291,7 @@ class Identifier(Analysis):
             self.inv_callsites[f].add(c)
 
         # create map of blocks to the function they reside in
-        self.block_to_func = dict()
+        self.block_to_func = {}
         for f in self._cfg.functions.values():
             for b in f.graph.nodes():
                 self.block_to_func[b.addr] = f
@@ -357,7 +357,7 @@ class Identifier(Analysis):
 
         # get the accesses of calling func
         calling_func = self.block_to_func[callsite]
-        reverse_accesses = dict()
+        reverse_accesses = {}
         calling_func_info = self.func_info[calling_func]
         stack_var_accesses = calling_func_info.stack_var_accesses
         for stack_var, v in stack_var_accesses.items():
@@ -476,7 +476,7 @@ class Identifier(Analysis):
 
         initial_state = self.base_symbolic_state.copy()
 
-        reg_dict = dict()
+        reg_dict = {}
         for r in self._reg_list + [self._bp_reg]:
             reg_dict[hash(initial_state.registers.load(r))] = r
 
@@ -682,7 +682,7 @@ class Identifier(Analysis):
                 if is_buffer:
                     buffers.add(bp_off)
 
-        stack_args = list()
+        stack_args = []
         stack_arg_accesses = defaultdict(set)
         for v in stack_vars:
             if v > 0:

--- a/angr/analyses/propagator/vex_vars.py
+++ b/angr/analyses/propagator/vex_vars.py
@@ -3,7 +3,7 @@
 
 class VEXVariable:
 
-    __slots__ = tuple()
+    __slots__ = ()
 
     def __hash__(self):
         raise NotImplementedError()

--- a/angr/analyses/typehoon/typevars.py
+++ b/angr/analyses/typehoon/typevars.py
@@ -389,7 +389,7 @@ class TypeVariables:
 
 class BaseLabel:
 
-    __slots__ = tuple()
+    __slots__ = ()
 
     def __eq__(self, other):
         return type(self) is type(other) and hash(self) == hash(other)
@@ -422,7 +422,7 @@ class FuncOut(BaseLabel):
 
 class Load(BaseLabel):
 
-    __slots__ = tuple()
+    __slots__ = ()
 
     def __repr__(self):
         return "load"
@@ -430,7 +430,7 @@ class Load(BaseLabel):
 
 class Store(BaseLabel):
 
-    __slots__ = tuple()
+    __slots__ = ()
 
     def __repr__(self):
         return "store"

--- a/angr/code_location.py
+++ b/angr/code_location.py
@@ -60,7 +60,7 @@ class CodeLocation:
         ss = [ ]
         if self.info:
             for k, v in self.info.items():
-                if v != tuple() and v is not None:
+                if v != () and v is not None:
                     ss.append("%s=%s" % (k, v))
             if ss:
                 s += " with %s" % ", ".join(ss)

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -113,7 +113,7 @@ class SimEngineLight(
 
         if not self._call_stack:
             # contextful but the callstack is empty
-            return tuple()
+            return ()
 
         # Convert to Tuple to make `context` hashable if not None
         call_stack_addresses = tuple(self._call_stack)

--- a/angr/exploration_techniques/unique.py
+++ b/angr/exploration_techniques/unique.py
@@ -22,7 +22,7 @@ class UniqueSearch(ExplorationTechnique):
         super(UniqueSearch, self).__init__()
         self.similarity_func = similarity_func or UniqueSearch.similarity
         self.deferred_stash = deferred_stash
-        self.uniqueness = dict()
+        self.uniqueness = {}
         self.num_deadended = 0
 
     def setup(self, simgr):

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -113,7 +113,7 @@ class Function(Serializable):
         self._local_block_addrs = set()  # a set of addresses of all blocks inside the function
 
         self.info = {}  # storing special information, like $gp values for MIPS32
-        self.tags = tuple()  # store function tags. can be set manually by performing CodeTagging analysis.
+        self.tags = ()  # store function tags. can be set manually by performing CodeTagging analysis.
 
         # TODO: Can we remove the following two members?
         # Register offsets of those arguments passed in registers

--- a/angr/knowledge_plugins/functions/soot_function.py
+++ b/angr/knowledge_plugins/functions/soot_function.py
@@ -101,7 +101,7 @@ class SootFunction(Function):
         self._local_block_addrs = set()  # a set of addresses of all blocks inside the function
 
         self.info = { }  # storing special information, like $gp values for MIPS32
-        self.tags = tuple()  # store function tags. can be set manually by performing CodeTagging analysis.
+        self.tags = ()  # store function tags. can be set manually by performing CodeTagging analysis.
 
     def normalize(self):
         # The Shimple CFG is already normalized.

--- a/angr/serializable.py
+++ b/angr/serializable.py
@@ -4,7 +4,7 @@ class Serializable:
     The base class of all protobuf-serializable classes in angr.
     """
 
-    __slots__ = tuple()
+    __slots__ = ()
 
     @classmethod
     def _get_cmsg(cls):

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -2674,7 +2674,7 @@ def _make_scope(predefined_types=None):
     Generate CParser scope_stack argument to parse method
     """
     all_types = ChainMap(predefined_types or {}, ALL_TYPES)
-    scope = dict()
+    scope = {}
     for ty in all_types:
         if ty in BASIC_TYPES:
             continue
@@ -2871,7 +2871,7 @@ def _accepts_scope_stack():
     def parse(self,text, filename='', debug=False, scope_stack=None):
         self.clex.filename = filename
         self.clex.reset_lineno()
-        self._scope_stack = [dict()] if scope_stack is None else scope_stack
+        self._scope_stack = [{}] if scope_stack is None else scope_stack
         self._last_yielded_token = None
         return self.cparser.parse(
             input=text,

--- a/angr/state_plugins/trace_additions.py
+++ b/angr/state_plugins/trace_additions.py
@@ -308,7 +308,7 @@ class ChallRespInfo(angr.state_plugins.SimStatePlugin):
         # for each constraint we check what the max stdin it has and how much stdout we have
         self.stdin_min_stdout_constraints = {}
         self.stdin_min_stdout_reads = {}
-        self.format_infos = dict()
+        self.format_infos = {}
         self.pending_info = None
         self.str_to_int_pairs = []
         self.int_to_str_pairs = []
@@ -633,11 +633,11 @@ class ZenPlugin(angr.state_plugins.SimStatePlugin):
     def __init__(self, max_depth=13):
         angr.state_plugins.SimStatePlugin.__init__(self)
         # dict from cache key to asts
-        self.replacements = dict()
+        self.replacements = {}
         # dict from zen vars to the depth
-        self.depths = dict()
+        self.depths = {}
         # dict from zen vars to the bytes contained
-        self.byte_dict = dict()
+        self.byte_dict = {}
         # the max depth an object can have before it is replaced with a zen object with no constraint
         self.max_depth = max_depth
         # the zen replacement constraints (the ones that don't preconstrain input)

--- a/tests/common.py
+++ b/tests/common.py
@@ -48,7 +48,7 @@ def slow_test(func):
     slow_test_env = (
         os.environ["SKIP_SLOW_TESTS"].lower()
         if "SKIP_SLOW_TESTS" in os.environ
-        else str()
+        else ""
     )
     return skipIf(
         slow_test_env == "true" or slow_test_env == "1", "Skipping slow test"

--- a/tests/knowledge_plugins/functions/test_function.py
+++ b/tests/knowledge_plugins/functions/test_function.py
@@ -23,7 +23,7 @@ def makeFunction(function_manager, function_address, function_name):
 class MockFunctionManager:
     def __init__(self):
         self.callgraph = networkx.MultiDiGraph()
-        self._function_map = dict()
+        self._function_map = {}
     def function(self, address):
         return self._function_map[address]
 

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -15,7 +15,7 @@ class TestIdentifier(unittest.TestCase):
         p = angr.Project(os.path.join(bin_location, "tests", "i386", "identifiable"))
         idfer = p.analyses.Identifier(require_predecessors=False)
 
-        seen = dict()
+        seen = {}
         for addr, symbol in idfer.run():
             seen[addr] = symbol
 


### PR DESCRIPTION
**Also** changes what I suspect is a bug in `bindiff.py`:
```
-        self._attributes_a = dict()
-        self._attributes_a = dict()
+        self._attributes_a = {}
+        self._attributes_b = {}
```

This is fixed in both places in bindiff; if this was intentional I can revert it.