### PR TITLE
Do nothing when we find a dead DirtyStatement (don't raise exception or remove it)

### DIFF
--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -4,7 +4,7 @@ import logging
 
 from ailment import AILBlockWalker
 from ailment.block import Block
-from ailment.statement import Statement, Assignment, Store, Call, ConditionalJump
+from ailment.statement import Statement, Assignment, Store, Call, ConditionalJump, DirtyStatement
 from ailment.expression import (
     Register,
     Convert,
@@ -1207,7 +1207,7 @@ class AILSimplifier(Analysis):
                 continue
 
             for idx, stmt in enumerate(block.statements):
-                if idx in stmts_to_remove:
+                if idx in stmts_to_remove and not isinstance(stmt, DirtyStatement):
                     if isinstance(stmt, (Assignment, Store)):
                         # Skip Assignment and Store statements
                         # if this statement triggers a call, it should only be removed if it's in self._calls_to_remove


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/34r7hm4n/dev/amp-hackathon-nov-23/test_angr.py", line 37, in test_one_batch
    dec = project.analyses.Decompiler(function, flavor="psuedocode")
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/decompiler.py", line 96, in __init__
    self._decompile()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/decompiler.py", line 157, in _decompile
    clinic = self.project.analyses.Clinic(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 111, in __init__
    self._analyze()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 239, in _analyze
    self._simplify_function(
  File "/home/34r7hm4n/dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 726, in _simplify_function
    simplified = self._simplify_function_once(
  File "/home/34r7hm4n/dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 756, in _simplify_function_once
    simp = self.project.analyses.AILSimplifier(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 104, in __init__
    self._simplify()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 161, in _simplify
    r = self._remove_dead_assignments()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 1250, in _remove_dead_assignments
    raise NotImplementedError()
NotImplementedError
```
