### PR TITLE
Fix duplicate definitions

### DIFF
--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -14,7 +14,6 @@ from ...knowledge_plugins.key_definitions.definition import Definition
 from .. import Analysis, register_analysis
 
 if TYPE_CHECKING:
-    from angr.calling_conventions import SimCC
     from angr.storage.memory_mixins.paged_memory.pages.multi_values import MultiValues
     from angr.knowledge_plugins.key_definitions.live_definitions import LiveDefinitions
 
@@ -288,12 +287,12 @@ class CallSiteMaker(Analysis):
 
         return s
 
-    def _determine_variadic_arguments(self, func, cc: 'SimCC', call_stmt) -> Optional[int]:
+    def _determine_variadic_arguments(self, func, cc: SimCC, call_stmt) -> Optional[int]:
         if "printf" in func.name or "scanf" in func.name:
             return self._determine_variadic_arguments_for_format_strings(func, cc, call_stmt)
         return None
 
-    def _determine_variadic_arguments_for_format_strings(self, func, cc: 'SimCC', call_stmt) -> Optional[int]:
+    def _determine_variadic_arguments_for_format_strings(self, func, cc: SimCC, call_stmt) -> Optional[int]:
         proto = func.prototype
         if proto is None:
             # TODO: Support cases where prototypes are not available

--- a/angr/engines/soot/expressions/__init__.py
+++ b/angr/engines/soot/expressions/__init__.py
@@ -45,6 +45,5 @@ from .phi import SimSootExpr_Phi
 from .staticfieldref import SimSootExpr_StaticFieldRef
 from .thisref import SimSootExpr_ThisRef
 from .paramref import SimSootExpr_ParamRef
-from .arrayref import SimSootExpr_ArrayRef
 from .unsupported import SimSootExpr_Unsupported
 from .instanceOf import SimSootExpr_InstanceOf

--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -964,8 +964,8 @@ def amd64g_check_ldmxcsr(state, mxcsr):
 
 # https://github.com/angr/vex/blob/master/priv/guest_amd64_helpers.c#L2304
 def amd64g_create_mxcsr(state, sseround):
-    sseround &= 3
-    return 0x1F80 | (sseround << 13)
+    return 0x1F80 | ((sseround & 3) << 13)
+
 
 
 # https://github.com/angr/vex/blob/master/priv/guest_amd64_helpers.c#L2316
@@ -1355,9 +1355,6 @@ EmFail_S390X_fpext = 17
 EmFail_S390X_invalid_PFPO_rounding_mode = 18
 EmFail_S390X_invalid_PFPO_function = 19
 
-
-def amd64g_create_mxcsr(state, sseround):
-    return 0x1F80 | ((sseround & 3) << 13)
 
 def amd64g_check_ldmxcsr(state, mxcsr):
     rmode = claripy.LShR(mxcsr, 13) & 3

--- a/angr/simos/javavm.py
+++ b/angr/simos/javavm.py
@@ -8,17 +8,17 @@ from claripy import BVS, BVV, StringS, StringV, FSORT_FLOAT, FSORT_DOUBLE, FPV, 
 from claripy.ast.fp import FP, fpToIEEEBV
 from claripy.ast.bv import BV
 
-from ..calling_conventions import DEFAULT_CC, SimCCSoot
-from ..engines.soot import SootMixin
-from ..engines.soot.expressions import SimSootExpr_NewArray #, SimSootExpr_NewMultiArray
-from ..engines.soot.values import (SimSootValue_ArrayRef,
+from angr.calling_conventions import DEFAULT_CC, SimCCSoot
+from angr.engines.soot import SootMixin
+from angr.engines.soot.expressions import SimSootExpr_NewArray #, SimSootExpr_NewMultiArray
+from angr.engines.soot.values import (SimSootValue_ArrayRef,
                                    SimSootValue_StringRef,
                                    SimSootValue_ThisRef,
                                    SimSootValue_StaticFieldRef)
-from ..errors import AngrSimOSError
-from ..procedures.java_jni import jni_functions
-from ..sim_state import SimState
-from ..sim_type import SimTypeFunction, SimTypeNum
+from angr.errors import AngrSimOSError
+from angr.procedures.java_jni import jni_functions
+from angr.sim_state import SimState
+from angr.sim_type import SimTypeFunction, SimTypeNum
 from .simos import SimOS
 
 l = logging.getLogger('angr.simos.JavaVM')
@@ -461,5 +461,3 @@ def prepare_native_return_state(native_state):
     Note: Redirection needed for pickling.
     """
     return SootMixin.prepare_native_return_state(native_state)
-
-from .. import sim_options as options

--- a/angr/simos/javavm.py
+++ b/angr/simos/javavm.py
@@ -8,17 +8,17 @@ from claripy import BVS, BVV, StringS, StringV, FSORT_FLOAT, FSORT_DOUBLE, FPV, 
 from claripy.ast.fp import FP, fpToIEEEBV
 from claripy.ast.bv import BV
 
-from angr.calling_conventions import DEFAULT_CC, SimCCSoot
-from angr.engines.soot import SootMixin
-from angr.engines.soot.expressions import SimSootExpr_NewArray #, SimSootExpr_NewMultiArray
-from angr.engines.soot.values import (SimSootValue_ArrayRef,
+from ..calling_conventions import DEFAULT_CC, SimCCSoot
+from ..engines.soot import SootMixin
+from ..engines.soot.expressions import SimSootExpr_NewArray #, SimSootExpr_NewMultiArray
+from ..engines.soot.values import (SimSootValue_ArrayRef,
                                    SimSootValue_StringRef,
                                    SimSootValue_ThisRef,
                                    SimSootValue_StaticFieldRef)
-from angr.errors import AngrSimOSError
-from angr.procedures.java_jni import jni_functions
-from angr.sim_state import SimState
-from angr.sim_type import SimTypeFunction, SimTypeNum
+from ..errors import AngrSimOSError
+from ..procedures.java_jni import jni_functions
+from ..sim_state import SimState
+from ..sim_type import SimTypeFunction, SimTypeNum
 from .simos import SimOS
 
 l = logging.getLogger('angr.simos.JavaVM')

--- a/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
@@ -52,6 +52,7 @@ class RegionedMemoryMixin(MemoryMixin):
 
         if regioned_memory_cls is None:
             # delayed import
+            global RegionedMemory
             if RegionedMemory is None:
                 from angr.storage.memory_mixins import RegionedMemory
             regioned_memory_cls = RegionedMemory

--- a/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
@@ -6,16 +6,16 @@ import claripy
 from claripy.ast import Bool, Bits, BV
 from claripy.vsa import StridedInterval, ValueSet, RegionAnnotation
 
-from angr.sim_options import (AVOID_MULTIVALUED_READS, CONSERVATIVE_READ_STRATEGY,
+from ....sim_options import (AVOID_MULTIVALUED_READS, CONSERVATIVE_READ_STRATEGY,
     KEEP_MEMORY_READS_DISCRETE, CONSERVATIVE_WRITE_STRATEGY)
-from angr.state_plugins.sim_action_object import _raw_ast
-from angr.errors import SimMemoryError, SimAbstractMemoryError
-from angr.storage.memory_mixins import MemoryMixin
+from ....state_plugins.sim_action_object import _raw_ast
+from ....errors import SimMemoryError, SimAbstractMemoryError
+from .. import MemoryMixin
 from .region_data import AddressWrapper, RegionMap
 from .abstract_address_descriptor import AbstractAddressDescriptor
 
 if TYPE_CHECKING:
-    from angr.sim_state import SimState
+    from ....sim_state import SimState
 
 
 _l = logging.getLogger(name=__name__)
@@ -49,7 +49,7 @@ class RegionedMemoryMixin(MemoryMixin):
 
         if regioned_memory_cls is None:
             # delayed import
-            from angr.storage.memory_mixins import RegionedMemory
+            from .. import RegionedMemory
             regioned_memory_cls = RegionedMemory
 
         self._regioned_memory_cls = regioned_memory_cls

--- a/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
@@ -6,17 +6,19 @@ import claripy
 from claripy.ast import Bool, Bits, BV
 from claripy.vsa import StridedInterval, ValueSet, RegionAnnotation
 
-from ....sim_options import (HYBRID_SOLVER, APPROXIMATE_FIRST, AVOID_MULTIVALUED_READS, CONSERVATIVE_READ_STRATEGY,
+from angr.sim_options import (HYBRID_SOLVER, APPROXIMATE_FIRST, AVOID_MULTIVALUED_READS, CONSERVATIVE_READ_STRATEGY,
     KEEP_MEMORY_READS_DISCRETE, CONSERVATIVE_WRITE_STRATEGY)
-from ....state_plugins.sim_action_object import _raw_ast
-from ....errors import SimMemoryError, SimAbstractMemoryError
-from .. import MemoryMixin
+from angr.state_plugins.sim_action_object import _raw_ast
+from angr.errors import SimMemoryError, SimAbstractMemoryError
+from angr.storage.memory_mixins import MemoryMixin
 from .region_data import AddressWrapper, RegionMap
 from .abstract_address_descriptor import AbstractAddressDescriptor
 
 if TYPE_CHECKING:
-    from ....sim_state import SimState
-    from .. import RegionedMemory
+    from angr.sim_state import SimState
+    from angr.storage.memory_mixins import RegionedMemory
+else:
+    RegionedMemory = None
 
 
 _l = logging.getLogger(name=__name__)
@@ -50,7 +52,8 @@ class RegionedMemoryMixin(MemoryMixin):
 
         if regioned_memory_cls is None:
             # delayed import
-            from .. import RegionedMemory
+            if RegionedMemory is None:
+                from angr.storage.memory_mixins import RegionedMemory
             regioned_memory_cls = RegionedMemory
 
         self._regioned_memory_cls = regioned_memory_cls

--- a/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
@@ -16,9 +16,6 @@ from .abstract_address_descriptor import AbstractAddressDescriptor
 
 if TYPE_CHECKING:
     from angr.sim_state import SimState
-    from angr.storage.memory_mixins import RegionedMemory
-else:
-    RegionedMemory = None
 
 
 _l = logging.getLogger(name=__name__)
@@ -52,9 +49,7 @@ class RegionedMemoryMixin(MemoryMixin):
 
         if regioned_memory_cls is None:
             # delayed import
-            global RegionedMemory
-            if RegionedMemory is None:
-                from angr.storage.memory_mixins import RegionedMemory
+            from angr.storage.memory_mixins import RegionedMemory
             regioned_memory_cls = RegionedMemory
 
         self._regioned_memory_cls = regioned_memory_cls

--- a/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
@@ -6,7 +6,7 @@ import claripy
 from claripy.ast import Bool, Bits, BV
 from claripy.vsa import StridedInterval, ValueSet, RegionAnnotation
 
-from angr.sim_options import (HYBRID_SOLVER, APPROXIMATE_FIRST, AVOID_MULTIVALUED_READS, CONSERVATIVE_READ_STRATEGY,
+from angr.sim_options import (AVOID_MULTIVALUED_READS, CONSERVATIVE_READ_STRATEGY,
     KEEP_MEMORY_READS_DISCRETE, CONSERVATIVE_WRITE_STRATEGY)
 from angr.state_plugins.sim_action_object import _raw_ast
 from angr.errors import SimMemoryError, SimAbstractMemoryError


### PR DESCRIPTION
Implements: https://github.com/angr/angr/issues/3684#issuecomment-1362486330

Before merging, the final duplicate needs to be addressed:

`def amd64g_create_mxcsr(state, sseround):`
https://github.com/angr/angr/blob/9a3926655e10ead4a8efd411ad42fb80dd747998/angr/engines/vex/claripy/ccall.py#L943
https://github.com/angr/angr/blob/9a3926655e10ead4a8efd411ad42fb80dd747998/angr/engines/vex/claripy/ccall.py#L1362