### PR TITLE
Move MemoryMixin to own file

### DIFF
--- a/angr/storage/__init__.py
+++ b/angr/storage/__init__.py
@@ -4,13 +4,12 @@ DUMMY_SYMBOLIC_READ_VALUE = 0xC0DEB4BE
 
 from .file import SimFile
 from .memory_object import SimMemoryObject
-from .memory_mixins import MemoryMixin, DefaultMemory
+from .memory_mixins import DefaultMemory
 
 
 __all__ = (
     "DUMMY_SYMBOLIC_READ_VALUE",
     "SimFile",
     "SimMemoryObject",
-    "MemoryMixin",
     "DefaultMemory",
 )

--- a/angr/storage/memory_mixins/__init__.py
+++ b/angr/storage/memory_mixins/__init__.py
@@ -195,7 +195,7 @@ class LabeledMemory(
     LabeledMemory is used in static analysis. It allows storing values with labels, such as `Definition`.
     """
 
-    def _default_value(self, addr, size, **kwargs):
+    def _default_value(self, addr, size, **kwargs):  # pylint:disable=arguments-differ
         # TODO: Make _default_value() a separate Mixin
 
         if kwargs.get("name", "").startswith("merge_uc_"):
@@ -216,7 +216,7 @@ class MultiValuedMemory(
     PagedMemoryMixin,
     PagedMemoryMultiValueMixin,
 ):
-    def _default_value(self, addr, size, **kwargs):
+    def _default_value(self, addr, size, **kwargs):  # pylint:disable=arguments-differ
         # TODO: Make _default_value() a separate Mixin
 
         if kwargs.get("name", "").startswith("merge_uc_"):

--- a/angr/storage/memory_mixins/__init__.py
+++ b/angr/storage/memory_mixins/__init__.py
@@ -1,160 +1,6 @@
-# pylint:disable=abstract-method,wrong-import-position,unused-argument,missing-class-docstring,arguments-differ
 from __future__ import annotations
-from typing import Any
-from collections.abc import Iterable
 
-import claripy
-
-from angr.state_plugins.plugin import SimStatePlugin
-from angr.errors import SimMemoryError
-
-
-class MemoryMixin(SimStatePlugin):
-    SUPPORTS_CONCRETE_LOAD = False
-
-    def __init__(self, memory_id=None, endness="Iend_BE"):
-        super().__init__()
-        self.id = memory_id
-        self.endness = endness
-
-    def copy(self, memo):
-        o = type(self).__new__(type(self))
-        o.id = self.id
-        o.endness = self.endness
-        return o
-
-    @property
-    def category(self):
-        """
-        Return the category of this SimMemory instance. It can be one of the three following categories: reg, mem,
-        or file.
-        """
-
-        if self.id in ("reg", "mem"):
-            return self.id
-
-        if self.id.startswith("file"):
-            return "file"
-
-        if "_" in self.id:
-            return self.id.split("_")[0]
-
-        raise SimMemoryError(f'Unknown SimMemory category for memory_id "{self.id}"')
-
-    @property
-    def variable_key_prefix(self):
-        s = self.category
-        if s == "file":
-            return (s, self.id)
-        return (s,)
-
-    def find(self, addr, data, max_search, **kwargs):
-        pass
-
-    def _add_constraints(self, c, add_constraints=True, condition=None, **kwargs):
-        if add_constraints:
-            to_add = c & condition | ~condition if condition is not None else c
-            self.state.add_constraints(to_add)
-
-    def load(self, addr, size=None, **kwargs):
-        pass
-
-    def store(self, addr, data, **kwargs):
-        pass
-
-    def merge(self, others, merge_conditions, common_ancestor=None) -> bool:
-        pass
-
-    def compare(self, other) -> bool:
-        pass
-
-    def widen(self, others):
-        pass
-
-    def permissions(self, addr, permissions=None, **kwargs):
-        pass
-
-    def map_region(self, addr, length, permissions, init_zero=False, **kwargs):
-        pass
-
-    def unmap_region(self, addr, length, **kwargs):
-        pass
-
-    # Optional interface:
-    def concrete_load(self, addr, size, writing=False, **kwargs) -> memoryview:
-        """
-        Set SUPPORTS_CONCRETE_LOAD to True and implement concrete_load if reading concrete bytes is faster in this
-        memory model.
-
-        :param addr:    The address to load from.
-        :param size:    Size of the memory read.
-        :param writing:
-        :return:        A memoryview into the loaded bytes.
-        """
-        raise NotImplementedError
-
-    def erase(self, addr, size=None, **kwargs) -> None:
-        """
-        Set [addr:addr+size) to uninitialized. In many cases this will be faster than overwriting those locations with
-        new values. This is commonly used during static data flow analysis.
-
-        :param addr:    The address to start erasing.
-        :param size:    The number of bytes for erasing.
-        :return:        None
-        """
-        raise NotImplementedError
-
-    def _default_value(self, addr, size, name=None, inspect=True, events=True, key=None, **kwargs):
-        """
-        Override this method to provide default values for a variety of edge cases and base cases.
-
-        :param addr:    If this value is being filled to provide a default memory value, this will be its address.
-                        Otherwise, None.
-        :param size:    The size in bytes of the value to return
-        :param name:    A descriptive identifier for the value, for if a symbol is created.
-
-        The ``inspect``, ``events``, and ``key`` parameters are for ``state.solver.Unconstrained``, if it is used.
-        """
-
-    def _merge_values(self, values: Iterable[tuple[Any, Any]], merged_size: int, **kwargs) -> Any | None:
-        """
-        Override this method to provide value merging support.
-
-        :param values:          A collection of values with their merge conditions.
-        :param merged_size:     The size (in bytes) of the merged value.
-        :return:                The merged value, or None to skip merging of the current value.
-        """
-        raise NotImplementedError
-
-    def _merge_labels(self, labels: Iterable[dict], **kwargs) -> dict | None:
-        """
-        Override this method to provide label merging support.
-
-        :param labels:          A collection of labels.
-        :return:                The merged label, or None to skip merging of the current label.
-        """
-        raise NotImplementedError
-
-    def replace_all(self, old: claripy.ast.BV, new: claripy.ast.BV):
-        raise NotImplementedError
-
-    def _replace_all(self, addrs: Iterable[int], old: claripy.ast.BV, new: claripy.ast.BV):
-        raise NotImplementedError
-
-    def copy_contents(self, dst, src, size, condition=None, **kwargs):
-        """
-        Override this method to provide faster copying of large chunks of data.
-
-        :param dst:     The destination of copying.
-        :param src:     The source of copying.
-        :param size:    The size of copying.
-        :param condition:   The storing condition.
-        :param kwargs:      Other parameters.
-        :return:        None
-        """
-        raise NotImplementedError
-
-
+from angr.sim_state import SimState
 from .actions_mixin import ActionsMixinHigh, ActionsMixinLow
 from .address_concretization_mixin import AddressConcretizationMixin
 from .bvv_conversion_mixin import DataNormalizationMixin
@@ -213,6 +59,8 @@ from .regioned_memory import (
 )
 from .keyvalue_memory_mixin import KeyValueMemoryMixin
 from .javavm_memory_mixin import JavaVmMemoryMixin
+
+# pylint:disable=missing-class-docstring
 
 
 class DefaultMemory(
@@ -393,8 +241,6 @@ class JavaVmMemory(
     pass
 
 
-from angr.sim_state import SimState
-
 SimState.register_default("sym_memory", DefaultMemory)
 SimState.register_default("fast_memory", FastMemory)
 SimState.register_default("abs_memory", AbstractMemory)
@@ -403,7 +249,6 @@ SimState.register_default("javavm_memory", JavaVmMemory)
 
 
 __all__ = (
-    "MemoryMixin",
     "ActionsMixinHigh",
     "ActionsMixinLow",
     "AddressConcretizationMixin",

--- a/angr/storage/memory_mixins/actions_mixin.py
+++ b/angr/storage/memory_mixins/actions_mixin.py
@@ -3,7 +3,7 @@ import claripy
 
 from angr.state_plugins.sim_action import SimActionData, SimActionObject
 from angr import sim_options as o
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class ActionsMixinHigh(MemoryMixin):

--- a/angr/storage/memory_mixins/address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/address_concretization_mixin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import claripy
 
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 from angr import sim_options as options
 from angr import concretization_strategies
 from angr.sim_state_options import SimStateOptions

--- a/angr/storage/memory_mixins/bvv_conversion_mixin.py
+++ b/angr/storage/memory_mixins/bvv_conversion_mixin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import logging
 import claripy
 
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 l = logging.getLogger(__name__)
 

--- a/angr/storage/memory_mixins/clouseau_mixin.py
+++ b/angr/storage/memory_mixins/clouseau_mixin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from . import MemoryMixin
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class InspectMixinHigh(MemoryMixin):

--- a/angr/storage/memory_mixins/conditional_store_mixin.py
+++ b/angr/storage/memory_mixins/conditional_store_mixin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import claripy
 
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class ConditionalMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/convenient_mappings_mixin.py
+++ b/angr/storage/memory_mixins/convenient_mappings_mixin.py
@@ -7,7 +7,7 @@ import claripy
 from angr import sim_options as options
 from angr.utils.cowdict import ChainMapCOW
 from angr.errors import SimMemoryError, SimMemoryMissingError
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 l = logging.getLogger(name=__name__)
 

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -3,7 +3,7 @@ import logging
 
 import claripy
 
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 from angr import sim_options as options
 from angr.misc.ux import once
 from angr.errors import SimMemoryMissingError

--- a/angr/storage/memory_mixins/dirty_addrs_mixin.py
+++ b/angr/storage/memory_mixins/dirty_addrs_mixin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from . import MemoryMixin
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class DirtyAddrsMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/hex_dumper_mixin.py
+++ b/angr/storage/memory_mixins/hex_dumper_mixin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import string
 
 from angr.errors import SimValueError
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 import contextlib
 
 

--- a/angr/storage/memory_mixins/javavm_memory_mixin.py
+++ b/angr/storage/memory_mixins/javavm_memory_mixin.py
@@ -16,7 +16,7 @@ from angr.engines.soot.values import (
     SimSootValue_StaticFieldRef,
     SimSootValue_StringRef,
 )
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 l = logging.getLogger(name=__name__)

--- a/angr/storage/memory_mixins/keyvalue_memory_mixin.py
+++ b/angr/storage/memory_mixins/keyvalue_memory_mixin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class TypedVariable:

--- a/angr/storage/memory_mixins/label_merger_mixin.py
+++ b/angr/storage/memory_mixins/label_merger_mixin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from collections.abc import Iterable
 
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class LabelMergerMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/memory_mixin.py
+++ b/angr/storage/memory_mixins/memory_mixin.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import claripy
+
+from angr.errors import SimMemoryError
+from angr.state_plugins.plugin import SimStatePlugin
+
+
+class MemoryMixin(SimStatePlugin):
+    SUPPORTS_CONCRETE_LOAD = False
+
+    def __init__(self, memory_id=None, endness="Iend_BE"):
+        super().__init__()
+        self.id = memory_id
+        self.endness = endness
+
+    def copy(self, memo):
+        o = type(self).__new__(type(self))
+        o.id = self.id
+        o.endness = self.endness
+        return o
+
+    @property
+    def category(self):
+        """
+        Return the category of this SimMemory instance. It can be one of the three following categories: reg, mem,
+        or file.
+        """
+
+        if self.id in ("reg", "mem"):
+            return self.id
+
+        if self.id.startswith("file"):
+            return "file"
+
+        if "_" in self.id:
+            return self.id.split("_")[0]
+
+        raise SimMemoryError(f'Unknown SimMemory category for memory_id "{self.id}"')
+
+    @property
+    def variable_key_prefix(self):
+        s = self.category
+        if s == "file":
+            return (s, self.id)
+        return (s,)
+
+    def find(self, addr, data, max_search, **kwargs):
+        pass
+
+    def _add_constraints(self, c, add_constraints=True, condition=None, **kwargs):
+        if add_constraints:
+            to_add = c & condition | ~condition if condition is not None else c
+            self.state.add_constraints(to_add)
+
+    def load(self, addr, size=None, **kwargs):
+        pass
+
+    def store(self, addr, data, **kwargs):
+        pass
+
+    def merge(self, others, merge_conditions, common_ancestor=None) -> bool:
+        pass
+
+    def compare(self, other) -> bool:
+        pass
+
+    def widen(self, others):
+        pass
+
+    def permissions(self, addr, permissions=None, **kwargs):
+        pass
+
+    def map_region(self, addr, length, permissions, init_zero=False, **kwargs):
+        pass
+
+    def unmap_region(self, addr, length, **kwargs):
+        pass
+
+    # Optional interface:
+    def concrete_load(self, addr, size, writing=False, **kwargs) -> memoryview:
+        """
+        Set SUPPORTS_CONCRETE_LOAD to True and implement concrete_load if reading concrete bytes is faster in this
+        memory model.
+
+        :param addr:    The address to load from.
+        :param size:    Size of the memory read.
+        :param writing:
+        :return:        A memoryview into the loaded bytes.
+        """
+        raise NotImplementedError
+
+    def erase(self, addr, size=None, **kwargs) -> None:
+        """
+        Set [addr:addr+size) to uninitialized. In many cases this will be faster than overwriting those locations with
+        new values. This is commonly used during static data flow analysis.
+
+        :param addr:    The address to start erasing.
+        :param size:    The number of bytes for erasing.
+        :return:        None
+        """
+        raise NotImplementedError
+
+    def _default_value(self, addr, size, name=None, inspect=True, events=True, key=None, **kwargs):
+        """
+        Override this method to provide default values for a variety of edge cases and base cases.
+
+        :param addr:    If this value is being filled to provide a default memory value, this will be its address.
+                        Otherwise, None.
+        :param size:    The size in bytes of the value to return
+        :param name:    A descriptive identifier for the value, for if a symbol is created.
+
+        The ``inspect``, ``events``, and ``key`` parameters are for ``state.solver.Unconstrained``, if it is used.
+        """
+
+    def _merge_values(self, values: Iterable[tuple[Any, Any]], merged_size: int, **kwargs) -> Any | None:
+        """
+        Override this method to provide value merging support.
+
+        :param values:          A collection of values with their merge conditions.
+        :param merged_size:     The size (in bytes) of the merged value.
+        :return:                The merged value, or None to skip merging of the current value.
+        """
+        raise NotImplementedError
+
+    def _merge_labels(self, labels: Iterable[dict], **kwargs) -> dict | None:
+        """
+        Override this method to provide label merging support.
+
+        :param labels:          A collection of labels.
+        :return:                The merged label, or None to skip merging of the current label.
+        """
+        raise NotImplementedError
+
+    def replace_all(self, old: claripy.ast.BV, new: claripy.ast.BV):
+        raise NotImplementedError
+
+    def _replace_all(self, addrs: Iterable[int], old: claripy.ast.BV, new: claripy.ast.BV):
+        raise NotImplementedError
+
+    def copy_contents(self, dst, src, size, condition=None, **kwargs):
+        """
+        Override this method to provide faster copying of large chunks of data.
+
+        :param dst:     The destination of copying.
+        :param src:     The source of copying.
+        :param size:    The size of copying.
+        :param condition:   The storing condition.
+        :param kwargs:      Other parameters.
+        :return:        None
+        """
+        raise NotImplementedError

--- a/angr/storage/memory_mixins/memory_mixin.py
+++ b/angr/storage/memory_mixins/memory_mixin.py
@@ -10,6 +10,12 @@ from angr.state_plugins.plugin import SimStatePlugin
 
 
 class MemoryMixin(SimStatePlugin):
+    """
+    Base class for memory mixins. In angr, all memory objects are made by
+    subclassing one or more MemoryMixins, each adding some functionality to the
+    memory object.
+    """
+
     SUPPORTS_CONCRETE_LOAD = False
 
     def __init__(self, memory_id=None, endness="Iend_BE"):
@@ -17,7 +23,7 @@ class MemoryMixin(SimStatePlugin):
         self.id = memory_id
         self.endness = endness
 
-    def copy(self, memo):
+    def copy(self, memo):  # pylint:disable=unused-argument
         o = type(self).__new__(type(self))
         o.id = self.id
         o.endness = self.endness
@@ -51,7 +57,7 @@ class MemoryMixin(SimStatePlugin):
     def find(self, addr, data, max_search, **kwargs):
         pass
 
-    def _add_constraints(self, c, add_constraints=True, condition=None, **kwargs):
+    def _add_constraints(self, c, add_constraints=True, condition=None, **kwargs):  # pylint:disable=unused-argument
         if add_constraints:
             to_add = c & condition | ~condition if condition is not None else c
             self.state.add_constraints(to_add)
@@ -104,7 +110,9 @@ class MemoryMixin(SimStatePlugin):
         """
         raise NotImplementedError
 
-    def _default_value(self, addr, size, name=None, inspect=True, events=True, key=None, **kwargs):
+    def _default_value(  # pylint:disable=too-many-positional-arguments
+        self, addr, size, name=None, inspect=True, events=True, key=None, **kwargs
+    ):
         """
         Override this method to provide default values for a variety of edge cases and base cases.
 

--- a/angr/storage/memory_mixins/multi_value_merger_mixin.py
+++ b/angr/storage/memory_mixins/multi_value_merger_mixin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 from collections.abc import Iterable, Callable
 
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class MultiValueMergerMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/name_resolution_mixin.py
+++ b/angr/storage/memory_mixins/name_resolution_mixin.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+
 import claripy
 from archinfo.arch_arm import is_arm_arch
-from . import MemoryMixin
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 stn_map = {"st%d" % n: n for n in range(8)}
 tag_map = {"tag%d" % n: n for n in range(8)}

--- a/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import claripy
 
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 from angr.storage.memory_mixins.paged_memory.pages import PageType, ListPage, UltraPage, MVListPage
 from angr.errors import SimMemoryError
 

--- a/angr/storage/memory_mixins/paged_memory/paged_memory_multivalue_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_multivalue_mixin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from angr.storage.memory_mixins import MemoryMixin
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class PagedMemoryMultiValueMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/paged_memory/pages/__init__.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import typing
 
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 from .cooperation import CooperationBase, MemoryObjectMixin
 from .ispo_mixin import ISPOMixin
 from .refcount_mixin import RefcountMixin

--- a/angr/storage/memory_mixins/paged_memory/pages/history_tracking_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/history_tracking_mixin.py
@@ -1,7 +1,7 @@
 # pylint:disable=arguments-differ,unused-argument,no-member
 from __future__ import annotations
 
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 from angr.utils.segment_list import SegmentList
 from .refcount_mixin import RefcountMixin
 

--- a/angr/storage/memory_mixins/paged_memory/pages/ispo_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/ispo_mixin.py
@@ -1,6 +1,7 @@
 # pylint:disable=arguments-differ
 from __future__ import annotations
-from angr.storage.memory_mixins import MemoryMixin
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class ISPOMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/paged_memory/pages/permissions_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/permissions_mixin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import claripy
 
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class PermissionsMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/paged_memory/pages/refcount_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/refcount_mixin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from angr.storage.memory_mixins import MemoryMixin
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 from angr.misc import PicklableLock
 
 

--- a/angr/storage/memory_mixins/regioned_memory/abstract_merger_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/abstract_merger_mixin.py
@@ -4,8 +4,7 @@ import logging
 from collections.abc import Iterable
 from typing import Any
 
-
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 l = logging.getLogger(name=__name__)
 

--- a/angr/storage/memory_mixins/regioned_memory/region_category_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/region_category_mixin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from angr.storage.memory_mixins import MemoryMixin
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class RegionCategoryMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/regioned_memory/region_meta_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/region_meta_mixin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import copy
 from typing import Any
 
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class Segment:

--- a/angr/storage/memory_mixins/regioned_memory/regioned_address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_address_concretization_mixin.py
@@ -6,7 +6,7 @@ import claripy
 from angr.sim_options import HYBRID_SOLVER, APPROXIMATE_FIRST
 from angr import concretization_strategies
 from angr.errors import SimMergeError, SimMemoryAddressError
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 from .abstract_address_descriptor import AbstractAddressDescriptor
 from .region_data import AddressWrapper
 

--- a/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/regioned_memory_mixin.py
@@ -11,7 +11,7 @@ from claripy.ast import Bool, Bits, BV
 from angr.sim_options import AVOID_MULTIVALUED_READS, CONSERVATIVE_READ_STRATEGY, CONSERVATIVE_WRITE_STRATEGY
 from angr.state_plugins.sim_action_object import _raw_ast
 from angr.errors import SimMemoryError, SimAbstractMemoryError
-from angr.storage.memory_mixins import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 from .region_data import AddressWrapper, RegionMap
 from .abstract_address_descriptor import AbstractAddressDescriptor
 

--- a/angr/storage/memory_mixins/simple_interface_mixin.py
+++ b/angr/storage/memory_mixins/simple_interface_mixin.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+
 import claripy
 
-from . import MemoryMixin
 from angr.errors import SimMemoryError
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class SimpleInterfaceMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/simplification_mixin.py
+++ b/angr/storage/memory_mixins/simplification_mixin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from . import MemoryMixin
+
 from angr import sim_options as options
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class SimplificationMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/size_resolution_mixin.py
+++ b/angr/storage/memory_mixins/size_resolution_mixin.py
@@ -3,8 +3,8 @@ import logging
 
 import claripy
 
-from . import MemoryMixin
 from angr.errors import SimMemoryLimitError, SimMemoryError, SimUnsatError
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 l = logging.getLogger(__name__)
 

--- a/angr/storage/memory_mixins/slotted_memory.py
+++ b/angr/storage/memory_mixins/slotted_memory.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import claripy
 
-from . import MemoryMixin
-from .paged_memory.pages.ispo_mixin import ISPOMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
+from angr.storage.memory_mixins.paged_memory.pages.ispo_mixin import ISPOMixin
 from angr.errors import SimMergeError
 
 

--- a/angr/storage/memory_mixins/smart_find_mixin.py
+++ b/angr/storage/memory_mixins/smart_find_mixin.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import claripy
 
-from . import MemoryMixin
 from angr.errors import SimSegfaultException
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class SmartFindMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/symbolic_merger_mixin.py
+++ b/angr/storage/memory_mixins/symbolic_merger_mixin.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import Any
 
 import claripy
 
-from . import MemoryMixin
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class SymbolicMergerMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/top_merger_mixin.py
+++ b/angr/storage/memory_mixins/top_merger_mixin.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-from typing import Any
-from collections.abc import Iterable, Callable
 
-from . import MemoryMixin
+from collections.abc import Iterable, Callable
+from typing import Any
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class TopMergerMixin(MemoryMixin):

--- a/angr/storage/memory_mixins/underconstrained_mixin.py
+++ b/angr/storage/memory_mixins/underconstrained_mixin.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
-import claripy
+
 import logging
 
-from . import MemoryMixin
+import claripy
+
 from angr import sim_options as o
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 l = logging.getLogger(__name__)
 

--- a/angr/storage/memory_mixins/unwrapper_mixin.py
+++ b/angr/storage/memory_mixins/unwrapper_mixin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from . import MemoryMixin
+
+from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 
 class UnwrapperMixin(MemoryMixin):


### PR DESCRIPTION
This allows us to drop the circular imports for MemoryMixin