### PR TITLE
BVV values should be resized before getting into registers

### DIFF
--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -449,7 +449,11 @@ class SimProcedure:
             ret_addr = self._compute_ret_addr(expr)  # pylint:disable=assignment-from-no-return
         elif self.use_state_arguments:
             # in case we guess the prototype wrong, use the return value's size as a hint to fix it
-            if self.guessed_prototype and isinstance(expr, claripy.ast.bv.BV) and self.prototype.returnty.size != len(expr):
+            if (
+                self.guessed_prototype
+                and isinstance(expr, claripy.ast.bv.BV)
+                and self.prototype.returnty.size != len(expr)
+            ):
                 self.fix_prototype_returnty(len(expr))
 
             ret_addr = self.cc.teardown_callsite(self.state, return_val=expr, prototype=self.prototype)

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 from typing import TYPE_CHECKING, Union, Tuple
 
+import claripy
 from cle import SymbolType
 from archinfo.arch_soot import SootAddressDescriptor
 
@@ -410,6 +411,12 @@ class SimProcedure:
         p = procedure(project=self.project, **kwargs)
         return p.execute(self.state, None, arguments=e_args)
 
+    def fix_prototype_returnty(self, ret_size):
+        if ret_size not in [8, 16, 32, 64]:
+            raise NotImplementedError(f"return type of size {ret_size} is not handled!")
+        returnty = SimTypeNum(ret_size, signed=False, label=f"u{ret_size}")
+        self.prototype.returnty = returnty
+
     def ret(self, expr=None):
         """
         Add an exit representing a return from this function.
@@ -441,7 +448,11 @@ class SimProcedure:
         if isinstance(self.addr, SootAddressDescriptor):
             ret_addr = self._compute_ret_addr(expr)  # pylint:disable=assignment-from-no-return
         elif self.use_state_arguments:
-            ret_addr = self.cc.teardown_callsite(self.state, expr, prototype=self.prototype)
+            # in case we guess the prototype wrong, use the return value's size as a hint to fix it
+            if self.guessed_prototype and isinstance(expr, claripy.ast.bv.BV) and self.prototype.returnty.size != len(expr):
+                self.fix_prototype_returnty(len(expr))
+
+            ret_addr = self.cc.teardown_callsite(self.state, return_val=expr, prototype=self.prototype)
 
         if not self.should_add_successors:
             l.debug("Returning without setting exits due to 'internal' call.")
@@ -569,6 +580,6 @@ class SimProcedure:
 from . import sim_options as o
 from angr.errors import SimProcedureError, SimShadowStackError
 from angr.state_plugins.sim_action import SimActionExit
-from angr.calling_conventions import DEFAULT_CC, SimTypeFunction, SimTypePointer, SimTypeChar, ArgSession
+from angr.calling_conventions import DEFAULT_CC, SimTypeFunction, SimTypePointer, SimTypeChar, ArgSession, SimTypeNum
 from .state_plugins import BP_AFTER, BP_BEFORE, NO_OVERRIDE
 from .sim_type import parse_signature, parse_type


### PR DESCRIPTION
in case of executing sim_procedures, the return value may be intentionally set to a BVV value that has a smaller size than the register size (for example, `puts` returns 4 bytes BVV). When the short BVV gets into the registers, it actually cannot fit the whole 8 bytes, which can trigger the "not enough data for store" assert in `storage/memory_mixins/size_resolution_mixin.py` as follow:
~~~
    def store(self, addr, data, size=None, **kwargs):
        max_size = len(data) // self.state.arch.byte_width
        if size is None:
            out_size = max_size
        elif type(size) is int:
            out_size = size
        elif getattr(size, "op", None) == "BVV":
            out_size = size.args[0]
        else:
            raise Exception("Size must be concretely resolved by this point in the memory stack")

        if out_size > max_size:
            raise SimMemoryError("Not enough data for store")
        if out_size == 0:
            # skip zero-sized stores
            return

        super().store(addr, data, size=out_size, **kwargs)
~~~
This is because `data` is the 4-byte BVV and `size` is 8-byte (register size). And the `max_size` is `data`'s size. As a result, it does not have enough data for store.

I think the fix should be at calling_convention level: extend the BVV before storing it into registers.