### PR TITLE
deterministicly sort C variable types

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1409,6 +1409,7 @@ class CUnsupportedStatement(CStatement):
 
 
 class CDirtyStatement(CExpression):
+
     __slots__ = ("dirty",)
 
     def __init__(self, dirty, **kwargs):

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -499,7 +499,7 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
             vartypes = [x[1] for x in cvar_and_vartypes]
             count = Counter(vartypes)
             vartypes = sorted(
-                vartypes, key=lambda x: (isinstance(x, (SimTypeChar, SimTypeInt, SimTypeFloat)), count[x], repr(x))
+                count.copy(), key=lambda x: (isinstance(x, (SimTypeChar, SimTypeInt, SimTypeFloat)), count[x], repr(x))
             )
 
             for i, var_type in enumerate(vartypes):

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -497,7 +497,9 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
             #   * the repr of the type itself
             # TODO: The type selection should actually happen during variable unification
             count = Counter([x[1] for x in cvar_and_vartypes])
-            vartypes = sorted(count, key=lambda x: (isinstance(x, (SimTypeChar, SimTypeInt, SimTypeFloat)), count[x], repr(x)))
+            vartypes = sorted(
+                count, key=lambda x: (isinstance(x, (SimTypeChar, SimTypeInt, SimTypeFloat)), count[x], repr(x))
+            )
 
             for i, var_type in enumerate(vartypes):
                 if i == 0:

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -496,9 +496,10 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
             #   * the number of occurrences
             #   * the repr of the type itself
             # TODO: The type selection should actually happen during variable unification
-            count = Counter([x[1] for x in cvar_and_vartypes])
+            vartypes = [x[1] for x in cvar_and_vartypes]
+            count = Counter(vartypes)
             vartypes = sorted(
-                count, key=lambda x: (isinstance(x, (SimTypeChar, SimTypeInt, SimTypeFloat)), count[x], repr(x))
+                vartypes, key=lambda x: (isinstance(x, (SimTypeChar, SimTypeInt, SimTypeFloat)), count[x], repr(x))
             )
 
             for i, var_type in enumerate(vartypes):
@@ -2172,8 +2173,8 @@ class CConstant(CExpression):
                     v = refval.content.decode("utf-8")
                 else:
                     # it's a string
-                    assert isinstance(v, str)
                     v = refval
+                    assert isinstance(v, str)
                 yield CConstant.str_to_c_str(v), self
             elif isinstance(self._type, SimTypePointer) and isinstance(self._type.pts_to, SimTypeWideChar):
                 refval = self.reference_values[self._type]

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1,7 +1,7 @@
 # pylint:disable=missing-class-docstring,too-many-boolean-expressions,unused-argument,no-self-use
 from typing import Optional, Any, TYPE_CHECKING
 from collections.abc import Callable
-from collections import defaultdict
+from collections import defaultdict, Counter
 import logging
 import struct
 
@@ -491,19 +491,13 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
             else:
                 name = str(variable)
 
-            # sort by number of occurrences, with a preference of non-basic types
+            # sort by the following:
+            #   * if it's a a non-basic type
+            #   * the number of occurrences
+            #   * the repr of the type itself
             # TODO: The type selection should actually happen during variable unification
-            vartypes = [x[1] for x in cvar_and_vartypes]
-            nonprimitive_vartypes = [
-                vt for vt in vartypes if not isinstance(vt, (SimTypeChar, SimTypeInt, SimTypeFloat))
-            ]
-            vartypes = list(dict.fromkeys(sorted(vartypes, key=vartypes.count, reverse=True)))
-            if nonprimitive_vartypes:
-                nonprimitive_vartypes = list(
-                    dict.fromkeys(sorted(nonprimitive_vartypes, key=nonprimitive_vartypes.count, reverse=True))
-                )
-                vartypes.remove(nonprimitive_vartypes[0])
-                vartypes.insert(0, nonprimitive_vartypes[0])
+            count = Counter([x[1] for x in cvar_and_vartypes])
+            vartypes = sorted(count, key=lambda x: (isinstance(x, (SimTypeChar, SimTypeInt, SimTypeFloat)), count[x], repr(x)))
 
             for i, var_type in enumerate(vartypes):
                 if i == 0:

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1408,7 +1408,6 @@ class CUnsupportedStatement(CStatement):
 
 
 class CDirtyStatement(CExpression):
-
     __slots__ = ("dirty",)
 
     def __init__(self, dirty, **kwargs):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3647,6 +3647,23 @@ class TestDecompiler(unittest.TestCase):
             max_width_assigns = re.findall(rf"{indent*2}max_width = xdectoumax\(", text)
             assert len(max_width_assigns) == 1
 
+    def test_deterministic_sorting_c_variables(self, decompiler_options=None):
+        bin_path = os.path.join(test_location, "x86_64", "BitBlaster.exe")
+
+        first = None
+
+        for i in range(5):
+            proj = angr.Project(bin_path, auto_load_libs=False)
+            cfg = proj.analyses.CFGFast(normalize=True)
+            function = cfg.functions[4203344]
+            function.normalize()
+            decomp = proj.analyses.Decompiler(func=function, cfg=cfg, options=[(PARAM_TO_OPTION["show_casts"], False)])
+            text = decomp.codegen.text
+            if first is None:
+                first = decomp.codegen.text
+            else:
+                assert first == decomp.codegen.text
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3648,6 +3648,7 @@ class TestDecompiler(unittest.TestCase):
             assert len(max_width_assigns) == 1
 
     def test_deterministic_sorting_c_variables(self, decompiler_options=None):
+        # https://github.com/angr/angr/issues/4746
         bin_path = os.path.join(test_location, "x86_64", "BitBlaster.exe")
 
         first = None

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3659,7 +3659,6 @@ class TestDecompiler(unittest.TestCase):
             function = cfg.functions[4203344]
             function.normalize()
             decomp = proj.analyses.Decompiler(func=function, cfg=cfg, options=[(PARAM_TO_OPTION["show_casts"], False)])
-            text = decomp.codegen.text
             if first is None:
                 first = decomp.codegen.text
             else:

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3650,13 +3650,16 @@ class TestDecompiler(unittest.TestCase):
     def test_deterministic_sorting_c_variables(self, decompiler_options=None):
         # https://github.com/angr/angr/issues/4746
         bin_path = os.path.join(test_location, "x86_64", "BitBlaster.exe")
-        proj = angr.Project(bin_path, auto_load_libs=False)
-        cfg = proj.analyses.CFGFast(normalize=True)
-        function = cfg.functions[4203344]
-        function.normalize()
 
         first = None
         for _ in range(5):
+            # TODO: the following lines (CFG creation) are supposed to be deterministic as well, but are not.
+            #  this should be fixed in another PR and moved out of the loop in this testcase.
+            proj = angr.Project(bin_path, auto_load_libs=False)
+            cfg = proj.analyses.CFGFast(normalize=True)
+            function = cfg.functions[4203344]
+            function.normalize()
+            # re-create decompilation
             decomp = proj.analyses.Decompiler(func=function, cfg=cfg, options=[(PARAM_TO_OPTION["show_casts"], False)])
             if first is None:
                 first = decomp.codegen.text

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3653,7 +3653,7 @@ class TestDecompiler(unittest.TestCase):
 
         first = None
 
-        for i in range(5):
+        for _ in range(5):
             proj = angr.Project(bin_path, auto_load_libs=False)
             cfg = proj.analyses.CFGFast(normalize=True)
             function = cfg.functions[4203344]

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3650,19 +3650,18 @@ class TestDecompiler(unittest.TestCase):
     def test_deterministic_sorting_c_variables(self, decompiler_options=None):
         # https://github.com/angr/angr/issues/4746
         bin_path = os.path.join(test_location, "x86_64", "BitBlaster.exe")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        function = cfg.functions[4203344]
+        function.normalize()
 
         first = None
-
         for _ in range(5):
-            proj = angr.Project(bin_path, auto_load_libs=False)
-            cfg = proj.analyses.CFGFast(normalize=True)
-            function = cfg.functions[4203344]
-            function.normalize()
             decomp = proj.analyses.Decompiler(func=function, cfg=cfg, options=[(PARAM_TO_OPTION["show_casts"], False)])
             if first is None:
                 first = decomp.codegen.text
             else:
-                assert first == decomp.codegen.text
+                assert first == decomp.codegen.text, "Decompilation is not deterministic"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Decompiling the same binary should always result in the same decompilation.  As is, identifying variable types is not determinstic.  This PR fixes the sorting of variable types to be deterministic.

Example:

```python deterministic-variable-names.py
#!/usr/bin/env python

import difflib
import logging
import sys

from sortedcontainers import SortedDict

import angr
from angr.analyses.decompiler.decompilation_options import (
    PARAM_TO_OPTION,
    DecompilationOption,
)

logging.basicConfig(level=logging.CRITICAL, force=True)


def analyze_binary(binary_path):
    project = angr.Project(binary_path, auto_load_libs=False)
    cfg = project.analyses.CFGFast(normalize=True)
    function = cfg.functions[4203344]
    function.normalize()
    decomp = project.analyses.Decompiler(func=function, cfg=cfg, options=[(PARAM_TO_OPTION["show_casts"], False)])
    return decomp.codegen.text


def main():
    result = None
    for i in range(10):
        print(f"run {i}")
        latest = analyze_binary(sys.argv[1]).split("\n")
        if result is None:
            result = latest
        elif result != latest:
            for diff in difflib.unified_diff(result, latest):
                print(diff)
            break

if __name__ == "__main__":
    main()
```

When run the above example python with a locally built version of `BitBlaster.exe` from the Cyber Grand Challenge will generate the following output:

```
❯ python deterministic-variable-names.py ./BitBlaster.exe
run 0
run 1
---

+++

@@ -22,7 +22,7 @@

     unsigned int v15;  // [bp-0x270]
     unsigned int v16;  // [bp-0x26c]
     unsigned short v17;  // [bp-0x268]
-    unsigned int v18;  // [bp-0x64], Other Possible Types: char
+    char v18;  // [bp-0x64], Other Possible Types: unsigned int
     unsigned int v19;  // [bp-0x60]
     unsigned int v20;  // [bp-0x58]
     struct_0 *v21;  // [bp-0x14]

```
