### PR TITLE
If sp_offset is not available, assume sp_offset = 0

### DIFF
--- a/angr/analyses/variable_recovery/engine_vex.py
+++ b/angr/analyses/variable_recovery/engine_vex.py
@@ -181,7 +181,7 @@ class SimEngineVRVEX(
 
         try:
             arg_locs = func.calling_convention.arg_locs(func.prototype)
-        except TypeError:
+        except (TypeError, ValueError):
             func.prototype = None
             return
 

--- a/angr/analyses/variable_recovery/engine_vex.py
+++ b/angr/analyses/variable_recovery/engine_vex.py
@@ -181,7 +181,7 @@ class SimEngineVRVEX(
 
         try:
             arg_locs = func.calling_convention.arg_locs(func.prototype)
-        except:
+        except TypeError:
             func.prototype = None
             return
 


### PR DESCRIPTION
```
Function sub_60001429 [1610617897]
  Syscall: False
  SP difference: 0
  Has return: False
  Returning: False
  Alignment: False
  Arguments: reg: [], stack: []
  Blocks: [0x60001429, 0x6000144d, 0x6000145f, 0x60001469, 0x60001471, 0x6000147f, 0x60001489, 0x6000148f, 0x60001497, 0x600014f1, 0x60001535, 0x6000154b, 0x60001581, 0x6000156f, 0x60001591, 0x60001595, 0x60001599, 0x6000159d, 0x600015a1, 0x600015a7, 0x600015ab, 0x600015b3, 0x600015b7, 0x600015bb]
  Calling convention: None
Traceback (most recent call last):
  File "/home/34r7hm4n/dev/amp-hackathon-nov-23/test_angr.py", line 34, in test_one_batch
    dec = project.analyses.Decompiler(function, flavor="psuedocode", options=options)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/decompiler.py", line 96, in __init__
    self._decompile()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/decompiler.py", line 157, in _decompile
    clinic = self.project.analyses.Clinic(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 111, in __init__
    self._analyze()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 166, in _analyze
    self._recover_calling_conventions()
  File "/home/34r7hm4n/dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 447, in _recover_calling_conventions
    cc = self.project.analyses.CallingConvention(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/calling_convention.py", line 125, in __init__
    self._analyze_callsite_only()
  File "/home/34r7hm4n/dev/angr/angr/analyses/calling_convention.py", line 218, in _analyze_callsite_only
    self._analyze_callsite(
  File "/home/34r7hm4n/dev/angr/angr/analyses/calling_convention.py", line 381, in _analyze_callsite
    fact = self._collect_callsite_fact(caller_block, call_insn_addr, rda.model)
  File "/home/34r7hm4n/dev/angr/angr/analyses/calling_convention.py", line 504, in _collect_callsite_fact
    self._analyze_callsite_arguments(cc, caller_block, call_insn_addr, rda, fact)
  File "/home/34r7hm4n/dev/angr/angr/analyses/calling_convention.py", line 574, in _analyze_callsite_arguments
    defs_by_stack_offset = {
  File "/home/34r7hm4n/dev/angr/angr/analyses/calling_convention.py", line 575, in <dictcomp>
    d.atom.addr.offset - sp_offset: d
TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
```