### PR TITLE
Update pcode engine for pypcode 2.0.0

### DIFF
--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -133,6 +133,8 @@ class IROp(DisassemblyPiece):
         self.irsb = irsb
 
     def __str__(self):
+        if pcode and isinstance(self.obj, pypcode.PcodeOp):
+            return pypcode.PcodePrettyPrinter.fmt_op(self.obj)
         return str(self.obj)
 
     def _render(self, formatting):  # pylint:disable=unused-argument
@@ -1078,9 +1080,14 @@ class Disassembly(Analysis):
 
         if irsb.statements is not None:
             if pcode is not None and isinstance(self.project.factory.default_engine, pcode.HeavyPcodeMixin):
-                for ins in irsb._instructions:
-                    addr = ins.address.offset
-                    addr_to_ops_map[addr].extend([IROp(addr, op.seq.uniq, op, irsb) for op in ins.ops])
+                addr = None
+                stmt_idx = 0
+                for op in irsb._ops:
+                    if op.opcode == pypcode.OpCode.IMARK:
+                        addr = op.inputs[0].offset
+                    else:
+                        addr_to_ops_map[addr].append(IROp(addr, stmt_idx, op, irsb))
+                    stmt_idx += 1
             else:
                 for seq, stmt in enumerate(irsb.statements):
                     if isinstance(stmt, pyvex.stmt.IMark):

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -695,28 +695,21 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
             else:
                 raise CouldNotResolveException()
 
-        for instr in pcode_irsb._instructions:
-            if curr_stmt_start_addr is not None:
-                # we've reached a new instruction. Time to store the post state
-                self._set_post_state(curr_stmt_start_addr, state.freeze())
-            curr_stmt_start_addr = instr.address.offset
-            self._set_pre_state(curr_stmt_start_addr, state.freeze())
-
-            for op in instr.ops:
-                op: "pypcode.PcodeOp"
+        is_call = False
+        for op in pcode_irsb._ops:
+            if op.opcode == pypcode.OpCode.IMARK:
+                if curr_stmt_start_addr is not None:
+                    # we've reached a new instruction. Time to store the post state
+                    self._set_post_state(curr_stmt_start_addr, state.freeze())
+                curr_stmt_start_addr = op.inputs[0].offset
+                self._set_pre_state(curr_stmt_start_addr, state.freeze())
+            else:
                 try:
                     resolve_op(op)
                 except CouldNotResolveException:
                     pass
 
-        # examine the last instruction and determine if this is a call instruction
-        is_call = False
-        if pcode_irsb._instructions:
-            last_instr = pcode_irsb._instructions[-1]
-            if last_instr.ops:
-                last_op = last_instr.ops[-1]
-                if last_op.opcode == pypcode.OpCode.CALL:
-                    is_call = True
+                is_call |= op.opcode == pypcode.OpCode.CALL
 
         # stack pointer adjustment
         if self.project.arch.sp_offset in self.reg_offsets and is_call:

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -5,9 +5,8 @@
 #     - Fix default_exit_target
 #     - Fix/remove NotImplementedError's
 
-import copy
 import logging
-from typing import Union, Optional, Iterable, Sequence, Tuple, List
+from typing import Union, Optional, Iterable, Sequence, Tuple
 
 import archinfo
 from archinfo import ArchARM, ArchPcode
@@ -54,7 +53,7 @@ class ExitStatement:
 
 class PcodeDisassemblerBlock(DisassemblerBlock):
     """
-    Helper class to represent a block of dissassembled target architecture
+    Helper class to represent a block of disassembled target architecture
     instructions
     """
 
@@ -73,15 +72,15 @@ class PcodeDisassemblerInsn(DisassemblerInsn):
 
     @property
     def address(self) -> int:
-        return self.insn.address.offset
+        return self.insn.addr.offset
 
     @property
     def mnemonic(self) -> str:
-        return self.insn.asm_mnem
+        return self.insn.mnem
 
     @property
     def op_str(self) -> str:
-        return self.insn.asm_body
+        return self.insn.body
 
 
 class IRSB:
@@ -107,7 +106,7 @@ class IRSB:
         "_direct_next",
         "_exit_statements",
         "_instruction_addresses",
-        "_instructions",
+        "_ops",
         "_size",
         "_statements",
         "_disassembly",
@@ -122,8 +121,8 @@ class IRSB:
 
     _direct_next: Optional[bool]
     _exit_statements: Sequence[Tuple[int, int, ExitStatement]]
-    _instruction_addresses: Sequence[int]
-    _instructions: Sequence[pypcode.Translation]
+    _instruction_addresses: Optional[Sequence[int]]
+    _ops: Sequence[pypcode.PcodeOp]  # FIXME: Merge into _statements
     _size: Optional[int]
     _statements: Iterable  # Note: currently unused
     _disassembly: Optional[PcodeDisassemblerBlock]
@@ -189,8 +188,8 @@ class IRSB:
 
         self._direct_next = None
         self._exit_statements = []
-        self._instruction_addresses = ()
-        self._instructions: List["pypcode.Translation"] = []
+        self._instruction_addresses = None
+        self._ops = []
         self._size = None
         self._statements = []
         self.addr = mem_addr
@@ -258,15 +257,7 @@ class IRSB:
             nxt=self.next,
             jumpkind=self.jumpkind,
             direct_next=self.direct_next,
-            # deepcopy call to 'pickle' fails.
-            # shallow copy should work since _instructions shouldn't mutate
-            instructions=copy.copy(self._instructions),
-            # statements = None, #unused
-            # instruction_addresses = None # computed
-            # tyenv = None # unused
-            # exit_statements = None # currently unused
-            # default_exit_target = None # currently unused
-            # size = None # computed
+            ops=self._ops[:],
         )
 
         return new
@@ -277,22 +268,14 @@ class IRSB:
         The appended irsb's jumpkind and default exit are used.
         :param extendwith: The IRSB to append to this IRSB
         """
-        # see _set_attributes call in 'copy' def for notes on other attributes
         self._set_attributes(
             nxt=extendwith.next,
             jumpkind=extendwith.jumpkind,
             direct_next=extendwith.direct_next,
-            instructions=copy.copy(self._instructions),
+            ops=self._ops + extendwith._ops,
         )
 
-        # append instructions if new
-        addrs = self.instruction_addresses
-        newinsns = [insn for insn in extendwith._instructions if insn.address not in addrs]
-        self._instructions.extend(newinsns)
-
-        # reset disassem. now disassem will be recomputed if irsb.disassembly is called
         self._disassembly = None
-
         return self
 
     def invalidate_direct_next(self) -> None:
@@ -353,22 +336,27 @@ class IRSB:
         """
         The number of instructions in this block
         """
-        return len(self._instructions)
+        return len(self.instruction_addresses)
 
     @property
     def instruction_addresses(self) -> Sequence[int]:
         """
         Addresses of instructions in this block.
         """
-        return [ins.address.offset for ins in self._instructions]
+        if self._instruction_addresses is None:
+            self._instruction_addresses = []
+            for op in self._ops:
+                if op.opcode == pypcode.OpCode.IMARK:
+                    for vn in op.inputs:
+                        self._instruction_addresses.append(vn.offset)
+        return self._instruction_addresses
 
     @property
     def size(self) -> int:
         """
         The size of this block, in bytes
         """
-        if self._size is None:
-            self._size = sum(ins.length for ins in self._instructions)
+        assert self._size is not None
         return self._size
 
     @property
@@ -437,10 +425,12 @@ class IRSB:
         """
         sa = []
         sa.append("IRSB {")
-        for i, ins in enumerate(self._instructions):
-            sa.append("   %02d | ------ %08x, %d ------" % (i, ins.address.offset, ins.length))
-            for op in ins.ops:
-                sa.append("  +%02d | %s" % (op.seq.uniq, pypcode.PcodePrettyPrinter.fmt_op(op)))
+        for i, op in enumerate(self._ops):
+            if op.opcode == pypcode.OpCode.IMARK:
+                for vn in op.inputs[:]:
+                    sa.append(f"   {i:02d} | ------ {vn.offset:08x}, {vn.size} ------")
+            else:
+                sa.append(f"   {i:02d} | {pypcode.PcodePrettyPrinter.fmt_op(op)}")
 
         if isinstance(self.next, int):
             next_str = "%x" % self.next
@@ -466,7 +456,7 @@ class IRSB:
         jumpkind: Optional[str] = None,
         direct_next: Optional[bool] = None,
         size: Optional[int] = None,
-        instructions: Optional[Iterable[pypcode.Translation]] = None,
+        ops: Optional[Sequence[pypcode.PcodeOp]] = None,
         instruction_addresses: Optional[Iterable[int]] = None,
         exit_statements: Sequence[Tuple[int, int, ExitStatement]] = None,
         default_exit_target: Optional = None,
@@ -477,7 +467,7 @@ class IRSB:
         self.jumpkind = jumpkind
         self._direct_next = direct_next
         self._size = size
-        self._instructions = instructions or []
+        self._ops = ops or []
         self._instruction_addresses = instruction_addresses
         self._exit_statements = exit_statements or []
         self.default_exit_target = default_exit_target
@@ -490,7 +480,7 @@ class IRSB:
             irsb.jumpkind,
             irsb.direct_next,
             irsb.size,
-            instructions=irsb._instructions,
+            ops=irsb._ops,
             instruction_addresses=irsb._instruction_addresses,
             exit_statements=irsb.exit_statements,
             default_exit_target=irsb.default_exit_target,
@@ -506,10 +496,6 @@ class IRSB:
 
     @property
     def disassembly(self) -> PcodeDisassemblerBlock:
-        if self._disassembly is None:
-            insns = [PcodeDisassemblerInsn(ins) for ins in self._instructions]
-            thumb = False  # FIXME
-            self._disassembly = PcodeDisassemblerBlock(self.addr, insns, thumb, self.arch)
         return self._disassembly
 
 
@@ -838,11 +824,7 @@ class PcodeBasicBlockLifter:
                 raise NotImplementedError()
             langid = archinfo_to_lang_map[arch.name]
 
-        langs = {l.id: l for a in pypcode.Arch.enumerate() for l in a.languages}
-
-        lang = langs[langid]
-
-        self.context = pypcode.Context(lang)
+        self.context = pypcode.Context(langid)
         self.behaviors = BehaviorFactory()
 
     def lift(
@@ -856,16 +838,18 @@ class PcodeBasicBlockLifter:
         branch_delay_slot: bool = False,
         is_sparc32: bool = False,
     ) -> None:
+        assert irsb.addr == baseaddr
+        assert bytes_offset < len(data)
+
         if max_bytes is None or max_bytes > MAX_BYTES:
-            max_bytes = min(len(data), MAX_BYTES)
+            max_bytes = min(len(data) - bytes_offset, MAX_BYTES)
         if max_inst is None or max_inst > MAX_INSTRUCTIONS:
             max_inst = MAX_INSTRUCTIONS
 
         irsb.behaviors = self.behaviors  # FIXME
 
         # Translate
-        addr = baseaddr + bytes_offset
-        sliced_data = data[bytes_offset : bytes_offset + max_bytes]
+        sliced_data = bytes(data[bytes_offset : bytes_offset + max_bytes])
 
         if is_sparc32:
             # workaround to handle SPARC V8 decoding before having a SPARC V8 Sleigh file
@@ -884,56 +868,88 @@ class PcodeBasicBlockLifter:
                         sliced_data = sliced_data[:index] + rett_seq + nop_seq + sliced_data[index + 8 :]
                         index = sliced_data.find(seq)
 
-        result = self.context.translate(sliced_data, addr, max_inst, max_bytes, True)
-        irsb._instructions = result.instructions
+        sliced_data = bytes(sliced_data)
+
         # Post-process block to mark exits and next block
         next_block = None
-        is_branch = False
-        for insn in irsb._instructions:
-            for op in insn.ops:
-                if op.opcode in [pypcode.OpCode.BRANCH, pypcode.OpCode.CBRANCH] and op.inputs[0].get_addr().is_constant:
-                    # P-code relative branch (op.seq.pc.offset + op.seq.uniq + op.inputs[0].offset)
+        irsb._instruction_addresses = []
+        fallthru_addr = irsb.addr
+
+        try:
+            translation = self.context.translate(
+                sliced_data,
+                irsb.addr,
+                max_instructions=max_inst,
+                max_bytes=max_bytes,
+                flags=pypcode.TranslateFlags.BB_TERMINATING,
+            )
+            irsb._ops = translation.ops
+
+            last_decode_addr = irsb.addr
+            last_imark_idx = 0
+            for op_idx, op in enumerate(irsb._ops):
+                # OpCode space begins with control ops ending with RETURN. Quickly filter non-control instructions.
+                if op.opcode > pypcode.OpCode.RETURN:
                     continue
+
+                if op.opcode == pypcode.OpCode.IMARK:
+                    irsb._instruction_addresses.extend([vn.offset for vn in op.inputs])
+                    last_decode_addr = op.inputs[0].offset
+                    fallthru_addr = op.inputs[-1].offset + op.inputs[-1].size
+                    last_imark_idx = op_idx
+                    continue
+
+                if op.opcode in {pypcode.OpCode.BRANCH, pypcode.OpCode.CBRANCH} and op.inputs[0].space.name == "const":
+                    # P-code relative branch (op_idx + op.inputs[0].offset)
+                    # Note: We only model these in execution
+                    continue
+
                 if op.opcode == pypcode.OpCode.CBRANCH:
                     irsb._exit_statements.append(
-                        (op.seq.pc.offset, op.seq.uniq, ExitStatement(op.inputs[0].offset, "Ijk_Boring"))
+                        (last_decode_addr, op_idx - last_imark_idx, ExitStatement(op.inputs[0].offset, "Ijk_Boring"))
                     )
-                    is_branch = True
                 elif op.opcode == pypcode.OpCode.BRANCH:
                     if next_block is None:
                         next_block = (op.inputs[0].offset, "Ijk_Boring")
-                    is_branch = True
                 elif op.opcode == pypcode.OpCode.BRANCHIND:
                     if next_block is None:
                         next_block = (None, "Ijk_Boring")
-                    is_branch = True
                 elif op.opcode == pypcode.OpCode.CALL:
                     if next_block is None:
                         next_block = (op.inputs[0].offset, "Ijk_Call")
-                    is_branch = True
                 elif op.opcode == pypcode.OpCode.CALLIND:
                     if next_block is None:
                         next_block = (None, "Ijk_Call")
-                    is_branch = True
                 elif op.opcode == pypcode.OpCode.RETURN:
                     if next_block is None:
                         next_block = (None, "Ijk_Ret")
-                    is_branch = True
 
-        if is_branch and branch_delay_slot:
-            # adjust the block size accordingly if branch delay slot exists for this architecture
-            irsb._size = irsb.size + irsb._instructions[-1].length
+            # FIXME: Do this lazily
+            disasm = self.context.disassemble(
+                sliced_data,
+                irsb.addr,
+                max_instructions=max_inst,
+                max_bytes=fallthru_addr - irsb.addr,
+            )
+            irsb._disassembly = PcodeDisassemblerBlock(
+                addr=irsb.addr,
+                insns=[PcodeDisassemblerInsn(ins) for ins in disasm.instructions],
+                thumb=False,
+                arch=irsb.arch,
+            )
 
-        if len(irsb._instructions) > 0:
-            fallthru_addr = irsb.addr + irsb.size
-        else:
-            fallthru_addr = addr
-
-        if result.error:
+        except (pypcode.BadDataError, pypcode.UnimplError):
             next_block = (fallthru_addr, "Ijk_NoDecode")
-        elif next_block is None:
+        except (pypcode.LowlevelError, IndexError):
+            # FIXME:
+            # - IndexError: Give more data
+            # - pypcode.LowlevelError: Sometimes a decoding failure
+            next_block = (irsb.addr, "Ijk_NoDecode")
+
+        if next_block is None:
             next_block = (fallthru_addr, "Ijk_Boring")
 
+        irsb._size = fallthru_addr - irsb.addr
         irsb.next, irsb.jumpkind = next_block
 
 
@@ -971,7 +987,7 @@ class PcodeLifterEngineMixin(SimEngineBase):
 
     def __init__(
         self,
-        project,
+        project=None,
         use_cache: Optional[bool] = None,
         cache_size: int = 50000,
         default_opt_level: int = 1,
@@ -1270,12 +1286,7 @@ class PcodeLifterEngineMixin(SimEngineBase):
 
         # phase x: error handling
         except PyVEXError as e:
-            l.debug("VEX translation error at %#x", addr)
-            # FIXME
-            # if isinstance(buff, bytes):
-            #     l.debug("Using bytes: %r", buff)
-            # else:
-            #     l.debug("Using bytes: %r", pyvex.ffi.buffer(buff, size))
+            l.debug("Translation error at %#x", addr)
             raise SimTranslationError("Unable to translate bytecode") from e
 
     def _load_bytes(

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,10 +61,10 @@ docs =
     sphinx
     sphinx-autodoc-typehints
 pcode =
-    pypcode==1.1
+    pypcode~=2.0
 testing =
     keystone-engine
-    pypcode==1.1
+    pypcode~=2.0
     pytest
     pytest-split
     pytest-xdist

--- a/tests/engines/pcode/test_emulate.py
+++ b/tests/engines/pcode/test_emulate.py
@@ -1,0 +1,600 @@
+import logging
+import unittest
+import operator
+from dataclasses import dataclass
+from typing import Optional, List
+
+import claripy
+from pypcode import OpCode
+
+import angr
+from angr.engines.pcode.behavior import BehaviorFactory
+from angr.engines.pcode.emulate import PcodeEmulatorMixin
+from angr.sim_state import SimState
+from angr.engines import SimSuccessors
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(eq=True)
+class MockAddrSpace:
+    """
+    Mock AddrSpace
+    """
+
+    name: str
+
+
+CONST_SPACE = MockAddrSpace("const")
+RAM_SPACE = MockAddrSpace("ram")
+REGISTER_SPACE = MockAddrSpace("register")
+UNIQUE_SPACE = MockAddrSpace("unique")
+
+
+@dataclass(eq=True)
+class MockVarnode:
+    """
+    Mock Varnode
+    """
+
+    space: MockAddrSpace
+    offset: int
+    size: int
+
+    register_name: str = "<mock>"
+    space_encoded_in_offset: Optional[MockAddrSpace] = None
+
+    def getRegisterName(self) -> str:
+        return self.register_name
+
+    def getSpaceFromConst(self) -> Optional[MockAddrSpace]:
+        return self.space_encoded_in_offset
+
+
+@dataclass(eq=True)
+class MockPcodeOp:
+    """
+    Mock P-Code Op
+    """
+
+    opcode: OpCode
+    output: Optional[MockVarnode]
+    inputs: List[MockVarnode]
+
+
+BEHAVIORS = BehaviorFactory()
+
+
+@dataclass
+class MockIRSB:
+    """
+    Mock IRSB
+    """
+
+    _ops: List[MockPcodeOp]
+    addr: int = 0
+    behaviors: BehaviorFactory = BEHAVIORS
+
+
+OP = MockPcodeOp
+VN = MockVarnode
+
+
+class TestPcodeEmulatorMixin(unittest.TestCase):
+    """
+    Test P-Code engine emulator mixin
+    """
+
+    @staticmethod
+    def _step_irsb(irsb, state=None):
+        emulator = PcodeEmulatorMixin()
+        # FIMXE: *sigh* it's not so easy to use the mixin in isolation
+
+        emulator.project = angr.load_shellcode(b"\x90", arch="AMD64")
+        if state is None:
+            state = SimState(arch="AMD64")
+        emulator.state = state
+        emulator.state.history.recent_bbl_addrs.append(0)
+        emulator.successors = SimSuccessors(0, emulator.state)
+        emulator.handle_pcode_block(irsb)
+        emulator.successors.processed = True
+        return emulator.successors
+
+    def _test_branch_and_call_common(self, opcode: OpCode):
+        target_addr = 0x12345678
+        successors = self._step_irsb(
+            MockIRSB(
+                [
+                    OP(
+                        OpCode.IMARK,
+                        None,
+                        [VN(RAM_SPACE, 0, 1)],
+                    ),
+                    OP(
+                        opcode,
+                        None,
+                        [VN(RAM_SPACE, target_addr, 1)],
+                    ),
+                ]
+            )
+        )
+
+        assert len(successors.all_successors) == 1
+        state = successors.all_successors[0]
+        assert state.solver.eval(state.regs.pc == target_addr)
+
+    def test_branch(self):
+        self._test_branch_and_call_common(OpCode.BRANCH)
+
+    def test_call(self):
+        self._test_branch_and_call_common(OpCode.CALL)
+
+    def _test_branchind_and_callind_common(self, opcode: OpCode):
+        target_addr = 0x12345678
+        target_pointer_addr = 0x100000
+        target_pointer_size = 8
+
+        state = SimState(arch="AMD64")
+        state.memory.store(target_pointer_addr, claripy.BVV(target_addr, 8 * target_pointer_size), endness="IEnd_LE")
+
+        successors = self._step_irsb(
+            MockIRSB(
+                [
+                    OP(
+                        OpCode.IMARK,
+                        None,
+                        [VN(RAM_SPACE, 0, 1)],
+                    ),
+                    OP(
+                        opcode,
+                        None,
+                        [VN(RAM_SPACE, target_pointer_addr, target_pointer_size)],
+                    ),
+                ]
+            ),
+            state,
+        )
+
+        assert len(successors.all_successors) == 1
+        state = successors.all_successors[0]
+        assert state.solver.eval(state.regs.pc == target_addr)
+
+    def test_branchind(self):
+        self._test_branchind_and_callind_common(OpCode.BRANCHIND)
+
+    def test_callind(self):
+        self._test_branchind_and_callind_common(OpCode.CALLIND)
+
+    def _test_cbranch_common(self, cond: claripy.BVV):
+        condition_addr = 0x100000
+        target_addr = 0x12345678
+        fallthru_addr = 1
+
+        state = SimState(arch="AMD64")
+        state.memory.store(condition_addr, cond)
+
+        successors = self._step_irsb(
+            MockIRSB(
+                [
+                    OP(
+                        OpCode.IMARK,
+                        None,
+                        [VN(RAM_SPACE, 0, fallthru_addr)],
+                    ),
+                    OP(
+                        OpCode.CBRANCH,
+                        None,
+                        [VN(RAM_SPACE, target_addr, 8), VN(RAM_SPACE, condition_addr, 1)],
+                    ),
+                ]
+            ),
+            state,
+        )
+
+        if cond.concrete:
+            if state.solver.eval(cond):
+                sat_pc, unsat_pc = target_addr, fallthru_addr
+            else:
+                sat_pc, unsat_pc = fallthru_addr, target_addr
+
+            assert len(successors.successors) == 1
+            state = successors.successors[0]
+            assert state.solver.eval(state.regs.pc == sat_pc)
+
+            assert len(successors.unsat_successors) == 1
+            state = successors.unsat_successors[0]
+            assert state.solver.eval(state.regs.pc == unsat_pc)
+        else:
+            assert len(successors.successors) == 2
+            pcs = {state.solver.eval(state.regs.pc) for state in successors.successors}
+            assert pcs == {target_addr, fallthru_addr}
+
+    def test_cbranch_taken(self):
+        self._test_cbranch_common(claripy.BVV(1, 8))
+        self._test_cbranch_common(claripy.BVV(2, 8))
+
+    def test_cbranch_not_taken(self):
+        self._test_cbranch_common(claripy.BVV(0, 8))
+
+    def test_cbranch_symbolic(self):
+        self._test_cbranch_common(claripy.BVS("condition", 8))
+
+    def _test_rel_cbranch_common(self, cond: claripy.BVV):
+        condition_addr = 0x100000
+        start_addr = 0
+        target_addr = start_addr
+        target_stmt = 1
+        instruction_len = 1
+        fallthru_addr = start_addr + instruction_len
+        cbranch_idx = 2
+
+        state = SimState(arch="AMD64")
+        state.memory.store(condition_addr, cond)
+
+        successors = self._step_irsb(
+            MockIRSB(
+                [
+                    # Op 0
+                    OP(
+                        OpCode.IMARK,
+                        None,
+                        [VN(RAM_SPACE, start_addr, instruction_len)],
+                    ),
+                    # Op 1
+                    OP(
+                        OpCode.INT_ADD,
+                        VN(UNIQUE_SPACE, 0, 8),
+                        [VN(UNIQUE_SPACE, 0, 8), VN(CONST_SPACE, 1, 8)],
+                    ),
+                    # Op 2
+                    OP(
+                        OpCode.CBRANCH,
+                        None,
+                        [VN(CONST_SPACE, target_stmt - cbranch_idx, 8), VN(RAM_SPACE, condition_addr, 1)],
+                    ),
+                ]
+            ),
+            state,
+        )
+
+        if cond.concrete:
+            if state.solver.eval(cond):
+                sat_pc, unsat_pc = target_addr, fallthru_addr
+                sat_stmt, unsat_stmt = target_stmt, 0
+            else:
+                sat_pc, unsat_pc = fallthru_addr, target_addr
+                sat_stmt, unsat_stmt = 0, target_stmt
+
+            assert len(successors.successors) == 1
+            state = successors.successors[0]
+            assert state.solver.eval(state.regs.pc == sat_pc)
+            assert state.scratch.statement_offset == sat_stmt
+
+            assert len(successors.unsat_successors) == 1
+            state = successors.unsat_successors[0]
+            assert state.solver.eval(state.regs.pc == unsat_pc)
+            assert state.scratch.statement_offset == unsat_stmt
+
+        else:
+            assert len(successors.successors) == 2
+            pcs = {
+                (state.solver.eval(state.regs.pc), state.scratch.statement_offset) for state in successors.successors
+            }
+            assert pcs == {(target_addr, target_stmt), (fallthru_addr, 0)}
+
+    def test_rel_cbranch_taken(self):
+        self._test_rel_cbranch_common(claripy.BVV(1, 8))
+        self._test_rel_cbranch_common(claripy.BVV(2, 8))
+
+    def test_rel_cbranch_not_taken(self):
+        self._test_rel_cbranch_common(claripy.BVV(0, 8))
+
+    def test_rel_cbranch_symbolic(self):
+        self._test_cbranch_common(claripy.BVS("condition", 8))
+
+    def test_load_store(self):
+        addr = 0x133700000
+        addr2 = 0x999900000
+        value = claripy.BVV(0xFEDCBA9876543210, 64)
+        state = SimState(arch="AMD64")
+        state.memory.store(addr, value)
+        state.regs.rax = addr
+
+        # Load value from RAM[addr] and store it into RAM[addr2]
+
+        successors = self._step_irsb(
+            MockIRSB(
+                [
+                    OP(
+                        OpCode.IMARK,
+                        None,
+                        [VN(RAM_SPACE, 0, 1)],
+                    ),
+                    OP(
+                        OpCode.COPY,
+                        VN(UNIQUE_SPACE, 0, 8),
+                        [VN(CONST_SPACE, addr, 8)],
+                    ),
+                    OP(
+                        OpCode.LOAD,
+                        VN(UNIQUE_SPACE, 8, 8),
+                        [VN(CONST_SPACE, 0xCACACACA, 0, space_encoded_in_offset=RAM_SPACE), VN(UNIQUE_SPACE, 0, 8)],
+                    ),
+                    OP(
+                        OpCode.COPY,
+                        VN(UNIQUE_SPACE, 0, 8),
+                        [VN(CONST_SPACE, addr2, 8)],
+                    ),
+                    OP(
+                        OpCode.STORE,
+                        None,
+                        [
+                            VN(CONST_SPACE, 0xCACACACA, 0, space_encoded_in_offset=RAM_SPACE),
+                            VN(UNIQUE_SPACE, 0, 8),
+                            VN(UNIQUE_SPACE, 8, 8),
+                        ],
+                    ),
+                ],
+            ),
+            state,
+        )
+
+        new_state = successors.successors[0]
+        assert new_state.solver.is_true(new_state.memory.load(addr2, 8) == value)
+
+    def _test_single_arith_binary_op(self, opcode: OpCode):
+        opcode_to_operation = {
+            OpCode.BOOL_AND: operator.and_,
+            OpCode.BOOL_OR: operator.or_,
+            OpCode.BOOL_XOR: operator.xor,
+            OpCode.INT_ADD: operator.add,
+            OpCode.INT_AND: operator.and_,
+            OpCode.INT_DIV: operator.floordiv,
+            OpCode.INT_EQUAL: operator.eq,
+            OpCode.INT_LEFT: operator.lshift,
+            OpCode.INT_LESS: operator.lt,
+            OpCode.INT_LESSEQUAL: operator.le,
+            OpCode.INT_MULT: operator.mul,
+            OpCode.INT_NOTEQUAL: operator.ne,
+            OpCode.INT_OR: operator.or_,
+            OpCode.INT_REM: operator.mod,
+            OpCode.INT_RIGHT: claripy.LShR,
+            OpCode.INT_SLESS: claripy.SLT,
+            OpCode.INT_SLESSEQUAL: claripy.SLE,
+            OpCode.INT_SRIGHT: operator.rshift,
+            OpCode.INT_SUB: operator.sub,
+            OpCode.INT_XOR: operator.xor,
+        }
+
+        operation = opcode_to_operation.get(opcode)
+        assert operation is not None
+
+        is_boolean = opcode in {OpCode.BOOL_AND, OpCode.BOOL_OR, OpCode.BOOL_XOR}
+        is_comparison = opcode in {
+            OpCode.INT_EQUAL,
+            OpCode.INT_LESS,
+            OpCode.INT_LESSEQUAL,
+            OpCode.INT_NOTEQUAL,
+            OpCode.INT_SLESS,
+            OpCode.INT_SLESSEQUAL,
+        }
+
+        operand_size = 1 if is_boolean else 4
+
+        result_addr = 0x100000
+        result_size = 1 if is_comparison else operand_size
+
+        x_addr, x = 0, claripy.BVS("x", operand_size * 8)
+        y_addr, y = operand_size, claripy.BVS("y", operand_size * 8)
+
+        state = SimState(arch="AMD64", remove_options={"SIMPLIFY_MEMORY_WRITES"})
+        state.memory.store(x_addr, x, endness="Iend_LE")
+        state.memory.store(y_addr, y, endness="Iend_LE")
+
+        successors = self._step_irsb(
+            MockIRSB(
+                [
+                    OP(
+                        OpCode.IMARK,
+                        None,
+                        [VN(RAM_SPACE, 0, 1)],
+                    ),
+                    OP(
+                        opcode,
+                        VN(RAM_SPACE, result_addr, operand_size),
+                        [VN(RAM_SPACE, x_addr, operand_size), VN(RAM_SPACE, y_addr, operand_size)],
+                    ),
+                ]
+            ),
+            state,
+        )
+
+        assert len(successors.all_successors) == 1
+        state = successors.all_successors[0]
+        assert state.solver.eval(state.regs.pc == 1)
+
+        result = state.memory.load(result_addr, result_size, endness="Iend_LE")
+
+        if is_boolean:
+            booleanize = angr.engines.pcode.behavior.OpBehavior.booleanize
+            expected_result = operation(booleanize(x), booleanize(y)).zero_extend(7)
+        elif is_comparison:
+            expected_result = claripy.If(operation(x, y), claripy.BVV(1, 1), claripy.BVV(0, 1)).zero_extend(7)
+        else:
+            expected_result = operation(x, y)
+
+        assert claripy.backends.z3.is_true(result == expected_result)
+
+    def test_arith_binary_ops(self):
+        for opcode in [
+            OpCode.BOOL_AND,
+            OpCode.BOOL_OR,
+            OpCode.BOOL_XOR,
+            OpCode.INT_ADD,
+            OpCode.INT_AND,
+            OpCode.INT_DIV,
+            OpCode.INT_EQUAL,
+            OpCode.INT_LEFT,
+            OpCode.INT_LESS,
+            OpCode.INT_LESSEQUAL,
+            OpCode.INT_MULT,
+            OpCode.INT_NOTEQUAL,
+            OpCode.INT_OR,
+            OpCode.INT_REM,
+            OpCode.INT_RIGHT,
+            # OpCode.INT_SDIV,  # FIXME
+            OpCode.INT_SLESS,
+            OpCode.INT_SLESSEQUAL,
+            OpCode.INT_SRIGHT,
+            OpCode.INT_SUB,
+            OpCode.INT_XOR,
+        ]:
+            with self.subTest(opcode):
+                self._test_single_arith_binary_op(opcode)
+
+    def _test_single_arith_unary_op(self, opcode: OpCode):
+        opcode_to_operation = {
+            OpCode.INT_NEGATE: operator.inv,
+            OpCode.INT_2COMP: operator.neg,
+        }
+
+        operation = opcode_to_operation.get(opcode)
+        assert operation is not None
+
+        operand_size = 4
+
+        result_size = operand_size
+        result_addr = 0x100000
+
+        x_addr, x = 0, claripy.BVS("x", operand_size * 8)
+
+        state = SimState(arch="AMD64", remove_options={"SIMPLIFY_MEMORY_WRITES"})
+        state.memory.store(x_addr, x, endness="Iend_LE")
+
+        successors = self._step_irsb(
+            MockIRSB(
+                [
+                    OP(
+                        OpCode.IMARK,
+                        None,
+                        [VN(RAM_SPACE, 0, 1)],
+                    ),
+                    OP(
+                        opcode,
+                        VN(RAM_SPACE, result_addr, operand_size),
+                        [VN(RAM_SPACE, x_addr, operand_size)],
+                    ),
+                ]
+            ),
+            state,
+        )
+
+        assert len(successors.all_successors) == 1
+        state = successors.all_successors[0]
+        assert state.solver.eval(state.regs.pc == 1)
+
+        result = state.memory.load(result_addr, result_size, endness="Iend_LE")
+        expected_result = operation(x)
+
+        assert claripy.backends.z3.is_true(result == expected_result)
+
+    def test_arith_unary_ops(self):
+        for opcode in [
+            OpCode.INT_NEGATE,
+            OpCode.INT_2COMP,
+        ]:
+            with self.subTest(opcode):
+                self._test_single_arith_unary_op(opcode)
+
+    def _test_other_unary_common(self, opcode, input_value, expected_value):
+        operand_addr = 0x200000
+        operand_size = input_value.size() // 8
+
+        result_addr = 0x100000
+        result_size = expected_value.size() // 8
+
+        state = SimState(arch="AMD64", remove_options={"SIMPLIFY_MEMORY_WRITES"})
+        state.memory.store(operand_addr, input_value, endness="Iend_LE")
+        state.memory.store(result_addr, claripy.BVV(b"\xCA" * result_size), endness="Iend_LE")
+
+        successors = self._step_irsb(
+            MockIRSB(
+                [
+                    OP(
+                        OpCode.IMARK,
+                        None,
+                        [VN(RAM_SPACE, 0, 1)],
+                    ),
+                    OP(
+                        opcode,
+                        VN(RAM_SPACE, result_addr, result_size),
+                        [VN(RAM_SPACE, operand_addr, operand_size)],
+                    ),
+                ],
+            ),
+            state,
+        )
+
+        assert len(successors.all_successors) == 1
+        state = successors.successors[0]
+        v = state.memory.load(result_addr, result_size, endness="Iend_LE")
+        assert state.solver.eval(v == expected_value)
+
+    def test_bool_negate(self):
+        # FIXME: Should values >1 be considered true? If some op only clears the 0th bit this may be incorrect
+        self._test_other_unary_common(OpCode.BOOL_NEGATE, claripy.BVV(0, 8), claripy.BVV(1, 8))
+        self._test_other_unary_common(OpCode.BOOL_NEGATE, claripy.BVV(1, 8), claripy.BVV(0, 8))
+        self._test_other_unary_common(OpCode.BOOL_NEGATE, claripy.BVV(0xFF, 8), claripy.BVV(0, 8))
+
+    def test_zext(self):
+        self._test_other_unary_common(OpCode.INT_ZEXT, claripy.BVV(0x7234, 16), claripy.BVV(0x7234, 16))
+        self._test_other_unary_common(OpCode.INT_ZEXT, claripy.BVV(0x7234, 16), claripy.BVV(0x0000_7234, 32))
+        self._test_other_unary_common(OpCode.INT_ZEXT, claripy.BVV(0x8234, 16), claripy.BVV(0x0000_8234, 32))
+
+    def test_sext(self):
+        self._test_other_unary_common(OpCode.INT_SEXT, claripy.BVV(0x7234, 16), claripy.BVV(0x7234, 16))
+        self._test_other_unary_common(OpCode.INT_SEXT, claripy.BVV(0x7234, 16), claripy.BVV(0x0000_7234, 32))
+        self._test_other_unary_common(OpCode.INT_SEXT, claripy.BVV(0x8234, 16), claripy.BVV(0xFFFF_8234, 32))
+
+    def test_popcount(self):
+        self._test_other_unary_common(OpCode.POPCOUNT, claripy.BVV(0, 32), claripy.BVV(0, 32))
+        self._test_other_unary_common(OpCode.POPCOUNT, claripy.BVV(0x12345678, 32), claripy.BVV(13, 32))
+        self._test_other_unary_common(OpCode.POPCOUNT, claripy.BVV(0xFFFFFFFF, 32), claripy.BVV(32, 32))
+
+    # TODO: Add tests for the following ops:
+    # * = FIXME
+    # ! = Not Implemented
+    #
+    # ! OpCode.CPOOLREF
+    #   OpCode.FLOAT_ABS
+    #   OpCode.FLOAT_ADD
+    #   OpCode.FLOAT_CEIL
+    #   OpCode.FLOAT_DIV
+    #   OpCode.FLOAT_EQUAL
+    #   OpCode.FLOAT_FLOAT2FLOAT
+    #   OpCode.FLOAT_FLOOR
+    #   OpCode.FLOAT_INT2FLOAT
+    #   OpCode.FLOAT_LESS
+    #   OpCode.FLOAT_LESSEQUAL
+    #   OpCode.FLOAT_MULT
+    #   OpCode.FLOAT_NAN
+    #   OpCode.FLOAT_NEG
+    #   OpCode.FLOAT_NOTEQUAL
+    #   OpCode.FLOAT_ROUND
+    #   OpCode.FLOAT_SQRT
+    #   OpCode.FLOAT_SUB
+    #   OpCode.FLOAT_TRUNC
+    #   OpCode.INT_CARRY
+    #   OpCode.INT_SBORROW
+    #   OpCode.INT_SCARRY
+    # * OpCode.INT_SDIV
+    # * OpCode.INT_SREM
+    # ! OpCode.NEW
+    #   OpCode.RETURN
+
+
+if __name__ == "__main__":
+    log.setLevel(logging.DEBUG)
+    logging.getLogger("angr.engines.pcode").setLevel(logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
Now that pypcode 2.0.0 is released, pulling in updates from [AMP](https://github.com/angr/angr/tree/amp_nov_2023) branch, with some minor improvement in testing and cleanup.

- Update pcode engine for pypcode 2.0.0 compat
- Add more tests
- Add a couple extra pcode SPARC compat changes

Depends on angr/ailment#189