### PR TITLE
Reassembler: fix missing intel_syntax

### DIFF
--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -2181,7 +2181,7 @@ class Reassembler(Analysis):
                 )
             all_assembly_lines.append(data.assembly(comments=comments, symbolized=symbolized))
 
-        s = "\n".join(all_assembly_lines)
+        s += "\n".join(all_assembly_lines)
 
         return s
 


### PR DESCRIPTION
Set syntax to intel would not produce
```
.intel_syntax noprefix
```
correctly.

This PR (should) fixes this issue.