### PR TITLE
Prefer type annotations to comments + bug fixes

### DIFF
--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -140,7 +140,7 @@ class BinaryOptimizer(Analysis):
         self.optimize()
 
     def optimize(self):
-        f: angr.knowledge_plugins.Function
+        f: Function
         for f in self.kb.functions.values():
             # if there are unresolved targets in this function, we do not try to optimize it
             unresolvable_targets = (SIM_PROCEDURES['stubs']['UnresolvableJumpTarget'],
@@ -157,7 +157,7 @@ class BinaryOptimizer(Analysis):
     def _optimize_function(self, function):
         """
 
-        :param angr.knowledge.Function function:
+        :param Function function:
         :return:
         """
 
@@ -362,7 +362,7 @@ class BinaryOptimizer(Analysis):
         - Prologue and epilogue of the function is identifiable.
         - At least one register is not used in the entire function.
 
-        :param angr.knowledge.Function function:
+        :param Function function:
         :param networkx.MultiDiGraph data_graph:
         :return: None
         """
@@ -621,7 +621,7 @@ class BinaryOptimizer(Analysis):
 
         BROKEN - DO NOT USE IT
 
-        :param angr.knowledge.Function function:
+        :param Function function:
         :param networkx.MultiDiGraph data_graph:
         :return: None
         """

--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -136,7 +136,8 @@ class BinaryOptimizer(Analysis):
         self.optimize()
 
     def optimize(self):
-        for f in self.kb.functions.values():  # type: angr.knowledge.Function
+        f: angr.knowledge.Function
+        for f in self.kb.functions.values():
             # if there are unresolved targets in this function, we do not try to optimize it
             unresolvable_targets = (SIM_PROCEDURES['stubs']['UnresolvableJumpTarget'],
                                     SIM_PROCEDURES['stubs']['UnresolvableCallTarget'])
@@ -449,7 +450,8 @@ class BinaryOptimizer(Analysis):
         # look at consumer of those esp variables. no other instruction should be consuming them
         # esp_consumer_insns = { insn0.address, insn1.address, insn2.address, insn3.address, insn4.address,
         #                        insn5.address} | esp_insns
-        # for esp_variable in esp_variables:  # type: angr.analyses.ddg.ProgramVariable
+        # esp_variable: angr.analyses.ddg.ProgramVariable
+        # for esp_variable in esp_variables:
         #     consumers = data_graph.successors(esp_variable)
         #     if any([ consumer.location.ins_addr not in esp_consumer_insns for consumer in consumers ]):
         #         return

--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -3,12 +3,12 @@ import re
 from typing import TYPE_CHECKING
 from collections import defaultdict
 
-from . import Analysis, CFGEmulated, DDG
-
 from angr.knowledge_base import KnowledgeBase
 from angr.codenode import HookNode
 from angr.sim_variable import SimConstantVariable, SimRegisterVariable, SimMemoryVariable, SimStackVariable
 from angr import SIM_PROCEDURES
+
+from . import Analysis, CFGEmulated, DDG
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins import Function

--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -1,13 +1,17 @@
 import logging
 import re
+from typing import TYPE_CHECKING
 from collections import defaultdict
 
 from . import Analysis, CFGEmulated, DDG
 
-from ..knowledge_base import KnowledgeBase
-from .. import SIM_PROCEDURES
-from ..codenode import HookNode
-from ..sim_variable import SimConstantVariable, SimRegisterVariable, SimMemoryVariable, SimStackVariable
+from angr.knowledge_base import KnowledgeBase
+from angr.codenode import HookNode
+from angr.sim_variable import SimConstantVariable, SimRegisterVariable, SimMemoryVariable, SimStackVariable
+from angr import SIM_PROCEDURES
+
+if TYPE_CHECKING:
+    from angr.knowledge_plugins import Function
 
 l = logging.getLogger(name=__name__)
 
@@ -136,7 +140,7 @@ class BinaryOptimizer(Analysis):
         self.optimize()
 
     def optimize(self):
-        f: angr.knowledge.Function
+        f: angr.knowledge_plugins.Function
         for f in self.kb.functions.values():
             # if there are unresolved targets in this function, we do not try to optimize it
             unresolvable_targets = (SIM_PROCEDURES['stubs']['UnresolvableJumpTarget'],

--- a/angr/analyses/cfg/cfg_arch_options.py
+++ b/angr/analyses/cfg/cfg_arch_options.py
@@ -71,7 +71,7 @@ class CFGArchOptions:
     def __setattr__(self, option_name, option_value):
         if option_name in self._options:
 
-            # type checking
+            # Type checking
             sort = self.OPTIONS[self.arch.name][option_name][0]
 
             if sort is None or isinstance(option_value, sort):

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -13,19 +13,19 @@ import archinfo
 from archinfo.arch_soot import SootAddressDescriptor
 from archinfo.arch_arm import is_arm_arch, get_real_address_if_arm
 
-from ...knowledge_plugins.functions.function_manager import FunctionManager
-from ...knowledge_plugins.functions.function import Function
-from ...knowledge_plugins.cfg import IndirectJump, CFGNode, CFGENode, CFGModel  # pylint:disable=unused-import
-from ...misc.ux import deprecated
-from ...procedures.stubs.UnresolvableJumpTarget import UnresolvableJumpTarget
-from ...utils.constants import DEFAULT_STATEMENT
-from ...procedures.procedure_dict import SIM_PROCEDURES
-from ...errors import SimTranslationError, SimMemoryError, SimIRSBError, SimEngineError, AngrUnsupportedSyscallError, \
+from angr.knowledge_plugins.functions.function_manager import FunctionManager
+from angr.knowledge_plugins.functions.function import Function
+from angr.knowledge_plugins.cfg import IndirectJump, CFGNode, CFGENode, CFGModel  # pylint:disable=unused-import
+from angr.misc.ux import deprecated
+from angr.procedures.stubs.UnresolvableJumpTarget import UnresolvableJumpTarget
+from angr.utils.constants import DEFAULT_STATEMENT
+from angr.procedures.procedure_dict import SIM_PROCEDURES
+from angr.errors import SimTranslationError, SimMemoryError, SimIRSBError, SimEngineError, AngrUnsupportedSyscallError, \
     SimError
-from ...codenode import HookNode, BlockNode
-from ...engines.vex.lifter import VEX_IRSB_MAX_SIZE, VEX_IRSB_MAX_INST
-from .. import Analysis
-from ..stack_pointer_tracker import StackPointerTracker
+from angr.codenode import HookNode, BlockNode
+from angr.engines.vex.lifter import VEX_IRSB_MAX_SIZE, VEX_IRSB_MAX_INST
+from angr.analyses import Analysis
+from angr.analyses.stack_pointer_tracker import StackPointerTracker
 from .indirect_jump_resolvers.default_resolvers import default_indirect_jump_resolvers
 
 l = logging.getLogger(name=__name__)
@@ -171,7 +171,7 @@ class CFGBase(Analysis):
         if model is not None:
             self._model = model
         else:
-            self._model: angr.knowledge_plugins.cfg.CFGModel = self.kb.cfgs.new_model(self.tag)
+            self._model: CFGModel = self.kb.cfgs.new_model(self.tag)
 
     def __contains__(self, cfg_node):
         return cfg_node in self.graph
@@ -957,10 +957,10 @@ class CFGBase(Analysis):
 
         analyzed_functions = set()
         # short-hand
-        functions: angr.knowledge.FunctionManager = self.kb.functions
+        functions: FunctionManager = self.kb.functions
 
         while all_functions:
-            func: angr.knowledge.Function = all_functions.pop(-1)
+            func: Function = all_functions.pop(-1)
             analyzed_functions.add(func.addr)
 
             if func.returning is not None:

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -171,7 +171,7 @@ class CFGBase(Analysis):
         if model is not None:
             self._model = model
         else:
-            self._model = self.kb.cfgs.new_model(self.tag)  # type: angr.knowledge_plugins.cfg.CFGModel
+            self._model: angr.knowledge_plugins.cfg.CFGModel = self.kb.cfgs.new_model(self.tag)
 
     def __contains__(self, cfg_node):
         return cfg_node in self.graph
@@ -957,10 +957,10 @@ class CFGBase(Analysis):
 
         analyzed_functions = set()
         # short-hand
-        functions = self.kb.functions  # type: angr.knowledge.FunctionManager
+        functions: angr.knowledge.FunctionManager = self.kb.functions
 
         while all_functions:
-            func = all_functions.pop(-1)  # type: angr.knowledge.Function
+            func: angr.knowledge.Function = all_functions.pop(-1)
             analyzed_functions.add(func.addr)
 
             if func.returning is not None:
@@ -2006,7 +2006,7 @@ class CFGBase(Analysis):
         traversed = set() if traversed_cfg_nodes is None else traversed_cfg_nodes
 
         while stack:
-            n = stack.pop(last=False)  # type: CFGNode
+            n: CFGNode = stack.pop(last=False)
 
             if n in traversed:
                 continue
@@ -2550,7 +2550,7 @@ class CFGBase(Analysis):
             self.indirect_jumps[addr] = ij
             resolved = False
         else:
-            ij = self.indirect_jumps[addr]  # type: IndirectJump
+            ij: IndirectJump = self.indirect_jumps[addr]
             resolved = len(ij.resolved_targets) > 0
 
         return resolved, ij.resolved_targets, ij
@@ -2571,7 +2571,9 @@ class CFGBase(Analysis):
         l.info("%d indirect jumps to resolve.", len(self._indirect_jumps_to_resolve))
 
         all_targets = set()
-        for idx, jump in enumerate(self._indirect_jumps_to_resolve):  # type:int,IndirectJump
+        idx: int
+        jump: IndirectJump
+        for idx, jump in enumerate(self._indirect_jumps_to_resolve):
             if self._low_priority:
                 self._release_gil(idx, 50, 0.000001)
             all_targets |= self._process_one_indirect_jump(jump)

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1201,8 +1201,8 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
             the_jobs = [ ]
             if block_id in self._pending_jobs:
-                the_jobs = self._pending_jobs.pop(block_id)
-                for the_job in the_jobs:  # type: Pendingjob
+                the_jobs: Pendingjob = self._pending_jobs.pop(block_id)
+                for the_job in the_jobs:
                     self._deregister_analysis_job(the_job.caller_func_addr, the_job)
             else:
                 the_jobs = [job]
@@ -3128,7 +3128,8 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
         if loop_callback is not None:
             graph_copy = networkx.DiGraph(self._graph)
 
-            for loop in loop_finder.loops:  # type: angr.analyses.loopfinder.Loop
+            loop: angr.analyses.loopfinder.Loop
+            for loop in loop_finder.loops:
                 loop_callback(graph_copy, loop)
 
             self.model.graph = graph_copy

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1201,7 +1201,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-metho
 
             the_jobs = [ ]
             if block_id in self._pending_jobs:
-                the_jobs: Pendingjob = self._pending_jobs.pop(block_id)
+                the_jobs: "Pendingjob" = self._pending_jobs.pop(block_id)
                 for the_job in the_jobs:
                     self._deregister_analysis_job(the_job.caller_func_addr, the_job)
             else:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1268,7 +1268,8 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         # l.debug("... got %d jobs: %s", len(jobs), jobs)
 
-        for job_ in jobs:  # type: CFGJob
+        job_: CFGJob
+        for job_ in jobs:
             # register those jobs
             self._register_analysis_job(job_.func_addr, job_)
 
@@ -2725,7 +2726,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
             return elfheader_sort, elfheader_size
 
         try:
-            ref = next(iter(self.kb.xrefs.get_xrefs_by_dst(data_addr)))  # type: XRef
+            ref: XRef = next(iter(self.kb.xrefs.get_xrefs_by_dst(data_addr)))
             irsb_addr = ref.block_addr
             stmt_idx = ref.stmt_idx
         except StopIteration:

--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -57,7 +57,7 @@ class CFGFastSoot(CFGFast):
 
         self._function_returns = defaultdict(set)
 
-        entry = self.project.entry  # type:SootAddressDescriptor
+        entry: SootAddressDescriptor = self.project.entry
         entry_func = entry.method
 
         obj = self.project.loader.main_object

--- a/angr/analyses/cfg/cfg_utils.py
+++ b/angr/analyses/cfg/cfg_utils.py
@@ -220,7 +220,7 @@ class CFGUtils:
             # randomly pick one
             loop_head = next(iter(scc))
 
-        subgraph = graph.subgraph(scc).copy()  # type: networkx.DiGraph
+        subgraph: networkx.DiGraph = graph.subgraph(scc).copy()
         for src, _ in list(subgraph.in_edges(loop_head)):
             subgraph.remove_edge(src, loop_head)
 

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -1,5 +1,5 @@
 # pylint:disable=wrong-import-position,wrong-import-order
-from typing import Tuple, Optional, Dict, Sequence, TYPE_CHECKING
+from typing import Tuple, Optional, Dict, Sequence, TYPE_CHECKING, List
 import logging
 import functools
 from collections import defaultdict, OrderedDict
@@ -70,9 +70,9 @@ class JumpTargetBaseAddr:
     def __init__(self, stmt_loc, stmt, tmp, base_addr=None, tmp_1=None):
         self.stmt_loc = stmt_loc
         self.stmt = stmt
-        self.tmp = tmp  # type:int
+        self.tmp: int = tmp
         self.tmp_1 = tmp_1
-        self.base_addr = base_addr  # type:int
+        self.base_addr: int = base_addr
 
         assert base_addr is not None or tmp_1 is not None
 
@@ -972,7 +972,7 @@ class JumpTableResolver(IndirectJumpResolver):
         # initialization
         load_stmt_loc, load_stmt, load_size = None, None, None
         stmts_to_remove = [stmt_loc]
-        stmts_adding_base_addr = []  # type: list[JumpTargetBaseAddr]
+        stmts_adding_base_addr: List[JumpTargetBaseAddr] = []
         # All temporary variables that hold indirect addresses loaded out of the memory
         # Obviously, load_stmt.tmp must be here
         # if there are additional data transferring statements between the Load statement and the base-address-adding

--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -416,7 +416,8 @@ class DDGViewInstruction:
         else:
             graph = self._ddg.data_graph
 
-        for n in graph.nodes():  # type: ProgramVariable
+        n: ProgramVariable
+        for n in graph.nodes():
             if n.location.ins_addr == self._insn_addr:
                 defs.add(DDGViewItem(self._ddg, n, simplified=self._simplified))
 
@@ -1540,7 +1541,8 @@ class DDG(Analysis):
 
         defs = []
 
-        for n in graph.nodes():  # type: ProgramVariable
+        n: ProgramVariable
+        for n in graph.nodes():
             if n.variable == variable:
                 if location is None:
                     defs.append(n)

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -792,7 +792,8 @@ class AILSimplifier(Analysis):
         rd = self._compute_reaching_definitions()
         stackarg_offsets = {tpl[1] for tpl in self._stack_arg_offsets} \
             if self._stack_arg_offsets is not None else None
-        for def_ in rd.all_definitions:  # type: Definition
+        def_: Definition
+        for def_ in rd.all_definitions:
             if def_.dummy:
                 continue
             # we do not remove references to global memory regions no matter what

--- a/angr/analyses/decompiler/ailgraph_walker.py
+++ b/angr/analyses/decompiler/ailgraph_walker.py
@@ -11,7 +11,7 @@ class AILGraphWalker:
     """
     def __init__(self, graph, handler, replace_nodes: bool=False):
 
-        self.graph = graph  # type: networkx.DiGraph
+        self.graph: networkx.DiGraph = graph
         self.handler = handler
         self._replace_nodes = replace_nodes
 

--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -230,7 +230,7 @@ class CallSiteMaker(Analysis):
             else:
                 # Find the definition
                 # FIXME: Multiple definitions - we need phi nodes
-                value, def_ = next(iter(values_and_defs_))  # type:Definition
+                value, def_ = next(iter(values_and_defs_))
                 variable = self._find_variable_from_definition(def_)
                 return value, variable
 

--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -5,18 +5,18 @@ import logging
 import archinfo
 from ailment import Stmt, Expr
 
-from ...procedures.stubs.format_parser import FormatParser, FormatSpecifier
-from ...errors import SimMemoryMissingError
-from ...sim_type import SimTypeBottom, SimTypePointer, SimTypeChar, SimTypeInt
-from ...calling_conventions import SimRegArg, SimStackArg, SimCC
-from ...knowledge_plugins.key_definitions.constants import OP_BEFORE
-from ...knowledge_plugins.key_definitions.definition import Definition
-from .. import Analysis, register_analysis
+from angr.procedures.stubs.format_parser import FormatParser, FormatSpecifier
+from angr.errors import SimMemoryMissingError
+from angr.sim_type import SimTypeBottom, SimTypePointer, SimTypeChar, SimTypeInt
+from angr.calling_conventions import SimRegArg, SimStackArg, SimCC
+from angr.knowledge_plugins.key_definitions.constants import OP_BEFORE
+from angr.analyses import Analysis, register_analysis
 
 if TYPE_CHECKING:
     from angr.calling_conventions import SimCC
     from angr.storage.memory_mixins.paged_memory.pages.multi_values import MultiValues
     from angr.knowledge_plugins.key_definitions.live_definitions import LiveDefinitions
+    from angr.knowledge_plugins.key_definitions.definition import Definition
 
 
 l = logging.getLogger(name=__name__)
@@ -79,7 +79,7 @@ class CallSiteMaker(Analysis):
                         if variadic_args:
                             callsite_ty = copy.copy(prototype)
                             callsite_ty.args = list(callsite_ty.args)
-                            for i in range(variadic_args):
+                            for _ in range(variadic_args):
                                 callsite_ty.args.append(SimTypeInt().with_arch(self.project.arch))
                             arg_locs = cc.arg_locs(callsite_ty)
 
@@ -174,7 +174,7 @@ class CallSiteMaker(Analysis):
 
         self.result_block = new_block
 
-    def _find_variable_from_definition(self, def_):
+    def _find_variable_from_definition(self, def_: "Definition"):
         """
 
         :param Definition def_: The reaching definition of a variable.

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -714,7 +714,7 @@ class Clinic(Analysis):
                 return
             if isinstance(self.function.prototype.returnty, SimTypeFloat) \
                     or any(isinstance(arg, SimTypeFloat) for arg in self.function.prototype.args):
-                # type inference does not yet support floating point variables, but calling convention analysis does
+                # Type inference does not yet support floating point variables, but calling convention analysis does
                 # FIXME: remove this branch once type inference supports floating point variables
                 return
 

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -307,7 +307,7 @@ class Decompiler(Analysis):
         else:
             must_struct = None
 
-        # type inference
+        # Type inference
         try:
             tp = self.project.analyses.Typehoon(type_constraints, kb=var_kb, var_mapping=var_to_typevar,
                                                 must_struct=must_struct, ground_truth=groundtruth)

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -87,13 +87,13 @@ class OptimizationPass(BaseOptimizationPass):
         # self._blocks is just a cache
         self._blocks_by_addr: Dict[int,Set[ailment.Block]] = blocks_by_addr
         self._blocks_by_addr_and_idx: Dict[Tuple[int,Optional[int]],ailment.Block] = blocks_by_addr_and_idx
-        self._graph = graph  # type: Optional[networkx.DiGraph]
+        self._graph: Optional[networkx.DiGraph] = graph
         self._variable_kb = variable_kb
         self._ri = region_identifier
         self._rd = reaching_definitions
 
         # output
-        self.out_graph = None  # type: Optional[networkx.DiGraph]
+        self.out_graph: Optional[networkx.DiGraph] = None
 
     @property
     def blocks_by_addr(self) -> Dict[int,Set[ailment.Block]]:

--- a/angr/analyses/init_finder.py
+++ b/angr/analyses/init_finder.py
@@ -46,14 +46,14 @@ class SimEngineInitFinderVEX(
             if not obj.has_memory:
                 # Objects without memory are definitely uninitialized
                 return True
-            section = obj.find_section_containing(addr)  # type: Section
+            section: Section = obj.find_section_containing(addr)
             if section is not None:
                 return section.name in {'.bss', }
 
             if isinstance(obj, MetaELF):
                 # for ELFs, if p_memsz >= p_filesz, the extra bytes are considered NOBITS
                 # https://docs.oracle.com/cd/E19120-01/open.solaris/819-0690/gjpww/index.html
-                segment = obj.find_segment_containing(addr)  # type: Segment
+                segment: Segment = obj.find_segment_containing(addr)
                 if segment is not None and segment.memsize > segment.filesize:
                     return segment.vaddr + segment.filesize <= addr < segment.vaddr + segment.memsize
         return False

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 import logging
 import re
 import string
@@ -19,6 +20,9 @@ from ..knowledge_plugins.cfg.memory_data import MemoryDataSort
 from ..knowledge_plugins.functions import Function
 from ..knowledge_base import KnowledgeBase
 from ..sim_variable import SimMemoryVariable, SimTemporaryVariable
+
+if TYPE_CHECKING:
+    from .cfg import CFGNode
 
 l = logging.getLogger(name=__name__)
 
@@ -2821,7 +2825,7 @@ class Reassembler(Analysis):
 
             # execute the single basic block and see how the value is used
             base_graph = networkx.DiGraph()
-            candidate_node: angr.analyses.cfg_node.CFGNode = self.cfg.model.get_any_node(candidate.irsb_addr)
+            candidate_node: CFGNode = self.cfg.model.get_any_node(candidate.irsb_addr)
             if candidate_node is None:
                 continue
             base_graph.add_node(candidate_node)
@@ -2831,7 +2835,7 @@ class Reassembler(Analysis):
                                                     keep_state=True,
                                                     base_graph=base_graph
                                                     )
-            candidate_irsb: SimIRSB = cfg.get_any_irsb(candidate.irsb_addr)
+            candidate_irsb = cfg.get_any_irsb(candidate.irsb_addr)
             ddg = self.project.analyses[DDG].prep(kb=tmp_kb)(cfg=cfg)
 
             mem_var_node = None

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -1126,7 +1126,8 @@ class Procedure:
             s = self.asm_code
             assembly.append((self.addr, s))
         elif self.blocks:
-            for b in sorted(self.blocks, key=lambda x:x.addr):  # type: BasicBlock
+            b: BasicBlock
+            for b in sorted(self.blocks, key=lambda x:x.addr):
                 s = b.assembly(comments=comments, symbolized=symbolized)
                 assembly.append((b.addr, s))
 
@@ -1141,7 +1142,8 @@ class Procedure:
         """
 
         addrs = [ ]
-        for b in sorted(self.blocks, key=lambda x: x.addr):  # type: BasicBlock
+        b: BasicBlock
+        for b in sorted(self.blocks, key=lambda x: x.addr):
             addrs.extend(b.instruction_addresses())
 
         return sorted(set(addrs), key=lambda x: x[0])
@@ -2073,7 +2075,8 @@ class Reassembler(Analysis):
 
         # Get all instruction addresses, and modify those labels pointing to the middle of an instruction
         insn_addrs =  [ ]
-        for proc in self.procedures:  # type: Procedure
+        proc: Procedure
+        for proc in self.procedures:
             insn_addrs.extend(proc.instruction_addresses())
         # just to be safe
         insn_addrs = sorted(set(insn_addrs), key=lambda x: x[0])
@@ -2818,7 +2821,7 @@ class Reassembler(Analysis):
 
             # execute the single basic block and see how the value is used
             base_graph = networkx.DiGraph()
-            candidate_node = self.cfg.model.get_any_node(candidate.irsb_addr)  # type: angr.analyses.cfg_node.CFGNode
+            candidate_node: angr.analyses.cfg_node.CFGNode = self.cfg.model.get_any_node(candidate.irsb_addr)
             if candidate_node is None:
                 continue
             base_graph.add_node(candidate_node)
@@ -2828,7 +2831,7 @@ class Reassembler(Analysis):
                                                     keep_state=True,
                                                     base_graph=base_graph
                                                     )
-            candidate_irsb = cfg.get_any_irsb(candidate.irsb_addr)  # type: SimIRSB
+            candidate_irsb: SimIRSB = cfg.get_any_irsb(candidate.irsb_addr)
             ddg = self.project.analyses[DDG].prep(kb=tmp_kb)(cfg=cfg)
 
             mem_var_node = None

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -132,7 +132,7 @@ class SimpleSolver:
         # collect equivalence relations
         for constraint in self._constraints:
             if isinstance(constraint, Equivalence):
-                # type_a == type_b
+                #| type_a == type_b
                 # we apply unification and removes one of them
                 ta, tb = constraint.type_a, constraint.type_b
                 if isinstance(ta, TypeConstant) and isinstance(tb, TypeVariable):

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -411,7 +411,7 @@ class SimEngineVRAIL(
                 remainder = r0.data % claripy.ZeroExt(from_size - to_size, r1.data)
 
         return RichR(remainder,
-                     # typevar=r0.typevar,  # FIXME: Handle typevars for Div
+                     #| typevar=r0.typevar,  # FIXME: Handle typevars for Div
                      )
 
     def _ail_handle_DivMod(self, expr: ailment.Expr.BinaryOp):
@@ -443,7 +443,7 @@ class SimEngineVRAIL(
             )
 
         return RichR(r,
-                     # typevar=r0.typevar,  # FIXME: Handle typevars for DivMod
+                     #| typevar=r0.typevar,  # FIXME: Handle typevars for DivMod
                      )
 
     def _ail_handle_Xor(self, expr):

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -558,7 +558,7 @@ class SimEngineVRBase(SimEngineLight):
                         concrete_offset = None
                         dynamic_offset = stack_offset
                 else:
-                    # type(stack_offset) is int
+                    #| type(stack_offset) is int
                     concrete_offset = stack_offset
                     dynamic_offset = None
 
@@ -826,7 +826,7 @@ class SimEngineVRBase(SimEngineLight):
                     self.state.typevars.add_type_variable(var, codeloc, typevar)
                 else:
                     # FIXME: This is an extremely stupid hack. Fix it later.
-                    # typevar = next(reversed(list(self.state.typevars[var].values())))
+                    #| typevar = next(reversed(list(self.state.typevars[var].values())))
                     typevar = self.state.typevars[var]
 
         if len(value_list) == 1:

--- a/angr/analyses/variable_recovery/variable_recovery.py
+++ b/angr/analyses/variable_recovery/variable_recovery.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import Tuple
 
 import claripy
-import angr # type annotations; pylint: disable=unused-import
+import angr # For type annotations; pylint: disable=unused-import
 
 from ...errors import SimMemoryMissingError
 from ...storage.memory_mixins.paged_memory.pages.multi_values import MultiValues

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -1,4 +1,4 @@
-from typing import List, Generator, TYPE_CHECKING
+from typing import List, Generator, TYPE_CHECKING, Optional
 import logging
 from collections import defaultdict
 
@@ -45,9 +45,9 @@ class VFGJob(CFGJobBase):
         # if this job has a call successor, do we plan to skip the call successor or not
         self.call_skipped = False
         # if the call is skipped, calling stack of the skipped function is saved in `call_context_key`
-        self.call_function_key = None  # type: FunctionKey
+        self.call_function_key: Optional[FunctionKey] = None
 
-        self.call_task = None  # type: CallAnalysis
+        self.call_task: Optional[CallAnalysis] = None
 
     @property
     def block_id(self):
@@ -1025,11 +1025,13 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
         """
 
         :param iterable jobs:
-        :return: True if should widen, Flase otherwise
+        :return: True if should widen, False otherwise
         :rtype: bool
         """
 
-        job_0, _ = jobs[-2:]  # type: VFGJob
+        job_0: VFGJob
+        _: VFGJob
+        job_0, _ = jobs[-2:]
 
         addr = job_0.addr
 
@@ -1049,7 +1051,9 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
         :return:
         """
 
-        job_0, job_1 = jobs[-2:]  # type: VFGJob
+        job_0: VFGJob
+        job_1: VFGJob
+        job_0, job_1 = jobs[-2:]
 
         # update jobs
         for job in jobs:
@@ -1076,7 +1080,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
             # We don't have any paths remaining. Let's pop a previously-missing return to
             # process
 
-            top_task = self._top_task  # type: FunctionAnalysis
+            top_task: FunctionAnalysis = self._top_task
             func_addr = top_task.function_address
 
             pending_ret_key = self._get_pending_job(func_addr)
@@ -1729,7 +1733,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
 
     def _trace_pending_job(self, job_key):
 
-        pending_job = self._pending_returns.pop(job_key)  # type: PendingJob
+        pending_job: PendingJob = self._pending_returns.pop(job_key)
         addr = job_key.addr
 
         # Unlike CFG, we will still trace those blocks that have been traced before. In other words, we don't
@@ -1755,7 +1759,8 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
     def _get_pending_job(self, func_addr):
 
         pending_ret_key = None
-        for k in self._pending_returns.keys():  # type: BlockID
+        k: BlockID
+        for k in self._pending_returns.keys():
             if k.func_addr == func_addr:
                 pending_ret_key = k
                 break

--- a/angr/angrdb/serializers/cfg_model.py
+++ b/angr/angrdb/serializers/cfg_model.py
@@ -34,7 +34,7 @@ class CFGModelSerializer:
     @staticmethod
     def load(session, db_kb, ident, cfg_manager, loader=None):
 
-        db_cfg = session.query(DbCFGModel).filter_by(kb=db_kb, ident=ident).scalar()  # type: DbCFGModel
+        db_cfg: DbCFGModel = session.query(DbCFGModel).filter_by(kb=db_kb, ident=ident).scalar()
         if db_cfg is None:
             return None
 

--- a/angr/angrdb/serializers/loader.py
+++ b/angr/angrdb/serializers/loader.py
@@ -48,7 +48,7 @@ class LoaderSerializer:
         all_objects = { }  # path to object
         main_object = None
 
-        db_objects = session.query(DbObject)  # type: List[DbObject]
+        db_objects: List[DbObject] = session.query(DbObject)
 
         for db_o in db_objects:
             all_objects[db_o.path] = db_o

--- a/angr/block.py
+++ b/angr/block.py
@@ -199,7 +199,7 @@ class Block(Serializable):
         self._load_from_ro_regions = load_from_ro_regions
 
         self._instructions = num_inst
-        self._instruction_addrs = [] # type: List[int]
+        self._instruction_addrs: List[int] = []
 
         self._parse_vex_info(self._vex)
 

--- a/angr/distributed/server.py
+++ b/angr/distributed/server.py
@@ -59,7 +59,7 @@ class Server:
 
         self._workers = [ ]
         self._stopped = False
-        self._active_workers = multiprocessing.Value('i', lock=True)  # type: multiprocessing.Value
+        self._active_workers = multiprocessing.Value('i', lock=True)
 
     def __setstate__(self, state):
 

--- a/angr/engines/engine.py
+++ b/angr/engines/engine.py
@@ -20,7 +20,7 @@ class SimEngineBase:
     def __init__(self, project=None, **kwargs):
         if kwargs:
             raise TypeError("Unused initializer args: " + ", ".join(kwargs.keys()))
-        self.project = project  # type: Optional[angr.Project]
+        self.project: Optional[angr.Project] = project
         self.state = None
 
     __tls = ('state',)

--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -64,7 +64,7 @@ class CCallMultivaluedException(Exception):
 ### x86* data ###
 ##################
 
-data = {
+data: Dict[str, Dict[str, Dict[str, Optional[int]]]] = {
     'AMD64': {
         'CondTypes': { },
         'CondBitOffsets': { },
@@ -76,7 +76,7 @@ data = {
         'CondBitMasks': { },
         'OpTypes': { },
     }
-} # type: Dict[str, Dict[str, Dict[str, Optional[int]]]]
+}
 
 # condition types
 data['AMD64']['CondTypes']['CondO']      = 0  # /* overflow           */

--- a/angr/exploration_techniques/__init__.py
+++ b/angr/exploration_techniques/__init__.py
@@ -1,5 +1,5 @@
 # pylint:disable=unused-import,missing-class-docstring,wrong-import-position
-import angr  # type annotations
+import angr  # For type annotations
 
 
 class ExplorationTechnique:
@@ -25,7 +25,7 @@ class ExplorationTechnique:
     def __init__(self):
         # this attribute will be set from above by the manager
         if not hasattr(self, 'project'):
-            self.project = None # type: angr.project.Project
+            self.project: angr.project.Project = None
 
     def setup(self, simgr):
         """

--- a/angr/exploration_techniques/bucketizer.py
+++ b/angr/exploration_techniques/bucketizer.py
@@ -21,7 +21,7 @@ class Bucketizer(ExplorationTechnique):
     def successors(self, simgr, state, **kwargs):
 
         # step first
-        successors = super().successors(simgr, state, **kwargs)  # type: SimSuccessors
+        successors: SimSuccessors = super().successors(simgr, state, **kwargs)
 
         # if there are more than one successor, we try to get rid of the ones that we don't want
 

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, TYPE_CHECKING
 import logging
 import cle
 
@@ -7,6 +7,9 @@ from capstone import CS_GRP_CALL, CS_GRP_IRET, CS_GRP_JUMP, CS_GRP_RET
 from . import ExplorationTechnique
 from .. import BP_BEFORE, BP_AFTER, sim_options
 from ..errors import AngrTracerError, SimIRSBNoDecodeError
+
+if TYPE_CHECKING:
+    from angr.sim_state import SimState
 
 
 l = logging.getLogger(name=__name__)
@@ -178,7 +181,7 @@ class Tracer(ExplorationTechnique):
         self._fd_bytes = None
 
         # keep track of the last basic block we hit
-        self.predecessors: List[angr.SimState] = [None] * keep_predecessors
+        self.predecessors: List["SimState"] = [None] * keep_predecessors
         self.last_state = None
 
         # whether we should follow the trace
@@ -501,7 +504,7 @@ class Tracer(ExplorationTechnique):
         self._update_state_tracking(res[0])
         return res[0]
 
-    def _update_state_tracking(self, state: 'angr.SimState'):
+    def _update_state_tracking(self, state: "SimState"):
         idx = state.globals['trace_idx']
         sync = state.globals['sync_idx']
         timer = state.globals['sync_timer']
@@ -671,7 +674,7 @@ class Tracer(ExplorationTechnique):
         else:
             raise AngrTracerError("Trace desynced on jumping into %#x, where no library is mapped!" % state_addr)
 
-    def _check_qemu_block_in_unicorn_block(self, state: 'angr.SimState', trace_curr_idx, state_desync_block_idx):
+    def _check_qemu_block_in_unicorn_block(self, state: "SimState", trace_curr_idx, state_desync_block_idx):
         """
         Check if desync occurred because unicorn block was split into multiple blocks in qemu tracer. If yes, find the
         correct increment for trace index
@@ -712,7 +715,7 @@ class Tracer(ExplorationTechnique):
 
         return (True, next_contain_index - trace_curr_idx)
 
-    def _check_qemu_unicorn_large_block_split(self, state: 'angr.SimState', trace_curr_idx, state_desync_block_idx):
+    def _check_qemu_unicorn_large_block_split(self, state: "SimState", trace_curr_idx, state_desync_block_idx):
         """
         Check if desync occurred because large blocks are split up at different instructions by qemu and unicorn. This
         is done by reconstructing part of block executed so far from the trace and state history and checking if they

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -172,13 +172,13 @@ class Tracer(ExplorationTechnique):
         self._follow_unsat = follow_unsat
         self._fast_forward_to_entry = fast_forward_to_entry
 
-        self._aslr_slides = {}  # type: Dict[cle.Backend, int]
+        self._aslr_slides: Dict[cle.Backend, int] = {}
         self._current_slide = None
 
         self._fd_bytes = None
 
         # keep track of the last basic block we hit
-        self.predecessors = [None] * keep_predecessors # type: List[angr.SimState]
+        self.predecessors: List[angr.SimState] = [None] * keep_predecessors
         self.last_state = None
 
         # whether we should follow the trace

--- a/angr/keyed_region.py
+++ b/angr/keyed_region.py
@@ -187,8 +187,11 @@ class KeyedRegion:
             raise ValueError("The canonical sizes of two KeyedRegion objects must equal.")
 
         # TODO: is the current solution not optimal enough?
-        for _, item in other._storage.items():  # type: RegionObject
-            for so in item.stored_objects:  # type: StoredObject
+        _: RegionObject
+        item: RegionObject
+        for _, item in other._storage.items():
+            so: StoredObject
+            for so in item.stored_objects:
                 if replacements and so.obj in replacements:
                     so = StoredObject(so.start, replacements[so.obj], so.size)
                 self._object_mapping[so.obj_id] = so
@@ -205,8 +208,11 @@ class KeyedRegion:
         :return:        self
         """
 
-        for _, item in other._storage.items():  # type: RegionObject
-            for so in item.stored_objects:  # type: StoredObject
+        _: RegionObject
+        item: RegionObject
+        for _, item in other._storage.items():
+            so: StoredObject
+            for so in item.stored_objects:
                 if replacements and so.obj in replacements:
                     so = StoredObject(so.start, replacements[so.obj], so.size)
                 self._object_mapping[so.obj_id] = so
@@ -226,7 +232,7 @@ class KeyedRegion:
             old_var_id = id(old_var)
             if old_var_id in self._object_mapping:
                 # FIXME: we need to check if old_var still exists in the storage
-                old_so = self._object_mapping[old_var_id]  # type: StoredObject
+                old_so: StoredObject = self._object_mapping[old_var_id]
                 self._store(old_so.start, new_var, old_so.size, overwrite=True)
 
         return self

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -1,6 +1,6 @@
 import traceback
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union, Optional
 
 from archinfo.arch_soot import SootAddressDescriptor
 import archinfo
@@ -75,9 +75,9 @@ class CFGNode(Serializable):
         self.no_ret = no_ret
         self._cfg_model: 'CFGModel' = cfg
         self.function_address = function_address
-        self.block_id = block_id  # type: int or BlockID
+        self.block_id: Union[BlockID, int] = block_id
         self.thumb = thumb
-        self.byte_string = byte_string  # type: None or bytes
+        self.byte_string: Optional[bytes] = byte_string
 
         self._name = None
         if name is not None:

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -5,14 +5,15 @@ from typing import TYPE_CHECKING, Union, Optional
 from archinfo.arch_soot import SootAddressDescriptor
 import archinfo
 
-from ...codenode import BlockNode, HookNode, SyscallNode
-from ...engines.successors import SimSuccessors
-from ...serializable import Serializable
-from ...protos import cfg_pb2
-from ...errors import AngrError, SimError
+from angr.codenode import BlockNode, HookNode, SyscallNode
+from angr.engines.successors import SimSuccessors
+from angr.serializable import Serializable
+from angr.protos import cfg_pb2
+from angr.errors import AngrError, SimError
 
 if TYPE_CHECKING:
     from .cfg_model import CFGModel
+    import angr
 
 _l = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ class CFGNode(Serializable):
         self.no_ret = no_ret
         self._cfg_model: 'CFGModel' = cfg
         self.function_address = function_address
-        self.block_id: Union[BlockID, int] = block_id
+        self.block_id: Union["angr.analyses.cfg.cfg_job_base.BlockID", int] = block_id
         self.thumb = thumb
         self.byte_string: Optional[bytes] = byte_string
 

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -96,7 +96,7 @@ class Function(Serializable):
         # Calling convention
         self.calling_convention: Optional[SimCC] = None
         # Function prototype
-        self.prototype = None  # type: Optional[SimTypeFunction]
+        self.prototype: Optional[SimTypeFunction] = None
         self.is_prototype_guessed: bool = True
         # Whether this function returns or not. `None` means it's not determined yet
         self._returning = None
@@ -121,7 +121,7 @@ class Function(Serializable):
         # Stack offsets of those arguments passed in stack variables
         self._argument_stack_variables = []
 
-        self._project = None  # type: Optional[Project] # will be initialized upon the first access to self.project
+        self._project: Optional[Project] = None  # will be initialized upon the first access to self.project
 
         self.ran_cca = False  # this is set by CompleteCallingConventions to avoid reprocessing failed functions
 
@@ -1484,7 +1484,9 @@ class Function(Serializable):
         if len(func_def.keys()) > 1:
             raise Exception("Too many definitions: %s " % list(func_def.keys()))
 
-        name, ty = func_def.popitem() # type: str, SimTypeFunction
+        name: str
+        ty: SimTypeFunction
+        name, ty = func_def.popitem()
         self.name = name
         self.prototype = ty.with_arch(self.project.arch)
         # setup the calling convention

--- a/angr/knowledge_plugins/structured_code/manager.py
+++ b/angr/knowledge_plugins/structured_code/manager.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 class StructuredCodeManager(KnowledgeBasePlugin):
     def __init__(self, kb):
-        self._kb = kb  # type: KnowledgeBase
+        self._kb: KnowledgeBase = kb
         self.cached: Dict[Any, 'DecompilationCache'] = {}
 
     def _normalize_key(self, item):

--- a/angr/misc/plugins.py
+++ b/angr/misc/plugins.py
@@ -23,9 +23,9 @@ class PluginHub:
 
     def __init__(self):
         super().__init__()
-        self._active_plugins = {} # type: Dict[str, SimStatePlugin]
-        self._active_preset = None # type: Optional[PluginPreset]
-        self._provided_by_preset = [] # type: List[int]
+        self._active_plugins: Dict[str, SimStatePlugin] = {}
+        self._active_preset: Optional[PluginPreset] = None
+        self._provided_by_preset: List[int] = []
 
     #
     #   Class methods for registration
@@ -212,7 +212,7 @@ class PluginPreset:
     """
 
     def __init__(self):
-        self._default_plugins = {} # type: Dict[str, Type['SimStatePlugin']]
+        self._default_plugins: Dict[str, Type['SimStatePlugin']] = {}
 
     def activate(self, hub):  # pylint:disable=no-self-use,unused-argument
         """

--- a/angr/procedures/definitions/parse_win32json.py
+++ b/angr/procedures/definitions/parse_win32json.py
@@ -132,7 +132,7 @@ def create_angr_type_from_json(t):
         # for member in t["Values"]:
         #     new_enum.append(member["Name"], int(member["Value"]))
         # real_new_type = binaryninja.types.Type.named_type_from_type(t["Name"], binaryninja.types.Type.enumeration_type(arch,new_enum))
-        # typelib.add_named_type(t["Name"], real_new_type)
+        #| typelib.add_named_type(t["Name"], real_new_type)
     elif t["Kind"] == "Struct":
         real_new_type = handle_json_type(t)
         typelib.add_named_type(t["Name"], real_new_type)
@@ -158,7 +158,7 @@ def create_angr_type_from_json(t):
         #         param_list.append(real_new_param)
         #     new_func = binaryninja.types.Type.function(ret_type, param_list)
         #     new_struct.append(binaryninja.types.Type.pointer(arch, new_func), method["Name"])
-        # typelib.add_named_type(t["Name"], binaryninja.types.Type.structure_type(new_struct))
+        #| typelib.add_named_type(t["Name"], binaryninja.types.Type.structure_type(new_struct))
     elif t["Kind"] == "ComClassID":
         return None
     elif t["Kind"] == "Union":

--- a/angr/procedures/java_jni/__init__.py
+++ b/angr/procedures/java_jni/__init__.py
@@ -1,7 +1,7 @@
 import collections
 import itertools
 import logging
-from typing import Optional
+import typing
 
 from archinfo import ArchSoot
 from claripy import BVV, StrSubstr
@@ -20,7 +20,7 @@ class JNISimProcedure(SimProcedure):
     """
 
     # Java type of return value
-    return_ty: Optional[str] = None
+    return_ty: typing.Optional[str] = None
 
     # jboolean constants
     JNI_TRUE = 1
@@ -200,7 +200,7 @@ class JNISimProcedure(SimProcedure):
 #
 # JNI function table
 # => Map all interface function to the name of their corresponding SimProcedure
-jni_functions: collections.OrderedDict[str, str] = collections.OrderedDict()
+jni_functions: typing.OrderedDict[str, str] = collections.OrderedDict()
 not_implemented = "UnsupportedJNIFunction"
 
 # Reserved Entries

--- a/angr/procedures/java_jni/__init__.py
+++ b/angr/procedures/java_jni/__init__.py
@@ -200,7 +200,7 @@ class JNISimProcedure(SimProcedure):
 #
 # JNI function table
 # => Map all interface function to the name of their corresponding SimProcedure
-jni_functions = collections.OrderedDict() # type: collections.OrderedDict[str, str]
+jni_functions: collections.OrderedDict[str, str] = collections.OrderedDict()
 not_implemented = "UnsupportedJNIFunction"
 
 # Reserved Entries

--- a/angr/project.py
+++ b/angr/project.py
@@ -141,7 +141,7 @@ class Project:
         if isinstance(arch, str):
             self.arch = archinfo.arch_from_id(arch)  # may raise ArchError, let the user see this
         elif isinstance(arch, archinfo.Arch):
-            self.arch = arch # type: archinfo.Arch
+            self.arch: archinfo.Arch = arch
         elif arch is None:
             self.arch = self.loader.main_object.arch
         else:

--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -64,9 +64,9 @@ class SimulationManager:
     ALL = '_ALL'
     DROP = '_DROP'
 
-    _integral_stashes = (
+    _integral_stashes: Tuple[str] = (
         'active', 'stashed', 'pruned', 'unsat', 'errored', 'deadended', 'unconstrained'
-    ) # type: Tuple[str]
+    )
 
     def __init__(self,
             project,
@@ -90,7 +90,7 @@ class SimulationManager:
 
         if stashes is None:
             stashes = self._create_integral_stashes()
-        self._stashes = stashes # type: defaultdict[str, List['SimState']]
+        self._stashes: DefaultDict[str, List['SimState']] = stashes
         self._hierarchy = StateHierarchy() if hierarchy is None else hierarchy
         self._save_unsat = save_unsat
         self._auto_drop = {SimulationManager.DROP, }

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -105,13 +105,13 @@ class SimProcedure:
         is_function=None, **kwargs
     ):
         # WE'LL FIGURE IT OUT
-        self.project = project # type: angr.Project
-        self.arch = project.arch if project is not None else None  # type: archinfo.arch.Arch
+        self.project: angr.Project = project
+        self.arch: archinfo.arch.Arch  = project.arch if project is not None else None
         self.addr = None
-        self.cc = cc # type: angr.SimCC
+        self.cc: angr.SimCC = cc
         if type(prototype) is str:
             prototype = parse_signature(prototype)
-        self.prototype = prototype  # type: angr.sim_type.SimTypeFunction
+        self.prototype: angr.sim_type.SimTypeFunction = prototype
         self.canonical = self
 
         self.kwargs = kwargs

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -11,7 +11,7 @@ from archinfo import Arch
 
 l = logging.getLogger(name=__name__)
 
-import angr # type annotations; pylint:disable=unused-import
+import angr # For type annotations; pylint:disable=unused-import
 import claripy
 import archinfo
 from archinfo.arch_soot import SootAddressDescriptor

--- a/angr/state_plugins/history.py
+++ b/angr/state_plugins/history.py
@@ -39,7 +39,7 @@ class SimStateHistory(SimStatePlugin):
         self.jump_target = None if clone is None else clone.jump_target
         self.jump_source = None if clone is None else clone.jump_source
         self.jump_avoidable = None if clone is None else clone.jump_avoidable
-        self.jump_guard = None if clone is None else clone.jump_guard  # type: Optional[BV]
+        self.jump_guard: Optional[BV] = None if clone is None else clone.jump_guard
         self.jumpkind = None if clone is None else clone.jumpkind
 
         # the execution log for this history

--- a/angr/state_plugins/plugin.py
+++ b/angr/state_plugins/plugin.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-import angr # type annotations; pylint: disable=unused-import
+import angr # For type annotations; pylint: disable=unused-import
 import logging
 
 from ..misc.ux import once
@@ -17,7 +17,7 @@ class SimStatePlugin:
     STRONGREF_STATE = False
 
     def __init__(self):
-        self.state = cast(angr.SimState, None) # type: angr.SimState
+        self.state: angr.SimState = cast(angr.SimState, None)
 
     def set_state(self, state):
         """

--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -25,7 +25,7 @@ class SimRegNameView(SimStatePlugin):
         :rtype:       claripy.ast.Base
         """
 
-        state = super().__getattribute__('state') # type: SimState
+        state: SimState = super().__getattribute__('state')
 
         if isinstance(k, str) and k.startswith('_'):
             k = k[1:]

--- a/angr/storage/file.py
+++ b/angr/storage/file.py
@@ -479,7 +479,7 @@ class SimPackets(SimFileBase):
                 raise SimFileError(f"SimPackets could not fit the current packet into the read request of {size} bytes: {self.content[pos]}")
             return self.content[pos] + (pos+1,)
 
-        # typecheck
+        # Type check
         if type(size) is int:
             size = self.state.solver.BVV(size, self.state.arch.bits)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -14,8 +14,8 @@ class TestDb(unittest.TestCase):
         bin_path = os.path.join(test_location, "x86_64", "fauxware")
 
         proj = angr.Project(bin_path, auto_load_libs=False)
-        cfg = proj.analyses.CFGFast(data_references=True, cross_references=True,
-                                    normalize=True)  # type: angr.analyses.CFGFast
+        cfg: angr.analyses.CFGFast = proj.analyses.CFGFast(data_references=True, cross_references=True,
+                                    normalize=True)
         proj.kb.comments[proj.entry] = "Entry point"
 
         dtemp = tempfile.mkdtemp()
@@ -71,8 +71,8 @@ class TestDb(unittest.TestCase):
         bin_path = os.path.join(test_location, "x86_64", "fauxware")
 
         proj = angr.Project(bin_path, auto_load_libs=False)
-        _ = proj.analyses.CFGFast(data_references=True, cross_references=True,
-                                  normalize=True)  # type: angr.analyses.CFGFast
+        _: angr.analyses.CFGFast = proj.analyses.CFGFast(data_references=True, cross_references=True,
+                                  normalize=True)
         proj.kb.comments[proj.entry] = "Entry point"
 
         dtemp = tempfile.mkdtemp()
@@ -114,8 +114,8 @@ class TestDb(unittest.TestCase):
         bin_path = os.path.join(test_location, "x86_64", "fauxware")
 
         proj = angr.Project(bin_path, auto_load_libs=False)
-        _ = proj.analyses.CFGFast(data_references=True, cross_references=True,
-                                  normalize=True)  # type: angr.analyses.CFGFast
+        _: angr.analyses.CFGFast = proj.analyses.CFGFast(data_references=True, cross_references=True,
+                                  normalize=True)
         proj.kb.comments[proj.entry] = "Entry point"
 
         dtemp = tempfile.mkdtemp()

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -32,7 +32,7 @@ class TestFunction(unittest.TestCase):
             os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False
         )
         cfg = p.analyses.CFG()
-        func_main = cfg.kb.functions["main"]  # type: angr.knowledge_plugins.Function
+        func_main: angr.knowledge_plugins.Function = cfg.kb.functions["main"]
 
         func_main.apply_definition("int main(int argc, char** argv)")
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,7 @@
 # pylint:disable=unused-variable
 
+from typing import Dict
+
 import archinfo
 import claripy
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -234,18 +234,18 @@ def test_union_struct_referencing_each_other():
 
 def test_top_type():
     angr.types.register_types({"undefined": angr.types.SimTypeTop()})
-    fdef = angr.types.parse_defns(
+    fdef: Dict[str, SimTypeFunction]  = angr.types.parse_defns(
         "undefined f(undefined param_1, int param_2);"
-    )  # type: Dict[str, SimTypeFunction]
+    )
     sig = fdef["f"]
     assert sig.args == [angr.types.SimTypeTop(), angr.types.SimTypeInt()]
 
 
 def test_arg_names():
     angr.types.register_types({"undefined": angr.types.SimTypeTop()})
-    fdef = angr.types.parse_defns(
+    fdef: Dict[str, SimTypeFunction] = angr.types.parse_defns(
         "int f(int param_1, int param_2);"
-    )  # type: Dict[str, SimTypeFunction]
+    )
     sig = fdef["f"]
     assert sig.arg_names == ["param_1", "param_2"]
 
@@ -256,13 +256,13 @@ def test_arg_names():
     ), "Function type generated with .with_arch() doesn't have identical arg_names"
 
     # If for some reason only some of the parameters are named, the list can only be partially not None, but has to match the positions
-    fdef = angr.types.parse_defns(
+    fdef: Dict[str, SimTypeFunction] = angr.types.parse_defns(
         "int f(int param1, int);"
-    )  # type: Dict[str, SimTypeFunction]
+    )
     sig = fdef["f"]
     assert sig.arg_names == ["param1", None]
 
-    fdef = angr.types.parse_defns("int f();")  # type: Dict[str, SimTypeFunction]
+    fdef: Dict[str, SimTypeFunction] = angr.types.parse_defns("int f();")
     sig = fdef["f"]
     assert sig.arg_names == ()
 


### PR DESCRIPTION
CI output should be double checked; I glanced at the type comments briefly but didn't thoroughly check if they were correct when converting the comments into annotations. Since annotations are comments this means there might be a `NameError` or something as a result. CI should fail if so though I believe.

I fixed some bugs such as comments that made no sense and comments that should have been `Optional` or used the wrong type `defaultdict -> DefaultDict` for example.