### PR TITLE
Revert #4350 due to inconsistent bug

### DIFF
--- a/angr/procedures/definitions/msvcr.py
+++ b/angr/procedures/definitions/msvcr.py
@@ -13,6 +13,3 @@ libc.set_non_returning('_exit', 'abort', 'exit', '_invoke_watson')
 libc.add_alias('_initterm', '_initterm_e')
 
 libc.set_default_cc('AMD64', SimCCMicrosoftAMD64)
-
-for name, procedure in libc.procedures.items():
-    libc.set_prototype(name, procedure.prototype)


### PR DESCRIPTION
This reverts commit aac3c1745b414f28d9641e09b4e9ef3f44c48ad2, associated with #4350, because of a reoccurring bug in the `test_decompilation_call_expr_folding_into_if_conditions` testcase. I tested commits before this commit for around 30 mins on a loop to verify it was not them. 

@AOS002 would you be able to propose another PR to add this fix with correct functionality? 
To verify you've made a good PR, run:
```
while pytest tests/analyses/decompiler/test_decompiler.py::TestDecompiler::test_decompilation_call_expr_folding_into_if_conditions; do :; done
``` 

For at least 10 mins. 