### PR TITLE
Do not remove ternary assignments in block simplifier

### DIFF
--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -3,8 +3,8 @@ import logging
 from typing import Optional, Union, Type, Iterable, Tuple, Set, TYPE_CHECKING
 
 from ailment.statement import Statement, Assignment, Call, Store, Jump
-from ailment.expression import Expression, Tmp, Load, Const, Register, Convert, ITE
-from ailment import AILBlockWalker
+from ailment.expression import Expression, Tmp, Load, Const, Register, Convert
+from ailment import AILBlockWalker, AILBlockWalkerBase
 
 from angr.code_location import ExternalCodeLocation
 
@@ -24,6 +24,24 @@ if TYPE_CHECKING:
 
 
 _l = logging.getLogger(name=__name__)
+
+
+class HasCallExprWalker(AILBlockWalkerBase):
+    """
+    Test if an expression contains a call expression inside.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.has_call_expr = False
+
+    def _handle_Call(self, stmt_idx: int, stmt: Call, block: Optional["Block"]):  # pylint:disable=unused-argument
+        self.has_call_expr = True
+
+    def _handle_CallExpr(  # pylint:disable=unused-argument
+        self, expr_idx: int, expr: Call, stmt_idx: int, stmt: Statement, block: Optional["Block"]
+    ):
+        self.has_call_expr = True
 
 
 class BlockSimplifier(Analysis):
@@ -338,9 +356,13 @@ class BlockSimplifier(Analysis):
                     if stmt.dst.tmp_idx not in used_tmps:
                         continue
 
-                # dead assignments involving ternary expressions are not removed since they execute code
-                if idx in dead_defs_stmt_idx and not isinstance(stmt.src, ITE):
-                    continue
+                # is it a dead virgin?
+                if idx in dead_defs_stmt_idx:
+                    # does .src involve any Call expressions? if so, we cannot remove it
+                    walker = HasCallExprWalker()
+                    walker.walk_expression(stmt.src)
+                    if not walker.has_call_expr:
+                        continue
 
                 if stmt.src == stmt.dst:
                     continue

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -332,14 +332,14 @@ class BlockSimplifier(Analysis):
 
         # Remove dead assignments
         for idx, stmt in enumerate(block.statements):
-            # dead assignments involving ternary expressions are not removed since they execute code
-            if type(stmt) is Assignment and not isinstance(stmt.src, ITE):
+            if type(stmt) is Assignment:
+                # tmps can't execute new code
                 if type(stmt.dst) is Tmp:
                     if stmt.dst.tmp_idx not in used_tmps:
                         continue
 
-                # is it a dead virgin?
-                if idx in dead_defs_stmt_idx:
+                # dead assignments involving ternary expressions are not removed since they execute code
+                if idx in dead_defs_stmt_idx and not isinstance(stmt.src, ITE):
                     continue
 
                 if stmt.src == stmt.dst:

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional, Union, Type, Iterable, Tuple, Set, TYPE_CHECKING
 
 from ailment.statement import Statement, Assignment, Call, Store, Jump
-from ailment.expression import Expression, Tmp, Load, Const, Register, Convert
+from ailment.expression import Expression, Tmp, Load, Const, Register, Convert, ITE
 from ailment import AILBlockWalker
 
 from angr.code_location import ExternalCodeLocation
@@ -332,7 +332,8 @@ class BlockSimplifier(Analysis):
 
         # Remove dead assignments
         for idx, stmt in enumerate(block.statements):
-            if type(stmt) is Assignment:
+            # dead assignments involving ternary expressions are not removed since they execute code
+            if type(stmt) is Assignment and not isinstance(stmt.src, ITE):
                 if type(stmt.dst) is Tmp:
                     if stmt.dst.tmp_idx not in used_tmps:
                         continue


### PR DESCRIPTION
Original:
```c
int print_only_size(unsigned long a0)
{
    char v0;  // [bp-0x2a8]
    char *v2;  // rdi

    if (a0 != -1)
        v2 = human_readable(a0, &v0, human_output_opts, 0x1, output_block_size);
    else
        v2 = dcgettext(NULL, "Infinity", 0x5);
    fputs_unlocked(v2, stdout);
    return;
}
```
Master version:
```c
int print_only_size(char *a0)
{
    fputs_unlocked(a0, stdout);
    return;
}
```

The ternary has a dead assignment inside it's expression, which causes the entire assignment to be removed. However, dead assignments removal should never consider ITE assignments since they always execute code. 