### PR TITLE
Fix all references to the archived angr-doc repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ project.execute()
 # Quick Start
 
 - [Install Instructions](https://docs.angr.io/introductory-errata/install)
-- Documentation as [HTML](https://docs.angr.io/) and as a [Github repository](https://github.com/angr/angr-doc)
+- Documentation as [HTML](https://docs.angr.io/) and sources in the angr [Github repository](https://github.com/angr/angr/tree/master/docs)
 - Dive right in: [top-level-accessible methods](https://docs.angr.io/core-concepts/toplevel)
 - [Examples using angr to solve CTF challenges](https://docs.angr.io/examples).
 - [API Reference](https://angr.io/api-doc/)

--- a/docs/advanced-topics/java_support.rst
+++ b/docs/advanced-topics/java_support.rst
@@ -56,16 +56,16 @@ There are multiple examples available:
 
 
 * Easy Java crackmes: `java_crackme1
-  <https://github.com/angr/angr-doc/tree/master/examples/java_crackme1>`_,
+  <https://github.com/angr/angr-examples/tree/master/examples/java_crackme1>`_,
   `java_simple3
-  <https://github.com/angr/angr-doc/tree/master/examples/java_simple3>`_,
+  <https://github.com/angr/angr-examples/tree/master/examples/java_simple3>`_,
   `java_simple4
-  <https://github.com/angr/angr-doc/tree/master/examples/java_simple4>`_
+  <https://github.com/angr/angr-examples/tree/master/examples/java_simple4>`_
 * A more complex example (solving a CTF challenge): `ictf2017_javaisnotfun
-  <https://github.com/angr/angr-doc/tree/master/examples/ictf2017_javaisnotfun>`_,
+  <https://github.com/angr/angr-examples/tree/master/examples/ictf2017_javaisnotfun>`_,
   `blogpost <https://angr.io/blog/java_angr/>`_
 * Symbolically executing an Android app (using a mix of Java and native code):
   `java_androidnative1
-  <https://github.com/angr/angr-doc/tree/master/examples/java_androidnative1>`_
+  <https://github.com/angr/angr-examples/tree/master/examples/java_androidnative1>`_
 * Many other low-level tests: `test_java
   <https://github.com/angr/angr/blob/master/tests/test_java.py>`_

--- a/docs/appendix/changelog.rst
+++ b/docs/appendix/changelog.rst
@@ -387,7 +387,7 @@ angr 4.6.5.25
 -------------
 
 New state constructor - ``call_state``. Comes with a refactor to ``SimCC``, a refactor to ``callable``, and the removal of ``PathGroup.call``.
-All these changes are thoroughly documented, in ``angr-doc/docs/structured_data.md``
+All these changes are thoroughly documented, in ``angr/docs/advanced-topics/structured_data.md``
 
 Refactor of ``SimType`` to make it easier to use types - they can be instanciated without a SimState and one can be added later.
 Comes with some usability improvements to SimMemView.

--- a/docs/appendix/more-examples.rst
+++ b/docs/appendix/more-examples.rst
@@ -13,9 +13,9 @@ Script author: Stanislas Lejay (github: `@P1kachu
 Script runtime: ~31 minutes
 
 Here is the `binary
-<https://github.com/angr/angr-doc/tree/master/examples/hackcon2016_angry-reverser/yolomolo>`_
+<https://github.com/angr/angr-examples/tree/master/examples/hackcon2016_angry-reverser/yolomolo>`_
 and the `script
-<https://github.com/angr/angr-doc/tree/master/examples/hackcon2016_angry-reverser/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/hackcon2016_angry-reverser/solve.py>`_
 
 ReverseMe example: SecurityFest 2016 - fairlight
 ------------------------------------------------
@@ -30,33 +30,23 @@ against 14 checks. Possible to solve the challenge using angr without reversing
 any of the checks.
 
 Here is the `binary
-<https://github.com/angr/angr-doc/tree/master/examples/securityfest_fairlight/fairlight>`_
+<https://github.com/angr/angr-examples/tree/master/examples/securityfest_fairlight/fairlight>`_
 and the `script
-<https://github.com/angr/angr-doc/tree/master/examples/securityfest_fairlight/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/securityfest_fairlight/solve.py>`_
 
 ReverseMe example: DEFCON Quals 2016 - baby-re
 ----------------------------------------------
 
 
-* Script 0
+Authors David Manouchehri (github: `@Manouchehri <https://github.com/Manouchehri>`_\ ),
+Stanislas Lejay (github: `@P1kachu <https://github.com/P1kachu>`_\ ) and Audrey Dutcher (github: @rhelmot).
 
-    author: David Manouchehri (github: `@Manouchehri <https://github.com/Manouchehri>`_\ )
-
-    Script runtime: 8 minutes
-
-* Script 1
-
-    author: Stanislas Lejay (github: `@P1kachu <https://github.com/P1kachu>`_\ )
-
-    Script runtime: 11 sec
+Script runtime: 10 sec
 
 Here is the `binary
-<https://github.com/angr/angr-doc/blob/master/examples/defcon2016quals_baby-re_1/baby-re>`_
-and the scripts:
-
-
-* `script0 <https://github.com/angr/angr-doc/tree/master/examples/defcon2016quals_baby-re_0/solve.py>`_
-* `script1 <https://github.com/angr/angr-doc/tree/master/examples/defcon2016quals_baby-re_1/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/defcon2016quals_baby-re/baby-re>`_
+and the `script
+<https://github.com/angr/angr-examples/tree/master/examples/defcon2016quals_baby-re/solve.py>`_
 
 ReverseMe example: Google CTF - Unbreakable Enterprise Product Activation (150 points)
 --------------------------------------------------------------------------------------
@@ -82,9 +72,9 @@ Challenge Description:
 
 
 Here are the binary and scripts: `script 0
-<https://github.com/angr/angr-doc/tree/master/examples/google2016_unbreakable_0>`_\
+<https://github.com/angr/angr-examples/tree/master/examples/google2016_unbreakable_0>`_\
 , `script_1
-<https://github.com/angr/angr-doc/tree/master/examples/google2016_unbreakable_1>`_
+<https://github.com/angr/angr-examples/tree/master/examples/google2016_unbreakable_1>`_
 
 ReverseMe example: EKOPARTY CTF - Fuckzing reverse (250 points)
 ---------------------------------------------------------------
@@ -104,7 +94,7 @@ Challenge Description:
 
 
 Both sample binaries and the script are located `here
-<https://github.com/angr/angr-doc/tree/master/examples/ekopartyctf2016_rev250>`_
+<https://github.com/angr/angr-examples/tree/master/examples/ekopartyctf2016_rev250>`_
 and additional information be found at the author's `write-up
 <http://van.prooyen.com/reversing/2016/10/30/Fuckzing-reverse-Writeup.html>`_.
 
@@ -124,9 +114,9 @@ legit Windows APIs). Other than that, angr works really well for solving this
 challenge."
 
 The `binary
-<https://github.com/angr/angr-doc/tree/master/examples/whitehatvn2015_re400/re400.exe>`_
+<https://github.com/angr/angr-examples/tree/master/examples/whitehatvn2015_re400/re400.exe>`_
 and the `script
-<https://github.com/angr/angr-doc/tree/master/examples/whitehatvn2015_re400/solve.py>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/whitehatvn2015_re400/solve.py>`_.
 
 ReverseMe example: EKOPARTY CTF 2015 - rev 100
 ----------------------------------------------
@@ -139,9 +129,9 @@ This is a painful challenge to solve with angr. I should have done things in a
 smarter way.
 
 Here is the `binary
-<https://github.com/angr/angr-doc/tree/master/examples/ekopartyctf2015_rev100/counter>`_
+<https://github.com/angr/angr-examples/tree/master/examples/ekopartyctf2015_rev100/counter>`_
 and the `script
-<https://github.com/angr/angr-doc/tree/master/examples/ekopartyctf2015_rev100/solve.py>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/ekopartyctf2015_rev100/solve.py>`_.
 
 ReverseMe example: ASIS CTF Finals 2015 - fake
 ----------------------------------------------
@@ -153,9 +143,9 @@ Script runtime: 1 min 57 sec
 The solution is pretty straight-forward.
 
 The `binary
-<https://github.com/angr/angr-doc/tree/master/examples/asisctffinals2015_fake/fake>`_
+<https://github.com/angr/angr-examples/tree/master/examples/asisctffinals2015_fake/fake>`_
 and the `script
-<https://github.com/angr/angr-doc/tree/master/examples/asisctffinals2015_fake/solve.py>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/asisctffinals2015_fake/solve.py>`_.
 
 ReverseMe example: Defcamp CTF Qualification 2015 - Reversing 100
 -----------------------------------------------------------------
@@ -165,9 +155,9 @@ Author: Fish Wang (github: @ltfish)
 angr solves this challenge with almost zero user-interference.
 
 See the `script
-<https://github.com/angr/angr-doc/tree/master/examples/defcamp_r100/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/defcamp_r100/solve.py>`_
 and the `binary
-<https://github.com/angr/angr-doc/tree/master/examples/defcamp_r100/r100>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/defcamp_r100/r100>`_.
 
 ReverseMe example: Defcamp CTF Qualification 2015 - Reversing 200
 -----------------------------------------------------------------
@@ -178,9 +168,9 @@ angr solves this challenge with almost zero user-interference. Veritesting is
 required to retrieve the flag promptly.
 
 The `script
-<https://github.com/angr/angr-doc/tree/master/examples/defcamp_r200/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/defcamp_r200/solve.py>`_
 and the `binary
-<https://github.com/angr/angr-doc/tree/master/examples/defcamp_r200/r200>`_. It
+<https://github.com/angr/angr-examples/tree/master/examples/defcamp_r200/r200>`_. It
 takes a few minutes to run on my laptop.
 
 ReverseMe example: MMA CTF 2015 - HowToUse
@@ -190,9 +180,9 @@ Author: Audrey Dutcher (github: @rhelmot)
 
 We solved this simple reversing challenge with angr, since we were too lazy to
 reverse it or run it in Windows. The resulting `script
-<https://github.com/angr/angr-doc/tree/master/examples/mma_howtouse/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/mma_howtouse/solve.py>`_
 shows how we grabbed the flag out of the `DLL
-<https://github.com/angr/angr-doc/tree/master/examples/mma_howtouse/howtouse.dll>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/mma_howtouse/howtouse.dll>`_.
 
 CrackMe example: MMA CTF 2015 - SimpleHash
 ------------------------------------------
@@ -201,10 +191,10 @@ Author: Chris Salls (github: @salls)
 
 This crackme is 95% solvable with angr, but we did have to overcome some
 difficulties. The `script
-<https://github.com/angr/angr-doc/tree/master/examples/mma_simplehash/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/mma_simplehash/solve.py>`_
 describes the difficulties that were encountered and how we worked around them.
 The binary can be found `here
-<https://github.com/angr/angr-doc/tree/master/examples/mma_simplehash/simple_hash>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/mma_simplehash/simple_hash>`_.
 
 ReverseMe example: FlareOn 2015 - Challenge 10
 ----------------------------------------------
@@ -215,7 +205,7 @@ angr acts as a binary loader and an emulator in solving this challenge. I didn't
 have to load the driver onto my Windows box.
 
 The `script
-<https://github.com/angr/angr-doc/tree/master/examples/flareon2015_10/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/flareon2015_10/solve.py>`_
 demonstrates how to hook at arbitrary program points without affecting the
 intended bytes to be executed (a zero-length hook). It also shows how to read
 bytes out of memory and decode as a string.
@@ -230,10 +220,10 @@ ReverseMe example: FlareOn 2015 - Challenge 2
 Author: Chris Salls (github: @salls)
 
 This `reversing challenge
-<https://github.com/angr/angr-doc/tree/master/examples/flareon2015_2/very_success>`_
+<https://github.com/angr/angr-examples/tree/master/examples/flareon2015_2/very_success>`_
 is simple to solve almost entirely with angr, and a lot faster than trying to
 reverse the password checking function. The script is `here
-<https://github.com/angr/angr-doc/tree/master/examples/flareon2015_2/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/flareon2015_2/solve.py>`_
 
 ReverseMe example: 0ctf 2016 - momo
 -----------------------------------
@@ -244,9 +234,9 @@ This challenge is a `movfuscated <https://github.com/xoreaxeaxeax/movfuscator>`_
 binary. To find the correct password after exploring the binary with Qira it is
 possible to understand how to find the places in the binary where every
 character is checked using capstone and using angr to load the `binary
-<https://github.com/angr/angr-doc/blob/master/examples/0ctf_momo_3/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/0ctf_momo_3/solve.py>`_
 and brute-force the single characters of the flag. Be aware that the `script
-<https://github.com/angr/angr-doc/blob/master/examples/0ctf_momo_3/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/0ctf_momo_3/solve.py>`_
 is really slow. Runtime: > 1 hour.
 
 CrackMe example: 9447 CTF 2015 - Reversing 330, "nobranch"
@@ -258,9 +248,9 @@ angr cannot currently solve this problem natively, as the problem is too complex
 for z3 to solve. Formatting the constraints to z3 a little differently allows z3
 to come up with an answer relatively quickly. (I was asleep while it was
 solving, so I don't know exactly how long!) The script for this is `here
-<https://github.com/angr/angr-doc/tree/master/examples/9447_nobranch/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/9447_nobranch/solve.py>`_
 and the binary is `here
-<https://github.com/angr/angr-doc/tree/master/examples/9447_nobranch/nobranch>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/9447_nobranch/nobranch>`_.
 
 CrackMe example: ais3_crackme
 -----------------------------
@@ -276,7 +266,7 @@ ReverseMe: Modern Binary Exploitation - CSCI 4968
 Author: David Manouchehri (GitHub `@Manouchehri <https://github.com/Manouchehri>`_\ )
 
 `This folder
-<https://github.com/angr/angr-doc/tree/master/examples/CSCI-4968-MBE/challenges>`_
+<https://github.com/angr/angr-examples/tree/master/examples/CSCI-4968-MBE/challenges>`_
 contains scripts used to solve some of the challenges with angr. At the moment
 it only contains the examples from the IOLI crackme suite, but eventually other
 solutions will be added.
@@ -285,10 +275,10 @@ CrackMe example: Android License Check
 --------------------------------------
 
 Author: Bernhard Mueller (GitHub `@b-mueller
-<https://github.com/angr/angr-doc/tree/master/examples/>`_\ )
+<https://github.com/angr/angr-examples/tree/master/examples/>`_\ )
 
 A `native binary for Android/ARM
-<https://github.com/angr/angr-doc/tree/master/examples/android_arm_license_validation>`_
+<https://github.com/angr/angr-examples/tree/master/examples/android_arm_license_validation>`_
 that validates a license key passed as a command line argument. It was created
 for the symbolic execution tutorial in the `OWASP Mobile Testing Guide
 <https://github.com/OWASP/owasp-mstg/>`_.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -29,7 +29,7 @@ This is a basic script that explains how to use angr to symbolically execute a
 program and produce concrete input satisfying certain conditions.
 
 Binary, source, and script are found `here.
-<https://github.com/angr/angr-doc/tree/master/examples/fauxware>`_
+<https://github.com/angr/angr-examples/tree/master/examples/fauxware>`_
 
 Reversing
 ---------
@@ -54,9 +54,9 @@ be found at the b01lers github `here
 <https://github.com/b01lers/b01lers-ctf-2020/tree/master/rev/100_little_engine>`_.
 
 The angr solution script is `here
-<https://github.com/angr/angr-doc/tree/master/examples/b01lersctf2020_little_engine/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/b01lersctf2020_little_engine/solve.py>`_
 and the binary is `here
-<https://github.com/angr/angr-doc/tree/master/examples/b01lersctf2020_little_engine/engine>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/b01lersctf2020_little_engine/engine>`_.
 
 Whitehat CTF 2015 - Crypto 400
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,9 +73,9 @@ Since angr cannot solve the actual crypto part of the challenge, we use it just
 to reduce the keyspace, and brute-force the rest.
 
 You can find this script `here
-<https://github.com/angr/angr-doc/tree/master/examples/whitehat_crypto400/solve.py>`_
+<https://github.com/angr/angr-examples/tree/master/examples/whitehat_crypto400/solve.py>`_
 and the binary `here
-<https://github.com/angr/angr-doc/tree/master/examples/whitehat_crypto400/whitehat_crypto400>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/whitehat_crypto400/whitehat_crypto400>`_.
 
 CSAW CTF 2015 Quals - Reversing 500, "wyvern"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,9 +88,9 @@ CSAW CTF 2015 Quals - Reversing 500, "wyvern"
 
 angr can outright solve this challenge with very little assistance from the
 user. The script to do so is `here
-<https://github.com/angr/angr-doc/tree/master/examples/csaw_wyvern/solve.py>_`
+<https://github.com/angr/angr-examples/tree/master/examples/csaw_wyvern/solve.py>_`
 and the binary is `here
-<https://github.com/angr/angr-doc/tree/master/examples/csaw_wyvern/wyvern>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/csaw_wyvern/wyvern>`_.
 
 TUMCTF 2016 - zwiebel
 ^^^^^^^^^^^^^^^^^^^^^
@@ -114,9 +114,9 @@ The long-term goal of optimizing angr is to execute this script within 10
 minutes. Pretty ambitious :P
 
 Here is the `binary
-<https://github.com/angr/angr-doc/tree/master/examples/tumctf2016_zwiebel/zwiebel>`_
+<https://github.com/angr/angr-examples/tree/master/examples/tumctf2016_zwiebel/zwiebel>`_
 and the `script
-<https://github.com/angr/angr-doc/tree/master/examples/tumctf2016_zwiebel/solve.py>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/tumctf2016_zwiebel/solve.py>`_.
 
 FlareOn 2015 - Challenge 5
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -128,7 +128,7 @@ FlareOn 2015 - Challenge 5
    Concepts presented: Windows support
 
 This is another `reversing challenge
-<https://github.com/angr/angr-doc/tree/master/examples/flareon2015_5/sender>`_
+<https://github.com/angr/angr-examples/tree/master/examples/flareon2015_5/sender>`_
 from the FlareOn challenges.
 
 "The challenge is designed to teach you about PCAP file parsing and traffic
@@ -166,7 +166,7 @@ somehow.
 angr easily solves this problem. We only have to direct it to the right
 direction at every branch, and the solver finds the flag at a glance.
 
-Files are `here <https://github.com/angr/angr-doc/tree/master/examples/0ctf_trace>`_.
+Files are `here <https://github.com/angr/angr-examples/tree/master/examples/0ctf_trace>`_.
 
 ASIS CTF Finals 2015 - license
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,9 +182,9 @@ read operations of the flag file, we actually pass in a filesystem with the
 correct file created.
 
 Here is the `binary
-<https://github.com/angr/angr-doc/tree/master/examples/asisctffinals2015_license/license>`_
+<https://github.com/angr/angr-examples/tree/master/examples/asisctffinals2015_license/license>`_
 and the `script
-<https://github.com/angr/angr-doc/tree/master/examples/asisctffinals2015_license/solve.py>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/asisctffinals2015_license/solve.py>`_.
 
 DEFCON Quals 2017 - Crackme2000
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ DEFCON Quals 2017 - Crackme2000
 
 DEFCON Quals had a whole category for automatic reversing in 2017. Our scripts
 are `here
-<https:////github.com/angr/angr-doc/tree/master/examples/defcon2017quals_crackme2000>`_.
+<https:////github.com/angr/angr-examples/tree/master/examples/defcon2017quals_crackme2000>`_.
 
 Vulnerability Discovery
 -----------------------
@@ -220,9 +220,9 @@ hit the right path, angr has to solve for a password argument, but angr solved
 this in less than 2 seconds on my machine using the standard Python interpreter.
 The script might look large, but that's only because I've heavily commented it
 to be more helpful to beginners. The challenge binary is `here
-<https://github.com/angr/angr-doc/tree/master/examples/strcpy_find/strcpy_test>`_
+<https://github.com/angr/angr-examples/tree/master/examples/strcpy_find/strcpy_test>`_
 and the script is `here
-<https://github.com/angr/angr-doc/tree/master/examples/strcpy_find/solve.py>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/strcpy_find/solve.py>`_.
 
 CGC crash identification
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -239,7 +239,7 @@ Challenge: `link
 The binary can run in the DECREE VM: `link
 <http://repo.cybergrandchallenge.com/boxes/>`_ A copy of the original challenge
 and the angr solution is provided `here
-<https://github.com/angr/angr-doc/tree/master/examples/CADET_00001>`_
+<https://github.com/angr/angr-examples/tree/master/examples/CADET_00001>`_
 CADET_00001.adapted (by Jacopo Corbetta) is the same program, modified to be
 runnable in an Intel x86 Linux machine.
 
@@ -254,9 +254,9 @@ Grub "back to 28" bug
 This is the demonstration presented at 32c3. The script uses angr to discover
 the input to crash grub's password entry prompt.
 
-`script <https://github.com/angr/angr-doc/tree/master/examples/grub/solve.py>`_ -
+`script <https://github.com/angr/angr-examples/tree/master/examples/grub/solve.py>`_ -
 `vulnerable module
-<https://github.com/angr/angr-doc/tree/master/examples/grub/crypto.mod>`_
+<https://github.com/angr/angr-examples/tree/master/examples/grub/crypto.mod>`_
 
 Exploitation
 ------------
@@ -274,7 +274,7 @@ Insomnihack Simple AEG
 Demonstration for Insomni'hack 2016.  The script is a very simple implementation
 of AEG.
 
-`script <https://github.com/angr/angr-doc/tree/master/examples/insomnihack_aeg/solve.py>`_
+`script <https://github.com/angr/angr-examples/tree/master/examples/insomnihack_aeg/solve.py>`_
 
 SecuInside 2016 Quals - mbrainfuzz - symbolic exploration for exploitability conditions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -294,7 +294,7 @@ executed. angr is used to find the way through the binary to the memcpy() and to
 generate valid inputs to every checking function individually.
 
 The sample binaries and the script are located `here
-<https://github.com/angr/angr-doc/tree/master/examples/secuinside2016mbrainfuzz>`_
+<https://github.com/angr/angr-examples/tree/master/examples/secuinside2016mbrainfuzz>`_
 and additional information be found at the author's `Write-Up
 <https://tasteless.eu/post/2016/07/secuinside-mbrainfuzz/>`_.
 
@@ -314,6 +314,6 @@ removed the checks from the binary, used angrop to build the ropchains, and
 instrumented them with the inputs to pass the checks.
 
 The various challenge files are located `here
-<https://github.com/angr/angr-doc/tree/master/examples/secconquals2016_ropsynth>`_,
+<https://github.com/angr/angr-examples/tree/master/examples/secconquals2016_ropsynth>`_,
 with the actual solve script `here
-<https://github.com/angr/angr-doc/tree/master/examples/secconquals2016_ropsynth/solve.py>`_.
+<https://github.com/angr/angr-examples/tree/master/examples/secconquals2016_ropsynth/solve.py>`_.


### PR DESCRIPTION
While here fix the text for `baby-re` after the scripts were merged in angr/angr-examples@58ce4b1