### PR TITLE
Cache hashes for TypeVariables, TypeConstraints, and Labels

### DIFF
--- a/angr/analyses/typehoon/typevars.py
+++ b/angr/analyses/typehoon/typevars.py
@@ -451,7 +451,7 @@ class BaseLabel:
     __slots__ = ("_cached_hash",)
 
     def __init__(self):
-        self._cached_hash = hash((type(self), *tuple(getattr(self, k) for k in self.__slots__)))
+        self._cached_hash = hash((type(self), *tuple(getattr(self, k) for k in self.__slots__ if k != "_cached_hash")))
 
     def __eq__(self, other):
         return type(self) is type(other) and self._cached_hash == other._cached_hash


### PR DESCRIPTION
I did some profiling on `tests/analyses/decompiler/test_decompiler.py::TestDecompiler::test_function_pointer_identification`
and `tests/analyses/decompiler/test_decompiler.py::TestDecompiler::test_decompiling_true_a_x86_64_0` and found that 17% of time was spent in the built-in hash function. Adding caches brought this down to just under 10%, but there must be some knock-on effects because the overall run times went from 86 and 82 seconds to 49 and 42 seconds, respectively. These two tests previously were some of the slowest tests in angr.