### PR TITLE
Set Endness for MemoryLocation Atom In atom.from_argument

### DIFF
--- a/angr/knowledge_plugins/key_definitions/atoms.py
+++ b/angr/knowledge_plugins/key_definitions/atoms.py
@@ -84,7 +84,9 @@ class Atom:
         elif isinstance(argument, SimStackArg):
             if sp is None:
                 raise ValueError("You must provide a stack pointer to translate a SimStackArg")
-            return MemoryLocation(SpOffset(arch.bits, argument.stack_offset + sp), argument.size, endness=arch.memory_endness)
+            return MemoryLocation(
+                SpOffset(arch.bits, argument.stack_offset + sp), argument.size, endness=arch.memory_endness
+            )
         else:
             raise TypeError("Argument type %s is not yet supported." % type(argument))
 

--- a/angr/knowledge_plugins/key_definitions/atoms.py
+++ b/angr/knowledge_plugins/key_definitions/atoms.py
@@ -71,7 +71,7 @@ class Atom:
         Instanciate an `Atom` from a given argument.
 
         :param argument: The argument to create a new atom from.
-        :param registers: A mapping representing the registers of a given architecture.
+        :param arch: The argument representing archinfo architecture for argument.
         :param full_reg: Whether to return an atom indicating the entire register if the argument only specifies a
                         slice of the register.
         :param sp:      The current stack offset. Optional. Only used when argument is a SimStackArg.
@@ -84,7 +84,7 @@ class Atom:
         elif isinstance(argument, SimStackArg):
             if sp is None:
                 raise ValueError("You must provide a stack pointer to translate a SimStackArg")
-            return MemoryLocation(SpOffset(arch.bits, argument.stack_offset + sp), argument.size)
+            return MemoryLocation(SpOffset(arch.bits, argument.stack_offset + sp), argument.size, endness=arch.memory_endness)
         else:
             raise TypeError("Argument type %s is not yet supported." % type(argument))
 


### PR DESCRIPTION
# What is This Pull Request Fixing

This Pull request is fixing issue https://github.com/angr/angr/issues/4521. 

More detail is provided on that issue and goes more into depth

# tl;dr

- When making `MemoryLocation` atoms in RDA from `angr.knowledge_plugins.key_definitions.atoms.from_argument`, the `from_argument` function does not initialize the `MemoryLocation` object with an endness.
- Not allocating with an endness will make anything that processes that Atom default to Big Endian.
- A simple fix is just adding this assignment when creating a `MemoryLocation` atom.