### PR TITLE
Decompiler: Manage `DecompilationCache` entries in `kb.decompilations`

### DIFF
--- a/angr/analyses/decompiler/decompilation_cache.py
+++ b/angr/analyses/decompiler/decompilation_cache.py
@@ -14,6 +14,7 @@ class DecompilationCache:
     """
 
     __slots__ = (
+        "parameters",
         "addr",
         "type_constraints",
         "func_typevar",
@@ -25,6 +26,7 @@ class DecompilationCache:
     )
 
     def __init__(self, addr):
+        self.parameters: dict[str, Any] = {}
         self.addr = addr
         self.type_constraints: set | None = None
         self.func_typevar = None

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -122,7 +122,7 @@ class Decompiler(Analysis):
 
         # Load from cache
         try:
-            cache = self.kb.structured_code[(self.func.addr, self._flavor)]
+            cache = self.kb.decompilations[self.func.addr]
             old_codegen = cache.codegen
             old_clinic = cache.clinic
             ite_exprs = cache.ite_exprs if self._ite_exprs is None else self._ite_exprs
@@ -301,6 +301,8 @@ class Decompiler(Analysis):
         self.ail_graph = clinic.cc_graph
         self.cache.codegen = codegen
         self.cache.clinic = self.clinic
+
+        self.kb.decompilations[self.func.addr] = self.cache
 
     def _recover_regions(self, graph: networkx.DiGraph, condition_processor, update_graph: bool = True):
         return self.project.analyses[RegionIdentifier].prep(kb=self.kb)(

--- a/angr/knowledge_plugins/__init__.py
+++ b/angr/knowledge_plugins/__init__.py
@@ -17,6 +17,7 @@ from .structured_code import StructuredCodeManager
 from .types import TypesStore
 from .callsite_prototypes import CallsitePrototypes
 from .custom_strings import CustomStrings
+from .decompilation import DecompilationManager
 
 
 __all__ = (
@@ -38,4 +39,5 @@ __all__ = (
     "TypesStore",
     "CallsitePrototypes",
     "CustomStrings",
+    "DecompilationManager",
 )

--- a/angr/knowledge_plugins/decompilation.py
+++ b/angr/knowledge_plugins/decompilation.py
@@ -1,0 +1,45 @@
+# pylint:disable=import-outside-toplevel
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from .plugin import KnowledgeBasePlugin
+
+if TYPE_CHECKING:
+    from angr.analyses.decompiler.decompilation_cache import DecompilationCache
+
+
+class DecompilationManager(KnowledgeBasePlugin):
+    """A knowledge base plugin to store decompilation results."""
+
+    def __init__(self, kb):
+        super().__init__(kb=kb)
+        self.cached: dict[Any, DecompilationCache] = {}
+
+    def _normalize_key(self, item: int | str):
+        if type(item) is str:
+            item = (self._kb.labels.lookup(item[0]), *item[1:])
+        return item
+
+    def __getitem__(self, item) -> DecompilationCache:
+        return self.cached[self._normalize_key(item)]
+
+    def __setitem__(self, key, value: DecompilationCache):
+        self.cached[self._normalize_key(key)] = value
+
+    def __contains__(self, key):
+        return self._normalize_key(key) in self.cached
+
+    def __delitem__(self, key):
+        del self.cached[self._normalize_key(key)]
+
+    def discard(self, key):
+        normalized_key = self._normalize_key(key)
+        if normalized_key in self.cached:
+            del self.cached[normalized_key]
+
+    def copy(self):
+        raise NotImplementedError
+
+
+KnowledgeBasePlugin.register_default("decompilations", DecompilationManager)


### PR DESCRIPTION
Decompiler caching as it works today:
* `Decompiler` analysis makes use of `CStructuredCodeGen` for C pseudocode generation
* `CStructuredCodeGen` caches its results in `StructuredCodeManager` via `kb.structured_code`.
   * Likewise, `ImportSourceCode` analysis also caches its results in `kb.structured_code` as it is a `BaseStructuredCodeGenerator`
* `Decompiler` analysis checks `kb.structured_code` for optimistic re-use of prior work
* `StructuredCodeManager` automatically wraps inserted `BaseStructuredCodeGenerator` results as `DecompilationCache`, with misc. other fields not strictly related to code generation (but concerning Decompilation) defaulting to None
* angr-management [updates](https://github.com/angr/angr-management/blob/389bf4f482e9f08a3e7130e8853ede9f824db1f1/angrmanagement/data/jobs/decompile_function.py#L33) `kb.structured_code` whenever it runs `Decompiler` analysis with `Decompiler::cache` results to cache additional results that the above flow is unable to capture, such as the direct results of `Clinic` analysis

A few issues:
* Some parameters, like `options` and `optimization_passes` (`preset`), may influence decompilation results. These parameters are not checked when using cached `DecompilationCache` entries.
* Incomplete `DecompilationCache` entries are inserted into the `StructuredCodeManager`. When running decompilation again, some work is lost.
* `Decompiler` assumes `DecompilationCache::codegen` is actually a `CStructuredCodeGen` and accesses `CStructuredCodeGenerator::_variable_kb`
* angr-management is left responsible for inserting a fully-formed `DecompilationCache` entry into the knowledge base, overwriting what `CStructuredCodeGen` put there.

Instead of trying to shoehorn `DecompilationCache` items into the `StructuredCodeManager` this PR begins separating these concerns with the following changes:
* Add `DecompilationManager` to the knowledge base via `kb.decompilations`
* Add `DecompilationCache` entries to the knowledge base in `Decompiler` analysis
* Check `Decompiler` parameters for cache invalidation
* Add `use_cache` parameter to `Decompiler` analysis as a way to clearly disable loading from cache

Phased changes to come in follow-up PRs:
* Remove decompilation knowledge base insertion in angr-management.
* Remove `StructuredCodeManager`'s wrapping of entries in `DecompilationCache` objects
* Serialization
