### PR TITLE
Rename SuccessorsMixin to SuccessorsEngine, move to successors module

### DIFF
--- a/angr/engines/__init__.py
+++ b/angr/engines/__init__.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from .successors import SimSuccessors
-from .engine import SimEngine, SuccessorsMixin
-
-from .vex import HeavyVEXMixin, TrackActionsMixin, SimInspectMixin, HeavyResilienceMixin, SuperFastpathMixin
-from .procedure import ProcedureMixin, ProcedureEngine
-from .unicorn import SimEngineUnicorn
+from .engine import SimEngine
 from .failure import SimEngineFailure
-from .syscall import SimEngineSyscall
 from .hook import HooksMixin
+from .procedure import ProcedureEngine, ProcedureMixin
 from .soot import SootMixin
+from .successors import SimSuccessors, SuccessorsEngine
+from .syscall import SimEngineSyscall
+from .unicorn import SimEngineUnicorn
+from .vex import HeavyResilienceMixin, HeavyVEXMixin, SimInspectMixin, SuperFastpathMixin, TrackActionsMixin
 
 
 class UberEngine(
@@ -47,7 +46,7 @@ __all__ = [
     "SimInspectMixin",
     "SimSuccessors",
     "SootMixin",
-    "SuccessorsMixin",
+    "SuccessorsEngine",
     "SuperFastpathMixin",
     "TrackActionsMixin",
     "UberEngine",

--- a/angr/engines/engine.py
+++ b/angr/engines/engine.py
@@ -1,27 +1,14 @@
 from __future__ import annotations
 
-from typing import Generic, TypeVar
 import abc
-import logging
+from typing import Generic, TypeVar
 
-import claripy
-from archinfo.arch_soot import SootAddressDescriptor
 
 import angr
-from angr.sim_state import SimState
-from angr import sim_options as o
-from angr.errors import SimException
-from angr.state_plugins.inspect import BP_AFTER, BP_BEFORE
-from .successors import SimSuccessors
-
-
-l = logging.getLogger(name=__name__)
-
 
 StateType = TypeVar("StateType")
 ResultType = TypeVar("ResultType")
 DataType_co = TypeVar("DataType_co", covariant=True)
-HeavyState = SimState[int | SootAddressDescriptor, claripy.ast.BV | SootAddressDescriptor]
 
 
 class SimEngine(Generic[StateType, ResultType], metaclass=abc.ABCMeta):
@@ -40,109 +27,3 @@ class SimEngine(Generic[StateType, ResultType], metaclass=abc.ABCMeta):
 
     def __setstate__(self, state):
         self.project = state[0]
-
-
-class SuccessorsMixin(SimEngine[HeavyState, SimSuccessors]):
-    """
-    A mixin for SimEngine which implements ``process`` to perform common operations related to symbolic execution
-    and dispatches to a ``process_successors`` method to fill a SimSuccessors object with the results.
-    """
-
-    def __init__(self, project: angr.Project):
-        super().__init__(project)
-
-        self.successors: SimSuccessors | None = None
-
-    def process(self, state: HeavyState, **kwargs) -> SimSuccessors:  # pylint:disable=unused-argument
-        """
-        Perform execution with a state.
-
-        You should only override this method in a subclass in order to provide the correct method signature and
-        docstring. You should override the ``_process`` method to do your actual execution.
-
-        :param state:       The state with which to execute. This state will be copied before
-                            modification.
-        :param inline:      This is an inline execution. Do not bother copying the state.
-        :param force_addr:  Force execution to pretend that we're working at this concrete address
-        :returns:           A SimSuccessors object categorizing the execution's successor states
-        """
-        inline = kwargs.pop("inline", False)
-        force_addr = kwargs.pop("force_addr", None)
-
-        ip = state._ip
-        addr = (
-            (ip if isinstance(ip, SootAddressDescriptor) else state.solver.eval(ip))
-            if force_addr is None
-            else force_addr
-        )
-
-        # make a copy of the initial state for actual processing, if needed
-        new_state = state.copy() if not inline and o.COPY_STATES in state.options else state
-        # enforce this distinction
-        old_state = state
-        del state
-        self.state = new_state
-
-        # we have now officially begun the stepping process! now is where we "cycle" a state's
-        # data - move the "present" into the "past" by pushing an entry on the history stack.
-        # nuance: make sure to copy from the PREVIOUS state to the CURRENT one
-        # to avoid creating a dead link in the history, messing up the statehierarchy
-        new_state.register_plugin("history", old_state.history.make_child())
-        new_state.history.recent_bbl_addrs.append(addr)
-        if new_state.arch.unicorn_support:
-            assert isinstance(addr, int)
-            new_state.scratch.executed_pages_set = {addr & ~0xFFF}
-
-        self.successors = SimSuccessors(addr, old_state)
-
-        new_state._inspect(
-            "engine_process", when=BP_BEFORE, sim_engine=self, sim_successors=self.successors, address=addr
-        )
-        self.successors = new_state._inspect_getattr("sim_successors", self.successors)
-        try:
-            self.process_successors(self.successors, **kwargs)
-        except SimException as e:
-            if o.EXCEPTION_HANDLING not in old_state.options:
-                raise
-            assert old_state.project is not None
-            old_state.project.simos.handle_exception(self.successors, self, e)
-
-        new_state._inspect("engine_process", when=BP_AFTER, sim_successors=self.successors, address=addr)
-        self.successors = new_state._inspect_getattr("sim_successors", self.successors)
-        assert self.successors is not None
-
-        # downsizing
-        if new_state.supports_inspect:
-            new_state.inspect.downsize()
-        # if not TRACK, clear actions on OLD state
-        # if o.TRACK_ACTION_HISTORY not in old_state.options:
-        #    old_state.history.recent_events = []
-
-        # fix up the descriptions...
-        description = str(self.successors)
-        l.info("Ticked state: %s", description)
-        for succ in self.successors.all_successors:
-            succ.history.recent_description = description
-        for succ in self.successors.flat_successors:
-            succ.history.recent_description = description
-
-        return self.successors
-
-    def process_successors(self, successors, **kwargs):  # pylint:disable=unused-argument,no-self-use
-        """
-        Implement this function to fill out the SimSuccessors object with the results of stepping state.
-
-        In order to implement a model where multiple mixins can potentially handle a request, a mixin may implement
-        this method and then perform a super() call if it wants to pass on handling to the next mixin.
-
-        Keep in mind python's method resolution order when composing multiple classes implementing this method.
-        In short: left-to-right, depth-first, but deferring any base classes which are shared by multiple subclasses
-        (the merge point of a diamond pattern in the inheritance graph) until the last point where they would be
-        encountered in this depth-first search. For example, if you have classes A, B(A), C(B), D(A), E(C, D), then the
-        method resolution order will be E, C, B, D, A.
-
-        :param state:           The state to manipulate
-        :param successors:      The successors object to fill out
-        :param kwargs:          Any extra arguments. Do not fail if you are passed unexpected arguments.
-        """
-        successors.processed = False  # mark failure

--- a/angr/engines/failure.py
+++ b/angr/engines/failure.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import logging
 
 from angr.errors import AngrExitError
-from .engine import SuccessorsMixin
+from .successors import SuccessorsEngine
 from .procedure import ProcedureMixin
 
 l = logging.getLogger(name=__name__)
 
 
-class SimEngineFailure(SuccessorsMixin, ProcedureMixin):
+class SimEngineFailure(SuccessorsEngine, ProcedureMixin):
     def process_successors(self, successors, **kwargs):
         state = self.state
         jumpkind = state.history.parent.jumpkind if state.history and state.history.parent else None

--- a/angr/engines/hook.py
+++ b/angr/engines/hook.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
 
-from .engine import SuccessorsMixin
+from .successors import SuccessorsEngine
 from .procedure import ProcedureMixin
 from archinfo.arch_soot import SootAddressDescriptor
 
@@ -9,7 +9,7 @@ l = logging.getLogger(name=__name__)
 
 
 # pylint: disable=abstract-method,unused-argument,arguments-differ
-class HooksMixin(SuccessorsMixin, ProcedureMixin):
+class HooksMixin(SuccessorsEngine, ProcedureMixin):
     """
     A SimEngine mixin which adds a SimSuccessors handler which will look into the project's hooks and run the hook at
     the current address.

--- a/angr/engines/pcode/engine.py
+++ b/angr/engines/pcode/engine.py
@@ -5,7 +5,7 @@ import claripy
 import logging
 
 from angr.calling_conventions import DEFAULT_CC, default_cc, SimRegArg
-from angr.engines.engine import SuccessorsMixin, SimSuccessors
+from angr.engines.successors import SuccessorsEngine, SimSuccessors
 from angr.misc.ux import once
 from angr.utils.constants import DEFAULT_STATEMENT
 from angr import sim_options as o
@@ -19,7 +19,7 @@ l = logging.getLogger(__name__)
 
 
 class HeavyPcodeMixin(
-    SuccessorsMixin,
+    SuccessorsEngine,
     PcodeLifterEngineMixin,
     PcodeEmulatorMixin,
 ):

--- a/angr/engines/procedure.py
+++ b/angr/engines/procedure.py
@@ -4,7 +4,7 @@ import logging
 from angr import sim_options as o
 from angr import errors
 from angr.state_plugins.inspect import BP_BEFORE, BP_AFTER
-from .engine import SuccessorsMixin
+from .successors import SuccessorsEngine
 
 
 l = logging.getLogger(name=__name__)
@@ -58,7 +58,7 @@ class ProcedureMixin:
         successors.processed = True
 
 
-class ProcedureEngine(ProcedureMixin, SuccessorsMixin):
+class ProcedureEngine(ProcedureMixin, SuccessorsEngine):
     """
     A SimEngine that you may use if you only care about processing SimProcedures. *Requires* the procedure
     kwarg to be passed to process.

--- a/angr/engines/soot/engine.py
+++ b/angr/engines/soot/engine.py
@@ -15,7 +15,7 @@ from angr.errors import SimEngineError, SimTranslationError
 from cle import CLEError
 from angr.state_plugins.inspect import BP_AFTER, BP_BEFORE
 from angr.sim_type import SimTypeFunction, parse_type
-from angr.engines.engine import SuccessorsMixin
+from angr.engines.successors import SuccessorsEngine
 from angr.engines.procedure import ProcedureMixin
 from .exceptions import BlockTerminationNotice, IncorrectLocationException
 from .statements import SimSootStmt_Return, SimSootStmt_ReturnVoid, translate_stmt
@@ -26,7 +26,7 @@ l = logging.getLogger("angr.engines.soot.engine")
 # pylint: disable=arguments-differ
 
 
-class SootMixin(SuccessorsMixin, ProcedureMixin):
+class SootMixin(SuccessorsEngine, ProcedureMixin):
     """
     Execution engine based on Soot.
     """

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -1,23 +1,31 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+
 import logging
+from typing import TYPE_CHECKING
 
 import claripy
-
 from archinfo.arch_soot import ArchSoot, SootAddressDescriptor
 
+import angr
 from angr import sim_options as o
 from angr.calling_conventions import SYSCALL_CC
-from angr.errors import SimSolverModeError, AngrUnsupportedSyscallError, AngrSyscallError, SimValueError, SimUnsatError
-from angr.storage import DUMMY_SYMBOLIC_READ_VALUE
-from angr.state_plugins.inspect import BP_BEFORE, BP_AFTER
+from angr.engines.engine import SimEngine
+from angr.errors import (
+    AngrSyscallError,
+    AngrUnsupportedSyscallError,
+    SimException,
+    SimSolverModeError,
+    SimUnsatError,
+    SimValueError,
+)
+from angr.sim_state import SimState
 from angr.state_plugins.callstack import CallStack
+from angr.state_plugins.inspect import BP_AFTER, BP_BEFORE
 from angr.state_plugins.sim_action_object import _raw_ast
-
+from angr.storage import DUMMY_SYMBOLIC_READ_VALUE
 
 if TYPE_CHECKING:
     from angr import SimState
-    from angr.engines.engine import HeavyState
 
 
 l = logging.getLogger(name=__name__)
@@ -539,3 +547,112 @@ class SimSuccessors:
         addrs = state.solver.eval_upto(ip, limit)
 
         return [(ip == addr, addr) for addr in addrs]
+
+
+HeavyState = SimState[int | SootAddressDescriptor, claripy.ast.BV | SootAddressDescriptor]
+
+
+class SuccessorsEngine(SimEngine[HeavyState, SimSuccessors]):
+    """
+    A mixin for SimEngine which implements ``process`` to perform common operations related to symbolic execution
+    and dispatches to a ``process_successors`` method to fill a SimSuccessors object with the results.
+    """
+
+    def __init__(self, project: angr.Project):
+        super().__init__(project)
+
+        self.successors: SimSuccessors | None = None
+
+    def process(self, state: HeavyState, **kwargs) -> SimSuccessors:  # pylint:disable=unused-argument
+        """
+        Perform execution with a state.
+
+        You should only override this method in a subclass in order to provide the correct method signature and
+        docstring. You should override the ``_process`` method to do your actual execution.
+
+        :param state:       The state with which to execute. This state will be copied before
+                            modification.
+        :param inline:      This is an inline execution. Do not bother copying the state.
+        :param force_addr:  Force execution to pretend that we're working at this concrete address
+        :returns:           A SimSuccessors object categorizing the execution's successor states
+        """
+        inline = kwargs.pop("inline", False)
+        force_addr = kwargs.pop("force_addr", None)
+
+        ip = state._ip
+        addr = (
+            (ip if isinstance(ip, SootAddressDescriptor) else state.solver.eval(ip))
+            if force_addr is None
+            else force_addr
+        )
+
+        # make a copy of the initial state for actual processing, if needed
+        new_state = state.copy() if not inline and o.COPY_STATES in state.options else state
+        # enforce this distinction
+        old_state = state
+        del state
+        self.state = new_state
+
+        # we have now officially begun the stepping process! now is where we "cycle" a state's
+        # data - move the "present" into the "past" by pushing an entry on the history stack.
+        # nuance: make sure to copy from the PREVIOUS state to the CURRENT one
+        # to avoid creating a dead link in the history, messing up the statehierarchy
+        new_state.register_plugin("history", old_state.history.make_child())
+        new_state.history.recent_bbl_addrs.append(addr)
+        if new_state.arch.unicorn_support:
+            assert isinstance(addr, int)
+            new_state.scratch.executed_pages_set = {addr & ~0xFFF}
+
+        self.successors = SimSuccessors(addr, old_state)
+
+        new_state._inspect(
+            "engine_process", when=BP_BEFORE, sim_engine=self, sim_successors=self.successors, address=addr
+        )
+        self.successors = new_state._inspect_getattr("sim_successors", self.successors)
+        try:
+            self.process_successors(self.successors, **kwargs)
+        except SimException as e:
+            if o.EXCEPTION_HANDLING not in old_state.options:
+                raise
+            assert old_state.project is not None
+            old_state.project.simos.handle_exception(self.successors, self, e)
+
+        new_state._inspect("engine_process", when=BP_AFTER, sim_successors=self.successors, address=addr)
+        self.successors = new_state._inspect_getattr("sim_successors", self.successors)
+        assert self.successors is not None
+
+        # downsizing
+        if new_state.supports_inspect:
+            new_state.inspect.downsize()
+        # if not TRACK, clear actions on OLD state
+        # if o.TRACK_ACTION_HISTORY not in old_state.options:
+        #    old_state.history.recent_events = []
+
+        # fix up the descriptions...
+        description = str(self.successors)
+        l.info("Ticked state: %s", description)
+        for succ in self.successors.all_successors:
+            succ.history.recent_description = description
+        for succ in self.successors.flat_successors:
+            succ.history.recent_description = description
+
+        return self.successors
+
+    def process_successors(self, successors, **kwargs):  # pylint:disable=unused-argument,no-self-use
+        """
+        Implement this function to fill out the SimSuccessors object with the results of stepping state.
+
+        In order to implement a model where multiple mixins can potentially handle a request, a mixin may implement
+        this method and then perform a super() call if it wants to pass on handling to the next mixin.
+
+        Keep in mind python's method resolution order when composing multiple classes implementing this method.
+        In short: left-to-right, depth-first, but deferring any base classes which are shared by multiple subclasses
+        (the merge point of a diamond pattern in the inheritance graph) until the last point where they would be
+        encountered in this depth-first search. For example, if you have classes A, B(A), C(B), D(A), E(C, D), then the
+        method resolution order will be E, C, B, D, A.
+
+        :param state:           The state to manipulate
+        :param successors:      The successors object to fill out
+        :param kwargs:          Any extra arguments. Do not fail if you are passed unexpected arguments.
+        """
+        successors.processed = False  # mark failure

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
 import claripy
 from archinfo.arch_soot import ArchSoot, SootAddressDescriptor
@@ -23,9 +22,6 @@ from angr.state_plugins.callstack import CallStack
 from angr.state_plugins.inspect import BP_AFTER, BP_BEFORE
 from angr.state_plugins.sim_action_object import _raw_ast
 from angr.storage import DUMMY_SYMBOLIC_READ_VALUE
-
-if TYPE_CHECKING:
-    from angr import SimState
 
 
 l = logging.getLogger(name=__name__)
@@ -308,7 +304,7 @@ class SimSuccessors:
             else:
                 # The architecture doesn't have an ip_at_syscall register.
                 # Nothing to do but hope vigorously.
-                l.warning(f"Handling syscall on arch {state.arch.name:s} without ip_at_syscall register")
+                l.warning("Handling syscall on arch %s without ip_at_syscall register", state.arch.name)
 
             try:
                 symbolic_syscall_num, concrete_syscall_nums = self._resolve_syscall(state)

--- a/angr/engines/syscall.py
+++ b/angr/engines/syscall.py
@@ -3,14 +3,14 @@ import logging
 
 import angr
 from angr.errors import AngrUnsupportedSyscallError
-from .engine import SuccessorsMixin
+from .successors import SuccessorsEngine
 from .procedure import ProcedureMixin
 
 l = logging.getLogger(name=__name__)
 
 
 # pylint:disable=abstract-method,arguments-differ
-class SimEngineSyscall(SuccessorsMixin, ProcedureMixin):
+class SimEngineSyscall(SuccessorsEngine, ProcedureMixin):
     """
     A SimEngine mixin which adds a successors handling step that checks if a syscall was just requested and if so
     handles it as a step.

--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -8,7 +8,7 @@ import claripy
 
 import angr
 from angr.errors import SimIRSBError, SimIRSBNoDecodeError, SimValueError
-from .engine import SuccessorsMixin
+from .successors import SuccessorsEngine
 from .vex.heavy.heavy import VEXEarlyExit
 from angr import sim_options as o
 from angr.misc.ux import once
@@ -21,7 +21,7 @@ from angr.utils.constants import DEFAULT_STATEMENT
 l = logging.getLogger(name=__name__)
 
 
-class SimEngineUnicorn(SuccessorsMixin):
+class SimEngineUnicorn(SuccessorsEngine):
     """
     Concrete execution in the Unicorn Engine, a fork of qemu.
 

--- a/angr/engines/vex/heavy/heavy.py
+++ b/angr/engines/vex/heavy/heavy.py
@@ -3,7 +3,7 @@ import logging
 import claripy
 import pyvex
 
-from angr.engines.engine import SuccessorsMixin
+from angr.engines.successors import SuccessorsEngine
 from angr.engines.vex.light import VEXMixin
 from angr.engines.vex.lifter import VEXLifter
 from angr.engines.vex.claripy.datalayer import ClaripyDataMixin, symbol
@@ -57,7 +57,7 @@ class SimStateStorageMixin(VEXMixin):
 
 
 # pylint:disable=arguments-differ
-class HeavyVEXMixin(SuccessorsMixin, ClaripyDataMixin, SimStateStorageMixin, VEXMixin, VEXLifter):
+class HeavyVEXMixin(SuccessorsEngine, ClaripyDataMixin, SimStateStorageMixin, VEXMixin, VEXLifter):
     """
     Execution engine based on VEX, Valgrind's IR.
 


### PR DESCRIPTION
The idea here is to categorize this class as an engine rather than simply a mixin, because it is the base class for the various "Heavy" engines, rather than just a class you would mix into another class to provide some minor functional augmentation.

https://github.com/angr/angr-platforms/pull/75