### PR TITLE
Remove backend references in test cases

### DIFF
--- a/tests/analyses/cfg/test_cfgemulated.py
+++ b/tests/analyses/cfg/test_cfgemulated.py
@@ -618,12 +618,4 @@ class TestCfgemulate(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.getLogger("angr.state_plugins.abstract_memory").setLevel(logging.DEBUG)
-    # logging.getLogger("angr.state_plugins.symbolic_memory").setLevel(logging.DEBUG)
-    # logging.getLogger("angr.analyses.cfg.cfg_emulated").setLevel(logging.DEBUG)
-    # logging.getLogger("s_irsb").setLevel(logging.DEBUG)
-    # Temporarily disable the warnings of claripy backend
-    # logging.getLogger("claripy.backends.backend").setLevel(logging.ERROR)
-    # logging.getLogger("claripy.claripy").setLevel(logging.ERROR)
-
     unittest.main()

--- a/tests/analyses/cfg/test_cfgemulated.py
+++ b/tests/analyses/cfg/test_cfgemulated.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
 
-import time
-import pickle
-import networkx
-
 import logging
+import time
 import os
+import pickle
 import unittest
+
+import networkx
 
 import angr
 from angr import options as o
@@ -23,6 +23,7 @@ test_location = os.path.join(bin_location, "tests")
 
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
+# pylint: disable=no-member
 class TestCfgemulate(unittest.TestCase):
     def compare_cfg(self, standard, g, function_list):
         """

--- a/tests/engines/pcode/test_emulate.py
+++ b/tests/engines/pcode/test_emulate.py
@@ -431,7 +431,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         else:
             expected_result = operation(x, y)
 
-        assert claripy.backends.z3.is_true(result == expected_result)
+        assert claripy.Solver().is_true(result == expected_result)
 
     def test_arith_binary_ops(self):
         for opcode in [
@@ -504,7 +504,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         result = state.memory.load(result_addr, result_size, endness="Iend_LE")
         expected_result = operation(x)
 
-        assert claripy.backends.z3.is_true(result == expected_result)
+        assert claripy.Solver().is_true(result == expected_result)
 
     def test_arith_unary_ops(self):
         for opcode in [

--- a/tests/engines/pcode/test_emulate.py
+++ b/tests/engines/pcode/test_emulate.py
@@ -431,7 +431,9 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         else:
             expected_result = operation(x, y)
 
-        assert claripy.Solver().is_true(result == expected_result)
+        solver = claripy.Solver()
+        maybe_true = solver.eval(result == expected_result, 1)[0]
+        assert solver.is_true(maybe_true)
 
     def test_arith_binary_ops(self):
         for opcode in [

--- a/tests/engines/vex/test_vex.py
+++ b/tests/engines/vex/test_vex.py
@@ -492,7 +492,9 @@ class TestVex(unittest.TestCase):
         sim_successors = HeavyVEXMixin(None).process(state.copy(), irsb=irsb)
         exit_state = sim_successors.all_successors[0]
 
-        assert claripy.Solver().is_true(exit_state.regs.ebp == state.regs.esp - 4)
+        solver = claripy.Solver()
+        maybe_true = solver.eval(exit_state.regs.ebp == state.regs.esp - 4, 1)[0]
+        assert solver.is_true(maybe_true)
 
     def test_loadg_no_constraint_creation(self):
         state = SimState(arch="armel", mode="symbolic")

--- a/tests/engines/vex/test_vex.py
+++ b/tests/engines/vex/test_vex.py
@@ -492,7 +492,7 @@ class TestVex(unittest.TestCase):
         sim_successors = HeavyVEXMixin(None).process(state.copy(), irsb=irsb)
         exit_state = sim_successors.all_successors[0]
 
-        assert claripy.backends.z3.is_true(exit_state.regs.ebp == state.regs.esp - 4)
+        assert claripy.Solver().is_true(exit_state.regs.ebp == state.regs.esp - 4)
 
     def test_loadg_no_constraint_creation(self):
         state = SimState(arch="armel", mode="symbolic")

--- a/tests/procedures/libc/test_string.py
+++ b/tests/procedures/libc/test_string.py
@@ -346,7 +346,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
         ss_res = strstr(s, arguments=[addr_haystack, addr_needle])
         results = set(s.solver.eval_upto(ss_res, len(haystack) * 2))
-        expected = {(claripy.backends.concrete.convert(addr_haystack).value + i) for i in range(len(haystack))} | {0}
+        expected = {(addr_haystack.concrete_value + i) for i in range(len(haystack))} | {0}
         assert results == expected
 
         s_match = s.copy()
@@ -385,8 +385,8 @@ class TestStringSimProcedures(unittest.TestCase):
         num_possible = min(s.libc.max_symbolic_strstr, 1 + (len(str_haystack) - len(str_needle)) // 8)
         expected = set(
             range(
-                claripy.backends.concrete.convert(addr_haystack).value,
-                claripy.backends.concrete.convert(addr_haystack).value + num_possible,
+                addr_haystack.concrete_value,
+                addr_haystack.concrete_value + num_possible,
             )
         )
         results = set(s_match.solver.eval_exact(ss_res, num_possible))


### PR DESCRIPTION
This is similar to #4768, but scoped only to tests where the added overhead of a solver is not significant.