### PR TITLE
Variable Recovery: Make constant choice in the case of reading memory of overlapping variables

### DIFF
--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -614,6 +614,12 @@ class SimEngineVRBase(SimEngineLight):
 
                 if len(all_vars) > 1:
                     # overlapping variables
+                    all_vars = list(all_vars)
+
+                    # sort by some value so that the outcome here isn't random
+                    all_vars.sort(reverse=True, key=lambda val: (val[0], val[1].offset, val[1].base
+, val[1].base_addr, val[1].size))
+
                     l.warning(
                         "Reading memory with overlapping variables: %s. Ignoring all but the first one.", all_vars
                     )

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -617,8 +617,10 @@ class SimEngineVRBase(SimEngineLight):
                     all_vars = list(all_vars)
 
                     # sort by some value so that the outcome here isn't random
-                    all_vars.sort(reverse=True, key=lambda val: (val[0], val[1].offset, val[1].base
-, val[1].base_addr, val[1].size))
+                    all_vars.sort(
+                        reverse=True,
+                        key=lambda val: (val[0], val[1].offset, val[1].base, val[1].base_addr, val[1].size),
+                    )
 
                     l.warning(
                         "Reading memory with overlapping variables: %s. Ignoring all but the first one.", all_vars


### PR DESCRIPTION
This line in variable recovery causes non-deterministic results, because `all_vars` is a set:
https://github.com/angr/angr/blob/wip/constant-overlapping-vars/angr/analyses/variable_recovery/engine_base.py#L627

At least with this fix the choice will be deterministic. 

@ltfish reviewed and approved on slack