### PR TITLE
Decompiler: Fix CFunctionCall c_repr_chunks for str callee_target

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1299,6 +1299,8 @@ class CFunctionCall(CStatement, CExpression):
             if self.show_disambiguated_name and self._is_target_ambiguous(func_name):
                 func_name = self.callee_func.get_unambiguous_name(display_name=func_name)
             yield func_name, self
+        elif isinstance(self.callee_target, str):
+            yield self.callee_target, self
         else:
             yield from CExpression._try_c_repr_chunks(self.callee_target)
 


### PR DESCRIPTION
Fixes an issue where function calls with string target names (e.g. uninlined strcpy) are not correctly resolved in angr-management.

If the function call is generated with a string in callee_target, yield the CFunctionCall object properly so it will be tracked in position maps.