### PR TITLE
Fix checking of invalid instructions against the dirty addresses set.

### DIFF
--- a/angr/engines/vex/heavy/heavy.py
+++ b/angr/engines/vex/heavy/heavy.py
@@ -251,7 +251,13 @@ class HeavyVEXMixin(SuccessorsMixin, ClaripyDataMixin, SimStateStorageMixin, VEX
 
         # Raise an exception if we're suddenly in self-modifying code
         if (self.project is None or self.project.selfmodifying_code) and self.state.scratch.dirty_addrs:
-            for subaddr in range(stmt.len):
+            instruction_len = stmt.len
+            if instruction_len == 0:
+                # We don't know how long this instruction is.
+                # Conservatively assume it is the maximum instruction
+                # length for the purpose of dirty checks.
+                instruction_len = self.project.arch.max_inst_bytes
+            for subaddr in range(instruction_len):
                 if subaddr + stmt.addr in self.state.scratch.dirty_addrs:
                     raise errors.SimReliftException(self.state)
 

--- a/tests/sim/test_self_modifying_code.py
+++ b/tests/sim/test_self_modifying_code.py
@@ -68,11 +68,9 @@ class TestSelfModifyingCOde(TestCase):
         # .byte 0x6
         # mov rax, 0x1234
         # int3
-        code = b'\xc6\x05\x00\x00\x00\x00\x90\x06H\xc7\xc04\x12\x00\x00\xcc'
+        code = b"\xc6\x05\x00\x00\x00\x00\x90\x06H\xc7\xc04\x12\x00\x00\xcc"
         proj = angr.load_shellcode(code, "amd64", selfmodifying_code=True)
-        state = proj.factory.blank_state(
-            addr=0,
-            add_options={angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS})
+        state = proj.factory.blank_state(addr=0, add_options={angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS})
 
         simgr = proj.factory.simgr(state)
         simgr.step()
@@ -92,11 +90,9 @@ class TestSelfModifyingCOde(TestCase):
         # .byte 0xff
         # mov rbx, 0x1234
         # int3
-        code = b'H1\xc0\xc6\x05\x01\x00\x00\x00\xc0\xff\xffH\xc7\xc34\x12\x00\x00\xcc'
+        code = b"H1\xc0\xc6\x05\x01\x00\x00\x00\xc0\xff\xffH\xc7\xc34\x12\x00\x00\xcc"
         proj = angr.load_shellcode(code, "amd64", selfmodifying_code=True)
-        state = proj.factory.blank_state(
-            addr=0,
-            add_options={angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS})
+        state = proj.factory.blank_state(addr=0, add_options={angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS})
 
         simgr = proj.factory.simgr(state)
         simgr.step()
@@ -110,6 +106,7 @@ class TestSelfModifyingCOde(TestCase):
         rbx = simgr.active[0].regs.rbx
         assert rbx.concrete
         assert rbx.concrete_value == 0x1234
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
When an instruction cannot be disassembled, VEX can output an IMark with
an instruction length 0. Before this change, such instructions would
never trigger the dirty addresses set, so even after they have been
overwritten with a valid instruction, the engine would continue
emulating the stale, pre-overwrite IR. Fix this by conservatively
assuming that unknown-length instruction have the maximum instruction
length when checking whether they overlap a dirty addresses.
