### PR TITLE
ConditionConstantPropagation and a fix.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1149,8 +1149,9 @@ class Clinic(Analysis):
 
         cached_rd, cached_prop = None, None
         cache_item = None
+        cache_key = ail_block.addr, ail_block.idx
         if cache:
-            cache_item = cache.get(ail_block, None)
+            cache_item = cache.get(cache_key, None)
             if cache_item:
                 # cache hit
                 cached_rd = cache_item.rd
@@ -1169,8 +1170,8 @@ class Clinic(Analysis):
         # update the cache
         if cache is not None:
             if cache_item:
-                del cache[ail_block]
-            cache[simp.result_block] = BlockCache(simp._reaching_definitions, simp._propagator)
+                del cache[cache_key]
+            cache[cache_key] = BlockCache(simp._reaching_definitions, simp._propagator)
         return simp.result_block
 
     @timethis

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -18,7 +18,7 @@ from angr.utils import is_pyinstaller
 from angr.utils.graph import dominates, inverted_idoms
 from angr.block import Block, BlockNode
 from angr.errors import AngrRuntimeError
-from .peephole_optimizations import InvertNegatedLogicalConjunctionsAndDisjunctions
+from .peephole_optimizations import InvertNegatedLogicalConjunctionsAndDisjunctions, RemoveRedundantNots
 from .structuring.structurer_nodes import (
     MultiNode,
     EmptyBlockNotice,
@@ -231,7 +231,7 @@ class ConditionProcessor:
         self._ast2annotations = {}
 
         self._peephole_expr_optimizations = [
-            cls(None, None, None) for cls in [InvertNegatedLogicalConjunctionsAndDisjunctions]
+            cls(None, None, None) for cls in [InvertNegatedLogicalConjunctionsAndDisjunctions, RemoveRedundantNots]
         ]
 
     def clear(self):

--- a/angr/analyses/decompiler/optimization_passes/__init__.py
+++ b/angr/analyses/decompiler/optimization_passes/__init__.py
@@ -32,6 +32,7 @@ from .const_prop_reverter import ConstPropOptReverter
 from .call_stmt_rewriter import CallStatementRewriter
 from .duplication_reverter import DuplicationReverter
 from .switch_reused_entry_rewriter import SwitchReusedEntryRewriter
+from .condition_constprop import ConditionConstantPropagation
 
 if TYPE_CHECKING:
     from angr.analyses.decompiler.presets import DecompilationPreset
@@ -66,6 +67,7 @@ ALL_OPTIMIZATION_PASSES = [
     InlinedStringTransformationSimplifier,
     CallStatementRewriter,
     TagSlicer,
+    ConditionConstantPropagation,
 ]
 
 # these passes may duplicate code to remove gotos or improve the structure of the graph
@@ -113,6 +115,7 @@ __all__ = (
     "BasePointerSaveSimplifier",
     "CallStatementRewriter",
     "CodeMotionOptimization",
+    "ConditionConstantPropagation",
     "ConstPropOptReverter",
     "ConstantDereferencesSimplifier",
     "CrossJumpReverter",

--- a/angr/analyses/decompiler/optimization_passes/condition_constprop.py
+++ b/angr/analyses/decompiler/optimization_passes/condition_constprop.py
@@ -41,7 +41,7 @@ class CCondPropBlockWalker(AILBlockWalker):
         super().walk(block)
         return self._new_block
 
-    def _handle_stmt(self, stmt_idx: int, stmt: Statement, block: Block):
+    def _handle_stmt(self, stmt_idx: int, stmt: Statement, block: Block):  # type: ignore
         r = super()._handle_stmt(stmt_idx, stmt, block)
         if r is not None:
             # replace the original statement
@@ -49,7 +49,7 @@ class CCondPropBlockWalker(AILBlockWalker):
                 self._new_block = block.copy()
             self._new_block.statements[stmt_idx] = r
 
-    def _handle_VirtualVariable(
+    def _handle_VirtualVariable(  # type: ignore
         self, expr_idx: int, expr: VirtualVariable, stmt_idx: int, stmt: Statement, block: Block | None
     ) -> Const | None:
         if expr.varid == self.vvar_id:
@@ -66,7 +66,7 @@ class ConditionConstantPropagation(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_SINGLE_BLOCK_SIMPLIFICATION
     NAME = "Propagate constants using information deduced from conditionals."
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = __doc__.strip()  # type: ignore
 
     def __init__(self, func, **kwargs):
         super().__init__(func, **kwargs)
@@ -107,10 +107,10 @@ class ConditionConstantPropagation(OptimizationPass):
             frontier = df.get(head_block)
             if frontier is None:
                 continue
-            slice = RegionIdentifier.slice_graph(self._graph, head_block, frontier, include_frontier=False)
+            graph_slice = RegionIdentifier.slice_graph(self._graph, head_block, frontier, include_frontier=False)
             for ccond in cconds:
                 walker = CCondPropBlockWalker(ccond.vvar_id, ccond.value)
-                for block in slice:
+                for block in graph_slice:
                     new_block = walker.walk(block)
                     if new_block is not None:
                         self._update_block(block, new_block)
@@ -134,15 +134,15 @@ class ConditionConstantPropagation(OptimizationPass):
                     op0, op1 = cond.operands
                     if isinstance(op0, Const):
                         op0, op1 = op1, op0
-                    if isinstance(op0, VirtualVariable) and isinstance(op1, Const):
+                    if isinstance(op0, VirtualVariable) and isinstance(op1, Const) and op1.is_int:
                         if op == "CmpEQ":
                             ccond = ConstantCondition(
-                                op0.varid, op1, last_stmt.true_target.value, last_stmt.true_target_idx
+                                op0.varid, op1, last_stmt.true_target.value, last_stmt.true_target_idx  # type: ignore
                             )
                             cconds.append(ccond)
                         elif op == "CmpNE":
                             ccond = ConstantCondition(
-                                op0.varid, op1, last_stmt.false_target.value, last_stmt.false_target_idx
+                                op0.varid, op1, last_stmt.false_target.value, last_stmt.false_target_idx  # type: ignore
                             )
                             cconds.append(ccond)
 

--- a/angr/analyses/decompiler/optimization_passes/condition_constprop.py
+++ b/angr/analyses/decompiler/optimization_passes/condition_constprop.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import networkx
+
+from ailment import AILBlockWalker, Block
+from ailment.statement import ConditionalJump, Statement
+from ailment.expression import Const, BinaryOp, VirtualVariable
+
+from angr.analyses.decompiler.region_identifier import RegionIdentifier
+from .optimization_pass import OptimizationPass, OptimizationPassStage
+
+
+class ConstantCondition:
+    """
+    Describes an opportunity for replacing a vvar with a constant value.
+    """
+
+    def __init__(self, vvar_id: int, value: Const, block_addr: int, block_idx: int | None):
+        self.vvar_id = vvar_id
+        self.value = value
+        self.block_addr = block_addr
+        self.block_idx = block_idx
+
+    def __repr__(self):
+        return f"<ConstCond vvar_{self.vvar_id} == {self.value} since {self.block_addr:#x}-{self.block_idx}>"
+
+
+class CCondPropBlockWalker(AILBlockWalker):
+    """
+    Block walker for ConditionConstantPropagation to replace vvars with constant values.
+    """
+
+    def __init__(self, vvar_id: int, const_value: Const):
+        super().__init__()
+        self._new_block: Block | None = None  # output
+        self.vvar_id = vvar_id
+        self.const_value = const_value
+
+    def walk(self, block: Block):
+        self._new_block = None
+        super().walk(block)
+        return self._new_block
+
+    def _handle_stmt(self, stmt_idx: int, stmt: Statement, block: Block):
+        r = super()._handle_stmt(stmt_idx, stmt, block)
+        if r is not None:
+            # replace the original statement
+            if self._new_block is None:
+                self._new_block = block.copy()
+            self._new_block.statements[stmt_idx] = r
+
+    def _handle_VirtualVariable(
+        self, expr_idx: int, expr: VirtualVariable, stmt_idx: int, stmt: Statement, block: Block | None
+    ) -> Const | None:
+        if expr.varid == self.vvar_id:
+            return Const(expr.idx, None, self.const_value.value, self.const_value.bits, **expr.tags)
+        return None
+
+
+class ConditionConstantPropagation(OptimizationPass):
+    """
+    Reason about constant propagation opportunities from conditionals and propagate constants in the graph accordingly.
+    """
+
+    ARCHES = None
+    PLATFORMS = None
+    STAGE = OptimizationPassStage.AFTER_SINGLE_BLOCK_SIMPLIFICATION
+    NAME = "Propagate constants using information deduced from conditionals."
+    DESCRIPTION = __doc__.strip()
+
+    def __init__(self, func, **kwargs):
+        super().__init__(func, **kwargs)
+        self.analyze()
+
+    def _check(self):
+        cconds = self._find_const_conditions()
+        if not cconds:
+            return False, None
+        return True, {"cconds": cconds}
+
+    def _analyze(self, cache=None):
+        if not cache or cache.get("cconds", None) is None:  # noqa: SIM108
+            cconds = self._find_const_conditions()
+        else:
+            cconds = cache["cconds"]
+
+        if not cconds:
+            return
+
+        # group cconds according to their sources
+        cconds_by_src: dict[tuple[int, int | None], list[ConstantCondition]] = {}
+        for ccond in cconds:
+            src = ccond.block_addr, ccond.block_idx
+            if src not in cconds_by_src:
+                cconds_by_src[src] = []
+            cconds_by_src[src].append(ccond)
+
+        # calculate a dominance frontier for each block
+        entry_node_addr, entry_node_idx = self.entry_node_addr
+        entry_node = self._get_block(entry_node_addr, idx=entry_node_idx)
+        df = networkx.algorithms.dominance_frontiers(self._graph, entry_node)
+
+        for src, cconds in cconds_by_src.items():
+            head_block = self._get_block(src[0], idx=src[1])
+            if head_block is None:
+                continue
+            frontier = df.get(head_block)
+            if frontier is None:
+                continue
+            slice = RegionIdentifier.slice_graph(self._graph, head_block, frontier, include_frontier=False)
+            for ccond in cconds:
+                walker = CCondPropBlockWalker(ccond.vvar_id, ccond.value)
+                for block in slice:
+                    new_block = walker.walk(block)
+                    if new_block is not None:
+                        self._update_block(block, new_block)
+
+    def _find_const_conditions(self) -> list[ConstantCondition]:
+        cconds = []
+
+        for block in self._graph:
+            if block.statements:
+                last_stmt = block.statements[-1]
+                if (
+                    not isinstance(last_stmt, ConditionalJump)
+                    or not isinstance(last_stmt.true_target, Const)
+                    or not isinstance(last_stmt.false_target, Const)
+                ):
+                    continue
+
+                if isinstance(last_stmt.condition, BinaryOp):
+                    cond = last_stmt.condition
+                    op = cond.op
+                    op0, op1 = cond.operands
+                    if isinstance(op0, Const):
+                        op0, op1 = op1, op0
+                    if isinstance(op0, VirtualVariable) and isinstance(op1, Const):
+                        if op == "CmpEQ":
+                            ccond = ConstantCondition(
+                                op0.varid, op1, last_stmt.true_target.value, last_stmt.true_target_idx
+                            )
+                            cconds.append(ccond)
+                        elif op == "CmpNE":
+                            ccond = ConstantCondition(
+                                op0.varid, op1, last_stmt.false_target.value, last_stmt.false_target_idx
+                            )
+                            cconds.append(ccond)
+
+        return cconds

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -111,12 +111,15 @@ class OptimizationPass(BaseOptimizationPass):
     The base class for any function-level graph optimization pass.
     """
 
+    _graph: networkx.DiGraph
+
     def __init__(
         self,
         func,
+        *,
+        graph,
         blocks_by_addr=None,
         blocks_by_addr_and_idx=None,
-        graph=None,
         variable_kb=None,
         region_identifier=None,
         reaching_definitions=None,
@@ -132,7 +135,7 @@ class OptimizationPass(BaseOptimizationPass):
         # self._blocks is just a cache
         self._blocks_by_addr: dict[int, set[ailment.Block]] = blocks_by_addr or {}
         self._blocks_by_addr_and_idx: dict[tuple[int, int | None], ailment.Block] = blocks_by_addr_and_idx or {}
-        self._graph: networkx.DiGraph = graph
+        self._graph = graph
         self._variable_kb = variable_kb
         self._ri = region_identifier
         self._rd = reaching_definitions

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -132,7 +132,7 @@ class OptimizationPass(BaseOptimizationPass):
         # self._blocks is just a cache
         self._blocks_by_addr: dict[int, set[ailment.Block]] = blocks_by_addr or {}
         self._blocks_by_addr_and_idx: dict[tuple[int, int | None], ailment.Block] = blocks_by_addr_and_idx or {}
-        self._graph: networkx.DiGraph | None = graph
+        self._graph: networkx.DiGraph = graph
         self._variable_kb = variable_kb
         self._ri = region_identifier
         self._rd = reaching_definitions

--- a/angr/analyses/decompiler/presets/fast.py
+++ b/angr/analyses/decompiler/presets/fast.py
@@ -21,6 +21,7 @@ from angr.analyses.decompiler.optimization_passes import (
     CallStatementRewriter,
     DeadblockRemover,
     SwitchReusedEntryRewriter,
+    ConditionConstantPropagation,
 )
 
 
@@ -47,6 +48,7 @@ preset_fast = DecompilationPreset(
         FlipBooleanCmp,
         InlinedStringTransformationSimplifier,
         CallStatementRewriter,
+        ConditionConstantPropagation,
     ],
 )
 

--- a/angr/analyses/decompiler/presets/full.py
+++ b/angr/analyses/decompiler/presets/full.py
@@ -26,6 +26,7 @@ from angr.analyses.decompiler.optimization_passes import (
     InlinedStringTransformationSimplifier,
     CallStatementRewriter,
     SwitchReusedEntryRewriter,
+    ConditionConstantPropagation,
 )
 
 
@@ -57,6 +58,7 @@ preset_full = DecompilationPreset(
         InlinedStringTransformationSimplifier,
         CallStatementRewriter,
         SwitchReusedEntryRewriter,
+        ConditionConstantPropagation,
     ],
 )
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2081,8 +2081,10 @@ class TestDecompiler(unittest.TestCase):
         self._print_decompilation_result(d)
 
         # expected: if (*(v4) || *((char *)*((long long *)a1)) != (char)a3 || a0 == *((long long *)a1) || (v5 & -0x100))
-        assert d.codegen.text.count("||") == 3
-        assert d.codegen.text.count("&&") == 0
+        # also acceptable: if (!v3 && *(a1)->field_0 == a3 && a0 != *(a1) && !(v2 & 0xffffffffffffff00))
+        and_count = d.codegen.text.count("&&")
+        or_count = d.codegen.text.count("||")
+        assert (or_count == 3 and and_count == 0) or (and_count == 3 and or_count == 0)
 
     @for_all_structuring_algos
     def test_decompiling_base32_basenc_do_decode(self, decompiler_options=None):


### PR DESCRIPTION
- Add ConditionConstantPropagation to propagate constants recovered from == and != conditonals during decompilation.
- Fix non-determinism in single-successor while structuring.
- Fix a rare KeyError when querying block simplification cache using the AIL block, which may change after optimization.