### PR TITLE
Fix percentage update calculation in complete_calling_conventions.py

### DIFF
--- a/angr/analyses/complete_calling_conventions.py
+++ b/angr/analyses/complete_calling_conventions.py
@@ -185,7 +185,7 @@ class CompleteCallingConventionsAnalysis(Analysis):
                 if self._cc_callback is not None:
                     self._cc_callback(func_addr)
 
-                percentage = idx + 1 / total_funcs * 100.0
+                percentage = (idx + 1) / total_funcs * 100.0
                 self._update_progress(percentage, text=f"{idx + 1}/{total_funcs} - {func.demangled_name}")
                 if self._low_priority:
                     self._release_gil(idx + 1, 10, 0.000001)


### PR DESCRIPTION
This was the result of an error in this commit: https://github.com/angr/angr/pull/4793/files#diff-231bce5e39ce9ec4aa88c55fbb60ad2d062e19e22e83559e99d0c61559517d9bR188