### PR TITLE
handle not finding initial blocks when simplifying stack canaries

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
@@ -182,7 +182,11 @@ class StackCanarySimplifier(OptimizationPass):
 
         while True:
             traversed.add(block_addr)
-            first_block = next(self._get_blocks(block_addr))
+            try:
+                first_block = next(self._get_blocks(block_addr))
+            except StopIteration:
+                break
+
             if first_block is None:
                 break
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3674,5 +3674,6 @@ class TestDecompiler(unittest.TestCase):
         function.normalize()
         proj.analyses.Decompiler(func=function, cfg=cfg)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3666,6 +3666,13 @@ class TestDecompiler(unittest.TestCase):
             else:
                 assert first == decomp.codegen.text, "Decompilation is not deterministic"
 
+    def test_stop_iteration_in_canary_init_stmt(self):
+        bin_path = os.path.join(test_location, "x86_64", "hello_gcc9_reassembler")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        function = cfg.functions[4198577]
+        function.normalize()
+        proj.analyses.Decompiler(func=function, cfg=cfg)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
StackCanarySimplifier._find_canary_init_stmt fails if it cannot find an
initial block as it calls `next(self.get_blocks(block_addr))` outside of
an iterator.

This PR handles the exception similarly to what happens if the next call
returns None.

The included integration test validates decompilation of a single
function from an existing binary failed prior to this fix.
