### PR TITLE
Disable self-modifying code tests on non-linux

### DIFF
--- a/tests/analyses/test_smc.py
+++ b/tests/analyses/test_smc.py
@@ -8,6 +8,7 @@ import unittest
 import archinfo
 
 import angr
+from tests.common import skip_if_not_linux
 
 
 def nasm(asm: str) -> bytes:
@@ -45,6 +46,7 @@ def gcc(c: str) -> str:
             os.unlink(f_in.name)
 
 
+@skip_if_not_linux
 class TestTraceClassifier(unittest.TestCase):
     """
     TraceClassifier tests


### PR DESCRIPTION
These tests were written to assemble or compile their test cases at test-runtime. This is a **TERRIBLE** idea for portability, maintainability, and portability reasons. Someone should compile these and commit them to the binaries repo so that this test can be re-enabled.