### PR TITLE
Feature: flag to disable code output on decompilation (for AIL graphs)

### DIFF
--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3452,14 +3452,12 @@ class TestDecompiler(unittest.TestCase):
         # a few nodes found at the end of this graph
         assert len(d.unoptimized_ail_graph.nodes) < len(d.ail_graph.nodes)
         unopt_rets = sum(
-            [
-                1
-                for n in d.unoptimized_ail_graph.nodes
-                if n.statements and isinstance(n.statements[-1], ailment.statement.Return)
-            ]
+            1
+            for n in d.unoptimized_ail_graph.nodes
+            if n.statements and isinstance(n.statements[-1], ailment.statement.Return)
         )
         opt_rets = sum(
-            [1 for n in d.ail_graph.nodes if n.statements and isinstance(n.statements[-1], ailment.statement.Return)]
+            1 for n in d.ail_graph.nodes if n.statements and isinstance(n.statements[-1], ailment.statement.Return)
         )
         assert unopt_rets < opt_rets
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3446,6 +3446,7 @@ class TestDecompiler(unittest.TestCase):
 
         # we should have skipped generating code
         assert d.codegen is None
+        assert d.seq_node is None
 
         # in this function, binop, we should have triggered the ReturnDuplicator, which will duplicate
         # a few nodes found at the end of this graph


### PR DESCRIPTION
Allows you to use all the optimizations that generally occur in our Decompilation pass, but with the purpose of getting an AIL graph (avoids structuring). This will give a great speed up to people only using the Decompiler for an AIL graph. 