### PR TITLE
reassembler: Fix addition type error in address calculation

### DIFF
--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -730,7 +730,7 @@ class Instruction:
             elif operand.type == capstone.CS_OP_MEM:
                 operand_offsets.append(capstone_instr.disp_offset)
             else:
-                operand_offsets.append(None)
+                operand_offsets.append(0)
 
         if self.addr is not None:
             self._initialize(capstone_instr.operands, operand_offsets)


### PR DESCRIPTION
When an instruction contains an operand that is neither a memory nor an immediate operand (e.g. a floating-point operand) then `operand_offset` is set to `None`:

https://github.com/angr/angr/blob/b0d099550163ca56424994c8ee80b8cacec6490c/angr/analyses/reassembler.py#L726-L733

This causes a type error when calculating the address in `register_instruction_reference`:

https://github.com/angr/angr/blob/b0d099550163ca56424994c8ee80b8cacec6490c/angr/analyses/reassembler.py#L1980

I ran into this issue while packaging angr for [Guix](https://guix.gnu.org) where `test_ln_gcc_O2` fails because of this:

	self = <Reassembler Analysis Result at 0x7fffe4c63190>, insn_addr = 4201104
	ref_addr = 6344696, sort = 'absolute', operand_offset = None

	    def register_instruction_reference(self, insn_addr, ref_addr, sort, operand_offset):
		if not self.log_relocations:
		    return

	>       addr = insn_addr + operand_offset
	E       TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'

It seems to me that this regression was introduced in #1739, it is presently unclear to me why this doesn't fail on the CI. Looking at the aforementioned pull request, it seems to me that it was intended to use a zero offset for these instructions. This commit changes the implementation accordingly, thereby fixing the aforementioned test failure for me.