### PR TITLE
Decompiler: Properly decompile functions with long cascading data flows.

### DIFF
--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -268,13 +268,13 @@ class AILSimplifier(Analysis):
                             tags["reg_name"] = self.project.arch.translate_register_name(
                                 def_.atom.reg_offset, size=to_size
                             )
+                            tags["write_size"] = stmt.dst.size
                             new_assignment_dst = Register(
                                 stmt.dst.idx,
                                 None,
                                 def_.atom.reg_offset,
                                 to_size * self.project.arch.byte_width,
                                 **tags,
-                                write_size=stmt.dst.size,
                             )
                             new_assignment_src = Convert(
                                 stmt.src.idx,  # FIXME: This is a hack

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -415,7 +415,7 @@ class AILSimplifier(Analysis):
                                 use_expr_1.op,
                                 [new_use_expr_1_operands[0], new_use_expr_1_operands[1]],
                                 use_expr_1.signed,
-                                bits=use_expr_1.bits,
+                                bits=to_size * 8,
                                 floating_point=use_expr_1.floating_point,
                                 rounding_mode=use_expr_1.rounding_mode,
                                 **use_expr_1.tags,
@@ -426,7 +426,7 @@ class AILSimplifier(Analysis):
                                 the_block, {use_loc: {use_expr_2: use_expr_2.operand}}
                             )
                             # then replace use_expr_1
-                            if r and other_operand is not new_other_operand:
+                            if r:
                                 r, new_block = BlockSimplifier._replace_and_build(
                                     new_block, {use_loc: {use_expr_1: new_use_expr_1}}
                                 )

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -1047,15 +1047,16 @@ class AILSimplifier(Analysis):
                 # check if any atoms that the call relies on has been overwritten by statements in between the def site
                 # and the use site.
                 defsite_all_expr_uses = set(rd.all_uses.get_uses_by_location(the_def.codeloc))
-                defsite_defs_per_atom = defaultdict(set)
+                defsite_used_atoms = set()
                 for dd in defsite_all_expr_uses:
-                    defsite_defs_per_atom[dd.atom].add(dd)
+                    defsite_used_atoms.add(dd.atom)
                 usesite_expr_def_outdated = False
-                for defsite_expr_atom, defsite_expr_uses in defsite_defs_per_atom.items():
+                for defsite_expr_atom in defsite_used_atoms:
                     usesite_expr_uses = set(rd.get_defs(defsite_expr_atom, u, OP_BEFORE))
                     if not usesite_expr_uses:
                         # the atom is not defined at the use site - it's fine
                         continue
+                    defsite_expr_uses = set(rd.get_defs(defsite_expr_atom, the_def.codeloc, OP_BEFORE))
                     if usesite_expr_uses != defsite_expr_uses:
                         # special case: ok if this atom is assigned to at the def site and has not been overwritten
                         if len(usesite_expr_uses) == 1:

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -415,17 +415,17 @@ class AILSimplifier(Analysis):
                                 new_other_operand = Convert(
                                     None, use_expr_2.from_bits, use_expr_2.to_bits, False, other_operand
                                 )
-                                # first remove the old conversion
-                                r, new_block = BlockSimplifier._replace_and_build(
-                                    the_block, {use_loc: {use_expr_2: use_expr_2.operand}}
-                                )
-                                if r:
-                                    r, new_block = BlockSimplifier._replace_and_build(
-                                        new_block, {use_loc: {other_operand: new_other_operand}}
-                                    )
                             else:
-                                r = True
-                                new_block = the_block
+                                # Some operations, like Sar and Shl, have operands with different sizes
+                                new_other_operand = other_operand
+                            # first remove the old conversion
+                            r, new_block = BlockSimplifier._replace_and_build(
+                                the_block, {use_loc: {use_expr_2: use_expr_2.operand}}
+                            )
+                            if r and other_operand is not new_other_operand:
+                                r, new_block = BlockSimplifier._replace_and_build(
+                                    new_block, {use_loc: {other_operand: new_other_operand}}
+                                )
                             if r:
                                 r, new_block = BlockSimplifier._replace_and_build(
                                     new_block, {use_loc: {use_expr_0: new_use_expr_0}}

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -510,7 +510,11 @@ class AILSimplifier(Analysis):
                     return 2, ("mask", (first_op, second_op)) if second_op is not None else ("mask", (first_op,))
                 if mask == 0xFFFF_FFFF:
                     return 4, ("mask", (first_op, second_op)) if second_op is not None else ("mask", (first_op,))
-            if (first_op.operands[0] is expr or first_op.operands[1] is expr) and isinstance(second_op, Convert):
+            if (
+                (first_op.operands[0] is expr or first_op.operands[1] is expr)
+                and isinstance(second_op, Convert)
+                and second_op.from_bits == expr.bits
+            ):
                 return min(expr.bits, second_op.to_bits) // self.project.arch.byte_width, (
                     "binop-convert",
                     (expr, first_op, second_op),

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -803,6 +803,16 @@ class AILSimplifier(Analysis):
                     # only when all uses are determined by the same definition will we continue with the simplification
                     continue
 
+                # one more check: there can be at most one assignment in all these use locations
+                assignment_ctr = 0
+                for use_loc, used_expr in all_uses:
+                    block = addr_and_idx_to_block[(use_loc.block_addr, use_loc.block_idx)]
+                    stmt = block.statements[use_loc.stmt_idx]
+                    if isinstance(stmt, Assignment):
+                        assignment_ctr += 1
+                if assignment_ctr > 1:
+                    continue
+
                 all_uses_with_def = {(to_replace_def, use_and_expr) for use_and_expr in all_uses}
 
                 remove_initial_assignment = False  # expression folding will take care of it

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -296,7 +296,10 @@ class BlockSimplifier(Analysis):
         # Find dead assignments
         dead_defs_stmt_idx = set()
         all_defs: Iterable["Definition"] = rd.all_definitions
-        stackarg_offsets = {tpl[1] for tpl in self._stack_arg_offsets} if self._stack_arg_offsets is not None else None
+        mask = (1 << self.project.arch.bits) - 1
+        stackarg_offsets = (
+            {(tpl[1] & mask) for tpl in self._stack_arg_offsets} if self._stack_arg_offsets is not None else None
+        )
         for d in all_defs:
             if isinstance(d.codeloc, ExternalCodeLocation) or d.dummy:
                 continue
@@ -304,7 +307,7 @@ class BlockSimplifier(Analysis):
                 if not self._remove_dead_memdefs:
                     # we always remove definitions for stack arguments
                     if stackarg_offsets is not None and isinstance(d.atom.addr, atoms.SpOffset):
-                        if d.atom.addr.offset not in stackarg_offsets:
+                        if (d.atom.addr.offset & mask) not in stackarg_offsets:
                             continue
                     else:
                         continue

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -172,6 +172,8 @@ class BlockSimplifier(Analysis):
         return sum(1 for stmt in block.statements if not (isinstance(stmt, Jump) and isinstance(stmt.target, Const)))
 
     def _simplify_block_once(self, block):
+        block = self._peephole_optimize(block)
+
         nonconstant_stmts = self._count_nonconstant_statements(block)
         has_propagatable_assignments = self._has_propagatable_assignments(block)
 
@@ -381,6 +383,7 @@ class BlockSimplifier(Analysis):
         # expressions are updated in place
         peephole_optimize_exprs(block, self._expr_peephole_opts)
 
+        # run statement-level optimizations
         statements, stmts_updated = peephole_optimize_stmts(block, self._stmt_peephole_opts)
 
         if not stmts_updated:

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -266,7 +266,7 @@ class BlockSimplifier(Analysis):
 
         if stmts_to_remove:
             stmt_ids_to_remove = {a.stmt_idx for a in stmts_to_remove}
-            all_stmts = dict((idx, stmt) for idx, stmt in enumerate(new_statements) if idx not in stmt_ids_to_remove)
+            all_stmts = {idx: stmt for idx, stmt in enumerate(new_statements) if idx not in stmt_ids_to_remove}
             filtered_stmts = sorted(all_stmts.items(), key=lambda x: x[0])
             new_statements = [stmt for _, stmt in filtered_stmts]
 

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -154,6 +154,7 @@ class BlockSimplifier(Analysis):
                     stack_pointer_tracker=self._stack_pointer_tracker,
                     observe_all=False,
                     observe_callback=observe_callback,
+                    func_addr=self.func_addr,
                 )
                 .model
             )

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -523,7 +523,7 @@ class Clinic(Analysis):
         if type(block_node) is not BlockNode:
             return block_node
 
-        block = self.project.factory.block(block_node.addr, block_node.size)
+        block = self.project.factory.block(block_node.addr, block_node.size, cross_insn_opt=False)
 
         ail_block = ailment.IRSBConverter.convert(block.vex, self._ail_manager)
         return ail_block

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -63,6 +63,7 @@ class Clinic(Analysis):
         must_struct: Optional[Set[str]] = None,
         variable_kb=None,
         reset_variable_names=False,
+        rewrite_ites_to_diamonds=True,
         cache: Optional["DecompilationCache"] = None,
     ):
         if not func.normalized:
@@ -89,6 +90,7 @@ class Clinic(Analysis):
         self.peephole_optimizations = peephole_optimizations
         self._must_struct = must_struct
         self._reset_variable_names = reset_variable_names
+        self._rewrite_ites_to_diamonds = rewrite_ites_to_diamonds
         self.reaching_definitions: Optional[ReachingDefinitionsAnalysis] = None
         self._cache = cache
 
@@ -176,7 +178,8 @@ class Clinic(Analysis):
         self._convert_all()
 
         ail_graph = self._make_ailgraph()
-        self._rewrite_ite_expressions(ail_graph)
+        if self._rewrite_ites_to_diamonds:
+            self._rewrite_ite_expressions(ail_graph)
         self._remove_redundant_jump_blocks(ail_graph)
         if self._insert_labels:
             self._insert_block_labels(ail_graph)

--- a/angr/analyses/decompiler/decompilation_options.py
+++ b/angr/analyses/decompiler/decompilation_options.py
@@ -67,6 +67,16 @@ options = [
         default_value=False,
     ),
     O(
+        "Rewrite ITE expressions into diamond-shaped control-flow regions",
+        "Rewrite ITE expressions into diamond-shaped control-flow regions, which usually result in better decompilation"
+        " output.",
+        bool,
+        "clinic",
+        "rewrite_ites_to_diamonds",
+        category="Graph",
+        default_value=True,
+    ),
+    O(
         "Leave the largest loop successor tree outside the loop region",
         "During region identification, treating the largest successor tree of a loop as a member of the loop body "
         "sometimes leads to seemingly unnatural and gigantic loops. Enabling this option will treat such successor "

--- a/angr/analyses/decompiler/expression_counters.py
+++ b/angr/analyses/decompiler/expression_counters.py
@@ -1,0 +1,40 @@
+from typing import Optional, Any, DefaultDict, Tuple
+from collections import defaultdict
+
+from ailment.expression import Expression, Register
+from ailment.statement import Statement
+from ailment.block_walker import AILBlockWalkerBase
+from ailment import Block
+
+
+class SingleExpressionCounter(AILBlockWalkerBase):
+    """
+    Count the occurrence of subexpr in expr.
+    """
+
+    def __init__(self, stmt, subexpr):
+        super().__init__()
+        self.subexpr = subexpr
+        self.count = 0
+        self.walk_statement(stmt)
+
+    def _handle_expr(
+        self, expr_idx: int, expr: Expression, stmt_idx: int, stmt: Optional[Statement], block: Optional[Block]
+    ) -> Any:
+        if expr == self.subexpr:
+            self.count += 1
+        return super()._handle_expr(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class RegisterExpressionCounter(AILBlockWalkerBase):
+    """
+    Count the occurrence of all register expressions in expr
+    """
+
+    def __init__(self, expr):
+        super().__init__()
+        self.counts: DefaultDict[Tuple[int, int], int] = defaultdict(int)
+        self.walk_expression(expr)
+
+    def _handle_Register(self, expr_idx: int, expr: Register, stmt_idx: int, stmt: Statement, block: Optional[Block]):
+        self.counts[expr.reg_offset, expr.size] += 1

--- a/angr/analyses/decompiler/expression_counters.py
+++ b/angr/analyses/decompiler/expression_counters.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, DefaultDict, Tuple, Union
+from typing import Optional, Any, DefaultDict, Tuple, Union, Iterable, Set
 from collections import defaultdict
 
 from ailment.expression import Expression, Register
@@ -31,10 +31,15 @@ class RegisterExpressionCounter(AILBlockWalkerBase):
     Count the occurrence of all register expressions in expr
     """
 
-    def __init__(self, expr):
+    def __init__(self, expr_or_stmt: Union[Expression, Statement]):
         super().__init__()
         self.counts: DefaultDict[Tuple[int, int], int] = defaultdict(int)
-        self.walk_expression(expr)
+        if isinstance(expr_or_stmt, Expression):
+            self.walk_expression(expr_or_stmt)
+        elif isinstance(expr_or_stmt, Statement):
+            self.walk_statement(expr_or_stmt)
+        else:
+            raise TypeError(f"Unsupported argument type {type(expr_or_stmt)}")
 
     def _handle_Register(self, expr_idx: int, expr: Register, stmt_idx: int, stmt: Statement, block: Optional[Block]):
         self.counts[expr.reg_offset, expr.size] += 1
@@ -45,10 +50,10 @@ class OperatorCounter(AILBlockWalkerBase):
     Count the occurrence of a given expression operator.
     """
 
-    def __init__(self, operator: str, expr_or_stmt: Union[Expression, Statement]):
+    def __init__(self, operator: Union[str, Iterable[str]], expr_or_stmt: Union[Expression, Statement]):
         super().__init__()
         self.count = 0
-        self.operator = operator
+        self.operators: Set[str] = {operator} if isinstance(operator, str) else set(operator)
         if isinstance(expr_or_stmt, Expression):
             self.walk_expression(expr_or_stmt)
         elif isinstance(expr_or_stmt, Statement):
@@ -57,11 +62,11 @@ class OperatorCounter(AILBlockWalkerBase):
             raise TypeError(f"Unsupported argument type {type(expr_or_stmt)}")
 
     def _handle_BinaryOp(self, expr_idx: int, expr: "BinaryOp", stmt_idx: int, stmt: Statement, block: Optional[Block]):
-        if expr.op == self.operator:
+        if expr.op in self.operators:
             self.count += 1
         return super()._handle_BinaryOp(expr_idx, expr, stmt_idx, stmt, block)
 
     def _handle_UnaryOp(self, expr_idx: int, expr: "UnaryOp", stmt_idx: int, stmt: Statement, block: Optional[Block]):
-        if expr.op == self.operator:
+        if expr.op in self.operators:
             self.count += 1
         return super()._handle_UnaryOp(expr_idx, expr, stmt_idx, stmt, block)

--- a/angr/analyses/decompiler/expression_counters.py
+++ b/angr/analyses/decompiler/expression_counters.py
@@ -1,10 +1,13 @@
-from typing import Optional, Any, DefaultDict, Tuple, Union, Iterable, Set
+from typing import Optional, Any, DefaultDict, Tuple, Union, Iterable, Set, TYPE_CHECKING
 from collections import defaultdict
 
 from ailment.expression import Expression, Register
 from ailment.statement import Statement
 from ailment.block_walker import AILBlockWalkerBase
 from ailment import Block
+
+if TYPE_CHECKING:
+    from ailment.expression import BinaryOp, UnaryOp
 
 
 class SingleExpressionCounter(AILBlockWalkerBase):

--- a/angr/analyses/decompiler/peephole_optimizations/__init__.py
+++ b/angr/analyses/decompiler/peephole_optimizations/__init__.py
@@ -39,6 +39,7 @@ from .single_bit_cond_to_boolexpr import SingleBitCondToBoolExpr
 from .sar_to_signed_div import SarToSignedDiv
 from .tidy_stack_addr import TidyStackAddr
 from .invert_negated_logical_conjuction_disjunction import InvertNegatedLogicalConjunctionsAndDisjunctions
+from .rol_ror import RolRorRewriter
 
 from .base import PeepholeOptimizationExprBase, PeepholeOptimizationStmtBase
 

--- a/angr/analyses/decompiler/peephole_optimizations/a_div_const_add_a_mul_n_div_const.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_div_const_add_a_mul_n_div_const.py
@@ -9,7 +9,7 @@ class ADivConstAddAMulNDivConst(PeepholeOptimizationExprBase):
     NAME = "a / N0 + (a * N1) / N0 => a * (N1 + 1) / N0"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if expr.op == "Add" and len(expr.operands) == 2:
             op0, op1 = expr.operands
             if isinstance(op0, BinaryOp) and op0.op == "Div" and isinstance(op0.operands[1], Const):

--- a/angr/analyses/decompiler/peephole_optimizations/a_mul_const_div_shr_const.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_mul_const_div_shr_const.py
@@ -9,7 +9,7 @@ class AMulConstDivShrConst(PeepholeOptimizationExprBase):
     NAME = "(A * N0 / N1) >> N2 => (A * (N0 / 2 ** N2) / N1)"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if (
             expr.op == "Shr"
             and len(expr.operands) == 2

--- a/angr/analyses/decompiler/peephole_optimizations/a_shl_const_sub_a.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_shl_const_sub_a.py
@@ -9,7 +9,7 @@ class AShlConstSubA(PeepholeOptimizationExprBase):
     NAME = "(a << N) - a => (a * (2 ** N - 1))"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if (
             expr.op == "Sub"
             and len(expr.operands) == 2

--- a/angr/analyses/decompiler/peephole_optimizations/a_sub_a_div.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_sub_a_div.py
@@ -9,7 +9,7 @@ class ASubADiv(PeepholeOptimizationExprBase):
     NAME = "a - a / N => a * (N - 1) / N"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if expr.op == "Sub" and len(expr.operands) == 2:
             expr0, expr1 = expr.operands
             if isinstance(expr1, BinaryOp) and expr1.op == "Div" and isinstance(expr1.operands[1], Const):

--- a/angr/analyses/decompiler/peephole_optimizations/a_sub_a_div_const_mul_const.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_sub_a_div_const_mul_const.py
@@ -9,7 +9,7 @@ class ASubADivConstMulConst(PeepholeOptimizationExprBase):
     NAME = "a - (a / N) * N => a % N"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if (
             expr.op == "Sub"
             and len(expr.operands) == 2

--- a/angr/analyses/decompiler/peephole_optimizations/a_sub_a_sub_n.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_sub_a_sub_n.py
@@ -9,7 +9,7 @@ class ASubASubN(PeepholeOptimizationExprBase):
     NAME = "expr - (expr - N) => N"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # Sub(A, Sub(A, N)) ==> N
         if expr.op == "Sub" and isinstance(expr.operands[1], BinaryOp) and expr.operands[1].op == "Sub":
             if expr.operands[0] == expr.operands[1].operands[0]:

--- a/angr/analyses/decompiler/peephole_optimizations/arm_cmpf.py
+++ b/angr/analyses/decompiler/peephole_optimizations/arm_cmpf.py
@@ -13,7 +13,7 @@ class ARMCmpF(PeepholeOptimizationExprBase):
     NAME = "Simplifying CmpF on ARM"
     expr_classes = (Convert,)  # all expressions are allowed
 
-    def optimize(self, expr: Convert):
+    def optimize(self, expr: Convert, **kwargs):
         # CmpF values
         # - 0x45 Unordered
         # - 0x01 LT

--- a/angr/analyses/decompiler/peephole_optimizations/base.py
+++ b/angr/analyses/decompiler/peephole_optimizations/base.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
-from ailment.expression import BinaryOp, UnaryOp
+from ailment.expression import BinaryOp, UnaryOp, Expression
+from ailment.statement import Assignment
+from ailment import Block
 from angr.project import Project
 from angr.knowledge_base import KnowledgeBase
 
@@ -61,6 +63,16 @@ class PeepholeOptimizationExprBase:
     #
     # Util methods
     #
+
+    @staticmethod
+    def find_definition(ail_expr: Expression, stmt_idx: int, block: Block) -> None:
+        idx = stmt_idx - 1
+        if idx >= 0:
+            stmt = block.statements[idx]
+            if isinstance(stmt, Assignment):
+                if stmt.dst.likes(ail_expr):
+                    return stmt.src
+        return None
 
     @staticmethod
     def is_bool_expr(ail_expr):

--- a/angr/analyses/decompiler/peephole_optimizations/base.py
+++ b/angr/analyses/decompiler/peephole_optimizations/base.py
@@ -28,7 +28,7 @@ class PeepholeOptimizationStmtBase:
         self.kb = kb
         self.func_addr = func_addr
 
-    def optimize(self, stmt):
+    def optimize(self, stmt, stmt_idx: int = None, block=None, **kwargs):
         raise NotImplementedError("_optimize() is not implemented.")
 
 
@@ -55,7 +55,7 @@ class PeepholeOptimizationExprBase:
         self.kb = kb
         self.func_addr = func_addr
 
-    def optimize(self, expr):
+    def optimize(self, expr, **kwargs):
         raise NotImplementedError("_optimize() is not implemented.")
 
     #

--- a/angr/analyses/decompiler/peephole_optimizations/basepointeroffset_add_n.py
+++ b/angr/analyses/decompiler/peephole_optimizations/basepointeroffset_add_n.py
@@ -9,7 +9,7 @@ class BasePointerOffsetAddN(PeepholeOptimizationExprBase):
     NAME = "(Ptr - M) + N => Ptr - (M - N)"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if (
             expr.op in ("Add", "Sub")
             and isinstance(expr.operands[0], BasePointerOffset)

--- a/angr/analyses/decompiler/peephole_optimizations/basepointeroffset_and_mask.py
+++ b/angr/analyses/decompiler/peephole_optimizations/basepointeroffset_and_mask.py
@@ -9,7 +9,7 @@ class BasePointerOffsetAndMask(PeepholeOptimizationExprBase):
     NAME = "Ptr & mask => Ptr"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if expr.op == "And" and isinstance(expr.operands[0], BasePointerOffset) and isinstance(expr.operands[1], Const):
             # is it a mask?
             mask = expr.operands[1].value

--- a/angr/analyses/decompiler/peephole_optimizations/bitwise_or_to_logical_or.py
+++ b/angr/analyses/decompiler/peephole_optimizations/bitwise_or_to_logical_or.py
@@ -16,7 +16,7 @@ class BitwiseOrToLogicalOr(PeepholeOptimizationExprBase):
     NAME = "(a | b) == 0 => (a == 0) && (b == 0) ; (a | b) != 0 => (a != 0) || (b != 0)"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if (
             expr.op in {"CmpEQ", "CmpNE"}
             and isinstance(expr.operands[0], BinaryOp)

--- a/angr/analyses/decompiler/peephole_optimizations/bool_expr_xor_1.py
+++ b/angr/analyses/decompiler/peephole_optimizations/bool_expr_xor_1.py
@@ -9,7 +9,7 @@ class BoolExprXor1(PeepholeOptimizationExprBase):
     NAME = "bool_expr ^ 1 => !bool_expr (a)"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # Conv(1->N, some_bool_expr) ^ 1 ==> Conv(1->N, Not(some_bool_expr))
         if expr.op == "Xor" and isinstance(expr.operands[1], Const) and expr.operands[1].value == 1:
             arg0 = expr.operands[0]

--- a/angr/analyses/decompiler/peephole_optimizations/bswap.py
+++ b/angr/analyses/decompiler/peephole_optimizations/bswap.py
@@ -12,7 +12,7 @@ class Bswap(PeepholeOptimizationExprBase):
     NAME = "Simplifying bswap_16()"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # bswap_16
         #   And(
         #     (

--- a/angr/analyses/decompiler/peephole_optimizations/coalesce_same_cascading_ifs.py
+++ b/angr/analyses/decompiler/peephole_optimizations/coalesce_same_cascading_ifs.py
@@ -10,7 +10,7 @@ class CoalesceSameCascadingIfs(PeepholeOptimizationStmtBase):
     NAME = "Coalescing cascading If constructs"
     stmt_classes = (ConditionalJump,)
 
-    def optimize(self, stmt: ConditionalJump):
+    def optimize(self, stmt: ConditionalJump, stmt_idx: int = None, block=None, **kwargs):
         cond = stmt.condition
 
         # if (cond) {ITE(cond, true_branch, false_branch)} else {} ==> if (cond) {true_branch} else {}

--- a/angr/analyses/decompiler/peephole_optimizations/const_mull_a_shift.py
+++ b/angr/analyses/decompiler/peephole_optimizations/const_mull_a_shift.py
@@ -16,7 +16,7 @@ class ConstMullAShift(PeepholeOptimizationExprBase):
     NAME = "Conv(64->32, (N * a) >> M) => a / N1"
     expr_classes = (Convert, BinaryOp)
 
-    def optimize(self, expr: Union[Convert, BinaryOp]):
+    def optimize(self, expr: Union[Convert, BinaryOp], **kwargs):
         r = None
 
         if isinstance(expr, Convert):

--- a/angr/analyses/decompiler/peephole_optimizations/constant_derefs.py
+++ b/angr/analyses/decompiler/peephole_optimizations/constant_derefs.py
@@ -13,7 +13,7 @@ class ConstantDereferences(PeepholeOptimizationExprBase):
     NAME = "Dereference constant references"
     expr_classes = (Load,)
 
-    def optimize(self, expr: Load):
+    def optimize(self, expr: Load, **kwargs):
         if isinstance(expr.addr, Const):
             # is it loading from a read-only section?
             sec = self.project.loader.find_section_containing(expr.addr.value)

--- a/angr/analyses/decompiler/peephole_optimizations/conv_a_sub0_shr_and.py
+++ b/angr/analyses/decompiler/peephole_optimizations/conv_a_sub0_shr_and.py
@@ -9,7 +9,7 @@ class ConvASub0ShrAnd(PeepholeOptimizationExprBase):
     NAME = "Conv(M->1, (expr >> N) & 1) => expr < 0"
     expr_classes = (Convert,)  # all expressions are allowed
 
-    def optimize(self, expr: Convert):
+    def optimize(self, expr: Convert, **kwargs):
         # Conv(M->1, ((expr) >> N) & 1) => expr < 0
         # Conv(M->1, ((expr - 0) >> N) & 1) => expr < 0
         if expr.to_bits == 1:

--- a/angr/analyses/decompiler/peephole_optimizations/conv_shl_shr.py
+++ b/angr/analyses/decompiler/peephole_optimizations/conv_shl_shr.py
@@ -9,7 +9,7 @@ class ConvShlShr(PeepholeOptimizationExprBase):
     NAME = "(expr << P) >> Q => (expr & mask) >> R"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # (Conv(M->N, expr) << P) >> Q  ==>  (Conv(M->N, expr) & bitmask) >> (Q-P), where
         #       Q >= P, and
         #       M < N, and

--- a/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
+++ b/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
@@ -172,6 +172,8 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 return new_expr
 
         elif expr.op == "Or":
+            if isinstance(expr.operands[0], Const) and isinstance(expr.operands[1], Const):
+                return Const(expr.idx, None, expr.operands[0].value | expr.operands[1].value, expr.bits, **expr.tags)
             if isinstance(expr.operands[0], Const) and expr.operands[0].value == 0:
                 return expr.operands[1]
             if isinstance(expr.operands[1], Const) and expr.operands[1].value == 0:

--- a/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
+++ b/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
@@ -15,7 +15,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
     NAME = "Eager expression evaluation"
     expr_classes = (BinaryOp, UnaryOp)
 
-    def optimize(self, expr):
+    def optimize(self, expr, **kwargs):
         if isinstance(expr, BinaryOp):
             return self._optimize_binaryop(expr)
         elif isinstance(expr, UnaryOp):

--- a/angr/analyses/decompiler/peephole_optimizations/extended_byte_and_mask.py
+++ b/angr/analyses/decompiler/peephole_optimizations/extended_byte_and_mask.py
@@ -15,7 +15,7 @@ class ExtendedByteAndMask(PeepholeOptimizationExprBase):
     NAME = "extended byte & 0xff..ff => extended byte"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         #
         if expr.op == "And" and isinstance(expr.operands[1], Const):
             mask = expr.operands[1].value

--- a/angr/analyses/decompiler/peephole_optimizations/invert_negated_logical_conjuction_disjunction.py
+++ b/angr/analyses/decompiler/peephole_optimizations/invert_negated_logical_conjuction_disjunction.py
@@ -13,7 +13,7 @@ class InvertNegatedLogicalConjunctionsAndDisjunctions(PeepholeOptimizationExprBa
     NAME = "!(A && B) => A || B; !(A || B) => A && B"
     expr_classes = (UnaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: UnaryOp):
+    def optimize(self, expr: UnaryOp, **kwargs):
         if expr.op == "Not":
             if isinstance(expr.operand, BinaryOp):
                 if expr.operand.op == "LogicalAnd":

--- a/angr/analyses/decompiler/peephole_optimizations/one_sub_bool.py
+++ b/angr/analyses/decompiler/peephole_optimizations/one_sub_bool.py
@@ -9,7 +9,7 @@ class OneSubBool(PeepholeOptimizationExprBase):
     NAME = "1 - bool_expr => !bool_expr"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # Sub(1, Conv(1->N, some bool expression)) ==> Conv(1->N, Not(some bool expression))
         if (
             expr.op == "Sub"

--- a/angr/analyses/decompiler/peephole_optimizations/remove_cascading_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_cascading_conversions.py
@@ -9,7 +9,7 @@ class RemoveCascadingConversions(PeepholeOptimizationExprBase):
     NAME = "Remove adjacent conversions"
     expr_classes = (Convert,)
 
-    def optimize(self, expr: Convert):
+    def optimize(self, expr: Convert, **kwargs):
         if isinstance(expr.operand, Convert):
             inner = expr.operand
             if inner.from_bits == expr.to_bits:

--- a/angr/analyses/decompiler/peephole_optimizations/remove_empty_if_body.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_empty_if_body.py
@@ -10,7 +10,7 @@ class RemoveEmptyIfBody(PeepholeOptimizationStmtBase):
     NAME = "Remove empty If bodies"
     stmt_classes = (ConditionalJump,)
 
-    def optimize(self, stmt: ConditionalJump):
+    def optimize(self, stmt: ConditionalJump, stmt_idx: int = None, block=None, **kwargs):
         cond = stmt.condition
 
         # if (!cond) {} else { ITE(cond, true_branch, false_branch } ==> if (cond) { ITE(...) } else {}

--- a/angr/analyses/decompiler/peephole_optimizations/remove_noop_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_noop_conversions.py
@@ -10,7 +10,7 @@ class RemoveNoopConversions(PeepholeOptimizationExprBase):
     NAME = "Remove no-op conversions"
     expr_classes = (Convert,)
 
-    def optimize(self, expr: Convert):
+    def optimize(self, expr: Convert, **kwargs):
         if expr.from_bits == expr.to_bits:
             return expr.operand
 

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_bitmasks.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_bitmasks.py
@@ -21,7 +21,7 @@ class RemoveRedundantBitmasks(PeepholeOptimizationExprBase):
     NAME = "Remove redundant bitmasks"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # And(expr, full_N_bitmask) ==> expr
         # And(Conv(1->N, expr), bitmask) ==> Conv(1->N, expr)
         # And(Conv(1->N, bool_expr), bitmask) ==> Conv(1->N, bool_expr)

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
@@ -10,7 +10,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
     NAME = "Remove redundant conversions around binary operators"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # TODO make this lhs/rhs agnostic
         if isinstance(expr.operands[0], Convert):
             # check: is the lhs convert an up-cast and is rhs a const?

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_ite_branch.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_ite_branch.py
@@ -9,7 +9,7 @@ class RemoveRedundantITEBranches(PeepholeOptimizationExprBase):
     NAME = "Remove redundant ITE branches"
     expr_classes = (ITE,)
 
-    def optimize(self, expr: ITE):
+    def optimize(self, expr: ITE, **kwargs):
         # ITE(cond, a, ITE(!cond, b, c)) ==> ITE(cond, a, b)
         if isinstance(expr.iffalse, ITE):
             # cascading ITEs

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_ite_comparisons.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_ite_comparisons.py
@@ -13,7 +13,7 @@ class RemoveRedundantITEComparisons(PeepholeOptimizationExprBase):
     NAME = "Remove redundant ITE comparisons"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # ITE(cond, a, b) == a  ==>  cond
         # ITE(cond, a, b) == b  ==>  !cond
         # ITE(cond, a, b) != a  ==>  !cond

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_nots.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_nots.py
@@ -9,7 +9,7 @@ class RemoveRedundantNots(PeepholeOptimizationExprBase):
     NAME = "Remove redundant Nots"
     expr_classes = (UnaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: UnaryOp):
+    def optimize(self, expr: UnaryOp, **kwargs):
         # Not(Not(expr)) ==> expr
         if expr.op == "Not" and isinstance(expr.operand, UnaryOp) and expr.operand.op == "Not":
             return expr.operand.operand

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_reinterprets.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_reinterprets.py
@@ -15,7 +15,7 @@ class RemoveRedundantReinterprets(PeepholeOptimizationExprBase):
     NAME = "Simplifying nested and constant Reinterprets"
     expr_classes = (Reinterpret,)  # all expressions are allowed
 
-    def optimize(self, expr: Reinterpret):
+    def optimize(self, expr: Reinterpret, **kwargs):
         if isinstance(expr.operand, Reinterpret):
             inner = expr.operand
             if expr.from_type == inner.to_type and expr.to_type == inner.from_type:

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_shifts.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_shifts.py
@@ -9,7 +9,7 @@ class RemoveRedundantShifts(PeepholeOptimizationExprBase):
     NAME = "Remove redundant bitshifts"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # (expr << N) >> N  ==> Convert((M-N)->M, Convert(M->(M-N), expr))
         if expr.op in ("Shr", "Sar") and isinstance(expr.operands[1], Const):
             expr_a = expr.operands[0]

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_shifts_around_comparators.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_shifts_around_comparators.py
@@ -15,7 +15,7 @@ class RemoveRedundantShiftsAroundComparators(PeepholeOptimizationExprBase):
     NAME = "Remove redundant bitshifts for operands around a comparator"
     expr_classes = (BinaryOp,)  # all expressions are allowed
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # (expr_0 << N) < (expr_1 << N)  ==> expr_0 << expr_1
         # FIXME: This optimization is unsafe but seems to work for all existing case
         if expr.op in {"CmpLE", "CmpLT", "CmpEQ", "CmpNE", "CmpGE", "CmpGT"}:

--- a/angr/analyses/decompiler/peephole_optimizations/rewrite_bit_extractions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/rewrite_bit_extractions.py
@@ -15,7 +15,7 @@ class RewriteBitExtractions(PeepholeOptimizationExprBase):
     NAME = "Bit-extraction Rewriter"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if expr.op == "And" and isinstance(expr.operands[1], Const) and expr.operands[1].value == 1:
             raw_expr = expr.operands[0]
             bit_offset = 0

--- a/angr/analyses/decompiler/peephole_optimizations/rewrite_mips_gp_loads.py
+++ b/angr/analyses/decompiler/peephole_optimizations/rewrite_mips_gp_loads.py
@@ -14,7 +14,7 @@ class RewriteMipsGpLoads(PeepholeOptimizationExprBase):
     NAME = "MIPS GP-based Loads Rewriter"
     expr_classes = (Load,)
 
-    def optimize(self, expr: Load):
+    def optimize(self, expr: Load, **kwargs):
         # Load(addr=(gp<8> - 0x7fc0<64>), size=8, endness=Iend_LE) - replace it with gp for this function
         if self.project.arch.name not in {"MIPS32", "MIPS64"}:
             return None

--- a/angr/analyses/decompiler/peephole_optimizations/rol_ror.py
+++ b/angr/analyses/decompiler/peephole_optimizations/rol_ror.py
@@ -1,0 +1,77 @@
+from ailment.statement import Assignment
+from ailment.expression import BinaryOp, Const, Tmp
+
+from .base import PeepholeOptimizationStmtBase
+
+
+class RolRorRewriter(PeepholeOptimizationStmtBase):
+    """
+    Rewrites consecutive statements into ROL (rotate shift left) or ROR (rotate shift right) statements.
+    """
+
+    __slots__ = ()
+
+    NAME = "ROL/ROR rewriter"
+    stmt_classes = (Assignment,)
+
+    def optimize(self, stmt: Assignment, stmt_idx: int = None, block=None, **kwargs):
+        # Rol example:
+        #    61 | t304 = Shr32(t301,0x19)
+        #    62 | t306 = Shl32(t301,0x07)
+        #    63 | t303 = Or32(t306,t304)
+        #
+        # Ror example:
+        #    98 | 0x140002a06 | t453 = (Conv(64->32, r9<8>) << 0x11<8>)
+        #    99 | 0x140002a06 | t455 = (Conv(64->32, r9<8>) >> 0xf<8>)
+        #    100 | 0x140002a06 | t452 = (t455 | t453)
+        if stmt_idx < 2:
+            return None
+        if not (isinstance(stmt.src, BinaryOp) and stmt.src.op == "Or"):
+            return None
+
+        op0, op1 = stmt.src.operands
+        if not (isinstance(op0, Tmp) and isinstance(op1, Tmp)):
+            return None
+        # check the previous two instructions
+        stmt_1 = block.statements[stmt_idx - 1]
+        stmt_2 = block.statements[stmt_idx - 2]
+        if not (isinstance(stmt_1, Assignment) and isinstance(stmt_1.src, BinaryOp)):
+            return None
+        if not (isinstance(stmt_2, Assignment) and isinstance(stmt_2.src, BinaryOp)):
+            return None
+
+        if not isinstance(stmt_1.dst, Tmp):
+            return None
+        if not isinstance(stmt_2.dst, Tmp):
+            return None
+
+        if {stmt_1.dst.tmp_idx, stmt_2.dst.tmp_idx} != {op0.tmp_idx, op1.tmp_idx}:
+            return None
+
+        stmt1_op0, stmt1_op1 = stmt_1.src.operands
+        stmt2_op0, stmt2_op1 = stmt_2.src.operands
+
+        if not (stmt1_op0.likes(stmt2_op0)):
+            return None
+
+        if not (isinstance(stmt1_op1, Const) and isinstance(stmt2_op1, Const)):
+            return None
+
+        if stmt_1.src.op == "Shl" and stmt_2.src.op == "Shr" and stmt1_op1.value + stmt2_op1.value == stmt.dst.bits:
+            new_stmt = Assignment(
+                stmt.idx,
+                stmt.dst,
+                BinaryOp(None, "Rol", [stmt1_op0, stmt1_op1], False, bits=stmt.dst.bits, **stmt_1.src.tags),
+                **stmt.tags,
+            )
+            return new_stmt
+        elif stmt_1.src.op == "Shr" and stmt_2.src.op == "Shl" and stmt1_op1.value + stmt2_op1.value == stmt.dst.bits:
+            new_stmt = Assignment(
+                stmt.idx,
+                stmt.dst,
+                BinaryOp(None, "Ror", [stmt1_op0, stmt1_op1], False, bits=stmt.dst.bits, **stmt_1.src.tags),
+                **stmt.tags,
+            )
+            return new_stmt
+
+        return None

--- a/angr/analyses/decompiler/peephole_optimizations/sar_to_signed_div.py
+++ b/angr/analyses/decompiler/peephole_optimizations/sar_to_signed_div.py
@@ -1,5 +1,5 @@
 from typing import Optional, Tuple
-from ailment.expression import Convert, BinaryOp, Const, ITE, Expression
+from ailment.expression import Convert, BinaryOp, Const, ITE, Expression, Register
 
 from .base import PeepholeOptimizationExprBase
 
@@ -14,16 +14,23 @@ class SarToSignedDiv(PeepholeOptimizationExprBase):
     NAME = "(signed(expr)? expr + A ** 2 - 1: expr) >>s A => expr /s 2 ** A"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, stmt_idx: int = None, block=None):
         if expr.op == "Sar":
             if isinstance(expr.operands[1], Const):
                 op0, const = expr.operands
+
+                if isinstance(op0, Register) and stmt_idx is not None and block is not None:
+                    # look back by one statement to find its definition
+                    op0 = self.find_definition(op0, stmt_idx, block)
+                    # TODO: Ensure the new op0 does not have any expressions that overlap with the old op0 (a register)
+
                 const_value = const.value
                 conv = None
                 if isinstance(op0, Convert):
                     # unpack it
                     conv = op0
                     op0 = op0.operand
+
                 if isinstance(op0, ITE):
                     r = self._check_signedness(op0.cond)
                     if r is not None:

--- a/angr/analyses/decompiler/peephole_optimizations/sar_to_signed_div.py
+++ b/angr/analyses/decompiler/peephole_optimizations/sar_to_signed_div.py
@@ -11,7 +11,7 @@ class SarToSignedDiv(PeepholeOptimizationExprBase):
 
     __slots__ = ()
 
-    NAME = "(signed(expr)? expr + A ** 2 - 1: expr) <<s A => expr /s 2 ** A"
+    NAME = "(signed(expr)? expr + A ** 2 - 1: expr) >>s A => expr /s 2 ** A"
     expr_classes = (BinaryOp,)
 
     def optimize(self, expr: BinaryOp):

--- a/angr/analyses/decompiler/peephole_optimizations/simplify_pc_relative_loads.py
+++ b/angr/analyses/decompiler/peephole_optimizations/simplify_pc_relative_loads.py
@@ -14,7 +14,7 @@ class SimplifyPcRelativeLoads(PeepholeOptimizationExprBase):
     NAME = "Simplify PC-relative loads"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         # Load(addr) + pc ==> Const()
         if expr.op == "Add" and len(expr.operands) == 2 and isinstance(expr.operands[0], Load):
             op0, op1 = expr.operands

--- a/angr/analyses/decompiler/peephole_optimizations/single_bit_cond_to_boolexpr.py
+++ b/angr/analyses/decompiler/peephole_optimizations/single_bit_cond_to_boolexpr.py
@@ -13,7 +13,7 @@ class SingleBitCondToBoolExpr(PeepholeOptimizationExprBase):
     NAME = "Convert single-bit conditions to bool expressions (== 0 or == 1)"
     expr_classes = (ITE,)
 
-    def optimize(self, expr: ITE):
+    def optimize(self, expr: ITE, **kwargs):
         if isinstance(expr.cond, Convert) and expr.cond.to_bits == 1 and expr.cond.from_bits > 1:
             cond_inner = expr.cond.operand
             if isinstance(cond_inner, BinaryOp):

--- a/angr/analyses/decompiler/peephole_optimizations/single_bit_xor.py
+++ b/angr/analyses/decompiler/peephole_optimizations/single_bit_xor.py
@@ -9,7 +9,7 @@ class SingleBitXor(PeepholeOptimizationExprBase):
     NAME = "bool_expr ^ 1 => !bool_expr (b)"
     expr_classes = (Convert,)
 
-    def optimize(self, expr: Convert):
+    def optimize(self, expr: Convert, **kwargs):
         # Convert(N->1, (Convert(1->N, t_x) ^ 0x1<N>) ==> Not(t_x)
         if expr.to_bits == 1:
             xor_expr = expr.operand

--- a/angr/analyses/decompiler/peephole_optimizations/tidy_stack_addr.py
+++ b/angr/analyses/decompiler/peephole_optimizations/tidy_stack_addr.py
@@ -18,7 +18,7 @@ class TidyStackAddr(PeepholeOptimizationExprBase):
     NAME = "Tidy stack addresses"
     expr_classes = (BinaryOp,)
 
-    def optimize(self, expr: BinaryOp):
+    def optimize(self, expr: BinaryOp, **kwargs):
         if expr.op not in ("Add", "Sub"):
             return None
 

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1753,6 +1753,8 @@ class CBinaryOp(CExpression):
             "CmpEQ": self._c_repr_chunks_cmpeq,
             "CmpNE": self._c_repr_chunks_cmpne,
             "Concat": self._c_repr_chunks_concat,
+            "Rol": self._c_repr_chunks_rol,
+            "Ror": self._c_repr_chunks_ror,
         }
 
         handler = OP_MAP.get(self.op, None)
@@ -1865,6 +1867,24 @@ class CBinaryOp(CExpression):
 
     def _c_repr_chunks_concat(self):
         yield from self._c_repr_chunks(" CONCAT ")
+
+    def _c_repr_chunks_rol(self):
+        yield "__ROL__", self
+        paren = CClosingObject("(")
+        yield "(", paren
+        yield from self._try_c_repr_chunks(self.lhs)
+        yield ", ", None
+        yield from self._try_c_repr_chunks(self.rhs)
+        yield ")", paren
+
+    def _c_repr_chunks_ror(self):
+        yield "__ROR__", self
+        paren = CClosingObject("(")
+        yield "(", paren
+        yield from self._try_c_repr_chunks(self.lhs)
+        yield ", ", None
+        yield from self._try_c_repr_chunks(self.rhs)
+        yield ")", paren
 
 
 class CTypeCast(CExpression):

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -511,14 +511,14 @@ def peephole_optimize_stmts(block, stmt_opts):
     statements = []
 
     # run statement optimizers
-    for stmt in block.statements:
+    for stmt_idx, stmt in enumerate(block.statements):
         old_stmt = stmt
         redo = True
         while redo:
             redo = False
             for opt in stmt_opts:
                 if isinstance(stmt, opt.stmt_classes):
-                    r = opt.optimize(stmt)
+                    r = opt.optimize(stmt, stmt_idx=stmt_idx, block=block)
                     if r is not None and r is not stmt:
                         stmt = r
                         redo = True

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -452,7 +452,7 @@ def peephole_optimize_exprs(block, expr_opts):
             redo = False
             for expr_opt in expr_opts:
                 if isinstance(expr, expr_opt.expr_classes):
-                    r = expr_opt.optimize(expr)
+                    r = expr_opt.optimize(expr, stmt_idx=stmt_idx, block=block)
                     if r is not None and r is not expr:
                         expr = r
                         redo = True

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -480,6 +480,10 @@ class SimEnginePropagatorAIL(
                                     isinstance(stmt, Stmt.Assignment)
                                     and isinstance(stmt.dst, Expr.Register)
                                     and stmt.dst.size == expr.size
+                                    and all_subexprs[0].likes(stmt.src)
+                                    and (
+                                        not self.state._replacements or reg_def.codeloc not in self.state._replacements
+                                    )
                                 ):
                                     # ok we are getting rid of the original statement
                                     outdated = False

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -359,15 +359,15 @@ class SimEnginePropagatorAIL(
                 sb_offset = self._stack_pointer_tracker.offset_before(self.ins_addr, self.arch.sp_offset)
                 if sb_offset is not None:
                     new_expr = Expr.StackBaseOffset(None, self.arch.bits, sb_offset)
-                    self.state.add_replacement(self._codeloc(), expr, new_expr)
+                    self.state.add_replacement(self._codeloc(), expr, new_expr, bp_as_gpr=self.bp_as_gpr)
                     return PropValue.from_value_and_details(
                         self.sp_offset(expr.bits, sb_offset), expr.size, new_expr, self._codeloc()
                     )
-            elif expr.reg_offset == self.arch.bp_offset:
+            elif expr.reg_offset == self.arch.bp_offset and not self.bp_as_gpr:
                 sb_offset = self._stack_pointer_tracker.offset_before(self.ins_addr, self.arch.bp_offset)
                 if sb_offset is not None:
                     new_expr = Expr.StackBaseOffset(None, self.arch.bits, sb_offset)
-                    self.state.add_replacement(self._codeloc(), expr, new_expr)
+                    self.state.add_replacement(self._codeloc(), expr, new_expr, bp_as_gpr=self.bp_as_gpr)
                     return PropValue.from_value_and_details(
                         self.sp_offset(expr.bits, sb_offset), expr.size, new_expr, self._codeloc()
                     )
@@ -498,6 +498,7 @@ class SimEnginePropagatorAIL(
                             subexpr,
                             force_replace=force_replace,
                             stmt_to_remove=stmt_to_remove,
+                            bp_as_gpr=self.bp_as_gpr,
                         )
                 else:
                     is_concatenation, result_expr = _test_concatenation(new_expr)
@@ -510,6 +511,7 @@ class SimEnginePropagatorAIL(
                             result_expr,
                             force_replace=force_replace,
                             stmt_to_remove=stmt_to_remove,
+                            bp_as_gpr=self.bp_as_gpr,
                         )
             elif all_subexprs and None not in all_subexprs and len(all_subexprs) == 1:
                 # if the expression has been replaced before, we should remove previous replacements
@@ -555,7 +557,7 @@ class SimEnginePropagatorAIL(
 
             if not replaced:
                 l.debug("Add a replacement: %s with TOP", expr)
-                self.state.add_replacement(self._codeloc(), expr, self.state.top(expr.bits))
+                self.state.add_replacement(self._codeloc(), expr, self.state.top(expr.bits), bp_as_gpr=self.bp_as_gpr)
             else:
                 return new_expr
 

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -473,7 +473,16 @@ class SimEnginePropagatorAIL(
                             self._assignment_has_unreplaceable_subexprs = True
             elif all_subexprs and None not in all_subexprs and len(all_subexprs) == 1:
                 # if the expression has been replaced before, we should remove previous replacements
-                updated_codelocs = self.state.revert_past_replacements(all_subexprs[0], to_replace=expr)
+                reg_defs = self._reaching_definitions.get_defs(
+                    Register(expr.reg_offset, expr.size), self._codeloc(), OP_BEFORE
+                )
+                if len(reg_defs) == 1:
+                    reg_def = next(iter(reg_defs))
+                else:
+                    reg_def = None
+                updated_codelocs = self.state.revert_past_replacements(
+                    all_subexprs[0], to_replace=expr, to_replace_def=reg_def
+                )
                 # scan through the code locations and recursively remove assignment replacements
                 if self._reaching_definitions is not None:
                     while updated_codelocs:

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -461,7 +461,15 @@ class SimEnginePropagatorAIL(
                     subexpr = all_subexprs[0]
                     if subexpr.size == expr.size:
                         l.debug("Try to add a replacement: %s with %s", expr, subexpr)
-                        replaced = self.state.add_replacement(self._codeloc(), expr, subexpr)
+                        # we always replace the expression if the current statement is an indirect jump. this is to
+                        # ensure the dynamically calculated jump targets are always using the originally defined
+                        # expressions, which usually leads to better decompilation output.
+                        replaced = self.state.add_replacement(
+                            self._codeloc(),
+                            expr,
+                            subexpr,
+                            force_replace=isinstance(self.block.statements[self.stmt_idx], Stmt.Jump),
+                        )
                         if not replaced:
                             self._assignment_has_unreplaceable_subexprs = True
                 else:

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -425,6 +425,8 @@ class SimEnginePropagatorAIL(
 
         stmt_to_remove = None
         if new_expr is not None:
+            has_avoid_ = False
+
             # check if this new_expr uses any expression that has been overwritten
             replaced = False
             outdated = False
@@ -446,7 +448,7 @@ class SimEnginePropagatorAIL(
                 all_subexprs
                 and None not in all_subexprs
                 and len(all_subexprs) == 1
-                and outdated
+                and has_avoid_
                 and self._reaching_definitions is not None
             ):
                 # special case:

--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -481,9 +481,7 @@ class SimEnginePropagatorAIL(
                                     and isinstance(stmt.dst, Expr.Register)
                                     and stmt.dst.size == expr.size
                                     and all_subexprs[0].likes(stmt.src)
-                                    and (
-                                        not self.state._replacements or reg_def.codeloc not in self.state._replacements
-                                    )
+                                    and not self.state.has_replacements_at(reg_def.codeloc)
                                 ):
                                     # ok we are getting rid of the original statement
                                     outdated = False

--- a/angr/analyses/propagator/engine_base.py
+++ b/angr/analyses/propagator/engine_base.py
@@ -18,6 +18,7 @@ class SimEnginePropagatorBase(SimEngineLight):  # pylint:disable=abstract-method
         propagate_tmps=True,
         arch=None,
         reaching_definitions: Optional["ReachingDefinitionsModel"] = None,
+        immediate_stmt_removal: bool = False,
     ):
         super().__init__()
 
@@ -28,6 +29,8 @@ class SimEnginePropagatorBase(SimEngineLight):  # pylint:disable=abstract-method
         self._load_callback = None
         self._propagate_tmps: bool = propagate_tmps
         self._reaching_definitions = reaching_definitions
+        self._immediate_stmt_removal = immediate_stmt_removal
+        self.stmts_to_remove = set()
 
         # Used in the AIL engine
         self._stack_pointer_tracker = stack_pointer_tracker

--- a/angr/analyses/propagator/engine_base.py
+++ b/angr/analyses/propagator/engine_base.py
@@ -35,6 +35,8 @@ class SimEnginePropagatorBase(SimEngineLight):  # pylint:disable=abstract-method
         # Used in the AIL engine
         self._stack_pointer_tracker = stack_pointer_tracker
 
+        self._skip_replacement_registers = None
+
     def process(self, state, *args, **kwargs):
         self.project = kwargs.pop("project", None)
         self.base_state = kwargs.pop("base_state", None)

--- a/angr/analyses/propagator/engine_base.py
+++ b/angr/analyses/propagator/engine_base.py
@@ -19,6 +19,7 @@ class SimEnginePropagatorBase(SimEngineLight):  # pylint:disable=abstract-method
         arch=None,
         reaching_definitions: Optional["ReachingDefinitionsModel"] = None,
         immediate_stmt_removal: bool = False,
+        bp_as_gpr: bool = False,
     ):
         super().__init__()
 
@@ -30,6 +31,7 @@ class SimEnginePropagatorBase(SimEngineLight):  # pylint:disable=abstract-method
         self._propagate_tmps: bool = propagate_tmps
         self._reaching_definitions = reaching_definitions
         self._immediate_stmt_removal = immediate_stmt_removal
+        self.bp_as_gpr = bp_as_gpr
         self.stmts_to_remove = set()
 
         # Used in the AIL engine

--- a/angr/analyses/propagator/engine_base.py
+++ b/angr/analyses/propagator/engine_base.py
@@ -35,7 +35,7 @@ class SimEnginePropagatorBase(SimEngineLight):  # pylint:disable=abstract-method
         # Used in the AIL engine
         self._stack_pointer_tracker = stack_pointer_tracker
 
-        self._skip_replacement_registers = None
+        self._multi_occurrence_registers = None
 
     def process(self, state, *args, **kwargs):
         self.project = kwargs.pop("project", None)

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -152,8 +152,21 @@ class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-
             self, order_jobs=True, allow_merging=True, allow_widening=False, graph_visitor=graph_visitor
         )
 
+        bp_as_gpr = False
+        the_func = None
+        if self._function is not None:
+            the_func = self._function
+        else:
+            if self._func_addr is not None:
+                the_func = self.kb.functions.get_by_addr(self._func_addr)
+        if the_func is not None:
+            bp_as_gpr = the_func.info.get("bp_as_gpr", False)
+
         self._engine_vex = SimEnginePropagatorVEX(
-            project=self.project, arch=self.project.arch, reaching_definitions=self._reaching_definitions
+            project=self.project,
+            arch=self.project.arch,
+            reaching_definitions=self._reaching_definitions,
+            bp_as_gpr=bp_as_gpr,
         )
         self._engine_ail = SimEnginePropagatorAIL(
             arch=self.project.arch,
@@ -162,6 +175,7 @@ class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-
             propagate_tmps=block is not None,
             reaching_definitions=self._reaching_definitions,
             immediate_stmt_removal=self._immediate_stmt_removal,
+            bp_as_gpr=bp_as_gpr,
         )
 
         # optimization: skip state copying for the initial state

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -283,6 +283,7 @@ class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-
 
         if self._immediate_stmt_removal:
             self.stmts_to_remove |= engine.stmts_to_remove
+            engine.stmts_to_remove = set()
 
         self.model.node_iterations[block_key] += 1
         self.model.states[block_key] = state

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -158,7 +158,10 @@ class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-
             the_func = self._function
         else:
             if self._func_addr is not None:
-                the_func = self.kb.functions.get_by_addr(self._func_addr)
+                try:
+                    the_func = self.kb.functions.get_by_addr(self._func_addr)
+                except KeyError:
+                    pass
         if the_func is not None:
             bp_as_gpr = the_func.info.get("bp_as_gpr", False)
 

--- a/angr/analyses/propagator/propagator.py
+++ b/angr/analyses/propagator/propagator.py
@@ -226,6 +226,7 @@ class PropagatorAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-
         cls = PropagatorAILState if isinstance(node, ailment.Block) else PropagatorVEXState
         self._initial_state = cls.initial_state(
             self.project,
+            rda=self._reaching_definitions,
             only_consts=self._only_consts,
             gp=self._gp,
             do_binops=self._do_binops,

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -37,6 +37,7 @@ class SimEngineRDAIL(
         function_handler: Optional[FunctionHandler] = None,
         stack_pointer_tracker=None,
         use_callee_saved_regs_at_return=True,
+        bp_as_gpr: bool = False,
     ):
         super().__init__()
         self.project = project
@@ -45,6 +46,7 @@ class SimEngineRDAIL(
         self._dep_graph = None
         self._stack_pointer_tracker = stack_pointer_tracker
         self._use_callee_saved_regs_at_return = use_callee_saved_regs_at_return
+        self.bp_as_gpr = bp_as_gpr
 
         self._stmt_handlers = {
             ailment.Stmt.Assignment: self._ail_handle_Assignment,
@@ -413,7 +415,7 @@ class SimEngineRDAIL(
                 sb_offset = self._stack_pointer_tracker.offset_before(self.ins_addr, self.arch.sp_offset)
                 if sb_offset is not None:
                     return MultiValues(v=self.state._initial_stack_pointer() + sb_offset)
-            elif reg_offset == self.arch.bp_offset:
+            elif reg_offset == self.arch.bp_offset and not self.bp_as_gpr:
                 sb_offset = self._stack_pointer_tracker.offset_before(self.ins_addr, self.arch.bp_offset)
                 if sb_offset is not None:
                     return MultiValues(v=self.state._initial_stack_pointer() + sb_offset)

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -613,7 +613,7 @@ class SimEngineRDAIL(
 
         return r
 
-    def _ail_handle_Neg(self, expr: ailment.Expr.UnaryOp) -> MultiValues:
+    def _ail_handle_BitwiseNeg(self, expr: ailment.Expr.UnaryOp) -> MultiValues:
         operand: MultiValues = self._expr(expr.operand)
         bits = expr.bits
 
@@ -621,7 +621,7 @@ class SimEngineRDAIL(
         operand_v = operand.one_value()
 
         if operand_v is not None and operand_v.concrete:
-            r = MultiValues(offset_to_values={0: {-operand_v}})
+            r = MultiValues(offset_to_values={0: {~operand_v}})
         else:
             r = MultiValues(offset_to_values={0: {self.state.top(bits)}})
 
@@ -886,6 +886,20 @@ class SimEngineRDAIL(
             r = MultiValues(self.state.top(bits))
 
         return r
+
+    def _ail_handle_Rol(self, expr: ailment.Expr.BinaryOp) -> MultiValues:
+        self._expr(expr.operands[0])
+        self._expr(expr.operands[1])
+        bits = expr.bits
+
+        return MultiValues(self.state.top(bits))
+
+    def _ail_handle_Ror(self, expr: ailment.Expr.BinaryOp) -> MultiValues:
+        self._expr(expr.operands[0])
+        self._expr(expr.operands[1])
+        bits = expr.bits
+
+        return MultiValues(self.state.top(bits))
 
     def _ail_handle_And(self, expr: ailment.Expr.BinaryOp) -> MultiValues:
         expr0: MultiValues = self._expr(expr.operands[0])

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -73,6 +73,7 @@ class ReachingDefinitionsAnalysis(
         use_callee_saved_regs_at_return=True,
         interfunction_level: int = 0,
         track_liveness: bool = True,
+        func_addr: Optional[int] = None,
     ):
         """
         :param subject:                         The subject of the analysis: a function, or a single basic block
@@ -129,6 +130,7 @@ class ReachingDefinitionsAnalysis(
         self._init_state = init_state
         self._canonical_size = canonical_size
         self._use_callee_saved_regs_at_return = use_callee_saved_regs_at_return
+        self._func_addr = func_addr
 
         if dep_graph is None or dep_graph is False:
             self._dep_graph = None
@@ -168,6 +170,16 @@ class ReachingDefinitionsAnalysis(
             track_liveness=track_liveness,
         )
 
+        bp_as_gpr = False
+        the_func = None
+        if isinstance(self.subject.content, Function):
+            the_func = self.subject.content
+        else:
+            if self._func_addr is not None:
+                the_func = self.kb.functions.get_by_addr(self._func_addr)
+        if the_func is not None:
+            bp_as_gpr = the_func.info.get("bp_as_gpr", False)
+
         self._engine_vex = SimEngineRDVEX(
             self.project,
             functions=self.kb.functions,
@@ -178,6 +190,7 @@ class ReachingDefinitionsAnalysis(
             function_handler=self._function_handler,
             stack_pointer_tracker=stack_pointer_tracker,
             use_callee_saved_regs_at_return=self._use_callee_saved_regs_at_return,
+            bp_as_gpr=bp_as_gpr,
         )
 
         self._visited_blocks: Set[Any] = visited_blocks or set()

--- a/angr/analyses/reaching_definitions/reaching_definitions.py
+++ b/angr/analyses/reaching_definitions/reaching_definitions.py
@@ -176,7 +176,10 @@ class ReachingDefinitionsAnalysis(
             the_func = self.subject.content
         else:
             if self._func_addr is not None:
-                the_func = self.kb.functions.get_by_addr(self._func_addr)
+                try:
+                    the_func = self.kb.functions.get_by_addr(self._func_addr)
+                except KeyError:
+                    pass
         if the_func is not None:
             bp_as_gpr = the_func.info.get("bp_as_gpr", False)
 

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -46,6 +46,12 @@ class SimEngineVRAIL(
             data = self._expr(stmt.src)
             size = stmt.src.bits // 8
 
+            if hasattr(stmt.dst, "write_size") and stmt.dst.write_size > size:
+                # zero-fill this register
+                self._assign_to_register(
+                    offset, RichR(self.state.top(stmt.dst.write_size * 8)), stmt.dst.write_size, create_variable=False
+                )
+
             self._assign_to_register(offset, data, size, src=stmt.src, dst=stmt.dst)
 
         elif dst_type is ailment.Expr.Tmp:
@@ -604,6 +610,26 @@ class SimEngineVRAIL(
         r = self.state.top(expr.bits)
         return RichR(r, typevar=r0.typevar)
 
+    def _ail_handle_Rol(self, expr):
+        arg0, arg1 = expr.operands
+
+        r0 = self._expr(arg0)
+        _ = self._expr(arg1)
+        result_size = arg0.bits
+
+        r = self.state.top(result_size)
+        return RichR(r, typevar=r0.typevar)
+
+    def _ail_handle_Ror(self, expr):
+        arg0, arg1 = expr.operands
+
+        r0 = self._expr(arg0)
+        _ = self._expr(arg1)
+        result_size = arg0.bits
+
+        r = self.state.top(result_size)
+        return RichR(r, typevar=r0.typevar)
+
     def _ail_handle_Concat(self, expr):
         arg0, arg1 = expr.operands
 
@@ -638,6 +664,22 @@ class SimEngineVRAIL(
         if expr.data.concrete:
             return RichR(
                 -expr.data,
+                typevar=typeconsts.int_type(result_size),
+                type_constraints=None,
+            )
+
+        r = self.state.top(result_size)
+        return RichR(r, typevar=expr.typevar)
+
+    def _ail_handle_BitwiseNeg(self, expr):
+        arg = expr.operands[0]
+        expr = self._expr(arg)
+
+        result_size = arg.bits
+
+        if expr.data.concrete:
+            return RichR(
+                ~expr.data,
                 typevar=typeconsts.int_type(result_size),
                 type_constraints=None,
             )

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -451,6 +451,8 @@ class VariableRecoveryFast(ForwardAnalysis, VariableRecoveryBase):  # pylint:dis
         pass
 
     def _post_analysis(self):
+        VariableRecoveryBase._post_analysis(self)
+
         self.variable_manager["global"].assign_variable_names(labels=self.kb.labels)
         self.variable_manager[self.function.addr].assign_variable_names()
 

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -1216,6 +1216,30 @@ class SimEngineLightAILMixin(SimEngineLightMixin):
     def _ail_handle_Sal(self, expr):
         return self._ail_handle_Shl(expr)
 
+    def _ail_handle_Rol(self, expr):
+        arg0, arg1 = expr.operands
+        expr_0 = self._expr(arg0)
+        expr_1 = self._expr(arg1)
+
+        if expr_0 is None:
+            expr_0 = arg0
+        if expr_1 is None:
+            expr_1 = arg1
+
+        return ailment.Expr.BinaryOp(expr.idx, "Rol", [expr_0, expr_1], expr.signed, **expr.tags)
+
+    def _ail_handle_Ror(self, expr):
+        arg0, arg1 = expr.operands
+        expr_0 = self._expr(arg0)
+        expr_1 = self._expr(arg1)
+
+        if expr_0 is None:
+            expr_0 = arg0
+        if expr_1 is None:
+            expr_1 = arg1
+
+        return ailment.Expr.BinaryOp(expr.idx, "Ror", [expr_0, expr_1], expr.signed, **expr.tags)
+
     def _ail_handle_Sar(self, expr):
         arg0, arg1 = expr.operands
         expr_0 = self._expr(arg0)
@@ -1259,10 +1283,21 @@ class SimEngineLightAILMixin(SimEngineLightMixin):
         if data is None:
             return None
 
-        try:
-            return ~data  # pylint:disable=invalid-unary-operand-type
-        except TypeError:
-            return ailment.Expr.UnaryOp(expr.idx, "Not", data, **expr.tags)
+        return ailment.Expr.UnaryOp(expr.idx, "Not", data, **expr.tags)
+
+    def _ail_handle_Neg(self, expr):
+        data = self._expr(expr.operand)
+        if data is None:
+            return None
+
+        return ailment.Expr.UnaryOp(expr.idx, "Neg", data, **expr.tags)
+
+    def _ail_handle_BitwiseNeg(self, expr):
+        data = self._expr(expr.operand)
+        if data is None:
+            return None
+
+        return ailment.Expr.UnaryOp(expr.idx, "BitwiseNeg", data, **expr.tags)
 
 
 # Compatibility

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -754,6 +754,7 @@ class PropagatorAILState(PropagatorState):
         new,
         force_replace: bool = False,
         stmt_to_remove: Optional[CodeLocation] = None,
+        bp_as_gpr: bool = False,
     ) -> bool:
         if self._only_consts:
             if self.is_const_or_register(new) or self.is_top(new):
@@ -788,7 +789,7 @@ class PropagatorAILState(PropagatorState):
             if (
                 isinstance(old, ailment.Expr.Tmp)
                 or isinstance(old, ailment.Expr.Register)
-                and old.reg_offset in {self.arch.sp_offset, self.arch.bp_offset}
+                and (old.reg_offset == self.arch.sp_offset or (not bp_as_gpr and old.reg_offset == self.arch.bp_offset))
             ):
                 self._replacements[codeloc][old] = new
                 replaced = True

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -200,6 +200,14 @@ class PropagatorState:
 
         :return:            Whether merging has happened or not.
         """
+
+        def _get_repl_size(repl_value: Union[Dict, ailment.Expression, claripy.ast.Bits]) -> int:
+            if isinstance(repl_value, dict):
+                return _get_repl_size(repl_value["expr"])
+            if isinstance(repl_value, ailment.Expression):
+                return repl_value.bits
+            return repl_value.size()
+
         merge_occurred = False
         for loc, vars_ in replacements_1.items():
             if loc not in replacements_0:
@@ -212,7 +220,7 @@ class PropagatorState:
                         merge_occurred = True
                     else:
                         if PropagatorState.is_top(repl) or PropagatorState.is_top(replacements_0[loc][var]):
-                            t = PropagatorState.top(repl.bits if isinstance(repl, ailment.Expression) else repl.size())
+                            t = PropagatorState.top(_get_repl_size(repl))
                             replacements_0[loc][var] = t
                             merge_occurred = True
                         elif (

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -787,7 +787,7 @@ class PropagatorAILState(PropagatorState):
         else:
             prop_count = 0
             def_ = None
-            if isinstance(old, ailment.Expr.Tmp) and isinstance(new, ailment.Expr.Const):
+            if isinstance(old, ailment.Expr.Tmp) or isinstance(new, ailment.Expr.Const):
                 # we always propagate tmp and constants
                 pass
             else:

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -275,6 +275,15 @@ class PropagatorState:
     def filter_replacements(self):
         pass
 
+    def has_replacements_at(self, codeloc: CodeLocation) -> bool:
+        if not self._replacements:
+            return False
+        if codeloc not in self._replacements:
+            return False
+        if all(self.is_top(replaced_by) for replaced_by in self._replacements[codeloc].values()):
+            return False
+        return True
+
 
 # VEX state
 

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -805,12 +805,13 @@ class PropagatorAILState(PropagatorState):
 
     def revert_past_replacements(self, replaced_by, to_replace=None) -> Set[CodeLocation]:
         updated_codelocs = set()
-        for codeloc_ in self._expr_used_locs[replaced_by]:
-            for key, replace_with in list(self.model.replacements[codeloc_].items()):
-                if not self.is_top(replace_with) and replace_with == replaced_by:
-                    if to_replace is None or to_replace.likes(key):
-                        self.model.replacements[codeloc_][key] = self.top(1)
-                        updated_codelocs.add(codeloc_)
+        if self.model.replacements is not None:
+            for codeloc_ in self._expr_used_locs[replaced_by]:
+                for key, replace_with in list(self.model.replacements[codeloc_].items()):
+                    if not self.is_top(replace_with) and replace_with == replaced_by:
+                        if to_replace is None or to_replace.likes(key):
+                            self.model.replacements[codeloc_][key] = self.top(1)
+                            updated_codelocs.add(codeloc_)
 
         for codeloc_ in self._replacements:
             for key, replace_with in list(self._replacements[codeloc_].items()):

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -14,6 +14,7 @@ from angr.engines.light.engine import SimEngineLight
 from angr.code_location import CodeLocation
 from angr.knowledge_plugins.key_definitions import atoms
 from angr.knowledge_plugins.key_definitions.constants import OP_BEFORE
+from angr.engines.light.data import SpOffset
 
 from .prop_value import PropValue, Detail
 
@@ -794,6 +795,12 @@ class PropagatorAILState(PropagatorState):
                 if self.rda is not None:
                     if isinstance(old, ailment.Expr.Register):
                         defs = self.rda.get_defs(atoms.Register(old.reg_offset, old.size), codeloc, OP_BEFORE)
+                        if len(defs) == 1:
+                            def_ = next(iter(defs))
+                    elif isinstance(old, ailment.Expr.Load) and isinstance(old.addr, ailment.Expr.StackBaseOffset):
+                        defs = self.rda.get_defs(
+                            atoms.MemoryLocation(SpOffset(old.addr.bits, old.addr.offset), old.size), codeloc, OP_BEFORE
+                        )
                         if len(defs) == 1:
                             def_ = next(iter(defs))
                     if def_ is not None:

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -247,7 +247,7 @@ class PropagatorState:
     def init_replacements(self):
         self._replacements = defaultdict(dict)
 
-    def add_replacement(self, codeloc, old: CodeLocation, new) -> bool:
+    def add_replacement(self, codeloc: CodeLocation, old, new, force_replace: bool = False) -> bool:
         """
         Add a replacement record: Replacing expression `old` with `new` at program location `codeloc`.
         If the self._only_consts flag is set to true, only constant values will be set.
@@ -746,7 +746,7 @@ class PropagatorAILState(PropagatorState):
         prop_value = PropValue.from_value_and_labels(value, labels)
         return prop_value
 
-    def add_replacement(self, codeloc: CodeLocation, old, new) -> bool:
+    def add_replacement(self, codeloc: CodeLocation, old, new, force_replace: bool = False) -> bool:
         if self._only_consts:
             if self.is_const_or_register(new) or self.is_top(new):
                 pass
@@ -808,7 +808,8 @@ class PropagatorAILState(PropagatorState):
                     prop_count = len(self._expr_used_locs[new])
 
             if (  # pylint:disable=too-many-boolean-expressions
-                prop_count <= self._max_prop_expr_occurrence
+                force_replace
+                or prop_count <= self._max_prop_expr_occurrence
                 or isinstance(new, ailment.Expr.StackBaseOffset)
                 or isinstance(new, ailment.Expr.Convert)
                 and isinstance(new.operand, ailment.Expr.StackBaseOffset)

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1388,8 +1388,8 @@ class TestDecompiler(unittest.TestCase):
         assert "+1" not in line_0
 
         # make sure v % 7 is present
-        line_mod_7 = [line for line in lines if re.search(r"v\d+ % 7", line)]
-        assert len(line_mod_7) == 2
+        line_mod_7 = [line for line in lines if re.search(r"[^v]*v\d+[)]* % 7", line)]
+        assert len(line_mod_7) == 1
 
         # make sure all "connection_infos" are followed by a square bracket
         # we don't allow bizarre expressions like (&connection_infos)[1234]...

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1406,6 +1406,8 @@ class TestDecompiler(unittest.TestCase):
         cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
 
         f = proj.kb.functions["put_space"]
+        assert f.info.get("bp_as_gpr", False) is True
+
         proj.analyses.VariableRecoveryFast(f)
         cca = proj.analyses.CallingConvention(f)
         f.prototype = cca.prototype

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3113,6 +3113,9 @@ class TestDecompiler(unittest.TestCase):
             ror_count += line.count("__ROR__")
             count = line.count("__ROL__") + line.count("__ROR__")
             assert count <= 1
+
+            assert "tmp" not in line
+            assert "..." not in line
         assert rol_count == 44
         assert ror_count == 20
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3071,9 +3071,9 @@ class TestDecompiler(unittest.TestCase):
         lines = lines[func_starting_line:]
         end_of_variable_list_line = [idx for idx, line in enumerate(lines) if not line.strip(" ")][0]
         lines = lines[end_of_variable_list_line + 1 :]
-        # the first line of the code should be an if statement. all other variables should have been eliminated by
+        # the second line of the code should be an if statement. all other variables should have been eliminated by
         # proper propagation
-        assert lines[0].strip(" ").startswith("if (")
+        assert lines[1].strip(" ").startswith("if (")
 
     @structuring_algo("phoenix")
     def test_decompiling_incorrect_duplication_chcon_main(self, decompiler_options=None):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2523,7 +2523,7 @@ class TestDecompiler(unittest.TestCase):
         self._print_decompilation_result(d)
 
         assert "default:" in d.codegen.text
-        assert "case 1:" in d.codegen.text
+        assert "case 49:" in d.codegen.text
         assert "case 50:" not in d.codegen.text
         assert "case 51:" not in d.codegen.text
         assert "case 52:" not in d.codegen.text

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1234,9 +1234,9 @@ class TestDecompiler(unittest.TestCase):
         assert len(stmts) == 5
         assert stmts[1].lhs.unified_variable == stmts[0].rhs.unified_variable
         assert stmts[3].lhs.unified_variable == stmts[2].rhs.unified_variable
-        assert stmts[4].lhs.operand.expr.variable == stmts[2].lhs.variable
-        assert stmts[4].rhs.operand.expr.variable == stmts[0].lhs.variable
-        assert dw.condition.lhs.operand.expr.variable == stmts[2].lhs.variable
+        assert stmts[4].lhs.operand.variable == stmts[2].lhs.variable
+        assert stmts[4].rhs.operand.variable == stmts[0].lhs.variable
+        assert dw.condition.lhs.operand.variable == stmts[2].lhs.variable
 
     @for_all_structuring_algos
     def test_decompiling_nl_i386_pie(self, decompiler_options=None):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2052,9 +2052,6 @@ class TestDecompiler(unittest.TestCase):
 
         f = proj.kb.functions["main"]
 
-        # enable rewrite_ites_to_diamonds
-        set_decompiler_option(decompiler_options, [("rewrite_ites_to_diamonds", False)])
-
         d = proj.analyses[Decompiler].prep()(f, cfg=cfg.model, options=decompiler_options)
         self._print_decompilation_result(d)
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2052,6 +2052,9 @@ class TestDecompiler(unittest.TestCase):
 
         f = proj.kb.functions["main"]
 
+        # enable rewrite_ites_to_diamonds
+        set_decompiler_option(decompiler_options, [("rewrite_ites_to_diamonds", False)])
+
         d = proj.analyses[Decompiler].prep()(f, cfg=cfg.model, options=decompiler_options)
         self._print_decompilation_result(d)
 


### PR DESCRIPTION
Fixed many bugs:

- Handle a few corner cases in Propagator (AIL engine) where expressions are propagated when they should not have been.
- Enable `track_tmps` in getting RDA result in AILSimplifier.
- Clinic now uses no-cross-insn-opt VEX blocks.
- Add a peephole optimizer to recognize ROL and ROR operations.
- Fix a bug in expression narrowing where only the lower half of registers are written after narrowing, leading to incorrectly identified variables.
- Support one more case in expression narrowing.
- Support one more case in expression copy propagation and dead assignment elimination.