### PR TITLE
Mark tests broken on windows

### DIFF
--- a/tests/analyses/test_identifier.py
+++ b/tests/analyses/test_identifier.py
@@ -4,6 +4,7 @@ __package__ = __package__ or "tests.analyses"  # pylint:disable=redefined-builti
 
 import logging
 import os
+import sys
 import unittest
 
 import angr
@@ -11,6 +12,7 @@ import angr
 from ..common import bin_location
 
 
+@unittest.skipIf(sys.platform == "win32", "broken on windows")
 class TestIdentifier(unittest.TestCase):
     def test_comparison_identification(self):
         true_symbols = {0x804A3D0: "strncmp", 0x804A0F0: "strcmp", 0x8048E60: "memcmp", 0x8049F40: "strcasecmp"}

--- a/tests/engines/test_unicorn.py
+++ b/tests/engines/test_unicorn.py
@@ -6,6 +6,7 @@ import gc
 import os
 import pickle
 import re
+import sys
 import unittest
 
 import angr
@@ -36,6 +37,7 @@ def _compare_trace(trace, expected):
         assert trace_item_str == expected_str
 
 
+@unittest.skipIf(sys.platform == "win32", "broken on windows")
 class TestUnicorn(unittest.TestCase):
     def test_stops(self):
         p = angr.Project(os.path.join(test_location, "i386", "uc_stop"), auto_load_libs=False)

--- a/tests/exploration_techniques/test_driller_core.py
+++ b/tests/exploration_techniques/test_driller_core.py
@@ -3,6 +3,7 @@
 __package__ = __package__ or "tests.exploration_techniques"  # pylint:disable=redefined-builtin
 
 import os
+import sys
 import unittest
 
 import angr
@@ -15,6 +16,7 @@ test_location = os.path.join(bin_location, "tests")
 
 
 class TestDrillerCore(unittest.TestCase):
+    @unittest.skipIf(sys.platform == "win32", "broken on windows")
     def test_cgc(self):
         binary = os.path.join(test_location, "cgc", "sc1_0b32aa01_01")
         simgr, tracer = tracer_cgc(binary, "driller_core_cgc", b"AAAA", copy_states=True, follow_unsat=True)

--- a/tests/exploration_techniques/test_oppologist.py
+++ b/tests/exploration_techniques/test_oppologist.py
@@ -4,6 +4,7 @@ __package__ = __package__ or "tests.exploration_techniques"  # pylint:disable=re
 
 import unittest
 import os
+import sys
 
 import angr
 
@@ -42,6 +43,7 @@ class TestOppologist(unittest.TestCase):
         else:
             assert stdout.count(b"\n") == 2
 
+    @unittest.skipIf(sys.platform == "win32", "broken on windows")
     def test_cromu_70(self):
         p = angr.Project(os.path.join(test_location, "cgc", "CROMU_00070"))
         inp = bytes.fromhex(

--- a/tests/exploration_techniques/test_tracer.py
+++ b/tests/exploration_techniques/test_tracer.py
@@ -4,6 +4,7 @@ __package__ = __package__ or "tests.exploration_techniques"  # pylint:disable=re
 
 import logging
 import os
+import sys
 import unittest
 
 import angr
@@ -126,6 +127,7 @@ def tracer_linux(filename, test_name, stdin, add_options=None, remove_options=No
     return simgr, t
 
 
+@unittest.skipIf(sys.platform == "win32", "broken on windows")
 class TestTracer(unittest.TestCase):
     def test_recursion(self):
         blob = bytes.fromhex(

--- a/tests/state_plugins/posix/test_files.py
+++ b/tests/state_plugins/posix/test_files.py
@@ -3,6 +3,7 @@
 __package__ = __package__ or "tests.state_plugins.posix"  # pylint:disable=redefined-builtin
 
 import os
+import sys
 import unittest
 
 import angr
@@ -38,6 +39,7 @@ class TestFile(unittest.TestCase):
         assert len(data.variables) == 1
         assert "oops" in next(iter(data.variables))
 
+    @unittest.skipIf(sys.platform == "win32", "broken on windows")
     def test_concrete_fs_resolution(self):
         bin_path = os.path.join(test_location, "i386", "fauxware")
         proj = angr.Project(bin_path, auto_load_libs=False)


### PR DESCRIPTION
This is a cleanup and merge of test markers from #4043. Some of these tests failing on windows affect macOS, which I intend to mark soon as well and figured merging this first would help reduce future conflicts.