### PR TITLE
Remove as_bytes=True from Arch.asm calls

### DIFF
--- a/tests/analyses/cfg/test_cfg_patching.py
+++ b/tests/analyses/cfg/test_cfg_patching.py
@@ -29,7 +29,7 @@ FAUXWARE_PATH = os.path.join(bin_location, "tests", "x86_64", "fauxware")
 
 def apply_patches(proj: angr.Project, patches: list[tuple[int, str]]):
     for addr, asm in patches:
-        patch_bytes = proj.arch.keystone.asm(asm, addr, as_bytes=True)[0]
+        patch_bytes = proj.arch.keystone.asm(asm, addr)[0]
         proj.kb.patches.add_patch(addr, patch_bytes)
 
 

--- a/tests/analyses/test_smc.py
+++ b/tests/analyses/test_smc.py
@@ -96,7 +96,7 @@ class TestTraceClassifier(unittest.TestCase):
         """
         arch = archinfo.ArchAMD64()
         code_asm = "mov eax, 0xdeadbeef; ret"
-        code_bytes, _ = arch.keystone.asm(code_asm, as_bytes=True)
+        code_bytes, _ = arch.keystone.asm(code_asm)
         code_as_hex = "".join(f"\\x{b:02x}" for b in code_bytes)
         code_len = len(code_bytes)
         c_src = f"""

--- a/tests/knowledge_plugins/test_patches.py
+++ b/tests/knowledge_plugins/test_patches.py
@@ -39,7 +39,7 @@ class PatchTests(unittest.TestCase):
         proj = angr.Project(binpath, auto_load_libs=False)
 
         addr = 0x4007D3
-        patch_bytes = proj.arch.keystone.asm("inc rax; leave; ret", addr, as_bytes=True)[0]
+        patch_bytes = proj.arch.keystone.asm("inc rax; leave; ret", addr)[0]
         proj.kb.patches.add_patch(addr, patch_bytes)
 
         b = proj.factory.block(addr)


### PR DESCRIPTION
This parameter is default, there is no point specifying it.