### PR TITLE
SPropagator: Propagate global variable to uses more aggressively.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1043,6 +1043,7 @@ class Clinic(Analysis):
                                 reg_name=self.project.arch.translate_register_name(
                                     ret_reg_offset, size=self.project.arch.bits
                                 ),
+                                **target.tags,
                             )
                             call_stmt = ailment.Stmt.Call(
                                 None,

--- a/angr/analyses/decompiler/dephication/graph_vvar_mapping.py
+++ b/angr/analyses/decompiler/dephication/graph_vvar_mapping.py
@@ -290,8 +290,7 @@ class GraphDephicationVVarMapping(Analysis):  # pylint:disable=abstract-method
         for stmt in dst_block.statements:
             if isinstance(stmt, Label):
                 continue
-            r, _ = is_phi_assignment(stmt)
-            if r:
+            if is_phi_assignment(stmt):
                 for src_, vvar in stmt.src.src_and_vvars:
                     if src_ == src and vvar is not None and vvar.varid == vvar_id:
                         return True

--- a/angr/analyses/decompiler/ssailification/traversal.py
+++ b/angr/analyses/decompiler/ssailification/traversal.py
@@ -32,6 +32,7 @@ class TraversalAnalysis(ForwardAnalysis[None, NodeType, object, object]):
         )
         self._engine_ail = SimEngineSSATraversal(
             self.project.arch,
+            self.project.simos,
             sp_tracker=sp_tracker,
             bp_as_gpr=bp_as_gpr,
             stackvars=self._stackvars,

--- a/angr/analyses/s_liveness.py
+++ b/angr/analyses/s_liveness.py
@@ -5,7 +5,7 @@ from ailment.expression import VirtualVariable
 from ailment.statement import Assignment
 
 from angr.analyses import Analysis, register_analysis
-from angr.utils.ssa import is_phi_assignment, VVarUsesCollector
+from angr.utils.ssa import VVarUsesCollector, phi_assignment_get_src
 
 
 class SLivenessModel:
@@ -85,8 +85,8 @@ class SLivenessAnalysis(Analysis):
                 if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable):
                     live.discard(stmt.dst.varid)
 
-                r, phi_expr = is_phi_assignment(stmt)
-                if r:
+                phi_expr = phi_assignment_get_src(stmt)
+                if phi_expr is not None:
                     for src, vvar in phi_expr.src_and_vvars:
                         if src not in live_in_by_pred:
                             live_in_by_pred[src] = live.copy()

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1654,7 +1654,7 @@ class SimCCAMD64WindowsSyscall(SimCCSyscall):
 class SimCCARM(SimCC):
     ARG_REGS = ["r0", "r1", "r2", "r3"]
     FP_ARG_REGS = []  # regular arg regs are used as fp arg regs
-    CALLER_SAVED_REGS = []
+    CALLER_SAVED_REGS = ["r0", "r1", "r2", "r3"]
     RETURN_ADDR = SimRegArg("lr", 4)
     RETURN_VAL = SimRegArg("r0", 4)
     OVERFLOW_RETURN_VAL = SimRegArg("r1", 4)

--- a/angr/utils/ssa/__init__.py
+++ b/angr/utils/ssa/__init__.py
@@ -178,10 +178,14 @@ def is_const_vvar_load_dirty_assignment(stmt: Statement) -> bool:
     return False
 
 
-def is_phi_assignment(stmt: Statement) -> tuple[bool, Phi | None]:
+def is_phi_assignment(stmt: Statement) -> bool:
+    return isinstance(stmt, Assignment) and isinstance(stmt.src, Phi)
+
+
+def phi_assignment_get_src(stmt: Statement) -> Phi | None:
     if isinstance(stmt, Assignment) and isinstance(stmt.src, Phi):
-        return True, stmt.src
-    return False, None
+        return stmt.src
+    return None
 
 
 __all__ = (
@@ -190,6 +194,7 @@ __all__ = (
     "get_vvar_uselocs",
     "is_const_assignment",
     "is_phi_assignment",
+    "phi_assignment_get_src",
     "is_const_and_vvar_assignment",
     "is_const_vvar_load_assignment",
     "is_const_vvar_load_dirty_assignment",

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2012,7 +2012,7 @@ class TestDecompiler(unittest.TestCase):
         m = re.search(r"[*(]*v(\d+)\)*=[^=;]*input_seek_errno[^=;]*;", condensed)
         assert m is not None
         v_input_seed_errno = m.group(1)
-        assert re.search(r"v" + v_input_seed_errno + "=__errno_location\(\);", condensed)
+        assert re.search(r"v" + v_input_seed_errno + r"=__errno_location\(\);", condensed)
 
     @structuring_algo("sailr")
     def test_decompiling_dd_iwrite(self, decompiler_options=None):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2005,15 +2005,14 @@ class TestDecompiler(unittest.TestCase):
         self._print_decompilation_result(d)
 
         condensed = d.codegen.text.replace(" ", "").replace("\n", "")
-        #         v1 = *((int *)&input_seek_errno);
-        #         if (v1 == 29)
+        #         if (*((int *)&input_seek_errno) == 29)
         #             return 1;
-        #         v2 = __errno_location();
-        #         *(v2) = v1;
-        m = re.search(r"v(\d+)=[^=;]*input_seek_errno[^=;]*;", condensed)
+        #         v1 = __errno_location();
+        #         *(v1) = *((int *)&input_seek_errno);
+        m = re.search(r"[*(]*v(\d+)\)*=[^=;]*input_seek_errno[^=;]*;", condensed)
         assert m is not None
         v_input_seed_errno = m.group(1)
-        assert re.search(r"v\d=__errno_location\(\);\*\(v\d\)=v" + v_input_seed_errno + r";", condensed)
+        assert re.search(r"v" + v_input_seed_errno + "=__errno_location\(\);", condensed)
 
     @structuring_algo("sailr")
     def test_decompiling_dd_iwrite(self, decompiler_options=None):
@@ -2999,9 +2998,16 @@ class TestDecompiler(unittest.TestCase):
             f, cfg=cfg.model, options=decompiler_options_0, optimization_passes=all_optimization_passes
         )
         self._print_decompilation_result(dec)
+        # do
+        # {
+        #     v3 = fgetc(v2);
+        #     *(a0) = v3;
+        # } while (v3 == -1 && (v2 = *(&in_stream),
+        #                       v1 &= check_and_close(*(__errno_location())) & open_next_file(),
+        #                       *(&in_stream)));
         assert (
             re.search(
-                r"v\d+ = [^\n]*in_stream[^\n]*, v\d+ &= [^\n]*check_and_close\([^\n]+open_next_file\([^\n]+, [^\n]*v\d+\)",
+                r"v\d+ = [^\n]*in_stream[^\n]*, v\d+ &= [^\n]*check_and_close\(\*\(__errno_location\(\)\)\)[^\n]+open_next_file\(\)",
                 dec.codegen.text,
             )
             is not None


### PR DESCRIPTION
Also includes:
- Ensure is_phi_assignment() returns a bool instead of a tuple.
- Add phi_assignment_get_src() to get the Phi variable.
- Fix a bug in TraversalEngine that caller-saved registers are not cleared after calls.
- Update caller-saved registers for SimCCARM.