### PR TITLE
pcode: Implement new lzcount op

### DIFF
--- a/angr/engines/pcode/behavior.py
+++ b/angr/engines/pcode/behavior.py
@@ -886,6 +886,23 @@ class OpBehaviorPopcount(OpBehavior):
         return expr
 
 
+class OpBehaviorLzcount(OpBehavior):
+    """
+    Behavior for the LZCOUNT operation.
+    """
+
+    def __init__(self):
+        super().__init__(OpCode.LZCOUNT, True)
+
+    def evaluate_unary(self, size_out: int, size_in: int, in1: BV) -> BV:
+        expr = claripy.BVV(len(in1), size_out * 8)
+        for pos in range(len(in1)):
+            expr = claripy.If(
+                claripy.Extract(pos, pos, in1) == claripy.BVV(1, 1), claripy.BVV(len(in1) - pos - 1, size_out * 8), expr
+            )
+        return expr
+
+
 class BehaviorFactory:
     """
     Returns the behavior object for a given opcode.
@@ -973,5 +990,6 @@ class BehaviorFactory:
                 OpCode.INSERT: OpBehavior(OpCode.INSERT, False, True),
                 OpCode.EXTRACT: OpBehavior(OpCode.EXTRACT, False, True),
                 OpCode.POPCOUNT: OpBehaviorPopcount(),
+                OpCode.LZCOUNT: OpBehaviorLzcount(),
             }
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,10 +63,10 @@ docs =
     sphinx
     sphinx-autodoc-typehints
 pcode =
-    pypcode~=2.0.0
+    pypcode~=2.1.0
 testing =
     keystone-engine
-    pypcode~=2.0.0
+    pypcode~=2.1.0
     pytest
     pytest-split
     pytest-xdist

--- a/tests/engines/pcode/test_emulate.py
+++ b/tests/engines/pcode/test_emulate.py
@@ -568,6 +568,14 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         self._test_other_unary_common(OpCode.POPCOUNT, claripy.BVV(0x12345678, 32), claripy.BVV(13, 32))
         self._test_other_unary_common(OpCode.POPCOUNT, claripy.BVV(0xFFFFFFFF, 32), claripy.BVV(32, 32))
 
+    def test_lzcount(self):
+        self._test_other_unary_common(OpCode.LZCOUNT, claripy.BVV(0xFFFF, 16), claripy.BVV(0, 16))
+        self._test_other_unary_common(OpCode.LZCOUNT, claripy.BVV(0x7FFF, 16), claripy.BVV(1, 16))
+        self._test_other_unary_common(OpCode.LZCOUNT, claripy.BVV(0x3F0F, 16), claripy.BVV(2, 16))
+        self._test_other_unary_common(OpCode.LZCOUNT, claripy.BVV(0x0080, 16), claripy.BVV(8, 16))
+        self._test_other_unary_common(OpCode.LZCOUNT, claripy.BVV(0x0001, 16), claripy.BVV(15, 16))
+        self._test_other_unary_common(OpCode.LZCOUNT, claripy.BVV(0x0000, 16), claripy.BVV(16, 16))
+
     # TODO: Add tests for the following ops:
     # * = FIXME
     # ! = Not Implemented


### PR DESCRIPTION
pypcode 2.1.0 is now released and adds a new opcode lzcount. pypcode minimum version is now Python 3.10. Merge after we drop <3.10 on angr.

#4621
