### PR TITLE
Hide everything from RTD indexer to force it back to default search

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
 
 search:
   ignore:
-    - *
+    - '*'

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,7 @@ build:
       - pip install git+https://github.com/angr/claripy.git
       - pip install git+https://github.com/angr/ailment.git
       - pip install --no-build-isolation .[angrdb,docs,pcode]
+
+search:
+  ignore:
+    - *


### PR DESCRIPTION
The note in this section of the docs suggests that if their search finds no results it will fall back to the default (good) search. https://docs.readthedocs.io/en/stable/config-file/v2.html#search-ignore