### PR TITLE
Mark tests that fail on apple silicon macs

### DIFF
--- a/tests/engines/test_unicorn.py
+++ b/tests/engines/test_unicorn.py
@@ -5,6 +5,7 @@ __package__ = __package__ or "tests.engines"  # pylint:disable=redefined-builtin
 import gc
 import os
 import pickle
+import platform
 import re
 import sys
 import unittest
@@ -38,6 +39,7 @@ def _compare_trace(trace, expected):
 
 
 @unittest.skipIf(sys.platform == "win32", "broken on windows")
+@unittest.skipIf(platform.system() == "Darwin" and platform.machine() == "arm64", "broken on apple silicon")
 class TestUnicorn(unittest.TestCase):
     def test_stops(self):
         p = angr.Project(os.path.join(test_location, "i386", "uc_stop"), auto_load_libs=False)

--- a/tests/exploration_techniques/test_driller_core.py
+++ b/tests/exploration_techniques/test_driller_core.py
@@ -3,6 +3,7 @@
 __package__ = __package__ or "tests.exploration_techniques"  # pylint:disable=redefined-builtin
 
 import os
+import platform
 import sys
 import unittest
 
@@ -15,6 +16,7 @@ from ..common import bin_location
 test_location = os.path.join(bin_location, "tests")
 
 
+@unittest.skipIf(platform.system() == "Darwin" and platform.machine() == "arm64", "Broken on apple silicon")
 class TestDrillerCore(unittest.TestCase):
     @unittest.skipIf(sys.platform == "win32", "broken on windows")
     def test_cgc(self):

--- a/tests/exploration_techniques/test_tracer.py
+++ b/tests/exploration_techniques/test_tracer.py
@@ -4,6 +4,7 @@ __package__ = __package__ or "tests.exploration_techniques"  # pylint:disable=re
 
 import logging
 import os
+import platform
 import sys
 import unittest
 
@@ -129,6 +130,7 @@ def tracer_linux(filename, test_name, stdin, add_options=None, remove_options=No
 
 @unittest.skipIf(sys.platform == "win32", "broken on windows")
 class TestTracer(unittest.TestCase):
+    @unittest.skipIf(platform.system() == "Darwin" and platform.machine() == "arm64", "Broken on apple silicon")
     def test_recursion(self):
         blob = bytes.fromhex(
             "00aadd114000000000000000200000001d0000000005000000aadd2a1100001d0000000001e8030000aadd21118611b3b3b3b3b3e3b1b"
@@ -328,6 +330,7 @@ class TestTracer(unittest.TestCase):
             syscall_data=rand_syscall_data,
         )
 
+    @unittest.skipIf(platform.system() == "Darwin" and platform.machine() == "arm64", "Broken on apple silicon")
     def test_cgc_se1_palindrome_raw(self):
         b = os.path.join(bin_location, "tests", "cgc", "sc1_0b32aa01_01")
         # test a valid palindrome
@@ -472,6 +475,7 @@ class TestTracer(unittest.TestCase):
             add_options=add_options,
         )
 
+    @unittest.skipIf(platform.system() == "Darwin" and platform.machine() == "arm64", "Broken on apple silicon")
     def test_symbolic_sized_receives(self):
         b = os.path.join(bin_location, "tests", "cgc", "CROMU_00070")
 


### PR DESCRIPTION
This marks tests failing on apple silicon. With this there is only one remaining decompiler failure. All of these are unicorn/tracer related, so native dependencies.