### PR TITLE
Add a flag to omit function headers when generating code

### DIFF
--- a/tests/analyses/decompiler/test_structurer.py
+++ b/tests/analyses/decompiler/test_structurer.py
@@ -278,8 +278,10 @@ class TestStructurer(unittest.TestCase):
 
         # do an entire round of decompilation and code generation to get a sequence and full function
         # to test against
-        d = p.analyses[Decompiler](f, cfg=cfg.model)
-        top_sequence = d.seq_node
+        dec = p.analyses[Decompiler](f, cfg=cfg.model)
+        top_sequence = dec.seq_node
+        full_text = dec.codegen.text.replace("\n", "")
+        codegen = dec.codegen
 
         # full code, without the header and variable definitions
         # the outputed code will be missing corrected variable names, which can be corrected by passing
@@ -293,6 +295,16 @@ class TestStructurer(unittest.TestCase):
         assert "if" in if_code
         assert "accepted()" in if_code
         assert "read" not in if_code  # should only be found in the code above the if
+
+        # generate only code under first if-stmt with correct variables by modifying the original codegen object
+        codegen._sequence = if_seq
+        codegen._indent = 4
+        codegen.omit_func_header = True
+        codegen._analyze()
+        if_code_corrected = codegen.text.replace("\n", "")
+        assert "if" in if_code_corrected
+        assert if_code_corrected in full_text
+        assert if_code_corrected != full_text
 
 
 if __name__ == "__main__":

--- a/tests/analyses/decompiler/test_structurer.py
+++ b/tests/analyses/decompiler/test_structurer.py
@@ -9,6 +9,7 @@ import networkx
 
 import angr
 import angr.analyses.decompiler
+from angr.analyses import Decompiler
 from angr.analyses.decompiler.structuring import DreamStructurer
 
 from ...common import bin_location
@@ -269,6 +270,29 @@ class TestStructurer(unittest.TestCase):
         codegen = p.analyses.StructuredCodeGenerator(test_func, s.result, cfg=cfg, ail_graph=clinic.graph)
 
         print(codegen.text)
+
+    def test_partial_code_generation(self):
+        p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        cfg = p.analyses.CFG(data_references=True, normalize=True)
+        f = cfg.kb.functions["main"]
+
+        # do an entire round of decompilation and code generation to get a sequence and full function
+        # to test against
+        d = p.analyses[Decompiler](f, cfg=cfg.model)
+        top_sequence = d.seq_node
+
+        # full code, without the header and variable definitions
+        # the outputed code will be missing corrected variable names, which can be corrected by passing
+        # private properties from the original codegen object
+        func_no_header = p.analyses.StructuredCodeGenerator(f, top_sequence, cfg=cfg, omit_func_header=True).text
+        assert "int main(" not in func_no_header
+
+        # generate only code under and in the first if-stmt
+        if_seq = top_sequence.nodes[1]
+        if_code = p.analyses.StructuredCodeGenerator(f, if_seq, cfg=cfg, omit_func_header=True).text
+        assert "if" in if_code
+        assert "accepted()" in if_code
+        assert "read" not in if_code  # should only be found in the code above the if
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- you can now omit any sub-sequence in the code without a giant header being present