### PR TITLE
Fix an incorrect type check in memory reading

### DIFF
--- a/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
@@ -643,10 +643,10 @@ class LabeledPagesMixin(PagedMemoryMixin):
         if endness is None:
             endness = self.endness
 
-        if type(size) is not int:
+        if not isinstance(size, int):
             raise TypeError("Need size to be resolved to an int by this point")
 
-        if type(addr) is not int:
+        if not isinstance(addr, int):
             raise TypeError("Need addr to be resolved to an int by this point")
 
         pageno, pageoff = self._divide_addr(addr)

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3440,6 +3440,16 @@ class TestDecompiler(unittest.TestCase):
         # should not crash!
         assert text.count("407710288") == 1 or text.count("0x184d2a50") == 1
 
+    def test_hostname_bad_mem_read(self, decompiler_options=None):
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "hostname")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        proj.analyses.CompleteCallingConventions(cfg=cfg, recover_variables=True)
+        f = proj.kb.functions["main"]
+        d = proj.analyses[Decompiler].prep()(f, cfg=cfg.model, options=decompiler_options)
+
+        assert d.codegen is not None
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Previous Error
On decompiling `main` in `hostname`:

```python
ERROR | 09:26:33 | angrmanagement.data.instance | Exception while running job "Decompiling":
Traceback (most recent call last):
  File "/Users/mahaloz/github/angr-dev/angr-management/angrmanagement/data/instance.py", line 343, in _worker
    result = job.run(self)
             ^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr-management/angrmanagement/data/jobs/job.py", line 69, in run
    r = self._run(inst)
        ^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr-management/angrmanagement/data/jobs/decompile_function.py", line 17, in _run
    decompiler = inst.project.analyses.Decompiler(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/decompiler.py", line 100, in __init__
    self._decompile()
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/decompiler.py", line 161, in _decompile
    clinic = self.project.analyses.Clinic(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/clinic.py", line 150, in __init__
    self._analyze_for_decompiling()
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/clinic.py", line 337, in _analyze_for_decompiling
    self._simplify_function(
  File "/Users/mahaloz/github/angr-dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/clinic.py", line 868, in _simplify_function
    simplified = self._simplify_function_once(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/clinic.py", line 898, in _simplify_function_once
    simp = self.project.analyses.AILSimplifier(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 105, in __init__
    self._simplify()
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 118, in _simplify
    folded_exprs = self._fold_exprs()
                   ^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 549, in _fold_exprs
    propagator = self._compute_propagation(immediate_stmt_removal=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 194, in _compute_propagation
    prop = self.project.analyses.Propagator(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/analysis.py", line 216, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/analysis.py", line 201, in wrapper
    oself.__init__(*args, **kwargs)
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/propagator.py", line 191, in __init__
    self._analyze()
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/propagator.py", line 416, in _analyze
    self._analysis_core_graph()
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/forward_analysis/forward_analysis.py", line 269, in _analysis_core_graph
    changed, output_state = self._run_on_node(n, job_state)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/propagator.py", line 295, in _run_on_node
    state = engine.process(
            ^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/engine_base.py", line 47, in process
    self._process(state, None, block=kwargs.pop("block", None))
  File "/Users/mahaloz/github/angr-dev/angr/angr/engines/light/engine.py", line 807, in _process
    self._process_Stmt(whitelist=whitelist)
  File "/Users/mahaloz/github/angr-dev/angr/angr/engines/light/engine.py", line 823, in _process_Stmt
    self._handle_Stmt(stmt)
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/engine_ail.py", line 74, in _handle_Stmt
    super()._handle_Stmt(stmt)
  File "/Users/mahaloz/github/angr-dev/angr/angr/engines/light/engine.py", line 874, in _handle_Stmt
    getattr(self, old_handler)(stmt)
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/engine_ail.py", line 254, in _ail_handle_ConditionalJump
    condition = self._expr(stmt.condition)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/engine_ail.py", line 292, in _expr
    return super()._expr(expr)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/engines/light/engine.py", line 843, in _expr
    return h(expr)
           ^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/engines/light/engine.py", line 960, in _ail_handle_BinaryOp
    return handler(expr)
           ^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/engine_ail.py", line 820, in _ail_handle_Cmp
    operand_0_value = self._expr(expr.operands[0])
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/engine_ail.py", line 292, in _expr
    return super()._expr(expr)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/engines/light/engine.py", line 843, in _expr
    return h(expr)
           ^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/analyses/propagator/engine_ail.py", line 419, in _ail_handle_Register
    new_expr = self.state.load_register(expr)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/knowledge_plugins/propagations/states.py", line 793, in load_register
    value, labels = self._registers.load_with_labels(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahaloz/github/angr-dev/angr/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py", line 650, in load_with_labels
    raise TypeError("Need addr to be resolved to an int by this point")
TypeError: Need addr to be resolved to an int by this point
```