### PR TITLE
Decompiler: Support decompiling amd64-no-ob-check jumptables.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1690,6 +1690,9 @@ class Clinic(Analysis):
             elif stmt_type is ailment.Stmt.ConditionalJump:
                 self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt, stmt.condition)
 
+            elif stmt_type is ailment.Stmt.Jump and not isinstance(stmt.target, ailment.Expr.Const):
+                self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt, stmt.target)
+
             elif stmt_type is ailment.Stmt.Call:
                 self._link_variables_on_call(variable_manager, global_variables, block, stmt_idx, stmt, is_expr=False)
 

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -1,4 +1,5 @@
 # pylint:disable=line-too-long,import-outside-toplevel,import-error,multiple-statements,too-many-boolean-expressions
+# ruff: noqa: SIM102
 from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 from collections import defaultdict, OrderedDict

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -1673,6 +1673,7 @@ class PhoenixStructurer(StructurerBase):
             except EmptyBlockNotice:
                 return False
             return len(last_stmts) == 1 and isinstance(last_stmts[0], Jump)
+        return False
 
     def _is_switch_cases_address_loaded_from_memory_head_or_jumpnode(self, graph, node) -> bool:
         if self._is_node_unstructured_switch_case_head(node):

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -277,6 +277,7 @@ def switch_extract_bitwiseand_jumptable_info(last_stmt: ailment.Stmt.Jump) -> tu
 
     if coeff is not None and index_expr is not None and lb is not None and ub is not None:
         return index_expr, lb, ub
+    return None
 
 
 def get_ast_subexprs(claripy_ast):

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -175,6 +175,110 @@ def switch_extract_cmp_bounds(last_stmt: ailment.Stmt.ConditionalJump) -> tuple[
     return None
 
 
+def switch_extract_bitwiseand_jumptable_info(last_stmt: ailment.Stmt.Jump) -> tuple[Any, int, int] | None:
+    """
+    Check the last statement of the switch-case header node (whose address is loaded from a jump table and computed
+    using an index) and extract necessary information for rebuilding the switch-case construct.
+
+    An example of the statement:
+
+    Goto(Conv(32->s64, (
+        Load(addr=(0x4530e4<64> + (Conv(32->64, (Conv(64->32, vvar_287{reg 32}) & 0x3<32>)) * 0x4<64>)),
+             size=4, endness=Iend_LE) + 0x4530e4<32>))
+    )
+
+    :param last_stmt:   The last statement of the switch-case header node.
+    :return:            A tuple of (index expression, lower bound, upper bound), or None
+    """
+
+    if not isinstance(last_stmt, ailment.Stmt.Jump):
+        return None
+
+    # unpack the target expression
+    target = last_stmt.target
+    jump_addr_offset = None
+    jumptable_load_addr = None
+    while True:
+        if isinstance(target, ailment.Expr.Convert) and (
+            (target.from_bits == 32 and target.to_bits == 64) or (target.from_bits == 16 and target.to_bits == 32)
+        ):
+            target = target.operand
+            continue
+        if isinstance(target, ailment.Expr.BinaryOp) and target.op == "Add":
+            if isinstance(target.operands[0], ailment.Expr.Const) and isinstance(target.operands[1], ailment.Expr.Load):
+                jump_addr_offset = target.operands[0]
+                jumptable_load_addr = target.operands[1].addr
+                break
+            if isinstance(target.operands[1], ailment.Expr.Const) and isinstance(target.operands[0], ailment.Expr.Load):
+                jump_addr_offset = target.operands[1]
+                jumptable_load_addr = target.operands[0].addr
+                break
+            return None
+        if isinstance(target, ailment.Expr.Const):
+            return None
+        break
+
+    if jump_addr_offset is None or jumptable_load_addr is None:
+        return None
+
+    # parse jumptable_load_addr
+    jumptable_offset = None
+    jumptable_base_addr = None
+    if isinstance(jumptable_load_addr, ailment.Expr.BinaryOp) and jumptable_load_addr.op == "Add":
+        if isinstance(jumptable_load_addr.operands[0], ailment.Expr.Const):
+            jumptable_base_addr = jumptable_load_addr.operands[0]
+            jumptable_offset = jumptable_load_addr.operands[1]
+        elif isinstance(jumptable_load_addr.operands[1], ailment.Expr.Const):
+            jumptable_offset = jumptable_load_addr.operands[0]
+            jumptable_base_addr = jumptable_load_addr.operands[1]
+
+    if jumptable_offset is None or jumptable_base_addr is None:
+        return None
+
+    # parse jumptable_offset
+    expr = jumptable_offset
+    coeff = None
+    index_expr = None
+    lb = None
+    ub = None
+    while expr is not None:
+        if isinstance(expr, ailment.Expr.BinaryOp):
+            if expr.op == "Mul":
+                if isinstance(expr.operands[1], ailment.Expr.Const):
+                    coeff = expr.operands[1].value
+                    expr = expr.operands[0]
+                elif isinstance(expr.operands[0], ailment.Expr.Const):
+                    coeff = expr.operands[0].value
+                    expr = expr.operands[1]
+                else:
+                    return None
+            elif expr.op == "And":
+                masks = {0x1, 0x3, 0x7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, 0x1FF, 0x3FF}
+                if isinstance(expr.operands[1], ailment.Expr.Const) and expr.operands[1].value in masks:
+                    lb = 0
+                    ub = expr.operands[1].value
+                    index_expr = expr
+                    break
+                if isinstance(expr.operands[0], ailment.Expr.Const) and expr.operands[1].value in masks:
+                    lb = 0
+                    ub = expr.operands[0].value
+                    index_expr = expr
+                    break
+                return None
+            else:
+                return None
+        elif isinstance(expr, ailment.Expr.Convert):
+            if expr.is_signed is False:
+                expr = expr.operand
+            else:
+                return None
+        else:
+            break
+
+    if coeff is not None and index_expr is not None and lb is not None and ub is not None:
+        return index_expr, lb, ub
+
+
 def get_ast_subexprs(claripy_ast):
     queue = [claripy_ast]
     while queue:

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -107,8 +107,9 @@ class SimEngineVRAIL(
         size = stmt.size
         self._store(addr_r, data, size, atom=stmt)
 
-    def _handle_stmt_Jump(self, stmt):
-        pass
+    def _handle_stmt_Jump(self, stmt: ailment.Stmt.Jump):
+        if not isinstance(stmt.target, ailment.Expr.Const):
+            self._expr(stmt.target)
 
     def _handle_stmt_ConditionalJump(self, stmt):
         self._expr(stmt.condition)

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1494,7 +1494,6 @@ class TestDecompiler(unittest.TestCase):
         cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
 
         f = proj.kb.functions["main"]
-        proj.analyses.VariableRecoveryFast(f)
         cca = proj.analyses.CallingConvention(f)
         f.prototype = cca.prototype
         f.calling_convention = cca.cc
@@ -4020,6 +4019,19 @@ class TestDecompiler(unittest.TestCase):
         assert "probe_stack" not in d.codegen.text
         # "{reg 48}" would show up if SPTracker does not understand __rust_probestack
         assert "{reg " not in d.codegen.text
+
+    def test_decompiling_amd64_single_block_jumptable(self, decompiler_options=None):
+        bin_path = os.path.join(
+            test_location, "x86_64", "1cbbf108f44c8f4babde546d26425ca5340dccf878d306b90eb0fbec2f83ab51"
+        )
+        proj = angr.Project(bin_path, auto_load_libs=False)
+
+        cfg = proj.analyses.CFGFast(normalize=True)
+        f = proj.kb.functions[0x40BCF0]
+        d = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
+        self._print_decompilation_result(d)
+
+        assert d.codegen.text.count("switch") == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also fix structuring failures when the jump table header node is not empty after structuring.

Depends on #5170.