### PR TITLE
Add KB as parameter to KnowledgeBasePlugin for consistency

### DIFF
--- a/angr/knowledge_plugins/callsite_prototypes.py
+++ b/angr/knowledge_plugins/callsite_prototypes.py
@@ -11,8 +11,7 @@ class CallsitePrototypes(KnowledgeBasePlugin):
     """
 
     def __init__(self, kb):
-        super().__init__()
-        self._kb = kb
+        super().__init__(kb=kb)
 
         self._prototypes: Dict[int, Tuple[SimCC, SimTypeFunction, bool]] = {}
 

--- a/angr/knowledge_plugins/cfg/cfg_manager.py
+++ b/angr/knowledge_plugins/cfg/cfg_manager.py
@@ -11,6 +11,7 @@ class CFGManager(KnowledgeBasePlugin):
     """
     This is the CFG manager, it manages CFGs
     """
+
     def __init__(self, kb):
         super().__init__(kb=kb)
 

--- a/angr/knowledge_plugins/cfg/cfg_manager.py
+++ b/angr/knowledge_plugins/cfg/cfg_manager.py
@@ -8,6 +8,9 @@ from .cfg_model import CFGModel
 
 
 class CFGManager(KnowledgeBasePlugin):
+    """
+    This is the CFG manager, it manages CFGs
+    """
     def __init__(self, kb):
         super().__init__(kb=kb)
 

--- a/angr/knowledge_plugins/cfg/cfg_manager.py
+++ b/angr/knowledge_plugins/cfg/cfg_manager.py
@@ -9,9 +9,8 @@ from .cfg_model import CFGModel
 
 class CFGManager(KnowledgeBasePlugin):
     def __init__(self, kb):
-        super().__init__()
+        super().__init__(kb=kb)
 
-        self._kb = kb
         self.cfgs = {}
 
     def __repr__(self):

--- a/angr/knowledge_plugins/comments.py
+++ b/angr/knowledge_plugins/comments.py
@@ -2,6 +2,9 @@ from .plugin import KnowledgeBasePlugin
 
 
 class Comments(KnowledgeBasePlugin, dict):
+    """
+    Tracks comments via a Dict of Address -> Text
+    """
     def copy(self):
         o = Comments(self._kb)
         o.update(self)

--- a/angr/knowledge_plugins/comments.py
+++ b/angr/knowledge_plugins/comments.py
@@ -5,6 +5,7 @@ class Comments(KnowledgeBasePlugin, dict):
     """
     Tracks comments via a Dict of Address -> Text
     """
+
     def copy(self):
         o = Comments(self._kb)
         o.update(self)

--- a/angr/knowledge_plugins/comments.py
+++ b/angr/knowledge_plugins/comments.py
@@ -2,10 +2,6 @@ from .plugin import KnowledgeBasePlugin
 
 
 class Comments(KnowledgeBasePlugin, dict):
-    def __init__(self, kb):
-        super().__init__()
-        self._kb = kb
-
     def copy(self):
         o = Comments(self._kb)
         o.update(self)

--- a/angr/knowledge_plugins/custom_strings.py
+++ b/angr/knowledge_plugins/custom_strings.py
@@ -9,8 +9,7 @@ class CustomStrings(KnowledgeBasePlugin):
     """
 
     def __init__(self, kb):
-        super().__init__()
-        self._kb = kb
+        super().__init__(kb=kb)
 
         self.string_id = 0
         self.strings: Dict[int, bytes] = {}

--- a/angr/knowledge_plugins/data.py
+++ b/angr/knowledge_plugins/data.py
@@ -2,10 +2,6 @@ from .plugin import KnowledgeBasePlugin
 
 
 class Data(KnowledgeBasePlugin):
-    def __init__(self, kb):
-        super().__init__()
-        self._kb = kb
-
     def copy(self):
         raise NotImplementedError
 

--- a/angr/knowledge_plugins/data.py
+++ b/angr/knowledge_plugins/data.py
@@ -2,6 +2,18 @@ from .plugin import KnowledgeBasePlugin
 
 
 class Data(KnowledgeBasePlugin):
+    """
+    The knowledge what purpose this plugin serves has been lost to the passing of time
+    but the linter does not care for these failures of mere mortals and demands a docstring anyway.
+    The pact has been made, and no violations of the rules will be tolerated,
+    even if the spirit does not match the letter.
+    Making the plugin smaller has only increased the weight of the failure, and thus this file has drawn its ire.
+
+    The only thing left to do is to attempt to find meaning in the meaninglessness,
+    as the only act of rebellion against the uncaring forces that bind us.
+    For is this not what being human is all about?
+    """
+
     def copy(self):
         raise NotImplementedError
 

--- a/angr/knowledge_plugins/debug_variables.py
+++ b/angr/knowledge_plugins/debug_variables.py
@@ -131,8 +131,7 @@ class DebugVariableManager(KnowledgeBasePlugin):
     """
 
     def __init__(self, kb: "KnowledgeBase"):
-        super().__init__()
-        self._kb: "KnowledgeBase" = kb
+        super().__init__(kb=kb)
         self._dvar_containers = {}
 
     def from_name_and_pc(self, var_name: str, pc_addr: int) -> Variable:

--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -80,8 +80,7 @@ class FunctionManager(KnowledgeBasePlugin, collections.abc.Mapping):
     """
 
     def __init__(self, kb):
-        super().__init__()
-        self._kb = kb
+        super().__init__(kb=kb)
         self.function_address_types = self._kb._project.arch.function_address_types
         self.address_types = self._kb._project.arch.address_types
         self._function_map: Dict[int, Function] = FunctionDict(self, key_types=self.function_address_types)

--- a/angr/knowledge_plugins/indirect_jumps.py
+++ b/angr/knowledge_plugins/indirect_jumps.py
@@ -4,6 +4,9 @@ from .plugin import KnowledgeBasePlugin
 
 
 class IndirectJumps(KnowledgeBasePlugin, dict):
+    """
+    This plugin tracks the targets of indirect jumps
+    """
     def __init__(self, kb):
         super().__init__(kb=kb)
         self.unresolved = set()

--- a/angr/knowledge_plugins/indirect_jumps.py
+++ b/angr/knowledge_plugins/indirect_jumps.py
@@ -7,6 +7,7 @@ class IndirectJumps(KnowledgeBasePlugin, dict):
     """
     This plugin tracks the targets of indirect jumps
     """
+
     def __init__(self, kb):
         super().__init__(kb=kb)
         self.unresolved = set()

--- a/angr/knowledge_plugins/indirect_jumps.py
+++ b/angr/knowledge_plugins/indirect_jumps.py
@@ -5,8 +5,7 @@ from .plugin import KnowledgeBasePlugin
 
 class IndirectJumps(KnowledgeBasePlugin, dict):
     def __init__(self, kb):
-        super().__init__()
-        self._kb = kb
+        super().__init__(kb=kb)
         self.unresolved = set()
 
         # dict format: {indirect_address: [resolved_addresses]}

--- a/angr/knowledge_plugins/key_definitions/key_definition_manager.py
+++ b/angr/knowledge_plugins/key_definitions/key_definition_manager.py
@@ -38,7 +38,7 @@ class KeyDefinitionManager(KnowledgeBasePlugin):
     """
 
     def __init__(self, kb: "KnowledgeBase"):
-        self.kb = kb
+        super().__init__(kb=kb)
         self.model_by_funcaddr: Dict[int, ReachingDefinitionsModel] = {}
 
     def has_model(self, func_addr: int):
@@ -46,9 +46,9 @@ class KeyDefinitionManager(KnowledgeBasePlugin):
 
     def get_model(self, func_addr: int):
         if func_addr not in self.model_by_funcaddr:
-            if not self.kb.functions.contains_addr(func_addr):
+            if not self._kb.functions.contains_addr(func_addr):
                 return None
-            func = self.kb.functions[func_addr]
+            func = self._kb.functions[func_addr]
             if func.is_simprocedure or func.is_plt or func.alignment:
                 return None
             callsites = list(func.get_call_sites())
@@ -64,15 +64,15 @@ class KeyDefinitionManager(KnowledgeBasePlugin):
                 call_insn_addr = block.instruction_addrs[-1]
                 call_insn_addrs.add(call_insn_addr)
             observer = RDAObserverControl(func_addr, callsites, call_insn_addrs)
-            rda = self.kb._project.analyses.ReachingDefinitions(
-                subject=self.kb.functions[func_addr], observe_callback=observer.rda_observe_callback
+            rda = self._kb._project.analyses.ReachingDefinitions(
+                subject=self._kb.functions[func_addr], observe_callback=observer.rda_observe_callback
             )
             self.model_by_funcaddr[func_addr] = rda.model
 
         return self.model_by_funcaddr[func_addr]
 
     def copy(self) -> "KeyDefinitionManager":
-        dm = KeyDefinitionManager(self.kb)
+        dm = KeyDefinitionManager(self._kb)
         dm.model_by_funcaddr = dict(map(lambda x: (x[0], x[1].copy()), self.model_by_funcaddr.items()))
         return dm
 

--- a/angr/knowledge_plugins/labels.py
+++ b/angr/knowledge_plugins/labels.py
@@ -6,7 +6,7 @@ from .plugin import KnowledgeBasePlugin
 
 class Labels(KnowledgeBasePlugin):
     def __init__(self, kb):
-        self._kb = kb
+        super().__init__(kb=kb)
         self._labels = {}
         self._reverse_labels = {}
 

--- a/angr/knowledge_plugins/patches.py
+++ b/angr/knowledge_plugins/patches.py
@@ -27,10 +27,9 @@ class PatchManager(KnowledgeBasePlugin):
     """
 
     def __init__(self, kb):
-        super().__init__()
+        super().__init__(kb=kb)
 
         self._patches: Dict[int, Patch] = SortedDict()
-        self._kb = kb
         self._patched_entry_state = None
 
     def add_patch(self, addr, new_bytes, comment: Optional[str] = None):

--- a/angr/knowledge_plugins/plugin.py
+++ b/angr/knowledge_plugins/plugin.py
@@ -1,7 +1,18 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from angr.knowledge_base.knowledge_base import KnowledgeBase
+
 default_plugins = {}
 
 
 class KnowledgeBasePlugin:
+    def __init__(self, kb: "KnowledgeBase"):
+        # This call is needed, because some Plugins like TypesStore inherit from KnowledgeBasePlugin and something else
+        # So we still need to call the constructor of the other class.
+        super().__init__()
+        self._kb = kb
+
     def copy(self):
         raise NotImplementedError
 

--- a/angr/knowledge_plugins/propagations/propagation_manager.py
+++ b/angr/knowledge_plugins/propagations/propagation_manager.py
@@ -10,7 +10,7 @@ class PropagationManager(KnowledgeBasePlugin):
     """
 
     def __init__(self, kb):
-        self._kb = kb
+        super().__init__(kb=kb)
         self._propagations: Dict[Tuple, PropagationModel] = {}
 
     def exists(self, prop_key: Tuple) -> bool:

--- a/angr/knowledge_plugins/structured_code/manager.py
+++ b/angr/knowledge_plugins/structured_code/manager.py
@@ -4,14 +4,13 @@ from typing import Dict, Any, Union, TYPE_CHECKING
 from .. import KnowledgeBasePlugin
 
 if TYPE_CHECKING:
-    from angr.knowledge_base import KnowledgeBase
     from angr.analyses.decompiler.structured_codegen import BaseStructuredCodeGenerator
     from angr.analyses.decompiler.decompilation_cache import DecompilationCache
 
 
 class StructuredCodeManager(KnowledgeBasePlugin):
     def __init__(self, kb):
-        self._kb: KnowledgeBase = kb
+        super().__init__(kb=kb)
         self.cached: Dict[Any, "DecompilationCache"] = {}
 
     def _normalize_key(self, item):

--- a/angr/knowledge_plugins/sync/sync_controller.py
+++ b/angr/knowledge_plugins/sync/sync_controller.py
@@ -90,9 +90,8 @@ class SyncController(KnowledgeBasePlugin):
         # import binsync upon the first use of this class
         import_binsync()
 
-        super().__init__()
+        super().__init__(kb=kb)
 
-        self._kb: KnowledgeBasePlugin = kb
         self.client: Optional["binsync.client.Client"] = None
 
     #

--- a/angr/knowledge_plugins/sync/sync_controller.py
+++ b/angr/knowledge_plugins/sync/sync_controller.py
@@ -2,17 +2,16 @@
 from functools import wraps
 from typing import Optional, List
 
+from ... import knowledge_plugins
+from ...knowledge_plugins.plugin import KnowledgeBasePlugin
+from ...sim_variable import SimStackVariable
+from ..variables.variable_manager import VariableManagerInternal
+
 binsync_available = None
 binsync = None
 Client = None
 StackVariable = None
 StackOffsetType = None
-
-
-from ... import knowledge_plugins
-from ...knowledge_plugins.plugin import KnowledgeBasePlugin
-from ...sim_variable import SimStackVariable
-from ..variables.variable_manager import VariableManagerInternal
 
 
 def import_binsync():

--- a/angr/knowledge_plugins/types.py
+++ b/angr/knowledge_plugins/types.py
@@ -33,11 +33,10 @@ class TypesStore(KnowledgeBasePlugin, UserDict):
     """
 
     def __init__(self, kb):
-        super().__init__()
-        self.kb = kb
+        super().__init__(kb=kb)
 
     def copy(self):
-        o = TypesStore(self.kb)
+        o = TypesStore(self._kb)
         o.update(super().items())
         return o
 
@@ -51,7 +50,7 @@ class TypesStore(KnowledgeBasePlugin, UserDict):
         if type(value) is not TypeRef:
             raise TypeError("Can only store TypeRefs in TypesStore")
 
-        super().__setitem__(item, value.with_arch(self.kb._project.arch))
+        super().__setitem__(item, value.with_arch(self._kb._project.arch))
 
     def __iter__(self):
         yield from super().__iter__()

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -82,9 +82,9 @@ class VariableManagerInternal(Serializable):
 
         self._variable_accesses: Dict[SimVariable, Set[VariableAccess]] = defaultdict(set)
         self._insn_to_variable: Dict[int, Set[Tuple[SimVariable, int]]] = defaultdict(set)
-        self._stmt_to_variable: Dict[
-            Union[Tuple[int, int], Tuple[int, int, int]], Set[Tuple[SimVariable, int]]
-        ] = defaultdict(set)
+        self._stmt_to_variable: Dict[Union[Tuple[int, int], Tuple[int, int, int]], Set[Tuple[SimVariable, int]]] = (
+            defaultdict(set)
+        )
         self._variable_to_stmt: Dict[SimVariable, Set[Union[Tuple[int, int], Tuple[int, int, int]]]] = defaultdict(set)
         self._atom_to_variable: Dict[
             Union[Tuple[int, int], Tuple[int, int, int]], Dict[int, Set[Tuple[SimVariable, int]]]

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -29,7 +29,6 @@ from ..types import TypesStore
 from .variable_access import VariableAccess, VariableAccessSort
 
 if TYPE_CHECKING:
-    from ...knowledge_base import KnowledgeBase
     from angr.code_location import CodeLocation
 
 l = logging.getLogger(name=__name__)
@@ -83,9 +82,9 @@ class VariableManagerInternal(Serializable):
 
         self._variable_accesses: Dict[SimVariable, Set[VariableAccess]] = defaultdict(set)
         self._insn_to_variable: Dict[int, Set[Tuple[SimVariable, int]]] = defaultdict(set)
-        self._stmt_to_variable: Dict[Union[Tuple[int, int], Tuple[int, int, int]], Set[Tuple[SimVariable, int]]] = (
-            defaultdict(set)
-        )
+        self._stmt_to_variable: Dict[
+            Union[Tuple[int, int], Tuple[int, int, int]], Set[Tuple[SimVariable, int]]
+        ] = defaultdict(set)
         self._variable_to_stmt: Dict[SimVariable, Set[Union[Tuple[int, int], Tuple[int, int, int]]]] = defaultdict(set)
         self._atom_to_variable: Dict[
             Union[Tuple[int, int], Tuple[int, int, int]], Dict[int, Set[Tuple[SimVariable, int]]]
@@ -1012,8 +1011,7 @@ class VariableManager(KnowledgeBasePlugin):
     """
 
     def __init__(self, kb):
-        super().__init__()
-        self._kb: "KnowledgeBase" = kb
+        super().__init__(kb=kb)
         self.global_manager = VariableManagerInternal(self)
         self.function_managers: Dict[int, VariableManagerInternal] = {}
 

--- a/angr/knowledge_plugins/xrefs/xref_manager.py
+++ b/angr/knowledge_plugins/xrefs/xref_manager.py
@@ -13,8 +13,7 @@ l = logging.getLogger(name=__name__)
 
 class XRefManager(KnowledgeBasePlugin, Serializable):
     def __init__(self, kb):
-        super().__init__()
-        self._kb = kb
+        super().__init__(kb=kb)
 
         self.xrefs_by_ins_addr: Dict[int, Set[XRef]] = defaultdict(set)
         self.xrefs_by_dst: Dict[int, Set[XRef]] = defaultdict(set)

--- a/tests/knowledge_plugins/test_kb_plugins.py
+++ b/tests/knowledge_plugins/test_kb_plugins.py
@@ -75,8 +75,7 @@ class TestKbPlugins(unittest.TestCase):
 
         # Check that explicitly creating and registering new kind of plugin also works
         class TestPlugin(angr.knowledge_plugins.KnowledgeBasePlugin):
-            def __init__(self, kb=None):
-                self._kb = kb
+            pass
 
         # Assert that unknown plugins return None when using "get_knowledge"
         assert p.kb.get_knowledge(TestPlugin) is None


### PR DESCRIPTION
In practice every KnowledgeBasePlugin got the KB as an argument, but the naming `kb` or `_kb` wasn't consistent.
This is now standardized by moving it into the base class 