### PR TITLE
Correctly process infinite LoopNodes (found by @capysix)

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -482,6 +482,8 @@ class ConditionProcessor:
                     continue
             raise EmptyBlockNotice()
         if type(block) is LoopNode:
+            if block.sequence_node is None:
+                raise EmptyBlockNotice()
             return cls.get_last_statements(block.sequence_node)
         if type(block) is ConditionalBreakNode:
             return [block]

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3423,6 +3423,18 @@ class TestDecompiler(unittest.TestCase):
         assert "-1" in text
         assert "16" in text
 
+    @structuring_algo("phoenix")
+    def test_infinite_loop_arm(self, decompiler_options=None):
+        bin_path = os.path.join(test_location, "aarch64", "decompiler", "test_inf_loop_arm")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        proj.analyses.CompleteCallingConventions(cfg=cfg, recover_variables=True)
+        f = proj.kb.functions["main"]
+        d = proj.analyses[Decompiler].prep()(f, cfg=cfg.model, options=decompiler_options)
+
+        assert d.codegen is not None
+        assert "while (true)" in d.codegen.text
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug
If you have an infinite loop, like the source below, you trigger a `NotImplementedError`:
```c
#include <stdio.h>

int main(int argc, char** argv) {
    int do_reboot = (int) argv[1][0];
    puts(do_reboot);
    if (do_reboot) {
        puts("rebooting");
        while(1);
    }
    puts("goodbye");
}
```