### PR TITLE
Add __neg__ to convert_claripy_bool_ast

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -643,6 +643,7 @@ class ConditionProcessor:
 
         _mapping = {
             "Not": lambda cond_, tags: _unary_op_reduce("Not", cond_.args[0], tags),
+            "__neg__": lambda cond_, tags: _unary_op_reduce("Not", cond_.args[0], tags),
             "__invert__": lambda cond_, tags: _unary_op_reduce("BitwiseNeg", cond_.args[0], tags),
             "And": lambda cond_, tags: _binary_op_reduce("LogicalAnd", cond_.args, tags),
             "Or": lambda cond_, tags: _binary_op_reduce("LogicalOr", cond_.args, tags),


### PR DESCRIPTION
For whatever reason, since the last 3 commits on master `__neg__` has been showing up all over the place and causing the following crash:
```
NotImplementedError: Condition variable <BV32 -ailexpr_Conv(64->32, 4797340611340532571)> has an unsupported operator __neg__. Consider implementing.
```

This add support for it. 