### PR TITLE
Type RDA methods as claripy.ast.bv.BV instead of ast.base.Base or ast.BV

### DIFF
--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -488,7 +488,7 @@ class ReachingDefinitionsState:
     def get_values(self, spec: Union[Atom, Definition]) -> Optional[MultiValues]:
         return self.live_definitions.get_values(spec)
 
-    def get_one_value(self, spec: Union[Atom, Definition]) -> Optional[claripy.ast.base.Base]:
+    def get_one_value(self, spec: Union[Atom, Definition]) -> Optional[claripy.ast.bv.BV]:
         return self.live_definitions.get_one_value(spec)
 
     def get_concrete_value(self, spec: Union[Atom, Definition]) -> Optional[int]:

--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -288,7 +288,7 @@ class LiveDefinitions:
                 return True
         return False
 
-    def stack_address(self, offset: int) -> claripy.ast.Base:
+    def stack_address(self, offset: int) -> Optional[claripy.ast.bv.BV]:
         base = claripy.BVS("stack_base", self.arch.bits, explicit_name=True)
         if offset:
             return base + offset
@@ -655,7 +655,7 @@ class LiveDefinitions:
     def get_value_from_definition(self, definition: Definition) -> Optional[MultiValues]:
         return self.get_value_from_atom(definition.atom)
 
-    def get_one_value_from_definition(self, definition: Definition) -> Optional[claripy.ast.base.Base]:
+    def get_one_value_from_definition(self, definition: Definition) -> Optional[claripy.ast.bv.BV]:
         return self.get_one_value_from_atom(definition.atom)
 
     def get_concrete_value_from_definition(self, definition: Definition) -> Optional[int]:
@@ -690,7 +690,7 @@ class LiveDefinitions:
         else:
             return None
 
-    def get_one_value_from_atom(self, atom: Atom) -> Optional[claripy.ast.BV]:
+    def get_one_value_from_atom(self, atom: Atom) -> Optional[claripy.ast.bv.BV]:
         r = self.get_value_from_atom(atom)
         if r is None:
             return None
@@ -710,7 +710,7 @@ class LiveDefinitions:
         else:
             return self.get_value_from_definition(spec)
 
-    def get_one_value(self, spec: Union[Atom, Definition]) -> Optional[claripy.ast.base.Base]:
+    def get_one_value(self, spec: Union[Atom, Definition]) -> Optional[claripy.ast.bv.BV]:
         if isinstance(spec, Atom):
             return self.get_one_value_from_atom(spec)
         else:

--- a/angr/storage/memory_mixins/paged_memory/pages/multi_values.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/multi_values.py
@@ -100,7 +100,7 @@ class MultiValues:
                 for v in remaining_values:
                     self.add_value(offset, v)
 
-    def one_value(self) -> Optional[claripy.ast.BV]:
+    def one_value(self) -> Optional[claripy.ast.bv.BV]:
         if self._single_value is not None:
             return self._single_value
 
@@ -171,7 +171,7 @@ class MultiValues:
             return {0}
         return set() if not self._values else set(self._values.keys())
 
-    def values(self) -> Iterator[Set[claripy.ast.BV]]:
+    def values(self) -> Iterator[Set[claripy.ast.bv.BV]]:
         if self._single_value is not None:
             yield {self._single_value}
         else:
@@ -179,7 +179,7 @@ class MultiValues:
                 return
             yield from self._values.values()
 
-    def items(self) -> Iterator[Tuple[int, Set[claripy.ast.BV]]]:
+    def items(self) -> Iterator[Tuple[int, Set[claripy.ast.bv.BV]]]:
         if self._single_value is not None:
             yield 0, {self._single_value}
         else:


### PR DESCRIPTION
This fixes two minor type annoyances:
1. Some of the RDA methods were typed as returning `Base` but in reality always returned a BV (and often were calling methods that were already typed as returning BV). This becomes an issue because `Base` doesn't define addition so code like `state.get_one_value(...) + 8` doesn't type check
2. Some methods were typed as `claripy.ast.BV` instead of `claripy.ast.bv.BV`. The former is the [lambda stub](https://github.com/angr/claripy/blob/master/claripy/ast/__init__.py#L18) and not the actual class