### PR TITLE
pcode: add support for 32-bit RISC-V calling convention

### DIFF
--- a/angr/engines/pcode/cc.py
+++ b/angr/engines/pcode/cc.py
@@ -96,6 +96,8 @@ def register_pcode_arch_default_cc(arch: ArchPcode):
         # we have a bunch of manually specified mappings
         manual_cc_mapping = {
             "68000:BE:32:default": SimCCM68k,
+            "RISCV:LE:32:RV32G": SimCCRISCV,
+            "RISCV:LE:32:RV32GC": SimCCRISCV,
             "RISCV:LE:64:RV64G": SimCCRISCV,
             "RISCV:LE:64:RV64GC": SimCCRISCV,
             "sparc:BE:32:default": SimCCSPARC,


### PR DESCRIPTION
In terms of the calling convention, there are no differences between 32-bit and 64-bit RISC-V regarding register handling. Hence, adding the 32-bit RISC-V pcode architecture to the existing list and mapping it to `SimCCRISCV` should suffice.

See: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc

This is a follow-up to https://github.com/angr/angr-platforms/issues/62 (CC: @twizmwazin) where I originally tried to use the 32-bit RISC-V lifter provided by angr-platform to analyze some 32-bit RISC-V binaries and found some issues with this lifter. I was pointed to pcode as an alternative, while trying out the pcode lifter with my binaries, I noticed that no default calling convention seems to be defined for 32-bit RISC-V. With this patch applied, I can successfully discover all execution paths in the 32-bit RISC-V binary mentioned in the referenced angr-platforms issue.