### PR TITLE
Fix some logic bugs in MultiValues

### DIFF
--- a/angr/storage/memory_mixins/paged_memory/pages/multi_values.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/multi_values.py
@@ -49,9 +49,12 @@ class MultiValues:
             else None
         )
 
+        if self._single_value is None and self._values is None:
+            self._values = {}
+
         # if only one value is passed in, assign it to self._single_value
         if self._values:
-            if len(self._values) == 0 and 0 in self._values and len(self._values[0]) == 0:
+            if len(self._values) == 1 and 0 in self._values and len(self._values[0]) == 1:
                 self._single_value = next(iter(self._values[0]))
                 self._values = None
 
@@ -152,6 +155,9 @@ class MultiValues:
             return self._single_value.length
 
         assert self._values is not None
+
+        if len(self._values) == 0:
+            return 0
 
         max_offset = max(self._values.keys())
         max_len = max(x.size() for x in self._values[max_offset])

--- a/tests/storage/test_multivalues.py
+++ b/tests/storage/test_multivalues.py
@@ -37,7 +37,7 @@ class TestMultiValues(TestCase):
         mv2 = MultiValues(mv)
         assert mv2._single_value is not None
         assert v.concrete_value == mv2._single_value.concrete_value
-        assert len(mv) == 64
+        assert len(mv2) == 64
 
 if __name__ == "__main__":
     main()

--- a/tests/storage/test_multivalues.py
+++ b/tests/storage/test_multivalues.py
@@ -21,6 +21,23 @@ class TestMultiValues(TestCase):
         assert mv._values[5] == {claripy.BVV(0xCC, 8), claripy.BVV(0x38, 8), claripy.BVV(0, 8)}
         assert mv._values[6] == {claripy.BVV(1, 16), claripy.BVV(0x1338, 16)}
 
+    def test_multivalues_empty(self):
+        mv = MultiValues()
+        assert mv._single_value is None
+        assert mv._values == {}
+        assert len(mv) == 0
+
+    def test_multivalues_single_value(self):
+        v = claripy.BVV(0x1338133813371337, 64)
+        mv = MultiValues(v)
+        assert mv._single_value is not None
+        assert v.concrete_value == mv._single_value.concrete_value
+        assert len(mv) == 64
+
+        mv2 = MultiValues(mv)
+        assert mv2._single_value is not None
+        assert v.concrete_value == mv2._single_value.concrete_value
+        assert len(mv) == 64
 
 if __name__ == "__main__":
     main()

--- a/tests/storage/test_multivalues.py
+++ b/tests/storage/test_multivalues.py
@@ -39,5 +39,6 @@ class TestMultiValues(TestCase):
         assert v.concrete_value == mv2._single_value.concrete_value
         assert len(mv2) == 64
 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
```
Function _ZN3ros12TimerManagerINS_8WallTimeENS_12WallDurationENS_14WallTimerEventEE14waitingCompareEii [4898156]
  Syscall: False
  SP difference: 0
  Has return: True
  Returning: True
  Alignment: False
  Arguments: reg: [], stack: []
  Blocks: [0x4abd6c, 0x4abf94, 0x4abd84, 0x4abe98, 0x4abd9c, 0x4abd8c, 0x4abdac, 0x4abeb0, 0x4abebc, 0x4abdb8, 0x4abdec, 0x4abdbc, 0x4abde0, 0x4abdfc, 0x4abdd0, 0x4abea0, 0x4abe20, 0x4abe08, 0x4abddc, 0x4abe68, 0x4abea8, 0x4abf84, 0x4abe28, 0x4abe0c, 0x4abe70, 0x4abe38, 0x4abe34, 0x4abe78, 0x4abe40, 0x4abe8c, 0x4abe48, 0x4abec4, 0x4abe5c, 0x4abed4, 0x4abf24, 0x4abedc, 0x4abf34, 0x4abef0, 0x4abf3c, 0x4abefc, 0x4abf50, 0x4abf9c, 0x4abf14, 0x4abf5c, 0x4abfa4, 0x4abf20, 0x4abfa8, 0x4abf74, 0x4abfb0, 0x4abf80]
  Calling convention: <SimCCARMHF>
Traceback (most recent call last):
  File "/home/34r7hm4n/dev/amp-hackathon-nov-23/test_angr.py", line 37, in test_one_batch
    dec = project.analyses.Decompiler(function, flavor="psuedocode")
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/decompiler.py", line 96, in __init__
    self._decompile()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/decompiler.py", line 157, in _decompile
    clinic = self.project.analyses.Clinic(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 111, in __init__
    self._analyze()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 264, in _analyze
    self._simplify_function(
  File "/home/34r7hm4n/dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 726, in _simplify_function
    simplified = self._simplify_function_once(
  File "/home/34r7hm4n/dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/clinic.py", line 756, in _simplify_function_once
    simp = self.project.analyses.AILSimplifier(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 104, in __init__
    self._simplify()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 117, in _simplify
    folded_exprs = self._fold_exprs()
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 538, in _fold_exprs
    propagator = self._compute_propagation(immediate_stmt_removal=True)
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 198, in _compute_propagation
    reaching_definitions=self._compute_reaching_definitions(),
  File "/home/34r7hm4n/dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 178, in _compute_reaching_definitions
    rd = self.project.analyses.ReachingDefinitions(
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/reaching_definitions.py", line 202, in __init__
    self._analyze()
  File "/home/34r7hm4n/dev/angr/angr/analyses/forward_analysis/forward_analysis.py", line 252, in _analyze
    self._analysis_core_graph()
  File "/home/34r7hm4n/dev/angr/angr/analyses/forward_analysis/forward_analysis.py", line 269, in _analysis_core_graph
    changed, output_state = self._run_on_node(n, job_state)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/reaching_definitions.py", line 524, in _run_on_node
    state = engine.process(
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 85, in process
    self._process(
  File "/home/34r7hm4n/dev/angr/angr/engines/light/engine.py", line 800, in _process
    self._process_Stmt(whitelist=whitelist)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 119, in _process_Stmt
    super()._process_Stmt(whitelist=whitelist)
  File "/home/34r7hm4n/dev/angr/angr/engines/light/engine.py", line 816, in _process_Stmt
    self._handle_Stmt(stmt)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 130, in _handle_Stmt
    handler(stmt)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 153, in _ail_handle_Assignment
    src = self._expr(stmt.src)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 141, in _expr
    return handler(expr)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 545, in _ail_handle_Convert
    to_conv: MultiValues = self._expr(expr.operand)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 141, in _expr
    return handler(expr)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 395, in _ail_handle_CallExpr
    data = self._handle_Call_base(expr, is_expr=True)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/engine_ail.py", line 277, in _handle_Call_base
    self._function_handler.handle_function(self.state, data)
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/function_handler.py", line 435, in handle_function
    _, defs = state.kill_and_add_definition(
  File "/home/34r7hm4n/dev/angr/angr/analyses/reaching_definitions/rd_state.py", line 351, in kill_and_add_definition
    mv = self.live_definitions.kill_and_add_definition(
  File "/home/34r7hm4n/dev/angr/angr/knowledge_plugins/key_definitions/live_definitions.py", line 534, in kill_and_add_definition
    self.registers.store(
  File "/home/34r7hm4n/dev/angr/angr/storage/memory_mixins/size_resolution_mixin.py", line 32, in store
    max_size = len(data) // self.state.arch.byte_width
  File "/home/34r7hm4n/dev/angr/angr/storage/memory_mixins/paged_memory/pages/multi_values.py", line 154, in __len__
    assert self._values is not None
AssertionError
```