### PR TITLE
Disable commenting of Gotos by default

### DIFF
--- a/angr/analyses/decompiler/decompilation_options.py
+++ b/angr/analyses/decompiler/decompilation_options.py
@@ -103,7 +103,7 @@ options = [
         "codegen",
         "comment_gotos",
         category="Display",
-        default_value=True,
+        default_value=False,
         clears_cache=False,
     ),
     O(


### PR DESCRIPTION
Since Phoenix is the default structuring algorithm in angr-management now, it would be nice to no longer comment the gotos (since they do correspond to real labels now). This turns off goto commenting by default. 