### PR TITLE
Mark more tests as slow

### DIFF
--- a/tests/analyses/cfg/test_cfg_rust_got_resolution.py
+++ b/tests/analyses/cfg/test_cfg_rust_got_resolution.py
@@ -6,7 +6,7 @@ import unittest
 
 import angr
 
-from ...common import bin_location
+from ...common import bin_location, slow_test
 
 
 test_location = os.path.join(bin_location, "tests")
@@ -15,6 +15,7 @@ test_location = os.path.join(bin_location, "tests")
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
 class TestCfgRustGotResolution(unittest.TestCase):
+    @slow_test
     def test_rust_got_resolution(self):
         # Test a simple Rust binary sample.
         #

--- a/tests/analyses/cfg/test_jumptables.py
+++ b/tests/analyses/cfg/test_jumptables.py
@@ -16,7 +16,7 @@ from angr.analyses.cfg.indirect_jump_resolvers import JumpTableResolver
 if TYPE_CHECKING:
     from angr.knowledge_plugins.cfg import IndirectJump
 
-from ...common import bin_location, compile_c, has_32_bit_compiler_support, skip_if_not_linux
+from ...common import bin_location, compile_c, has_32_bit_compiler_support, skip_if_not_linux, slow_test
 
 
 test_location = os.path.join(bin_location, "tests")
@@ -2796,6 +2796,7 @@ class TestJumpTableResolver(unittest.TestCase):
     # Some jump tables are in fact vtables
     #
 
+    @slow_test
     def test_vtable_amd64_libc_ubuntu_2004(self):
         p = angr.Project(
             os.path.join(test_location, "x86_64", "elf_with_static_libc_ubuntu_2004_stripped"), auto_load_libs=False

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1178,6 +1178,7 @@ class TestDecompiler(unittest.TestCase):
 
         assert "__stack_chk_fail" not in code  # stack canary checks should be removed by default
 
+    @slow_test
     @for_all_structuring_algos
     def test_decompiling_newburry_main(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "newbury")
@@ -2519,6 +2520,7 @@ class TestDecompiler(unittest.TestCase):
 
         assert d.codegen.text.count("switch") == 0
 
+    @slow_test
     @structuring_algo("phoenix")
     def test_eager_returns_simplifier_no_duplication_of_default_case(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "ls_ubuntu_2004")
@@ -3033,6 +3035,7 @@ class TestDecompiler(unittest.TestCase):
         self._print_decompilation_result(dec)
         assert dec.codegen.text == saved
 
+    @slow_test
     @for_all_structuring_algos
     def test_function_pointer_identification(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "rust_hello_world")


### PR DESCRIPTION
This marks tests taking more than a minute in CI as slow. Will still be run nightly, of course.