### PR TITLE
Remove uninitialized parameter from BVS

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -10,6 +10,7 @@ import functools
 import pyvex
 import claripy
 from archinfo.arch_arm import is_arm_arch
+from claripy.annotation import UninitializedAnnotation
 
 from angr import sim_options as o
 from angr import BP, BP_BEFORE, BP_AFTER
@@ -2169,7 +2170,7 @@ class JumpTableResolver(IndirectJumpResolver):
         read_addr = state.inspect.mem_read_address
         cond = state.inspect.mem_read_condition
 
-        if not isinstance(read_addr, int) and read_addr.uninitialized and cond is None:
+        if not isinstance(read_addr, int) and read_addr.has_annotation_type(UninitializedAnnotation) and cond is None:
             # if this AST has been initialized before, just use the cached addr
             cached_addr = self._cached_memread_addrs.get(read_addr, None)
             if cached_addr is not None:

--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -408,18 +408,23 @@ class SimSolver(SimStatePlugin):
         if key is not None and eternal and key in self.eternal_tracked_variables:
             r = self.eternal_tracked_variables[key]
             # pylint: disable=too-many-boolean-expressions
-            if size != r.length or uninitialized != r.uninitialized or bool(explicit_name) ^ (r.args[0] == name):
+            if (
+                size != r.length
+                or uninitialized != r.has_annotation_type(claripy.annotation.UninitializedAnnotation)
+                or bool(explicit_name) ^ (r.args[0] == name)
+            ):
                 l.warning("Variable %s being retrieved with different settings than it was tracked with", name)
         else:
             r = claripy.BVS(
                 name,
                 size,
-                uninitialized=uninitialized,
                 explicit_name=explicit_name,
                 **kwargs,
             )
             if any(x is not None for x in (min, max, stride)):
                 r = r.annotate(claripy.annotation.StridedIntervalAnnotation(stride, min, max))
+            if uninitialized:
+                r = r.annotate(claripy.annotation.UninitializedAnnotation())
             if key is not None:
                 self.register_variable(r, key, eternal)
 

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -990,7 +990,7 @@ class Unicorn(SimStatePlugin):
         :param from_where: the ID of the memory region it comes from ('mem' or 'reg')
         :returns: the value to be inserted into Unicorn, or None
         """
-        allowed_annotations = (claripy.annotations.UninitializedAnnotation,)
+        allowed_annotations = (claripy.annotation.UninitializedAnnotation,)
         filtered_annotations = [
             a for a in d.annotations if not isinstance(a, allowed_annotations) and not a.eliminatable
         ]

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -990,7 +990,11 @@ class Unicorn(SimStatePlugin):
         :param from_where: the ID of the memory region it comes from ('mem' or 'reg')
         :returns: the value to be inserted into Unicorn, or None
         """
-        if len(d.annotations):
+        allowed_annotations = (claripy.annotations.UninitializedAnnotation,)
+        filtered_annotations = [
+            a for a in d.annotations if not isinstance(a, allowed_annotations) and not a.eliminatable
+        ]
+        if len(filtered_annotations) > 0:
             l.debug("Blocking annotated AST.")
             return None
         if not d.symbolic:

--- a/angr/storage/memory_mixins/regioned_memory/abstract_merger_mixin.py
+++ b/angr/storage/memory_mixins/regioned_memory/abstract_merger_mixin.py
@@ -4,6 +4,8 @@ import logging
 from collections.abc import Iterable
 from typing import Any
 
+from claripy.annotation import UninitializedAnnotation
+
 from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
 l = logging.getLogger(name=__name__)
@@ -17,13 +19,13 @@ class AbstractMergerMixin(MemoryMixin):
         merged_val = values[0][0]
 
         for tm, _ in values[1:]:
-            if tm.uninitialized:
+            if tm.has_annotation_type(UninitializedAnnotation):
                 continue
             l.info("Merging %s %s...", merged_val, tm)
             merged_val = merged_val.union(tm)
             l.info("... Merged to %s", merged_val)
 
-        if not values[0][0].uninitialized and merged_val.identical(values[0][0]):
+        if not values[0][0].has_annotation_type(UninitializedAnnotation) and merged_val.identical(values[0][0]):
             return None
 
         return merged_val

--- a/angr/storage/memory_mixins/smart_find_mixin.py
+++ b/angr/storage/memory_mixins/smart_find_mixin.py
@@ -134,7 +134,7 @@ class SmartFindMixin(MemoryMixin):
     def _find_are_bytes_symbolic(self, b):
         if not b.symbolic:
             return False
-        if b.uninitialized:
+        if b.has_annotation_type(claripy.annotation.UninitializedAnnotation):
             return True
         return len(self.state.solver.eval_upto(b, 2)) > 1
 

--- a/angr/storage/memory_mixins/underconstrained_mixin.py
+++ b/angr/storage/memory_mixins/underconstrained_mixin.py
@@ -52,7 +52,7 @@ class UnderconstrainedMixin(MemoryMixin):
         if (
             o.UNDER_CONSTRAINED_SYMEXEC in self.state.options
             and isinstance(addr, claripy.ast.Base)
-            and addr.uninitialized
+            and addr.has_annotation_type(claripy.annotation.UninitializedAnnotation)
             and self.state.uc_manager.get_alloc_depth(addr) is not None
         ) and (
             not self.state.uc_manager.is_bounded(addr)

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -128,9 +128,9 @@ class TestMemory(unittest.TestCase):
         expr = s.memory.load(100, 4)
         assert expr is claripy.BVV(0x1337, 32)
         expr = s.memory.load(100, 2)
-        assert expr is claripy.BVV(0, 16)
+        assert expr.clear_annotations() is claripy.BVV(0, 16)
         expr = s.memory.load(102, 2)
-        assert expr is claripy.BVV(0x1337, 16)
+        assert expr.clear_annotations() is claripy.BVV(0x1337, 16)
 
         # partially symbolic
         expr = s.memory.load(102, 4)
@@ -141,13 +141,13 @@ class TestMemory(unittest.TestCase):
         # partial overwrite
         s.memory.store(101, claripy.BVV(0x1415, 16))
         expr = s.memory.load(101, 3)
-        assert expr is claripy.BVV(0x141537, 24)
+        assert expr.clear_annotations() is claripy.BVV(0x141537, 24)
         expr = s.memory.load(100, 2)
         assert s.solver.min(expr) == 0x14
         expr = s.memory.load(102, 2)
-        assert expr is claripy.BVV(0x1537, 16)
+        assert expr.clear_annotations() is claripy.BVV(0x1537, 16)
         expr = s.memory.load(102, 2, endness="Iend_LE")
-        assert expr is claripy.BVV(0x3715, 16)
+        assert expr.clear_annotations() is claripy.BVV(0x3715, 16)
 
         s.memory.store(0x100, claripy.BVV(b"AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"), endness="Iend_LE")
         expr = s.memory.load(0x104, 13)

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -6,6 +6,7 @@ import time
 import unittest
 
 import claripy
+from claripy.annotation import UninitializedAnnotation
 
 from angr.storage.memory_mixins import (
     DataNormalizationMixin,
@@ -756,7 +757,7 @@ class TestMemory(unittest.TestCase):
         # test that under-constrained load is constrained
         ptr1 = state.memory.load(0x4141414141414000, size=8, endness="Iend_LE")
         assert state.uc_manager.get_alloc_depth(ptr1) == 0
-        assert ptr1.uninitialized
+        assert ptr1.has_annotation_type(UninitializedAnnotation)
         state.memory.load(ptr1, size=1)
         # ptr1 should have been constrained
         assert state.solver.min_int(ptr1) == state.solver.max_int(ptr1)
@@ -764,7 +765,7 @@ class TestMemory(unittest.TestCase):
         # test that under-constrained store is constrained
         ptr2 = state.memory.load(0x4141414141414008, size=8, endness="Iend_LE")
         assert state.uc_manager.get_alloc_depth(ptr2) == 0
-        assert ptr2.uninitialized
+        assert ptr2.has_annotation_type(UninitializedAnnotation)
         state.memory.store(ptr2, b"\x41", size=1)
         # ptr2 should have been constrained
         assert state.solver.min_int(ptr2) == state.solver.max_int(ptr2)
@@ -777,7 +778,7 @@ class TestMemory(unittest.TestCase):
             state.memory.load(0x4141414141414010, size=4, endness="Iend_LE"),
             state.memory.load(0x4141414141414014, size=4, endness="Iend_LE"),
         )
-        assert ptr3.uninitialized
+        assert ptr3.has_annotation_type(UninitializedAnnotation)
         assert state.uc_manager.get_alloc_depth(ptr3) is None  # because uc_alloc_depth doesn't carry across Concat
         # we don't care what these do, as long as they don't crash
         state.memory.store(ptr3, b"\x41", size=1)


### PR DESCRIPTION
Two steps backwards for removing use of vsa backend, one step forward for removing an unnecessary built-in param.

https://github.com/angr/claripy/pull/581