### PR TITLE
Flip the order of the deref overloads

### DIFF
--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -566,19 +566,19 @@ class ReachingDefinitionsState:
     @overload
     def deref(
         self,
-        pointer: Union[MultiValues, Atom, Definition, Iterable[Atom], Iterable[Definition]],
+        pointer: Union[int, claripy.ast.bv.BV, HeapAddress, SpOffset],
         size: Union[int, DerefSize],
         endness: str = ...,
-    ) -> Set[MemoryLocation]:
+    ) -> Optional[MemoryLocation]:
         ...
 
     @overload
     def deref(
         self,
-        pointer: Union[int, claripy.ast.BV, HeapAddress, SpOffset],
+        pointer: Union[MultiValues, Atom, Definition, Iterable[Atom], Iterable[Definition]],
         size: Union[int, DerefSize],
         endness: str = ...,
-    ) -> Optional[MemoryLocation]:
+    ) -> Set[MemoryLocation]:
         ...
 
     def deref(


### PR DESCRIPTION
I don't fully understand what's going on here yet, but with the previous order mypy fails to properly detect which overload should apply in a very common use case. Consider the following example code:

```python
from typing import Optional, Set

import claripy
from angr.analyses.reaching_definitions import ReachingDefinitionsState
from angr.knowledge_plugins.key_definitions import Definition
from angr.knowledge_plugins.key_definitions.atoms import MemoryLocation, Atom
from angr.storage.memory_mixins.paged_memory.pages.multi_values import MultiValues

state: "ReachingDefinitionsState" = ...

location: Optional[MemoryLocation]
locations: Set[MemoryLocation]

# int -> Optional[MemoryLocation]
location = state.deref(0, 8)

# BV -> Optional[MemoryLocation]
# Fails type check if the overloads are in the old ordering: Incompatible types in assignment (expression has type "set[MemoryLocation]", variable has type "MemoryLocation | None")
bv: claripy.ast.bv.BV = ...
location = state.deref(bv, 8)

# Atom -> Set[MemoryLocation]
locations = state.deref(Atom.reg("x1", arch=state.arch), 8)

# MultiValues -> Set[MemoryLocation]
locations = state.deref(MultiValues(), 8)

# Iterable[Atom] -> Set[MemoryLocation]
locations = state.deref([Atom.reg("x1", arch=state.arch)], 8)

# Definition -> Set[MemoryLocation]
definition: Definition = ...
locations = state.deref(definition, 8)

# Iterable[Definition] -> Set[MemoryLocation]
locations = state.deref([definition], 8)
```

So, for some reason, mypy doesn't realize that for a claripy.BVV the overload:
```python
    @overload
    def deref(
        self,
        pointer: Union[int, claripy.ast.BV, HeapAddress, SpOffset],
        size: Union[int, DerefSize],
        endness: str = ...,
    ) -> Optional[MemoryLocation]:
        ...
```
should apply.
IIRC overloads are checked in order, and the first applicable one is used, so for some reason the first overload
```python
    @overload
    def deref(
        self,
        pointer: Union[MultiValues, Atom, Definition, Iterable[Atom], Iterable[Definition]],
        size: Union[int, DerefSize],
        endness: str = ...,
    ) -> Set[MemoryLocation]:
        ...
```

covers the scenario where a `claripy.ast.BV` is passed.

Flipping the order doesn't seem to affect any other case, so I consider it an acceptable workaround to flip the order, though I'd rather understand what is going on here, but I'm out of ideas.
