### PR TITLE
Disable corpus tests for pull requests

### DIFF
--- a/.github/workflows/corpus_test.yml
+++ b/.github/workflows/corpus_test.yml
@@ -1,9 +1,6 @@
 name: Corpus Test
 
 on:
-  pull_request:
-    branches:
-      - master
   workflow_call:
     inputs:
       corpus_github_path:


### PR DESCRIPTION
The plan is to re-enable this once issues are worked out