### PR TITLE
Allow pcode syscalls

### DIFF
--- a/angr/engines/pcode/emulate.py
+++ b/angr/engines/pcode/emulate.py
@@ -92,7 +92,7 @@ class PcodeEmulatorMixin(SimEngineBase):
                 self.state,
                 fallthru_addr,
                 self.state.scratch.guard,
-                "Ijk_Boring",
+                irsb.jumpkind,
                 exit_stmt_idx=DEFAULT_STATEMENT,
                 exit_ins_addr=self.state.scratch.ins_addr,
             )

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -269,11 +269,11 @@ class SimSuccessors:
         # categorize the state
         if o.APPROXIMATE_GUARDS in state.options and state.solver.is_false(state.scratch.guard, exact=False):
             if o.VALIDATE_APPROXIMATIONS in state.options and state.satisfiable():
-                raise Exception("WTF")
+                raise AssertionError("WTF")
             self.unsat_successors.append(state)
         elif o.APPROXIMATE_SATISFIABILITY in state.options and not state.solver.satisfiable(exact=False):
             if o.VALIDATE_APPROXIMATIONS in state.options and state.solver.satisfiable():
-                raise Exception("WTF")
+                raise AssertionError("WTF")
             self.unsat_successors.append(state)
         elif (not state.scratch.guard.symbolic and state.solver.is_false(state.scratch.guard)) or (
             o.LAZY_SOLVES not in state.options and not state.satisfiable()
@@ -297,13 +297,13 @@ class SimSuccessors:
 
             if "ip_at_syscall" in state.arch.registers:
                 # Misuse the ip_at_syscall register to save the return address for this syscall
-                # state.ip *might be* changed to be the real address of syscall SimProcedures by syscall handling code in
-                # angr
+                # state.ip *might be* changed to be the real address 
+                # of syscall SimProcedures by syscall handling code in angr
                 state.regs.ip_at_syscall = state.ip
             else:
                 # The architecture doesn't have an ip_at_syscall register.
                 # Nothing to do but hope vigorously.
-                l.warning(f"Handling syscall on arch {state.arch.name} without ip_at_syscall register")
+                l.warning(f"Handling syscall on arch {state.arch.name:s} without ip_at_syscall register")
 
             try:
                 symbolic_syscall_num, concrete_syscall_nums = self._resolve_syscall(state)

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -295,10 +295,15 @@ class SimSuccessors:
             # syscall
             self.successors.append(state)
 
-            # Misuse the ip_at_syscall register to save the return address for this syscall
-            # state.ip *might be* changed to be the real address of syscall SimProcedures by syscall handling code in
-            # angr
-            state.regs.ip_at_syscall = state.ip
+            if "ip_at_syscall" in state.arch.registers:
+                # Misuse the ip_at_syscall register to save the return address for this syscall
+                # state.ip *might be* changed to be the real address of syscall SimProcedures by syscall handling code in
+                # angr
+                state.regs.ip_at_syscall = state.ip
+            else:
+                # The architecture doesn't have an ip_at_syscall register.
+                # Nothing to do but hope vigorously.
+                l.warning(f"Handling syscall on arch {state.arch.name} without ip_at_syscall register")
 
             try:
                 symbolic_syscall_num, concrete_syscall_nums = self._resolve_syscall(state)

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -297,7 +297,7 @@ class SimSuccessors:
 
             if "ip_at_syscall" in state.arch.registers:
                 # Misuse the ip_at_syscall register to save the return address for this syscall
-                # state.ip *might be* changed to be the real address 
+                # state.ip *might be* changed to be the real address
                 # of syscall SimProcedures by syscall handling code in angr
                 state.regs.ip_at_syscall = state.ip
             else:

--- a/tests/engines/pcode/test_emulate.py
+++ b/tests/engines/pcode/test_emulate.py
@@ -81,6 +81,7 @@ class MockIRSB:
     _ops: list[MockPcodeOp]
     addr: int = 0
     behaviors: BehaviorFactory = BEHAVIORS
+    jumpkind: str = "Ijk_Boring"
 
 
 OP = MockPcodeOp


### PR DESCRIPTION
This feature includes two small changes with the goal of modelling syscalls on pcode-based architectures

First, the pcode engine hard-coded the fall-through jumpkind, making it impossible to rewrite IRSBs to model syscalls or other non-boring jumps.  This pull takes the default jumpkind from the IRSB instead.
Note that this doesn't allow for conditional or indirect jumps with non-boring jumpkinds.  If these are needed, I can revisit.

Second, the syscall jump handler has a hard-coded vex-ism that fails for pcode.  angr misuses the pseudo-register `ip_at_syscall` to save the syscall return target in case `state.ip` gets clobbered.  The pcode machine models don't have an `ip_at_syscall` register.  This pull only writes to the `ip_at_syscall` register if it exists, and warns if it doesn't.  Limited tests showed that `state.ip` remained unclobbered enough to work.
