### PR TITLE
Fix pcode test_emulate erroring if pcode is not installed

### DIFF
--- a/angr/engines/pcode/behavior.py
+++ b/angr/engines/pcode/behavior.py
@@ -1,11 +1,15 @@
 import operator
 from typing import Callable, Iterable, Tuple
 
-from pypcode import OpCode
 import claripy
 from claripy.ast.bv import BV
 
 from ...errors import AngrError
+
+try:
+    from pypcode import OpCode
+except ImportError:
+    OpCode = None
 
 # pylint:disable=abstract-method
 
@@ -889,7 +893,8 @@ class BehaviorFactory:
 
     def __init__(self):
         self._behaviors = {}
-        self._register_behaviors()
+        if OpCode:
+            self._register_behaviors()
 
     def get_behavior_for_opcode(self, opcode: int) -> OpBehavior:
         return self._behaviors[opcode]

--- a/angr/engines/pcode/emulate.py
+++ b/angr/engines/pcode/emulate.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional
 
-from pypcode import OpCode, Varnode, PcodeOp
 import claripy
 from claripy.ast.bv import BV
 
@@ -12,6 +11,11 @@ from .behavior import OpBehavior
 from ...errors import AngrError
 from ...state_plugins.inspect import BP_BEFORE, BP_AFTER
 
+try:
+    from pypcode import OpCode, Varnode, PcodeOp
+except ImportError:
+    pass
+
 
 l = logging.getLogger(__name__)
 
@@ -21,7 +25,7 @@ class PcodeEmulatorMixin(SimEngineBase):
     Mixin for p-code execution.
     """
 
-    _current_op: Optional[PcodeOp]
+    _current_op: Optional["PcodeOp"]
     _current_op_idx: int
     _current_behavior: Optional[OpBehavior]
 
@@ -125,7 +129,7 @@ class PcodeEmulatorMixin(SimEngineBase):
 
         self._current_behavior = None
 
-    def _map_register_name(self, varnode: Varnode) -> int:
+    def _map_register_name(self, varnode: "Varnode") -> int:
         """
         Map SLEIGH register offset to ArchInfo register offset based on name.
 
@@ -159,7 +163,7 @@ class PcodeEmulatorMixin(SimEngineBase):
         else:
             return v_in
 
-    def _set_value(self, varnode: Varnode, value: BV) -> None:
+    def _set_value(self, varnode: "Varnode", value: BV) -> None:
         """
         Store a value for a given varnode.
 
@@ -190,7 +194,7 @@ class PcodeEmulatorMixin(SimEngineBase):
         else:
             raise AngrError(f"Attempted write to unhandled address space '{space.name}'")
 
-    def _get_value(self, varnode: Varnode) -> BV:
+    def _get_value(self, varnode: "Varnode") -> BV:
         """
         Get a value for a given varnode.
 

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -10,7 +10,6 @@ from typing import Union, Optional, Iterable, Sequence, Tuple
 
 import archinfo
 from archinfo import ArchARM, ArchPcode
-import pypcode
 import cle
 from cachetools import LRUCache
 
@@ -26,6 +25,13 @@ from ...misc.ux import once
 from ...errors import SimEngineError, SimTranslationError, SimError
 from ... import sim_options as o
 from ...block import DisassemblerBlock, DisassemblerInsn
+
+
+try:
+    import pypcode
+except ImportError:
+    pypcode = None
+
 
 l = logging.getLogger(__name__)
 
@@ -122,7 +128,7 @@ class IRSB:
     _direct_next: Optional[bool]
     _exit_statements: Sequence[Tuple[int, int, ExitStatement]]
     _instruction_addresses: Optional[Sequence[int]]
-    _ops: Sequence[pypcode.PcodeOp]  # FIXME: Merge into _statements
+    _ops: Sequence["pypcode.PcodeOp"]  # FIXME: Merge into _statements
     _size: Optional[int]
     _statements: Iterable  # Note: currently unused
     _disassembly: Optional[PcodeDisassemblerBlock]
@@ -456,7 +462,7 @@ class IRSB:
         jumpkind: Optional[str] = None,
         direct_next: Optional[bool] = None,
         size: Optional[int] = None,
-        ops: Optional[Sequence[pypcode.PcodeOp]] = None,
+        ops: Optional[Sequence["pypcode.PcodeOp"]] = None,
         instruction_addresses: Optional[Iterable[int]] = None,
         exit_statements: Sequence[Tuple[int, int, ExitStatement]] = None,
         default_exit_target: Optional = None,
@@ -807,7 +813,7 @@ class PcodeBasicBlockLifter:
     Lifts basic blocks to P-code
     """
 
-    context: pypcode.Context
+    context: "pypcode.Context"
     behaviors: BehaviorFactory
 
     def __init__(self, arch: archinfo.Arch):


### PR DESCRIPTION
This changes `test_emulate.py` to skip tests if pypcode is not installed rather than erroring on failed imports.