### PR TITLE
load register even if size != self.gpr_size

### DIFF
--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -519,8 +519,9 @@ class PropagatorVEXState(PropagatorState):
 
     def load_register(self, offset, size):
         # TODO: Fix me
-        if size != self.gpr_size:
-            return self.top(size * self.arch.byte_width).annotate(RegisterAnnotation(offset, size))
+        # load register even if size != self.gpr_size
+        # if size != self.gpr_size:
+        #     return self.top(size * self.arch.byte_width).annotate(RegisterAnnotation(offset, size))
 
         try:
             v = self._registers.load(offset, size=size)


### PR DESCRIPTION
examples of size != self.gpr_size: al, dl