### PR TITLE
Support recovering struct member access

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1389,12 +1389,24 @@ class Clinic(Analysis):
         for block in ail_graph.nodes():
             self._link_variables_on_block(block, tmp_kb)
 
+        # Link struct member info to Store statements
+        for block in ail_graph.nodes():
+            self._link_struct_member_info_on_block(block, tmp_kb)
+
         if self._cache is not None:
             self._cache.type_constraints = vr.type_constraints
             self._cache.func_typevar = vr.func_typevar
             self._cache.var_to_typevar = vr.var_to_typevars
 
         return tmp_kb
+
+    def _link_struct_member_info_on_block(self, block, kb):
+        variable_manager = kb.variables[self.function.addr]
+        for stmt in block.statements:
+            if isinstance(stmt, ailment.Stmt.Store) and isinstance((var := stmt.variable), SimStackVariable):
+                offset = var.offset
+                if offset in variable_manager.stack_offset_to_struct_member_info:
+                    stmt.tags["struct_member_info"] = variable_manager.stack_offset_to_struct_member_info[offset]
 
     def _link_variables_on_block(self, block, kb):
         """

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -3224,8 +3224,12 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
             return old_ty
 
         if stmt.variable is not None:
-            cvar = self._variable(stmt.variable, stmt.size)
-            offset = stmt.offset or 0
+            if "struct_member_info" in stmt.tags:
+                offset, var, _ = stmt.struct_member_info
+                cvar = self._variable(var, stmt.size)
+            else:
+                cvar = self._variable(stmt.variable, stmt.size)
+                offset = stmt.offset or 0
             assert type(offset) is int  # I refuse to deal with the alternative
 
             cdst = self._access_constant_offset(self._get_variable_reference(cvar), offset, cdata.type, True, negotiate)

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -112,6 +112,8 @@ class VariableManagerInternal(Serializable):
         # optimization
         self._variables_without_writes = set()
 
+        self.stack_offset_to_struct_member_info: dict[SimStackVariable, (int, SimStackVariable, SimStruct)] = {}
+
         self.ret_val_size = None
 
     #
@@ -972,6 +974,9 @@ class VariableManagerInternal(Serializable):
                         self.variable_to_types[other_var] = ty
                         if mark_manual:
                             self.variables_with_manual_types.add(other_var)
+        if isinstance(var, SimStackVariable) and isinstance(ty, TypeRef) and isinstance(ty.type, SimStruct):
+            for offset in ty.type.offsets.values():
+                self.stack_offset_to_struct_member_info[var.offset + offset] = (offset, var, ty)
 
     def get_variable_type(self, var) -> SimType | None:
         return self.variable_to_types.get(var, None)

--- a/tests/analyses/decompiler/test_struct_member_access.py
+++ b/tests/analyses/decompiler/test_struct_member_access.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os.path
+import unittest
+
+import angr
+from angr import default_cc
+
+from ...common import bin_location
+
+
+test_location = os.path.join(bin_location, "tests")
+
+
+# pylint: disable=missing-class-docstring
+# pylint: disable=no-self-use
+class TestStructMemberAccess(unittest.TestCase):
+    def test_struct_member_write(self):
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "struct_member_access")
+        proj = angr.Project(bin_path, auto_load_libs=False, load_debug_info=True)
+
+        cfg = proj.analyses.CFG(data_references=True, normalize=True)
+
+        main_func = cfg.functions["main"]
+        foo_func = cfg.functions["foo"]
+
+        angr.types.register_types(angr.types.parse_type("struct Test {char* a; long long b; int c;}"))
+
+        foo_func.calling_convention = default_cc(
+            proj.arch.name, platform=proj.simos.name if proj.simos is not None else None
+        )(proj.arch)
+        foo_func.prototype = angr.types.parse_type("void (struct Test *a)").with_arch(proj.arch)
+
+        dec = proj.analyses.Decompiler(main_func, cfg=cfg)
+        text = dec.codegen.text
+        assert '.a = "123"' in text
+        assert ".b = 2" in text
+        assert ".c = 3" in text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Link stack variables to corresponding struct fields.
Before:
```c
typedef struct Test {
    char *a;
    unsigned long long b;
    unsigned int c;
} Test;

int main()
{
    Test v0;  // [bp-0x28]
    unsigned long long v1;  // [bp-0x20]
    unsigned int v2;  // [bp-0x18]

    v0.a = "123";
    v1 = 2;
    v2 = 3;
    foo(&v0);
    return 0;
}
```

Now:
```c
typedef struct Test {
    char *a;
    unsigned long long b;
    unsigned int c;
} Test;

int main()
{
    Test v0;  // [bp-0x28]

    v0.a = "123";
    v0.b = 2;
    v0.c = 3;
    foo(&v0);
    return 0;
}
```