### PR TITLE
Rewrite dfs_back_edges to be iterative

### DIFF
--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -85,31 +85,33 @@ def to_acyclic_graph(
 
 def dfs_back_edges(graph, start_node):
     """
-    Do a DFS traversal of the graph, and return with the back edges.
-
-    Note: This is just a naive recursive implementation, feel free to replace it.
-    I couldn't find anything in networkx to do this functionality. Although the
-    name suggest it, but `dfs_labeled_edges` is doing something different.
+    Perform an iterative DFS traversal of the graph, returning back edges.
 
     :param graph:       The graph to traverse.
-    :param start_node:  The node where to start the traversal
-    :returns:           An iterator of 'backward' edges
+    :param start_node:  The node where to start the traversal.
+    :returns:           An iterator of 'backward' edges.
     """
+    if start_node not in graph:
+        return  # Ensures that the start node is in the graph
 
-    visited = set()
-    finished = set()
+    visited = set()  # Tracks visited nodes
+    finished = set()  # Tracks nodes whose descendants are fully explored
+    stack = [(start_node, iter(graph[start_node]))]
 
-    def _dfs_back_edges_core(node):
+    while stack:
+        node, children = stack[-1]
         visited.add(node)
-        for child in iter(graph[node]):
-            if child not in finished:
-                if child in visited:
-                    yield node, child
-                else:
-                    yield from _dfs_back_edges_core(child)
-        finished.add(node)
 
-    yield from _dfs_back_edges_core(start_node)
+        try:
+            child = next(children)
+            if child in visited:
+                if child not in finished:
+                    yield node, child  # Found a back edge
+            elif child not in finished:  # Check if the child has not been finished
+                stack.append((child, iter(graph[child])))
+        except StopIteration:
+            stack.pop()  # Done with this node's children
+            finished.add(node)  # Mark this node as finished
 
 
 def subgraph_between_nodes(graph, source, frontier, include_frontier=False):


### PR DESCRIPTION
Turns out you can just ask ChatGPT4 to do rewriting like this: https://chat.openai.com/share/aa214b1d-ced6-4f5d-ac42-db9074f39755

This looks correct enough at a first glance but I didn't look into it more. I'm mostly curious if this is already enough to pass the CI tests. I'm a bit confused how the back edges are used elsewhere, from my quick check of what "back edge" means, they are a part of the DFS traversal and not the graph itself?