### PR TITLE
Fixed more bugs when decomposing large symbolic BVs before writing to memory

### DIFF
--- a/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
@@ -175,7 +175,7 @@ class PagedMemoryMixin(MemoryMixin):
         # l.debug("%s.store(%#x, %s, %s)", self.id, addr, data, endness)
 
         pageno, pageoff = self._divide_addr(addr)
-        sub_gen = self.PAGE_TYPE._decompose_objects(addr, data, endness, memory=self, **kwargs)
+        sub_gen = self.PAGE_TYPE._decompose_objects(addr, data, endness, memory=self, max_size=self.page_size, **kwargs)
         next(sub_gen)
 
         # fasttrack basic case

--- a/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
@@ -128,17 +128,18 @@ class MemoryObjectMixin(CooperationBase):
         while True:
             if data.symbolic and data.op == "Concat" and data.size() > size * 8:
                 # Generate new memory object with only size bytes to speed up extracting bytes
-                cur_data_size = 0
+                cur_data_size_bits = 0
+                requested_size_bits = size * 8
                 cur_data = []
-                while cur_data_size < size:
+                while cur_data_size_bits < requested_size_bits:
                     if next_elem_size_left == 0:
                         next_elem_index += 1
 
                     next_elem = data.args[next_elem_index]
                     cur_data.append(next_elem)
-                    next_elem_size_left = next_elem.size() // 8
-                    added_size = min(size - cur_data_size, next_elem.size() // 8)
-                    cur_data_size += added_size
+                    next_elem_size_left = next_elem.size()
+                    added_size = min(requested_size_bits - cur_data_size_bits, next_elem.size())
+                    cur_data_size_bits += added_size
                     next_elem_size_left = next_elem_size_left - added_size
 
                 cur_data = claripy.Concat(*cur_data)

--- a/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/cooperation.py
@@ -125,8 +125,9 @@ class MemoryObjectMixin(CooperationBase):
             next_elem_index = 0
 
         size = yield
+        max_size = kwargs.get("max_size", size)
         while True:
-            if data.symbolic and data.op == "Concat" and data.size() > size * 8:
+            if data.symbolic and data.op == "Concat" and data.size() > max_size:
                 # Generate new memory object with only size bytes to speed up extracting bytes
                 cur_data_size_bits = 0
                 requested_size_bits = size * 8


### PR DESCRIPTION
This PR fixes two more bugs also reported in [#3706](https://github.com/angr/angr/issues/3706#issuecomment-1420413689) but with a different root cause. Two specific fixes have been made:

1. Previously, we were computing size of smaller symbolic BVs in bytes when decomposing, which caused issues if bit-sized symbolic BVs are involved. To fix this, we compute size now in bits instead of bytes.
2. A particular edge case occurs when decomposing a BV because a memory write spans multiple pages. My guess is this occurs because endianness of value being written is not taken in account when decomposing and this causes problem when recomposing bytes together(eg: writing an integer to memory such that the value spans two pages). I disabled decomposing values that are less than 1 page in size and that seems to fix this. If this issue arises again later, I think we can revisit this decision then.