### PR TITLE
SimLinux: Explicitly check syscall opcode

### DIFF
--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -193,7 +193,7 @@ class SimLinux(SimUserland):
             jk = state.history.parent.jumpkind
         if jk == "Ijk_Sys_int128":
             return "i386"
-        if jk == "Ijk_Sys_syscall" and state.solver.eval(state.memory.load(state.regs.ip_at_syscall, 2) == 0x050f):
+        if jk == "Ijk_Sys_syscall" and state.solver.eval(state.memory.load(state.regs.ip_at_syscall, 2) == 0x050F):
             return "amd64"
         raise AngrSyscallError(f"Unknown syscall jumpkind {jk}")
 

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -193,7 +193,7 @@ class SimLinux(SimUserland):
             jk = state.history.parent.jumpkind
         if jk == "Ijk_Sys_int128":
             return "i386"
-        if jk == "Ijk_Sys_syscall":
+        if jk == "Ijk_Sys_syscall" and state.solver.eval(state.memory.load(state.regs.ip_at_syscall, 2) == 0x050f):
             return "amd64"
         raise AngrSyscallError(f"Unknown syscall jumpkind {jk}")
 


### PR DESCRIPTION
After https://github.com/angr/vex/commit/390c47639d597eedbfc844f585131ba3561fabf9, avoid false positives in syscall ABI detection. Resolves failing test case invoking `int 0xd2`