### PR TITLE
Fix some CLI problems and add `--catch-exceptions` flag

### DIFF
--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -15,16 +15,41 @@ class COMMANDS:
 
 def main():
     parser = argparse.ArgumentParser(description="The angr CLI allows you to decompile and analyze binaries.")
-    parser.add_argument("command", help="The command to run", choices=COMMANDS.ALL_COMMANDS)
-    parser.add_argument("binary", help="The path to the binary to analyze")
-    parser.add_argument("--functions", help="The functions to analyze", nargs="+")
     parser.add_argument(
-        "--structurer", help="The structurer to use", choices=STRUCTURER_CLASSES.keys(), default="phoenix"
+        "command",
+        help="""
+        The analysis type to run on the binary. All analysis is output to stdout.""",
+        choices=COMMANDS.ALL_COMMANDS,
+    )
+    parser.add_argument("binary", help="The path to the binary to analyze.", nargs="*")
+    parser.add_argument(
+        "--functions",
+        help="""
+        The functions to analyze under the current command. Functions can either be expressed as names found in the
+        symbols of the binary or as addresses like: 0x401000.""",
+        nargs="+",
+    )
+    parser.add_argument(
+        "--catch-exceptions",
+        help="""
+        Catch exceptions during analysis. The scope of error handling may depend on the command used for analysis.
+        If multiple functions are specified for analysis, each function will be handled individually.""",
+        action="store_true",
+        default=False,
+    )
+    # decompilation-specific arguments
+    parser.add_argument(
+        "--structurer",
+        help="The structuring algorithm to use for decompilation.",
+        choices=STRUCTURER_CLASSES.keys(),
+        default="phoenix",
     )
 
     args = parser.parse_args()
     if args.command == COMMANDS.DECOMPILE:
-        decompilation = decompile_functions(args.binary, functions=args.functions, structurer=args.structurer)
+        decompilation = decompile_functions(
+            args.binary, functions=args.functions, structurer=args.structurer, catch_errors=args.catch_exceptions
+        )
         print(decompilation)
     else:
         parser.print_help()

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, Any, Union, List, Iterable
 import logging
 
 import networkx
-from rich.progress import track
+import tqdm
 
 import ailment
 import angr
@@ -582,7 +582,7 @@ def peephole_optimize_multistmts(block, stmt_opts):
     return statements, any_update
 
 
-def decompile_functions(path, functions=None, structurer=None, catch_errors=True) -> Optional[str]:
+def decompile_functions(path, functions=None, structurer=None, catch_errors=False) -> Optional[str]:
     """
     Decompile a binary into a set of functions.
 
@@ -616,16 +616,20 @@ def decompile_functions(path, functions=None, structurer=None, catch_errors=True
     functions = normalized_functions
 
     # verify that all functions exist
-    for func in functions:
+    for func in list(functions):
         if func not in cfg.functions:
-            raise ValueError(f"Function {func} does not exist in the CFG.")
+            if catch_errors:
+                _l.warning("Function %s does not exist in the CFG.", str(func))
+                functions.remove(func)
+            else:
+                raise ValueError(f"Function {func} does not exist in the CFG.")
 
     # decompile all functions
     decompilation = ""
     dec_options = [
         (PARAM_TO_OPTION["structurer_cls"], structurer),
     ]
-    for func in track(functions, description="Decompiling functions", transient=True):
+    for func in tqdm.tqdm(functions, desc="Decompiling functions"):
         f = cfg.functions[func]
         if f is None or f.is_plt:
             continue


### PR DESCRIPTION
`angr decompile /bin/true --functions main some_fake_func --catch-exceptions` will no longer crash the entire decompilation. 