### PR TITLE
Update calling_conventions.py

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2049,6 +2049,7 @@ class SimCCPowerPC(SimCC):
     STACKARG_SP_BUFF = 8
     RETURN_ADDR = SimRegArg("lr", 4)
     RETURN_VAL = SimRegArg("r3", 4)
+    OVERFLOW_RETURN_VAL = SimRegArg("r4",4)
     ARCH = archinfo.ArchPPC32
 
 

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2049,7 +2049,7 @@ class SimCCPowerPC(SimCC):
     STACKARG_SP_BUFF = 8
     RETURN_ADDR = SimRegArg("lr", 4)
     RETURN_VAL = SimRegArg("r3", 4)
-    OVERFLOW_RETURN_VAL = SimRegArg("r4",4)
+    OVERFLOW_RETURN_VAL = SimRegArg("r4", 4)
     ARCH = archinfo.ArchPPC32
 
 


### PR DESCRIPTION
32-bit PowerPC architecture stores the second half of the location in r4 when a double-length return value is returned