### PR TITLE
replace_node_in_graph: Drop 'node not in graph' assertion

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/utils.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/utils.py
@@ -8,8 +8,8 @@ from ailment import Const
 from ailment.block import Block
 from ailment.statement import Statement, ConditionalJump, Jump
 
-from .errors import UnsupportedAILNodeError
 from angr.analyses.decompiler.structuring.structurer_nodes import IncompleteSwitchCaseHeadStatement
+from .errors import UnsupportedAILNodeError
 
 
 _l = logging.getLogger(name=__name__)

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/utils.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/utils.py
@@ -47,8 +47,6 @@ def replace_node_in_graph(graph: nx.DiGraph, node, replace_with):
         else:
             graph.add_edge(replace_with, dst)
 
-    assert node not in graph
-
 
 def bfs_list_blocks(start_block: Block, graph: nx.DiGraph):
     blocks = []


### PR DESCRIPTION
assertion fails when nodes are equal

Fix #5098 
