### PR TITLE
Use io buffer in CLI tests

### DIFF
--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 import argparse
+import sys
 
 from angr.analyses.decompiler import DECOMPILATION_PRESETS
 from angr.analyses.decompiler.structuring import STRUCTURER_CLASSES, DEFAULT_STRUCTURER
@@ -15,7 +17,7 @@ class COMMANDS:
     ALL_COMMANDS = [DECOMPILE]
 
 
-def main():
+def main(args=sys.argv, out=sys.stdout):
     parser = argparse.ArgumentParser(description="The angr CLI allows you to decompile and analyze binaries.")
     parser.add_argument(
         "command",
@@ -67,7 +69,7 @@ def main():
         default="default",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     if args.command == COMMANDS.DECOMPILE:
         decompilation = decompile_functions(
             args.binary,
@@ -78,9 +80,9 @@ def main():
             base_address=args.base_addr,
             preset=args.preset,
         )
-        print(decompilation)
+        print(decompilation, file=out)
     else:
-        parser.print_help()
+        parser.print_help(file=out)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests"  # pylint:disable=redefined-builtin
 
+import io
 import os
-import subprocess
 import re
 import unittest
 
 import angr
+from angr.__main__ import main
 from angr.analyses.decompiler.utils import decompile_functions
 from angr.misc.testing import is_testing
 
@@ -23,8 +24,9 @@ WORKER = is_testing or bool(
 
 
 def run_cli(*args):
-    proc = subprocess.run(["python3", "-m", "angr", *args], text=True, check=True, capture_output=True)
-    return proc.stdout
+    output = io.StringIO()
+    main(args, output)
+    return output.getvalue()
 
 
 class TestCommandLineInterface(unittest.TestCase):


### PR DESCRIPTION
Instead of calling the CLI via subprocess, support passing arguments and output files so it can be run directly.