### PR TITLE
Update TestCtypeLocale to work cross-platform

### DIFF
--- a/tests/procedures/glibc/test_ctype_locale.py
+++ b/tests/procedures/glibc/test_ctype_locale.py
@@ -5,19 +5,17 @@ from __future__ import annotations
 __package__ = __package__ or "tests.procedures.glibc"  # pylint:disable=redefined-builtin
 
 import os
-import subprocess
 import unittest
 
 import angr
 
-from tests.common import bin_location, skip_if_not_linux
+from tests.common import bin_location
 
 
 test_location = os.path.join(bin_location, "tests")
 
 
 class TestCtypeLocale(unittest.TestCase):
-    @skip_if_not_linux
     def test_ctype_b_loc(self):
         """
         test_ctype_locale.test_ctype_b_loc
@@ -60,10 +58,11 @@ class TestCtypeLocale(unittest.TestCase):
             result += b"%d->0x%x\n" % (i, state.mem[table_ptr + i * 2].short.unsigned.concrete)
 
         # Check output of compiled C program that uses ctype_b_loc()
-        output = subprocess.check_output(bin_path, shell=True)
+        sim_mgr = b.factory.simulation_manager(b.factory.full_init_state(remove_options={angr.options.SYMBOLIC}))
+        sim_mgr.run()
+        output = sim_mgr.one_deadended.posix.dumps(1)
         assert result == output
 
-    @skip_if_not_linux
     def test_ctype_tolower_loc(self):
         """
         test_ctype_locale.test_ctype_tolower_loc
@@ -109,10 +108,11 @@ class TestCtypeLocale(unittest.TestCase):
             result += b"%d->0x%x\n" % (i, state.mem[table_ptr + i * 4].int.unsigned.concrete)
 
         # Check output of compiled C program that uses ctype_tolower_loc()
-        output = subprocess.check_output(bin_path, shell=True)
+        sim_mgr = b.factory.simulation_manager(b.factory.full_init_state(remove_options={angr.options.SYMBOLIC}))
+        sim_mgr.run()
+        output = sim_mgr.one_deadended.posix.dumps(1)
         assert result == output
 
-    @skip_if_not_linux
     def test_ctype_toupper_loc(self):
         """
         test_ctype_locale.test_ctype_toupper_loc
@@ -158,7 +158,9 @@ class TestCtypeLocale(unittest.TestCase):
             result += b"%d->0x%x\n" % (i, state.mem[table_ptr + i * 4].int.unsigned.concrete)
 
         # Check output of compiled C program that uses ctype_toupper_loc()
-        output = subprocess.check_output(bin_path, shell=True)
+        sim_mgr = b.factory.simulation_manager(b.factory.full_init_state(remove_options={angr.options.SYMBOLIC}))
+        sim_mgr.run()
+        output = sim_mgr.one_deadended.posix.dumps(1)
         assert result == output
 
 


### PR DESCRIPTION
Basically just replacing the subprocess call with a concrete execution with angr.