### PR TITLE
Fix smoketest CI in windows

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -19,24 +19,24 @@ jobs:
       - run: python -m venv $HOME\venv
         name: Create venv
       - run: |
-          %USERPROFILE%\venv\Scripts\activate &
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" &
-          pip install "setuptools>=59" wheel cffi "unicorn==2.0.1" &
-          pip install git+https://github.com/angr/archinfo.git &
-          pip install git+https://github.com/angr/pyvex.git &
-          pip install git+https://github.com/angr/cle.git &
-          pip install git+https://github.com/angr/claripy.git &
+          call %USERPROFILE%\venv\Scripts\activate
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          pip install "setuptools>=59" wheel cffi "unicorn==2.0.1"
+          pip install git+https://github.com/angr/archinfo.git
+          pip install git+https://github.com/angr/pyvex.git
+          pip install git+https://github.com/angr/cle.git
+          pip install git+https://github.com/angr/claripy.git
           pip install git+https://github.com/angr/ailment.git
         name: Install dependencies
         shell: cmd
       - run: |
-          %USERPROFILE%\venv\Scripts\activate &
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" &
+          call %USERPROFILE%\venv\Scripts\activate
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           pip install --no-build-isolation . 
         name: Install angr
         shell: cmd
       - run: |
-          %USERPROFILE%\venv\Scripts\activate &
+          %USERPROFILE%\venv\Scripts\activate
           python -c "import angr; print('It works!')"
         name: Import angr
         shell: cmd

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -32,11 +32,11 @@ jobs:
       - run: |
           call %USERPROFILE%\venv\Scripts\activate
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          pip install --no-build-isolation . 
+          pip install --no-build-isolation .
         name: Install angr
         shell: cmd
       - run: |
-          %USERPROFILE%\venv\Scripts\activate
+          call %USERPROFILE%\venv\Scripts\activate
           python -c "import angr; print('It works!')"
         name: Import angr
         shell: cmd

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -19,24 +19,24 @@ jobs:
       - run: python -m venv $HOME\venv
         name: Create venv
       - run: |
-          %USERPROFILE%\venv\Scripts\activate
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          pip install "setuptools>=59" wheel cffi "unicorn==2.0.1"
-          pip install git+https://github.com/angr/archinfo.git
-          pip install git+https://github.com/angr/pyvex.git
-          pip install git+https://github.com/angr/cle.git
-          pip install git+https://github.com/angr/claripy.git
+          %USERPROFILE%\venv\Scripts\activate &
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" &
+          pip install "setuptools>=59" wheel cffi "unicorn==2.0.1" &
+          pip install git+https://github.com/angr/archinfo.git &
+          pip install git+https://github.com/angr/pyvex.git &
+          pip install git+https://github.com/angr/cle.git &
+          pip install git+https://github.com/angr/claripy.git &
           pip install git+https://github.com/angr/ailment.git
         name: Install dependencies
         shell: cmd
       - run: |
-          %USERPROFILE%\venv\Scripts\activate
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          pip install --no-build-isolation .
+          %USERPROFILE%\venv\Scripts\activate &
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" &
+          pip install --no-build-isolation . 
         name: Install angr
         shell: cmd
       - run: |
-          %USERPROFILE%\venv\Scripts\activate
+          %USERPROFILE%\venv\Scripts\activate &
           python -c "import angr; print('It works!')"
         name: Import angr
         shell: cmd


### PR DESCRIPTION
fix #3753, append `call` in front of `%USERPROFILE%\venv\Scripts\activate` to ensure that all the following cmd will run