### PR TITLE
Fix fp rounding not to cut off high values

### DIFF
--- a/angr/engines/vex/claripy/irop.py
+++ b/angr/engines/vex/claripy/irop.py
@@ -1002,7 +1002,9 @@ class SimIROp:
             mantissa_bits = fsort.mantissa-1 # -1 since FSort has mantissa value 1 higher than the number of bits
             exp_bits = fsort.exp
             rounded_fp = claripy.fpToFP(claripy.fp.RM.RM_NearestTiesEven, rounded_bv, fsort)
-            return claripy.If(args[1].raw_to_bv()[exp_bits+mantissa_bits-1:mantissa_bits] >= (2**(exp_bits-1)-1)+mantissa_bits, args[1].raw_to_fp(), rounded_fp)
+            exp_bv = args[1].raw_to_bv()[exp_bits+mantissa_bits-1:mantissa_bits]
+            exp_threshold = (2**(exp_bits-1)-1)+mantissa_bits
+            return claripy.If(exp_bv >= exp_threshold, args[1].raw_to_fp(), rounded_fp)
 
     def _generic_pack_saturation(self, args, src_size, dst_size, src_signed, dst_signed):
         """

--- a/angr/engines/vex/claripy/irop.py
+++ b/angr/engines/vex/claripy/irop.py
@@ -1010,6 +1010,8 @@ class SimIROp:
             else:
                 # TODO: other bit lengths
                 return rounded_fp
+
+    def _generic_pack_saturation(self, args, src_size, dst_size, src_signed, dst_signed):
         """
         Generic pack with saturation.
         Split args in chunks of src_size and then pack them into saturated chunks of dst_size bits.


### PR DESCRIPTION
This PR tries to implement the following TODO:

```py
# engines/vex/claripy/irop.py:996
# _op_fgeneric_Round
        else:
            # note: this a bad solution because it will cut off high values
            # TODO: look into fixing this
```

The change exploits the observation that if the exponent of a floating point is high enough, the value is already an integer. Therefore, it is possible to return the value directly. As far as I know, this also works well with special values such as inf and NaN.

One downside of this method is that this adds one layer of If-Then-Else. Therefore, if you think the downside is not acceptable to your design, feel free to reject this.

Also, please confirm the values since I may have mistakes there.