### PR TITLE
imp is deprecated in python3.12

### DIFF
--- a/angr/misc/bug_report.py
+++ b/angr/misc/bug_report.py
@@ -1,4 +1,4 @@
-import imp
+import importlib
 import os
 import sys
 import datetime
@@ -41,7 +41,7 @@ def print_versions():
     for m in angr_modules:
         print("######## %s #########" % m)
         try:
-            _, python_filename, _ = imp.find_module(m)
+            python_filename = importlib.util.find_spec(m).origin
         except ImportError:
             print("Python could not find " + m)
             continue


### PR DESCRIPTION
imp is replaced with importlib in python3.12