### PR TITLE
Handle storedata being IRExpr.Const

### DIFF
--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -334,7 +334,10 @@ class SimEngineRDVEX(
             addr = self._expr(stmt.addr)
             if addr.count() == 1:
                 addrs = next(iter(addr.values()))
-                size = self.tyenv.sizeof(stmt.storedata.tmp) // self.arch.byte_width
+                if isinstance(stmt.storedata, pyvex.IRExpr.Const):
+                    size = stmt.storedata.con.size // self.arch.byte_width
+                else:
+                    size = self.tyenv.sizeof(stmt.storedata.tmp) // self.arch.byte_width
 
                 self._store_core(addrs, size, storedata)
                 self.tmps[stmt.result] = MultiValues(claripy.BVV(1, 1))


### PR DESCRIPTION
`SimEngineRDVEX._handle_LLSC` assumed that `stmt.storedata` always has an attribute `tmp`
This doesn't actually hold and I have encountered code where we get an IRExpr.Const instead, in this case of value 0:
```
1000df90c  ldaxrb  wzr, [x22]
1000df910  stlxrb  w8, wzr, [x22]
1000df914  cbnz    w8, 0x1000df90c
```

This block lifts to:

```
IRSB {
   t0:Ity_I64 t1:Ity_I8 t2:Ity_I64 t3:Ity_I1 t4:Ity_I8 t5:Ity_I64 t6:Ity_I64 t7:Ity_I1 t8:Ity_I32 t9:Ity_I64 t10:Ity_I64

   00 | ------ IMark(0x1000df90c, 4, 0) ------
   01 | t0 = GET:I64(x22)
   02 | t1 = LDle-Linked(t0)
   03 | MBusEvent-Imbe_Fence
   04 | PUT(pc) = 0x00000001000df910
   05 | ------ IMark(0x1000df910, 4, 0) ------
   06 | t2 = GET:I64(x22)
   07 | MBusEvent-Imbe_Fence
   08 | t3 = ( STle-Cond(t2) = 0x00 )
   09 | t6 = 1Uto64(t3)
   10 | t5 = Xor64(t6,0x0000000000000001)
   11 | PUT(x8) = t5
   12 | PUT(pc) = 0x00000001000df914
   13 | ------ IMark(0x1000df914, 4, 0) ------
   14 | t9 = GET:I64(x8)
   15 | t8 = 64to32(t9)
   16 | t7 = CmpNE32(t8,0x00000000)
   17 | if (t7) { PUT(pc) = 0x1000df90c; Ijk_Boring }
   NEXT: PUT(pc) = 0x00000001000df918; Ijk_Boring
}
```

The problematic statement is at index 8 where the value is clearly a constant 0 and not a tmp value.

Other handlers for LLSC in other engines used to have this problem too, but this was then fixed with https://github.com/angr/angr/commit/61090316d8a81751903cb8c2d7cb0456f9d1d99a#diff-3c4d8c4dd289e689ad6c9b7526c5c7473302cd74a873021ef7ec47baf1b95019L202-R209

That fix doesn't work in this case because MultiValues have no size that could be used for the generic case. There might be a way to calculate the size based on the MultiValues in some way, but this seems more complicated and might introduce more subtle bugs, so for now this fix just checks if we are dealing with a const value, and if not just continues with the old behavior.
 
