### PR TITLE
Decompiler: Disable folding until some critical issues are fixed

### DIFF
--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -1118,7 +1118,10 @@ class AILSimplifier(Analysis):
         than once after simplification and graph structuring where conditions might be duplicated (e.g., in Dream).
         In such cases, the one-use expression folder in RegionSimplifier will perform this transformation.
         """
+        # Disabled until https://github.com/angr/angr/issues/5112 and related folding issues are fixed
+        return False
 
+        # pylint:disable=unreachable
         simplified = False
 
         equivalence = self._compute_equivalence()

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -88,6 +88,10 @@ class RegionSimplifier(Analysis):
     #
 
     def _fold_oneuse_expressions(self, region):
+        # Disabled until https://github.com/angr/angr/issues/5110 and related folding issues fixed
+        return region
+
+        # pylint:disable=unreachable
         variable_manager = self.variable_kb.variables[self.func.addr]
         expr_counter = ExpressionCounter(region, variable_manager)
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -533,9 +533,10 @@ class TestDecompiler(unittest.TestCase):
 
         m = re.search(r"strncmp\(a1, \S+, 64\)", code)
         assert m is not None
-        strncmp_expr = m.group(0)
-        strncmp_stmt = strncmp_expr + ";"
-        assert strncmp_stmt not in code, "Call expressions folding failed for strncmp()"
+        # Disable until https://github.com/angr/angr/issues/5113 fixed
+        # strncmp_expr = m.group(0)
+        # strncmp_stmt = strncmp_expr + ";"
+        # assert strncmp_stmt not in code, "Call expressions folding failed for strncmp()"
 
         lines = code.split("\n")
         for line in lines:
@@ -731,6 +732,7 @@ class TestDecompiler(unittest.TestCase):
             "local_strcat(char *a0, char *a1)" in lines[0]
         ), f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_decompilation_call_expr_folding(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "call_expr_folding")
@@ -768,6 +770,7 @@ class TestDecompiler(unittest.TestCase):
         code = dec.codegen.text
         assert code.count("strlen(") == 1
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_decompilation_call_expr_folding_mips64_true(self, decompiler_options=None):
         # This test is to ensure call expression folding correctly replaces call expressions in return statements
@@ -784,6 +787,7 @@ class TestDecompiler(unittest.TestCase):
         code = dec.codegen.text
         assert "version_etc_va(" in code
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_decompilation_call_expr_folding_x8664_calc(self, decompiler_options=None):
         # This test is to ensure call expression folding do not re-use out-dated definitions when folding expressions
@@ -813,6 +817,7 @@ class TestDecompiler(unittest.TestCase):
                 assert "strlen(" in line
                 assert line.count("strlen") == 1
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @structuring_algo("sailr")
     def test_decompilation_call_expr_folding_into_if_conditions(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "stat.o")
@@ -1103,6 +1108,7 @@ class TestDecompiler(unittest.TestCase):
         # We should not find "__stack_chk_fail" in the code
         assert "__stack_chk_fail" not in code
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_ifelseif_x8664(self, decompiler_options=None):
         # nested if-else should be transformed to cascading if-elseif constructs
@@ -1227,6 +1233,7 @@ class TestDecompiler(unittest.TestCase):
         m = re.search(r"if\([^=]+==0\)", code_without_spaces)
         assert m is None
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_simple_strcpy(self, decompiler_options=None):
         """
@@ -1663,6 +1670,7 @@ class TestDecompiler(unittest.TestCase):
         assert "b_ptr += 1;" in d.codegen.text
         assert "return c_ptr->c4->c2[argc].b2.a2;" in d.codegen.text
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_call_return_variable_folding(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "ls_gcc_O0")
@@ -2645,6 +2653,7 @@ class TestDecompiler(unittest.TestCase):
             idx = i.start()
             assert text[idx + 1] == "\n"
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_fauxware_read_packet_call_folding_into_store_stmt(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "fauxware_read_packet")
@@ -2720,6 +2729,7 @@ class TestDecompiler(unittest.TestCase):
         # there should be a ternary assignment in the code: x = (c ? a : b);
         assert re.search(r".+ = \(.+\?.+:.+\);", text) is not None
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_automatic_ternary_creation_2(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "head.o")
@@ -2767,6 +2777,7 @@ class TestDecompiler(unittest.TestCase):
         ternary_exprs = re.findall(r"\(.+\?.+:.+\);", text)
         assert len(ternary_exprs) == 2
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_ternary_propagation_2(self, decompiler_options=None):
         """
@@ -2929,6 +2940,7 @@ class TestDecompiler(unittest.TestCase):
         #     return;
         assert re.search(r"if\(.+?\)\{.+?\}return", text) is not None
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @structuring_algo("sailr")
     def test_numfmt_process_field(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "numfmt.o")
@@ -3662,6 +3674,7 @@ class TestDecompiler(unittest.TestCase):
         assert d.codegen.text.count("foo") == 1  # the recursive call
         assert "bar" not in d.codegen.text
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @for_all_structuring_algos
     def test_const_prop_reverter_fmt(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "fmt")
@@ -3754,6 +3767,7 @@ class TestDecompiler(unittest.TestCase):
 
         assert text.count("refresh_jobs") == 1
 
+    @unittest.skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     @structuring_algo("sailr")
     def test_fmt_deduplication(self, decompiler_options=None):
         # This testcase is highly related to the constant depropagation testcase above, also for the fmt binary

--- a/tests/analyses/test_api_obf_finder.py
+++ b/tests/analyses/test_api_obf_finder.py
@@ -1,7 +1,7 @@
 # pylint:disable=missing-class-docstring,no-self-use
 
 from __future__ import annotations
-from unittest import TestCase, main
+from unittest import TestCase, main, skip
 
 import os
 
@@ -18,6 +18,8 @@ binaries_base = os.path.join(
 
 
 class TestAPIObfFinder(TestCase):
+
+    @skip("Disable until https://github.com/angr/angr/issues/5113 fixed")
     def test_smoketest(self):
         bin_path = os.path.join(
             binaries_base, "x86_64", "windows", "fc7a8e64d88ad1d8c7446c606731901063706fd2fb6f9e237dda4cb4c966665b"


### PR DESCRIPTION
* Adjusts unrelated tests to not depend on folding
* Disables other tests that expect folding
* Adds new tests for things that should not be folded
* Disables folding
* See #5110 #5112 #5113 for more details
