### PR TITLE
Decompiler: Disambiguate called function names

### DIFF
--- a/angr/analyses/decompiler/decompilation_options.py
+++ b/angr/analyses/decompiler/decompilation_options.py
@@ -177,6 +177,16 @@ options = [
         clears_cache=True,
     ),
     O(
+        "Show disambiguated names",
+        "Disambiguate function names when they conflict with variables and other functions",
+        bool,
+        "codegen",
+        "show_disambiguated_name",
+        category="Display",
+        default_value=True,
+        clears_cache=True,
+    ),
+    O(
         "Structuring algorithm",
         "Select a structuring algorithm. Currently supports Dream and Phoenix.",
         type,

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1443,15 +1443,19 @@ class CVariable(CExpression):
     def type(self):
         return self.variable_type
 
-    def c_repr_chunks(self, indent=0, asexpr=False):
+    @property
+    def name(self):
         v = self.variable if self.unified_variable is None else self.unified_variable
 
         if v.name:
-            yield v.name, self
+            return v.name
         elif isinstance(v, SimTemporaryVariable):
-            yield "tmp_%d" % v.tmp_id, self
+            return "tmp_%d" % v.tmp_id
         else:
-            yield str(v), self
+            return str(v)
+
+    def c_repr_chunks(self, indent=0, asexpr=False):
+        yield self.name, self
 
 
 class CIndexedVariable(CExpression):

--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -347,6 +347,9 @@ class FunctionManager(KnowledgeBasePlugin, collections.abc.Mapping):
     def get_by_addr(self, addr) -> Function:
         return self._function_map.get(addr)
 
+    def get_by_name(self, name: str) -> Set[Function]:
+        return {f for f in self._function_map.values() if f.name == name}
+
     def _function_added(self, func: Function):
         """
         A callback method for adding a new function instance to the manager.

--- a/tests/knowledge_plugins/functions/test_function_manager.py
+++ b/tests/knowledge_plugins/functions/test_function_manager.py
@@ -121,6 +121,19 @@ class TestFunctionManager(unittest.TestCase):
         assert 0x400000 in self.project.kb.functions.keys()
         assert 0x400420 in self.project.kb.functions.keys()
 
+    def test_query(self):
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        proj.analyses.CFGFast(normalize=True, data_references=True)
+
+        assert proj.kb.functions["::read"].addr == 0x400530
+        assert proj.kb.functions["::0x400530::read"].addr == 0x400530
+        assert proj.kb.functions["::libc.so.0::read"].addr == 0x700010
+        with self.assertRaises(KeyError):
+            proj.kb.functions["::0x400531::read"]  # pylint:disable=pointless-statement
+        with self.assertRaises(KeyError):
+            proj.kb.functions["::bad::read"]  # pylint:disable=pointless-statement
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
To handle cases when called function names conflict with local variables and other functions, support using disambiguated names. Also support querying function manager by disambiguated names.


e.g.

```c
int puts(char *s)
{
    return ::libc.so.0::puts(s);
}
```

and

```c
int main(unsigned long puts, unsigned long a1)
{
    unsigned long v0;  // [bp-0x48]
    unsigned int v1;  // [bp-0x3c]
    char v2;  // [bp-0x2c], Other Possible Types: unsigned int
    char v3;  // [bp-0x28]
    char v4;  // [bp-0x20]
    char v5;  // [bp-0x18]
    char v6;  // [bp-0x10]

    v1 = puts;
    v0 = a1;
    v6 = 0;
    v4 = 0;
    ::puts("Username: ");
    read(0, &v5, 8);
    read(0, &v2, 1);
    ::puts("Password: ");
    read(0, &v3, 8);
    read(0, &v2, 1);
    v2 = authenticate(&v5, &v3);
    if (v2)
        return (unsigned int)accepted();
    rejected(); /* do not return */
}
```