### PR TITLE
Implement _handle_CmpGT and _handle_CmpGE for SimEngineRDVEX

### DIFF
--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -989,6 +989,34 @@ class SimEngineRDVEX(
                 return MultiValues(claripy.BVV(0, 1))
         return MultiValues(self.state.top(1))
 
+    def _handle_CmpGT(self, expr):
+        arg0, arg1 = expr.args
+        expr_0 = self._expr(arg0)
+        expr_1 = self._expr(arg1)
+
+        e0 = expr_0.one_value()
+        e1 = expr_1.one_value()
+        if e0 is not None and e1 is not None:
+            if not e0.symbolic and not e1.symbolic:
+                return MultiValues(claripy.BVV(1, 1) if e0.concrete_value > e1.concrete_value else claripy.BVV(0, 1))
+            elif e0 is e1:
+                return MultiValues(claripy.BVV(0, 1))
+        return MultiValues(self.state.top(1))
+
+    def _handle_CmpGE(self, expr):
+        arg0, arg1 = expr.args
+        expr_0 = self._expr(arg0)
+        expr_1 = self._expr(arg1)
+
+        e0 = expr_0.one_value()
+        e1 = expr_1.one_value()
+        if e0 is not None and e1 is not None:
+            if not e0.symbolic and not e1.symbolic:
+                return MultiValues(claripy.BVV(1, 1) if e0.concrete_value >= e1.concrete_value else claripy.BVV(0, 1))
+            elif e0 is e1:
+                return MultiValues(claripy.BVV(0, 1))
+        return MultiValues(self.state.top(1))
+
     # ppc only
     def _handle_CmpORD(self, expr):
         arg0, arg1 = expr.args


### PR DESCRIPTION
The root cause is SimEngineRDVEX didn't implement _handle_CmpGT and _handle_CmpGE.
Exception traceback:
```
Traceback (most recent call last):
  File "C:\Research\amp2023\amp-hackathon-nov-23\test_angr.py", line 39, in test_one
    project.analyses.Decompiler(function, flavor="psuedocode")
  File "C:\Dev\angr\angr\analyses\analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "C:\Dev\angr\angr\analyses\decompiler\decompiler.py", line 96, in __init__
    self._decompile()
  File "C:\Dev\angr\angr\analyses\decompiler\decompiler.py", line 157, in _decompile
    clinic = self.project.analyses.Clinic(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "C:\Dev\angr\angr\analyses\decompiler\clinic.py", line 111, in __init__
    self._analyze()
  File "C:\Dev\angr\angr\analyses\decompiler\clinic.py", line 166, in _analyze
    self._recover_calling_conventions()
  File "C:\Dev\angr\angr\utils\timing.py", line 43, in timed_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\decompiler\clinic.py", line 447, in _recover_calling_conventions
    cc = self.project.analyses.CallingConvention(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "C:\Dev\angr\angr\analyses\calling_convention.py", line 125, in __init__
    self._analyze_callsite_only()
  File "C:\Dev\angr\angr\analyses\calling_convention.py", line 218, in _analyze_callsite_only
    self._analyze_callsite(
  File "C:\Dev\angr\angr\analyses\calling_convention.py", line 375, in _analyze_callsite
    rda = self.project.analyses[ReachingDefinitionsAnalysis].prep()(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "C:\Dev\angr\angr\analyses\reaching_definitions\reaching_definitions.py", line 202, in __init__
    self._analyze()
  File "C:\Dev\angr\angr\analyses\forward_analysis\forward_analysis.py", line 252, in _analyze
    self._analysis_core_graph()
  File "C:\Dev\angr\angr\analyses\forward_analysis\forward_analysis.py", line 269, in _analysis_core_graph
    changed, output_state = self._run_on_node(n, job_state)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\reaching_definitions\reaching_definitions.py", line 524, in _run_on_node
    state = engine.process(
            ^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 55, in process
    self._process(
  File "C:\Dev\angr\angr\engines\light\engine.py", line 144, in _process
    self._process_Stmt(whitelist=whitelist)
  File "C:\Dev\angr\angr\engines\light\engine.py", line 164, in _process_Stmt
    self._handle_Stmt(stmt)
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 108, in _handle_Stmt
    super()._handle_Stmt(stmt)
  File "C:\Dev\angr\angr\engines\light\engine.py", line 194, in _handle_Stmt
    getattr(self, handler)(stmt)
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 115, in _handle_WrTmp
    data: MultiValues = self._expr(stmt.data)
                        ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 332, in _expr
    data = super()._expr(expr)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\engines\light\engine.py", line 234, in _expr
    return getattr(self, handler)(expr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\engines\light\engine.py", line 373, in _handle_Binop
    return getattr(self, handler)(expr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\engines\light\engine.py", line 736, in _handle_CmpGT
    return expr_0 > expr_1
           ^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'MultiValues' and 'MultiValues'
```