### PR TITLE
Omit the extra newline when a bodyless for-loop is present

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -829,17 +829,18 @@ class CForLoop(CStatement):
             yield from self.iterator.c_repr_chunks(indent=0, asexpr=True)
         yield ")", paren
 
-        if self.codegen.braces_on_own_lines:
-            yield "\n", None
-            yield indent_str, None
-        else:
-            yield " ", None
         if self.body is not None:
-            yield "{", brace
-            yield "\n", None
-            yield from self.body.c_repr_chunks(indent=indent + INDENT_DELTA)
-            yield indent_str, None
-            yield "}", brace
+            if self.codegen.braces_on_own_lines:
+                yield "\n", None
+                yield indent_str, None
+            else:
+                yield " ", None
+
+                yield "{", brace
+                yield "\n", None
+                yield from self.body.c_repr_chunks(indent=indent + INDENT_DELTA)
+                yield indent_str, None
+                yield "}", brace
         else:
             yield ";", None
         yield "\n", None

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -836,11 +836,11 @@ class CForLoop(CStatement):
             else:
                 yield " ", None
 
-                yield "{", brace
-                yield "\n", None
-                yield from self.body.c_repr_chunks(indent=indent + INDENT_DELTA)
-                yield indent_str, None
-                yield "}", brace
+            yield "{", brace
+            yield "\n", None
+            yield from self.body.c_repr_chunks(indent=indent + INDENT_DELTA)
+            yield indent_str, None
+            yield "}", brace
         else:
             yield ";", None
         yield "\n", None


### PR DESCRIPTION
Fixes:
```
for (*((unsigned int *)&a0) = v4[1]; (v3[2 * to_uchar(a0)] & 1); *((unsigned int *)&a0) = v5->field_1)
 ;
```
to:
```
for (*((unsigned int *)&a0) = v4[1]; (v3[2 * to_uchar(a0)] & 1); *((unsigned int *)&a0) = v5->field_1);
```