### PR TITLE
Incorrect prototype for stubs

### DIFF
--- a/angr/procedures/definitions/msvcr.py
+++ b/angr/procedures/definitions/msvcr.py
@@ -13,3 +13,6 @@ libc.set_non_returning('_exit', 'abort', 'exit', '_invoke_watson')
 libc.add_alias('_initterm', '_initterm_e')
 
 libc.set_default_cc('AMD64', SimCCMicrosoftAMD64)
+
+for name, procedure in libc.procedures.items():
+    libc.set_prototype(name, procedure.prototype)


### PR DESCRIPTION
Incorrect prototype for stubs when the prototypes are not set for certain libraries.
Reproduce using
```import angr
proj = angr.Project('/bin/true')
proc = angr.SIM_LIBRARIES.get('msvcr100.dll').get_stub('strcat', proj.arch)
print(proc.prototype)
```
Before fix
`() -> char*
`
After fix
`(char*, char*) -> char*
`