### PR TITLE
Fix an extra space in single stmt elses

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -937,17 +937,12 @@ class CIfElse(CStatement):
                 yield from self.else_node.c_repr_chunks(indent=indent)
             else:
                 if single_stmt_else:
-                    if self.codegen.braces_on_own_lines:
-                        yield indent_str, None
-                    else:
-                        yield " ", None
-                        yield indent_str, None
+                    yield indent_str, None
+                elif self.codegen.braces_on_own_lines:
+                    yield "\n", None
+                    yield indent_str, None
                 else:
-                    if self.codegen.braces_on_own_lines:
-                        yield "\n", None
-                        yield indent_str, None
-                    else:
-                        yield " ", None
+                    yield " ", None
 
                 yield "else", self
                 if self.codegen.braces_on_own_lines or single_stmt_else:


### PR DESCRIPTION
Fixes:
```
    if (*(v2) == 43)
        v3 = &v2[1];
     else
        v3 = &v2[*(v2) == 45];
```
To:
```
    if (*(v2) == 43)
        v3 = &v2[1];
    else
        v3 = &v2[*(v2) == 45];
```

Note: you can only trigger this bug when you have the `braces_on_newline` option set to `False`