### PR TITLE
Update Unicorn to version 2.0.1.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=59", "wheel", "pyvex==9.2.33.dev0", "unicorn>=2.0.1.post1"]
+requires = ["setuptools>=59", "wheel", "pyvex==9.2.33.dev0", "unicorn==2.0.1.post1"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=59", "wheel", "pyvex==9.2.33.dev0", "unicorn>=2.0.1"]
+requires = ["setuptools>=59", "wheel", "pyvex==9.2.33.dev0", "unicorn>=2.0.1.post1"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     rpyc
     sortedcontainers
     sympy
-    unicorn>=2.0.1,<=2.0.1.post1
+    unicorn==2.0.1.post1
     colorama;platform_system=='Windows'
 python_requires = >=3.8
 include_package_data = True


### PR DESCRIPTION
Unicorn version 2.0.1 is broken for some architectures (such as Apple Silicon on MacOS), so they released Unicorn 2.0.1.post1.

This changes Unicorn to version 2.0.1.post1 and fixes https://github.com/angr/angr/issues/3732.