### PR TITLE
Dephication: Fix two issues on vvar copying.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -600,7 +600,7 @@ class Clinic(Analysis):
             arg_list.append(arg_vvars[idx][1])
 
         # Get virtual variable mapping that can de-phi the SSA representation
-        vvar2vvar = self._collect_dephi_vvar_mapping_and_rewrite_blocks(ail_graph)
+        vvar2vvar, copied_vvar_ids = self._collect_dephi_vvar_mapping_and_rewrite_blocks(ail_graph, arg_vvars)
 
         # Recover variables on AIL blocks
         self._update_progress(80.0, text="Recovering variables")
@@ -608,7 +608,11 @@ class Clinic(Analysis):
 
         # Run simplification passes
         self._update_progress(85.0, text="Running simplifications 4")
-        ail_graph = self._run_simplification_passes(ail_graph, stage=OptimizationPassStage.AFTER_VARIABLE_RECOVERY)
+        ail_graph = self._run_simplification_passes(
+            ail_graph,
+            stage=OptimizationPassStage.AFTER_VARIABLE_RECOVERY,
+            avoid_vvar_ids=copied_vvar_ids,
+        )
 
         # Make function prototype
         self._update_progress(90.0, text="Making function prototype")
@@ -1389,16 +1393,19 @@ class Clinic(Analysis):
         return ssailification.out_graph
 
     @timethis
-    def _collect_dephi_vvar_mapping_and_rewrite_blocks(self, ail_graph: networkx.DiGraph) -> dict[int, int]:
+    def _collect_dephi_vvar_mapping_and_rewrite_blocks(
+        self, ail_graph: networkx.DiGraph, arg_vvars: dict[int, tuple[ailment.Expr.VirtualVariable, SimVariable]]
+    ) -> tuple[dict[int, int], set[int]]:
         dephication = self.project.analyses.GraphDephicationVVarMapping(
             self.function,
             ail_graph,
             fail_fast=self._fail_fast,
             entry=next(iter(bb for bb in ail_graph if (bb.addr, bb.idx) == self.entry_node_addr)),
             vvar_id_start=self.vvar_id_start,
+            arg_vvars=[arg_vvar for arg_vvar, _ in arg_vvars.values()],
         )
         self.vvar_id_start = dephication.vvar_id_start + 1
-        return dephication.vvar_to_vvar_mapping
+        return dephication.vvar_to_vvar_mapping, dephication.copied_vvar_ids
 
     @timethis
     def _make_argument_list(self) -> list[SimVariable]:

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -125,6 +125,7 @@ class OptimizationPass(BaseOptimizationPass):
         scratch: dict[str, Any] | None = None,
         force_loop_single_exit: bool = True,
         complete_successors: bool = False,
+        avoid_vvar_ids: set[int] | None = None,
         **kwargs,
     ):
         super().__init__(func)
@@ -143,6 +144,7 @@ class OptimizationPass(BaseOptimizationPass):
         )
         self._force_loop_single_exit = force_loop_single_exit
         self._complete_successors = complete_successors
+        self._avoid_vvar_ids = avoid_vvar_ids or set()
 
         # output
         self.out_graph: networkx.DiGraph | None = None
@@ -268,6 +270,7 @@ class OptimizationPass(BaseOptimizationPass):
                 func_graph=graph,
                 use_callee_saved_regs_at_return=False,
                 gp=self._func.info.get("gp", None) if self.project.arch.name in {"MIPS32", "MIPS64"} else None,
+                avoid_vvar_ids=self._avoid_vvar_ids,
             )
             if simp.simplified:
                 graph = simp.func_graph

--- a/angr/utils/ssa/__init__.py
+++ b/angr/utils/ssa/__init__.py
@@ -14,6 +14,9 @@ from .vvar_uses_collector import VVarUsesCollector
 from .tmp_uses_collector import TmpUsesCollector
 
 
+DEPHI_VVAR_REG_OFFSET = 4096
+
+
 @overload
 def get_reg_offset_base_and_size(
     reg_offset: int, arch: archinfo.Arch, size: int | None = None, resilient: Literal[True] = True
@@ -204,6 +207,10 @@ def phi_assignment_get_src(stmt: Statement) -> Phi | None:
     if isinstance(stmt, Assignment) and isinstance(stmt.src, Phi):
         return stmt.src
     return None
+
+
+def is_dephi_vvar(vvar: VirtualVariable) -> bool:
+    return vvar.varid == DEPHI_VVAR_REG_OFFSET
 
 
 __all__ = (


### PR DESCRIPTION
- Process function arguments when calculating interference graphs as if the arguments are defined at the beginning of the first function block.

- Ensure dephication-created vvars are not simplified away when AILSimplifier is folding expressions again.

- Add a test case.

Closes #5077.