### PR TITLE
Decompiler: Fix an infinite loop caused by type negotiation.

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -2944,9 +2944,11 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
     def _handle_Expr_Load(self, expr: Expr.Load):
         ty = self.default_simtype_from_size(expr.size)
 
-        def negotiate(old_ty, proposed_ty):
+        def negotiate(old_ty: SimType, proposed_ty: SimType) -> SimType:
             if old_ty.size == proposed_ty.size:
-                return proposed_ty
+                # we do not allow returning a struct for a primitive type
+                if not (isinstance(proposed_ty, SimStruct) and not isinstance(old_ty, SimStruct)):
+                    return proposed_ty
             return old_ty
 
         if expr.variable is not None:

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -1951,6 +1951,23 @@ class TestDecompiler(unittest.TestCase):
 
         assert "goto" not in d.codegen.text
 
+    @structuring_algo("phoenix")
+    def test_decompiling_ls_print_many_per_line(self, decompiler_options=None):
+        # complex variable types involved. a struct with only one field was causing _access() in
+        # CStructuredCodeGenerator to end up in an infinite loop.
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "ls.o")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+
+        f = proj.kb.functions["print_many_per_line"]
+        d = proj.analyses[Decompiler].prep()(f, cfg=cfg.model, options=decompiler_options)
+        self._print_decompilation_result(d)
+
+        # it should make somewhat sense
+        assert "calculate_columns(" in d.codegen.text
+        assert "putchar_unlocked(eolbyte)" in d.codegen.text
+
     @for_all_structuring_algos
     def test_eliminating_stack_canary_reused_stack_chk_fail_call(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "cksum-digest.o")


### PR DESCRIPTION
CStructuredCodeGenerator._access() may end up in an infinite loop when it tries to access offset 0 of any single-field structs. This is because type negotiation converts the first field into the struct type itself. As a temporary fix, we disallow type negotiation to return struct types if the old type is not a struct type.