### PR TITLE
Handle partially symbolic and fully concrete input correctly in native interface

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -516,7 +516,16 @@ def _load_native():
             ctypes.POINTER(ctypes.c_uint64),
             ctypes.c_uint64,
         )
-        _setup_prototype(h, "set_fd_bytes", state_t, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint64)
+        _setup_prototype(
+            h,
+            "set_fd_bytes",
+            state_t,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_uint64
+        )
         _setup_prototype(
             h,
             "set_random_syscall_data",

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -524,7 +524,7 @@ def _load_native():
             ctypes.c_void_p,
             ctypes.c_void_p,
             ctypes.c_uint64,
-            ctypes.c_uint64
+            ctypes.c_uint64,
         )
         _setup_prototype(
             h,

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -516,7 +516,7 @@ def _load_native():
             ctypes.POINTER(ctypes.c_uint64),
             ctypes.c_uint64,
         )
-        _setup_prototype(h, "set_fd_bytes", state_t, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint64)
+        _setup_prototype(h, "set_fd_bytes", state_t, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint64)
         _setup_prototype(
             h,
             "set_random_syscall_data",
@@ -1277,9 +1277,11 @@ class Unicorn(SimStatePlugin):
         # Pass all concrete fd bytes to native interface so that it can handle relevant syscalls
         if fd_bytes is not None:
             for fd_num, fd_data in fd_bytes.items():
-                fd_bytes_p = int(ffi.cast("uint64_t", ffi.from_buffer(memoryview(fd_data))))
+                # fd_data is a tuple whose first element is fd data and second is taints for each fd byte
+                fd_bytes_p = int(ffi.cast("uint64_t", ffi.from_buffer(memoryview(fd_data[0]))))
+                fd_taint_p = int(ffi.cast("uint64_t", ffi.from_buffer(memoryview(fd_data[1]))))
                 read_pos = self.state.solver.eval(self.state.posix.fd.get(fd_num).read_pos)
-                _UC_NATIVE.set_fd_bytes(self._uc_state, fd_num, fd_bytes_p, len(fd_data), read_pos)
+                _UC_NATIVE.set_fd_bytes(self._uc_state, fd_num, fd_bytes_p, fd_taint_p, len(fd_data[0]), read_pos)
         else:
             l.info("Input fds concrete data not specified. Handling some syscalls in native interface could fail.")
 

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2617,7 +2617,7 @@ void State::perform_cgc_receive() {
 		for (; curr_offset < actual_count; curr_offset++) {
 			if (tmp_taint_buf[curr_offset] != curr_taint_status) {
 				// Taint status of next byte differs. Update all previous ones
-				handle_write(buf + start_offset + slice_size, slice_size, true, (curr_taint_status == TAINT_SYMBOLIC));
+				handle_write(buf + start_offset, slice_size, true, (curr_taint_status == TAINT_SYMBOLIC));
 				if (stopped) {
 					free(tmp_buf);
 					return;
@@ -2632,7 +2632,7 @@ void State::perform_cgc_receive() {
 		}
 		if (start_offset != curr_offset) {
 			// Taint status of some more bytes need to be updated
-			handle_write(buf + start_offset + slice_size, slice_size, true, (curr_taint_status == TAINT_SYMBOLIC));
+			handle_write(buf + start_offset, slice_size, true, (curr_taint_status == TAINT_SYMBOLIC));
 			if (stopped) {
 				free(tmp_buf);
 				return;

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2441,12 +2441,12 @@ address_t State::get_stack_pointer() const {
 	return out;
 }
 
-void State::fd_init_bytes(uint64_t fd, char *bytes, uint64_t len, uint64_t read_pos) {
-	fd_details.emplace(fd, fd_data(bytes, len, read_pos));
+void State::fd_init_bytes(uint64_t fd, char *bytes, taint_t *taints, uint64_t len, uint64_t read_pos) {
+	fd_details.emplace(fd, fd_data(bytes, taints, len, read_pos));
 	return;
 }
 
-uint64_t State::fd_read(uint64_t fd, char *buf, uint64_t count) {
+uint64_t State::fd_read(uint64_t fd, char *buf, taint_t *&taints, uint64_t count) {
 	auto &fd_det = fd_details.at(fd);
 	if (fd_det.curr_pos >= fd_det.len) {
 		// No more bytes to read
@@ -2455,6 +2455,7 @@ uint64_t State::fd_read(uint64_t fd, char *buf, uint64_t count) {
 	// Truncate count of bytes to read if request exceeds number left in the "stream"
 	auto actual_count = std::min(count, fd_det.len - fd_det.curr_pos);
 	memcpy(buf, fd_det.bytes + fd_det.curr_pos, actual_count);
+	taints = fd_det.taints + fd_det.curr_pos;
 	fd_det.curr_pos += actual_count;
 	return actual_count;
 }
@@ -2601,18 +2602,41 @@ void State::perform_cgc_receive() {
 
 	// Perform read
 	char *tmp_buf = (char *)malloc(count);
-	auto actual_count = fd_read(fd, tmp_buf, count);
+	taint_t *tmp_taint_buf;
+	auto actual_count = fd_read(fd, tmp_buf, tmp_taint_buf, count);
 	if (stopped) {
 		// Possibly stopped when writing bytes read to memory. Treat as syscall failure.
 		free(tmp_buf);
 		return;
 	}
 	if (actual_count > 0) {
-		// Mark buf as symbolic
-		handle_write(buf, actual_count, true, true);
-		if (stopped) {
-			free(tmp_buf);
-			return;
+		// Update taint status. The taint status update tries to minimize updates by updating status of contiguous chunk
+		// of bytes with same taint
+		taint_t curr_taint_status = tmp_taint_buf[0];
+		uint64_t start_offset = 0, curr_offset = 1, slice_size = 1;
+		for (; curr_offset < actual_count; curr_offset++) {
+			if (tmp_taint_buf[curr_offset] != curr_taint_status) {
+				// Taint status of next byte differs. Update all previous ones
+				handle_write(buf + start_offset + slice_size, slice_size, true, (curr_taint_status == TAINT_SYMBOLIC));
+				if (stopped) {
+					free(tmp_buf);
+					return;
+				}
+				start_offset = curr_offset;
+				curr_taint_status = tmp_taint_buf[curr_offset];
+				slice_size = 0;
+			}
+			else {
+				slice_size++;
+			}
+		}
+		if (start_offset != curr_offset) {
+			// Taint status of some more bytes need to be updated
+			handle_write(buf + start_offset + slice_size, slice_size, true, (curr_taint_status == TAINT_SYMBOLIC));
+			if (stopped) {
+				free(tmp_buf);
+				return;
+			}
 		}
 		uc_mem_write(uc, buf, tmp_buf, actual_count);
 	}
@@ -3038,8 +3062,8 @@ transmit_record_t *simunicorn_process_transmit(State *state, uint32_t num) {
  */
 
 extern "C"
-void simunicorn_set_fd_bytes(State *state, uint64_t fd, char *input, uint64_t len, uint64_t read_pos) {
-	state->fd_init_bytes(fd, input, len, read_pos);
+void simunicorn_set_fd_bytes(State *state, uint64_t fd, char *input, taint_t *taints, uint64_t len, uint64_t read_pos) {
+	state->fd_init_bytes(fd, input, taints, len, read_pos);
 	return;
 }
 

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -488,11 +488,13 @@ typedef std::unordered_set<vex_tmp_id_t> TempSet;
 
 struct fd_data {
 	char *bytes;
+	taint_t *taints;
 	uint64_t curr_pos;
 	uint64_t len;
 
-	fd_data(char *fd_bytes, uint64_t fd_len, uint64_t fd_read_pos) {
+	fd_data(char *fd_bytes, taint_t *fd_taints, uint64_t fd_len, uint64_t fd_read_pos) {
 		bytes = fd_bytes;
+		taints = fd_taints;
 		curr_pos = fd_read_pos;
 		len = fd_len;
 	}
@@ -897,9 +899,9 @@ class State {
 
 		address_t get_stack_pointer() const;
 
-		void fd_init_bytes(uint64_t fd, char *bytes, uint64_t len, uint64_t read_pos);
+		void fd_init_bytes(uint64_t fd, char *bytes, taint_t *taints, uint64_t len, uint64_t read_pos);
 
-		uint64_t fd_read(uint64_t fd, char *buf, uint64_t count);
+		uint64_t fd_read(uint64_t fd, char *buf, taint_t *&taints, uint64_t count);
 
 		// Set random syscall data for replaying
 		void init_random_bytes(uint64_t *values, uint64_t *sizes, uint64_t count);

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -354,6 +354,45 @@ def test_cgc_se1_palindrome_raw():
     assert simgr.crashed
 
 
+def test_concrete_execution_in_native_interface():
+    """
+    Test if concrete execution without any symbolic bytes is done correctly when receive syscall is handled in native
+    interface
+    """
+
+    binary = os.path.join(bin_location, "tests", "cgc", "KPRCA_00052")
+    pov_file = os.path.join(bin_location, "tests_data", "cgc_povs", "KPRCA_00052_POV_00000.xml")
+    output_initial_bytes = (
+        b"Enter system password: \nWelcome to the CGC Pizzeria order management system.\n1. Input Order\n"
+        b"2. Update Order\n3. View One Orders\n4. View All Orders\n5. Delete Order\n6. Clear All Orders\n7. Logout\n"
+        b"Choice: Enter Pickup Name: Choose what the kind of pizza\n1. Pizza Pie - The classic!\n"
+        b"2. Pizza Sub - All the fun, on a bun\n3. Pizza Bowl - Our own twist\nChoice: Select Size\n1. Small\n"
+        b"2. Medium\n3. Large\nChoice: Successfully added a new Pizza Pie!\nSelect an option:\n1. Add Toppings\n"
+        b"2. Remove Toppings\n3. Add Sauce\n4. Remove Sauce\n5. Finished With Pizza\nChoice: Successfully added pizza!"
+        b"\n1. Add another Pizza\n2. Quit\nChoice: 0. Cancel\n==================================================\n  "
+        b"Item #1. Classic Pizza Pie, Size: SMALL\n    Selected Toppings\n\tNone\n    Sauce on the side\n\tNone\n"
+        b"--------------------------------------\n\t\tCalories: 1000\n\t\tCarbs   : 222\n\nPizza length... = 1\n\t\t"
+        b"Estimated wait time: 36 minute(s)\n==================================================\nChoice: "
+        b"Removed Item #1\n1. Add another Pizza\n2. Quit\nChoice: Order successfully added!\n1. Input Order\n"
+        b"2. Update Order\n3. View One Orders\n4. View All Orders\n5. Delete Order\n6. Clear All Orders\n7. Logout\n"
+        b"Choice: 1 - pov: Ordered 0 pizza(s)\n==================================================\n"
+        b"--------------------------------------\n\t\tCalories: 0\n\t\tCarbs   : 0\n\n"
+    )
+    add_options = {
+        angr.options.UNICORN_HANDLE_CGC_RECEIVE_SYSCALL,
+        angr.options.UNICORN_HANDLE_SYMBOLIC_ADDRESSES,
+        angr.options.UNICORN_HANDLE_SYMBOLIC_CONDITIONS,
+    }
+    trace_cgc_with_pov_file(
+        binary,
+        "concrete_execution_in_native_interface",
+        pov_file,
+        output_initial_bytes,
+        add_options=add_options,
+        symbolic_stdin=False,
+    )
+
+
 def test_d_flag_and_write_write_conflict_in_unicorn():
     """
     Check if d flag is handled correctly in unicorn native interface and write-write conflicts do not occur when

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -48,9 +48,9 @@ def tracer_cgc(
     )
     if add_options is not None and angr.options.UNICORN_HANDLE_CGC_RECEIVE_SYSCALL in add_options:
         if symbolic_stdin:
-            fd_data = {0: (stdin, b'\x01' * len(stdin))}
+            fd_data = {0: (stdin, b"\x01" * len(stdin))}
         else:
-            fd_data = {0: (stdin, b'\x00' * len(stdin))}
+            fd_data = {0: (stdin, b"\x00" * len(stdin))}
 
         t.set_fd_data(fd_data)
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -18,6 +18,7 @@ def tracer_cgc(
     add_options=None,
     remove_options=None,
     syscall_data=None,
+    symbolic_stdin=True,
 ):
     p = angr.Project(filename)
     p.simos.syscall_library.update(angr.SIM_LIBRARIES["cgcabi_tracer"])
@@ -46,7 +47,12 @@ def tracer_cgc(
         syscall_data=syscall_data,
     )
     if add_options is not None and angr.options.UNICORN_HANDLE_CGC_RECEIVE_SYSCALL in add_options:
-        t.set_fd_data({0: stdin})
+        if symbolic_stdin:
+            fd_data = {0: (stdin, b'\x01' * len(stdin))}
+        else:
+            fd_data = {0: (stdin, b'\x00' * len(stdin))}
+
+        t.set_fd_data(fd_data)
 
     simgr.use_technique(t)
     simgr.use_technique(angr.exploration_techniques.Oppologist())
@@ -65,6 +71,7 @@ def trace_cgc_with_pov_file(
     add_options=None,
     remove_options=None,
     syscall_data=None,
+    symbolic_stdin=True,
 ):
     assert os.path.isfile(pov_file)
     pov = load_cgc_pov(pov_file)
@@ -78,6 +85,7 @@ def trace_cgc_with_pov_file(
         add_options=add_options,
         remove_options=remove_options,
         syscall_data=syscall_data,
+        symbolic_stdin=symbolic_stdin,
     )
     simgr = trace_result[0]
     simgr.run()


### PR DESCRIPTION
Currently, the CGC receive implementation in the native interface assumes that input is fully symbolic, which results in taint being propagated incorrectly if the input is partially symbolic or fully concrete. This PR fixes this issue by passing the taint status of each input byte along with value of each input byte to the native interface so that taint can be selectively propagated as needed.