### PR TITLE
Do not perform narrow_exprs() on floating point and double precision floats

### DIFF
--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -236,7 +236,7 @@ class AILSimplifier(Analysis):
                 # only do this for general purpose register
                 skip_def = False
                 for reg in self.project.arch.register_list:
-                    if reg.vex_offset == def_.atom.reg_offset and not reg.general_purpose:
+                    if not reg.artificial and reg.vex_offset == def_.atom.reg_offset and not reg.general_purpose:
                         skip_def = True
                         break
 

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -233,6 +233,9 @@ class AILSimplifier(Analysis):
         sorted_defs = sorted(rd.all_definitions, key=lambda d: d.codeloc, reverse=True)
         for def_ in (d_ for d_ in sorted_defs if d_.codeloc.context is None):
             if isinstance(def_.atom, atoms.Register):
+                # we should not narrow floating point and double precision floats
+                if self.project.arch.translate_register_name(def_.atom.reg_offset, def_.atom.size).startswith("xmm"):
+                    continue
                 needs_narrowing, to_size, use_exprs = self._narrowing_needed(def_, rd, addr_and_idx_to_block)
                 if needs_narrowing:
                     # replace the definition

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -234,10 +234,10 @@ class AILSimplifier(Analysis):
         for def_ in (d_ for d_ in sorted_defs if d_.codeloc.context is None):
             if isinstance(def_.atom, atoms.Register):
                 # only do this for general purpose register
-                skip_def = True
+                skip_def = False
                 for reg in self.project.arch.register_list:
-                    if reg.vex_offset == def_.atom.reg_offset and reg.general_purpose:
-                        skip_def = False
+                    if reg.vex_offset == def_.atom.reg_offset and not reg.general_purpose:
+                        skip_def = True
                         break
 
                 if skip_def:

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -5,6 +5,7 @@ import enum
 from dataclasses import dataclass
 from typing import Dict, List, Tuple, Set, Optional, Iterable, Union, Type, Any, NamedTuple, TYPE_CHECKING
 
+import ipdb
 import networkx
 import capstone
 

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -5,7 +5,6 @@ import enum
 from dataclasses import dataclass
 from typing import Dict, List, Tuple, Set, Optional, Iterable, Union, Type, Any, NamedTuple, TYPE_CHECKING
 
-import ipdb
 import networkx
 import capstone
 

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -2098,6 +2098,14 @@ class CConstant(CExpression):
         self._fmt_setter["float"] = v
 
     @property
+    def fmt_double(self):
+        return self.fmt.get("double", False)
+
+    @fmt_double.setter
+    def fmt_double(self, v: bool):
+        self._fmt_setter["double"] = v
+
+    @property
     def type(self):
         return self._type
 
@@ -2190,6 +2198,11 @@ class CConstant(CExpression):
                 value += 2**self._type.size
             value &= 0xFF
             return repr(chr(value)) if value < 0x80 else f"'\\x{value:x}'"
+
+        if self.fmt_double:
+            if 0 < value <= 0xFFFF_FFFF_FFFF_FFFF:
+                str_value = str(struct.unpack("d", struct.pack("Q", value))[0])
+                return str_value
 
         if self.fmt_neg:
             if value > 0:


### PR DESCRIPTION
We should not be narrowing exprs that are floating point and double precision floats