### PR TITLE
Fix cyclic import from SwitchLowerer

### DIFF
--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -14,7 +14,6 @@ from ....knowledge_plugins.cfg import IndirectJumpType
 from ....utils.graph import dominates, inverted_idoms, to_acyclic_graph
 from ...cfg.cfg_utils import CFGUtils
 from ..sequence_walker import SequenceWalker
-from ..optimization_passes.lowered_switch_simplifier import LoweredSwitchSimplifier
 from ..utils import (
     remove_last_statement,
     extract_jump_targets,
@@ -939,6 +938,9 @@ class PhoenixStructurer(StructurerBase):
         if not r:
             # restore the graph to cascading if-then-elses
             l.warning("Cannot structure as a switch-case. Restore the sub graph to if-elses.")
+
+            # delay this import, since it's cyclic for anyone who uses Structuring in their optimizations
+            from ..optimization_passes.lowered_switch_simplifier import LoweredSwitchSimplifier
             LoweredSwitchSimplifier.restore_graph(node, last_stmt, graph, full_graph)
             raise GraphChangedNotification()
 

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -941,6 +941,7 @@ class PhoenixStructurer(StructurerBase):
 
             # delay this import, since it's cyclic for anyone who uses Structuring in their optimizations
             from ..optimization_passes.lowered_switch_simplifier import LoweredSwitchSimplifier
+
             LoweredSwitchSimplifier.restore_graph(node, last_stmt, graph, full_graph)
             raise GraphChangedNotification()
 


### PR DESCRIPTION
- triggerable cyclic import error when you import Phoenix in lowered_switch_simplifier (useful later in the pipeline).