### PR TITLE
pcode: Limit lift buffer size

### DIFF
--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -841,7 +841,7 @@ class PcodeBasicBlockLifter:
 
         # Translate
         addr = baseaddr + bytes_offset
-        result = self.context.translate(data[bytes_offset:bytes_offset+max_bytes], addr, max_inst, max_bytes, True)
+        result = self.context.translate(data[bytes_offset : bytes_offset + max_bytes], addr, max_inst, max_bytes, True)
         irsb._instructions = result.instructions
 
         # Post-process block to mark exits and next block
@@ -1251,7 +1251,7 @@ class PcodeLifterEngineMixin(SimEngineBase):
                         if isinstance(backer, (bytes, bytearray)):
                             avail = len(backer) - offset
                             size = min(avail, max_size)
-                            buff = backer[offset:offset+size]
+                            buff = backer[offset : offset + size]
                         elif isinstance(backer, list):
                             raise SimTranslationError(
                                 "Cannot lift block for arch with strange byte width. If you think you ought to be able "

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -841,7 +841,7 @@ class PcodeBasicBlockLifter:
 
         # Translate
         addr = baseaddr + bytes_offset
-        result = self.context.translate(data[bytes_offset:], addr, max_inst, max_bytes, True)
+        result = self.context.translate(data[bytes_offset:bytes_offset+max_bytes], addr, max_inst, max_bytes, True)
         irsb._instructions = result.instructions
 
         # Post-process block to mark exits and next block
@@ -1249,8 +1249,9 @@ class PcodeLifterEngineMixin(SimEngineBase):
                     if start <= addr:
                         offset = addr - start
                         if isinstance(backer, (bytes, bytearray)):
-                            buff = backer[offset:]
-                            size = len(backer) - offset
+                            avail = len(backer) - offset
+                            size = min(avail, max_size)
+                            buff = backer[offset:offset+size]
                         elif isinstance(backer, list):
                             raise SimTranslationError(
                                 "Cannot lift block for arch with strange byte width. If you think you ought to be able "


### PR DESCRIPTION
I have a larger pcode update coming with more performance improvements, but this simple patch improves CFGFast with pcode engine performance on a 16M binary by about 38% and is comparable to vex engine (albeit a bit slower, for now...)