### PR TITLE
RegionIdentifier: Include all single-in-degree loop successor nodes in loops.

### DIFF
--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -215,6 +215,9 @@ class RegionIdentifier(Analysis):
                 if graph.in_degree[exit_node] == 1 and graph.out_degree[exit_node] <= 1:
                     added.add(exit_node)
                     refined_loop_nodes.add(exit_node)
+                    refined_exit_nodes |= set(
+                        succ for succ in graph.successors(exit_node) if succ not in refined_loop_nodes
+                    )
                     refined_exit_nodes.remove(exit_node)
             if not added:
                 break

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -207,7 +207,7 @@ class RegionIdentifier(Analysis):
                 outside_successors = list(succ for succ in graph.successors(loop_node) if succ not in loop_subgraph)
                 if len(outside_successors) == 1:
                     outside_successor = outside_successors[0]
-                    if graph.in_degree[outside_successor] == 1:
+                    if graph.in_degree[outside_successor] == 1 and graph.out_degree[outside_successor] <= 1:
                         added.add(outside_successor)
                         loop_subgraph.add_edge(loop_node, outside_successor)
             if not added:


### PR DESCRIPTION
The new test case relies on #3744.