### PR TITLE
Disable sphinx.ext.viewcode to speed up doc builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
     "myst_parser",
 ]


### PR DESCRIPTION
Currently, highlighting embedded source code on the api docs page takes about 80% of the build time. This disables that to speed up the build, and users can be redirected to github or their local copy to reference source.