### PR TITLE
Fix Quality Estimator for cases of unused labels

### DIFF
--- a/angr/analyses/decompiler/counters/seq_cf_structure_counter.py
+++ b/angr/analyses/decompiler/counters/seq_cf_structure_counter.py
@@ -30,6 +30,8 @@ class ControlFlowStructureCounter(SequenceWalker):
 
         # eliminate gotos without labels
         self.goto_targets = {k: v for k, v in self.goto_targets.items() if k in self.ordered_labels}
+        # correct labels that are not used
+        self.ordered_labels = [lbl for lbl in self.ordered_labels if lbl in self.goto_targets]
 
     # pylint: disable=unused-argument
     def _handle_Block(self, node: ailment.Block, **kwargs):


### PR DESCRIPTION
## Reported Bug
``` 
ERROR: test_reverting_switch_clustering_and_lowering_cat_main (tests.analyses.decompiler.test_decompiler.TestDecompiler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/angr/angr/build/src/angr/tests/analyses/decompiler/test_decompiler.py", line 117, in inner
    ret_vals.append(func(*args, decompiler_options=new_opts, **kwargs))
  File "/__w/angr/angr/build/src/angr/tests/analyses/decompiler/test_decompiler.py", line 2355, in test_reverting_switch_clustering_and_lowering_cat_main
    d = proj.analyses[Decompiler].prep()(
  File "/__w/angr/angr/build/src/angr/angr/analyses/analysis.py", line 202, in wrapper
    oself.__init__(*args, **kwargs)
  File "/__w/angr/angr/build/src/angr/angr/analyses/decompiler/decompiler.py", line 105, in __init__
    self._decompile()
  File "/__w/angr/angr/build/src/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/__w/angr/angr/build/src/angr/angr/analyses/decompiler/decompiler.py", line 219, in _decompile
    clinic.graph, ri = self._run_region_simplification_passes(
  File "/__w/angr/angr/build/src/angr/angr/utils/timing.py", line 43, in timed_func
    return func(*args, **kwargs)
  File "/__w/angr/angr/build/src/angr/angr/analyses/decompiler/decompiler.py", line 392, in _run_region_simplification_passes
    a = pass_(
  File "/__w/angr/angr/build/src/angr/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py", line 179, in __init__
    self.analyze()
  File "/__w/angr/angr/build/src/angr/angr/analyses/decompiler/optimization_passes/optimization_pass.py", line 376, in analyze
    if self._must_improve_rel_quality and not self._improves_relative_quality():
  File "/__w/angr/angr/build/src/angr/angr/analyses/decompiler/optimization_passes/optimization_pass.py", line 521, in _improves_relative_quality
    right_curr_label_cnt = curr_labels[right_label]
KeyError: 4199814
```