### PR TITLE
fix use of deprecated `alignment` call

### DIFF
--- a/angr/knowledge_plugins/functions/function_parser.py
+++ b/angr/knowledge_plugins/functions/function_parser.py
@@ -33,7 +33,7 @@ class FunctionParser:
         obj.is_syscall = function.is_syscall
         obj.is_simprocedure = function.is_simprocedure
         obj.returning = function.returning
-        obj.alignment = function.alignment
+        obj.alignment = function.is_alignment
         obj.binary_name = function.binary_name or ""
         obj.normalized = function.normalized
 


### PR DESCRIPTION
Addresses a warning shown after applying #5000
