### PR TITLE
add filler callingconv registers

### DIFF
--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -751,14 +751,17 @@ class CallingConventionAnalysis(Analysis):
                 else:
                     int_args.append(arg)
 
+        stack_args = sorted([a for a in args if isinstance(a, SimStackArg)], key=lambda a: a.stack_offset)
+        stack_int_args = [a for a in stack_args if not a.is_fp]
+        stack_fp_args = [a for a in stack_args if a.is_fp]
         # match int args first
         for reg_name in cc.ARG_REGS:
             try:
                 arg = next(iter(a for a in int_args if isinstance(a, SimRegArg) and a.reg_name == reg_name))
             except StopIteration:
                 # have we reached the end of the args list?
-                if [a for a in int_args if isinstance(a, SimRegArg)]:
-                    # nope
+                if [a for a in int_args if isinstance(a, SimRegArg)] or len(stack_int_args) > 0:
+                    # haven't reached the end yet or there are stack args
                     arg = SimRegArg(reg_name, self.project.arch.bytes)
                 else:
                     break
@@ -773,8 +776,8 @@ class CallingConventionAnalysis(Analysis):
                     arg = next(iter(a for a in fp_args if isinstance(a, SimRegArg) and a.reg_name == reg_name))
                 except StopIteration:
                     # have we reached the end of the args list?
-                    if [a for a in fp_args if isinstance(a, SimRegArg)]:
-                        # nope
+                    if [a for a in fp_args if isinstance(a, SimRegArg)] or len(stack_fp_args) > 0:
+                        # haven't reached the end yet or there are stack args
                         arg = SimRegArg(reg_name, self.project.arch.bytes)
                     else:
                         break
@@ -782,7 +785,6 @@ class CallingConventionAnalysis(Analysis):
                 if arg in fp_args:
                     fp_args.remove(arg)
 
-        stack_args = sorted([a for a in args if isinstance(a, SimStackArg)], key=lambda a: a.stack_offset)
         return reg_args + int_args + fp_args + stack_args
 
     def _guess_arg_type(self, arg: SimFunctionArgument, cc: Optional[SimCC] = None) -> SimType:


### PR DESCRIPTION
```c
#include <stdio.h>

struct large_struct {
  unsigned long long data[8];
};

void print_struct(char * str /*rdi*/, struct large_struct s /*stack*/) {
  printf("%s %llu %llu %llu %llu %llu %llu %llu %llu\n", str, s.data[0], s.data[1], s.data[2], s.data[3], s.data[4], s.data[5], s.data[6], s.data[7]);
}

int main() {
  struct large_struct s;
  for (int i = 0; i < 8; i++) {
    s.data[i] = i + 1;
  }
  print_struct("hi", s);
  return 0;
}

```
Large struct argument is passed on the stack according to the calling convention. In the above example, the call to `print_struct` places `"hi"` in rdi, and `s` on the stack. angr correctly interprets this [here](https://github.com/angr/angr/blob/74565f4f022425018f887b20a4dae82e3b19e397/angr/analyses/calling_convention.py#L324) as `args` being `[<rdi>, [0x8], [0x10], [0x18], [0x20], [0x28], [0x30], [0x38], [0x40], [0x48]]`. However, this `args` variable gets discarded after `_analyze_function` returns, and a prototype is returned instead, which is essentially `(long long, long long, long long, long long, long long...) -> long long`. Subsequently in [here](https://github.com/angr/angr/blob/74565f4f022425018f887b20a4dae82e3b19e397/angr/analyses/decompiler/callsite_maker.py#L96), angr uses this prototype to reconstruct argument locations, resulting in `[<rdi>, <rsi>, <rdx>, <rcx>, <r8>, <r9>, [0x8], [0x10], [0x18], [0x20]]` which leads to a flawed decompilation.
```c
print_struct("hi", a1, v9 + 4, a3, a4, a5, v0, v1, v2, v3);
```

After implementing the fix in this PR, which essentially adds filler register arguments whenever a stack argument is present, the decompiled code becomes:
```c
print_struct("hi", a1, v9 + 4, a3, a4, a5, v0, v1, v2, v3, v4, v5, v6, v7, v8);
```

For both results above, arguments 2-6 are merely filler registers. However, prior to this fix, arguments v4-v8 ([0x28]-[0x48]) were missing due to above reason.

I'm uncertain if this is the correct location or method to address the issue.

The source code and binary are attached here:
[largestruct-arg.zip](https://github.com/angr/angr/files/11708113/largestruct-arg.zip)
