### PR TITLE
decompiler: Improved mapping of decompiler to AST nodes

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -255,8 +255,8 @@ class CConstruct:
                             if pos_to_node is not None:
                                 pos_to_node.add_mapping(pos, len(s), obj)
 
-                # add (), {}, and [] to mapping for highlighting as well as the full functions name
-                elif isinstance(obj, (CClosingObject, CFunction)):
+                # add (), {}, [], and [20] to mapping for highlighting as well as the full functions name
+                elif isinstance(obj, (CClosingObject, CFunction, CArrayTypeLength)):
                     if s is None:
                         continue
 
@@ -445,7 +445,7 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
                     if type_pre_spaces:
                         yield type_pre_spaces, None
                     yield name, cvariable
-                    yield type_post, var_type
+                    yield type_post, CArrayTypeLength(type_post)
                     yield ";  // ", None
                     yield variable.loc_repr(self.codegen.project.arch), None
                 # multiple types
@@ -2140,6 +2140,18 @@ class CClosingObject:
 
     def __init__(self, opening_symbol):
         self.opening_symbol = opening_symbol
+
+
+class CArrayTypeLength:
+    """
+    A class to represent the type information of fixed-size array lengths.
+    Examples: In "char foo[20]", this would be the "[20]".
+    """
+
+    __slots__ = ("text",)
+
+    def __init__(self, text):
+        self.text = text
 
 
 class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):


### PR DESCRIPTION
In order to use decompiler string to AST node mapping for coloring in anger-management, need to have more precise mappings.

This PR makes the following changes:

- Add a `CArrayTypeLength` class to handle the type information of an array length (e.g., in `char foo[2]` this would be `[2]`), because anger-management needs a way to differentiate a SimType (which the user would like to color) from this part.
- Add a `CStructFieldNameDef` class to refer to a field name inside of a struct definition. While there is `CStructField`, this is for accessing a field of a struct.
- Refactor how SimTypes are turned into `c_repr_chunks` so that it happens in one place (previously it was done in three places) in `type_to_c_repr_chunks`. 