### PR TITLE
Several fixes to enable CC detection for PCode-PPC.

### DIFF
--- a/angr/analyses/calling_convention.py
+++ b/angr/analyses/calling_convention.py
@@ -10,7 +10,7 @@ from pyvex.expr import RdTmp
 from archinfo.arch_arm import is_arm_arch, ArchARMHF
 import ailment
 
-from ..calling_conventions import SimFunctionArgument, SimRegArg, SimStackArg, SimCC, default_cc, unify_arch_name
+from ..calling_conventions import SimFunctionArgument, SimRegArg, SimStackArg, SimCC, default_cc
 from ..sim_type import (
     SimTypeInt,
     SimTypeFunction,

--- a/angr/analyses/complete_calling_conventions.py
+++ b/angr/analyses/complete_calling_conventions.py
@@ -288,6 +288,12 @@ class CompleteCallingConventionsAnalysis(Analysis):
             return func.calling_convention, func.prototype, self.kb.variables.get_function_manager(func_addr)
 
         if self._recover_variables and self.function_needs_variable_recovery(func):
+            # special case: we don't have a PCode-engine variable recovery analysis for PCode architectures!
+            if ":" in self.project.arch.name:
+                # this is a pcode architecture
+                if not self._func_graphs or func.addr not in self._func_graphs:
+                    return None, None, None
+
             _l.info("Performing variable recovery on %r...", func)
             try:
                 _ = self.project.analyses[VariableRecoveryFast].prep(kb=self.kb)(

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -99,6 +99,7 @@ class AILSimplifier(Analysis):
         narrow_expressions=False,
         only_consts=False,
         fold_callexprs_into_conditions=False,
+        use_callee_saved_regs_at_return=True,
     ):
         self.func = func
         self.func_graph = func_graph if func_graph is not None else func.graph
@@ -113,6 +114,7 @@ class AILSimplifier(Analysis):
         self._narrow_expressions = narrow_expressions
         self._only_consts = only_consts
         self._fold_callexprs_into_conditions = fold_callexprs_into_conditions
+        self._use_callee_saved_regs_at_return = use_callee_saved_regs_at_return
 
         self._calls_to_remove: Set[CodeLocation] = set()
         self._assignments_to_remove: Set[CodeLocation] = set()
@@ -198,6 +200,7 @@ class AILSimplifier(Analysis):
             func_graph=self.func_graph,
             # init_context=(),    <-- in case of fire break glass
             observe_all=True,  # observe_callback=self._simplify_function_rd_observe_callback
+            use_callee_saved_regs_at_return=self._use_callee_saved_regs_at_return,
         )
         self._reaching_definitions = rd
         return rd

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -468,7 +468,7 @@ class Clinic(Analysis):
                                         reg_name=cc.cc.RETURN_VAL.reg_name,
                                     )
 
-        # finally, recovery the calling convention of the current function
+        # finally, recover the calling convention of the current function
         if self.function.prototype is None or self.function.calling_convention is None:
             self.project.analyses.CompleteCallingConventions(
                 recover_variables=True,

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -29,7 +29,7 @@ from .. import Analysis, register_analysis
 from ..cfg.cfg_base import CFGBase
 from ..reaching_definitions import ReachingDefinitionsAnalysis
 from .ailgraph_walker import AILGraphWalker, RemoveNodeNotice
-from .optimization_passes import get_default_optimization_passes, OptimizationPassStage
+from .optimization_passes import get_default_optimization_passes, OptimizationPassStage, RegisterSaveAreaSimplifier
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.cfg import CFGModel
@@ -91,6 +91,8 @@ class Clinic(Analysis):
         self._reset_variable_names = reset_variable_names
         self.reaching_definitions: Optional[ReachingDefinitionsAnalysis] = None
         self._cache = cache
+
+        self._register_save_areas_removed: bool = False
 
         self._new_block_addrs = set()
 
@@ -758,6 +760,7 @@ class Clinic(Analysis):
             narrow_expressions=narrow_expressions,
             only_consts=only_consts,
             fold_callexprs_into_conditions=fold_callexprs_into_conditions,
+            use_callee_saved_regs_at_return=not self._register_save_areas_removed,
         )
         # cache the simplifier's RDA analysis
         self.reaching_definitions = simp._reaching_definitions
@@ -799,6 +802,11 @@ class Clinic(Analysis):
             if a.out_graph:
                 # use the new graph
                 ail_graph = a.out_graph
+                if isinstance(a, RegisterSaveAreaSimplifier):
+                    # register save area has been removed - we should no longer use callee-saved registers in RDA
+                    self._register_save_areas_removed = True
+                    # clear the cached RDA result
+                    self.reaching_definitions = None
 
         return ail_graph
 
@@ -849,7 +857,10 @@ class Clinic(Analysis):
 
         # Computing reaching definitions
         rd = self.project.analyses.ReachingDefinitions(
-            subject=self.function, func_graph=ail_graph, observe_callback=self._make_callsites_rd_observe_callback
+            subject=self.function,
+            func_graph=ail_graph,
+            observe_callback=self._make_callsites_rd_observe_callback,
+            use_callee_saved_regs_at_return=not self._register_save_areas_removed,
         )
 
         class TempClass:  # pylint:disable=missing-class-docstring

--- a/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
@@ -23,18 +23,9 @@ class RegisterSaveAreaSimplifier(OptimizationPass):
     Optimizes away register spilling effects, including callee-saved registers.
     """
 
-    ARCHES = [
-        "X86",
-        "AMD64",
-        "ARM",
-        "ARMEL",
-        "ARMHF",
-        "ARMCortexM",
-        "MIPS32",
-        "MIPS64",
-    ]
-    PLATFORMS = ["cgc", "linux"]
-    STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
+    ARCHES = None
+    PLATFORMS = None
+    STAGE = OptimizationPassStage.AFTER_SINGLE_BLOCK_SIMPLIFICATION
     NAME = "Simplify register save areas"
     DESCRIPTION = __doc__.strip()
 

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -66,6 +66,7 @@ class ReachingDefinitionsAnalysis(
         observe_callback=None,
         canonical_size=8,
         stack_pointer_tracker=None,
+        use_callee_saved_regs_at_return=True,
     ):
         """
         :param subject:                         The subject of the analysis: a function, or a single basic block
@@ -115,6 +116,7 @@ class ReachingDefinitionsAnalysis(
         self._observation_points = observation_points
         self._init_state = init_state
         self._canonical_size = canonical_size
+        self._use_callee_saved_regs_at_return = use_callee_saved_regs_at_return
 
         if dep_graph is None or dep_graph is False:
             self._dep_graph = None
@@ -151,6 +153,7 @@ class ReachingDefinitionsAnalysis(
             self.project,
             function_handler=self._function_handler,
             stack_pointer_tracker=stack_pointer_tracker,
+            use_callee_saved_regs_at_return=self._use_callee_saved_regs_at_return,
         )
 
         self._visited_blocks: Set[Any] = visited_blocks or set()

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1981,6 +1981,9 @@ class SimCCN64(SimCC):  # TODO: add n32
     ARCH = archinfo.ArchMIPS64
 
 
+SimCCO64 = SimCCN64  # compatibility
+
+
 class SimCCN64LinuxSyscall(SimCCSyscall):
     ARG_REGS = ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"]
     FP_ARG_REGS = []  # TODO: ???

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2173,6 +2173,11 @@ DEFAULT_CC: Dict[str, Type[SimCC]] = {
 
 def register_default_cc(arch: str, cc: Type[SimCC]):
     DEFAULT_CC[arch] = cc
+    if arch not in CC:
+        CC[arch] = [cc]
+    else:
+        if cc not in CC[arch]:
+            CC[arch].append(cc)
 
 
 ARCH_NAME_ALIASES = {

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1971,8 +1971,8 @@ class SimCCO32LinuxSyscall(SimCCSyscall):
         return state.regs.v0
 
 
-class SimCCO64(SimCC):  # TODO: add n32 and n64
-    ARG_REGS = ["a0", "a1", "a2", "a3"]
+class SimCCN64(SimCC):  # TODO: add n32
+    ARG_REGS = ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"]
     CALLER_SAVED_REGS = ["t9", "gp"]
     FP_ARG_REGS = []  # TODO: ???
     STACKARG_SP_BUFF = 32
@@ -1981,7 +1981,7 @@ class SimCCO64(SimCC):  # TODO: add n32 and n64
     ARCH = archinfo.ArchMIPS64
 
 
-class SimCCO64LinuxSyscall(SimCCSyscall):
+class SimCCN64LinuxSyscall(SimCCSyscall):
     ARG_REGS = ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"]
     FP_ARG_REGS = []  # TODO: ???
     RETURN_VAL = SimRegArg("v0", 8)
@@ -2136,7 +2136,7 @@ CC = {
         SimCCO32,
     ],
     "MIPS64": [
-        SimCCO64,
+        SimCCN64,
     ],
     "PPC32": [
         SimCCPowerPC,
@@ -2160,7 +2160,7 @@ DEFAULT_CC: Dict[str, Type[SimCC]] = {
     "ARMHF": SimCCARMHF,
     "ARMCortexM": SimCCARM,
     "MIPS32": SimCCO32,
-    "MIPS64": SimCCO64,
+    "MIPS64": SimCCN64,
     "PPC32": SimCCPowerPC,
     "PPC64": SimCCPowerPC64,
     "AARCH64": SimCCAArch64,
@@ -2274,8 +2274,8 @@ SYSCALL_CC: Dict[str, Dict[str, Type[SimCCSyscall]]] = {
         "Linux": SimCCO32LinuxSyscall,
     },
     "MIPS64": {
-        "default": SimCCO64LinuxSyscall,
-        "Linux": SimCCO64LinuxSyscall,
+        "default": SimCCN64LinuxSyscall,
+        "Linux": SimCCN64LinuxSyscall,
     },
     "PPC32": {
         "default": SimCCPowerPCLinuxSyscall,

--- a/angr/engines/pcode/cc.py
+++ b/angr/engines/pcode/cc.py
@@ -102,6 +102,7 @@ def register_pcode_arch_default_cc(arch: ArchPcode):
             "SuperH4:LE:32:default": SimCCSH4,
             "pa-risc:BE:32:default": SimCCPARISC,
             "PowerPC:BE:32:e200": SimCCPowerPC,
+            "PowerPC:BE:32:MPC8270": SimCCPowerPC,
             "Xtensa:LE:32:default": SimCCXtensa,
         }
         if arch.name in manual_cc_mapping:

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -620,6 +620,8 @@ class PropagatorAILState(PropagatorState):
             return True
         if isinstance(value, ailment.Expr.Const) or (isinstance(value, int) and value == 0):
             return True
+        if isinstance(value, ailment.Expr.StackBaseOffset):
+            return True
         # more hacks: also store the eq comparisons
         if isinstance(value, ailment.Expr.BinaryOp) and value.op == "CmpEQ":
             if all(isinstance(arg, (ailment.Expr.Const, ailment.Expr.Tmp)) for arg in value.operands):


### PR DESCRIPTION
- Fix RegisterSaveAreaSimplifier.
- Fix register name sanity check in CCA for PCode architectures.
- Allow replacing registers with StackBaseOffset objects during the constant propagation phase.
- Do not create empty calling conventions for PCode arch functions in complete CCA.