### PR TITLE
If num_find is zero attempt to explore all possible states

### DIFF
--- a/angr/exploration_techniques/explorer.py
+++ b/angr/exploration_techniques/explorer.py
@@ -12,7 +12,7 @@ l = logging.getLogger(name=__name__)
 class Explorer(ExplorationTechnique):
     """
     Search for up to "num_find" paths that satisfy condition "find", avoiding condition "avoid". Stashes found paths
-    into "find_stash' and avoided paths into "avoid_stash".
+    into "find_stash' and avoided paths into "avoid_stash". If "num_find" is zero, all possible paths will be explored.
 
     The "find" and "avoid" parameters may be any of:
 
@@ -143,4 +143,7 @@ class Explorer(ExplorationTechnique):
         return None
 
     def complete(self, simgr):
-        return len(simgr.stashes[self.find_stash]) >= self.num_find
+        if self.num_find == 0:
+            return False
+        else:
+            return len(simgr.stashes[self.find_stash]) >= self.num_find


### PR DESCRIPTION
I wanted to explore all possible paths (i.e. run `explore()` until the active stash is empty). The only(?) way to do that right now seems to be to set `num_find` in the `explore()` invocation to a very high number, for example:

```python
simgr.explore(num_find=999999999, find=…)
```

However, this does seem a bit hacky. Therefore, I propose adding a special value for `num_find` which causes all paths to be explored. This is implemented in this PR via `num_find=0`.