### PR TITLE
DuplicationReverter: Do not cache None as the entry block for a graph.

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -1174,9 +1174,9 @@ class DuplicationReverter(StructuringOptimizationPass):
             entry_blocks = [node for node in graph.nodes if graph.in_degree(node) == 0]
             entry_block = None if len(entry_blocks) != 1 else entry_blocks[0]
 
-            self._entry_node_cache[graph] = entry_block
             if entry_block is None:
                 return None
+            self._entry_node_cache[graph] = entry_block
 
         entry_blk = self._entry_node_cache[graph]
 


### PR DESCRIPTION
This PR solves the following exception:

```python
File f:\angr\angr\angr\analyses\decompiler\optimization_passes\duplication_reverter\duplication_reverter.py:139, in DuplicationReverter._search_for_deduplication_candidate(self)
    137 @timethis
    138 def _search_for_deduplication_candidate(self) -> tuple[Block, Block] | None:
--> 139     candidates = self._find_initial_candidates()
    140     if not candidates:
    141         _l.debug("There are no duplicate statements in this function, stopping analysis")

File f:\angr\angr\angr\analyses\decompiler\optimization_passes\duplication_reverter\duplication_reverter.py:1065, in DuplicationReverter._find_initial_candidates(self)
   1063 goto_candidates = []
   1064 for b0, b1 in combinations(candidate_subgraph, 2):
-> 1065     if self._is_valid_candidate(b0, b1):
   1066         pair = tuple(sorted([b0, b1], key=lambda x: x.addr))
   1067         goto_candidates.append(pair)

File f:\angr\angr\angr\analyses\decompiler\optimization_passes\duplication_reverter\duplication_reverter.py:1018, in DuplicationReverter._is_valid_candidate(self, b0, b1)
   1015             break
   1017 # must share a common dominator
-> 1018 return stmt_in_common and self.shared_common_conditional_dom((b0, b1), self.write_graph) is not None

File f:\angr\angr\angr\analyses\decompiler\optimization_passes\duplication_reverter\duplication_reverter.py:1194, in DuplicationReverter.shared_common_conditional_dom(self, nodes, graph)
   1191 entry_blk = self._entry_node_cache[graph]
   1193 if graph not in self._idom_cache:
-> 1194     self._idom_cache[graph] = nx.algorithms.immediate_dominators(graph, entry_blk)
   1196 idoms = self._idom_cache[graph]
   1198 # first check if any of the node pairs could be a dominating loop

File <class 'networkx.utils.decorators.argmap'> compilation 26:4, in argmap_immediate_dominators_23(G, start)
      2 import collections
      3 import gzip
----> 4 import inspect
      5 import itertools
      6 import re

File ~\venvs\angr\Lib\site-packages\networkx\algorithms\dominance.py:57, in immediate_dominators(G, start)
     15 """Returns the immediate dominators of all nodes of a directed graph.
     16
     17 Parameters
   (...)
     54        Software Practice & Experience, 4:110, 2001.
     55 """
     56 if start not in G:
---> 57     raise nx.NetworkXError("start is not in G")
     59 idom = {start: start}
     61 order = list(nx.dfs_postorder_nodes(G, start))

NetworkXError: start is not in G
> c:\users\fish\venvs\angr\lib\site-packages\networkx\algorithms\dominance.py(57)immediate_dominators()
     55     """
     56     if start not in G:
---> 57         raise nx.NetworkXError("start is not in G")
     58
     59     idom = {start: start}

ipdb> up
> f:\angr\angr\tests\analyses\decompiler\<class 'networkx.utils.decorators.argmap'> compilation 26(4)argmap_immediate_dominators_23()

ipdb> up
> f:\angr\angr\angr\analyses\decompiler\optimization_passes\duplication_reverter\duplication_reverter.py(1194)shared_common_conditional_dom()
   1192
   1193         if graph not in self._idom_cache:
-> 1194             self._idom_cache[graph] = nx.algorithms.immediate_dominators(graph, entry_blk)
   1195
   1196         idoms = self._idom_cache[graph]

ipdb> pp entry_blk
None
ipdb> pp graph
<networkx.classes.digraph.DiGraph object at 0x0000028AD6410510>
ipdb> up
> f:\angr\angr\angr\analyses\decompiler\optimization_passes\duplication_reverter\duplication_reverter.py(1018)_is_valid_candidate()
   1016
   1017         # must share a common dominator
-> 1018         return stmt_in_common and self.shared_common_conditional_dom((b0, b1), self.write_graph) is not None
   1019
   1020     @staticmethod

ipdb> down
> f:\angr\angr\angr\analyses\decompiler\optimization_passes\duplication_reverter\duplication_reverter.py(1194)shared_common_conditional_dom()
   1192
   1193         if graph not in self._idom_cache:
-> 1194             self._idom_cache[graph] = nx.algorithms.immediate_dominators(graph, entry_blk)
   1195
   1196         idoms = self._idom_cache[graph]

ipdb> pp self._entry_node_cache
{<networkx.classes.digraph.DiGraph object at 0x0000028AD6410510>: None}
```