### PR TITLE
Enable ARMEL as a concrete target

### DIFF
--- a/angr/project.py
+++ b/angr/project.py
@@ -180,7 +180,7 @@ class Project:
             )
             raise Exception("Incompatible options for the project")
 
-        if self.concrete_target and self.arch.name not in ["X86", "AMD64", "ARMHF", "MIPS32"]:
+        if self.concrete_target and self.arch.name not in ["X86", "AMD64", "ARMHF", "ARMEL", "MIPS32"]:
             l.critical("Concrete execution does not support yet the selected architecture. Aborting.")
             raise Exception("Incompatible options for the project")
 


### PR DESCRIPTION
When using PANDA as a backend for concrete execution (https://github.com/angr/angr-targets/pull/29) 32-bit arm binaries seem to work fine so it would be nice if they were allowed here.