### PR TITLE
Remove SimEngine.process

### DIFF
--- a/angr/engines/engine.py
+++ b/angr/engines/engine.py
@@ -24,10 +24,9 @@ DataType_co = TypeVar("DataType_co", covariant=True)
 HeavyState = SimState[int | SootAddressDescriptor, claripy.ast.BV | SootAddressDescriptor]
 
 
-class SimEngineBase(Generic[StateType]):
+class SimEngine(Generic[StateType, ResultType], metaclass=abc.ABCMeta):
     """
-    Even more basey of a base class for SimEngine. Used as a base by mixins which want access to the project but for
-    which having method `process` (contained in `SimEngine`) doesn't make sense
+    A SimEngine is a type which understands how to perform execution on a state.
     """
 
     state: StateType
@@ -41,21 +40,6 @@ class SimEngineBase(Generic[StateType]):
 
     def __setstate__(self, state):
         self.project = state[0]
-
-
-class SimEngine(Generic[StateType, ResultType], SimEngineBase[StateType], metaclass=abc.ABCMeta):
-    """
-    A SimEngine is a class which understands how to perform execution on a state. This is a base class.
-    """
-
-    @abc.abstractmethod
-    def process(self, state: StateType, **kwargs) -> ResultType:
-        """
-        The main entry point for an engine. Should take a state and return a result.
-
-        :param state:   The state to proceed from
-        :return:        The result. Whatever you want ;)
-        """
 
 
 class SuccessorsMixin(SimEngine[HeavyState, SimSuccessors]):

--- a/angr/engines/pcode/emulate.py
+++ b/angr/engines/pcode/emulate.py
@@ -4,7 +4,7 @@ import logging
 import claripy
 from claripy.ast.bv import BV
 
-from angr.engines.engine import SimEngineBase
+from angr.engines.engine import SimEngine
 from angr.utils.constants import DEFAULT_STATEMENT
 from .lifter import IRSB
 from .behavior import OpBehavior
@@ -19,7 +19,7 @@ with contextlib.suppress(ImportError):
 l = logging.getLogger(__name__)
 
 
-class PcodeEmulatorMixin(SimEngineBase):
+class PcodeEmulatorMixin(SimEngine):
     """
     Mixin for p-code execution.
     """

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -20,7 +20,7 @@ from cachetools import LRUCache
 from pyvex.errors import PyVEXError, SkipStatementsError, LiftingException
 
 from .behavior import BehaviorFactory
-from angr.engines.engine import SimEngineBase
+from angr.engines.engine import SimEngine
 from angr.state_plugins.inspect import BP_AFTER, BP_BEFORE
 from angr.sim_state import SimState
 from angr.misc.ux import once
@@ -981,7 +981,7 @@ class PcodeLifter(Lifter):
             raise LiftingException(f"pypcode: could not decode any instructions @ 0x{self.addr:x}")
 
 
-class PcodeLifterEngineMixin(SimEngineBase):
+class PcodeLifterEngineMixin(SimEngine):
     """
     Lifter mixin to lift from machine code to P-Code.
     """

--- a/angr/engines/vex/lifter.py
+++ b/angr/engines/vex/lifter.py
@@ -8,7 +8,7 @@ import cle
 from archinfo import ArchARM
 import claripy
 
-from angr.engines.engine import SimEngineBase
+from angr.engines.engine import SimEngine
 from angr.state_plugins.inspect import BP_AFTER, BP_BEFORE, NO_OVERRIDE
 from angr.misc.ux import once
 from angr.errors import SimEngineError, SimTranslationError, SimError
@@ -20,7 +20,7 @@ VEX_IRSB_MAX_SIZE = 400
 VEX_IRSB_MAX_INST = 99
 
 
-class VEXLifter(SimEngineBase):
+class VEXLifter(SimEngine):
     """
     Implements the VEX lifter engine mixin.
     """

--- a/angr/engines/vex/light/light.py
+++ b/angr/engines/vex/light/light.py
@@ -3,7 +3,7 @@ import logging
 
 import pyvex
 
-from angr.engines.engine import SimEngineBase
+from angr.engines.engine import SimEngine
 from angr.utils.constants import DEFAULT_STATEMENT
 
 l = logging.getLogger(name=__name__)
@@ -11,7 +11,7 @@ l = logging.getLogger(name=__name__)
 # pylint:disable=arguments-differ,unused-argument,no-self-use
 
 
-class VEXMixin(SimEngineBase):
+class VEXMixin(SimEngine):
     def __init__(self, project, **kwargs):
         super().__init__(project, **kwargs)
         self._vex_expr_handlers = []


### PR DESCRIPTION
The idea here is that we currently have two sets of engines that implement `process` very differently. We have the "Heavy" or "dynamic" engines which use the SuccessorsMixin, and then we have the "Light" or "static" (though fish points out theoretically Light engines can be used for dynamic analysis) which implement `process` requiring a specific `block` kwarg. Since these definitions are mutually incompatible, let's just delete the `process` method from the base class and let the child classes figure it out.