### PR TITLE
DuplicationReverter: Reduce RuntimeErrors to soft fails

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -287,7 +287,9 @@ class DuplicationReverter(StructuringOptimizationPass):
                                 break
 
                         if new_target is None:
-                            raise RuntimeError("Unable to correct a predecessor, this is a bug!")
+                            _l.debug("Unable to correct a predecessor, this is a bug!")
+                            self.write_graph = self.read_graph.copy()
+                            return False
 
                     replacement_map[target_addr] = new_target.addr
                     self.write_graph.add_edge(orig_pred, new_target)
@@ -316,7 +318,9 @@ class DuplicationReverter(StructuringOptimizationPass):
                         break
 
                 if new_succ is None:
-                    raise RuntimeError("Unable to find the successor for block with no jump or condition!")
+                    _l.debug("Unable to find the successor for block with no jump or condition!")
+                    self.write_graph = self.read_graph.copy()
+                    return False
 
                 self.write_graph.add_edge(orig_pred, new_succ)
 


### PR DESCRIPTION
re: #5096

Underlying issue still needs to be root caused, but we don't need to fail decompilation with a `RuntimeError` in this case. Reduce error to a debug message and abort the pass.