### PR TITLE
Use a typecheck instead of backend.convert to determine if object is an AST

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2960,7 +2960,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int], CFGBase):  # pylin
         simsucc = self.project.factory.default_engine.process(self._initial_state, irsb, force_addr=addr)
         if len(simsucc.successors) == 1:
             ip = simsucc.successors[0].ip
-            if claripy.backends.concrete.convert(ip) is not ip:
+            if isinstance(ip, claripy.ast.Base):
                 target_addr = ip.concrete_value
                 obj = self.project.loader.find_object_containing(target_addr, membership_check=False)
                 if (obj is not None and obj is not self.project.loader.main_object) or self.project.is_hooked(


### PR DESCRIPTION
Also from #4768, this change is self-contained and definitely a speedup in the failure case since it avoids generating an exception internally in claripy. Success case is less significant.