### PR TITLE
Improve temporary file creation method

### DIFF
--- a/angr/procedures/libc/tmpnam.py
+++ b/angr/procedures/libc/tmpnam.py
@@ -15,7 +15,7 @@ class tmpnam(angr.SimProcedure):
         if self.state.solver.eval(tmp_file_path_addr) != 0:
             return tmp_file_path_addr
 
-        tmp_fd , tmp_file_path = tempfile.mkstemp()
+        tmp_fd, tmp_file_path = tempfile.mkstemp()
         malloc = angr.SIM_PROCEDURES["libc"]["malloc"]
         addr = self.inline_call(malloc, L_tmpnam).ret_expr
         self.state.memory.store(addr, tmp_file_path.encode() + b"\x00")

--- a/angr/procedures/libc/tmpnam.py
+++ b/angr/procedures/libc/tmpnam.py
@@ -15,7 +15,7 @@ class tmpnam(angr.SimProcedure):
         if self.state.solver.eval(tmp_file_path_addr) != 0:
             return tmp_file_path_addr
 
-        tmp_file_path = tempfile.mktemp()
+        tmp_file_path = tempfile.mkstemp()[1]
         malloc = angr.SIM_PROCEDURES["libc"]["malloc"]
         addr = self.inline_call(malloc, L_tmpnam).ret_expr
         self.state.memory.store(addr, tmp_file_path.encode() + b"\x00")

--- a/angr/procedures/libc/tmpnam.py
+++ b/angr/procedures/libc/tmpnam.py
@@ -15,7 +15,7 @@ class tmpnam(angr.SimProcedure):
         if self.state.solver.eval(tmp_file_path_addr) != 0:
             return tmp_file_path_addr
 
-        tmp_file_path = tempfile.mkstemp()[1]
+        tmp_fd , tmp_file_path = tempfile.mkstemp()
         malloc = angr.SIM_PROCEDURES["libc"]["malloc"]
         addr = self.inline_call(malloc, L_tmpnam).ret_expr
         self.state.memory.store(addr, tmp_file_path.encode() + b"\x00")

--- a/angr/vaults.py
+++ b/angr/vaults.py
@@ -310,7 +310,7 @@ class VaultShelf(VaultDict):
     """
 
     def __init__(self, path=None):
-        self._path = tempfile.mktemp() if path is None else path
+        self._path = tempfile.mkstemp()[1] if path is None else path
         s = shelve.open(self._path, protocol=-1)
         super().__init__(s)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -64,7 +64,7 @@ def internaltest_cfgfast(p):
 
 
 def internaltest_project(fpath):
-    tpath = tempfile.mkstemp()[1]
+    tfile_descriptor, tpath = tempfile.mkstemp()
     shutil.copy(fpath, tpath)
 
     p = angr.Project(tpath, auto_load_libs=False)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -64,7 +64,7 @@ def internaltest_cfgfast(p):
 
 
 def internaltest_project(fpath):
-    tpath = tempfile.mktemp()
+    tpath = tempfile.mkstemp()[1]
     shutil.copy(fpath, tpath)
 
     p = angr.Project(tpath, auto_load_libs=False)


### PR DESCRIPTION
Mktemp is deprecated and insecure. This commit replaces it with a mkstemp function call. Mkstemp is a more secure method of creating temporary files since it will check if the file already exists and will not overwrite it.

Please see:
- [docs.python.org mktemp](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp)
- [docs.python.org mkstemp](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp)