### PR TITLE
Variable Recovery: Fixing stack offset calculation for complex stack operations

### DIFF
--- a/angr/analyses/variable_recovery/variable_recovery_base.py
+++ b/angr/analyses/variable_recovery/variable_recovery_base.py
@@ -253,26 +253,39 @@ class VariableRecoveryStateBase:
                 return True
         return False
 
+    @staticmethod
+    def extract_stack_offset_from_addr(addr: claripy.ast.Base) -> claripy.ast.Base:
+        r = None
+        if addr.op == "BVS":
+            r = claripy.BVV(0, addr.size())
+        elif addr.op == "BVV":
+            r = addr
+        elif addr.op == "__add__":
+            r = sum([VariableRecoveryStateBase.extract_stack_offset_from_addr(arg) for arg in addr.args])
+        elif addr.op == "__sub__":
+            r1 = VariableRecoveryStateBase.extract_stack_offset_from_addr(addr.args[0])
+            r2 = VariableRecoveryStateBase.extract_stack_offset_from_addr(addr.args[1])
+            r = r1 - r2
+        else:
+            # NOTE: The original code here didn't support mul or
+            # anything like that, so let's specify it as 0
+            r = claripy.BVV(0, addr.size())
+        return r
+
     def get_stack_offset(self, addr: claripy.ast.Base) -> Optional[int]:
         if "stack_base" in addr.variables:
-            r = None
-            if addr.op == "BVS":
-                return 0
-            elif addr.op == "__add__":
-                if len(addr.args) == 2 and addr.args[1].op == "BVV":
-                    r = addr.args[1]._model_concrete.value
-                if len(addr.args) == 1:
-                    return 0
-            elif addr.op == "__sub__" and len(addr.args) == 2 and addr.args[1].op == "BVV":
-                r = -addr.args[1]._model_concrete.value
+            r = VariableRecoveryStateBase.extract_stack_offset_from_addr(addr)
 
-            if r is not None:
-                # convert it to a signed integer
-                if r >= 2 ** (self.arch.bits - 1):
-                    return r - 2**self.arch.bits
-                if r < -(2 ** (self.arch.bits - 1)):
-                    return 2**self.arch.bits + r
-                return r
+            # VariableRecoveryStateBase should ensure that r is a BVV
+            assert r.concrete
+
+            val = r._model_concrete.value
+            # convert it to a signed integer
+            if val >= 2 ** (self.arch.bits - 1):
+                return val - 2**self.arch.bits
+            if val < -(2 ** (self.arch.bits - 1)):
+                return 2**self.arch.bits + val
+            return val
 
         return None
 

--- a/angr/analyses/variable_recovery/variable_recovery_base.py
+++ b/angr/analyses/variable_recovery/variable_recovery_base.py
@@ -261,7 +261,7 @@ class VariableRecoveryStateBase:
         elif addr.op == "BVV":
             r = addr
         elif addr.op == "__add__":
-            r = sum([VariableRecoveryStateBase.extract_stack_offset_from_addr(arg) for arg in addr.args])
+            r = sum(VariableRecoveryStateBase.extract_stack_offset_from_addr(arg) for arg in addr.args)
         elif addr.op == "__sub__":
             r1 = VariableRecoveryStateBase.extract_stack_offset_from_addr(addr.args[0])
             r2 = VariableRecoveryStateBase.extract_stack_offset_from_addr(addr.args[1])

--- a/angr/analyses/variable_recovery/variable_recovery_base.py
+++ b/angr/analyses/variable_recovery/variable_recovery_base.py
@@ -276,7 +276,7 @@ class VariableRecoveryStateBase:
         if "stack_base" in addr.variables:
             r = VariableRecoveryStateBase.extract_stack_offset_from_addr(addr)
 
-            # VariableRecoveryStateBase should ensure that r is a BVV
+            # extract_stack_offset_from_addr should ensure that r is a BVV
             assert r.concrete
 
             val = r._model_concrete.value


### PR DESCRIPTION
Prior code would incorrectly calculate the stack offset from complex instructions.

One example of this (in x86_64) is: `mov rax, [rbp+rax*0x8-0x98]` which is translated into an AIL instruction like the following:

```
stack_base-8 + (Cons(32->64, *(stack_base-184)) * 0x8)) - 0x98
```

This results in a claripy AST addr of:

```
stack_base + 0xFFFFFFFFFFFFFFF8 + top - 0x98
```

The old code would only extract the `0x98` as the offset, which conflicted with another variable on the stack (thus confusing those variables).

The fix that I have here is essentially to traverse the AST addr, and treat every symbolic value as 0.

Also, the old code was hard coded to only support adds of length 1 or 2, however in the example that I found the add had 3 elements. 

So the fix can now support an unlimited number of arguments to add.

I was not sure if this happened for sub as well, so I just left it hardcoded to support two arguments as before.

Another problem with the old code is that it used `BVV(0)` which could never work: it was not imported and it didn't specify the size.

Added a test case to check for this on the binary where I found this (babyheap_1.1):
https://github.com/angr/binaries/pull/103

