### PR TITLE
Perform read of size smaller than actual read size passed to CGC receive in native interface

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1273,7 +1273,8 @@ class Unicorn(SimStatePlugin):
                     )
 
             _UC_NATIVE.set_cgc_syscall_details(
-                self._uc_state, 2, cgc_transmit_addr, 3, cgc_receive_addr, 7, cgc_random_addr
+                self._uc_state, 2, cgc_transmit_addr, 3, cgc_receive_addr, self.state.cgc.max_receive_size,
+                7, cgc_random_addr
             )
 
         # set memory map callback so we can call it explicitly

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1273,8 +1273,14 @@ class Unicorn(SimStatePlugin):
                     )
 
             _UC_NATIVE.set_cgc_syscall_details(
-                self._uc_state, 2, cgc_transmit_addr, 3, cgc_receive_addr, self.state.cgc.max_receive_size,
-                7, cgc_random_addr
+                self._uc_state,
+                2,
+                cgc_transmit_addr,
+                3,
+                cgc_receive_addr,
+                self.state.cgc.max_receive_size,
+                7,
+                cgc_random_addr,
             )
 
         # set memory map callback so we can call it explicitly

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -481,6 +481,7 @@ def _load_native():
             ctypes.c_uint64,
             ctypes.c_uint32,
             ctypes.c_uint64,
+            ctypes.c_uint64,
             ctypes.c_uint32,
             ctypes.c_uint64,
         )

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -2600,6 +2600,10 @@ void State::perform_cgc_receive() {
 		return;
 	}
 
+	if ((cgc_receive_max_size != 0) && (count > cgc_receive_max_size)) {
+		count = cgc_receive_max_size;
+	}
+
 	// Perform read
 	char *tmp_buf = (char *)malloc(count);
 	taint_t *tmp_taint_buf;
@@ -3032,11 +3036,12 @@ bool simunicorn_is_interrupt_handled(State *state) {
 
 extern "C"
 void simunicorn_set_cgc_syscall_details(State *state, uint32_t transmit_num, uint64_t transmit_bbl,
-  uint32_t receive_num, uint64_t receive_bbl, uint32_t random_num, uint64_t random_bbl) {
+  uint32_t receive_num, uint64_t receive_bbl, uint64_t receive_size, uint32_t random_num, uint64_t random_bbl) {
 	state->cgc_random_sysno = random_num;
 	state->cgc_random_bbl = random_bbl;
 	state->cgc_receive_sysno = receive_num;
 	state->cgc_receive_bbl = receive_bbl;
+	state->cgc_receive_max_size = receive_size;
 	state->cgc_transmit_sysno = transmit_num;
 	state->cgc_transmit_bbl = transmit_bbl;
 }

--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -765,6 +765,7 @@ class State {
 		uint64_t cgc_random_bbl;
 		int32_t cgc_receive_sysno;
 		uint64_t cgc_receive_bbl;
+		uint64_t cgc_receive_max_size;
 		int32_t cgc_transmit_sysno;
 		uint64_t cgc_transmit_bbl;
 		bool handle_symbolic_syscalls;


### PR DESCRIPTION
This PR adds support  in native interface to perform reads of sizes smaller than size passed to CGC receive. It is essentially implementing #2731 in native interface.