### PR TITLE
Handle write-write conflicts involving syscalls that write concrete values to memory

### DIFF
--- a/native/sim_unicorn.hpp
+++ b/native/sim_unicorn.hpp
@@ -796,6 +796,10 @@ class State {
 		// Concrete writes to re-execute to avoid write-write conflicts
 		std::unordered_map<uint64_t, uint8_t> concrete_writes_to_reexecute;
 
+		// Concrete writes performed by syscalls. Used to determine if any write-write conflicts occur when syscall is
+		// re-executed.
+		std::unordered_set<address_t> syscall_concrete_writes;
+
 		// List of instructions that should be executed symbolically; used to store data to return
 		std::vector<sym_block_details_t> block_details_to_return;
 


### PR DESCRIPTION
Currently, we handle any write-write conflicts that occur due to re-executing syscalls that touch symbolic data(eg: read). However, this is not handled if syscalls do not touch any symbolic data, leading to trace desyncs. This PR fixes this by modifying the unicorn native interface to track any memory writes performed by syscalls(currently only CGC receive) and check for write-write conflicts that may arise due to re-execution of syscalls in python land.