### PR TITLE
remove partial use of ODict alias

### DIFF
--- a/angr/analyses/decompiler/structuring/dream.py
+++ b/angr/analyses/decompiler/structuring/dream.py
@@ -1,6 +1,5 @@
 # pylint:disable=multiple-statements,line-too-long,consider-using-enumerate
 from typing import Optional, Any, TYPE_CHECKING
-from collections import OrderedDict as ODict
 import logging
 from collections import defaultdict, OrderedDict
 
@@ -661,7 +660,7 @@ class DreamStructurer(StructurerBase):
         i,
         node,
         cmp_expr,
-        cases: ODict,
+        cases: OrderedDict,
         node_default,
         addr,
         addr2nodes,
@@ -909,7 +908,7 @@ class DreamStructurer(StructurerBase):
         head_node_idx: int,
         node_b_addr: int,
         addr2nodes: dict[int, set[CodeNode]],
-    ) -> tuple[ODict, Any, Any]:
+    ) -> tuple[OrderedDict, Any, Any]:
         """
         Discover all cases for the switch-case structure and build the switch-cases dict.
 
@@ -922,7 +921,7 @@ class DreamStructurer(StructurerBase):
         :return:                    A tuple of (dict of cases, the default node if exists, nodes to remove).
         """
 
-        cases: ODict[int | tuple[int, ...], SequenceNode] = OrderedDict()
+        cases: OrderedDict[int | tuple[int, ...], SequenceNode] = OrderedDict()
         to_remove = set()
         node_default = addr2nodes.get(node_b_addr, None)
         if node_default is not None:

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -1,7 +1,6 @@
 # pylint:disable=line-too-long,import-outside-toplevel,import-error,multiple-statements,too-many-boolean-expressions
 from typing import Any, DefaultDict, Optional, TYPE_CHECKING
-from collections import OrderedDict as ODict
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from enum import Enum
 import logging
 
@@ -1308,8 +1307,8 @@ class PhoenixStructurer(StructurerBase):
         node_b_addr,
         graph,
         full_graph,
-    ) -> tuple[ODict, Any, set[Any]]:
-        cases: ODict[int | tuple[int], SequenceNode] = ODict()
+    ) -> tuple[OrderedDict, Any, set[Any]]:
+        cases: OrderedDict[int | tuple[int], SequenceNode] = OrderedDict()
         to_remove = set()
 
         # it is possible that the default node gets duplicated by other analyses and creates a default node (addr.a)
@@ -1418,7 +1417,7 @@ class PhoenixStructurer(StructurerBase):
         self,
         head,
         cmp_expr,
-        cases: ODict,
+        cases: OrderedDict,
         node_default_addr: int,
         node_default,
         addr,

--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -1,6 +1,5 @@
 # pylint:disable=unused-argument
 from typing import Optional, Any, TYPE_CHECKING
-from collections import OrderedDict as ODict
 from collections import defaultdict, OrderedDict
 import logging
 
@@ -739,8 +738,8 @@ class StructurerBase(Analysis):
     #
 
     def _reorganize_switch_cases(
-        self, cases: ODict[int | tuple[int, ...], SequenceNode]
-    ) -> ODict[int | tuple[int, ...], SequenceNode]:
+        self, cases: OrderedDict[int | tuple[int, ...], SequenceNode]
+    ) -> OrderedDict[int | tuple[int, ...], SequenceNode]:
         new_cases = OrderedDict()
 
         caseid2gotoaddrs = {}

--- a/angr/analyses/decompiler/structuring/structurer_nodes.py
+++ b/angr/analyses/decompiler/structuring/structurer_nodes.py
@@ -1,6 +1,6 @@
 # pylint:disable=missing-class-docstring
 from typing import Any
-from collections import OrderedDict as ODict
+from collections import OrderedDict
 
 import claripy
 import ailment
@@ -358,9 +358,9 @@ class SwitchCaseNode(BaseNode):
         "addr",
     )
 
-    def __init__(self, switch_expr, cases: ODict[int | tuple[int, ...], SequenceNode], default_node, addr=None):
+    def __init__(self, switch_expr, cases: OrderedDict[int | tuple[int, ...], SequenceNode], default_node, addr=None):
         self.switch_expr = switch_expr
-        self.cases: ODict[int | tuple[int, ...], SequenceNode] = cases
+        self.cases: OrderedDict[int | tuple[int, ...], SequenceNode] = cases
         self.default_node = default_node
         self.addr = addr
 


### PR DESCRIPTION
Most of the codebase specifies OrderedDict directly.  In some cases, it's imported as an alias as ODict.  In some of _those_ cases, OrderedDict and ODict are both used.

This normalizes everythning to use OrderedDict directly.
