### PR TITLE
Fix bug in decomposing large symbolic BVs before storing in memory

### DIFF
--- a/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
@@ -110,17 +110,20 @@ class MemoryObjectMixin(CooperationBase):
         while True:
             if data.symbolic and data.op == 'Concat' and data.size() > size * 8:
                 # Generate new memory object with only size bytes to speed up extracting bytes
-                cur_data_size = min(size, next_elem_size_left)
-                cur_data = data.args[next_elem_index]
+                cur_data_size = 0
+                cur_data = []
                 while cur_data_size < size:
-                    next_elem_index += 1
+                    if next_elem_size_left == 0:
+                        next_elem_index += 1
+
                     next_elem = data.args[next_elem_index]
+                    cur_data.append(next_elem)
                     next_elem_size_left = next_elem.size() // 8
-                    added_size = min(size - cur_data_size, next_elem.size())
+                    added_size = min(size - cur_data_size, next_elem.size() // 8)
                     cur_data_size += added_size
                     next_elem_size_left = next_elem_size_left - added_size
-                    cur_data = cur_data.concat(next_elem)
 
+                cur_data = claripy.Concat(*cur_data)
                 if label is None:
                     memory_object = SimMemoryObject(cur_data, cur_addr, endness, byte_width=byte_width)
                 else:

--- a/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
@@ -101,12 +101,26 @@ class MemoryObjectMixin(CooperationBase):
             memory_object = SimMemoryObject(data, cur_addr, endness, byte_width=byte_width)
         else:
             memory_object = SimLabeledMemoryObject(data, cur_addr, endness, byte_width=byte_width, label=label)
+
+        if data.symbolic and data.op == 'Concat':
+            next_elem_size_left = data.args[0].size() // 8
+            next_elem_index = 0
+
         size = yield
         while True:
             if data.symbolic and data.op == 'Concat' and data.size() > size * 8:
-                start_offset = cur_addr - addr
                 # Generate new memory object with only size bytes to speed up extracting bytes
-                cur_data = data.args[start_offset].concat(*data.args[start_offset + 1:start_offset + size])
+                cur_data_size = min(size, next_elem_size_left)
+                cur_data = data.args[next_elem_index]
+                while cur_data_size < size:
+                    next_elem_index += 1
+                    next_elem = data.args[next_elem_index]
+                    next_elem_size_left = next_elem.size() // 8
+                    added_size = min(size - cur_data_size, next_elem.size())
+                    cur_data_size += added_size
+                    next_elem_size_left = next_elem_size_left - added_size
+                    cur_data = cur_data.concat(next_elem)
+
                 if label is None:
                     memory_object = SimMemoryObject(cur_data, cur_addr, endness, byte_width=byte_width)
                 else:


### PR DESCRIPTION
This PR fixes a bug (#3706) introduced in #3660. All CI tests pass and the CGC tracing tests I ran also succeed with no noticeable slowdown. See [this comment on #3706](https://github.com/angr/angr/issues/3706#issuecomment-1368674106) for more on the bug. 