### PR TITLE
Fix arg_locs function: Do not return arg_locs containing None

### DIFF
--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -104,7 +104,7 @@ class CallSiteMaker(Analysis):
                             callsite_ty.args.append(SimTypeInt().with_arch(self.project.arch))
                         arg_locs = cc.arg_locs(callsite_ty)
 
-        if arg_locs is not None and None not in arg_locs:
+        if arg_locs is not None:
             for arg_loc in arg_locs:
                 if isinstance(arg_loc, SimRegArg):
                     size = arg_loc.size

--- a/angr/analyses/reaching_definitions/function_handler.py
+++ b/angr/analyses/reaching_definitions/function_handler.py
@@ -542,9 +542,6 @@ class FunctionHandler:
     @staticmethod
     def c_args_as_atoms(state: "ReachingDefinitionsState", cc: SimCC, prototype: SimTypeFunction) -> List[Set[Atom]]:
         if not prototype.variadic:
-            if None in cc.arg_locs(prototype):
-                return []
-
             sp_value = state.get_one_value(Register(state.arch.sp_offset, state.arch.bytes), strip_annotations=True)
             sp = state.get_stack_offset(sp_value) if sp_value is not None else None
             atoms = []

--- a/angr/analyses/variable_recovery/engine_vex.py
+++ b/angr/analyses/variable_recovery/engine_vex.py
@@ -185,9 +185,6 @@ class SimEngineVRVEX(
             func.prototype = None
             return
 
-        if None in arg_locs:
-            return
-
         for arg_loc in arg_locs:
             for loc in arg_loc.get_footprint():
                 if isinstance(loc, SimRegArg):

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -788,7 +788,14 @@ class SimCC:
         if prototype._arch is None:
             prototype = prototype.with_arch(self.arch)
         session = self.arg_session(prototype.returnty)
-        return [self.next_arg(session, arg_ty) for arg_ty in prototype.args]
+        # Make sure there is no None in arg_locs by dropping args after (and including) the first None
+        arg_locs = []
+        for arg_ty in prototype.args:
+            arg = self.next_arg(session, arg_ty)
+            if arg is None:
+                break
+            arg_locs.append(arg)
+        return arg_locs
 
     def get_args(self, state, prototype, stack_base=None):
         arg_locs = self.arg_locs(prototype)


### PR DESCRIPTION
```
Function _ZN3ros7console5printEPNS0_10FilterBaseEPvNS0_6levels5LevelERKNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEEPKciSF_ [285632]
  Syscall: False
  SP difference: 0
  Has return: False
  Returning: True
  Alignment: False
  Arguments: reg: [], stack: []
  Blocks: [0x45bc0]
  Calling convention: <SimCCARMHF>
Traceback (most recent call last):
  File "/home/34r7hm4n/dev/amp-hackathon-nov-23/test_angr.py", line 38, in test_one_batch
    dec = project.analyses.Decompiler(function, flavor="psuedocode")
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/decompiler.py", line 96, in __init__
    self._decompile()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/decompiler.py", line 157, in _decompile
    clinic = self.project.analyses.Clinic(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 111, in __init__
    self._analyze()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 210, in _analyze
    self._simplify_function(
  File "/home/34r7hm4n/dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 726, in _simplify_function
    simplified = self._simplify_function_once(
  File "/home/34r7hm4n/dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 756, in _simplify_function_once
    simp = self.project.analyses.AILSimplifier(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 104, in __init__
    self._simplify()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 117, in _simplify
    folded_exprs = self._fold_exprs()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 538, in _fold_exprs
    propagator = self._compute_propagation(immediate_stmt_removal=True)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 198, in _compute_propagation
    reaching_definitions=self._compute_reaching_definitions(),
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 178, in _compute_reaching_definitions
    rd = self.project.analyses.ReachingDefinitions(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/reaching_definitions.py", line 202, in __init__
    self._analyze()
  File "/home/34r7hm4n/dev/angr/angr/analyses/forward_analysis/forward_analysis.py", line 252, in _analyze
    self._analysis_core_graph()
  File "/home/34r7hm4n/dev/angr/angr/analyses/forward_analysis/forward_analysis.py", line 267, in _analysis_core_graph
    job_state = self._initial_abstract_state(n)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/reaching_definitions.py", line 463, in _initial_abstract_state
    return ReachingDefinitionsState(
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/rd_state.py", line 127, in __init__
    self._set_initialization_values(subject, rtoc_value, initializer=initializer)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/rd_state.py", line 281, in _set_initialization_values
    initializer.initialize_function_state(self, subject.cc, subject.content.addr, rtoc_value)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/rd_initializer.py", line 60, in initialize_function_state
    self.initialize_all_function_arguments(state, func_addr, ex_loc, cc, prototype)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/rd_initializer.py", line 89, in initialize_all_function_arguments
    for arg in loc.get_footprint():
AttributeError: 'NoneType' object has no attribute 'get_footprint'
```