### PR TITLE
Return Const back if dereferencing a constant

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1399,7 +1399,10 @@ class Clinic(Analysis):
             )
             end_block_ail = ailment.IRSBConverter.convert(end_block.vex, self._ail_manager)
         else:
-            end_block_ail = next(iter(b for b in ail_graph if b.addr == end_block_addr))
+            try:
+                end_block_ail = next(iter(b for b in ail_graph if b.addr == end_block_addr))
+            except StopIteration:
+                return None
 
         # last check: if the first instruction of the end block has Sar, then we bail (due to the peephole optimization
         # SarToSignedDiv)

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -2721,6 +2721,9 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         o_constant, o_terms = extract_terms(expr)
 
         def bail_out():
+            if len(o_terms) == 0:
+                # probably a plain integer, return as is
+                return expr
             result = reduce(
                 lambda a1, a2: CBinaryOp("Add", a1, a2, codegen=self),
                 (


### PR DESCRIPTION
would crash because of empty `o_terms` since the expr is a constant

decompiled result before the crash
`g_20002b98 = (struct_0 *)sub_0;`
decompiled result after change
`g_20002b98 = &sub_0;`

expected result
`g_20002b98 = 0;`
