### PR TITLE
RDA: Reset uses dicts during state downsizing.

### DIFF
--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -585,6 +585,7 @@ class ReachingDefinitionsState:
 
     def downsize(self):
         self.all_definitions = set()
+        self.live_definitions.reset_uses()
 
     def pointer_to_atoms(self, pointer: MultiValues, size: int, endness: str) -> Set[MemoryLocation]:
         """

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -423,9 +423,11 @@ class ReachingDefinitionsAnalysis(
 
         # update all definitions and all uses
         self.all_definitions |= state.all_definitions
-        state.downsize()
         for use in [state.stack_uses, state.heap_uses, state.register_uses, state.memory_uses]:
             self.all_uses.merge(use)
+
+        # drop definitions and uses because we will not need them anymore
+        state.downsize()
 
         if self._node_iterations[block_key] < self._max_iterations:
             return True, state

--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -215,6 +215,12 @@ class LiveDefinitions:
 
         return rd
 
+    def reset_uses(self):
+        self.stack_uses = Uses()
+        self.register_uses = Uses()
+        self.memory_uses = Uses()
+        self.heap_uses = Uses()
+
     def _get_weakref(self):
         return weakref.proxy(self)
 


### PR DESCRIPTION
This PR makes decompilation faster.