### PR TITLE
Remove ADDS_EXITS in procedures not using it

### DIFF
--- a/angr/procedures/glibc/__libc_init.py
+++ b/angr/procedures/glibc/__libc_init.py
@@ -12,7 +12,7 @@ import angr
 # structors points to PRE_INIT_ARRAY, INIT_ARRAY, and FINI_ARRAY
 ######################################
 class __libc_init(angr.SimProcedure):
-    # pylint:disable=arguments-differ,unused-argument,attribute-defined-outside-init
+    # pylint:disable=arguments-differ,unused-argument,attribute-defined-outside-init,missing-class-docstring
 
     NO_RET = True
     local_vars = ("main", "argc", "argv", "envp")

--- a/angr/procedures/glibc/__libc_init.py
+++ b/angr/procedures/glibc/__libc_init.py
@@ -14,7 +14,6 @@ import angr
 class __libc_init(angr.SimProcedure):
     # pylint:disable=arguments-differ,unused-argument,attribute-defined-outside-init
 
-    ADDS_EXITS = True
     NO_RET = True
     local_vars = ("main", "argc", "argv", "envp")
 

--- a/angr/procedures/uclibc/__uClibc_main.py
+++ b/angr/procedures/uclibc/__uClibc_main.py
@@ -5,7 +5,6 @@ from ..glibc.__libc_start_main import __libc_start_main as fucker
 # __uClibc_main
 ######################################
 class __uClibc_main(fucker):
-    ADDS_EXITS = True
     NO_RET = True
 
     # This is called "fucker" cause otherwise the double underscores cause

--- a/angr/procedures/uclibc/__uClibc_main.py
+++ b/angr/procedures/uclibc/__uClibc_main.py
@@ -5,6 +5,7 @@ from ..glibc.__libc_start_main import __libc_start_main as fucker
 # __uClibc_main
 ######################################
 class __uClibc_main(fucker):
+    # pylint: disable=missing-class-docstring
     NO_RET = True
 
     # This is called "fucker" cause otherwise the double underscores cause

--- a/docs/extending-angr/simprocedures.rst
+++ b/docs/extending-angr/simprocedures.rst
@@ -234,7 +234,7 @@ attributes of your function so that static analysis knows what it's doing.
   returning
 * ``IS_SYSCALL``: Self-explanatory
 
-Furthermore, if you set ``ADDS_EXITS``, you may also want to define the method
+Furthermore, if you set ``ADDS_EXITS = True``, you'll need to define the method
 ``static_exits()``. This function takes a single parameter, a list of IRSBs that
 would be executed in the run-up to your function, and asks you to return a list
 of all the exits that you know would be produced by your function in that case.


### PR DESCRIPTION
Fixes https://github.com/angr/angr/issues/3906

Let's just add these `ADDS_EXITS = True` back when it's needed in the future.