### PR TITLE
CFGBase: Check if the node is None or not before calling in_edges().

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1549,15 +1549,17 @@ class CFGBase(Analysis):
             function.mark_nonreturning_calls_endpoints()
             if function.returning is False:
                 # remove all FakeRet edges that are related to this function
-                callsite_nodes = [
-                    src
-                    for src, _, data in self.graph.in_edges(self.model.get_any_node(function.addr), data=True)
-                    if data.get("jumpkind", None) == "Ijk_Call"
-                ]
-                for callsite_node in callsite_nodes:
-                    for _, dst, data in list(self.graph.out_edges(callsite_node, data=True)):
-                        if data.get("jumpkind", None) == "Ijk_FakeRet":
-                            self.graph.remove_edge(callsite_node, dst)
+                func_node = self.model.get_any_node(function.addr)
+                if func_node is not None:
+                    callsite_nodes = [
+                        src
+                        for src, _, data in self.graph.in_edges(func_node, data=True)
+                        if data.get("jumpkind", None) == "Ijk_Call"
+                    ]
+                    for callsite_node in callsite_nodes:
+                        for _, dst, data in list(self.graph.out_edges(callsite_node, data=True)):
+                            if data.get("jumpkind", None) == "Ijk_FakeRet":
+                                self.graph.remove_edge(callsite_node, dst)
 
         # Clear old functions dict
         self.kb.functions.clear()


### PR DESCRIPTION
This bug was leading to all FakeRet edges being removed from CFGs on certain binaries.