### PR TITLE
Project: Add symbol_hooked_by 

### DIFF
--- a/angr/project.py
+++ b/angr/project.py
@@ -586,7 +586,7 @@ class Project:
         self.hook(hook_addr, simproc, kwargs=kwargs, replace=replace)
         return hook_addr
 
-    def hooked_by_symbol(self, symbol_name) -> Optional[SimProcedure]:
+    def symbol_hooked_by(self, symbol_name) -> Optional[SimProcedure]:
         """
         Return the SimProcedure, if it exists, for the given symbol name.
 

--- a/angr/project.py
+++ b/angr/project.py
@@ -586,6 +586,21 @@ class Project:
         self.hook(hook_addr, simproc, kwargs=kwargs, replace=replace)
         return hook_addr
 
+    def hooked_by_symbol(self, symbol_name) -> Optional[SimProcedure]:
+        """
+        Return the SimProcedure, if it exists, for the given symbol name.
+
+        :param str symbol_name: Name of the symbol.
+        
+        :returns:    None if the address is not hooked.
+        """
+        sym = self.loader.find_symbol(symbol_name)
+        if sym is None:
+            l.warning("Could not find symbol %s", symbol_name)
+            return False
+        hook_addr, _ = self.simos.prepare_function_symbol(symbol_name, basic_addr=sym.rebased_addr)
+        return self.hooked_by(hook_addr)
+
     def is_symbol_hooked(self, symbol_name):
         """
         Check if a symbol is already hooked.

--- a/angr/project.py
+++ b/angr/project.py
@@ -591,7 +591,7 @@ class Project:
         Return the SimProcedure, if it exists, for the given symbol name.
 
         :param str symbol_name: Name of the symbol.
-        
+
         :returns:    None if the address is not hooked.
         """
         sym = self.loader.find_symbol(symbol_name)

--- a/tests/test_hook_by_symbol.py
+++ b/tests/test_hook_by_symbol.py
@@ -5,6 +5,7 @@ from angr.codenode import BlockNode, HookNode, SyscallNode
 
 BIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries")
 
+
 def test_hook_symbol() -> None:
     """
     Test the hook_symbol (and related functions) useing the inet_ntoa simprocedure for functionality
@@ -17,7 +18,7 @@ def test_hook_symbol() -> None:
 
     original_hook = proj.hooked_by_symbol("inet_ntoa")
 
-    assert isinstance(original_hook, angr.SIM_PROCEDURES['posix']['inet_ntoa'])
+    assert isinstance(original_hook, angr.SIM_PROCEDURES["posix"]["inet_ntoa"])
 
     # No intention to call this, just checking hooking
     class FakeInetNtoa(angr.SimProcedure):
@@ -26,7 +27,7 @@ def test_hook_symbol() -> None:
 
     fake_inet_ntoa = FakeInetNtoa()
 
-    # test not allowing replacement 
+    # test not allowing replacement
     proj.hook_symbol("inet_ntoa", fake_inet_ntoa, replace=False)
     assert proj.hooked_by_symbol("inet_ntoa") == original_hook
 

--- a/tests/test_hook_by_symbol.py
+++ b/tests/test_hook_by_symbol.py
@@ -1,7 +1,7 @@
+# pylint:disable=missing-class-docstring,no-self-use,arguments-differ,unused-argument
 import os
+
 import angr
-import claripy
-from angr.codenode import BlockNode, HookNode, SyscallNode
 
 BIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries")
 

--- a/tests/test_hook_by_symbol.py
+++ b/tests/test_hook_by_symbol.py
@@ -1,0 +1,36 @@
+import os
+import angr
+import claripy
+from angr.codenode import BlockNode, HookNode, SyscallNode
+
+BIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries")
+
+def test_hook_symbol() -> None:
+    """
+    Test the hook_symbol (and related functions) useing the inet_ntoa simprocedure for functionality
+    """
+    bin_path = os.path.join(BIN_PATH, "tests", "x86_64", "inet_ntoa")
+    proj = angr.Project(bin_path, auto_load_libs=False, use_sim_procedures=True)
+
+    assert proj.is_symbol_hooked("inet_ntoa")
+    assert not proj.is_symbol_hooked("not_expected_to_exist")
+
+    original_hook = proj.hooked_by_symbol("inet_ntoa")
+
+    assert isinstance(original_hook, angr.SIM_PROCEDURES['posix']['inet_ntoa'])
+
+    # No intention to call this, just checking hooking
+    class FakeInetNtoa(angr.SimProcedure):
+        def run(self, in_addr):
+            return None
+
+    fake_inet_ntoa = FakeInetNtoa()
+
+    # test not allowing replacement 
+    proj.hook_symbol("inet_ntoa", fake_inet_ntoa, replace=False)
+    assert proj.hooked_by_symbol("inet_ntoa") == original_hook
+
+    # test allowing replacement
+    proj.hook_symbol("inet_ntoa", fake_inet_ntoa, replace=True)
+    assert proj.hooked_by_symbol("inet_ntoa") != original_hook
+    assert proj.hooked_by_symbol("inet_ntoa") == fake_inet_ntoa

--- a/tests/test_symbol_hooked_by.py
+++ b/tests/test_symbol_hooked_by.py
@@ -16,7 +16,7 @@ def test_hook_symbol() -> None:
     assert proj.is_symbol_hooked("inet_ntoa")
     assert not proj.is_symbol_hooked("not_expected_to_exist")
 
-    original_hook = proj.hooked_by_symbol("inet_ntoa")
+    original_hook = proj.symbol_hooked_by("inet_ntoa")
 
     assert isinstance(original_hook, angr.SIM_PROCEDURES["posix"]["inet_ntoa"])
 
@@ -29,9 +29,9 @@ def test_hook_symbol() -> None:
 
     # test not allowing replacement
     proj.hook_symbol("inet_ntoa", fake_inet_ntoa, replace=False)
-    assert proj.hooked_by_symbol("inet_ntoa") == original_hook
+    assert proj.symbol_hooked_by("inet_ntoa") == original_hook
 
     # test allowing replacement
     proj.hook_symbol("inet_ntoa", fake_inet_ntoa, replace=True)
-    assert proj.hooked_by_symbol("inet_ntoa") != original_hook
-    assert proj.hooked_by_symbol("inet_ntoa") == fake_inet_ntoa
+    assert proj.symbol_hooked_by("inet_ntoa") != original_hook
+    assert proj.symbol_hooked_by("inet_ntoa") == fake_inet_ntoa


### PR DESCRIPTION
Adds the method `symbol_hooked_by` to `Project` so that users can access the SimProcedure that exists for a given symbol name.

There are functions `hooked_by`, `is_hooked`, and `hook` that all operate on an address. 

On the symbol level (where the user can pass in a string as a symbol name), there is currently `hook_symbol` and `is_symbol_hooked`, but no equivalent to `symbol_hooked_by`.

Also added a test case that tests `is_symbol_hooked` and `hook_symbol`, which didn't appear to exist before, in addition to the proposed `symbol_hooked_by`.