### PR TITLE
Support inlining of callees during decompilation

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
 import copy
 from collections import defaultdict, namedtuple
 import logging
 import enum
 from dataclasses import dataclass
-from typing import Optional, Any, NamedTuple, TYPE_CHECKING
+from typing import Any, NamedTuple, TYPE_CHECKING
 
 from collections.abc import Iterable
 
@@ -104,12 +105,12 @@ class Clinic(Analysis):
         variable_kb=None,
         reset_variable_names=False,
         rewrite_ites_to_diamonds=True,
-        cache: Optional["DecompilationCache"] = None,
+        cache: DecompilationCache | None = None,
         mode: ClinicMode = ClinicMode.DECOMPILE,
         sp_shift: int = 0,
-        inline_functions: Set[Function] | None = frozenset(),
-        inlined_counts: Dict[int, int] | None = None,
-        inlining_parents: Set[int] | None = None,
+        inline_functions: set[Function] | None = frozenset(),
+        inlined_counts: dict[int, int] | None = None,
+        inlining_parents: set[int] | None = None,
     ):
         if not func.normalized and mode == ClinicMode.DECOMPILE:
             raise ValueError("Decompilation must work on normalized function graphs.")
@@ -133,7 +134,7 @@ class Clinic(Analysis):
         self._remove_dead_memdefs = remove_dead_memdefs
         self._exception_edges = exception_edges
         self._sp_tracker_track_memory = sp_tracker_track_memory
-        self._cfg: Optional["CFGModel"] = cfg
+        self._cfg: CFGModel | None = cfg
         self.peephole_optimizations = peephole_optimizations
         self._must_struct = must_struct
         self._reset_variable_names = reset_variable_names

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -99,7 +99,7 @@ class Clinic(Analysis):
         optimization_passes=None,
         cfg=None,
         peephole_optimizations: None | (
-            Iterable[type["PeepholeOptimizationStmtBase"] | type["PeepholeOptimizationExprBase"]]
+            Iterable[type[PeepholeOptimizationStmtBase] | type[PeepholeOptimizationExprBase]]
         ) = None,  # pylint:disable=line-too-long
         must_struct: set[str] | None = None,
         variable_kb=None,

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -107,9 +107,9 @@ class Clinic(Analysis):
         cache: Optional["DecompilationCache"] = None,
         mode: ClinicMode = ClinicMode.DECOMPILE,
         sp_shift: int = 0,
-        inline_functions: Optional[Set[Function]] = frozenset(),
-        inlined_counts: Optional[Dict[int, int]] = None,
-        inlining_parents: Optional[Set[int]] = None,
+        inline_functions: Set[Function] | None = frozenset(),
+        inlined_counts: Dict[int, int] | None = None,
+        inlining_parents: Set[int] | None = None,
     ):
         if not func.normalized and mode == ClinicMode.DECOMPILE:
             raise ValueError("Decompilation must work on normalized function graphs.")

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -214,10 +214,6 @@ class Clinic(Analysis):
         # initialize the AIL conversion manager
         self._ail_manager = ailment.Manager(arch=self.project.arch)
 
-        # Track stack pointers
-        self._update_progress(15.0, text="Tracking stack pointers")
-        spt = self._track_stack_pointers()
-
         # Convert VEX blocks to AIL blocks and then simplify them
 
         self._update_progress(20.0, text="Converting VEX to AIL")
@@ -265,6 +261,10 @@ class Clinic(Analysis):
 
         # cached block-level reaching definition analysis results and propagator results
         block_simplification_cache: dict[ailment.Block, NamedTuple] | None = {}
+
+        # Track stack pointers
+        self._update_progress(15.0, text="Tracking stack pointers")
+        spt = self._track_stack_pointers()
 
         # Simplify blocks
         # we never remove dead memory definitions before making callsites. otherwise stack arguments may go missing

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -63,6 +63,7 @@ class Decompiler(Analysis):
         binop_operators=None,
         decompile=True,
         regen_clinic=True,
+        inline_functions=frozenset(),
         update_memory_data: bool = True,
         generate_code: bool = True,
     ):
@@ -88,6 +89,7 @@ class Decompiler(Analysis):
         self._regen_clinic = regen_clinic
         self._update_memory_data = update_memory_data
         self._generate_code = generate_code
+        self._inline_functions = inline_functions
 
         self.clinic = None  # mostly for debugging purposes
         self.codegen: Optional["CStructuredCodeGenerator"] = None
@@ -172,6 +174,7 @@ class Decompiler(Analysis):
                 must_struct=self._vars_must_struct,
                 cache=cache,
                 progress_callback=progress_callback,
+                inline_functions=self._inline_functions,
                 **self.options_to_params(self.options_by_class["clinic"]),
             )
         else:

--- a/angr/analyses/decompiler/optimization_passes/__init__.py
+++ b/angr/analyses/decompiler/optimization_passes/__init__.py
@@ -17,6 +17,7 @@ from .return_duplicator_low import ReturnDuplicatorLow
 from .return_duplicator_high import ReturnDuplicatorHigh
 from .const_derefs import ConstantDereferencesSimplifier
 from .register_save_area_simplifier import RegisterSaveAreaSimplifier
+from .spilled_register_finder import SpilledRegisterFinder
 from .ret_addr_save_simplifier import RetAddrSaveSimplifier
 from .x86_gcc_getpc_simplifier import X86GccGetPcSimplifier
 from .flip_boolean_cmp import FlipBooleanCmp

--- a/angr/analyses/decompiler/optimization_passes/spilled_register_finder.py
+++ b/angr/analyses/decompiler/optimization_passes/spilled_register_finder.py
@@ -1,0 +1,18 @@
+import logging
+
+from .register_save_area_simplifier import RegisterSaveAreaSimplifier
+
+
+_l = logging.getLogger(name=__name__)
+
+
+class SpilledRegisterFinder(RegisterSaveAreaSimplifier):
+    """
+    Finds spilled registers and tags them with pseudoregisters based on their stack offset.
+    """
+
+    @staticmethod
+    def _modify_statement(old_block, stmt_idx_: int, updated_blocks_, stack_offset: int = None):
+        old_stmt = old_block.statements[stmt_idx_]
+        pseudoreg = 0x1000000 - stack_offset
+        old_stmt.tags["pseudoreg"] = pseudoreg

--- a/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
@@ -182,7 +182,7 @@ class StackCanarySimplifier(OptimizationPass):
 
         while True:
             traversed.add(block_addr)
-            first_block = self._get_block(block_addr)
+            first_block = next(self._get_blocks(block_addr))
             if first_block is None:
                 break
 

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -443,6 +443,11 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
                 return True
         return False
 
+    def offsets_for(self, reg):
+        return [
+            o for block in self._func.blocks if (o := self.offset_after_block(block.addr, reg)) not in (TOP, BOTTOM)
+        ]
+
     #
     # Overridable methods
     #

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -318,6 +318,7 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
         block: Optional["Block"] = None,
         track_memory=True,
         cross_insn_opt=True,
+        initial_reg_values=None,
     ):
         if func is not None:
             if not func.normalized:
@@ -339,6 +340,9 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
         self._blocks = {}
         self._reg_value_at_block_start = defaultdict(dict)
         self.cross_insn_opt = cross_insn_opt
+
+        if initial_reg_values:
+            self._reg_value_at_block_start[func.addr if func is not None else block.addr] = initial_reg_values
 
         _l.debug("Running on function %r", self._func)
         self._analyze()

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -69,7 +69,7 @@ class Constant:
 
     def __sub__(self, other):
         if type(self) is type(other):
-            return Constant(self.val + other.val)
+            return Constant(self.val - other.val)
         else:
             raise CouldNotResolveException
 

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -1,6 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 import logging
 
+import ailment
 import claripy
 
 from ...storage.memory_mixins.paged_memory.pages.multi_values import MultiValues
@@ -252,7 +253,10 @@ class SimEngineVRBase(SimEngineLight):
 
             variable_manager = self.variable_manager[self.func_addr]
             var_candidates: list[tuple[SimVariable, int]] = variable_manager.find_variables_by_stmt(
-                self.block.addr, self.stmt_idx, "memory"
+                self.block.addr,
+                self.stmt_idx,
+                "memory",
+                block_idx=self.block.idx if isinstance(self.block, ailment.Block) else None,
             )
 
             # find the correct variable

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -586,7 +586,7 @@ class Function(Serializable):
             return False
 
     def __str__(self):
-        s = f"Function {self.name} [{self.addr}]\n"
+        s = f"Function {self.name} [{self.addr:#x}]\n"
         s += "  Syscall: %s\n" % self.is_syscall
         s += "  SP difference: %d\n" % self.sp_delta
         s += "  Has return: %s\n" % self.has_return

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1641,7 +1641,7 @@ class Function(Serializable):
         else:
             raise TypeError("calling_convention has to be one of: [SimCC, type(SimCC), None]")
 
-    def functions_called(self) -> set["Function"]:
+    def functions_reachable(self) -> set["Function"]:
         """
         :return: The set of all functions that can be reached from the function represented by self.
         """

--- a/tests/knowledge_plugins/functions/test_function.py
+++ b/tests/knowledge_plugins/functions/test_function.py
@@ -55,7 +55,7 @@ class TestFunction(TestCase):
             ]
         )
 
-        self.assertEqual(function.functions_called(), {C, D, E})
+        self.assertEqual(function.functions_reachable(), {C, D, E})
 
     def test_functions_called_with_recursive_function(self):
         recursive_function = makeFunction(self.function_manager, 0x40, "recursive_function")
@@ -70,7 +70,7 @@ class TestFunction(TestCase):
             ]
         )
 
-        self.assertEqual(recursive_function.functions_called(), {recursive_function, B})
+        self.assertEqual(recursive_function.functions_reachable(), {recursive_function, B})
 
     def test_functions_called_with_cyclic_dependencies(self):
         function = makeFunction(self.function_manager, 0x42, "function")
@@ -84,7 +84,7 @@ class TestFunction(TestCase):
             ]
         )
 
-        self.assertEqual(function.functions_called(), {function, C})
+        self.assertEqual(function.functions_reachable(), {function, C})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Traditionally, we decompile a function at a time, but this can be annoying with:

- complex data flow through small handlers
- wrapper functions
- all sorts of cases where you don't want to keep clicking into things

This PR adds support to angr to inline functions during decompilation, subjecting the resulting super-function to our optimizations (such as constant propagation that can eliminate portions of inlined functions). The functionality is enabled by passing an `inline_functions` of Function objects (current FIXME: it just checks addresses) to Decompiler (which passes it on to Clinic).

TODOs:
- [x] add testcases
- [x] make `inline_functions` consistent with its type annotation
- [x] check to see if the `callsite_maker` hackiness is still needed now that we're more careful about optimizations

The core inlining code is based on original exploration by @mrT4ntr4 (which doesn't apply cleanly to modern Clinic, otherwise I'd included the commits to preserve history) --- thanks, Suraj!