### PR TITLE
Upgrade unicorn to 2.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     rich>=13.1.0
     sortedcontainers
     sympy
-    unicorn==2.0.1.post1
+    unicorn>=2.1.0
     unique-log-filter
     colorama;platform_system=='Windows'
 python_requires = >=3.10


### PR DESCRIPTION
What does it take to do this?

It looks like it was originally pinned here: https://github.com/angr/angr/issues/3732.

As far as I can tell (I just tested it) `pip install unicorn` on a mac works no problem, and gives me 2.1.1.

The issue I'm facing is that `angr` has been marked as broken in `nixpkgs` as a result of pinning to an old version of unicorn (https://github.com/NixOS/nixpkgs/pull/344273). 