### PR TITLE
LiveDefinitions: Add shorthands for various definitions.

### DIFF
--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -171,6 +171,22 @@ class LiveDefinitions:
 
         self.uses_by_codeloc: Dict[CodeLocation, Set[Definition]] = defaultdict(set)
 
+    @property
+    def registers(self) -> MultiValuedMemory:
+        return self.register_definitions
+
+    @property
+    def stack(self) -> MultiValuedMemory:
+        return self.stack_definitions
+
+    @property
+    def memory(self) -> MultiValuedMemory:
+        return self.memory_definitions
+
+    @property
+    def heap(self) -> MultiValuedMemory:
+        return self.heap_definitions
+
     def __repr__(self):
         ctnt = "LiveDefs"
         if self.tmps:


### PR DESCRIPTION
First step towards deprecating various `_definitions` properties in LiveDefinitions.