### PR TITLE
Save the return definition of a function even if the ret will be handled by the caller

### DIFF
--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -256,6 +256,11 @@ class SimEngineRDAIL(
         ip = Register(self.arch.ip_offset, self.arch.bytes)
         self.state.kill_definitions(ip)
 
+        statement = self.block.statements[self.stmt_idx]
+        caller_will_handle_single_ret = True
+        if hasattr(statement, "dst") and statement.dst != stmt.ret_expr:
+            caller_will_handle_single_ret = False
+
         data = FunctionCallData(
             self.state.codeloc,
             self._function_handler.make_function_codeloc(
@@ -267,7 +272,7 @@ class SimEngineRDAIL(
             name=func_name,
             args_values=[self._expr(arg) for arg in stmt.args] if stmt.args is not None else None,
             redefine_locals=stmt.args is None and not is_expr,
-            caller_will_handle_single_ret=True,
+            caller_will_handle_single_ret=caller_will_handle_single_ret,
             ret_atoms={Atom.from_ail_expr(stmt.ret_expr, self.arch)} if stmt.ret_expr is not None else None,
         )
 

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -2444,11 +2444,8 @@ class TestDecompiler(unittest.TestCase):
         proj.analyses.CompleteCallingConventions(cfg=cfg, recover_variables=True)
         d = proj.analyses[Decompiler](f, cfg=cfg.model, options=decompiler_options)
 
-        target_addrs = {0x4045d8, 0x404575}
-        target_nodes = [
-            node for node in d.codegen.ail_graph.nodes
-            if node.addr in target_addrs
-        ]
+        target_addrs = {0x4045D8, 0x404575}
+        target_nodes = [node for node in d.codegen.ail_graph.nodes if node.addr in target_addrs]
 
         for target_node in target_nodes:
             # these are the two calls, their last arg should actually be r14


### PR DESCRIPTION
Potential fix for #3992
