### PR TITLE
Set edge formatter unicode endcap to ▸

### DIFF
--- a/angr/utils/formatting.py
+++ b/angr/utils/formatting.py
@@ -101,7 +101,7 @@ def add_edge_to_buffer(
         chars = {
             "start_cap": "╴",
             "start_corner": "╭" if descending else "╰",
-            "end_cap": "⧽",
+            "end_cap": "▸",
             "end_corner": "╰" if descending else "╭",
             "horizontal": "╌" if dashed else "─",
             "vertical": "╎" if dashed else "│",


### PR DESCRIPTION
Current symbol does not work ootb on Ubuntu 22.04.

U+25B8 appears to be supported everywhere. Tested macOS, Windows (new and old console).