### PR TITLE
rewrite_ite_expressions: Do not rewrite jump table heads.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1289,7 +1289,7 @@ class Clinic(Analysis):
     def _rewrite_ite_expressions(self, ail_graph):
         cfg = self._cfg
         for block in list(ail_graph):
-            if block.addr in cfg.jump_tables:
+            if cfg is not None and block.addr in cfg.jump_tables:
                 continue
 
             ite_ins_addrs = []

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1287,7 +1287,11 @@ class Clinic(Analysis):
         return graph
 
     def _rewrite_ite_expressions(self, ail_graph):
+        cfg = self._cfg
         for block in list(ail_graph):
+            if block.addr in cfg.jump_tables:
+                continue
+
             ite_ins_addrs = []
             for stmt in block.statements:
                 if isinstance(stmt, ailment.Stmt.Assignment) and isinstance(stmt.src, ailment.Expr.ITE):


### PR DESCRIPTION
This bug is triggered in `TestDecompiler.test_decompiling_libsoap`.