### PR TITLE
Handle SimUnion in refine_locs_with_struct_type by treating it as its largest member

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -158,6 +158,13 @@ def refine_locs_with_struct_type(
             for field, field_ty in arg_type.fields.items()
         }
         return SimStructArg(arg_type, locs)
+    if isinstance(arg_type, SimUnion):
+        # Treat a SimUnion as functionality equivalent to its longest member
+        for member in arg_type.members.values():
+            if member.size == arg_type.size:
+                break
+        return refine_locs_with_struct_type(arch, locs, member, offset)
+
     raise TypeError("I don't know how to lay out a %s" % arg_type)
 
 

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -162,9 +162,8 @@ def refine_locs_with_struct_type(
         # Treat a SimUnion as functionality equivalent to its longest member
         for member in arg_type.members.values():
             if member.size == arg_type.size:
-                break
-        return refine_locs_with_struct_type(arch, locs, member, offset)
-
+                return refine_locs_with_struct_type(arch, locs, member, offset)
+                
     raise TypeError("I don't know how to lay out a %s" % arg_type)
 
 

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -163,7 +163,7 @@ def refine_locs_with_struct_type(
         for member in arg_type.members.values():
             if member.size == arg_type.size:
                 return refine_locs_with_struct_type(arch, locs, member, offset)
-                
+
     raise TypeError("I don't know how to lay out a %s" % arg_type)
 
 


### PR DESCRIPTION
Fixes `TypeError: I don't know how to lay out a union None` when executing/parsing a SimUnion passed directly as a SimProcedure argument, typical of Windows ws2_32.dlls deprecated `inet_ntoa`

Raised in Issue https://github.com/angr/angr/issues/3496


