### PR TITLE
BVV is not directly comparable

### DIFF
--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -1029,6 +1029,8 @@ class SimEngineRDVEX(
 
         if e0 is not None and e1 is not None:
             if not e0.symbolic and not e1.symbolic:
+                e0 = e0.concrete_value
+                e1 = e1.concrete_value
                 if e0 < e1:
                     return MultiValues(claripy.BVV(0x8, bits))
                 elif e0 > e1:


### PR DESCRIPTION
```
Function CFE_ES_TaskPipe [4369388]
  Syscall: False
  SP difference: 0
  Has return: True
  Returning: True
  Alignment: False
  Arguments: reg: [], stack: []
  Blocks: [0x42abec, 0x42ac28, 0x42ac5c, 0x42ac34, 0x42ac68, 0x42ac8c, 0x42ac3c, 0x42b018, 0x42ac74, 0x42aca0, 0x42b030]
  Calling convention: None
Traceback (most recent call last):
  File "C:\Research\amp2023\amp-hackathon-nov-23\test_angr.py", line 39, in test_one
    project.analyses.Decompiler(function, flavor="psuedocode")
  File "C:\Dev\angr\angr\analyses\analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "C:\Dev\angr\angr\analyses\decompiler\decompiler.py", line 96, in __init__
    self._decompile()
  File "C:\Dev\angr\angr\analyses\decompiler\decompiler.py", line 157, in _decompile
    clinic = self.project.analyses.Clinic(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "C:\Dev\angr\angr\analyses\decompiler\clinic.py", line 111, in __init__
    self._analyze()
  File "C:\Dev\angr\angr\analyses\decompiler\clinic.py", line 166, in _analyze
    self._recover_calling_conventions()
  File "C:\Dev\angr\angr\utils\timing.py", line 43, in timed_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\decompiler\clinic.py", line 447, in _recover_calling_conventions
    cc = self.project.analyses.CallingConvention(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "C:\Dev\angr\angr\analyses\calling_convention.py", line 125, in __init__
    self._analyze_callsite_only()
  File "C:\Dev\angr\angr\analyses\calling_convention.py", line 218, in _analyze_callsite_only
    self._analyze_callsite(
  File "C:\Dev\angr\angr\analyses\calling_convention.py", line 375, in _analyze_callsite
    rda = self.project.analyses[ReachingDefinitionsAnalysis].prep()(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "C:\Dev\angr\angr\analyses\reaching_definitions\reaching_definitions.py", line 202, in __init__
    self._analyze()
  File "C:\Dev\angr\angr\analyses\forward_analysis\forward_analysis.py", line 252, in _analyze
    self._analysis_core_graph()
  File "C:\Dev\angr\angr\analyses\forward_analysis\forward_analysis.py", line 269, in _analysis_core_graph
    changed, output_state = self._run_on_node(n, job_state)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\reaching_definitions\reaching_definitions.py", line 524, in _run_on_node
    state = engine.process(
            ^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 55, in process
    self._process(
  File "C:\Dev\angr\angr\engines\light\engine.py", line 144, in _process
    self._process_Stmt(whitelist=whitelist)
  File "C:\Dev\angr\angr\engines\light\engine.py", line 164, in _process_Stmt
    self._handle_Stmt(stmt)
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 108, in _handle_Stmt
    super()._handle_Stmt(stmt)
  File "C:\Dev\angr\angr\engines\light\engine.py", line 194, in _handle_Stmt
    getattr(self, handler)(stmt)
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 115, in _handle_WrTmp
    data: MultiValues = self._expr(stmt.data)
                        ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 332, in _expr
    data = super()._expr(expr)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\engines\light\engine.py", line 234, in _expr
    return getattr(self, handler)(expr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\engines\light\engine.py", line 373, in _handle_Binop
    return getattr(self, handler)(expr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\angr\angr\analyses\reaching_definitions\engine_vex.py", line 1032, in _handle_CmpORD
    if e0 < e1:
       ^^^^^^^
  File "C:\Users\yibol\Envs\angr-dev\Lib\site-packages\claripy\ast\base.py", line 930, in __bool__
    raise ClaripyOperationError(
claripy.errors.ClaripyOperationError: testing Expressions for truthiness does not do what you want, as these expressions can be symbolic
```