### PR TITLE
Handle zero division in VRA

### DIFF
--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -445,10 +445,12 @@ class SimEngineVRAIL(
         if expr.floating_point:
             quotient = self.state.top(to_size)
         else:
-            if expr.signed:
+            if (r1.data == 0).is_true():
+                quotient = self.state.top(to_size)
+            elif expr.signed:
                 quotient = claripy.SDiv(r0.data, claripy.SignExt(from_size - to_size, r1.data))
             else:
-                quotient = r0.data / claripy.ZeroExt(from_size - to_size, r1.data)
+                quotient = r0.data // claripy.ZeroExt(from_size - to_size, r1.data)
 
         return RichR(
             quotient,
@@ -463,7 +465,9 @@ class SimEngineVRAIL(
         from_size = expr.from_bits
         to_size = expr.to_bits
 
-        if expr.signed:
+        if (r1.data == 0).is_true():
+            r = self.state.top(to_size * 2)
+        elif expr.signed:
             quotient = r0.data.SDiv(claripy.SignExt(from_size - to_size, r1.data))
             remainder = r0.data.SMod(claripy.SignExt(from_size - to_size, r1.data))
             quotient_size = to_size
@@ -496,7 +500,9 @@ class SimEngineVRAIL(
         if expr.floating_point:
             remainder = self.state.top(to_size)
         else:
-            if expr.signed:
+            if (r1.data == 0).is_true():
+                remainder = self.state.top(to_size)
+            elif expr.signed:
                 remainder = r0.data.SMod(claripy.SignExt(from_size - to_size, r1.data))
             else:
                 remainder = r0.data % claripy.ZeroExt(from_size - to_size, r1.data)

--- a/angr/analyses/variable_recovery/engine_vex.py
+++ b/angr/analyses/variable_recovery/engine_vex.py
@@ -42,8 +42,8 @@ class SimEngineVRVEX(
     def _is_top(self, expr: RichR) -> bool:
         return self.state.is_top(expr)
 
-    def _top(self, size: int):
-        return self.state.top(size)
+    def _top(self, size: int) -> RichR:
+        return RichR(self.state.top(size))
 
     def _process_Stmt(self, whitelist=None):
         scanner = VEXIRSBScanner(logger=self.l)


### PR DESCRIPTION
Also handle a gross type error in VRA's _top() function, which is used by the fallback functions in the base classes...