### PR TITLE
initialize t9 register in call_state() for mips32, mips64

### DIFF
--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -279,7 +279,7 @@ class SimOS:
             state.regs.r2 = toc
         elif state.arch.name in ("MIPS32", "MIPS64"):
             state.regs.t9 = addr
-            
+
         return state
 
     def prepare_call_state(self, calling_state, initial_state=None, preserve_registers=(), preserve_memory=()):

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -277,7 +277,9 @@ class SimOS:
 
         if state.arch.name == "PPC64" and toc is not None:
             state.regs.r2 = toc
-
+        elif state.arch.name in ("MIPS32", "MIPS64"):
+            state.regs.t9 = addr
+            
         return state
 
     def prepare_call_state(self, calling_state, initial_state=None, preserve_registers=(), preserve_memory=()):


### PR DESCRIPTION
In some compile optimization cases, the T9 register is initialized when calling a function, and callee uses the T9 register as is for function calls.

Symbolic Execution was not performed properly because the t9 register was not initialized in factory.call_state(). 

So I added this.