### PR TITLE
Track uc_alloc_depth in SimUCManager

### DIFF
--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -328,7 +328,16 @@ class SimSolver(SimStatePlugin):
     # Get unconstrained stuff
     #
     def Unconstrained(
-        self, name, bits, uninitialized=True, inspect=True, events=True, key=None, eternal=False, **kwargs
+        self,
+        name,
+        bits,
+        uninitialized=True,
+        inspect=True,
+        events=True,
+        key=None,
+        eternal=False,
+        uc_alloc_depth=None,
+        **kwargs,
     ):
         """
         Creates an unconstrained symbol or a default concrete value (0), based on the state options.
@@ -355,28 +364,18 @@ class SimSolver(SimStatePlugin):
                 r = claripy.TSI(bits=bits, name=name, uninitialized=uninitialized, **kwargs)
             else:
                 l.debug("Creating new unconstrained BV named %s", name)
-                if o.UNDER_CONSTRAINED_SYMEXEC in self.state.options:
-                    r = self.BVS(
-                        name,
-                        bits,
-                        uninitialized=uninitialized,
-                        key=key,
-                        eternal=eternal,
-                        inspect=inspect,
-                        events=events,
-                        **kwargs,
-                    )
-                else:
-                    r = self.BVS(
-                        name,
-                        bits,
-                        uninitialized=uninitialized,
-                        key=key,
-                        eternal=eternal,
-                        inspect=inspect,
-                        events=events,
-                        **kwargs,
-                    )
+                r = self.BVS(
+                    name,
+                    bits,
+                    uninitialized=uninitialized,
+                    key=key,
+                    eternal=eternal,
+                    inspect=inspect,
+                    events=events,
+                    **kwargs,
+                )
+                if uc_alloc_depth is not None:
+                    self.state.uc_manager.set_alloc_depth(r, uc_alloc_depth)
 
             return r
         # Return a default value, aka. 0

--- a/angr/storage/memory_mixins/underconstrained_mixin.py
+++ b/angr/storage/memory_mixins/underconstrained_mixin.py
@@ -51,7 +51,7 @@ class UnderconstrainedMixin(MemoryMixin):
             o.UNDER_CONSTRAINED_SYMEXEC in self.state.options
             and isinstance(addr, claripy.ast.Base)
             and addr.uninitialized
-            and addr.uc_alloc_depth is not None
+            and self.state.uc_manager.get_alloc_depth(addr) is not None
         ) and (
             not self.state.uc_manager.is_bounded(addr)
             or self.state.solver.max_int(addr) - self.state.solver.min_int(addr) >= self._unconstrained_range

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -780,7 +780,7 @@ class TestMemory(unittest.TestCase):
 
         # test that under-constrained load is constrained
         ptr1 = state.memory.load(0x4141414141414000, size=8, endness="Iend_LE")
-        assert ptr1.uc_alloc_depth == 0
+        assert state.uc_manager.get_alloc_depth(ptr1) == 0
         assert ptr1.uninitialized
         state.memory.load(ptr1, size=1)
         # ptr1 should have been constrained
@@ -788,7 +788,7 @@ class TestMemory(unittest.TestCase):
 
         # test that under-constrained store is constrained
         ptr2 = state.memory.load(0x4141414141414008, size=8, endness="Iend_LE")
-        assert ptr2.uc_alloc_depth == 0
+        assert state.uc_manager.get_alloc_depth(ptr2) == 0
         assert ptr2.uninitialized
         state.memory.store(ptr2, b"\x41", size=1)
         # ptr2 should have been constrained
@@ -803,7 +803,7 @@ class TestMemory(unittest.TestCase):
             state.memory.load(0x4141414141414014, size=4, endness="Iend_LE"),
         )
         assert ptr3.uninitialized
-        assert ptr3.uc_alloc_depth is None  # because uc_alloc_depth doesn't carry across Concat
+        assert state.uc_manager.get_alloc_depth(ptr3) is None  # because uc_alloc_depth doesn't carry across Concat
         # we don't care what these do, as long as they don't crash
         state.memory.store(ptr3, b"\x41", size=1)
         state.memory.load(ptr3, size=1)


### PR DESCRIPTION
This replaces the uc_alloc_depth field currently in claripy.ast.Base with a dict[Base, int] in SimUCManager. This will allow us to remove this use-specific field from claripy.