### PR TITLE
Fix: prevent SymbolicMergerMixin from producing an extra 0 in result expression

### DIFF
--- a/angr/storage/memory_mixins/symbolic_merger_mixin.py
+++ b/angr/storage/memory_mixins/symbolic_merger_mixin.py
@@ -5,7 +5,7 @@ from . import MemoryMixin
 
 class SymbolicMergerMixin(MemoryMixin):
     def _merge_values(self, values: Iterable[Tuple[Any, Any]], merged_size: int, **kwargs):
-        merged_val = self.state.solver.BVV(0, merged_size * self.state.arch.byte_width)
-        for tm, fv in values:
+        merged_val = values[0][0]
+        for tm, fv in values[1:]:
             merged_val = self.state.solver.If(fv, tm, merged_val)
         return merged_val


### PR DESCRIPTION
In the original implementation, `_merge_values` of class `SymbolicMergerMixin` would produce a nested `If` expression with an innermost element 0. This 0 is unnecessary. What's more, a conversion of this `If` to `ValueSet` (`expr._model_vsa`) would contain an unexpected 0. This behavior sometimes leads `VFG` analysis to be inaccurate and even unusable (in my own case, a sp reg value is inferred to be 0 as a result of the `reg_sp_expr._model_vsa` contains a zero).