### PR TITLE
Disable CodeMotion

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/__init__.py
+++ b/angr/analyses/decompiler/optimization_passes/__init__.py
@@ -55,7 +55,7 @@ _all_optimization_passes = [
     (LoweredSwitchSimplifier, True),
     (ReturnDuplicatorLow, True),
     (ReturnDeduplicator, True),
-    (CodeMotionOptimization, True),
+    (CodeMotionOptimization, False),
     (CrossJumpReverter, True),
     (FlipBooleanCmp, True),
     (InlinedStringTransformationSimplifier, True),

--- a/angr/analyses/decompiler/optimization_passes/code_motion.py
+++ b/angr/analyses/decompiler/optimization_passes/code_motion.py
@@ -59,6 +59,7 @@ class CodeMotionOptimization(OptimizationPass):
         return True, None
 
     def _analyze(self, cache=None):
+        _l.warning("CodeMotionOptimization is likely broken right now, use with caution!")
         optimization_runs = 0
         graph_copy = remove_labels(nx.DiGraph(self._graph))
         updates = True

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3386,6 +3386,7 @@ class TestDecompiler(unittest.TestCase):
         d = proj.analyses[Decompiler](proj.kb.functions.function(name="puts", plt=True), cfg=cfg.model)
         assert "::libc.so.0::puts" in d.codegen.text
 
+    @unittest.skip("This test is disabled until CodeMotion is reimplemented")
     @for_all_structuring_algos
     def test_code_motion_down_opt(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "code_motion_1")


### PR DESCRIPTION
#4695 introduced a new (and faster) way to do code motion correctly. Our old approach was a hack to do code motion without real RDA. After #4695 is merged, a new solution should be made. 