### PR TITLE
Eliminate misc same-line string concats

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -683,7 +683,7 @@ class ConditionProcessor:
                 cond_tags = {}
             return _mapping[cond.op](cond, cond_tags)
         raise NotImplementedError(
-            ("Condition variable %s has an unsupported operator %s. " "Consider implementing.") % (cond, cond.op)
+            ("Condition variable %s has an unsupported operator %s. Consider implementing.") % (cond, cond.op)
         )
 
     def claripy_ast_from_ail_condition(self, condition) -> claripy.ast.Bool:

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -505,7 +505,7 @@ class VFG(ForwardAnalysis, Analysis):  # pylint:disable=abstract-method
 
         if not self._cfg.normalized:
             l.warning(
-                "The given CFG is not normalized, which might impact the performance/accuracy of the VFG " "analysis."
+                "The given CFG is not normalized, which might impact the performance/accuracy of the VFG analysis."
             )
 
         # Prepare the state
@@ -1133,7 +1133,7 @@ class VFG(ForwardAnalysis, Analysis):  # pylint:disable=abstract-method
                 l.debug("No pending return for the current function %#x. Unwind the stack.", func_addr)
                 if not self._top_function_analysis_task.done:
                     l.warning(
-                        "The top function analysis task is not done yet. This might be a bug. " "Please report to Fish."
+                        "The top function analysis task is not done yet. This might be a bug. Please report to Fish."
                     )
                 # stack unwinding
                 while True:

--- a/angr/angrdb/__init__.py
+++ b/angr/angrdb/__init__.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     sqlalchemy = None
     raise ImportError(
-        "AngrDB relies on SQLAlchemy. Please install SQLAlchemy first by running:\n" "\tpip install sqlalchemy"
+        "AngrDB relies on SQLAlchemy. Please install SQLAlchemy first by running:\n\tpip install sqlalchemy"
     )
 
 from .db import AngrDB

--- a/angr/callable.py
+++ b/angr/callable.py
@@ -118,7 +118,7 @@ class Callable:
 
         if not ast.ext[0].body.block_items or not isinstance(ast.ext[0].body.block_items[0], pycparser.c_ast.FuncCall):
             raise AngrCallableError(
-                "Error in parsing the given C-style argument string: " "Cannot find the expected function call."
+                "Error in parsing the given C-style argument string: Cannot find the expected function call."
             )
 
         arg_exprs = ast.ext[0].body.block_items[0].args.exprs

--- a/angr/engines/pcode/engine.py
+++ b/angr/engines/pcode/engine.py
@@ -76,7 +76,7 @@ class HeavyPcodeMixin(
             insn_bytes = self.project.arch.asm(insn_text, addr=successors.addr, thumb=thumb)
             if insn_bytes is None:
                 raise errors.AngrAssemblyError(
-                    "Assembling failed. Please make sure keystone is installed, and the" " assembly string is correct."
+                    "Assembling failed. Please make sure keystone is installed, and the assembly string is correct."
                 )
 
         successors.sort = "IRSB"

--- a/angr/engines/soot/expressions/newArray.py
+++ b/angr/engines/soot/expressions/newArray.py
@@ -33,7 +33,7 @@ class SimSootExpr_NewArray(SimSootExpr):
         # overwrite size, if it *always* exceeds the maximum
         if True not in size_stays_below_maximum:
             l.warning(
-                "Array size %s always exceeds maximum size. " "It gets overwritten with the maximum %s.",
+                "Array size %s always exceeds maximum size. It gets overwritten with the maximum %s.",
                 array_size,
                 max_array_size,
             )
@@ -42,7 +42,7 @@ class SimSootExpr_NewArray(SimSootExpr):
         # bound size, if it *can* exceeds the maximum
         if True in size_stays_below_maximum and False in size_stays_below_maximum:
             l.warning(
-                "Array size %s can exceed maximum size. " "It gets bounded with the maximum %s.",
+                "Array size %s can exceed maximum size. It gets bounded with the maximum %s.",
                 array_size,
                 max_array_size,
             )

--- a/angr/engines/soot/expressions/newMultiArray.py
+++ b/angr/engines/soot/expressions/newMultiArray.py
@@ -45,7 +45,7 @@ class SimSootExpr_NewMultiArray(SimSootExpr):
         # overwrite size, if it *always* exceeds the maximum
         if True not in size_stays_below_maximum:
             l.warning(
-                "Array size %s always exceeds maximum size. " "It gets overwritten with the maximum %s.",
+                "Array size %s always exceeds maximum size. It gets overwritten with the maximum %s.",
                 multi_array_size,
                 max_multi_array_size,
             )
@@ -54,7 +54,7 @@ class SimSootExpr_NewMultiArray(SimSootExpr):
         # bound size, if it *can* exceeds the maximum
         if True in size_stays_below_maximum and False in size_stays_below_maximum:
             l.warning(
-                "Array size %s can exceed maximum size. " "It gets bounded with the maximum %s.",
+                "Array size %s can exceed maximum size. It gets bounded with the maximum %s.",
                 multi_array_size,
                 max_multi_array_size,
             )

--- a/angr/engines/vex/heavy/heavy.py
+++ b/angr/engines/vex/heavy/heavy.py
@@ -109,7 +109,7 @@ class HeavyVEXMixin(SuccessorsMixin, ClaripyDataMixin, SimStateStorageMixin, VEX
             insn_bytes = self.project.arch.asm(insn_text, addr=successors.addr, thumb=thumb)
             if insn_bytes is None:
                 raise errors.AngrAssemblyError(
-                    "Assembling failed. Please make sure keystone is installed, and the" " assembly string is correct."
+                    "Assembling failed. Please make sure keystone is installed, and the assembly string is correct."
                 )
 
         successors.sort = "IRSB"

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -328,7 +328,7 @@ class AngrObjectFactory:
             if byte_string is None:
                 # assembly failed
                 raise AngrAssemblyError(
-                    "Assembling failed. Please make sure keystone is installed, and the assembly" " string is correct."
+                    "Assembling failed. Please make sure keystone is installed, and the assembly string is correct."
                 )
 
         if max_size is not None:

--- a/angr/flirt/build_sig.py
+++ b/angr/flirt/build_sig.py
@@ -202,19 +202,19 @@ def main():
     parser.add_argument("sig_name", help="Name of the signature (a string inside the signature file)")
     parser.add_argument("sig_path", help="File name of the generated signature")
     parser.add_argument(
-        "--compiler", help="Name of the compiler (e.g., gcc, clang). It will be stored in the meta " "data file."
+        "--compiler", help="Name of the compiler (e.g., gcc, clang). It will be stored in the meta data file."
     )
     parser.add_argument(
-        "--compiler_version", help="Version of the compiler (e.g., 6). It will be stored in the meta " "data file."
+        "--compiler_version", help="Version of the compiler (e.g., 6). It will be stored in the meta data file."
     )
     # parser.add_argument("--platform", help="Name of the platform (e.g., windows/linux/macos). It will be stored in
     # the meta data file.")
     parser.add_argument(
-        "--os", help="Name of the operating system (e.g., ubuntu/debian). It will be stored in the " "meta data file."
+        "--os", help="Name of the operating system (e.g., ubuntu/debian). It will be stored in the meta data file."
     )
     parser.add_argument(
         "--os_version",
-        help="Version of the operating system (e.g., 20.04). It will be stored in the " "meta data file.",
+        help="Version of the operating system (e.g., 20.04). It will be stored in the meta data file.",
     )
     parser.add_argument("--pelf_path", help="Path of pelf")
     parser.add_argument("--sigmake_path", help="Path of sigmake")

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -178,7 +178,7 @@ class Function(Serializable):
         else:
             if self.project is None:
                 raise ValueError(
-                    "'syscall' must be specified if you do not specify a function manager for this new" " function."
+                    "'syscall' must be specified if you do not specify a function manager for this new function."
                 )
 
             # Determine whether this function is a syscall or not
@@ -190,8 +190,8 @@ class Function(Serializable):
         else:
             if self.project is None:
                 raise ValueError(
-                    "'is_simprocedure' must be specified if you do not specify a function manager for this"
-                    " new function."
+                    "'is_simprocedure' must be specified if you do not specify a function manager for this new "
+                    "function."
                 )
 
             if self.is_syscall or self.project.is_hooked(addr):
@@ -204,7 +204,7 @@ class Function(Serializable):
             # Whether this function is a PLT entry or not is fully relying on the PLT detection in CLE
             if self.project is None:
                 raise ValueError(
-                    "'is_plt' must be specified if you do not specify a function manager for this new" " function."
+                    "'is_plt' must be specified if you do not specify a function manager for this new function."
                 )
 
             self.is_plt = self.project.loader.find_plt_stub_name(addr) is not None
@@ -229,7 +229,7 @@ class Function(Serializable):
         else:
             if self.project is None:
                 raise ValueError(
-                    "'returning' must be specified if you do not specify a functio nmnager for this new" " function."
+                    "'returning' must be specified if you do not specify a function manager for this new function."
                 )
 
             self._returning = self._get_initial_returning()

--- a/angr/procedures/java_jni/__init__.py
+++ b/angr/procedures/java_jni/__init__.py
@@ -135,7 +135,7 @@ class JNISimProcedure(SimProcedure):
         for i in itertools.count():
             str_byte = self.state.memory.load(addr + i, size=1)
             if self.state.solver.symbolic(str_byte):
-                l.error("Loading of strings with symbolic chars is not supported. " "Character %d is concretized.", i)
+                l.error("Loading of strings with symbolic chars is not supported. Character %d is concretized.", i)
             str_byte = self.state.solver.eval(str_byte)
             if str_byte == 0:
                 break

--- a/angr/procedures/java_jni/array_operations.py
+++ b/angr/procedures/java_jni/array_operations.py
@@ -112,7 +112,7 @@ class GetObjectArrayElement(JNISimProcedure):
         if self.state.solver.symbolic(idx):
             idx = self.state.eval(idx)
             l.warning(
-                "Symbolic indices are not supported for object arrays %s. " "Index gets concretized to %s", array, idx
+                "Symbolic indices are not supported for object arrays %s. Index gets concretized to %s", array, idx
             )
 
         # load element and return reference to it
@@ -135,7 +135,7 @@ class SetObjectArrayElement(JNISimProcedure):
         if self.state.solver.symbolic(idx):
             idx = self.state.eval(idx)
             l.warning(
-                "Symbolic indices are not supported for object arrays %s. " "Index gets concretized to %s", array, idx
+                "Symbolic indices are not supported for object arrays %s. Index gets concretized to %s", array, idx
             )
 
         self.state.javavm_memory.store_array_element(array, idx, value)
@@ -177,7 +177,7 @@ class ReleaseArrayElements(JNISimProcedure):
     def run(self, ptr_env, array_, ptr_elems, mode_):
         if self.state.solver.symbolic(mode_):
             l.warning(
-                "Symbolic mode %s in JNI function ReleaseArrayElements" "is not supported and gets concretized.", mode_
+                "Symbolic mode %s in JNI function ReleaseArrayElements is not supported and gets concretized.", mode_
             )
         mode = self.state.solver.min(mode_)  # avoid JNI_ABORT by taking the minimum
 
@@ -230,7 +230,7 @@ class GetArrayRegion(JNISimProcedure):
         if state.solver.symbolic(length):
             midpoint_length = (state.solver.min(length) + state.solver.max(length)) // 2
             state.solver.add(length == midpoint_length)
-            l.warning("Symbolic lengths are currently not supported. " "Length is concretized to a midpoint value.")
+            l.warning("Symbolic lengths are currently not supported. Length is concretized to a midpoint value.")
         return state.solver.eval_one(length)
 
     @staticmethod
@@ -260,8 +260,7 @@ class GetArrayRegion(JNISimProcedure):
             # TODO raise java.lang.ArrayIndexOutOfBoundsException
             #      For now, we just skip this SimProcedure.
             l.error(
-                "Skipping SimProcedure: "
-                "Every combination of start_idx %s and length %s is invalid (array length %s).",
+                "Skipping SimProcedure: Every combination of start_idx %s and length %s is invalid (array length %s).",
                 start_idx,
                 length,
                 array.size,

--- a/angr/procedures/java_jni/not_implemented.py
+++ b/angr/procedures/java_jni/not_implemented.py
@@ -18,9 +18,7 @@ class UnsupportedJNIFunction(JNISimProcedure):
         function_name = jni_functions.keys()[function_idx]
 
         # show warning
-        l.warning(
-            "SimProcedure for JNI function %s is not implemented. " "Returning unconstrained symbol.", function_name
-        )
+        l.warning("SimProcedure for JNI function %s is not implemented. Returning unconstrained symbol.", function_name)
 
         # return unconstrained
         symbol_name = "unconstrained_ret_of_jni_func_%s" % function_name

--- a/angr/sim_state_options.py
+++ b/angr/sim_state_options.py
@@ -26,7 +26,7 @@ class StateOption:
         # Sanity check
         if not isinstance(self.default, tuple(self.types)):
             raise SimStateOptionsError(
-                "The type of the default value does not match the expected types of this state " "option."
+                "The type of the default value does not match the expected types of this state option."
             )
 
         # Speed optimization

--- a/angr/simos/javavm.py
+++ b/angr/simos/javavm.py
@@ -144,7 +144,7 @@ class SimJavaVM(SimOS):
 
         if not self.project.entry and not addr:
             raise ValueError(
-                "Failed to init blank state. Project entry is not set/invalid " "and no address was provided."
+                "Failed to init blank state. Project entry is not set/invalid and no address was provided."
             )
 
         # init state register
@@ -347,7 +347,7 @@ class SimJavaVM(SimOS):
         if to_type in ["float", "double"]:
             if value.symbolic:
                 # TODO extend support for floating point types
-                l.warning("No support for symbolic floating-point arguments." "Value gets concretized.")
+                l.warning("No support for symbolic floating-point arguments. Value gets concretized.")
             value = float(state.solver.eval(value))
             sort = FSORT_FLOAT if to_type == "float" else FSORT_DOUBLE
             return FPV(value, sort)
@@ -422,8 +422,8 @@ class SimJavaVM(SimOS):
                 return symbol.rebased_addr
 
         native_symbols = "\n".join(self.native_symbols.keys())
-        l.warning("No native method found that matches the Soot method '%s'. " "Skipping statement.", soot_method.name)
-        l.debug("Available symbols (prefix + encoded class path + encoded method " "name):\n%s", native_symbols)
+        l.warning("No native method found that matches the Soot method '%s'. Skipping statement.", soot_method.name)
+        l.debug("Available symbols (prefix + encoded class path + encoded method name):\n%s", native_symbols)
         return None
 
     def get_native_type(self, java_type):

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -362,7 +362,7 @@ class SimWindows(SimOS):
             except Exception as e:
                 # lol no
                 _l.error(
-                    "Got some weirdo error while re-executing %d instructions at %#x " "for exception windup",
+                    "Got some weirdo error while re-executing %d instructions at %#x for exception windup",
                     num_inst,
                     successors.initial_state.addr,
                 )

--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -164,7 +164,7 @@ class Concrete(SimStatePlugin):
                 )
             except SimConcreteRegisterError as exc:
                 l.debug(
-                    "Can't set register %s reason: %s, if this register is not used " "this message can be ignored",
+                    "Can't set register %s reason: %s, if this register is not used this message can be ignored",
                     register_name,
                     exc,
                 )

--- a/angr/state_plugins/scratch.py
+++ b/angr/state_plugins/scratch.py
@@ -107,7 +107,7 @@ class SimStateScratch(SimStatePlugin):
             v = self.temps[tmp]
             if v is None:
                 raise SimMissingTempError(
-                    "VEX temp variable %d does not exist. This is usually the result of an " "incorrect slicing." % tmp
+                    "VEX temp variable %d does not exist. This is usually the result of an incorrect slicing." % tmp
                 )
         except IndexError:
             raise SimMissingTempError("Accessing a temp that is illegal in this tyenv")

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -170,9 +170,9 @@ class STOP:
     stop_message[STOP_VEX_LIFT_FAILED] = "Failed to lift block to VEX"
     stop_message[STOP_SYMBOLIC_PC] = "Instruction pointer became symbolic"
     stop_message[STOP_SYMBOLIC_READ_ADDR] = "Attempted to read from symbolic address"
-    stop_message[STOP_SYMBOLIC_READ_SYMBOLIC_TRACKING_DISABLED] = (
-        "Attempted to read symbolic data from memory but " "symbolic tracking is disabled"
-    )
+    stop_message[
+        STOP_SYMBOLIC_READ_SYMBOLIC_TRACKING_DISABLED
+    ] = "Attempted to read symbolic data from memory but symbolic tracking is disabled"
     stop_message[STOP_SYMBOLIC_WRITE_ADDR] = "Attempted to write to symbolic address"
     stop_message[STOP_SYMBOLIC_BLOCK_EXIT_CONDITION] = "Guard condition of block's exit statement is symbolic"
     stop_message[STOP_SYMBOLIC_BLOCK_EXIT_TARGET] = "Target of default exit of block is symbolic"

--- a/angr/storage/memory_mixins/address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/address_concretization_mixin.py
@@ -30,7 +30,7 @@ SimStateOptions.register_option(
     "symbolic_ip_max_targets",
     int,
     default=256,
-    description="The maximum number of concrete addresses a symbolic instruction pointer " "can be concretized to.",
+    description="The maximum number of concrete addresses a symbolic instruction pointer can be concretized to.",
 )
 SimStateOptions.register_option(
     "jumptable_symbolic_ip_max_targets",

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -47,7 +47,7 @@ class DefaultFillerMixin(MemoryMixin):
             if once("mem_fill_warning"):
                 what = "memory" if is_mem else "register"
                 l.warning(
-                    "The program is accessing %s with an unspecified value. " "This could indicate unwanted behavior.",
+                    "The program is accessing %s with an unspecified value. This could indicate unwanted behavior.",
                     what,
                 )
                 l.warning(


### PR DESCRIPTION
Apparently black decided to minimize some multi line strings but didn't want to get rid of the string concats. Take out many same-line `"string " "concatenations"`