### PR TITLE
add typehint for known plugins in AnalysesHub

### DIFF
--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -148,7 +148,7 @@ class KnownAnalysesPlugin(typing.Protocol):
     VariableRecovery: "Type[VariableRecovery]"
 
 
-class AnalysesHubWithDefault(PluginVendor, KnownAnalysesPlugin):
+class AnalysesHubWithDefault(AnalysesHub, KnownAnalysesPlugin):
     """
     This class has type-hinting for all built-in analyses plugin
     """

--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -69,7 +69,7 @@ class AnalysisLogEntry:
 A = TypeVar("A", bound="Analysis")
 
 
-class KnownAnalysesPlugin(typing.Protocl):
+class KnownAnalysesPlugin(typing.Protocol):
     from .identifier import Identifier
     from .callee_cleanup_finder import CalleeCleanupFinder
     from .vsa_ddg import VSA_DDG

--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -94,30 +94,30 @@ class KnownAnalysesPlugin(typing.Protocl):
     from .variable_recovery import VariableRecoveryFast
     from .variable_recovery import VariableRecovery
 
-    Identifier: Identifier
-    CalleeCleanupFinder: CalleeCleanupFinder
-    VSA_DDG: VSA_DDG
-    CDG: CDG
-    BinDiff: BinDiff
-    CFGEmulated: CFGEmulated
-    CFB: CFBlanket
-    CFBlanket: CFBlanket
-    CFG: CFG
-    CFGFast: CFGFast
-    StaticHooker: StaticHooker
-    DDG: DDG
-    CongruencyCheck: CongruencyCheck
-    Reassembler: Reassembler
-    BackwardSlice: BackwardSlice
-    BinaryOptimizer: BinaryOptimizer
-    VFG: VFG
-    LoopFinder: LoopFinder
-    Disassembly: Disassembly
-    Veritesting: Veritesting
-    CodeTagging: CodeTagging
-    BoyScout: BoyScout
-    VariableRecoveryFast: VariableRecoveryFast
-    VariableRecovery: VariableRecovery
+    Identifier: Type[Identifier]
+    CalleeCleanupFinder: Type[CalleeCleanupFinder]
+    VSA_DDG: Type[VSA_DDG]
+    CDG: Type[CDG]
+    BinDiff: Type[BinDiff]
+    CFGEmulated: Type[CFGEmulated]
+    CFB: Type[CFBlanket]
+    CFBlanket: Type[CFBlanket]
+    CFG: Type[CFG]
+    CFGFast: Type[CFGFast]
+    StaticHooker: Type[StaticHooker]
+    DDG: Type[DDG]
+    CongruencyCheck: Type[CongruencyCheck]
+    Reassembler: Type[Reassembler]
+    BackwardSlice: Type[BackwardSlice]
+    BinaryOptimizer: Type[BinaryOptimizer]
+    VFG: Type[VFG]
+    LoopFinder: Type[LoopFinder]
+    Disassembly: Type[Disassembly]
+    Veritesting: Type[Veritesting]
+    CodeTagging: Type[CodeTagging]
+    BoyScout: Type[BoyScout]
+    VariableRecoveryFast: Type[VariableRecoveryFast]
+    VariableRecovery: Type[VariableRecovery]
 
 
 class AnalysesHub(PluginVendor, KnownAnalysesPlugin):

--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F401
 import functools
 import sys
 import contextlib
@@ -18,6 +19,29 @@ if TYPE_CHECKING:
     from ..knowledge_base import KnowledgeBase
     from ..project import Project
     from typing_extensions import ParamSpec
+    from .identifier import Identifier
+    from .callee_cleanup_finder import CalleeCleanupFinder
+    from .vsa_ddg import VSA_DDG
+    from .cdg import CDG
+    from .bindiff import BinDiff
+    from .cfg import CFGEmulated
+    from .cfg import CFBlanket
+    from .cfg import CFG
+    from .cfg import CFGFast
+    from .static_hooker import StaticHooker
+    from .ddg import DDG
+    from .congruency_check import CongruencyCheck
+    from .reassembler import Reassembler
+    from .backward_slice import BackwardSlice
+    from .binary_optimizer import BinaryOptimizer
+    from .vfg import VFG
+    from .loopfinder import LoopFinder
+    from .disassembly import Disassembly
+    from .veritesting import Veritesting
+    from .code_tagging import CodeTagging
+    from .boyscout import BoyScout
+    from .variable_recovery import VariableRecoveryFast
+    from .variable_recovery import VariableRecovery
 
     AnalysisParams = ParamSpec("AnalysisParams")
 
@@ -69,58 +93,7 @@ class AnalysisLogEntry:
 A = TypeVar("A", bound="Analysis")
 
 
-class KnownAnalysesPlugin(typing.Protocol):
-    from .identifier import Identifier
-    from .callee_cleanup_finder import CalleeCleanupFinder
-    from .vsa_ddg import VSA_DDG
-    from .cdg import CDG
-    from .bindiff import BinDiff
-    from .cfg import CFGEmulated
-    from .cfg import CFBlanket
-    from .cfg import CFG
-    from .cfg import CFGFast
-    from .static_hooker import StaticHooker
-    from .ddg import DDG
-    from .congruency_check import CongruencyCheck
-    from .reassembler import Reassembler
-    from .backward_slice import BackwardSlice
-    from .binary_optimizer import BinaryOptimizer
-    from .vfg import VFG
-    from .loopfinder import LoopFinder
-    from .disassembly import Disassembly
-    from .veritesting import Veritesting
-    from .code_tagging import CodeTagging
-    from .boyscout import BoyScout
-    from .variable_recovery import VariableRecoveryFast
-    from .variable_recovery import VariableRecovery
-
-    Identifier: Type[Identifier]
-    CalleeCleanupFinder: Type[CalleeCleanupFinder]
-    VSA_DDG: Type[VSA_DDG]
-    CDG: Type[CDG]
-    BinDiff: Type[BinDiff]
-    CFGEmulated: Type[CFGEmulated]
-    CFB: Type[CFBlanket]
-    CFBlanket: Type[CFBlanket]
-    CFG: Type[CFG]
-    CFGFast: Type[CFGFast]
-    StaticHooker: Type[StaticHooker]
-    DDG: Type[DDG]
-    CongruencyCheck: Type[CongruencyCheck]
-    Reassembler: Type[Reassembler]
-    BackwardSlice: Type[BackwardSlice]
-    BinaryOptimizer: Type[BinaryOptimizer]
-    VFG: Type[VFG]
-    LoopFinder: Type[LoopFinder]
-    Disassembly: Type[Disassembly]
-    Veritesting: Type[Veritesting]
-    CodeTagging: Type[CodeTagging]
-    BoyScout: Type[BoyScout]
-    VariableRecoveryFast: Type[VariableRecoveryFast]
-    VariableRecovery: Type[VariableRecovery]
-
-
-class AnalysesHub(PluginVendor, KnownAnalysesPlugin):
+class AnalysesHub(PluginVendor):
     """
     This class contains functions for all the registered and runnable analyses,
     """
@@ -146,6 +119,39 @@ class AnalysesHub(PluginVendor, KnownAnalysesPlugin):
 
     def __getitem__(self, plugin_cls: "Type[A]") -> "AnalysisFactory[A]":
         return AnalysisFactory(self.project, plugin_cls)
+
+
+class KnownAnalysesPlugin(typing.Protocol):
+    Identifier: "Type[Identifier]"
+    CalleeCleanupFinder: "Type[CalleeCleanupFinder]"
+    VSA_DDG: "Type[VSA_DDG]"
+    CDG: "Type[CDG]"
+    BinDiff: "Type[BinDiff]"
+    CFGEmulated: "Type[CFGEmulated]"
+    CFB: "Type[CFBlanket]"
+    CFBlanket: "Type[CFBlanket]"
+    CFG: "Type[CFG]"
+    CFGFast: "Type[CFGFast]"
+    StaticHooker: "Type[StaticHooker]"
+    DDG: "Type[DDG]"
+    CongruencyCheck: "Type[CongruencyCheck]"
+    Reassembler: "Type[Reassembler]"
+    BackwardSlice: "Type[BackwardSlice]"
+    BinaryOptimizer: "Type[BinaryOptimizer]"
+    VFG: "Type[VFG]"
+    LoopFinder: "Type[LoopFinder]"
+    Disassembly: "Type[Disassembly]"
+    Veritesting: "Type[Veritesting]"
+    CodeTagging: "Type[CodeTagging]"
+    BoyScout: "Type[BoyScout]"
+    VariableRecoveryFast: "Type[VariableRecoveryFast]"
+    VariableRecovery: "Type[VariableRecovery]"
+
+
+class AnalysesHubWithDefault(PluginVendor, KnownAnalysesPlugin):
+    """
+    This class has type-hinting for all built-in analyses plugin
+    """
 
 
 class AnalysisFactory(Generic[A]):

--- a/angr/analyses/analysis.py
+++ b/angr/analyses/analysis.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypeVar, Type, Generic, Callable, Optional
 
 import logging
 import time
+import typing
 
 from rich import progress
 
@@ -68,7 +69,58 @@ class AnalysisLogEntry:
 A = TypeVar("A", bound="Analysis")
 
 
-class AnalysesHub(PluginVendor):
+class KnownAnalysesPlugin(typing.Protocl):
+    from .identifier import Identifier
+    from .callee_cleanup_finder import CalleeCleanupFinder
+    from .vsa_ddg import VSA_DDG
+    from .cdg import CDG
+    from .bindiff import BinDiff
+    from .cfg import CFGEmulated
+    from .cfg import CFBlanket
+    from .cfg import CFG
+    from .cfg import CFGFast
+    from .static_hooker import StaticHooker
+    from .ddg import DDG
+    from .congruency_check import CongruencyCheck
+    from .reassembler import Reassembler
+    from .backward_slice import BackwardSlice
+    from .binary_optimizer import BinaryOptimizer
+    from .vfg import VFG
+    from .loopfinder import LoopFinder
+    from .disassembly import Disassembly
+    from .veritesting import Veritesting
+    from .code_tagging import CodeTagging
+    from .boyscout import BoyScout
+    from .variable_recovery import VariableRecoveryFast
+    from .variable_recovery import VariableRecovery
+
+    Identifier: Identifier
+    CalleeCleanupFinder: CalleeCleanupFinder
+    VSA_DDG: VSA_DDG
+    CDG: CDG
+    BinDiff: BinDiff
+    CFGEmulated: CFGEmulated
+    CFB: CFBlanket
+    CFBlanket: CFBlanket
+    CFG: CFG
+    CFGFast: CFGFast
+    StaticHooker: StaticHooker
+    DDG: DDG
+    CongruencyCheck: CongruencyCheck
+    Reassembler: Reassembler
+    BackwardSlice: BackwardSlice
+    BinaryOptimizer: BinaryOptimizer
+    VFG: VFG
+    LoopFinder: LoopFinder
+    Disassembly: Disassembly
+    Veritesting: Veritesting
+    CodeTagging: CodeTagging
+    BoyScout: BoyScout
+    VariableRecoveryFast: VariableRecoveryFast
+    VariableRecovery: VariableRecovery
+
+
+class AnalysesHub(PluginVendor, KnownAnalysesPlugin):
     """
     This class contains functions for all the registered and runnable analyses,
     """

--- a/angr/project.py
+++ b/angr/project.py
@@ -92,7 +92,7 @@ class Project:
     :type storage:      defaultdict(list)
     """
 
-    analyses: "AnalysesHub"
+    analyses: "AnalysesHubWithDefault"
     arch: archinfo.Arch
 
     def __init__(
@@ -802,6 +802,6 @@ class Project:
 
 from .factory import AngrObjectFactory
 from angr.simos import SimOS, os_mapping
-from .analyses.analysis import AnalysesHub
+from .analyses.analysis import AnalysesHub, AnalysesHubWithDefault
 from .knowledge_base import KnowledgeBase
 from .procedures import SIM_PROCEDURES, SIM_LIBRARIES


### PR DESCRIPTION
Previously, if you are trying to use proj.analyses.CFG, there are no IDE support for class definition. This PR using `typing.Protocol` to add the existing analyses plugin into AnalysesHub. Now IDE can read the parameter when using plguin like `proj.analyses.CFGEmulated`
![image](https://user-images.githubusercontent.com/45957390/231470950-a4eb0dc9-8778-4820-9f24-1bc9feaccd25.png)
