### PR TITLE
Add opentelemetry observability for analyses

### DIFF
--- a/angr/misc/telemetry.py
+++ b/angr/misc/telemetry.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+import enum
+
+try:
+    from opentelemetry.trace import get_current_span, Status, StatusCode, Tracer, get_tracer as _get_tracer
+except ImportError:
+    if TYPE_CHECKING:
+        raise
+
+    # pylint: disable=missing-class-docstring,unused-argument
+    class Status:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class StatusCode(enum.Enum):
+        OK = 0
+        UNSET = 1
+        ERROR = 2
+
+    class Tracer:
+        @staticmethod
+        def start_as_current_span(*args, **kwargs):
+            def inner(f):
+                return f
+
+            return inner
+
+        @staticmethod
+        def get_current_span(*args, **kwargs):
+            return Span()
+
+    def _get_tracer(*args, **kwargs):
+        return Tracer()
+
+    class Span:
+        @staticmethod
+        def set_attribute(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def add_event(*args, **kwargs):
+            pass
+
+    get_current_span = Tracer.get_current_span
+
+
+from angr import __version__
+
+__all__ = ["get_tracer", "get_current_span", "Status", "StatusCode"]
+
+
+def get_tracer(name: str) -> Tracer:
+    return _get_tracer(name, __version__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,8 @@ docs =
     sphinx-autodoc-typehints
 pcode =
     pypcode~=3.0
+telemetry =
+    opentelemetry-api
 testing =
     keystone-engine
     pypcode~=3.0


### PR DESCRIPTION
Should be a no-op when not explicitly enabled. Example code for enabling:

```
from opentelemetry import trace
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import (
    BatchSpanProcessor,
    ConsoleSpanExporter,
)

provider = TracerProvider()
processor = BatchSpanProcessor(ConsoleSpanExporter())
provider.add_span_processor(processor)

# Sets the global default tracer provider
trace.set_tracer_provider(provider)
```