### PR TITLE
Fix some links

### DIFF
--- a/docs/advanced-topics/file_system.rst
+++ b/docs/advanced-topics/file_system.rst
@@ -39,8 +39,8 @@ when the underlying storage don't support the appropriate operations - just like
 normal file descriptors!
 
 You may access the mapping from file descriptor number to file descriptor object
-in ``state.posix.fd``. The file descriptor API may be found `here
-<http://angr.io/api-doc/angr.html#angr.storage.file.SimFileDescriptorBase>`_.
+in ``state.posix.fd``. See the API document for
+:py:class:`angr.storage.file.SimFileDescriptorBase` for more details.
 
 Just tell me how to do what I want to do!
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,9 +48,7 @@ Just tell me how to do what I want to do!
 Okay okay!!
 
 To create a SimFile, you should just create an instance of the class you want to
-use. Refer to the `API docs
-<http://angr.io/api-doc/angr.html#module-angr.storage.file>`_ for the full
-instructions.
+use. Refer to :py:mod:`angr.storage.file` for the full instructions.
 
 Let's go through a few illustrative examples, which cover how you can work with
 a concrete file, a symbolic file, a file with mixed concrete and symbolic
@@ -270,9 +268,7 @@ it in the filesystem or serve stdin/stdout from it.
 
 The simulated filesystem is the ``state.fs`` plugin. You can store, load, and
 delete files from the filesystem, with the ``insert``, ``get``, and ``delete``
-methods. Refer to the `api docs
-<http://angr.io/api-doc/angr.html#module-angr.state_plugins.filesystem>`_ for
-details.
+methods. Refer to :py:mod:`angr.state_plugins.filesystem` for details.
 
 So to make our file available as ``/tmp/myfile``:
 

--- a/docs/advanced-topics/gotchas.rst
+++ b/docs/advanced-topics/gotchas.rst
@@ -19,12 +19,10 @@ There are several things that you can do:
 
 
 #. Disable the SimProcedure (you can exclude specific SimProcedures by passing
-   options to the `angr.Project class
-   <http://angr.io/api-doc/angr.html#module-angr.project>`_). This has the
-   drawback of likely leading to a path explosion, unless you are very careful
-   about constraining the input to the function in question. The path explosion
-   can be partially mitigated with other angr capabilities (such as
-   Veritesting).
+   options to the :py:class:`angr.Project` class. This has the drawback of
+   likely leading to a path explosion, unless you are very careful about
+   constraining the input to the function in question. The path explosion can be
+   partially mitigated with other angr capabilities (such as Veritesting).
 #. Replace the SimProcedure with something written directly to the situation in
    question. For example, our ``scanf`` implementation is not complete, but if
    you just need to support a single, known format string, you can write a hook

--- a/docs/advanced-topics/pipeline.rst
+++ b/docs/advanced-topics/pipeline.rst
@@ -185,9 +185,8 @@ are analyzing java bytecode, in which case it is very important.
 ``SimEngineVEX`` is the big fellow. It is used whenever any of the previous
 can't be used. It attempts to lift bytes from the current address into an IRSB,
 and then executes that IRSB symbolically. There are a huge number of parameters
-that can control this process, so I will merely link to the `API reference
-<http://angr.io/api-doc/angr.html#angr.engines.vex.engine.SimEngineVEX.process>`_
-describing them.
+that can control this process, so it is best to reference the API doc for
+:py:meth:`angr.engines.vex.engine.SimEngineVEX.process` describing them.
 
 The exact process by which SimEngineVEX digs into an IRSB is a little
 complicated, but essentially it runs all the block's statements in order. This

--- a/docs/advanced-topics/structured_data.rst
+++ b/docs/advanced-topics/structured_data.rst
@@ -175,10 +175,9 @@ the ``SimRegArg`` or ``SimStackArg`` classes. You can find them in the factory -
 
 Once you have a SimCC object, you can use it along with a SimState object and a
 function prototype (a SimTypeFunction) to extract or store function arguments
-more cleanly. Take a look at the `API documentation
-<http://angr.io/api-doc/angr.html#angr.calling_conventions.SimCC>`_ for details.
-Alternately, you can pass it to an interface that can use it to modify its own
-behavior, like ``p.factory.call_state``, or...
+more cleanly. Take a look at the :py:class:`angr.calling_conventions.SimCC>` for
+details. Alternately, you can pass it to an interface that can use it to modify
+its own behavior, like ``p.factory.call_state``, or...
 
 Callables
 ---------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
@@ -51,6 +52,18 @@ coverage_ignore_pyobjects = [
     "angr.analyses.decompiler.structured_codegen.c.StructuredCodeGenerator",  # Alias to CStructuredCodeGenerator
     "angr.sim_type.SimTypeFixedSizeArray",  # Alias to SimTypeArray
 ]
+
+# -- Options for intersphinx -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "ailment": ("https://docs.angr.io/projects/ailment/en/latest/", None),
+    "archinfo": ("https://docs.angr.io/projects/archinfo/en/latest/", None),
+    "claripy": ("https://docs.angr.io/projects/claripy/en/latest/", None),
+    "cle": ("https://docs.angr.io/projects/cle/en/latest/", None),
+    "pypcode": ("https://docs.angr.io/projects/pypcode/en/latest/", None),
+    "pyvex": ("https://docs.angr.io/projects/pyvex/en/latest/", None),
+}
 
 # -- Options for todos -------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/todo.html

--- a/docs/core-concepts/loading.rst
+++ b/docs/core-concepts/loading.rst
@@ -227,9 +227,9 @@ If you are loading something with ``angr.Project`` and you want to pass an
 option to the ``cle.Loader`` instance that Project implicitly creates, you can
 just pass the keyword argument directly to the Project constructor, and it will
 be passed on to CLE. You should look at the `CLE API docs.
-<http://angr.io/api-doc/cle.html>`_ if you want to know everything that could
-possibly be passed in as an option, but we will go over some important and
-frequently used options here.
+<https://docs.angr.io/projects/cle/en/latest/api.html>`_ if you want to know
+everything that could possibly be passed in as an option, but we will go over
+some important and frequently used options here.
 
 Basic Options
 ~~~~~~~~~~~~~
@@ -409,4 +409,5 @@ attempt to simplify its analysis by hooking complex library functions with
 SimProcedures that summarize the effects of the functions.
 
 In order to see all the things you can do with the CLE loader and its backends,
-look at the `CLE API docs. <http://angr.io/api-doc/cle.html>`_
+look at the `CLE API docs.
+<https://docs.angr.io/projects/cle/en/latest/api.html>`_

--- a/docs/core-concepts/pathgroups.rst
+++ b/docs/core-concepts/pathgroups.rst
@@ -272,8 +272,8 @@ Here's a quick overview of some of the built-in ones:
   constructor! Note that it frequenly doesn't play nice with other techniques
   due to the invasive way it implements static symbolic execution.
 
-Look at the API documentation for the `simulation manager
-<http://angr.io/api-doc/angr.html#module-angr.manager>`_ and `exploration
-techniques
-<http://angr.io/api-doc/angr.html#angr.exploration_techniques.ExplorationTechnique>`_
-for more information.
+Look at the API documentation for the
+:py:class:`~angr.sim_manager.SimulationManager` and
+:py:class:`~angr.exploration_techniques.ExplorationTechnique` classes for more
+information.
+

--- a/docs/core-concepts/states.rst
+++ b/docs/core-concepts/states.rst
@@ -48,12 +48,12 @@ Earlier, we showed how to use a Simulation Manager to do some basic execution.
 We'll show off the full capabilities of the simulation manager in the next
 chapter, but for now we can use a much simpler interface to demonstrate how
 symbolic execution works: ``state.step()``. This method will perform one step of
-symbolic execution and return an object called ```SimSuccessors``
-<http://angr.io/api-doc/angr.html#module-angr.engines.successors>`_. Unlike
-normal emulation, symbolic execution can produce several successor states that
-can be classified in a number of ways. For now, what we care about is the
-``.successors`` property of this object, which is a list containing all the
-"normal" successors of a given step.
+symbolic execution and return an object called
+:py:class:`angr.engines.successors.SimSuccessors`. Unlike normal emulation,
+symbolic execution can produce several successor states that can be classified
+in a number of ways. For now, what we care about is the ``.successors`` property
+of this object, which is a list containing all the "normal" successors of a
+given step.
 
 Why a list, instead of just a single successor state? Well, angr's process of
 symbolic execution is just the taking the operations of the individual
@@ -179,15 +179,13 @@ You can customize the state through several arguments to these constructors:
   this API can be a little unpredictable, but we're working on it.
 
 * To specify the calling convention used for a function with ``call_state``, you
-  can pass a ```SimCC`` instance
-  <http://angr.io/api-doc/angr.html#module-angr.calling_conventions>`_ as the
-  ``cc`` argument.:raw-html-m2r:`<br>` We try to pick a sane default, but for
-  special cases you will need to help angr out.
+  can pass a :py:class:`~angr.calling_conventions.SimCC` instance as the ``cc``
+  argument.:raw-html-m2r:`<br>` We try to pick a sane default, but for special
+  cases you will need to help angr out.
 
 There are several more options that can be used in any of these constructors!
-See the `docs
-<http://angr.io/api-doc/angr.html#angr.factory.AngrObjectFactory>`_ on the
-``project.factory`` object (an ``AngrObjectFactory``) for more details.
+See the docs on the ``project.factory`` object (an
+:py:class:`angr.factory.AngrObjectFactory`) for more details.
 
 Low level interface for memory
 ------------------------------

--- a/docs/core-concepts/toplevel.rst
+++ b/docs/core-concepts/toplevel.rst
@@ -300,10 +300,9 @@ angr comes pre-packaged with several built-in analyses that you can use to extra
     proj.analyses.CFGFast              proj.analyses.Reassembler
 
 A couple of these are documented later in this book, but in general, if you want
-to find how to use a given analysis, you should look in the `api documentation.
-<http://angr.io/api-doc/angr.html?highlight=cfg#module-angr.analysis>`_ As an
-extremely brief example: here's how you construct and use a quick control-flow
-graph:
+to find how to use a given analysis, you should look in the api documentation
+for :py:mod:`angr.analyses`. As an extremely brief example: here's how you
+construct and use a quick control-flow graph:
 
 .. code-block:: python
 

--- a/docs/extending-angr/environment.rst
+++ b/docs/extending-angr/environment.rst
@@ -62,10 +62,9 @@ The purpose of this categorization is to enable easy sharing of procedures among
 different libraries. For example. libc.so.6 contains all the C standard library
 functions, but so does msvcrt.dll! These relationships are represented with
 objects called ``SimLibraries`` which represent an actual shared library file,
-its functions, and their metadata. Take a look at `the API reference for
-SimLibrary
-<http://angr.io/api-doc/angr.html#angr.procedures.definitions.SimLibrary>`_ along
-with `the code for setting up glibc
+its functions, and their metadata. Take a look at the API reference for
+:py:class:`~angr.procedures.definitions.SimLibrary` along with `the code for
+setting up glibc
 <https://github.com/angr/angr/blob/master/angr/procedures/definitions/glibc.py>`_
 to learn how to use it.
 
@@ -110,8 +109,7 @@ Case 3, out-of-tree development, loose integration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Finally, if you don't want to mess with SimLibraries at all, you can do things
-purely on the project level with `hook_symbol
-<http://angr.io/api-doc/angr.html#angr.project.Project.hook_symbol>`_.
+purely on the project level with :py:meth:`~angr.project.Project.hook_symbol`.
 
 Syscalls
 --------
@@ -137,9 +135,8 @@ and adds them to the library, then adds several syscall number mappings,
 including separate mappings for ``mips-o32``, ``mips-n32``, and ``mips-n64``.
 
 In order for syscalls to be supported in the first place, the project's SimOS
-must inherit from `SimUserland
-<http://angr.io/api-doc/angr.html#angr.simos.userland.SimUserland>`_, itself a
-SimOS subclass. This requires the class to call SimUserland's constructor with a
+must inherit from :py:class:`~angr.simos.userland.SimUserland`, itself a SimOS
+subclass. This requires the class to call SimUserland's constructor with a
 super() call that includes the ``syscall_library`` keyword argument, specifying
 the specific SimSyscallLibrary that contains the appropriate procedures and
 mappings for the operating system. Additionally, the class's
@@ -247,8 +244,7 @@ A SimData can effectively specify some data that must be used to provide an
 unresolved import symbol. It has a number of mechanisms to make this more
 useful, including the ability to specify relocations and subdependencies.
 
-Look at the `SimData class reference
-<http://angr.io/api-doc/cle.html#cle.backends.externs.simdata.SimData>`_ and the
-`existing SimData subclasses
+Look at the SimData :py:class:`cle.backends.externs.simdata.SimData` class
+reference and the `existing SimData subclasses
 <https://github.com/angr/cle/tree/master/cle/backends/externs/simdata>`_ for
 guidelines on how to do this.

--- a/docs/extending-angr/state_plugins.rst
+++ b/docs/extending-angr/state_plugins.rst
@@ -15,9 +15,8 @@ My First Plugin
 ---------------
 
 Let's get started! All state plugins are implemented as subclasses of
-``angr.SimStatePlugin``. Once you've read this document, you can use the `API
-reference for this class
-<http://angr.io/api-doc/angr.html#angr.state_plugins.plugin.SimStatePlugin>`_ to
+``SimStatePlugin``. Once you've read this document, you can use the API
+reference for this class :py:class:`angr.state_plugins.plugin.SimStatePlugin` to
 quickly review the semantics of all the interfaces you should implement.
 
 The most important method you need to implement is ``copy``: it should be

--- a/docs/getting-started/helpwanted.rst
+++ b/docs/getting-started/helpwanted.rst
@@ -255,7 +255,7 @@ explosion is still *the* main problem preventing symbolic execution from being
 mainstream.
 
 angr provides an excellent base to implement new techniques to control path
-explosion. Most approaches can be easily implemented as `Exploration Techniques
-<http://angr.io/api-doc/angr.html#angr.exploration_techniques.ExplorationTechnique>`_
-and quickly evaluated (for example, on the `CGC dataset
+explosion. Most approaches can be easily implemented as
+:py:class:`~angr.exploration_techniques.ExplorationTechnique` s and quickly
+evaluated (for example, on the `CGC dataset
 <https://github.com/CyberGrandChallenge/samples>`_).


### PR DESCRIPTION
This PR fixes a handful of links that were using the old `http://angr.io/api-doc/` URL to reference API docs.