### PR TITLE
add support for MullEven

### DIFF
--- a/angr/engines/vex/claripy/irop.py
+++ b/angr/engines/vex/claripy/irop.py
@@ -1191,6 +1191,27 @@ class SimIROp:
             return v
         raise NotImplementedError(f"Unsupported set_size {self._set_size}")
 
+    @supports_vector
+    def _op_generic_MullEven(self, args):
+        """
+        widening signed/unsigned of even lanes, with lowest lane=zero
+        """
+        vec = args[0].chop(self._vector_size)
+        if len(vec) % 2 != 0:
+            raise SimOperationError("Invalid vector size for Iop_MullEven, expected even number of elements")
+
+        result_vector = []
+        for i in range(0, len(vec), 2):
+            if i == 0:
+                result_vector.append(claripy.BVV(0, self._vector_size))
+            if self._vector_signed == 'S':
+                multiplied_value = vec[i].sign_extend(self._vector_size) * vec[i + 1].sign_extend(self._vector_size)
+            else:
+                multiplied_value = vec[i].zero_extend(self._vector_size) * vec[i + 1].zero_extend(self._vector_size)
+            result_vector.append(multiplied_value)
+        return claripy.Concat(*reversed(result_vector))
+
+
     # def _op_Iop_Yl2xF64(self, args):
     #   rm = self._translate_rm(args[0])
     #   arg2_bv = args[2].raw_to_bv()


### PR DESCRIPTION
Add support for IopMullEven (https://github.com/angr/vex/blob/66fa43edd3a3b214fc028645b86c33cb8c7de888/pub/libvex_ir.h#L1481)

Functions that failed with error `UnsupportedIROpError: no calculate function identified for Iop_MullEven16Sx8`, now decompiles!