### PR TITLE
Mark more tests as slow

### DIFF
--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -27,7 +27,7 @@ from angr.analyses.decompiler.structuring.phoenix import MultiStmtExprMode
 from angr.misc.testing import is_testing
 from angr.utils.library import convert_cproto_to_py
 
-from ...common import bin_location
+from ...common import bin_location, slow_test
 
 
 test_location = os.path.join(bin_location, "tests")
@@ -393,6 +393,7 @@ class TestDecompiler(unittest.TestCase):
         else:
             assert code.count("32") == 2
 
+    @slow_test
     @for_all_structuring_algos
     def test_decompiling_true_a_x86_64_0(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "true_a")
@@ -602,6 +603,7 @@ class TestDecompiler(unittest.TestCase):
         else:
             assert False, "Did not find statement 'puts(\"Empty title\");'"
 
+    @slow_test
     @for_all_structuring_algos
     def test_decompiling_libsoap(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "armel", "libsoap.so")
@@ -1257,6 +1259,7 @@ class TestDecompiler(unittest.TestCase):
         )
         assert "\"For complete documentation, run: info coreutils '%s invocation'\\n\"" in d.codegen.text
 
+    @slow_test
     @for_all_structuring_algos
     def test_decompiling_x8664_cvs(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "cvs")
@@ -1662,6 +1665,7 @@ class TestDecompiler(unittest.TestCase):
         assert "b_ptr += 1;" in d.codegen.text
         assert "return c_ptr->c4->c2[argc].b2.a2;" in d.codegen.text
 
+    @slow_test
     @for_all_structuring_algos
     def test_call_return_variable_folding(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "ls_gcc_O0")

--- a/tests/analyses/test_flirt.py
+++ b/tests/analyses/test_flirt.py
@@ -7,10 +7,11 @@ import unittest
 
 import angr
 
-from ..common import bin_location
+from ..common import bin_location, slow_test
 
 
 class TestFlirt(unittest.TestCase):
+    @slow_test
     def test_amd64_elf_static_libc_ubuntu_2004(self):
         binary_path = os.path.join(bin_location, "tests", "x86_64", "elf_with_static_libc_ubuntu_2004_stripped")
         proj = angr.Project(binary_path, auto_load_libs=False, load_debug_info=False)
@@ -25,6 +26,7 @@ class TestFlirt(unittest.TestCase):
         assert cfg.functions[0x436980].is_default_name is False
         assert cfg.functions[0x436980].from_signature == "flirt"
 
+    @slow_test
     def test_armhf_elf_static_using_armel_libc(self):
         binary_path = os.path.join(bin_location, "tests", "armhf", "amp_challenge_07.gcc")
         proj = angr.Project(binary_path, auto_load_libs=False, load_debug_info=False)

--- a/tests/procedures/libc/test_string.py
+++ b/tests/procedures/libc/test_string.py
@@ -10,7 +10,7 @@ from itertools import combinations
 import angr
 from angr import SimState, SIM_LIBRARIES
 
-from ...common import broken
+from ...common import broken, slow_test
 
 log = logging.getLogger("angr.tests.string")
 
@@ -456,6 +456,7 @@ class TestStringSimProcedures(unittest.TestCase):
         s.add_constraints(ss2 == 0)
         assert not s.satisfiable()
 
+    @slow_test
     def test_memcpy(self):
         log.info("concrete src, concrete dst, concrete len")
         log.debug("... full copy")


### PR DESCRIPTION
pytest has a cool flag `--durations=N` to print out the times and names of the `N` slowest test. These tests take over a minute to run on my M2 Max MacBook Pro. With these changes I can run the remainder of the angr test suite in under 5 minutes. This will hopefully improve CI times slightly, and the tests will still be run nightly.