### PR TITLE
Add header comment support to decompiler

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -495,6 +495,13 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
             yield "\n", None
 
         yield indent_str, None
+        
+        # header comments (if they exist)
+        header_comments = self.codegen.kb.comments.get(self.codegen.cfunc.addr, [])
+        if header_comments:
+            header_cmt = self._line_wrap_comment("".join(header_comments))
+            yield header_cmt, None
+
         # return type
         yield self.functy.returnty.c_repr(name="").strip(" "), None
         yield " ", None
@@ -547,6 +554,29 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
         yield indent_str, None
         yield "}", brace
         yield "\n", None
+
+    @staticmethod
+    def _line_wrap_comment(comment: str, width=80) -> str:
+        lines = comment.splitlines()
+        wrapped_cmt = ""
+
+        for line in lines:
+            if len(line) < width:
+                wrapped_cmt += line + "\n"
+                continue
+
+            for i, c in enumerate(line):
+                if i % width == 0 and i != 0:
+                    wrapped_cmt += "\n"
+                wrapped_cmt += c
+
+            wrapped_cmt += "\n"
+
+        final_comment = ""
+        for line in wrapped_cmt.splitlines():
+            final_comment += f"// {line}\n"
+
+        return final_comment
 
 
 class CStatement(CConstruct):  # pylint:disable=abstract-method

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -495,7 +495,7 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
             yield "\n", None
 
         yield indent_str, None
-        
+
         # header comments (if they exist)
         header_comments = self.codegen.kb.comments.get(self.codegen.cfunc.addr, [])
         if header_comments:

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -572,11 +572,7 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
 
             wrapped_cmt += "\n"
 
-        final_comment = ""
-        for line in wrapped_cmt.splitlines():
-            final_comment += f"// {line}\n"
-
-        return final_comment
+        return "".join([f"// {line}\n" for line in wrapped_cmt.splitlines()])
 
 
 class CStatement(CConstruct):  # pylint:disable=abstract-method


### PR DESCRIPTION
## Why
Adds the support to have comments in the function header like IDA:
```c
// ==== AI Vuln Guess ====
// The vulnerability in this function is the use of the `read` function without che
// cking the size of input. Specifically, when reading into `v5` and `v3`, there is
//  no limit on how much data can be read in, which could lead to a buffer overflow
// .
// 
// To exploit this vulnerability, an attacker could provide more than 8 bytes of in
// put for either `v5` or `v3`, causing a buffer overflow and potentially overwriti
// ng other variables on the stack or even control flow information. This could all
// ow an attacker to execute arbitrary code or gain elevated privileges.
int main(unsigned long a1, unsigned long a2)
{
    unsigned long v0;  // [bp-0x48]
    char username;  // [bp-0x18]
    unsigned int auth_val;  // [bp-
```