### PR TITLE
Check for outdated defs

### DIFF
--- a/angr/analyses/propagator/engine_ail.py
+++ b/angr/analyses/propagator/engine_ail.py
@@ -302,8 +302,15 @@ class SimEnginePropagatorAIL(
                             if 0 in current_reg_value.offset_and_details:
                                 detail = current_reg_value.offset_and_details[0]
                                 if detail.def_at == def_at:
-                                    l.debug("Add a replacement: %s with %s", expr, reg_atom)
-                                    self.state.add_replacement(self._codeloc(), expr, reg_atom)
+                                    outdated = False
+                                    outdated_, has_avoid_ = self.is_using_outdated_def(
+                                        detail.expr, detail.def_at, self._codeloc(), avoid=expr
+                                    )
+                                    if outdated_ or has_avoid_:
+                                        outdated = True
+                                    if not outdated:
+                                        l.debug("Add a replacement: %s with %s", expr, reg_atom)
+                                        self.state.add_replacement(self._codeloc(), expr, reg_atom)
                                     top = self.state.top(expr.size * self.arch.byte_width)
                                     return PropValue.from_value_and_details(top, expr.size, expr, self._codeloc())
 


### PR DESCRIPTION
Check for outdated defs before replacing tmp with a register value

e.g.
```
rsi = Load(sp-4)
Store(sp-4,new_value)
t20 = Load(sp-4)
t31 = Load(t20)
```
`t20` in the `Load()` will be replaced with register `rsi` since they both have the same expr but this should not happen since a new value has been stored at that address and the value in `rsi` is outdated