### PR TITLE
Speed up RDA by implementing compare_states.

### DIFF
--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -184,6 +184,7 @@ class AILSimplifier(Analysis):
             observe_all=False,
             use_callee_saved_regs_at_return=self._use_callee_saved_regs_at_return,
             track_tmps=True,
+            element_limit=1,
         ).model
         self._reaching_definitions = rd
         return rd

--- a/angr/analyses/forward_analysis/forward_analysis.py
+++ b/angr/analyses/forward_analysis/forward_analysis.py
@@ -209,6 +209,20 @@ class ForwardAnalysis(Generic[AnalysisState, NodeType, JobType, JobKey]):
 
         raise NotImplementedError("_merge_states() is not implemented.")
 
+    def _compare_states(self, node: NodeType, old_state: AnalysisState, new_state: AnalysisState) -> bool:
+        """
+        Determine if the analysis has reached fixed point at `node`.
+
+        You can override this method to implement a faster _compare_states() method.
+
+        :param node:        The node that has been analyzed.
+        :param old_state:   The original output state out of node.
+        :param new_state:   The new output state out of node.
+        :return:            True if the analysis has reached fixed at node. False otherwise.
+        """
+        _, has_no_changes = self._merge_states(node, old_state, new_state)
+        return has_no_changes
+
     def _widen_states(self, *states: AnalysisState) -> AnalysisState:
         raise NotImplementedError("_widen_states() is not implemented.")
 
@@ -288,7 +302,7 @@ class ForwardAnalysis(Generic[AnalysisState, NodeType, JobType, JobKey]):
                     reached_fixedpoint = False
                 else:
                     # is the output state the same as the old one?
-                    _, reached_fixedpoint = self._merge_states(n, self._output_state[self._node_key(n)], output_state)
+                    reached_fixedpoint = self._compare_states(n, self._output_state[self._node_key(n)], output_state)
                 self._output_state[self._node_key(n)] = output_state
 
                 if not reached_fixedpoint:

--- a/angr/knowledge_plugins/key_definitions/environment.py
+++ b/angr/knowledge_plugins/key_definitions/environment.py
@@ -14,6 +14,8 @@ class Environment:
     **Note**: The <Environment> object does not store the values associated with variables themselves.
     """
 
+    __slots__ = ("_environment",)
+
     def __init__(self, environment: Dict[Union[str, Undefined], Set[claripy.ast.Base]] = None):
         self._environment: Dict[Union[str, Undefined], Set[claripy.ast.Base]] = environment or {}
 
@@ -81,3 +83,12 @@ class Environment:
 
         merge_occurred = new_env != self._environment
         return Environment(environment=new_env), merge_occurred
+
+    def compare(self, other: "Environment") -> bool:
+        for k in set(self._environment.keys()).union(set(other._environment.keys())):
+            if k not in self._environment:
+                return False
+            if k in self._environment and k in other._environment:
+                if not self._environment[k].issuperset(other._environment[k]):
+                    return False
+        return True

--- a/angr/storage/memory_mixins/__init__.py
+++ b/angr/storage/memory_mixins/__init__.py
@@ -67,6 +67,9 @@ class MemoryMixin(SimStatePlugin):
     def merge(self, others, merge_conditions, common_ancestor=None) -> bool:
         pass
 
+    def compare(self, other) -> bool:
+        pass
+
     def widen(self, others):
         pass
 

--- a/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
@@ -294,6 +294,24 @@ class PagedMemoryMixin(MemoryMixin):
 
         return bool(merged_bytes)
 
+    def compare(self, other: "PagedMemoryMixin") -> bool:
+        changed_pages_and_offsets: Dict[int, Optional[Set[int]]] = dict(self.changed_pages(other))
+
+        for page_no in sorted(changed_pages_and_offsets):
+            page = self._get_page(page_no, False)
+            page_addr = page_no * self.page_size
+            if page_no in other._pages:
+                r = page.compare(
+                    other._pages[page_no],
+                    page_addr=page_addr,
+                    memory=self,
+                    changed_offsets=changed_pages_and_offsets[page_no],
+                )
+                if r is False:
+                    return False
+
+        return True
+
     def permissions(self, addr, permissions=None, **kwargs):
         if type(addr) is not int:
             raise TypeError("addr must be an int in paged memory")

--- a/angr/storage/memory_mixins/paged_memory/pages/mv_list_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/mv_list_page.py
@@ -1,4 +1,4 @@
-# pylint:disable=abstract-method,arguments-differ
+# pylint:disable=abstract-method,arguments-differ,assignment-from-no-return
 import logging
 from typing import Optional, List, Set, Tuple, Union, Callable, Any, FrozenSet
 
@@ -277,7 +277,9 @@ class MVListPage(
         self.stored_offset |= merged_offsets
         return merged_offsets
 
-    def compare(self, other: "MVListPage", page_addr: int = None, memory=None, changed_offsets=None) -> bool:
+    def compare(
+        self, other: "MVListPage", page_addr: int = None, memory=None, changed_offsets=None
+    ) -> bool:  # pylint: disable=unused-argument
         compared_to = None
         for b in sorted(changed_offsets):
             if compared_to is not None and not b >= compared_to:


### PR DESCRIPTION
Also include the following improvements:

- Expose element_limit in RDA and LiveDefinitions. Set it to 1 during decompilation to speed up convergence.
- Micro optimizations in MVListPage.merge().