### PR TITLE
Disable CI for non-master branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-    - "**"
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -2,8 +2,8 @@ name: Install Smoketest
 
 on:
   push:
-    paths:
-      - "**"
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
With this change, in order to run CI, users will want to make a pull request. Because most of our development branches happen under this repo rather than personal forks, this will cut our CI usage roughly in half, and make it easier to understand since there will only be one run of the CI pipeline.

This change is motivated in part to reduce runner usage by the main pipeline to allow for windows and macos CI in the near future.