### PR TITLE
Add a public unmodified graph object to Decompiler

### DIFF
--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -175,6 +175,9 @@ class Decompiler(Analysis):
             clinic.cc_graph = clinic.copy_graph()
 
         self.clinic = clinic
+        # expose a copy of the graph before structuring optimizations happen
+        # use this graph if you need a reference of exact mapping of instructions to AIL statements
+        self.unmodified_clinic_graph = clinic.copy_graph()
         self.cache = cache
         self._variable_kb = clinic.variable_kb
         self._update_progress(70.0, text="Identifying regions")

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -90,6 +90,7 @@ class Decompiler(Analysis):
         self.cache: Optional[DecompilationCache] = None
         self.options_by_class = None
         self.seq_node = None
+        self.unmodified_clinic_graph = None
 
         if decompile:
             self._decompile()

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -175,9 +175,6 @@ class Decompiler(Analysis):
             clinic.cc_graph = clinic.copy_graph()
 
         self.clinic = clinic
-        # expose a copy of the graph before structuring optimizations happen
-        # use this graph if you need a reference of exact mapping of instructions to AIL statements
-        self.unmodified_clinic_graph = clinic.copy_graph()
         self.cache = cache
         self._variable_kb = clinic.variable_kb
         self._update_progress(70.0, text="Identifying regions")
@@ -186,6 +183,9 @@ class Decompiler(Analysis):
             # the function is empty
             return
 
+        # expose a copy of the graph before structuring optimizations happen
+        # use this graph if you need a reference of exact mapping of instructions to AIL statements
+        self.unmodified_clinic_graph = clinic.copy_graph()
         cond_proc = ConditionProcessor(self.project.arch)
 
         clinic.graph = self._run_graph_simplification_passes(


### PR DESCRIPTION
- Adds a copy of the clinic graph BEFORE any optimizations are run on it. This is useful for external tools and will be used in the next few PRs of SAILR code. 