### PR TITLE
sqlalchemy declaritive_base moved

### DIFF
--- a/angr/angrdb/models.py
+++ b/angr/angrdb/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from sqlalchemy import Column, Integer, String, Boolean, BLOB, ForeignKey
-from sqlalchemy.orm import relationship
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
 

--- a/angr/exploration_techniques/spiller_db.py
+++ b/angr/exploration_techniques/spiller_db.py
@@ -5,8 +5,7 @@ import datetime
 try:
     import sqlalchemy
     from sqlalchemy import Column, Integer, String, Boolean, DateTime, create_engine
-    from sqlalchemy.orm import sessionmaker
-    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import declarative_base, sessionmaker
     from sqlalchemy.exc import OperationalError
 
     Base = declarative_base()


### PR DESCRIPTION
This should address warnings from SQLAlchemy

`angr/angrdb/models.py:6: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9) Base = declarative_base()`
