### PR TITLE
Add 3 concretization strategies

### DIFF
--- a/angr/concretization_strategies/any_named.py
+++ b/angr/concretization_strategies/any_named.py
@@ -1,0 +1,31 @@
+from . import SimConcretizationStrategy
+
+class SimConcretizationStrategyAnyNamed(SimConcretizationStrategy):
+    """
+    Concretization strategy that returns any single solution and creates a BVS at the resulting address.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def _concretize(self, memory, addr, **kwargs):
+        mn, mx = self._range(memory, addr, **kwargs)
+        if mn == mx:
+            # Check if a variable already exists
+            for _, values in memory._name_mapping.items():
+                if mn in values:
+                    return [mn]
+        # Get any solution
+        child_constraints = (addr > 0x1000, addr < (1 << memory.state.arch.bits) - 0x10000, addr % 8 == 0)
+        extra_constraints = kwargs.pop("extra_constraints", None)
+        if extra_constraints is not None:
+            child_constraints += tuple(extra_constraints)
+        target = self._any(memory, addr, extra_constraints=child_constraints, **kwargs)
+        # Create new BVS
+        old_name = " ".join(repr(addr)[:-1].split(" ")[1:])
+        new_BVS = memory.state.solver.BVS(f"[{old_name}]", memory.state.arch.bits, explicit_name=True)
+        memory.store(target, new_BVS, endness=memory.state.arch.memory_endness)
+        # Enforce the address
+        memory.state.solver.add(addr == target)
+
+        return [target]

--- a/angr/concretization_strategies/any_named.py
+++ b/angr/concretization_strategies/any_named.py
@@ -1,5 +1,6 @@
 from . import SimConcretizationStrategy
 
+
 class SimConcretizationStrategyAnyNamed(SimConcretizationStrategy):
     """
     Concretization strategy that returns any single solution and creates a BVS at the resulting address.

--- a/angr/concretization_strategies/logging.py
+++ b/angr/concretization_strategies/logging.py
@@ -13,10 +13,16 @@ class SimConcretizationStrategyLogging(SimConcretizationStrategy):
         if answers is not None:
             if self._is_read_strategy:
                 logging.debug(
-                    "Read strategy %s on %s gave [%s]", type(self._strategy).__name__, addr, ", ".join([hex(answer) for answer in answers])
+                    "Read strategy %s on %s gave [%s]",
+                    type(self._strategy).__name__,
+                    addr,
+                    ", ".join([hex(answer) for answer in answers]),
                 )
             else:
                 logging.debug(
-                    "Write strategy %s on %s gave [%s]", type(self._strategy).__name__, addr, ", ".join([hex(answer) for answer in answers])
+                    "Write strategy %s on %s gave [%s]",
+                    type(self._strategy).__name__,
+                    addr,
+                    ", ".join([hex(answer) for answer in answers]),
                 )
         return answers

--- a/angr/concretization_strategies/logging.py
+++ b/angr/concretization_strategies/logging.py
@@ -6,7 +6,7 @@ class SimConcretizationStrategyLogging(SimConcretizationStrategy):
     """
     Concretization strategy that logs concretization results from another strategy.
     """
-    
+
     def __init__(self, strategy: SimConcretizationStrategy, is_read_strategy: bool):
         super().__init__()
         self._strategy = strategy

--- a/angr/concretization_strategies/logging.py
+++ b/angr/concretization_strategies/logging.py
@@ -1,0 +1,17 @@
+from . import SimConcretizationStrategy
+import logging
+
+class SimConcretizationStrategyLogging(SimConcretizationStrategy):
+    def __init__(self, strategy: SimConcretizationStrategy, is_read: bool):
+        super().__init__()
+        self._strategy = strategy
+        self._is_read = is_read
+
+    def _concretize(self, memory, addr, **kwargs):
+        answers = self._strategy._concretize(memory, addr, **kwargs)
+        if answers is not None:
+            if self._is_read:
+                logging.debug(f"Read strategy {type(self._strategy).__name__} on {addr} gave [{', '.join(map(hex, answers))}]")
+            else:
+                logging.debug(f"Write strategy {type(self._strategy).__name__} on {addr} gave [{', '.join(map(hex, answers))}]")
+        return answers

--- a/angr/concretization_strategies/logging.py
+++ b/angr/concretization_strategies/logging.py
@@ -1,22 +1,22 @@
-from . import SimConcretizationStrategy
 import logging
+from . import SimConcretizationStrategy
 
 
 class SimConcretizationStrategyLogging(SimConcretizationStrategy):
-    def __init__(self, strategy: SimConcretizationStrategy, is_read: bool):
+    def __init__(self, strategy: SimConcretizationStrategy, is_read_strategy: bool):
         super().__init__()
         self._strategy = strategy
-        self._is_read = is_read
+        self._is_read_strategy = is_read_strategy
 
     def _concretize(self, memory, addr, **kwargs):
         answers = self._strategy._concretize(memory, addr, **kwargs)
         if answers is not None:
-            if self._is_read:
+            if self._is_read_strategy:
                 logging.debug(
-                    f"Read strategy {type(self._strategy).__name__} on {addr} gave [{', '.join(map(hex, answers))}]"
+                    "Read strategy %s on %s gave [%s]", type(self._strategy).__name__, addr, ", ".join([hex(answer) for answer in answers])
                 )
             else:
                 logging.debug(
-                    f"Write strategy {type(self._strategy).__name__} on {addr} gave [{', '.join(map(hex, answers))}]"
+                    "Write strategy %s on %s gave [%s]", type(self._strategy).__name__, addr, ", ".join([hex(answer) for answer in answers])
                 )
         return answers

--- a/angr/concretization_strategies/logging.py
+++ b/angr/concretization_strategies/logging.py
@@ -1,6 +1,7 @@
 from . import SimConcretizationStrategy
 import logging
 
+
 class SimConcretizationStrategyLogging(SimConcretizationStrategy):
     def __init__(self, strategy: SimConcretizationStrategy, is_read: bool):
         super().__init__()
@@ -11,7 +12,11 @@ class SimConcretizationStrategyLogging(SimConcretizationStrategy):
         answers = self._strategy._concretize(memory, addr, **kwargs)
         if answers is not None:
             if self._is_read:
-                logging.debug(f"Read strategy {type(self._strategy).__name__} on {addr} gave [{', '.join(map(hex, answers))}]")
+                logging.debug(
+                    f"Read strategy {type(self._strategy).__name__} on {addr} gave [{', '.join(map(hex, answers))}]"
+                )
             else:
-                logging.debug(f"Write strategy {type(self._strategy).__name__} on {addr} gave [{', '.join(map(hex, answers))}]")
+                logging.debug(
+                    f"Write strategy {type(self._strategy).__name__} on {addr} gave [{', '.join(map(hex, answers))}]"
+                )
         return answers

--- a/angr/concretization_strategies/logging.py
+++ b/angr/concretization_strategies/logging.py
@@ -3,6 +3,10 @@ from . import SimConcretizationStrategy
 
 
 class SimConcretizationStrategyLogging(SimConcretizationStrategy):
+    """
+    Concretization strategy that logs concretization results from another strategy.
+    """
+    
     def __init__(self, strategy: SimConcretizationStrategy, is_read_strategy: bool):
         super().__init__()
         self._strategy = strategy

--- a/angr/concretization_strategies/signed_add.py
+++ b/angr/concretization_strategies/signed_add.py
@@ -1,5 +1,6 @@
 from . import SimConcretizationStrategy
 
+
 class SimConcretizationStrategySignedAdd(SimConcretizationStrategy):
     """
     Concretization strategy that changes additions of big offsets to substractions of small offsets.
@@ -16,7 +17,7 @@ class SimConcretizationStrategySignedAdd(SimConcretizationStrategy):
                 addr.args = (addr.args[1], addr.args[0])
             if addr.args[0].symbolic and addr.args[1].singlevalued:
                 # Check if negative argument
-                if memory.state.solver.is_true(addr.args[1] >= 1 << (addr.args[1].size()-1)):
+                if memory.state.solver.is_true(addr.args[1] >= 1 << (addr.args[1].size() - 1)):
                     new_arg = (1 << addr.args[1].size()) - memory.state.solver.eval(addr.args[1])
                     if new_arg < self._substraction_limit:
                         addr.op = "__sub__"

--- a/angr/concretization_strategies/signed_add.py
+++ b/angr/concretization_strategies/signed_add.py
@@ -22,4 +22,3 @@ class SimConcretizationStrategySignedAdd(SimConcretizationStrategy):
                     if new_arg < self._substraction_limit:
                         addr.op = "__sub__"
                         addr.args = (addr.args[0], memory.state.solver.BVV(new_arg, addr.args[1].size()))
-        return None

--- a/angr/concretization_strategies/signed_add.py
+++ b/angr/concretization_strategies/signed_add.py
@@ -1,0 +1,24 @@
+from . import SimConcretizationStrategy
+
+class SimConcretizationStrategySignedAdd(SimConcretizationStrategy):
+    """
+    Concretization strategy that changes additions of big offsets to substractions of small offsets.
+    """
+
+    def __init__(self, substraction_limit=0x10000):
+        super().__init__()
+        self._substraction_limit = substraction_limit
+
+    def _concretize(self, memory, addr, **kwargs):
+        if addr.depth == 2 and addr.op == "__add__":
+            if addr.args[0].singlevalued and addr.args[1].symbolic:
+                # Swap variable and immediate
+                addr.args = (addr.args[1], addr.args[0])
+            if addr.args[0].symbolic and addr.args[1].singlevalued:
+                # Check if negative argument
+                if memory.state.solver.is_true(addr.args[1] >= 1 << (addr.args[1].size()-1)):
+                    new_arg = (1 << addr.args[1].size()) - memory.state.solver.eval(addr.args[1])
+                    if new_arg < self._substraction_limit:
+                        addr.op = "__sub__"
+                        addr.args = (addr.args[0], memory.state.solver.BVV(new_arg, addr.args[1].size()))
+        return None


### PR DESCRIPTION
Adds 3 new concretization strategies:
- **SimConcretizationStrategyAnyNamed:** like the Any strategy, but also creates a BVS with bracket syntax (dereference of `var` creates `[var]`) and adds it to the solver to help better understand the memory constraints after the simulation
- **SimConcretizationStrategySignedAdd:** changes symbolic variables with big additions like `rax + 0xffffffffffffffff` to small substractions like `rax - 0x1`. (doing it inside a concretization strategy might not be the best idea, its kind of a hack, so I will let people who know angr better than me judge if it's useful)
- **SimConcretizationStrategyLogging:** basically a wrapper strategy that takes another strategy as input and logs all its concretizations

You can easily wrap all your strategies inside logging strategies to really have a good overview of memory accesses.
~~~python
state.memory.read_strategies = list(map(lambda s: SimConcretizationStrategyLogging(s, True), state.memory.read_strategies))
state.memory.write_strategies = list(map(lambda s: SimConcretizationStrategyLogging(s, False), state.memory.write_strategies))
~~~