### PR TITLE
Fix typed marker file for mypy

### DIFF
--- a/angr/py.typed
+++ b/angr/py.typed
@@ -1,1 +1,1 @@
-PARTIAL
+partial


### PR DESCRIPTION
Ref: https://github.com/pyvista/pyvista/pull/4863

---

Currently, `angr` package is not treated by mypy as a partial typed package due to uppercase `PARTIAL` in `py.typed` file.

https://github.com/python/mypy/blob/c7d2fa1525c9cbf0ab8859fd9ded526658677c28/mypy/modulefinder.py#L439

```python
from mypy.fscache import FileSystemCache
parsed = FileSystemCache().read("py.typed").decode().strip()
parsed == 'partial' #=> `'PARTIAL' == 'partial'` returns `False`
```
