### PR TITLE
Enable incremental CFG recovery and updating

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2234,8 +2234,7 @@ class CFGBase(Analysis):
                     callback(g, src, dst, data, blockaddr_to_function, known_functions, all_out_edges)
 
                     jumpkind = data.get("jumpkind", "")
-                    if not (jumpkind == "Ijk_Call" or jumpkind.startswith("Ijk_Sys")):
-                        # Only follow non call edges
+                    if not (jumpkind in ("Ijk_Call", "Ijk_Ret") or jumpkind.startswith("Ijk_Sys")):
                         if dst not in stack and dst not in traversed:
                             stack.add(dst)
 

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -227,8 +227,12 @@ class CFGBase(Analysis):
             if end < start:
                 raise AngrCFGError("Invalid region bounds (end precedes start)")
 
+        # Block factory returns patched state by default, so ensure we are also analyzing the patched state
+        if self._base_state is None and self.project.kb.patches.values():
+            self._base_state = self.project.kb.patches.patched_entry_state
+
         if exclude_sparse_regions:
-            regions = [r for r in regions if not self._is_region_extremely_sparse(*r, base_state=base_state)]
+            regions = [r for r in regions if not self._is_region_extremely_sparse(*r, base_state=self._base_state)]
 
         if skip_specific_regions:
             if base_state is not None:

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -730,7 +730,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int], CFGBase):  # pylin
             )
             cross_references = extra_cross_references
 
-        # data references collection and force smart scan mst be enabled at the same time. otherwise decoding errors
+        # data references collection and force smart scan must be enabled at the same time. otherwise decoding errors
         # caused by decoding data will lead to incorrect cascading re-lifting, which is suboptimal
         if force_smart_scan and not data_references:
             l.warning(
@@ -2854,7 +2854,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int], CFGBase):  # pylin
         :return:    None
         """
 
-        # add a node from this node to UnresolvableJumpTarget or UnresolvalbeCallTarget node,
+        # add a node from this node to UnresolvableJumpTarget or UnresolvableCallTarget node,
         # depending on its jump kind
         src_node = self._nodes[jump.addr]
         if jump.jumpkind == "Ijk_Boring":

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -809,7 +809,6 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int], CFGBase):  # pylin
         self._read_addr_to_run = defaultdict(list)
         self._write_addr_to_run = defaultdict(list)
 
-        self._function_prologue_addrs = None
         self._remaining_function_prologue_addrs = None
 
         # exception handling
@@ -1228,12 +1227,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int], CFGBase):  # pylin
         self._updated_nonreturning_functions = set()
 
         if self._use_function_prologues and self.project.concrete_target is None:
-            self._function_prologue_addrs = sorted(self._func_addrs_from_prologues())
-            # make a copy of those prologue addresses, so that we can pop from the list
-            self._remaining_function_prologue_addrs = self._function_prologue_addrs[::]
-
-            # make function_prologue_addrs a set for faster lookups
-            self._function_prologue_addrs = set(self._function_prologue_addrs)
+            self._remaining_function_prologue_addrs = sorted(self._func_addrs_from_prologues())
 
         # assumption management
         self._decoding_assumptions: Dict[int, DecodingAssumption] = {}

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -987,7 +987,7 @@ class Disassembly(Analysis):
         elif ranges is not None:
             cfg = self.project.kb.cfgs.get_most_accurate()
             fallback = True
-            if cfg is not None:
+            if self._block_bytes is None and cfg is not None:
                 try:
                     self._graph = cfg.graph
                     for start, end in ranges:

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -1111,7 +1111,7 @@ class Disassembly(Analysis):
                 aligned_block_addr = block.addr
                 cs = self.project.arch.capstone
             if block.bytestr is None:
-                bytestr = self.project.loader.memory.load(aligned_block_addr, block.size)
+                bytestr = self.project.factory.block(aligned_block_addr, block.size).bytes
             else:
                 bytestr = block.bytestr
             self.block_to_insn_addrs[block.addr] = []

--- a/angr/analyses/variable_recovery/variable_recovery_base.py
+++ b/angr/analyses/variable_recovery/variable_recovery_base.py
@@ -90,9 +90,6 @@ class VariableRecoveryBase(Analysis):
         self._instates: Dict[Any, VariableRecoveryStateBase] = {}
         self._dominance_frontiers = None
 
-        if func.addr in self.variable_manager:
-            del self.variable_manager[func.addr]
-
     #
     # Public methods
     #

--- a/angr/analyses/variable_recovery/variable_recovery_base.py
+++ b/angr/analyses/variable_recovery/variable_recovery_base.py
@@ -90,6 +90,9 @@ class VariableRecoveryBase(Analysis):
         self._instates: Dict[Any, VariableRecoveryStateBase] = {}
         self._dominance_frontiers = None
 
+        if func.addr in self.variable_manager:
+            del self.variable_manager[func.addr]
+
     #
     # Public methods
     #

--- a/angr/block.py
+++ b/angr/block.py
@@ -174,6 +174,9 @@ class Block(Serializable):
         if self.arch is None:
             raise ValueError('Either "project" or "arch" has to be specified.')
 
+        if project is not None and backup_state is None and project.kb.patches.values():
+            backup_state = project.kb.patches.patched_entry_state
+
         if isinstance(self.arch, ArchARM):
             if addr & 1 == 1:
                 thumb = True

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -1092,10 +1092,8 @@ class PcodeLifterEngineMixin(SimEngineBase):
         if skip_stmts is not True:
             skip_stmts = False
 
-        use_cache = self._use_cache
-        if skip_stmts or collect_data_refs:
-            # Do not cache the blocks if skip_stmts or collect_data_refs are enabled
-            use_cache = False
+        have_patches = self.project and self.project.kb.patches.items()
+        use_cache = self._use_cache and not (skip_stmts or collect_data_refs or have_patches or state)
 
         # phase 2: thumb normalization
         thumb = int(thumb)
@@ -1229,17 +1227,21 @@ class PcodeLifterEngineMixin(SimEngineBase):
 
         buff, size, offset = b"", 0, 0
 
-        # Load from the clemory if we can
-        smc = self.selfmodifying_code
+        # XXX: Prioritize loading from patched state, if we have patches
+        have_patches = self.project and self.project.kb.patches.items()
+        if state is None and have_patches:
+            state = self.project.kb.patches.patched_entry_state
+
+        load_from_state = self.selfmodifying_code or have_patches
 
         # skip loading from the clemory if we're using the ultra page
         # TODO: is this a good change? it neuters lookback optimizations
         # we can try concrete loading the full page but that has drawbacks too...
         # if state is not None and issubclass(getattr(state.memory, 'PAGE_TYPE', object), UltraPage):
-        #    smc = True
+        #    load_from_state = True
 
-        # when smc is not enabled or when state is not provided, we *always* attempt to load concrete data first
-        if not smc or not state:
+        # Load from the clemory if we can
+        if not load_from_state or not state:
             if isinstance(clemory, cle.Clemory):
                 try:
                     start, backer = next(clemory.backers(addr))
@@ -1266,14 +1268,14 @@ class PcodeLifterEngineMixin(SimEngineBase):
                     buff = state.solver.eval(state.memory.load(addr, max_size, inspect=False), cast_to=bytes)
                 size = len(buff)
 
-        # If that didn't work and if smc is enabled, try to load from the state
-        if smc and state and size == 0:
+        # If that didn't work and if load_from_state is enabled, try to load from the state
+        if load_from_state and state and size == 0:
             if state.memory.SUPPORTS_CONCRETE_LOAD:
                 buff = state.memory.concrete_load(addr, max_size)
             else:
                 buff = state.solver.eval(state.memory.load(addr, max_size, inspect=False), cast_to=bytes)
             size = len(buff)
-            if size < min(max_size, 10):  # arbitrary metric for doing the slow path
+            if self.selfmodifying_code and size < min(max_size, 10):  # arbitrary metric for doing the slow path
                 l.debug("SMC slow path")
                 buff_lst = []
                 symbolic_warned = False

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -396,14 +396,34 @@ class IRSB:
         """
         A set of the static jump targets of the basic block.
         """
-        raise NotImplementedError()
+        exits = set()
+
+        if self.exit_statements:
+            for _, _, stmt in self.exit_statements:
+                if stmt.dst is not None:
+                    exits.add(stmt.dst)
+
+        if self.next is not None:
+            exits.add(self.next)
+
+        return exits
 
     @property
     def constant_jump_targets_and_jumpkinds(self):
         """
         A dict of the static jump targets of the basic block to their jumpkind.
         """
-        raise NotImplementedError()
+        exits = {}
+
+        if self.exit_statements:
+            for _, _, stmt in self.exit_statements:
+                if stmt.dst is not None:
+                    exits[stmt.dst] = stmt.jumpkind
+
+        if self.next is not None:
+            exits[self.next] = self.jumpkind
+
+        return exits
 
     #
     # private methods

--- a/angr/engines/vex/lifter.py
+++ b/angr/engines/vex/lifter.py
@@ -342,7 +342,7 @@ class VEXLifter(SimEngineBase):
             else:
                 buff = state.solver.eval(state.memory.load(addr, max_size, inspect=False), cast_to=bytes)
             size = len(buff)
-            if size < min(max_size, 10):  # arbitrary metric for doing the slow path
+            if self.selfmodifying_code and size < min(max_size, 10):  # arbitrary metric for doing the slow path
                 l.debug("SMC slow path")
                 buff_lst = []
                 symbolic_warned = False

--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -1,7 +1,7 @@
 # pylint:disable=no-member
 import pickle
 import logging
-from typing import Optional, List, Dict, Tuple, DefaultDict, Callable, TYPE_CHECKING
+from typing import Optional, List, Dict, Tuple, DefaultDict, Callable, TYPE_CHECKING, Set
 from collections import defaultdict
 import bisect
 import string
@@ -21,7 +21,9 @@ from .memory_data import MemoryData, MemoryDataSort
 from .indirect_jump import IndirectJump
 
 if TYPE_CHECKING:
+    from angr.knowledge_base.knowledge_base import KnowledgeBase
     from angr.knowledge_plugins.xrefs import XRefManager, XRef
+    from angr.knowledge_plugins.functions import Function
     from angr.analyses.cfg.segment_list import SegmentList
 
 
@@ -48,6 +50,7 @@ class CFGModel(Serializable):
         "_node_addrs",
         "is_arm",
         "normalized",
+        "edges_to_repair",
     )
 
     def __init__(self, ident, cfg_manager=None, is_arm=False):
@@ -78,6 +81,8 @@ class CFGModel(Serializable):
         self._node_addrs: List[int] = []
 
         self.normalized = False
+
+        self.edges_to_repair = []
 
     #
     # Properties
@@ -211,6 +216,7 @@ class CFGModel(Serializable):
         model.insn_addr_to_memory_data = self.insn_addr_to_memory_data.copy()
         model._nodes_by_addr = self._nodes_by_addr.copy()
         model._nodes = self._nodes.copy()
+        model.edges_to_repair = self.edges_to_repair.copy()
 
         return model
 
@@ -345,6 +351,16 @@ class CFGModel(Serializable):
                     results.append(cfg_node)
 
         return results
+
+    def get_all_nodes_intersecting_region(self, addr: int, size: int = 1) -> Set[CFGNode]:
+        """
+        Get all CFGNodes that intersect the given region.
+
+        :param addr: Minimum address of target region.
+        :param size: Size of region, in bytes.
+        """
+        end_addr = addr + size
+        return {n for n in self.nodes() if not (addr >= (n.addr + n.size) or n.addr >= end_addr)}
 
     def nodes(self):
         """
@@ -926,3 +942,106 @@ class CFGModel(Serializable):
             if start <= addr < end:
                 return True
         return False
+
+    def remove_node_and_graph_node(self, node: CFGNode) -> None:
+        """
+        Like `remove_node`, but also removes node from the graph.
+
+        :param node: The node to remove.
+        """
+        self.graph.remove_node(node)
+        self.remove_node(node.addr, node)  # FIXME: block_id param
+
+    def get_intersecting_functions(
+        self,
+        addr: int,
+        size: int = 1,
+        kb: Optional["KnowledgeBase"] = None,
+    ) -> Set["Function"]:
+        """
+        Find all functions with nodes intersecting [addr, addr + size).
+
+        :param addr: Minimum address of target region.
+        :param size: Size of region, in bytes.
+        :param kb:   Knowledge base to search for functions in.
+        """
+        if kb is None:
+            if self.project is None:
+                raise AngrCFGError("Please provide knowledge base")
+            kb = self.project.kb
+
+        functions = set()
+        for func_addr in {n.function_address for n in self.get_all_nodes_intersecting_region(addr, size)}:
+            try:
+                func = kb.functions.get_by_addr(func_addr)
+            except KeyError:
+                l.error("Function %#x not found in KB", func_addr)
+                continue
+            functions.add(func)
+        return functions
+
+    def find_function_for_reflow_into_addr(
+        self, addr: int, kb: Optional["KnowledgeBase"] = None
+    ) -> Optional["Function"]:
+        """
+        Look for a function that flows into a new node at addr.
+
+        :param addr: Address of new block.
+        :param kb:   Knowledge base to search for functions in.
+        """
+        if kb is None:
+            if self.project is None:
+                raise AngrCFGError("Please provide knowledge base")
+            kb = self.project.kb
+
+        # FIXME: Track nodecodes as nodes in CFG and use graph to resolve instead of analyzing IRSBs here
+
+        func = kb.functions.floor_func(addr)
+        if func is None:
+            return None
+
+        for block in func.blocks:
+            irsb = block.vex
+            if (
+                irsb.jumpkind == "Ijk_Call" and irsb.addr + irsb.size == addr
+            ) or addr in irsb.constant_jump_targets_and_jumpkinds:
+                return func
+
+        return None
+
+    def clear_region_for_reflow(self, addr: int, size: int = 1, kb: Optional["KnowledgeBase"] = None) -> None:
+        """
+        Remove nodes in the graph intersecting region [addr, addr + size).
+
+        Any functions that intersect the range, and their associated nodes in the CFG, will also be removed from the
+        knowledge base for analysis.
+
+        :param addr: Minimum address of target region.
+        :param size: Size of the region, in bytes.
+        :param kb:   Knowledge base to search for functions in.
+        """
+        if kb is None and self.project is not None:
+            kb = self.project.kb
+
+        to_remove = {a for a in self.insn_addr_to_memory_data if addr <= a < (addr + size)}
+        for a in to_remove:
+            del self.insn_addr_to_memory_data[a]
+
+        if kb:
+            for func in self.get_intersecting_functions(addr, size, kb):
+                # Save incoming edges to the function for repairs on future edits
+                self.edges_to_repair.extend(list(self.graph.in_edges(self.get_all_nodes(func.addr), data=True)))
+
+                for block in func.blocks:
+                    for ins_addr in block.instruction_addrs:
+                        self.insn_addr_to_memory_data.pop(ins_addr, None)
+
+                    for node in self.get_all_nodes(block.addr):
+                        self.remove_node_and_graph_node(node)
+
+                del kb.functions[func.addr]
+
+        # FIXME: Gather any additional edges to nodes that are not part of a function
+
+        for node in self.get_all_nodes_intersecting_region(addr, size):
+            self.remove_node_and_graph_node(node)

--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -937,7 +937,8 @@ class CFGModel(Serializable):
     # Util methods
     #
 
-    def _addr_in_exec_memory_regions(self, addr: int, exec_mem_regions: List[Tuple[int, int]]) -> bool:
+    @staticmethod
+    def _addr_in_exec_memory_regions(addr: int, exec_mem_regions: List[Tuple[int, int]]) -> bool:
         for start, end in exec_mem_regions:
             if start <= addr < end:
                 return True

--- a/angr/knowledge_plugins/cfg/memory_data.py
+++ b/angr/knowledge_plugins/cfg/memory_data.py
@@ -66,6 +66,16 @@ class MemoryData(Serializable):
 
         self.content: Optional[bytes] = None  # temporary annotation
 
+    def __eq__(self, other: "MemoryData"):
+        return (
+            self.addr == other.addr
+            and self.size == other.size
+            and self.sort == other.sort
+            and self.max_size == other.max_size
+            and self.pointer_addr == other.pointer_addr
+            and self.content == other.content
+        )
+
     @property
     def address(self):
         return self.addr

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -766,6 +766,13 @@ class Function(Serializable):
         self.transition_graph = networkx.classes.digraph.DiGraph()
         self._local_transition_graph = None
 
+        self._ret_sites = set()
+        self._jumpout_sites = set()
+        self._callout_sites = set()
+        self._retout_sites = set()
+        self._endpoints = defaultdict(set)
+        self._call_sites = {}
+
     def _confirm_fakeret(self, src, dst):
         if src not in self.transition_graph or dst not in self.transition_graph[src]:
             raise AngrValueError(f"FakeRet edge ({src}, {dst}) is not in transition graph.")

--- a/angr/knowledge_plugins/patches.py
+++ b/angr/knowledge_plugins/patches.py
@@ -21,8 +21,7 @@ class PatchManager(KnowledgeBasePlugin):
     """
     A placeholder-style implementation for a binary patch manager. This class should be significantly changed in the
     future when all data about loaded binary objects are loaded into angr knowledge base from CLE. As of now, it only
-    stores byte-level replacements. Other angr components may choose to use or not use information provided by this
-    manager. In other words, it is not transparent.
+    stores byte-level replacements.
 
     Patches should not overlap, but it's user's responsibility to check for and avoid overlapping patches.
     """
@@ -32,16 +31,20 @@ class PatchManager(KnowledgeBasePlugin):
 
         self._patches: Dict[int, Patch] = SortedDict()
         self._kb = kb
+        self._patched_entry_state = None
 
     def add_patch(self, addr, new_bytes, comment: Optional[str] = None):
         self._patches[addr] = Patch(addr, new_bytes, comment=comment)
+        self._patched_entry_state = None
 
     def add_patch_obj(self, patch: Patch):
         self._patches[patch.addr] = patch
+        self._patched_entry_state = None
 
     def remove_patch(self, addr):
         if addr in self._patches:
             del self._patches[addr]
+        self._patched_entry_state = None
 
     def patch_addrs(self):
         return self._patches.keys()
@@ -111,6 +114,17 @@ class PatchManager(KnowledgeBasePlugin):
                 )
 
         return binary_bytes
+
+    def apply_patches_to_state(self, state):
+        for patch in self._patches.values():
+            state.memory.store(patch.addr, patch.new_bytes)
+
+    @property
+    def patched_entry_state(self):
+        if self._patched_entry_state is None:
+            self._patched_entry_state = self._kb._project.factory.entry_state()
+            self.apply_patches_to_state(self._patched_entry_state)
+        return self._patched_entry_state
 
 
 KnowledgeBasePlugin.register_default("patches", PatchManager)

--- a/tests/test_cfg_model.py
+++ b/tests/test_cfg_model.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# pylint:disable=no-self-use
+import os
+import unittest
+import logging
+
+import angr
+from angr.analyses import CFGFast
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+BINARIES_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
+FAUXWARE_PATH = os.path.join(BINARIES_PATH, "x86_64", "fauxware")
+
+
+class TestCfgModel(unittest.TestCase):
+    """
+    Test cases for CFGModel.
+    """
+
+    def test_cfgmodel_clear_region_for_reflow(self):
+        """Test CFGModel::clear_region_for_reflow."""
+        proj = angr.Project(FAUXWARE_PATH, auto_load_libs=False)
+        cfg = proj.analyses[CFGFast].prep()()
+        func = cfg.functions["authenticate"]
+
+        addr = 0x40068E
+        end_addr = 0x400692
+        cfg.model.clear_region_for_reflow(addr, end_addr - addr)
+
+        for addr in func.block_addrs:
+            assert cfg.model.get_any_node(addr) is None
+
+    def test_cfgmodel_clear_region_for_reflow_multifunc(self):
+        """Test CFGModel::clear_region_for_reflow across function boundaries."""
+        proj = angr.Project(FAUXWARE_PATH, auto_load_libs=False)
+        cfg = proj.analyses[CFGFast].prep()()
+
+        expected_removed_addrs = list(cfg.functions["accepted"].block_addrs) + list(
+            cfg.functions["rejected"].block_addrs
+        )
+
+        addr = 0x4006FB
+        end_addr = 0x4006FE
+        cfg.model.clear_region_for_reflow(addr, end_addr - addr)
+
+        for addr in expected_removed_addrs:
+            assert cfg.model.get_any_node(addr) is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cfg_patching.py
+++ b/tests/test_cfg_patching.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+# pylint:disable=no-self-use
+import os
+import unittest
+import logging
+import tempfile
+from typing import TYPE_CHECKING, List, Sequence, Tuple
+
+import angr
+from angr.analyses import CFGFast
+from angr.knowledge_plugins.cfg import MemoryData, MemoryDataSort
+
+if TYPE_CHECKING:
+    from angr.knowledge_plugins.cfg import CFGModel
+    from angr.knowledge_plugins.functions import Function, FunctionManager
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+BINARIES_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
+FAUXWARE_PATH = os.path.join(BINARIES_PATH, "x86_64", "fauxware")
+
+
+def apply_patches(proj: angr.Project, patches: List[Tuple[int, str]]):
+    for addr, asm in patches:
+        patch_bytes = proj.arch.keystone.asm(asm, addr, as_bytes=True)[0]
+        proj.kb.patches.add_patch(addr, patch_bytes)
+
+
+def assert_models_equal(model_a: "CFGModel", model_b: "CFGModel"):
+    assert model_a.graph.nodes() == model_b.graph.nodes()
+    assert model_a.graph.edges() == model_b.graph.edges()
+    # FIXME: Check more
+
+
+def assert_function_graphs_equal(function_a: "Function", function_b: "Function"):
+    nodes_a = function_a.graph.nodes()
+    nodes_b = function_b.graph.nodes()
+    if nodes_a != nodes_b:
+        log.error("Differing nodes!\nFunction:%s\nNodes A: %s\nNodes B: %s", function_a, nodes_a, nodes_b)
+        assert False
+    # FIXME: Check more
+
+
+def assert_all_function_equal(functions_a: "FunctionManager", functions_b: "FunctionManager"):
+    for f in functions_b:
+        assert f in functions_a, f"Extra function: {functions_b[f]}"
+    for f in functions_a:
+        assert f in functions_b, f"Missing function: {functions_a[f]}"
+        assert_function_graphs_equal(functions_a[f], functions_b[f])
+
+
+class TestCfgCombination(unittest.TestCase):
+    """
+    Tests that CFGFast can run with a prior model.
+    """
+
+    def test_cfgfast_combine_with_full_model(self):
+        """Run CFGFast once, then again with the model of the first."""
+        proj = angr.Project(FAUXWARE_PATH, auto_load_libs=False)
+        cfg_a = proj.analyses[CFGFast].prep()()
+        cfg_b = proj.analyses[CFGFast].prep()(model=cfg_a.model.copy())
+        assert_models_equal(cfg_a.model, cfg_b.model)
+        assert_all_function_equal(cfg_a.functions, cfg_b.functions)
+
+    def test_cfgfast_combine_with_partial_model(self):
+        """Run CFGFast on a region, then again on a second region with the model of the first."""
+
+        # Initial analysis just to pick up expected addresses
+        proj = angr.Project(FAUXWARE_PATH, auto_load_libs=False)
+        cfg = proj.analyses[CFGFast].prep()()
+        accepted_addr = cfg.functions["accepted"].addr
+        rejected_addr = cfg.functions["rejected"].addr
+        accepted_regions = [(n.addr, n.addr + n.size) for n in cfg.functions["accepted"].nodes]
+        rejected_regions = [(n.addr, n.addr + n.size) for n in cfg.functions["rejected"].nodes]
+
+        # Run partial analysis on the nodes we care about
+        proj = angr.Project(FAUXWARE_PATH, auto_load_libs=False)
+        cfg = proj.analyses[CFGFast].prep()(regions=accepted_regions)
+        assert accepted_addr in cfg.functions.function_addrs_set
+        assert rejected_addr not in cfg.functions.function_addrs_set
+
+        # Check continued analysis over another region combines correctly
+        cfg = proj.analyses[CFGFast].prep()(regions=rejected_regions, model=cfg.model.copy())
+        assert accepted_addr in cfg.functions.function_addrs_set
+        assert rejected_addr in cfg.functions.function_addrs_set
+
+        # Check analysis over union of regions yields same result
+        proj = angr.Project(FAUXWARE_PATH, auto_load_libs=False)
+        regions = accepted_regions + rejected_regions
+        cfg_combined = proj.analyses[CFGFast].prep()(regions=regions)
+        assert_models_equal(cfg.model, cfg_combined.model)
+        assert_all_function_equal(cfg.functions, cfg_combined.functions)
+
+    # FIXME: Add test of first analyzing a function A, then analyzing a function B called by A
+
+
+class TestCfgReclassification(unittest.TestCase):
+    """
+    Tests that code/data can be reclassified in CFG.
+    """
+
+    def test_cfgfast_preclassify_code_as_data(self):
+        """Classify a code region as data in an empty model, run CFGFast, ensure region remains classified as data."""
+        proj = angr.Project(FAUXWARE_PATH, auto_load_libs=False)
+        model = proj.kb.cfgs.new_model("initial")
+        md = MemoryData(0x40069D, 22, MemoryDataSort.String)
+        model.memory_data[md.addr] = md.copy()
+        cfg = proj.analyses[CFGFast].prep()(model=model)
+        assert cfg.model.memory_data[md.addr] == md
+
+        # Make sure the memory data item is not covered by any node
+        assert len(cfg.functions["authenticate"].graph.nodes) == 5
+        for n in cfg.functions["authenticate"].graph.nodes:
+            assert md.addr >= (n.addr + n.size) or n.addr >= (md.addr + md.size)
+            if (n.addr + n.size) == md.addr:
+                log.debug("Found adjacent node %s", n)
+                # FIXME: Successor address is still the same
+
+        # FIXME: Also test at function boundary
+
+    def test_cfgfast_reclassify_code_as_data(self):
+        """Run CFGFast, re-classify code within a function as data, then re-flow the function."""
+        proj = angr.Project(FAUXWARE_PATH, auto_load_libs=False)
+
+        # Initial analysis
+        cfg = proj.analyses[CFGFast].prep()()
+        func = cfg.functions["authenticate"]
+        function_addr = func.addr
+        original_number_of_nodes = len(func.graph.nodes)
+
+        # Define the data region and run analysis for function reconstruction
+        md = MemoryData(0x40069D, 22, MemoryDataSort.String)
+        cfg.model.memory_data[md.addr] = md.copy()
+        cfg.model.clear_region_for_reflow(func.addr)
+        cfg = proj.analyses[CFGFast].prep()(
+            symbols=False,
+            function_prologues=False,
+            start_at_entry=False,
+            force_smart_scan=False,
+            force_complete_scan=False,
+            function_starts=[function_addr],
+            model=cfg.model,
+        )
+
+        # Check memory data remains as configured and is not overlapped by any node
+        assert cfg.model.memory_data[md.addr] == md
+        assert len(cfg.functions["authenticate"].graph.nodes) == 5
+        for n in cfg.functions["authenticate"].graph.nodes:
+            assert md.addr >= (n.addr + n.size) or n.addr >= (md.addr + md.size)
+
+        # Now re-define the data as code again and ensure we have the correct number of nodes
+        del cfg.model.memory_data[md.addr]
+        cfg.model.clear_region_for_reflow(func.addr)
+        cfg = proj.analyses[CFGFast].prep()(
+            symbols=False,
+            function_prologues=False,
+            start_at_entry=False,
+            force_smart_scan=False,
+            force_complete_scan=False,
+            function_starts=[function_addr],
+            model=cfg.model,
+        )
+
+        assert len(cfg.functions["authenticate"].graph.nodes) == original_number_of_nodes
+
+        # FIXME: Test at function boundary
+
+    # FIXME: Test at partial offset into some data item
+    def test_cfgfast_preclassify_data_as_code(self):
+        """Classify some code that would not normally be classified as code."""
+        code = """
+        _start:
+            ret
+
+        not_discovered:
+            xor rax, rax
+            mov rcx, 5
+            .here:
+            inc rax
+            dec rcx
+            jnz .here
+            ret
+        """
+
+        not_discovered_addr = 0x1
+        proj = angr.load_shellcode(code, "AMD64")
+        cfg = proj.analyses[CFGFast].prep()(force_smart_scan=False)
+        assert len(cfg.functions) == 1
+
+        proj = angr.load_shellcode(code, "AMD64")
+        cfg = proj.analyses[CFGFast].prep()(force_smart_scan=False, function_starts=[not_discovered_addr])
+        assert len(cfg.functions) == 2
+        assert len(cfg.functions[not_discovered_addr].block_addrs) == 3
+
+    def test_cfgfast_reclassify_data_as_code(self):
+        """Run CFGFast, then re-classify some assumed data as code and run again."""
+        code = """
+        _start:
+            mov rax, [not_discovered]
+            ret
+
+        not_discovered:
+            xor rax, rax
+            mov rcx, 5
+            .here:
+            inc rax
+            dec rcx
+            jnz .here
+            ret
+        """
+
+        proj = angr.load_shellcode(code, "AMD64")
+        cfg = proj.analyses[CFGFast].prep()(force_smart_scan=False)
+        assert len(cfg.functions) == 1
+        not_discovered_addr = 0xB
+        del cfg.model.memory_data[not_discovered_addr]
+        cfg = proj.analyses[CFGFast].prep()(
+            start_at_entry=False, force_smart_scan=False, function_starts=[not_discovered_addr], model=cfg.model
+        )
+        assert len(cfg.functions) == 2
+        assert len(cfg.functions[0xB].block_addrs) == 3
+
+
+class TestCfgPatching(unittest.TestCase):
+    """
+    Test that patches made to the binary are correctly reflected in CFG.
+    """
+
+    def _test_patch(self, patches: Sequence[Tuple[int, str]]):
+        unpatched_binary_path = FAUXWARE_PATH
+        common_cfg_options = {
+            "normalize": True,
+            "resolve_indirect_jumps": True,
+            "data_references": True,
+            # "force_smart_scan": False,
+        }
+
+        # Create and load a pre-patched binary
+        log.debug("Recovering pre-patched CFG")
+        proj = angr.Project(unpatched_binary_path, auto_load_libs=False)
+        apply_patches(proj, patches)
+
+        with tempfile.NamedTemporaryFile(prefix="fauxware-patched-", delete=False) as f:
+            f.write(proj.kb.patches.apply_patches_to_binary())
+            f.close()
+            prepatched_proj = angr.Project(f.name, auto_load_libs=False)
+            expected_cfg = prepatched_proj.analyses[CFGFast].prep()(**common_cfg_options)
+
+            # Now create a new project, recover CFG, then patch and recover CFG again
+            proj = angr.Project(unpatched_binary_path, auto_load_libs=False)
+            log.debug("Recovering CFG before patching")
+            cfg_before_patching = proj.analyses[CFGFast].prep()(**common_cfg_options)
+            apply_patches(proj, patches)
+
+            log.debug("Recovering CFG after patching")
+            for p in proj.kb.patches.values():
+                cfg_before_patching.model.clear_region_for_reflow(p.addr, len(p.new_bytes))
+            cfg_after_patching = proj.analyses[CFGFast].prep()(**common_cfg_options, model=cfg_before_patching.model)
+
+            # Verify that the CFG of the patched binary matches the CFG of the pre-patched binary
+            assert_models_equal(expected_cfg.model, cfg_after_patching.model)
+
+            os.unlink(f.name)
+
+    #
+    # Patches that do not change block or function size
+    #
+
+    def test_cfg_patch_const_operand(self):
+        """
+        Patch a block, changing a data reference, with no effect on control.
+
+        Change print of "Username: " to "Password: ".
+        """
+        self._test_patch([(0x400734, "mov edi, 0x400920")])
+
+    def test_cfg_patch_ret_value(self):
+        """
+        Patch a block to redirect control, without changing the graph.
+
+        Change return value of `authenticate` in rejection branch to 1.
+        """
+        self._test_patch([(0x4006E6, "mov eax, 1")])
+
+    def test_cfg_patch_branch(self):
+        """
+        Patch a block, changing the graph.
+
+        Patch `authenticate` to always jump to accept branch, eliminating 1 block.
+        """
+        self._test_patch([(0x4006DD, "jne 0x4006df")])
+
+    def test_cfg_patch_call_target(self):
+        """
+        Patch a block, changing the graph, eliminate a cross reference.
+
+        Change call of `rejected` to `accepted`.
+        """
+        self._test_patch([(0x4007CE, "call 0x4006ed")])
+
+    # FIXME: Patches that change indirect jumps
+
+    #
+    # Patches that shrink blocks/function
+    #
+
+    def test_cfg_patch_shrink_encoding(self):
+        """
+        Shorten a block, but do not change graph.
+
+        Use a shorter instruction encoding.
+        """
+        self._test_patch([(0x4006DF, "xor eax, eax;  inc eax;  jmp 0x4006eb")])
+
+    def test_cfg_patch_shrink_branch(self):
+        """
+        Shorten a block, changing the graph.
+
+        Remove `strcmp` check in `authenticate`, just jump to accept branch.
+        """
+        self._test_patch([(0x4006DB, "jmp 0x4006df")])
+
+    def test_cfg_patch_shrink_ret_value(self):
+        """
+        Shorten a block, truncating a function.
+
+        Patch `authenticate` to always return 1
+        """
+        self._test_patch([(0x400664, "xor rax, rax;  inc rax;  ret")])
+
+    #
+    # Patches that grow blocks
+    #
+
+    def test_cfg_patch_grow_block_fallthru(self):
+        """
+        Patch a block to cover another block.
+
+        Ignore return value of `authenticate`, fallthru to accept branch.
+        """
+        self._test_patch([(0x4007BB, "nop;  nop;")])
+
+    def test_cfg_patch_grow_nocall(self):
+        """
+        Patch a block to eliminate all cross references to a function.
+
+        Patch out call to `authenticate`, fall thru.
+        """
+        self._test_patch([(0x4007AE, "xor rax, rax;  nop;  nop")])
+
+    def test_cfg_patch_grow_into_inter_function_padding(self):
+        """
+        Patch a block to grow into padded space between functions.
+
+        Prepend several NOPs to the last block of `main`.
+        """
+        self._test_patch([(0x4007D3, "nop; nop; nop; nop; leave; ret")])
+
+    def test_cfg_patch_grow_function_fallthru(self):
+        """
+        Patch a block that extends into another function.
+
+        Cut off the end of `authenticate` so it falls into `accepted`.
+        """
+        self._test_patch([(0x4006EC, "nop")])
+        # Will we have two functions? accepted() is still called so it will probably mark a function
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    log.setLevel(logging.DEBUG)
+    logging.getLogger("angr.analyses.cfg.cfg_fast").setLevel(logging.DEBUG)
+    logging.getLogger("angr.analyses.cfg.cfg_base").setLevel(logging.DEBUG)
+    unittest.main()

--- a/tests/test_cfgfast.py
+++ b/tests/test_cfgfast.py
@@ -763,43 +763,6 @@ class TestCfgfast(unittest.TestCase):
     # CFG with patches
     #
 
-    def test_cfg_with_patches(self):
-        path = os.path.join(test_location, "x86_64", "fauxware")
-        proj = angr.Project(path, auto_load_libs=False)
-
-        cfg = proj.analyses.CFGFast()
-        auth_func = cfg.functions["authenticate"]
-        auth_func_addr = auth_func.addr
-
-        # Take the authenticate function and add a retn patch for its very first block
-        kb = angr.KnowledgeBase(proj)
-        kb.patches.add_patch(auth_func_addr, b"\xc3")
-
-        # with this patch, there should only be one block with one instruction in authenticate()
-        _ = proj.analyses.CFGFast(kb=kb, use_patches=True)
-        patched_func = kb.functions["authenticate"]
-        assert len(patched_func.block_addrs_set) == 1
-        block = patched_func._get_block(auth_func_addr)
-        assert len(block.instruction_addrs) == 1
-
-        # let's try to patch the second instruction of that function to ret
-        kb = angr.KnowledgeBase(proj)
-        kb.patches.add_patch(auth_func._get_block(auth_func_addr).instruction_addrs[1], b"\xc3")
-
-        # with this patch, there should only be one block with two instructions in authenticate()
-        _ = proj.analyses.CFGFast(kb=kb, use_patches=True)
-        patched_func = kb.functions["authenticate"]
-        assert len(patched_func.block_addrs_set) == 1
-        block = patched_func._get_block(auth_func_addr)
-        assert len(block.instruction_addrs) == 2
-
-        # finally, if we generate a new CFG on a KB without any patch, we should still see the normal function (with 10
-        # blocks)
-        kb = angr.KnowledgeBase(proj)
-        _ = proj.analyses.CFGFast(kb=kb, use_patches=True)
-        not_patched_func = kb.functions["authenticate"]
-        assert len(not_patched_func.block_addrs_set) == 10
-
     def test_unresolvable_targets(self):
         path = os.path.join(test_location, "cgc", "CADET_00002")
         proj = angr.Project(path, auto_load_libs=False)


### PR DESCRIPTION
This set of patches is work-in-progress to improve CFG analysis given a prior model. The purpose is to enable incremental CFG recovery, updating an original CFG after patching code, and manual re-classification of code and data. New methods are added to `CFGModel` to support pruning nodes covering patched code, and convenience methods are added to `PatchManager` to support constructing a patched entry state. Tests are added that cover several typical patch scenarios, as well as partial model continuation, and re-classification.

Issues remain regarding consistent application of binary patches through all analyses/objects. Although multiple analyses, like `CFGFast`, support analysis of a given state, the analysis may inconsistently load from that state, often loading instead from loader memory, either directly or indirectly (e.g. via `project.factory.block`). Ideally, where appropriate, all analyses should take a state parameter and always read from it exclusively. (Issues #4018 #4019). In the mean time, instead of resolving those issues here, this PR applies patches to `CFGBase` and `Block` transparently by default. This solution is not perfect; preferably, everything would be state-specific, and a patched state would be like any other, but it is a simple interim solution for basic patch application and analysis.

There is additional work to be done to make patching/classification API more usable, especially concerning patch management. angr-management has some patch management features integrated to the `HexView` that I'd like to see moved into `PatchManager` eventually, specifically splitting and merging patches. Further, there are performance improvements to be made.

Dependent https://github.com/angr/angr-management/pull/1031
