### PR TITLE
clinic: process all SimFunctionArguments in fallback case

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1185,15 +1185,13 @@ class Clinic(Analysis):
                             name=arg_names[idx],
                             region=self.function.addr,
                         )
-                    elif isinstance(arg, SimStructArg):
+                    else:
                         argvar = SimVariable(
                             ident="arg_%d" % idx,
                             name=arg_names[idx],
                             region=self.function.addr,
                             size=arg.size,
                         )
-                    else:
-                        raise TypeError(f"Unsupported function argument type {type(arg)}.")
                     arg_vars.append(argvar)
             return arg_vars
         return []

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -17,7 +17,7 @@ from ...knowledge_plugins.functions import Function
 from ...knowledge_plugins.cfg.memory_data import MemoryDataSort
 from ...codenode import BlockNode
 from ...utils import timethis
-from ...calling_conventions import SimRegArg, SimStackArg, SimStructArg, SimFunctionArgument
+from ...calling_conventions import SimRegArg, SimStackArg, SimFunctionArgument
 from ...sim_type import (
     SimTypeChar,
     SimTypeInt,


### PR DESCRIPTION
What was previously the SimStructArg case should apply for all argument storage locations, I believe.