### PR TITLE
MultiSimplifierAILEngine: Drop a problematic Mul simplification

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/multi_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/multi_simplifier.py
@@ -184,18 +184,6 @@ class MultiSimplifierAILEngine(SimplifierAILEngine):
                     new_const = Expr.Const(const_.idx, None, const_.value * const_x0.value, const_.bits)
                     new_expr = Expr.BinaryOp(expr.idx, "Mul", [x, new_const], expr.signed, **expr.tags)
                     return new_expr
-            elif (
-                isinstance(operand_0, Expr.Convert)
-                and isinstance(operand_0.operand, Expr.BinaryOp)
-                and operand_0.operand.op == "Mul"
-                and isinstance(operand_0.operand.operands[1], Expr.Const)
-            ):
-                x = operand_0.operand.operands[0]
-                new_const = Expr.Const(
-                    operand_1.idx, None, operand_1.value * operand_0.operand.operands[1].value, operand_1.bits
-                )
-                new_expr = Expr.BinaryOp(expr.idx, "Mul", [x, new_const], expr.signed, **expr.tags)
-                return new_expr
 
         if (operand_0, operand_1) != (expr.operands[0], expr.operands[1]):
             return Expr.BinaryOp(expr.idx, "Mul", [operand_0, operand_1], expr.signed, **expr.tags)


### PR DESCRIPTION
This simplification may incorrectly remove conversions, e.g. below in statement 2

```
Before:
## Block 1c000c32a
00 | 0x1c000c32a | LABEL_1c000c32a:
01 | 0x1c000c337 | r13w<2> = 0x8<16>
02 | 0x1c000c33d | r15<8> = Conv(32->64, ((Conv(64->32, (Conv(32->64, Load(addr=stack_base+24, size=4, endness=Iend_LE)) * 0x3<64>)) * 0x10<32>) + 0x8<32>))
03 | 0x1c000c343 | if ((0xffff<32> < ((Conv(64->32, (Conv(32->64, Load(addr=stack_base+24, size=4, endness=Iend_LE)) + (Conv(32->64, Load(addr=stack_base+24, size=4, endness=Iend_LE)) << 0x1<8>))) << 0x4<8>) + 0x8<32>))) { Goto 0x1c000c344<64> } else { Goto 0x1c000c345<64> }


After:
## Block 1c000c32a
00 | 0x1c000c32a | LABEL_1c000c32a:
01 | 0x1c000c337 | r13w<2> = 0x8<16>
02 | 0x1c000c33d | r15<8> = Conv(32->64, ((Conv(32->64, Load(addr=stack_base+24, size=4, endness=Iend_LE)) * 0x30<32>) + 0x8<32>))
03 | 0x1c000c343 | if ((0xffff<32> < ((Conv(64->32, (Conv(32->64, Load(addr=stack_base+24, size=4, endness=Iend_LE)) + (Conv(32->64, Load(addr=stack_base+24, size=4, endness=Iend_LE)) << 0x1<8>))) << 0x4<8>) + 0x8<32>))) { Goto 0x1c000c344<64> } else { Goto 0x1c000c345<64> }
```

Drop the simplification for now.


Fixes one case of #4264