### PR TITLE
Move OrderedSet to angr

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -7,7 +7,6 @@ import networkx
 from sortedcontainers import SortedDict
 
 import pyvex
-from claripy.utils.orderedset import OrderedSet
 from cle import ELF, PE, Blob, TLSObject, MachO, ExternObject, KernelObject, FunctionHintSource, Hex, Coff, SRec, XBE
 from cle.backends import NamedRegion
 import archinfo
@@ -34,6 +33,7 @@ from angr.codenode import HookNode, BlockNode
 from angr.engines.vex.lifter import VEX_IRSB_MAX_SIZE, VEX_IRSB_MAX_INST
 from angr.analyses import Analysis
 from angr.analyses.stack_pointer_tracker import StackPointerTracker
+from angr.utils.orderedset import OrderedSet
 from .indirect_jump_resolvers.default_resolvers import default_indirect_jump_resolvers
 
 if TYPE_CHECKING:

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -7,8 +7,8 @@ import networkx
 
 from cle.backends.elf.compilation_unit import CompilationUnit
 from cle.backends.elf.variable import Variable
-from claripy.utils.orderedset import OrderedSet
 
+from angr.utils.orderedset import OrderedSet
 from ...protos import variables_pb2
 from ...serializable import Serializable
 from ...sim_variable import SimVariable, SimStackVariable, SimMemoryVariable, SimRegisterVariable

--- a/angr/utils/orderedset.py
+++ b/angr/utils/orderedset.py
@@ -1,0 +1,70 @@
+import collections.abc
+
+
+class OrderedSet(collections.abc.MutableSet):
+    """
+    Adapted from http://code.activestate.com/recipes/576694/
+    Originally created by Raymond Hettinger and licensed under MIT.
+    """
+
+    def __init__(self, iterable=None):
+        self.end = end = []
+        end += [None, end, end]  # sentinel node for doubly linked list
+        self.map = {}  # key --> [key, prev, next]
+        if iterable is not None:
+            self |= iterable
+
+    def __len__(self):
+        return len(self.map)
+
+    def __contains__(self, key):
+        return key in self.map
+
+    def add(self, key):
+        if key not in self.map:
+            end = self.end
+            curr = end[1]
+            curr[2] = end[1] = self.map[key] = [key, curr, end]
+
+    def discard(self, key):
+        if key in self.map:
+            key, prev, next_ = self.map.pop(key)
+            prev[2] = next_
+            next_[1] = prev
+
+    def __iter__(self):
+        end = self.end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def pop(self, last=True):  # pylint:disable=arguments-differ
+        if not self:
+            raise KeyError("set is empty")
+        key = self.end[1][0] if last else self.end[2][0]
+        self.discard(key)
+        return key
+
+    def __repr__(self):
+        if not self:
+            return f"{self.__class__.__name__}()"
+        return f"{self.__class__.__name__}({list(self)!r})"
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedSet):
+            return len(self) == len(other) and list(self) == list(other)
+        return set(self) == set(other)
+
+    def __getstate__(self):
+        return list(self)
+
+    def __setstate__(self, state):
+        self.__init__(state)

--- a/angr/utils/orderedset.py
+++ b/angr/utils/orderedset.py
@@ -20,15 +20,15 @@ class OrderedSet(collections.abc.MutableSet):
     def __contains__(self, key):
         return key in self.map
 
-    def add(self, key):
-        if key not in self.map:
+    def add(self, value):
+        if value not in self.map:
             end = self.end
             curr = end[1]
-            curr[2] = end[1] = self.map[key] = [key, curr, end]
+            curr[2] = end[1] = self.map[value] = [value, curr, end]
 
-    def discard(self, key):
-        if key in self.map:
-            key, prev, next_ = self.map.pop(key)
+    def discard(self, value):
+        if value in self.map:
+            value, prev, next_ = self.map.pop(value)
             prev[2] = next_
             next_[1] = prev
 


### PR DESCRIPTION
Claripy currently contains an ordered set implementation that it doesn't actually use. angr however, does use it. In an effort to remove it from claripy since it is unused there, add it to angr. I looked online to see if there were any popular ordered set implementations we could just use instead of maintaining our own, but none were particularly intriguing, so this seems appropriate.