### PR TITLE
Add many workflow

### DIFF
--- a/.github/workflows/many.yml
+++ b/.github/workflows/many.yml
@@ -1,0 +1,48 @@
+name: Test on many python versions
+
+on:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10"]
+        os: ["ubuntu-latest", "macos-latest"]
+    name: Test ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: angr
+      - uses: actions/checkout@v3
+        with:
+          repository: angr/binaries
+          path: binaries
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m venv $HOME/venv
+        name: Create venv
+        shell: bash
+      - run: |
+          source $HOME/venv/bin/activate
+          pip install "setuptools>=59" wheel cffi "unicorn==2.0.1.post1"
+          pip install git+https://github.com/angr/archinfo.git
+          pip install git+https://github.com/angr/pyvex.git
+          pip install git+https://github.com/angr/cle.git
+          pip install git+https://github.com/angr/claripy.git
+          pip install git+https://github.com/angr/ailment.git
+        name: Install dependencies
+      - run: |
+          source $HOME/venv/bin/activate
+          pip install --no-build-isolation ./angr[testing]
+        name: Install angr
+      - run: |
+          source $HOME/venv/bin/activate
+          pytest -n auto angr
+        name: Run pytest
+        env:
+          SKIP_SLOW_TESTS: true

--- a/.github/workflows/many.yml
+++ b/.github/workflows/many.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10"]
         os: ["ubuntu-latest", "macos-latest"]
+      fail-fast: false
     name: Test ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This is a workflow to just to run angr's tests on everything we expect to pass. I have it running on `pull_request` here, but when merged I intend to just limit it to `workflow_dispatch` and `workflow_call`. This should be run on occasion, especially using newer python versions, to detect any incompatibilities with newer versions (such as 3.12).