### PR TITLE
Fix modulo operation for invalid variables

### DIFF
--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -547,7 +547,7 @@ class SimEngineLightVEXMixin(SimEngineLightMixin):
         to_size = expr_1.size()
         if signed:
             quotient = expr_0.SDiv(claripy.SignExt(from_size - to_size, expr_1))
-            remainder = expr_1.SMod(claripy.SignExt(from_size - to_size, expr_1))
+            remainder = expr_0.SMod(claripy.SignExt(from_size - to_size, expr_1))
             quotient_size = to_size
             remainder_size = to_size
             return claripy.Concat(


### PR DESCRIPTION
In the _handle_DivMod function, we received exr_0 and exr_1 as args, and in the process of obtaining the quotient and the remainder, there was an error that the remainder of the operations for exr_1 and exr_1 were performed, so we corrected it.