### PR TITLE
DDG: implement __hash__ for DDGViewItem

### DIFF
--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -354,6 +354,15 @@ class DDGViewItem:
             and self._simplified == other._simplified
         )
 
+    def __hash__(self):
+        return hash(
+            (
+                self._ddg,
+                self._variable,
+                self._simplified,
+            )
+        )
+
     def _to_viewitem(self, prog_var):
         """
         Convert a ProgramVariable instance to a DDGViewItem object.
@@ -415,12 +424,11 @@ class DDGViewInstruction:
             return DDGViewItem(self._ddg, pv, simplified=self._simplified)
 
     @property
-    def definitions(self):
+    def definitions(self) -> list[DDGViewItem]:
         """
         Get all definitions located at the current instruction address.
 
         :return: A list of ProgramVariable instances.
-        :rtype:  list
         """
 
         defs = set()

--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from typing import List
 
 import networkx
 import pyvex
@@ -424,7 +425,7 @@ class DDGViewInstruction:
             return DDGViewItem(self._ddg, pv, simplified=self._simplified)
 
     @property
-    def definitions(self) -> list[DDGViewItem]:
+    def definitions(self) -> List[DDGViewItem]:
         """
         Get all definitions located at the current instruction address.
 

--- a/tests/test_ddg.py
+++ b/tests/test_ddg.py
@@ -6,6 +6,7 @@ import unittest
 
 import angr
 from angr.code_location import CodeLocation
+from angr.sim_variable import SimRegisterVariable
 
 
 l = logging.getLogger("angr.tests.test_ddg")
@@ -68,6 +69,17 @@ class TestDDG(unittest.TestCase):
             cl1,
             {"data": 14, "type": "tmp", "subtype": ("mem_addr",)},
         ) in in_edges
+
+        instr_view = ddg.view[0x400721]
+        assert instr_view is not None
+        definitions: list = instr_view.definitions
+        var = None
+        for definition in definitions:
+            if isinstance(definition._variable.variable, SimRegisterVariable):
+                var = definition._variable.variable
+                break
+        assert var is not None
+        assert var.reg == 56
 
     def test_ddg_0(self):
         binary_path = os.path.join(test_location, "x86_64", "datadep_test")


### PR DESCRIPTION
Hi!

`DDGViewInstruction.definitions` tries to build a set of  DDGViewItem, however a set can only contain hashable objects and  DDGViewItem does nto implement `__hash__`.

I wrote a quick `__hash__` function and completed the test case.

Best :sparkles: 