### PR TITLE
Remove STRINGS_ANALYSIS state option

### DIFF
--- a/angr/sim_options.py
+++ b/angr/sim_options.py
@@ -48,9 +48,6 @@ NO_SYMBOLIC_SYSCALL_RESOLUTION = "NO_SYMBOLIC_SYSCALL_RESOLUTION"
 # The absense of this option causes the analysis to avoid reasoning about most symbolic values.
 SYMBOLIC = "SYMBOLIC"
 
-# This variable causes claripy to use a string solver (CVC4)
-STRINGS_ANALYSIS = "STRINGS_ANALYSIS"
-
 # Generate symbolic values for non-existent values. The absence of this option causes Unconstrained() to return default
 # concrete values (like 0)
 SYMBOLIC_INITIAL_VALUES = "SYMBOLIC_INITIAL_VALUES"

--- a/angr/simos/javavm.py
+++ b/angr/simos/javavm.py
@@ -108,7 +108,6 @@ class SimJavaVM(SimOS):
             kwargs["os_name"] = self.name
         # enable support for string analysis
         add_options = kwargs.get("add_options", set())
-        add_options.add(options.STRINGS_ANALYSIS)
         add_options.add(options.COMPOSITE_SOLVER)
         kwargs["add_options"] = add_options
 

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -6,7 +6,6 @@ import os
 from typing import TypeVar, overload
 
 import claripy
-from claripy import backend_manager
 
 from angr import sim_options as o
 from angr.errors import SimValueError, SimUnsatError, SimSolverModeError, SimSolverOptionError
@@ -296,14 +295,7 @@ class SimSolver(SimStatePlugin):
         track = o.CONSTRAINT_TRACKING_IN_SOLVER in self.state.options
         approximate_first = o.APPROXIMATE_FIRST in self.state.options
 
-        if o.STRINGS_ANALYSIS in self.state.options:
-            if o.COMPOSITE_SOLVER in self.state.options:
-                self._stored_solver = claripy.SolverComposite(
-                    template_solver_string=claripy.SolverCompositeChild(
-                        backend=backend_manager.backends.z3, track=track
-                    )
-                )
-        elif o.ABSTRACT_SOLVER in self.state.options:
+        if o.ABSTRACT_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverVSA()
         elif o.SYMBOLIC in self.state.options and o.REPLACEMENT_SOLVER in self.state.options:
             self._stored_solver = claripy.SolverReplacement(auto_replace=False)


### PR DESCRIPTION
Since removing the SMT-LIB backends from claripy, this has had no effect.