### PR TITLE
Add _pytest to list of test environment modules

### DIFF
--- a/angr/misc/testing.py
+++ b/angr/misc/testing.py
@@ -1,6 +1,6 @@
 import sys
 
-TESTER_MODULE_NAMES = ["unittest", "pytest", "nose", "nose2"]
+TESTER_MODULE_NAMES = ["unittest", "pytest", "_pytest", "nose", "nose2"]
 
 
 def detect_test_env():


### PR DESCRIPTION
When using pytest-xdist, `pytest` doesn't show up in the stack but `_pytest` does.