### PR TITLE
Add seen list to workaround rare infinite loop in LoweredSwitchSimplifier

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -396,7 +396,14 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
             default_case_candidates = {}
             last_comp = None
             stack = [(head, 0, 0xFFFF_FFFF_FFFF_FFFF)]
-            while stack:
+
+            # cursed: there is an infinite loop in the following loop that
+            # occurs rarely. we need to keep track of the nodes we've seen
+            # to break out of the loop.
+            # FIXME: the root cause should be fixed and this workaround removed
+            seen = set()
+            while stack and tuple(stack) not in seen:
+                seen.add(tuple(stack))
                 comp, min_, max_ = stack.pop(0)
                 (
                     comp_type,

--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -400,6 +400,8 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
             # cursed: there is an infinite loop in the following loop that
             # occurs rarely. we need to keep track of the nodes we've seen
             # to break out of the loop.
+            # See https://github.com/angr/angr/pull/4953
+            #
             # FIXME: the root cause should be fixed and this workaround removed
             seen = set()
             while stack and tuple(stack) not in seen:

--- a/tests/analyses/decompiler/test_dogbolt_regressions.py
+++ b/tests/analyses/decompiler/test_dogbolt_regressions.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import unittest
+
+import angr
+
+from tests.common import bin_location
+
+
+BIN_PATH = os.path.join(bin_location, "tests", "dogbolt")
+
+
+class TestDogboltRegressions(unittest.TestCase):
+    def _run_dogbolt_test(self, binary_name: str):
+        p = angr.Project(os.path.join(BIN_PATH, binary_name), auto_load_libs=False, load_debug_info=False)
+
+        cfg = p.analyses.CFGFast(
+            normalize=True,
+            resolve_indirect_jumps=True,
+            data_references=True,
+        )
+        p.analyses.CompleteCallingConventions(cfg=cfg.model, recover_variables=True, analyze_callsites=True)
+
+        funcs_to_decompile = [
+            func
+            for func in cfg.functions.values()
+            if not func.is_plt and not func.is_simprocedure and not func.alignment
+        ]
+
+        for func in funcs_to_decompile:
+            decompiler = p.analyses.Decompiler(func, cfg=cfg.model)
+            self.assertIsNotNone(decompiler.codegen, f"No decompilation output for function {func.name}")
+
+    def test_megatest_arm64_freebsd(self):
+        """
+        This binary is used as a sample output on dogbolt as of October 2024,
+        and angr verstion 9.2.122 would time out when decompiling the __start
+        function due to an infinite loop in LoweredSwitchSimplifier. This test
+        case is used to verify that this does not regress.
+
+        See: https://github.com/angr/angr/pull/4953
+        """
+        self._run_dogbolt_test("megatest-arm64-freebsd")

--- a/tests/analyses/decompiler/test_dogbolt_regressions.py
+++ b/tests/analyses/decompiler/test_dogbolt_regressions.py
@@ -12,6 +12,10 @@ BIN_PATH = os.path.join(bin_location, "tests", "dogbolt")
 
 
 class TestDogboltRegressions(unittest.TestCase):
+    """
+    Tests to verify regressions do not occur on bugs found on dogbolt.
+    """
+
     def _run_dogbolt_test(self, binary_name: str):
         p = angr.Project(os.path.join(BIN_PATH, binary_name), auto_load_libs=False, load_debug_info=False)
 


### PR DESCRIPTION
Currently, this dogbolt sample times out with the angr decompiler: https://dogbolt.org/?id=5111f0f5-a5ac-4529-bd45-c2a6f30bfcb9. I tracked it down to this loop repeating infinitely. I didn't try and root cause it further but I found using this seen list prevented it and the output seemed reasonable. Might look to root cause it later (or anyone else is welcome to) but I want to merge this before the Tuesday release if a better solution is not found.

https://github.com/angr/binaries/pull/128