### PR TITLE
Finish the simple return feature by handling nested Sequence and Multi nodes

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/flip_boolean_cmp.py
+++ b/angr/analyses/decompiler/optimization_passes/flip_boolean_cmp.py
@@ -4,7 +4,7 @@ import ailment
 from ailment.expression import Op
 
 from ..structuring.structurer_nodes import ConditionNode
-from ..utils import is_simple_return_node
+from ..utils import structured_node_is_simple_return
 from .optimization_pass import SequenceOptimizationPass, OptimizationPassStage
 
 
@@ -33,6 +33,6 @@ class FlipBooleanCmp(SequenceOptimizationPass):
     def _analyze(self, cache=None):
         condition_nodes: List[ConditionNode] = cache or []
         for node in condition_nodes:
-            if isinstance(node.condition, Op) and is_simple_return_node(node.false_node, self._graph):
+            if isinstance(node.condition, Op) and structured_node_is_simple_return(node.false_node, self._graph):
                 node.condition = ailment.expression.negate(node.condition)
                 node.true_node, node.false_node = node.false_node, node.true_node

--- a/angr/analyses/decompiler/optimization_passes/flip_boolean_cmp.py
+++ b/angr/analyses/decompiler/optimization_passes/flip_boolean_cmp.py
@@ -4,7 +4,7 @@ import ailment
 from ailment.expression import Op
 
 from ..structuring.structurer_nodes import ConditionNode
-from ..structured_codegen.c import is_simple_return_node
+from ..utils import is_simple_return_node
 from .optimization_pass import SequenceOptimizationPass, OptimizationPassStage
 
 

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -173,6 +173,7 @@ def guess_value_type(value: int, project: "angr.Project") -> Optional[SimType]:
             return SimTypePointer(SimTypeBottom(label="void")).with_arch(project.arch)
     return None
 
+
 #
 #   C Representation Classes
 #

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -30,6 +30,7 @@ from ....sim_variable import SimVariable, SimTemporaryVariable, SimStackVariable
 from ....utils.constants import is_alignment_mask
 from ....utils.library import get_cpp_function_name
 from ....utils.loader import is_in_readonly_segment, is_in_readonly_section
+from ..utils import is_simple_return_node
 from ....errors import UnsupportedNodeTypeError
 from ....knowledge_plugins.cfg.memory_data import MemoryData, MemoryDataSort
 from ... import Analysis, register_analysis
@@ -171,36 +172,6 @@ def guess_value_type(value: int, project: "angr.Project") -> Optional[SimType]:
         if seg is not None and seg.is_readable:
             return SimTypePointer(SimTypeBottom(label="void")).with_arch(project.arch)
     return None
-
-
-def is_simple_return_node(node: Union[Block, SequenceNode], graph) -> bool:
-    """
-    Will check if a "simple return" is contained within the node a simple returns looks like this:
-    if (cond) {
-      // simple return
-      ...
-      return 0;
-    }
-    ...
-
-    Any block can end in a return as long as it does not have condition inside.
-    """
-    # sanity check: we need a graph to understand returning blocks
-    if graph is None:
-        return False
-
-    last_block = None
-    if isinstance(node, SequenceNode) and node.nodes:
-        for n in node.nodes:
-            if not isinstance(n, Block):
-                break
-        else:
-            last_block = n
-    elif isinstance(node, Block):
-        last_block = node
-
-    return last_block and last_block in graph and not list(graph.successors(last_block))
-
 
 #
 #   C Representation Classes

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -30,7 +30,7 @@ from ....sim_variable import SimVariable, SimTemporaryVariable, SimStackVariable
 from ....utils.constants import is_alignment_mask
 from ....utils.library import get_cpp_function_name
 from ....utils.loader import is_in_readonly_segment, is_in_readonly_section
-from ..utils import is_simple_return_node
+from ..utils import structured_node_is_simple_return
 from ....errors import UnsupportedNodeTypeError
 from ....knowledge_plugins.cfg.memory_data import MemoryData, MemoryDataSort
 from ... import Analysis, register_analysis
@@ -2786,7 +2786,7 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
             condition_and_nodes,
             else_node=else_node,
             simplify_else_scope=self.simplify_else_scope
-            and is_simple_return_node(condition_node.true_node, self.ail_graph),
+                                and structured_node_is_simple_return(condition_node.true_node, self.ail_graph),
             tags=tags,
             codegen=self,
         )

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -2786,7 +2786,7 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
             condition_and_nodes,
             else_node=else_node,
             simplify_else_scope=self.simplify_else_scope
-                                and structured_node_is_simple_return(condition_node.true_node, self.ail_graph),
+            and structured_node_is_simple_return(condition_node.true_node, self.ail_graph),
             tags=tags,
             codegen=self,
         )

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -389,7 +389,6 @@ def is_simple_return_node(node: Union["SequenceNode", "MultiNode"], graph: netwo
 
         return blocks
 
-
     # sanity check: we need a graph to understand returning blocks
     if graph is None:
         return False

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -359,10 +359,7 @@ def remove_labels(graph: networkx.DiGraph):
 
 
 def is_simple_return_node(node: Union["SequenceNode", "MultiNode"], graph: networkx.DiGraph) -> bool:
-    def flatten_packed_node(
-        packed_node: Union["SequenceNode", "MultiNode"]
-    ) -> List[ailment.Block]:
-
+    def flatten_packed_node(packed_node: Union["SequenceNode", "MultiNode"]) -> List[ailment.Block]:
         if not packed_node or not packed_node.nodes:
             return []
 

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -359,7 +359,23 @@ def remove_labels(graph: networkx.DiGraph):
 
 
 def is_simple_return_node(node: Union["SequenceNode", "MultiNode"], graph: networkx.DiGraph) -> bool:
+    """
+    Will check if a "simple return" is contained within the node a simple returns looks like this:
+    if (cond) {
+      // simple return
+      ...
+      return 0;
+    }
+    ...
+
+    Any block can end in a return as long as it does not have condition inside.
+    """
+
     def flatten_packed_node(packed_node: Union["SequenceNode", "MultiNode"]) -> List[ailment.Block]:
+        """
+        Unpacks nested SequenceNode and MultiNodes so we can handle nested instances of blocks
+        when determining whether a node is a simple return.
+        """
         if not packed_node or not packed_node.nodes:
             return []
 
@@ -373,17 +389,7 @@ def is_simple_return_node(node: Union["SequenceNode", "MultiNode"], graph: netwo
 
         return blocks
 
-    """
-    Will check if a "simple return" is contained within the node a simple returns looks like this:
-    if (cond) {
-      // simple return
-      ...
-      return 0;
-    }
-    ...
 
-    Any block can end in a return as long as it does not have condition inside.
-    """
     # sanity check: we need a graph to understand returning blocks
     if graph is None:
         return False


### PR DESCRIPTION
move is_simple_return_node from c.py into analyses/decompiler/utils.py.
unpack SequenceNode and MultiNode to check if all elements are Blocks, instead of what we were doing previously which was to ignore nested SequenceNode and MultiNodes.