### PR TITLE
fix typos

### DIFF
--- a/angr/analyses/binary_optimizer.py
+++ b/angr/analyses/binary_optimizer.py
@@ -104,7 +104,7 @@ class DeadAssignment:
 class BinaryOptimizer(Analysis):
     """
     This is a collection of binary optimization techniques we used in Mechanical Phish during the finals of Cyber Grand
-    Challange. It focuses on dealing with some serious speed-impacting code constructs, and *sort of* worked on *some*
+    Challenge. It focuses on dealing with some serious speed-impacting code constructs, and *sort of* worked on *some*
     CGC binaries compiled with O0. Use this analysis as a reference of how to use data dependency graph and such.
 
     There is no guarantee that BinaryOptimizer will ever work on non-CGC binaries. Feel free to give us PR or MR, but

--- a/angr/analyses/bindiff.py
+++ b/angr/analyses/bindiff.py
@@ -1014,9 +1014,9 @@ class BinDiff(Analysis):
             if cfg.kb.functions.function(function_addr) is None or cfg.kb.functions.function(function_addr).is_syscall:
                 continue
             if cfg.kb.functions.function(function_addr) is not None:
-                normalized_funtion = NormalizedFunction(cfg.kb.functions.function(function_addr))
-                number_of_basic_blocks = len(normalized_funtion.graph.nodes())
-                number_of_edges = len(normalized_funtion.graph.edges())
+                normalized_function = NormalizedFunction(cfg.kb.functions.function(function_addr))
+                number_of_basic_blocks = len(normalized_function.graph.nodes())
+                number_of_edges = len(normalized_function.graph.edges())
             else:
                 number_of_basic_blocks = 0
                 number_of_edges = 0

--- a/angr/analyses/cfg/cfg.py
+++ b/angr/analyses/cfg/cfg.py
@@ -15,7 +15,7 @@ class CFG(CFGFast):  # pylint: disable=abstract-method
     slow, dynamically-generated version of CFG.
 
     For multiple historical reasons, angr's CFG is accurate but slow, which does not meet what most people expect. We
-    developed CFGFast for light-speed CFG recovery, and renamed the old CFG class to CFGEmulated. For compability
+    developed CFGFast for light-speed CFG recovery, and renamed the old CFG class to CFGEmulated. For compatibility
     concerns, CFG was kept as an alias to CFGEmulated.
 
     However, so many new users of angr would load up a binary and generate a CFG immediately after running

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -97,7 +97,7 @@ class PendingJob:
     """
     A PendingJob is whatever will be put into our pending_exit list. A pending exit is an entry that created by the
     returning of a call or syscall. It is "pending" since we cannot immediately figure out whether this entry will
-    be executed or not. If the corresponding call/syscall intentially doesn't return, then the pending exit will be
+    be executed or not. If the corresponding call/syscall intentionally doesn't return, then the pending exit will be
     removed. If the corresponding call/syscall returns, then the pending exit will be removed as well (since a real
     entry is created from the returning and will be analyzed later). If the corresponding call/syscall might
     return, but for some reason (for example, an unsupported instruction is met during the analysis) our analysis
@@ -228,7 +228,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
         :param networkx.DiGraph base_graph:         A basic control flow graph to follow. Each node inside this graph
                                                     must have the following properties: `addr` and `size`. CFG recovery
                                                     will strictly follow nodes and edges shown in the graph, and discard
-                                                    any contorl flow that does not follow an existing edge in the base
+                                                    any control flow that does not follow an existing edge in the base
                                                     graph. For example, you can pass in a Function local transition
                                                     graph as the base graph, and CFGEmulated will traverse nodes and
                                                     edges and extract useful information.
@@ -1193,7 +1193,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
                 src_cfgnode = self._nodes[src_block_id]
                 depth = src_cfgnode.depth + 1
                 # the depth will not be updated later on even if this block has a greater depth on another path.
-                # consequently, the `max_steps` limit is not veyr precise - I didn't see a need to make it precise
+                # consequently, the `max_steps` limit is not very precise - I didn't see a need to make it precise
                 # though.
 
         if block_id not in self._nodes:
@@ -1946,7 +1946,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
 
     def _handle_actions(self, state, current_run, func, sp_addr, accessed_registers):
         """
-        For a given state and current location of of execution, will update a function by adding the offets of
+        For a given state and current location of of execution, will update a function by adding the offsets of
         appropriate actions to the stack variable or argument registers for the fnc.
 
         :param SimState state: upcoming state.
@@ -2614,7 +2614,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
         CFGNode.
 
         :param SimSuccessors current_block: SimSuccessor with address to attempt to navigate to.
-        :param dict block_artifacts:  Container of IRSB data - specifically used for known persistant register values.
+        :param dict block_artifacts:  Container of IRSB data - specifically used for known persistent register values.
         :param CFGNode cfg_node:      Current node interested around.
         :returns:                     Double-checked concrete successors.
         :rtype: List
@@ -2629,7 +2629,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
                 """
                 Class to overwrite registers.
 
-                :param int reg_offest:       Register offset to overwrite from.
+                :param int reg_offset:       Register offset to overwrite from.
                 :param dict info_collection: New register offsets to use (in container).
                 """
                 self._reg_offset = reg_offset
@@ -2752,7 +2752,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
         """
         Symbolically execute the first basic block of the specified function,
         then returns it. We prepares the state using the already existing
-        state in fastpath mode (if avaiable).
+        state in fastpath mode (if available).
         :param function_addr: The function address
         :return: A symbolic state if succeeded, None otherwise
         """

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -4075,7 +4075,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int], CFGBase):  # pylin
                     func = self.kb.functions.get_by_addr(current_function_addr)
                     pc_reg = return_from_func.info["get_pc"]
                     # the crazy thing is that GCC-generated code may adjust the register value accordingly after
-                    # returning! we must take into account the added offset (in the followin example, 0x8d36)
+                    # returning! we must take into account the added offset (in the following example, 0x8d36)
                     #
                     # e.g.
                     #  000011A1 call    __x86_get_pc_thunk_bx
@@ -4515,7 +4515,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int], CFGBase):  # pylin
         For MIPS32 simulates a new state where the global pointer is 0xffffffff
         from current address after three steps if the first successor does not
         adjust this value updates this function address (in function manager)
-        to use a conrete global pointer
+        to use a concrete global pointer
 
         :param addr: irsb address
         :param cfg_node:    The corresponding CFG node object.

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3452,7 +3452,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int], CFGBase):  # pylin
         self._model.add_node(new_node.addr, new_node)
 
         # the function starting at this point is probably totally incorrect
-        # hopefull future call to `make_functions()` will correct everything
+        # hopefully, a future call to `make_functions()` will correct everything
         if node.addr in self.kb.functions:
             del self.kb.functions[node.addr]
 

--- a/angr/analyses/cfg_slice_to_sink/cfg_slice_to_sink.py
+++ b/angr/analyses/cfg_slice_to_sink/cfg_slice_to_sink.py
@@ -94,7 +94,7 @@ class CFGSliceToSink:
 
     def path_between(self, source: int, destination: int, visited: set[Any] | None = None) -> bool:
         """
-        Check the existence of a path in the slice between two given node adresses.
+        Check the existence of a path in the slice between two given node addresses.
 
         :param source: The source address.
         :param destination: The destination address.

--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -1322,7 +1322,7 @@ class DDG(Analysis):
 
     def _data_graph_add_node(self, node):
         """
-        Add a noe in the data dependence graph.
+        Add a node in the data dependence graph.
 
         :param ProgramVariable node: The node to add.
         :return: None

--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -159,7 +159,7 @@ class LiveDefinitions:
         Add a new definition of variable.
 
         :param SimVariable variable: The variable being defined.
-        :param CodeLocation location: Location of the varaible being defined.
+        :param CodeLocation location: Location of the variable being defined.
         :param int size_threshold: The maximum bytes to consider for the variable.
         :return: True if the definition was new, False otherwise
         :rtype: bool
@@ -946,7 +946,7 @@ class DDG(Analysis):
             return self.project.arch.registers[reg_name][1]
 
         l.warning(
-            "_get_register_size(): unsupported register offset %d. Assum size 1. "
+            "_get_register_size(): unsupported register offset %d. Assume size 1. "
             "More register name mappings should be implemented in archinfo.",
             reg_offset,
         )

--- a/angr/analyses/decompiler/block_similarity.py
+++ b/angr/analyses/decompiler/block_similarity.py
@@ -74,7 +74,7 @@ def is_similar(
                 try:
                     t1_blk, t2_blk = find_block_by_addr(graph, t1), find_block_by_addr(graph, t2)
                 except ValueError:
-                    _l.warning("Could not find block by address in graph. It is likley that the graph is broken.")
+                    _l.warning("Could not find block by address in graph. It is likely that the graph is broken.")
                     return False
 
                 # special checks for when a node is empty:

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -64,7 +64,7 @@ _UNIFIABLE_COMPARISONS = {
 def _op_with_unified_size(op, conv, operand0, operand1):
     # ensure operand1 is of the same size as operand0
     if isinstance(operand1, ailment.Expr.Const):
-        # amazing - we do the eazy thing here
+        # amazing - we do the easy thing here
         return op(conv(operand0, nobool=True), operand1.value)
     if operand1.bits == operand0.bits:
         return op(conv(operand0, nobool=True), conv(operand1))

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -297,7 +297,7 @@ class Decompiler(Analysis):
         Runs optimizations that should be executed before region identification.
 
         :param ail_graph:   DiGraph with AIL Statements
-        :param reaching_defenitions: ReachingDefenitionAnalysis
+        :param reaching_definitions: ReachingDefinitionAnalysis
         :return:            The possibly new AIL DiGraph and RegionIdentifier
         """
         addr_and_idx_to_blocks: dict[tuple[int, int | None], ailment.Block] = {}
@@ -352,7 +352,7 @@ class Decompiler(Analysis):
 
         :param ail_graph:   DiGraph with AIL Statements
         :param ri:          RegionIdentifier
-        :param reaching_defenitions: ReachingDefenitionAnalysis
+        :param reaching_definitions: ReachingDefinitionAnalysis
         :return:            The possibly new AIL DiGraph and RegionIdentifier
         """
         addr_and_idx_to_blocks: dict[tuple[int, int | None], ailment.Block] = {}

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -723,7 +723,7 @@ class DuplicationReverter(StructuringOptimizationPass):
         if not cond1.condition.likes(cond2.condition):
             return False
 
-        # colect the true and false targets for the condition
+        # collect the true and false targets for the condition
         block_to_target_map = defaultdict(dict)
         for block, cond in ((block1, cond1), (block2, cond2)):
             for succ in graph.successors(block):
@@ -735,7 +735,7 @@ class DuplicationReverter(StructuringOptimizationPass):
                     # exit early if you ever can't find a supposed target
                     return False
 
-        # check if at least one block in succesors match
+        # check if at least one block in successors match
         mismatched_blocks = {}
         for target_type in block_to_target_map[block1]:
             t1_blk, t2_blk = block_to_target_map[block1][target_type], block_to_target_map[block2][target_type]
@@ -753,7 +753,7 @@ class DuplicationReverter(StructuringOptimizationPass):
         #   D             E
         #
         # A and B both share the same condition, point to a block that is either similar to each
-        # other or the same block, AND they have a mistmatch block D & E. We want to make a new NOP
+        # other or the same block, AND they have a mismatch block D & E. We want to make a new NOP
         # block that is between A->D and B->E to make a balanced merged graph:
         #
         #   A ---> C <--- B
@@ -915,7 +915,7 @@ class DuplicationReverter(StructuringOptimizationPass):
             full_condition_graph.remove_edge(*cycles[0])
 
         # now that we have a full target graph, we want to know the condensed conditions that allow
-        # control flow to get to that target end. We get the reaching conditions to construct a gaurding
+        # control flow to get to that target end. We get the reaching conditions to construct a guarding
         # node later
         self._ri.cond_proc.recover_reaching_conditions(None, graph=full_condition_graph)
         conditions_by_start = {}
@@ -1190,7 +1190,7 @@ class DuplicationReverter(StructuringOptimizationPass):
         node_level = [node]
         seen_nodes = set()
         while node_level:
-            # check if any of the nodes on the current level are dominaters to all nodes
+            # check if any of the nodes on the current level are dominates to all nodes
             for cnode in node_level:
                 if not cnode.statements:
                     continue

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -1190,7 +1190,7 @@ class DuplicationReverter(StructuringOptimizationPass):
         node_level = [node]
         seen_nodes = set()
         while node_level:
-            # check if any of the nodes on the current level are dominates to all nodes
+            # check if any of the nodes on the current level are dominators to all nodes
             for cnode in node_level:
                 if not cnode.statements:
                     continue

--- a/angr/analyses/decompiler/region_simplifiers/expr_folding.py
+++ b/angr/analyses/decompiler/region_simplifiers/expr_folding.py
@@ -163,7 +163,7 @@ class ExpressionUseFinder(AILBlockWalker):
 
         v16 = ((int)v23->field_5) + 1 & 255;
         v23->field_5 = ((char)(((int)v23->field_5) + 1 & 255));
-        v13 = printf("Received packet %d for connection with %d\\n", v16, a0 & 255);
+        v13 = printf("Recieved packet %d for connection with %d\\n", v16, a0 & 255);
 
     In this case, folding v16 into the last printf() expression would be incorrect, since v23->field_5 is updated by
     the second statement.

--- a/angr/analyses/decompiler/region_simplifiers/expr_folding.py
+++ b/angr/analyses/decompiler/region_simplifiers/expr_folding.py
@@ -163,7 +163,7 @@ class ExpressionUseFinder(AILBlockWalker):
 
         v16 = ((int)v23->field_5) + 1 & 255;
         v23->field_5 = ((char)(((int)v23->field_5) + 1 & 255));
-        v13 = printf("Recieved packet %d for connection with %d\\n", v16, a0 & 255);
+        v13 = printf("Received packet %d for connection with %d\\n", v16, a0 & 255);
 
     In this case, folding v16 into the last printf() expression would be incorrect, since v23->field_5 is updated by
     the second statement.

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -2242,7 +2242,7 @@ class PhoenixStructurer(StructurerBase):
         The original Phoenix algorithm had no support for multi-stmt expressions, such as the following:
         if ((x = y) && z) { ... }
 
-        There are multiple levels at which multi-stmt expressions can be used. If the Phoenix algorith is not not
+        There are multiple levels at which multi-stmt expressions can be used. If the Phoenix algorithm is not not
         set to be in improved mode, then we should not use multi-stmt expressions at all.
         """
         if not self._improve_algorithm:

--- a/angr/analyses/decompiler/structuring/sailr.py
+++ b/angr/analyses/decompiler/structuring/sailr.py
@@ -16,7 +16,7 @@ class SAILRStructurer(PhoenixStructurer):
 
     At a high-level, SAILR does three things different from the traditional Phoenix schema-based algorithm:
     1. It recursively structures the graph, rather than doing it in a single pass. This allows decisions to be made
-        based on the currrent state of what the decompilation would look like.
+        based on the current state of what the decompilation would look like.
     2. It performs deoptimizations targeting specific optimizations that introduces gotos and mis-structured code.
         It can only do this because of the recursive nature of the algorithm.
     3. It uses a more advanced heuristic for virtualizing edges, which is implemented in this class.

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -683,7 +683,7 @@ class MemoryOperand(Operand):
         # or
         # [ '[', Register, ']' ]
         # or
-        # [ Value, '(', Regsiter, ')' ]
+        # [ Value, '(', Register, ')' ]
 
         # it will be converted into more meaningful and Pythonic properties
 

--- a/angr/analyses/forward_analysis/visitors/graph.py
+++ b/angr/analyses/forward_analysis/visitors/graph.py
@@ -74,7 +74,7 @@ class GraphVisitor(Generic[NodeType]):
 
     def back_edges(self) -> list[tuple[NodeType, NodeType]]:
         """
-        Get a list of back edges. This function is optional. If not overriden, the traverser cannot achieve an optimal
+        Get a list of back edges. This function is optional. If not overridden, the traverser cannot achieve an optimal
         graph traversal order.
 
         :return:                A list of back edges (source -> destination).

--- a/angr/analyses/reaching_definitions/heap_allocator.py
+++ b/angr/analyses/reaching_definitions/heap_allocator.py
@@ -16,7 +16,7 @@ class HeapAllocator:
     - Take care of the size not to screw potential pointer arithmetic (avoid overlapping segments).
 
     The content of the heap itself is modeled using a <KeyedRegion> attribute in the <LiveDefinitions> state;
-    This class serves to generate consistent heap addresses to be used by the aforementionned.
+    This class serves to generate consistent heap addresses to be used by the aforementioned.
 
     *Note:* This has **NOT** been made to help detect heap vulnerabilities.
     """
@@ -31,10 +31,10 @@ class HeapAllocator:
 
     def allocate(self, size: int | UnknownSize) -> HeapAddress:
         """
-        Gives an address for a new memory chunck of <size> bytes.
+        Gives an address for a new memory chunk of <size> bytes.
 
-        :param size: The requested size for the chunck, in number of bytes.
-        :return: The address of the chunck.
+        :param size: The requested size for the chunk, in number of bytes.
+        :return: The address of the chunk.
         """
         address = self._next_heap_address
 
@@ -47,9 +47,9 @@ class HeapAllocator:
 
     def free(self, address: Undefined | HeapAddress):
         """
-        Mark the chunck pointed by <address> as freed.
+        Mark the chunk pointed by <address> as freed.
 
-        :param address: The address of the chunck to free.
+        :param address: The address of the chunk to free.
         """
 
         if isinstance(address, Undefined):

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -111,13 +111,13 @@ def fill_reg_map():
 def split_operands(s):
     operands = []
     operand = ""
-    in_paranthesis = False
+    in_parenthesis = False
     for i, c in enumerate(s):
-        if in_paranthesis and c == ")":
-            in_paranthesis = False
+        if in_parenthesis and c == ")":
+            in_parenthesis = False
         if c == "(":
-            in_paranthesis = True
-        if not in_paranthesis and c == "," and (i == len(s) - 1 or s[i + 1] == " "):
+            in_parenthesis = True
+        if not in_parenthesis and c == "," and (i == len(s) - 1 or s[i + 1] == " "):
             operands.append(operand)
             operand = ""
             continue
@@ -1698,7 +1698,7 @@ class Reassembler(Analysis):
 
     Tested on CGC, x86 and x86-64 binaries.
 
-    Discliamer: The reassembler is an empirical solution. Don't be surprised if it does not work on some binaries.
+    Disclaimer: The reassembler is an empirical solution. Don't be surprised if it does not work on some binaries.
     """
 
     def __init__(self, syntax="intel", remove_cgc_attachments=True, log_relocations=True):

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -112,7 +112,7 @@ class SimEngineVRBase(SimEngineLight):
         return False
 
     @staticmethod
-    def _parse_offseted_addr(addr: claripy.ast.BV) -> tuple[claripy.ast.BV, claripy.ast.BV, claripy.ast.BV] | None:
+    def _parse_offsetted_addr(addr: claripy.ast.BV) -> tuple[claripy.ast.BV, claripy.ast.BV, claripy.ast.BV] | None:
         if addr.op == "__add__" and len(addr.args) == 2:
             concrete_base, byte_offset = None, None
             if addr.args[0].concrete:
@@ -379,9 +379,9 @@ class SimEngineVRBase(SimEngineLight):
             # fully concrete. this is a global address
             self._store_to_global(addr.concrete_value, data, size, stmt=stmt)
             stored = True
-        elif self._addr_has_concrete_base(addr) and self._parse_offseted_addr(addr) is not None:
+        elif self._addr_has_concrete_base(addr) and self._parse_offsetted_addr(addr) is not None:
             # we are storing to a concrete global address with an offset
-            base_addr, offset, elem_size = self._parse_offseted_addr(addr)
+            base_addr, offset, elem_size = self._parse_offsetted_addr(addr)
             self._store_to_global(base_addr.concrete_value, data, size, stmt=stmt, offset=offset, elem_size=elem_size)
             stored = True
         else:
@@ -743,9 +743,9 @@ class SimEngineVRBase(SimEngineLight):
             v = self._load_from_global(addr.concrete_value, size, expr=expr)
             typevar = v.typevar
 
-        elif self._addr_has_concrete_base(addr) and self._parse_offseted_addr(addr) is not None:
+        elif self._addr_has_concrete_base(addr) and self._parse_offsetted_addr(addr) is not None:
             # Loading data from a memory address with an offset
-            base_addr, offset, elem_size = self._parse_offseted_addr(addr)
+            base_addr, offset, elem_size = self._parse_offsetted_addr(addr)
             v = self._load_from_global(base_addr.concrete_value, size, expr=expr, offset=offset, elem_size=elem_size)
             typevar = v.typevar
 

--- a/angr/analyses/variable_recovery/variable_recovery.py
+++ b/angr/analyses/variable_recovery/variable_recovery.py
@@ -435,7 +435,7 @@ class VariableRecovery(ForwardAnalysis, VariableRecoveryBase):  # pylint:disable
     This analysis follows SSA, which means every write creates a new variable in registers or memory (statck, heap,
     etc.). Things may get tricky when overlapping variable (in memory, as you cannot really have overlapping accesses
     to registers) accesses exist, and in such cases, a new variable will be created, and this new variable will overlap
-    with one or more existing varaibles. A decision procedure (which is pretty much TODO) is required at the end of this
+    with one or more existing variables. A decision procedure (which is pretty much TODO) is required at the end of this
     analysis to resolve the conflicts between overlapping variables.
     """
 

--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -358,7 +358,7 @@ class Veritesting(Analysis):
 
     def _join_merge_points(self, manager, merge_points):
         """
-        Merges together the appropriate execution points and unstashes them from the intermidiate merge_x_y stashes to
+        Merges together the appropriate execution points and unstashes them from the intermediate merge_x_y stashes to
         pruned (dropped), deadend or active stashes
 
         param SimulationManager manager:        current simulation context being stepped through

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -627,7 +627,7 @@ class VFG(ForwardAnalysis[SimState, VFGNode, VFGJob, BlockID], Analysis):  # pyl
 
         # did we reach the final address?
         if self._final_address is not None and job.addr == self._final_address:
-            # our analysis should be termianted here
+            # our analysis should be terminated here
             l.debug("%s is viewed as a final state. Skip.", job)
             raise AngrSkipJobNotice
 

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -714,7 +714,7 @@ class VFG(ForwardAnalysis[SimState, VFGNode, VFGJob, BlockID], Analysis):  # pyl
         vfg_node.state = input_state
 
         # Execute this basic block with input state, and get a new SimSuccessors instance
-        # unused result var is `error_occured`
+        # unused result var is `error_occurred`
         job.sim_successors, _, restart_analysis = self._get_simsuccessors(input_state, addr)
 
         if restart_analysis:
@@ -1419,7 +1419,7 @@ class VFG(ForwardAnalysis[SimState, VFGNode, VFGJob, BlockID], Analysis):  # pyl
     #
 
     def _get_simsuccessors(self, state: SimState, addr: int) -> tuple[SimSuccessors, bool, bool]:
-        error_occured = False
+        error_occurred = False
         restart_analysis = False
 
         jumpkind = "Ijk_Boring"
@@ -1434,19 +1434,19 @@ class VFG(ForwardAnalysis[SimState, VFGNode, VFGJob, BlockID], Analysis):  # pyl
             # It's a tragedy that we came across some instructions that VEX
             # does not support. I'll create a terminating stub there
             l.error("SimIRSBError occurred(%s). Creating a PathTerminator.", ex)
-            error_occured = True
+            error_occurred = True
             inst = SIM_PROCEDURES["stubs"]["PathTerminator"](state)
             sim_successors = ProcedureEngine().process(state, procedure=inst)
         except claripy.ClaripyError:
             l.error("ClaripyError: ", exc_info=True)
-            error_occured = True
+            error_occurred = True
             # Generate a PathTerminator to terminate the current path
             inst = SIM_PROCEDURES["stubs"]["PathTerminator"](state)
             sim_successors = ProcedureEngine().process(state, procedure=inst)
         except SimError:
             l.error("SimError: ", exc_info=True)
 
-            error_occured = True
+            error_occurred = True
             # Generate a PathTerminator to terminate the current path
             inst = SIM_PROCEDURES["stubs"]["PathTerminator"](state)
             sim_successors = ProcedureEngine().process(state, procedure=inst)
@@ -1456,10 +1456,10 @@ class VFG(ForwardAnalysis[SimState, VFGNode, VFGJob, BlockID], Analysis):  # pyl
             # We might be on a wrong branch, and is likely to encounter the
             # "No bytes in memory xxx" exception
             # Just ignore it
-            error_occured = True
+            error_occurred = True
             sim_successors = None
 
-        return sim_successors, error_occured, restart_analysis
+        return sim_successors, error_occurred, restart_analysis
 
     def _create_new_jobs(
         self, job: VFGJob, successor: SimState, new_block_id: BlockID, new_call_stack: CallStack

--- a/angr/block.py
+++ b/angr/block.py
@@ -22,7 +22,7 @@ DEFAULT_VEX_ENGINE = VEXLifter(None)  # this is only used when Block is not init
 
 class DisassemblerBlock:
     """
-    Helper class to represent a block of dissassembled target architecture
+    Helper class to represent a block of disassembled target architecture
     instructions
     """
 

--- a/angr/code_location.py
+++ b/angr/code_location.py
@@ -37,7 +37,7 @@ class CodeLocation:
                                     the entire block.
         :param class sim_procedure: The corresponding SimProcedure class.
         :param ins_addr:            The instruction address.
-        :param context:             A tuple that represents the context of this CodeLocation in contextful mode, or
+        :param context:             A tuple that represents the context of this CodeLocation in contextual mode, or
                                     None in contextless mode.
         :param kwargs:              Optional arguments, will be stored, but not used in __eq__ or __hash__.
         """

--- a/angr/concretization_strategies/__init__.py
+++ b/angr/concretization_strategies/__init__.py
@@ -14,7 +14,7 @@ class SimConcretizationStrategy:
         """
         Initializes the base SimConcretizationStrategy.
 
-        :param filter: A function, taking arguments of (SimMemory, claripy.AST) that determins
+        :param filter: A function, taking arguments of (SimMemory, claripy.AST) that determines
                        if this strategy can handle resolving the provided AST.
         :param exact: A flag (default: True) that determines if the convenience resolution
                       functions provided by this class use exact or approximate resolution.

--- a/angr/concretization_strategies/nonzero_range.py
+++ b/angr/concretization_strategies/nonzero_range.py
@@ -14,8 +14,8 @@ class SimConcretizationStrategyNonzeroRange(SimConcretizationStrategy):
     def _concretize(self, memory, addr, extra_constraints=None, **kwargs):
         mn, mx = self._range(memory, addr, extra_constraints=extra_constraints, **kwargs)
         if mx - mn <= self._limit:
-            child_constaints = (addr != 0,)
+            child_constraints = (addr != 0,)
             if extra_constraints is not None:
-                child_constaints += tuple(extra_constraints)
-            return self._eval(memory, addr, self._limit, extra_constraints=child_constaints, **kwargs)
+                child_constraints += tuple(extra_constraints)
+            return self._eval(memory, addr, self._limit, extra_constraints=child_constraints, **kwargs)
         return None

--- a/angr/concretization_strategies/signed_add.py
+++ b/angr/concretization_strategies/signed_add.py
@@ -6,12 +6,12 @@ from . import SimConcretizationStrategy
 
 class SimConcretizationStrategySignedAdd(SimConcretizationStrategy):
     """
-    Concretization strategy that changes additions of big offsets to substractions of small offsets.
+    Concretization strategy that changes additions of big offsets to subtractions of small offsets.
     """
 
-    def __init__(self, substraction_limit=0x10000):
+    def __init__(self, subtraction_limit=0x10000):
         super().__init__()
-        self._substraction_limit = substraction_limit
+        self._subtraction_limit = subtraction_limit
 
     def _concretize(self, memory, addr, **kwargs):
         if addr.depth == 2 and addr.op == "__add__":
@@ -25,6 +25,6 @@ class SimConcretizationStrategySignedAdd(SimConcretizationStrategy):
                 and memory.state.solver.is_true(addr.args[1] >= 1 << (addr.args[1].size() - 1))
             ):
                 new_arg = (1 << addr.args[1].size()) - memory.state.solver.eval(addr.args[1])
-                if new_arg < self._substraction_limit:
+                if new_arg < self._subtraction_limit:
                     addr.op = "__sub__"
                     addr.args = (addr.args[0], claripy.BVV(new_arg, addr.args[1].size()))

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -817,7 +817,7 @@ class PcodeBasicBlockLifter:
                 "AVR8": "avr8:LE:16:atmega256",
             }
             if arch.name not in archinfo_to_lang_map:
-                l.error("Unknown mapping of %s to pcode languge id", arch.name)
+                l.error("Unknown mapping of %s to pcode language id", arch.name)
                 raise NotImplementedError
             langid = archinfo_to_lang_map[arch.name]
 

--- a/angr/engines/soot/values/arrayref.py
+++ b/angr/engines/soot/values/arrayref.py
@@ -78,7 +78,7 @@ class SimSootValue_ArrayRef(SimSootValue):
 
     @staticmethod
     def check_array_bounds(idx, array, state):
-        # a valid idx fullfills the constraint
+        # a valid idx fulfills the constraint
         # 0 <= idx < length
         zero = claripy.BVV(0, 32)
         length = array.size

--- a/angr/engines/syscall.py
+++ b/angr/engines/syscall.py
@@ -32,7 +32,7 @@ class SimEngineSyscall(SuccessorsMixin, ProcedureMixin):
         if sys_procedure is None:
             if angr.sim_options.BYPASS_UNSUPPORTED_SYSCALL not in state.options:
                 raise AngrUnsupportedSyscallError(
-                    "Trying to perform a syscall on an emulated system which is not currently cofigured to support "
+                    "Trying to perform a syscall on an emulated system which is not currently configured to support "
                     "syscalls. To resolve this, make sure that your SimOS is a subclass of SimUserspace, or set the "
                     "BYPASS_UNSUPPORTED_SYSCALL state option."
                 )

--- a/angr/engines/vex/claripy/irop.py
+++ b/angr/engines/vex/claripy/irop.py
@@ -1014,7 +1014,7 @@ class SimIROp:
             return args[0].raw_to_bv()
         if self._to_type == "F":
             return args[0].raw_to_fp()
-        raise SimOperationError("unsupport Reinterp _to_type")
+        raise SimOperationError("unsupported Reinterp _to_type")
 
     @supports_vector
     def _op_fgeneric_Round(self, args):

--- a/angr/engines/vex/heavy/concretizers.py
+++ b/angr/engines/vex/heavy/concretizers.py
@@ -346,7 +346,7 @@ def concretize_yl2x(state, args):
             # TODO: Indicate floating-point invalid-operation exception
             return state.solver.FPV(arg_x, claripy.FSORT_DOUBLE)
 
-        # TODO: How to distiguish between +0 and -0?
+        # TODO: How to distinguish between +0 and -0?
         return state.solver.FPV(0, claripy.FSORT_DOUBLE)
 
     if arg_x == math.inf:

--- a/angr/exploration_techniques/__init__.py
+++ b/angr/exploration_techniques/__init__.py
@@ -18,9 +18,9 @@ class ExplorationTechnique:
     _hook_list = ("step", "filter", "selector", "step_state", "successors")
 
     def _get_hooks(self):
-        return {name: getattr(self, name) for name in self._hook_list if self._is_overriden(name)}
+        return {name: getattr(self, name) for name in self._hook_list if self._is_overridden(name)}
 
-    def _is_overriden(self, name):
+    def _is_overridden(self, name):
         return getattr(self, name).__code__ is not getattr(ExplorationTechnique, name).__code__
 
     def __init__(self):

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -794,7 +794,7 @@ class Tracer(ExplorationTechnique):
 
             if state_history_block_addr == big_block_start_addr:
                 # We found start of the big block and no control flow statements in between that and the block where
-                # desync happend.
+                # desync happened.
                 break
 
         # Let's find the address of the last byte of the big basic block using VEX lifter

--- a/angr/factory.py
+++ b/angr/factory.py
@@ -169,7 +169,7 @@ class AngrObjectFactory:
 
         grow_like_stack controls the behavior of allocating data at alloc_base. When data from args needs to be wrapped
         in a pointer, the pointer needs to point somewhere, so that data is dumped into memory at alloc_base. If you
-        set alloc_base to point to somewhere other than the stack, set grow_like_stack to False so that sequencial
+        set alloc_base to point to somewhere other than the stack, set grow_like_stack to False so that sequential
         allocations happen at increasing addresses.
         """
         return self.project.simos.state_call(addr, *args, **kwargs)
@@ -200,7 +200,7 @@ class AngrObjectFactory:
         elif isinstance(thing, SimState):
             thing = [thing]
         else:
-            raise AngrError(f"BadType to initialze SimulationManager: {thing!r}")
+            raise AngrError(f"BadType to initialize SimulationManager: {thing!r}")
 
         return SimulationManager(self.project, active_states=thing, **kwargs)
 

--- a/angr/flirt/build_sig.py
+++ b/angr/flirt/build_sig.py
@@ -134,7 +134,7 @@ def run_sigmake(sigmake_path: str, sig_name: str, pat_path: str, sig_path: str):
 def process_exc_file(exc_path: str):
     """
     We are doing the stupidest thing possible: For each batch of conflicts, we pick the most likely
-    result baed on a set of predefined rules.
+    result based on a set of predefined rules.
 
     TODO: Add caller-callee-based de-duplication.
     """

--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -280,7 +280,7 @@ class CFGModel(Serializable):
         :param addr:            Address of the beginning of the basic block. Set anyaddr to True to support arbitrary
                                 address.
         :param is_syscall:      Whether you want to get the syscall node or any other node. This is due to the fact that
-                                syscall SimProcedures have the same address as the targer it returns to.
+                                syscall SimProcedures have the same address as the target it returns to.
                                 None means get either, True means get a syscall node, False means get something that
                                 isn't a syscall node.
         :param anyaddr:         If anyaddr is True, then addr doesn't have to be the beginning address of a basic
@@ -597,7 +597,7 @@ class CFGModel(Serializable):
                     last_addr = sec.vaddr + sec.memsize
                 else:
                     # it does not belong to any section. what's the next adjacent section? any memory data does not go
-                    # beyong section boundaries
+                    # beyond section boundaries
                     next_sec = self.project.loader.find_section_next_to(data_addr)
                     if next_sec is not None:
                         next_sec_addr = next_sec.vaddr

--- a/angr/knowledge_plugins/debug_variables.py
+++ b/angr/knowledge_plugins/debug_variables.py
@@ -176,7 +176,7 @@ class DebugVariableManager(KnowledgeBasePlugin):
         """
         Add all variables in a list with the same visibility range
 
-        :param vlist:       A list of cle varibles to add
+        :param vlist:       A list of cle variables to add
         :param low_pc:      Start of the visibility scope as program counter address (rebased)
         :param high_pc:     End of the visibility scope as program counter address (rebased)
         """

--- a/angr/knowledge_plugins/functions/function_parser.py
+++ b/angr/knowledge_plugins/functions/function_parser.py
@@ -90,7 +90,7 @@ class FunctionParser:
     @staticmethod
     def parse_from_cmsg(cmsg, function_manager=None, project=None, all_func_addrs=None):
         """
-        :param cmsg: The data to instanciate the <Function> from.
+        :param cmsg: The data to instantiate the <Function> from.
 
         :return Function:
         """

--- a/angr/knowledge_plugins/key_definitions/atoms.py
+++ b/angr/knowledge_plugins/key_definitions/atoms.py
@@ -67,7 +67,7 @@ class Atom:
         argument: SimFunctionArgument, arch: Arch, full_reg=False, sp: int | None = None
     ) -> Register | MemoryLocation:
         """
-        Instanciate an `Atom` from a given argument.
+        instantiate an `Atom` from a given argument.
 
         :param argument: The argument to create a new atom from.
         :param arch: The argument representing archinfo architecture for argument.

--- a/angr/knowledge_plugins/key_definitions/atoms.py
+++ b/angr/knowledge_plugins/key_definitions/atoms.py
@@ -67,7 +67,7 @@ class Atom:
         argument: SimFunctionArgument, arch: Arch, full_reg=False, sp: int | None = None
     ) -> Register | MemoryLocation:
         """
-        instantiate an `Atom` from a given argument.
+        Instantiate an `Atom` from a given argument.
 
         :param argument: The argument to create a new atom from.
         :param arch: The argument representing archinfo architecture for argument.

--- a/angr/knowledge_plugins/key_definitions/rd_model.py
+++ b/angr/knowledge_plugins/key_definitions/rd_model.py
@@ -109,8 +109,8 @@ class ReachingDefinitionsModel:
             if k not in self.observed_results:
                 self.observed_results[k] = v
             else:
-                merged, merge_occured = self.observed_results[k].merge(v)
-                if merge_occured:
+                merged, merge_occurred = self.observed_results[k].merge(v)
+                if merge_occurred:
                     self.observed_results[k] = merged
         self.all_definitions.union(model.all_definitions)
         self.all_uses.merge(model.all_uses)

--- a/angr/knowledge_plugins/key_definitions/tag.py
+++ b/angr/knowledge_plugins/key_definitions/tag.py
@@ -61,18 +61,18 @@ class LocalVariableTag(FunctionTag):
 
 class ReturnValueTag(FunctionTag):
     """
-    A tag for a definiton of a return value
+    A tag for a definition of a return value
     of a function.
     """
 
 
 class InitialValueTag(Tag):
     """
-    A tag for a definiton of an initial value
+    A tag for a definition of an initial value
     """
 
 
 class UnknownSizeTag(Tag):
     """
-    A tag for a definiton of an initial value
+    A tag for a definition of an initial value
     """

--- a/angr/knowledge_plugins/propagations/states.py
+++ b/angr/knowledge_plugins/propagations/states.py
@@ -50,7 +50,7 @@ class PropagatorState:
     Describes the base state used in Propagator.
 
     :ivar arch:             Architecture of the binary.
-    :ivar gp:               alue of the global pointer for MIPS binaries.
+    :ivar gp:               value of the global pointer for MIPS binaries.
     :ivar _replacements:    Stores expressions to replace, keyed by CodeLocation instances
     :ivar _equivalence:      Stores equivalence constraints that Propagator discovers during the analysis.
     :ivar _only_consts:     Only track constants.

--- a/angr/knowledge_plugins/xrefs/xref.py
+++ b/angr/knowledge_plugins/xrefs/xref.py
@@ -133,7 +133,7 @@ class XRef(Serializable):
             ins_addr=cmsg.ea,
             block_addr=cmsg.block_ea,
             stmt_idx=cmsg.stmt_idx,
-            insn_op_idx=None if cmsg.operand_idx == -1 else cmsg.opearnd_idx,
+            insn_op_idx=None if cmsg.operand_idx == -1 else cmsg.operand_idx,
             dst=dst,
             xref_type=cmsg.ref_type,
         )

--- a/angr/misc/plugins.py
+++ b/angr/misc/plugins.py
@@ -266,7 +266,7 @@ class PluginPreset:
 class PluginVendor(Generic[P], PluginHub[P]):
     """
     A specialized hub which serves only as a plugin vendor, never having any "active" plugins.
-    It will directly return the plugins provided by the preset instead of instanciating them.
+    It will directly return the plugins provided by the preset instead of instantiating them.
     """
 
     def release_plugin(self, name):

--- a/angr/procedures/libc/strncmp.py
+++ b/angr/procedures/libc/strncmp.py
@@ -110,7 +110,7 @@ class strncmp(angr.SimProcedure):
                         b_conc -= ord(" ")
 
                 if a_conc != b_conc:
-                    l.debug("... found mis-matching concrete bytes 0x%x and 0x%x", a_conc, b_conc)
+                    l.debug("... found mismatching concrete bytes 0x%x and 0x%x", a_conc, b_conc)
                     if a_conc < b_conc:
                         return claripy.BVV(-1, 32)
                     return claripy.BVV(1, 32)

--- a/angr/procedures/linux_kernel/stat.py
+++ b/angr/procedures/linux_kernel/stat.py
@@ -7,7 +7,7 @@ from .fstat import fstat
 
 class stat(fstat):
     def run(self, p_addr, stat_buf):
-        # open tempory fd
+        # open temporary fd
         strlen = angr.SIM_PROCEDURES["libc"]["strlen"]
         p_strlen = self.inline_call(strlen, p_addr)
         p_expr = self.state.memory.load(p_addr, p_strlen.max_null_index, endness="Iend_BE")
@@ -17,7 +17,7 @@ class stat(fstat):
         # Use fstat to get the result and everything
         result = super().run(fd, stat_buf)
 
-        # close tempory fd
+        # close temporary fd
         self.state.posix.close(fd)
 
         return result

--- a/angr/procedures/posix/mmap.py
+++ b/angr/procedures/posix/mmap.py
@@ -37,7 +37,7 @@ class mmap(angr.SimProcedure):
                 raise angr.errors.SimPosixError("Can't map with a symbolic offset!!")
             sim_fd = self.state.posix.get_fd(fd)
             if sim_fd is None:
-                l.warning("Trying to map a non-exsitent fd")
+                l.warning("Trying to map a non-existent fd")
                 return -1
             if not isinstance(sim_fd, SimFileDescriptor) or sim_fd.file is None:
                 l.warning("Trying to map fd not supporting mmap (maybe a SimFileDescriptorDuplex?)")

--- a/angr/procedures/posix/strtok_r.py
+++ b/angr/procedures/posix/strtok_r.py
@@ -26,8 +26,8 @@ class strtok_r(angr.SimProcedure):
         strstr = angr.SIM_PROCEDURES["libc"]["strstr"]
         strlen = angr.SIM_PROCEDURES["libc"]["strlen"]
 
-        l.debug("Doin' a strtok_r!")
-        l.debug("... geting the saved state")
+        l.debug("Doing' a strtok_r!")
+        l.debug("... getting the saved state")
 
         saved_str_ptr = self.state.memory.load(save_ptr, self.state.arch.bytes, endness=self.state.arch.memory_endness)
         start_ptr = claripy.If(str_ptr == 0, saved_str_ptr, str_ptr)

--- a/angr/procedures/posix/strtok_r.py
+++ b/angr/procedures/posix/strtok_r.py
@@ -26,7 +26,7 @@ class strtok_r(angr.SimProcedure):
         strstr = angr.SIM_PROCEDURES["libc"]["strstr"]
         strlen = angr.SIM_PROCEDURES["libc"]["strlen"]
 
-        l.debug("Doing' a strtok_r!")
+        l.debug("Doin' a strtok_r!")
         l.debug("... getting the saved state")
 
         saved_str_ptr = self.state.memory.load(save_ptr, self.state.arch.bytes, endness=self.state.arch.memory_endness)

--- a/angr/procedures/win32/local_storage.py
+++ b/angr/procedures/win32/local_storage.py
@@ -30,10 +30,10 @@ class TlsSetValue(angr.SimProcedure):
     KEY = "win32_tls"
 
     def run(self, index, value):
-        conc_indexs = self.state.solver.eval_upto(index, 2)
-        if len(conc_indexs) != 1:
+        conc_indexes = self.state.solver.eval_upto(index, 2)
+        if len(conc_indexes) != 1:
             raise angr.errors.SimValueError("Can't handle symbolic index in TlsSetValue/FlsSetValue")
-        conc_index = conc_indexs[0]
+        conc_index = conc_indexes[0]
 
         if not has_index(self.state, conc_index, self.KEY):
             return 0
@@ -46,10 +46,10 @@ class TlsGetValue(angr.SimProcedure):
     KEY = "win32_tls"
 
     def run(self, index):
-        conc_indexs = self.state.solver.eval_upto(index, 2)
-        if len(conc_indexs) != 1:
+        conc_indexes = self.state.solver.eval_upto(index, 2)
+        if len(conc_indexes) != 1:
             raise angr.errors.SimValueError("Can't handle symbolic index in TlsGetValue/FlsGetValue")
-        conc_index = conc_indexs[0]
+        conc_index = conc_indexes[0]
 
         if not has_index(self.state, conc_index, self.KEY):
             return 0

--- a/angr/project.py
+++ b/angr/project.py
@@ -506,7 +506,7 @@ class Project:
                 l.warning("Address is already hooked, during hook(%s, %s). Re-hooking.", self._addr_to_str(addr), hook)
 
         if isinstance(hook, type):
-            raise TypeError("Please instanciate your SimProcedure before hooking with it")
+            raise TypeError("Please instantiate your SimProcedure before hooking with it")
 
         if callable(hook):
             hook = SIM_PROCEDURES["stubs"]["UserHook"](user_func=hook, length=length, **kwargs)

--- a/angr/sim_manager.py
+++ b/angr/sim_manager.py
@@ -263,11 +263,11 @@ class SimulationManager:
         if not isinstance(tech, ExplorationTechnique):
             raise SimulationManagerError
 
-        def _is_overriden(name):
+        def _is_overridden(name):
             return getattr(tech, name).__code__ is not getattr(ExplorationTechnique, name).__code__
 
-        overriden = filter(_is_overriden, ("step", "filter", "selector", "step_state", "successors"))
-        hooks = {name: getattr(tech, name) for name in overriden}
+        overridden = filter(_is_overridden, ("step", "filter", "selector", "step_state", "successors"))
+        hooks = {name: getattr(tech, name) for name in overridden}
         HookSet.remove_hooks(self, **hooks)
 
         self._techniques.remove(tech)
@@ -373,9 +373,9 @@ class SimulationManager:
         """
         if not self._techniques:
             return False
-        if not any(tech._is_overriden("complete") for tech in self._techniques):
+        if not any(tech._is_overridden("complete") for tech in self._techniques):
             return False
-        return self.completion_mode(tech.complete(self) for tech in self._techniques if tech._is_overriden("complete"))
+        return self.completion_mode(tech.complete(self) for tech in self._techniques if tech._is_overridden("complete"))
 
     def step(
         self,
@@ -781,7 +781,7 @@ class SimulationManager:
         :param merge_func:  If provided, instead of using state.merge, call this function with
                             the states as the argument. Should return the merged state.
         :param merge_key:   If provided, should be a function that takes a state and returns a key that will compare
-                            equal for all states that are allowed to be merged together, as a first aproximation.
+                            equal for all states that are allowed to be merged together, as a first approximation.
                             By default: uses PC, callstack, and open file descriptors.
         :param prune:       Whether to prune the stash prior to merging it
 

--- a/angr/sim_options.py
+++ b/angr/sim_options.py
@@ -45,7 +45,7 @@ NO_SYMBOLIC_JUMP_RESOLUTION = "NO_SYMBOLIC_JUMP_RESOLUTION"
 # This option prevents angr from doing hundreds of constraint solves when it hits a symbolic syscall
 NO_SYMBOLIC_SYSCALL_RESOLUTION = "NO_SYMBOLIC_SYSCALL_RESOLUTION"
 
-# The absense of this option causes the analysis to avoid reasoning about most symbolic values.
+# The absence of this option causes the analysis to avoid reasoning about most symbolic values.
 SYMBOLIC = "SYMBOLIC"
 
 # Generate symbolic values for non-existent values. The absence of this option causes Unconstrained() to return default
@@ -71,7 +71,7 @@ CONCRETIZE_SYMBOLIC_FILE_READ_SIZES = "CONCRETIZE_SYMBOLIC_FILE_READ_SIZES"
 FILES_HAVE_EOF = "FILES_HAVE_EOF"
 UNKNOWN_FILES_HAVE_EOF = FILES_HAVE_EOF
 
-# Attempting to open an unkown file will result in creating it with a symbolic length
+# Attempting to open an unknown file will result in creating it with a symbolic length
 ALL_FILES_EXIST = "ALL_FILES_EXIST"
 
 # Unknown files might or might not exist
@@ -313,7 +313,7 @@ CGC_ENFORCE_FD = "CGC_ENFORCE_FD"
 CGC_NON_BLOCKING_FDS = "CGC_NON_BLOCKING_FDS"
 
 # Allows memory breakpoints to get more accurate sizes in case of reading large chunks
-# Sacrafice performance for more fine tune memory read size
+# Sacrifice performance for more fine tune memory read size
 MEMORY_CHUNK_INDIVIDUAL_READS = "MEMORY_CHUNK_INDIVIDUAL_READS"
 
 # Synchronize memory mapping reported by angr with the concrete process.

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -411,7 +411,7 @@ class SimProcedure:
         :param arguments:       Any additional positional args will be used as arguments to the
                                 procedure call
         :param sim_kwargs:      Any additional keyword args will be passed as sim_kwargs to the
-                                procedure construtor
+                                procedure constructor
         """
         e_args = [claripy.BVV(a, self.state.arch.bits) if isinstance(a, int) else a for a in arguments]
         p = procedure(project=self.project, **kwargs)

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -21,7 +21,7 @@ from .sim_state_options import SimStateOptions
 from .state_plugins import SimStatePlugin
 
 
-def arch_overrideable(f):
+def arch_overridable(f):
     @functools.wraps(f)
     def wrapped_f(self, *args, **kwargs):
         if hasattr(self.arch, f.__name__):
@@ -787,7 +787,7 @@ class SimState(PluginHub):
     ### Stack operation helpers ###
     ###############################
 
-    @arch_overrideable
+    @arch_overridable
     def stack_push(self, thing):
         """
         Push 'thing' to the stack, writing the thing to memory and adjusting the stack pointer.
@@ -797,7 +797,7 @@ class SimState(PluginHub):
         self.regs.sp = sp
         return self.memory.store(sp, thing, endness=self.arch.memory_endness, size=self.arch.bytes)
 
-    @arch_overrideable
+    @arch_overridable
     def stack_pop(self):
         """
         Pops from the stack and returns the popped thing. The length will be the architecture word size.
@@ -806,7 +806,7 @@ class SimState(PluginHub):
         self.regs.sp = sp - self.arch.stack_change
         return self.memory.load(sp, self.arch.bytes, endness=self.arch.memory_endness)
 
-    @arch_overrideable
+    @arch_overridable
     def stack_read(self, offset, length, bp=False):
         """
         Reads length bytes, at an offset into the stack.
@@ -834,7 +834,7 @@ class SimState(PluginHub):
         return v
 
     # This handles the preparation of concrete function launches from abstract functions.
-    @arch_overrideable
+    @arch_overridable
     def prepare_callsite(self, retval, args, cc="wtf"):
         # TODO
         pass

--- a/angr/simos/javavm.py
+++ b/angr/simos/javavm.py
@@ -336,7 +336,7 @@ class SimJavaVM(SimOS):
     @staticmethod
     def cast_primitive(state, value, to_type):
         """
-        Cast the value of primtive types.
+        Cast the value of primitive types.
 
         :param value:       Bitvector storing the primitive value.
         :param to_type:     Name of the targeted type.

--- a/angr/state_plugins/cgc.py
+++ b/angr/state_plugins/cgc.py
@@ -84,7 +84,7 @@ class SimStateCGC(SimStatePlugin):
         return not self.state.solver.solution(a != 0, True)
 
     def _combine(self, others):
-        merging_occured = False
+        merging_occurred = False
 
         new_allocation_base = max(o.allocation_base for o in others)
         if self.state.solver.symbolic(new_allocation_base):
@@ -95,9 +95,9 @@ class SimStateCGC(SimStatePlugin):
 
         if concrete_allocation_base != concrete_new_allocation_base:
             self.allocation_base = new_allocation_base
-            merging_occured = True
+            merging_occurred = True
 
-        return merging_occured
+        return merging_occurred
 
     def merge(self, others, merge_conditions, common_ancestor=None):  # pylint: disable=unused-argument
         return self._combine(others)

--- a/angr/state_plugins/debug_variables.py
+++ b/angr/state_plugins/debug_variables.py
@@ -140,7 +140,7 @@ class SimDebugVariablePlugin(SimStatePlugin):
     This is the plugin you'll use to interact with (global/local) program variables.
     These variables have a name and a visibility scope which depends on the pc address of the state.
     With this plugin, you can access/modify the value of such variable or find its memory address.
-    For creating program varibles, or for importing them from cle, see the knowledge plugin debug_variables.
+    For creating program variables, or for importing them from cle, see the knowledge plugin debug_variables.
     Run ``p.kb.dvars.load_from_dwarf()`` before using this plugin.
 
     Example:

--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -365,7 +365,7 @@ class SimConcreteFilesystem(SimMount):
             self.cache[fname].set_state(state)
 
     def merge(self, others, merge_conditions, common_ancestor=None):
-        merging_occured = False
+        merging_occurred = False
 
         for o in others:
             if o.pathsep != self.pathsep:
@@ -391,8 +391,8 @@ class SimConcreteFilesystem(SimMount):
             else:
                 common_simfile = None
 
-            merging_occured |= subdeck[0].merge(subdeck[1:], merge_conditions, common_ancestor=common_simfile)
-        return merging_occured
+            merging_occurred |= subdeck[0].merge(subdeck[1:], merge_conditions, common_ancestor=common_simfile)
+        return merging_occurred
 
     def widen(self, others):  # pylint: disable=unused-argument
         if once("host_fs_widen_warning"):

--- a/angr/state_plugins/heap/heap_freelist.py
+++ b/angr/state_plugins/heap/heap_freelist.py
@@ -14,7 +14,7 @@ class Chunk:
     a chunk via a view into the memory plugin. Chunks may be adjacent, in different senses, to as many as four other
     chunks. For any given chunk, two of these chunks are adjacent to it in memory, and are referred to as the "previous"
     and "next" chunks throughout this implementation. For any given free chunk, there may also be two significant chunks
-    that are adjacent to it in some linked list of free chunks. These chunks are referred to the "backward" and "foward"
+    that are adjacent to it in some linked list of free chunks. These chunks are referred to the "backward" and "forward"
     chunks relative to the chunk in question.
 
     :ivar base: the location of the base of the chunk in memory

--- a/angr/state_plugins/heap/heap_freelist.py
+++ b/angr/state_plugins/heap/heap_freelist.py
@@ -1,21 +1,24 @@
+import logging
 from __future__ import annotations
 from . import SimHeapLibc
 from .utils import concretize
 from ...errors import SimHeapError
 
-import logging
 
 l = logging.getLogger("angr.state_plugins.heap.heap_freelist")
 
 
 class Chunk:
     """
-    The sort of chunk as would typically be found in a freelist-style heap implementation. Provides a representation of
-    a chunk via a view into the memory plugin. Chunks may be adjacent, in different senses, to as many as four other
-    chunks. For any given chunk, two of these chunks are adjacent to it in memory, and are referred to as the "previous"
-    and "next" chunks throughout this implementation. For any given free chunk, there may also be two significant chunks
-    that are adjacent to it in some linked list of free chunks. These chunks are referred to the "backward" and "forward"
-    chunks relative to the chunk in question.
+    The sort of chunk as would typically be found in a freelist-style heap
+    implementation. Provides a representation of a chunk via a view into the
+    memory plugin. Chunks may be adjacent, in different senses, to as many as
+    four other chunks. For any given chunk, two of these chunks are adjacent to
+    it in memory, and are referred to as the "previous" and "next" chunks
+    throughout this implementation. For any given free chunk, there may also be
+    two significant chunks that are adjacent to it in some linked list of free
+    chunks. These chunks are referred to the "backward" and "forward" chunks
+    relative to the chunk in question.
 
     :ivar base: the location of the base of the chunk in memory
     :ivar state: the program state that the chunk is resident in

--- a/angr/state_plugins/heap/heap_freelist.py
+++ b/angr/state_plugins/heap/heap_freelist.py
@@ -1,5 +1,5 @@
-import logging
 from __future__ import annotations
+import logging
 from . import SimHeapLibc
 from .utils import concretize
 from ...errors import SimHeapError

--- a/angr/state_plugins/javavm_classloader.py
+++ b/angr/state_plugins/javavm_classloader.py
@@ -84,7 +84,7 @@ class SimJavaVmClassloader(SimStatePlugin):
         self.initialized_classes.add(class_)
 
         if not class_.is_loaded:
-            l.warning("Class %r is not loaded in CLE. Skip initializiation.", class_)
+            l.warning("Class %r is not loaded in CLE. Skip initialization.", class_)
             return
 
         clinit_method = resolve_method(
@@ -107,7 +107,7 @@ class SimJavaVmClassloader(SimStatePlugin):
             self.state.memory.vm_static_table = simgr.deadended[-1].memory.vm_static_table.copy()
             self.state.memory.heap = simgr.deadended[-1].memory.heap.copy()
         else:
-            l.debug("Class initializer <clinit> is not loaded in CLE. Skip initializiation.")
+            l.debug("Class initializer <clinit> is not loaded in CLE. Skip initialization.")
 
     @property
     def initialized_classes(self):

--- a/angr/state_plugins/plugin.py
+++ b/angr/state_plugins/plugin.py
@@ -44,7 +44,7 @@ class SimStatePlugin:
         ``SimStatePlugin.memo``
 
         The base implementation of this function constructs a new instance of the plugin's class without calling its
-        initializer. If you super-call down to it, make sure you instanciate all the fields in your copy method!
+        initializer. If you super-call down to it, make sure you instantiate all the fields in your copy method!
 
         :param memo:    A dictionary mapping object identifiers (id(obj)) to their copied instance.  Use this to avoid
                         infinite recursion and diverged copies.

--- a/angr/state_plugins/scratch.py
+++ b/angr/state_plugins/scratch.py
@@ -76,7 +76,7 @@ class SimStateScratch(SimStatePlugin):
 
             self.statement_offset = scratch.statement_offset
 
-        # priveleges
+        # privileges
         self._priv_stack = [False]
 
     @property

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -342,7 +342,7 @@ class SimSolver(SimStatePlugin):
         :param events:          Set to False to avoid generating a SimEvent for the occasion
         :param key:             Set this to a tuple of increasingly specific identifiers (for example,
                                 ``('mem', 0xffbeff00)`` or ``('file', 4, 0x20)`` to cause it to be tracked, i.e.
-                                accessable through ``solver.get_variables``.
+                                accessible through ``solver.get_variables``.
         :param eternal:         Set to True in conjunction with setting a key to cause all states with the same
                                 ancestry to retrieve the same symbol when trying to create the value. If False, a
                                 counter will be appended to the key.
@@ -402,7 +402,7 @@ class SimSolver(SimStatePlugin):
         :param explicit_name:   Set to True to prevent an identifier from appended to the name to ensure uniqueness.
         :param key:             Set this to a tuple of increasingly specific identifiers (for example,
                                 ``('mem', 0xffbeff00)`` or ``('file', 4, 0x20)`` to cause it to be tracked, i.e.
-                                accessable through ``solver.get_variables``.
+                                accessible through ``solver.get_variables``.
         :param eternal:         Set to True in conjunction with setting a key to cause all states with the same
                                 ancestry to retrieve the same symbol when trying to create the value. If False, a
                                 counter will be appended to the key.
@@ -424,7 +424,7 @@ class SimSolver(SimStatePlugin):
                 or uninitialized != r.args[4]
                 or bool(explicit_name) ^ (r.args[0] == name)
             ):
-                l.warning("Variable %s being retrieved with differnt settings than it was tracked with", name)
+                l.warning("Variable %s being retrieved with different settings than it was tracked with", name)
         else:
             r = claripy.BVS(
                 name,

--- a/angr/state_plugins/trace_additions.py
+++ b/angr/state_plugins/trace_additions.py
@@ -717,7 +717,7 @@ class ZenPlugin(angr.state_plugins.SimStatePlugin):
         try:
             state.memory.permissions(state.solver.eval(buf))
         except angr.SimMemoryError:
-            l.warning("detected possible arbitary transmit to fd %d", fd)
+            l.warning("detected possible arbitrary transmit to fd %d", fd)
             if fd == 0 or fd == 1:
                 self.controlled_transmits.append((state.copy(), buf))
 

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1277,9 +1277,9 @@ class Unicorn(SimStatePlugin):
 
         # Initialize list of artificial VEX registers
         artificial_regs_list = (ctypes.c_uint64(offset) for offset in self.state.arch.artificial_registers_offsets)
-        artifical_regs_count = len(self.state.arch.artificial_registers_offsets)
-        artificial_regs_array = (ctypes.c_uint64 * artifical_regs_count)(*artificial_regs_list)
-        _UC_NATIVE.set_artificial_registers(self._uc_state, artificial_regs_array, artifical_regs_count)
+        artificial_regs_count = len(self.state.arch.artificial_registers_offsets)
+        artificial_regs_array = (ctypes.c_uint64 * artificial_regs_count)(*artificial_regs_list)
+        _UC_NATIVE.set_artificial_registers(self._uc_state, artificial_regs_array, artificial_regs_count)
 
         # Initialize VEX register offset to unicorn register ID mappings and VEX register offset to name map
         vex_reg_offsets = []

--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -121,7 +121,7 @@ class SimMemView(SimStatePlugin):
         - You first use [array index notation] to specify the address you'd like to load from
         - If at that address is a pointer, you may access the ``deref`` property to return a SimMemView at the
           address present in memory.
-        - You then specify a type for the data by simply accesing a property of that name. For a list of supported
+        - You then specify a type for the data by simply accessing a property of that name. For a list of supported
           types, look at ``state.mem.types``.
         - You can then *refine* the type. Any type may support any refinement it likes. Right now the only refinements
           supported are that you may access any member of a struct by its member name, and you may index into a
@@ -289,7 +289,7 @@ class SimMemView(SimStatePlugin):
 
     def array(self, n) -> SimMemView:
         if self._addr is None:
-            raise ValueError("Trying to produce array without specifying adddress")
+            raise ValueError("Trying to produce array without specifying address")
         if self._type is None:
             raise ValueError("Trying to produce array without specifying type")
         return self._deeper(ty=SimTypeFixedSizeArray(self._type, n))

--- a/angr/storage/memory_mixins/javavm_memory/javavm_memory_mixin.py
+++ b/angr/storage/memory_mixins/javavm_memory/javavm_memory_mixin.py
@@ -169,7 +169,7 @@ class JavaVmMemoryMixin(MemoryMixin):
             start_idx_options = []
             for concrete_start_idx in concrete_start_idxes:
                 start_idx_options.append(concrete_start_idx == start_idx)
-                # we store elements condtioned with the start index:
+                # we store elements conditioned with the start index:
                 # => if concrete_start_idx == start_idx
                 #    then store the value
                 #    else keep the current value

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -320,7 +320,7 @@ class Dominators:
     def _graph_successors(self, graph, node):
         """
         Return the successors of a node in the graph.
-        This method can be overriden in case there are special requirements with the graph and the successors. For
+        This method can be overridden in case there are special requirements with the graph and the successors. For
         example, when we are dealing with a control flow graph, we may not want to get the FakeRet successors.
 
         :param graph: The graph.

--- a/angr/vaults.py
+++ b/angr/vaults.py
@@ -54,7 +54,7 @@ class Vault(collections.abc.MutableMapping):
     """
 
     #
-    # These MUST be overriden.
+    # These MUST be overridden.
     #
 
     def _read_context(self, i):
@@ -76,7 +76,7 @@ class Vault(collections.abc.MutableMapping):
         raise NotImplementedError
 
     #
-    # Persistance managers
+    # Persistence managers
     #
 
     def __init__(self):

--- a/docs/advanced-topics/debug_var.rst
+++ b/docs/advanced-topics/debug_var.rst
@@ -8,7 +8,7 @@ use it.
 Setting up
 ----------
 
-To use it you need binary that is compiled with dwarf debuging
+To use it you need binary that is compiled with dwarf debugging
 information (ex: ``gcc -g``) and load in angr with the option
 ``load_debug_info``. After that you need to run
 ``project.kb.dvars.load_from_dwarf()`` to set up the feature and we’re

--- a/docs/advanced-topics/ir.rst
+++ b/docs/advanced-topics/ir.rst
@@ -159,7 +159,7 @@ a library called `PyVEX <https://github.com/angr/pyvex>`_ that exposes VEX into
 Python. In addition, PyVEX implements its own pretty-printing so that it can
 show register names instead of register offsets in PUT and GET instructions.
 
-PyVEX is accessable through angr through the ``Project.factory.block``
+PyVEX is accessible through angr through the ``Project.factory.block``
 interface. There are many different representations you could use to access
 syntactic properties of a block of code, but they all have in common the trait
 of analyzing a particular sequence of bytes. Through the ``factory.block``

--- a/docs/advanced-topics/mixins.rst
+++ b/docs/advanced-topics/mixins.rst
@@ -40,7 +40,7 @@ With this construction, we are able to define a very simple interface in the
 ``Base`` class, and by "mixing in" two mixins, we can create the ``FinalClass``
 which has the same interface but with additional features. This is accomplished
 through Python's powerful multiple inheritance model, which handles method
-dispatch by creating a *method resolution order*, or MRO, which is unsuprisingly
+dispatch by creating a *method resolution order*, or MRO, which is unsurprisingly
 a list which determines the order in which methods are called as execution
 proceeds through ``super()`` calls. You can view a class' MRO as such:
 
@@ -71,7 +71,7 @@ construction is illegal and will throw an exception at import time.
 
 This is complicated! If you find yourself confused, the canonical document
 explaining the rationale, history, and mechanics of Python's multiple
-inheritence can be found `here
+inheritance can be found `here
 <https://www.python.org/download/releases/2.3/mro/>`_.
 
 Mixins in Claripy Solvers

--- a/docs/advanced-topics/structured_data.rst
+++ b/docs/advanced-topics/structured_data.rst
@@ -9,7 +9,7 @@ Working with types
 
 angr has a system for representing types. These SimTypes are found in
 ``angr.types`` - an instance of any of these classes represents a type. Many of
-the types are incomplete unless they are supplamented with a SimState - their
+the types are incomplete unless they are supplemented with a SimState - their
 size depends on the architecture you're running under. You may do this with
 ``ty.with_arch(arch)``, which returns a copy of itself, with the architecture
 specified.

--- a/docs/analyses/cfg.rst
+++ b/docs/analyses/cfg.rst
@@ -145,7 +145,7 @@ and many more !
 CFGFast details
 ---------------
 
-CFGFast peforms a static control-flow and function recovery. Starting with the
+CFGFast performs a static control-flow and function recovery. Starting with the
 entry point (or any user-defined points) roughly the following procedure is
 performed:
 

--- a/docs/appendix/changelog.rst
+++ b/docs/appendix/changelog.rst
@@ -71,7 +71,7 @@ angr 8.18.10.25
 * The IDA backend for CLE has been removed. It has been broken for quite some time, but now it has been disabled for your own safety.
 * Surveyors have been removed! Finally! This is thanks to @danse-macabre who contributed an Exploration Technique for the Slicecutor. Backwards slicing has now been brought out of the angr dark ages.
 * SimCC can now be initialized with a string containing C function prototype in its ``func_ty`` argument
-* Similarly, Callable can now be run with its arguments instanciated from a string containing C expressions
+* Similarly, Callable can now be run with its arguments instantiated from a string containing C expressions
 * Tracer has been substantially refactored - it will now handle more kinds of desyncs, ASLR slides, and is much more friendly for hacking. We will be continuing to improve it!
 * The Oppologist and Driller have been refactored to play nice with other exploration techniques
 * SimProcedure continuations now have symbols in the externs object, so ``describe_addr`` will work on them. Additionally, the representation for SimProcedure (appearing in ``history.descriptions`` and ``project._sim_procedures`` among other places) has been improved to show this information.
@@ -129,7 +129,7 @@ angr 7.8.6.16
 
 * The modeling of file system is refactored.
 * (#808) Add a new class Control flow blanket (CFBlanket) to support generating a linear view of a control flow graph.
-* (#863) Add support to AIL, the new angr intermediate language (still pretty WIP though). Merged in several static analyses (reaching definition analysis, VEX-to-AIL translation, redundant assignment elimination, code region identification, conrol flow structuring, etc.) that support the development of decompilation in the near future.
+* (#863) Add support to AIL, the new angr intermediate language (still pretty WIP though). Merged in several static analyses (reaching definition analysis, VEX-to-AIL translation, redundant assignment elimination, code region identification, control flow structuring, etc.) that support the development of decompilation in the near future.
 * (#888) SimulationManager is extensively refactored and cleaned up.
 * (#892) Keystone is integrated. You can assemble instructions inside angr now.
 * (#897) A new class ``PluginHub`` is added. Plugins (analyses, engines) are refactored to be based on ``PluginHub``.
@@ -158,7 +158,7 @@ angr 7.7.12.16
 
 * You can now tell where the variables implicitly created by angr come from! ``state.solver.BVS`` now can take a ``key`` parameter, which describes its meaning in relation to the emulated environment. You can then use ``state.solver.get_variables(...)`` and ``state.solver.describe_variables(...)`` to map tags and ASTs to and from each other. Check out the `API docs <http://angr.io/api-doc/angr.html#angr.state_plugins.solver.SimSolver>`_!
 * The SimOS for a project is now a public property - ``project.simos`` instead of ``project._simos``. Additionally, the SimOS code structure has been shuffled around a bit - it's now a subpackage instead of a submodule.
-* The core components of Tracer and Driller have been refactored into Exploration Techniques and integrated into angr proper, so you can now follow instrution traces without installing another repostory! (credit @tyb0807)
+* The core components of Tracer and Driller have been refactored into Exploration Techniques and integrated into angr proper, so you can now follow instruction traces without installing another repository! (credit @tyb0807)
 * Archinfo now contains a ``byte_width`` parameter and angr supports emulation of platforms with non-octet bytes, lord help us
 * Upgraded to networkx 2 (credit @tyb0807)
 * Hopefully installation issues with capstone should be fixed FOREVER
@@ -215,7 +215,7 @@ Building off of the engine changes from the last release, we have begun to exten
 
 
 * We have rebased our fork of VEX on the latest master branch from Valgrind (as of 2 months ago, at least...). We have also submitted our patches to VEX to upstream, so we should be able to stop maintaining a fork pretty soon.
-* The way we interact with VEX has changed substancially, and should speed things up a bit.
+* The way we interact with VEX has changed substantially, and should speed things up a bit.
 * Loading sets of binaries with many import symbols has been sped up
 * Many, many improvements to angr-management, including the switch away from enaml to using pyside directly.
 
@@ -389,7 +389,7 @@ angr 4.6.5.25
 New state constructor - ``call_state``. Comes with a refactor to ``SimCC``, a refactor to ``callable``, and the removal of ``PathGroup.call``.
 All these changes are thoroughly documented, in ``angr/docs/advanced-topics/structured_data.md``
 
-Refactor of ``SimType`` to make it easier to use types - they can be instanciated without a SimState and one can be added later.
+Refactor of ``SimType`` to make it easier to use types - they can be instantiated without a SimState and one can be added later.
 Comes with some usability improvements to SimMemView.
 Also, there's a better wrapper around PyCParser for generating SimType instances from c declarations and definitions.
 Again, thoroughly documented, still in the structured data doc.

--- a/docs/appendix/cheatsheet.rst
+++ b/docs/appendix/cheatsheet.rst
@@ -204,7 +204,7 @@ are running forever)
    def killmyself():
        os.system('kill %d' % os.getpid())
    def sigint_handler(signum, frame):
-       print 'Stopping Execution for Debug. If you want to kill the programm issue: killmyself()'
+       print 'Stopping Execution for Debug. If you want to kill the program issue: killmyself()'
        if not "IPython" in sys.modules:
            import IPython
            IPython.embed()

--- a/docs/appendix/cheatsheet.rst
+++ b/docs/appendix/cheatsheet.rst
@@ -74,7 +74,7 @@ STDERR (1 here is the File Descriptor for STDOUT)
 
    simgr.explore(find=lambda s: "correct" in s.posix.dumps(1))
 
-Memory Managment on big searches (Auto Drop Stashes):
+Memory Management on big searches (Auto Drop Stashes):
 
 .. code-block:: python
 
@@ -195,7 +195,7 @@ Hooking with Simprocedure:
 Other useful tricks
 -------------------
 
-Drop into an ipython if a ctr+c is recieved (useful for debugging scripts that
+Drop into an ipython if a ctr+c is received (useful for debugging scripts that
 are running forever)
 
 .. code-block:: python
@@ -223,7 +223,7 @@ Get a basic block
 .. code-block:: python
 
    block = proj.factory.block(address)
-   block.capstone.pp() # Capstone object has pretty print and other data about the dissassembly
+   block.capstone.pp() # Capstone object has pretty print and other data about the disassembly
    block.vex.pp()      # Print vex representation
 
 State manipulation

--- a/docs/appendix/migration-7.rst
+++ b/docs/appendix/migration-7.rst
@@ -157,7 +157,7 @@ Changes to loading
 ------------------
 
 The ``hook_symbol`` method will no longer attempt to redo relocations for the given symbol, instead just hooking directly over the address of the symbol in whatever library it comes from.
-This speeds up loading substancially and ensures more consistent behavior for when mixing and matching native library code and SimProcedure summaries.
+This speeds up loading substantially and ensures more consistent behavior for when mixing and matching native library code and SimProcedure summaries.
 
 The angr externs object has been moved into CLE, which will ALWAYS make sure that every dependency is resolved to something, never left unrelocated.
 Similarly, CLE provides the "kernel object" used to provide addresses for syscalls now.

--- a/docs/appendix/migration-8.rst
+++ b/docs/appendix/migration-8.rst
@@ -13,8 +13,8 @@ To begin, just the standard py3k changes, the relevant parts of which we'll reha
 * Strings and bytestrings
 
   * Strings are now unicode by default, a new ``bytes`` type holds bytestrings
-  * Bytestring literals can be constructued with the b prefix, like ``b'ABCD'``
-  * Conversion between strings and bytestrings happens with ``.encode()`` and ``.decode()``, which use utf-8 as a default. The ``latin-1`` codec will map byte values to their equivilant unicode codepoints
+  * Bytestring literals can be constructed with the b prefix, like ``b'ABCD'``
+  * Conversion between strings and bytestrings happens with ``.encode()`` and ``.decode()``, which use utf-8 as a default. The ``latin-1`` codec will map byte values to their equivalent unicode codepoints
   * The ``ord()`` and ``chr()`` functions operate on strings, not bytestrings
   * Enumerating over or indexing into bytestrings produces an unsigned 8 bit integer, not a 1-byte bytestring
   * Bytestrings have all the string manipulation functions present on strings, including ``join``, ``upper``/``lower``, ``translate``, etc

--- a/docs/appendix/options.rst
+++ b/docs/appendix/options.rst
@@ -124,7 +124,7 @@ These are individual option objects, found as ``angr.options.XXX``.
      - ``fastpath``
      -
    * - ``AVOID_MULTIVALUED_WRITES``
-     - Do not perfrom any write that has a symbolic address
+     - Do not perform any write that has a symbolic address
      -
      - ``fastpath``
      -

--- a/docs/core-concepts/loading.rst
+++ b/docs/core-concepts/loading.rst
@@ -200,7 +200,7 @@ the full list of relocations for an object (as ``Relocation`` instances) as
 ``obj.imports``. There is no corresponding list of export symbols.
 
 A relocation's corresponding import symbol can be accessed as ``.symbol``. The
-address the relocation will write to is accessable through any of the address
+address the relocation will write to is accessible through any of the address
 identifiers you can use for Symbol, and you can get a reference to the object
 requesting the relocation with ``.owner`` as well.
 

--- a/docs/core-concepts/pathgroups.rst
+++ b/docs/core-concepts/pathgroups.rst
@@ -253,7 +253,7 @@ Here's a quick overview of some of the built-in ones:
   between simgr steps and stops exploration if it gets too low.
 * *Oppologist*: The "operation apologist" is an especially fun gadget - if this
   technique is enabled and angr encounters an unsupported instruction, for
-  example a bizzare and foreign floating point SIMD op, it will concretize all
+  example a bizarre and foreign floating point SIMD op, it will concretize all
   the inputs to that instruction and emulate the single instruction using the
   unicorn engine, allowing execution to continue.
 * *Spiller*: When there are too many states active, this technique can dump some

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -249,7 +249,7 @@ Grub "back to 28" bug
 .. code-block::
 
    Script author: Audrey Dutcher (github: @rhelmot)
-   Concepts presented: unusal target (custom function hooking required), use of exploration techniques to categorize and prune the program's state space
+   Concepts presented: unusual target (custom function hooking required), use of exploration techniques to categorize and prune the program's state space
 
 This is the demonstration presented at 32c3. The script uses angr to discover
 the input to crash grub's password entry prompt.

--- a/docs/extending-angr/environment.rst
+++ b/docs/extending-angr/environment.rst
@@ -178,7 +178,7 @@ easy access.
 
 The same thing about adding procedures to existing catalogs of dynamic library
 functions also applies to syscalls - implementing a linux syscall is as easy as
-writing the SimProcedure and dropping the implemementation into
+writing the SimProcedure and dropping the implementation into
 ``angr/procedures/linux_kernel``. As long as the class name matches one of the
 names in the number-to-name mapping of the SimLibrary (all the linux syscall
 numbers are included with recent releases of angr), it will be used.

--- a/docs/extending-angr/simprocedures.rst
+++ b/docs/extending-angr/simprocedures.rst
@@ -200,7 +200,7 @@ This is a particularly clever usage of the SimProcedure continuations. First,
 notice that the current project is available for use on the procedure instance.
 This is some powerful stuff you can get yourself into; for safety you generally
 only want to use the project as a read-only or append-only data structure. Here
-we're just getting the list of dynamic intializers from the loader. Then, for as
+we're just getting the list of dynamic initializers from the loader. Then, for as
 long as the list isn't empty, we pop a single function pointer out of the list,
 being careful not to mutate the list, since the list object is shared across
 states, and then call it, returning to the ``run_initializer`` function again.
@@ -285,7 +285,7 @@ As you should recall from the :ref:`section on loading a binary <Loading a
 Binary>`, dynamically linked programs have a list of symbols that they must
 import from the libraries they have listed as dependencies, and angr will make
 sure, rain or shine, that every import symbol gets resolved by *some* address,
-whether it's a real implementaion of the function or just a dummy address hooked
+whether it's a real implementation of the function or just a dummy address hooked
 with a do-nothing stub. As a result, you can just use the
 ``Project.hook_symbol`` API to hook the address referred to by a symbol!
 

--- a/docs/extending-angr/state_plugins.rst
+++ b/docs/extending-angr/state_plugins.rst
@@ -210,7 +210,7 @@ Setting Defaults
 To make it so that a plugin will automatically become available on a state when
 requested, without having to register it with the state first, you can register
 it as a *default*. The following code example will make it so that whenever you
-access ``state.my_plugin``, a new instance of ``MyPlugin`` will be instanciated
+access ``state.my_plugin``, a new instance of ``MyPlugin`` will be instantiated
 and registered with the state.
 
 .. code-block:: python

--- a/docs/getting-started/developing.rst
+++ b/docs/getting-started/developing.rst
@@ -114,7 +114,7 @@ circumstances write a docstring which doesn't provide more information than the
 name of the class. What you should try to write is a description of the
 environment that the class should be used in. If the class should not be
 instantiated by end-users, write a description of where it will be generated and
-how instances can be acquired. If the class should be instanciated by end-users,
+how instances can be acquired. If the class should be instantiated by end-users,
 explain what kind of object it represents at its core, what behavior is expected
 of its parameters, and how to safely manage objects of its type.
 

--- a/docs/getting-started/helpwanted.rst
+++ b/docs/getting-started/helpwanted.rst
@@ -203,7 +203,7 @@ improvement, each of which is its own research project:
 #. By creating testcases that achieve a "high-enough" code coverage of a given
    function, we can detect changes in functionality by applying the set of
    testcases to another implementation of the same function and analyzing
-   changes in code coverage. This can then be used as a sematic function diff.
+   changes in code coverage. This can then be used as a semantic function diff.
 
 Applying AFL's path selection criteria to symbolic execution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/native/sim_unicorn.cpp
+++ b/native/sim_unicorn.cpp
@@ -853,7 +853,7 @@ void State::handle_write(address_t address, int size, bool is_interrupt = false,
 					}
 					int64_t symbolic_write_end_addr = sym_stmt_it->mem_write_addr + sym_stmt_it->mem_write_size;
 					if ((curr_write_start_addr <= symbolic_write_start_addr) && (symbolic_write_end_addr <= curr_write_end_addr)) {
-						// Currrent write fully overwrites the previous written symbolic value and so the symbolic write
+						// Current write fully overwrites the previous written symbolic value and so the symbolic write
 						// instruction need not be re-executed
 						// TODO: How to handle partial overwrite?
 						stmts_to_erase.emplace(sym_stmt_it - first_stmt_it);

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2799,7 +2799,7 @@ class TestDecompiler(unittest.TestCase):
     @for_all_structuring_algos
     def test_bool_flipping_type2(self, decompiler_options=None):
         """
-        Assures Type2 Boolean Flips near the last statement of a function are not triggerd.
+        Assures Type2 Boolean Flips near the last statement of a function are not triggered.
         This testcase can also fail if `test_return_deduplication` fails.
         """
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "tsort.o")

--- a/tests/analyses/decompiler/test_structurer.py
+++ b/tests/analyses/decompiler/test_structurer.py
@@ -286,7 +286,7 @@ class TestStructurer(unittest.TestCase):
         codegen = dec.codegen
 
         # full code, without the header and variable definitions
-        # the outputed code will be missing corrected variable names, which can be corrected by passing
+        # the outputted code will be missing corrected variable names, which can be corrected by passing
         # private properties from the original codegen object
         func_no_header = p.analyses.StructuredCodeGenerator(f, top_sequence, cfg=cfg, omit_func_header=True).text
         assert "int main(" not in func_no_header

--- a/tests/analyses/reaching_definitions/test_dep_graph.py
+++ b/tests/analyses/reaching_definitions/test_dep_graph.py
@@ -104,7 +104,7 @@ class TestDepGraph(TestCase):
         dep_graph = DepGraph()
         self.assertEqual(isinstance(dep_graph.graph, networkx.DiGraph), True)
 
-    def test_dep_graph_refuses_to_instanciate_with_an_inadequate_graph(self):
+    def test_dep_graph_refuses_to_instantiate_with_an_inadequate_graph(self):
         a_graph = networkx.DiGraph([(1, 2)])
         self.assertRaises(TypeError, DepGraph, a_graph)
 

--- a/tests/analyses/reaching_definitions/test_heap_allocator.py
+++ b/tests/analyses/reaching_definitions/test_heap_allocator.py
@@ -18,20 +18,20 @@ class TestHeapAllocator(TestCase):
         self.assertTrue(isinstance(address, HeapAddress))
 
     def test_allocate_create_an_entry_after_the_previous_one(self):
-        size_of_first_chunck = 0x10
-        address = self.heap_allocator.allocate(size_of_first_chunck)
+        size_of_first_chunk = 0x10
+        address = self.heap_allocator.allocate(size_of_first_chunk)
         other_address = self.heap_allocator.allocate(0x10)
 
-        self.assertEqual(other_address.value - address.value, size_of_first_chunck)
+        self.assertEqual(other_address.value - address.value, size_of_first_chunk)
 
     def test_allocate_given_an_undefined_size_still_gives_a_concrete_address(self):
-        size_of_first_chunck = UNKNOWN_SIZE
-        address = self.heap_allocator.allocate(size_of_first_chunck)
+        size_of_first_chunk = UNKNOWN_SIZE
+        address = self.heap_allocator.allocate(size_of_first_chunk)
         other_address = self.heap_allocator.allocate(0x10)
 
         self.assertEqual(other_address.value - address.value, self.UNKNOWN_SIZE_DEFAULT_CONCRETE_VALUE)
 
-    def test_allocated_addresses_keeps_track_of_memory_chuncks_in_use(self):
+    def test_allocated_addresses_keeps_track_of_memory_chunks_in_use(self):
         address = self.heap_allocator.allocate(0x10)
 
         self.assertTrue(address in self.heap_allocator.allocated_addresses)

--- a/tests/analyses/reaching_definitions/test_subject.py
+++ b/tests/analyses/reaching_definitions/test_subject.py
@@ -43,12 +43,12 @@ class TestSubject(unittest.TestCase):
         assert subject.content == block
         assert subject.type == SubjectType.Block
 
-    def test_fails_when_instanciated_with_an_inadequate_object(self):
+    def test_fails_when_instantiated_with_an_inadequate_object(self):
         self.assertRaises(TypeError, Subject, "test-me", None)
 
     @mock.patch.object(Function, "_get_initial_binary_name", return_value="binary")
     @mock.patch.object(FunctionGraphVisitor, "sort_nodes")
-    def test_when_instanciated_with_a_function_need_other_attributes(self, _, __):
+    def test_when_instantiated_with_a_function_need_other_attributes(self, _, __):
         function = _a_mock_function(0x42, "function_name")
         func_graph = networkx.DiGraph()
         cc = "mock_cc"

--- a/tests/engines/test_unicorn.py
+++ b/tests/engines/test_unicorn.py
@@ -416,7 +416,7 @@ class TestUnicorn(unittest.TestCase):
         addr0 = 0x08048479  # at the beginning of a basic block, at end of stop_normal function
         addr1 = 0x080485D0  # this is at the beginning of main, in the middle of a basic block
         addr2 = 0x08048461  # another non-bb address, at the start of stop_normal
-        addr3 = 0x0804847C  # address of a block that should not get hit (stop_symbolc function)
+        addr3 = 0x0804847C  # address of a block that should not get hit (stop_symbolic function)
         addr4 = 0x08048632  # another address that shouldn't get hit, near end of main
         hits = {addr0: 0, addr1: 0, addr2: 0, addr3: 0, addr4: 0}
 

--- a/tests/knowledge_plugins/key_definitions/test_atoms.py
+++ b/tests/knowledge_plugins/key_definitions/test_atoms.py
@@ -10,7 +10,7 @@ from angr.knowledge_plugins.key_definitions.atoms import Atom, Register
 
 
 class TestAtoms(TestCase):
-    def test_from_argument_instanciate_a_Register_when_given_a_SimRegArg(self):
+    def test_from_argument_instantiate_a_Register_when_given_a_SimRegArg(self):
         argument = SimRegArg("r0", 4)
         arch = ArchMIPS32()
 

--- a/tests/sim/test_symbol_hooked_by.py
+++ b/tests/sim/test_symbol_hooked_by.py
@@ -18,7 +18,7 @@ test_location = os.path.join(bin_location, "tests")
 class TestSymbolHookedBy(unittest.TestCase):
     def test_hook_symbol(self):
         """
-        Test the hook_symbol (and related functions) useing the inet_ntoa simprocedure for functionality
+        Test the hook_symbol (and related functions) using the inet_ntoa simprocedure for functionality
         """
         bin_path = os.path.join(test_location, "x86_64", "inet_ntoa")
         proj = angr.Project(bin_path, auto_load_libs=False, use_sim_procedures=True)

--- a/tests/test_calling_conventions.py
+++ b/tests/test_calling_conventions.py
@@ -76,7 +76,7 @@ class TestCallingConvention(TestCase):
         execve = parse_file("int execve(const char *pathname, char *const argv[], char *const envp[]);")[0]["execve"]
         cc = p.factory.cc()
         assert all((x == y).is_true() for x, y in zip(cc.get_args(s, execve), (123, 456, 789)))
-        # however, this is defintely right
+        # however, this is definitely right
         assert [list(loc.get_footprint()) for loc in cc.arg_locs(execve)] == [
             [SimRegArg("rdi", 8)],
             [SimRegArg("rsi", 8)],


### PR DESCRIPTION
This mostly fixes comments, but in a handful of places fixes bugs due to typos.

One example:
```
-            insn_op_idx=None if cmsg.operand_idx == -1 else cmsg.opearnd_idx,
+            insn_op_idx=None if cmsg.operand_idx == -1 else cmsg.operand_idx,
```
