### PR TITLE
Fix occasional IndexError when synchronizing concrete CLE

### DIFF
--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -177,7 +177,7 @@ class Concrete(SimStatePlugin):
                 # removing version and extension information from the library name
                 cle_mapping_name = re.findall(r"[\w']+", cle_mapping_name)
                 concrete_mapping_name = re.findall(r"[\w']+", concrete_mapping_name)
-                return cle_mapping_name[0] == concrete_mapping_name[0]
+                return (cle_mapping_name[0] == concrete_mapping_name[0]) if len(concrete_mapping_name) else False
 
         l.debug("Synchronizing CLE backend with the concrete process memory mapping")
         try:


### PR DESCRIPTION
If a concrete target returns an empty string for a mapping's name, `concrete_mapping_name` becomes an empty list and this comparison would previously raise an IndexError. Instead of raising an error, we can just say the comparison is False.