### PR TITLE
CCA: Call-site result should not overwrite func result.

### DIFF
--- a/angr/analyses/calling_convention/calling_convention.py
+++ b/angr/analyses/calling_convention/calling_convention.py
@@ -928,8 +928,7 @@ class CallingConventionAnalysis(Analysis):
             if 5 <= ret_val_size <= 8:
                 return SimTypeLongLong()
 
-        # fallback
-        return SimTypeInt() if cc.arch.bits == 32 else SimTypeLongLong()
+        return SimTypeBottom(label="void")
 
     @staticmethod
     def _likely_saving_temp_reg(ail_block: ailment.Block, d: Definition, all_reg_defs: set[Definition]) -> bool:

--- a/angr/analyses/calling_convention/fact_collector.py
+++ b/angr/analyses/calling_convention/fact_collector.py
@@ -377,11 +377,14 @@ class FactCollector(Analysis):
                     continue
 
                 # if this block ends with a call to a function, we process the function first
-                func_succs = [succ for succ in func_graph.successors(node) if isinstance(succ, (Function, HookNode))]
+                func_succs = [
+                    succ
+                    for succ in func_graph.successors(node)
+                    if isinstance(succ, (Function, HookNode)) or self.kb.functions.contains_addr(succ.addr)
+                ]
                 if len(func_succs) == 1:
                     func_succ = func_succs[0]
-
-                    if isinstance(func_succ, HookNode) and self.kb.functions.contains_addr(func_succ.addr):
+                    if isinstance(func_succ, (BlockNode, HookNode)) and self.kb.functions.contains_addr(func_succ.addr):
                         # attempt to convert it into a function
                         func_succ = self.kb.functions.get_by_addr(func_succ.addr)
                     if isinstance(func_succ, Function):

--- a/angr/analyses/calling_convention/fact_collector.py
+++ b/angr/analyses/calling_convention/fact_collector.py
@@ -532,13 +532,8 @@ class FactCollector(Analysis):
                 ):
                     continue
                 reg_offset_created.add(offset)
-                if self.project.arch.name in {"AMD64", "X86"} and size < self.project.arch.bytes:
-                    # use complete registers on AMD64 and X86
-                    reg_name = self.project.arch.translate_register_name(offset, size=self.project.arch.bytes)
-                    arg = SimRegArg(reg_name, self.project.arch.bytes)
-                else:
-                    reg_name = self.project.arch.translate_register_name(offset, size=size)
-                    arg = SimRegArg(reg_name, size)
+                reg_name = self.project.arch.translate_register_name(offset, size=size)
+                arg = SimRegArg(reg_name, size)
                 self.input_args.append(arg)
 
         stack_offset_created = set()

--- a/angr/analyses/calling_convention/utils.py
+++ b/angr/analyses/calling_convention/utils.py
@@ -9,7 +9,9 @@ from angr.calling_conventions import SimCC
 l = logging.getLogger(__name__)
 
 
-def is_sane_register_variable(arch: archinfo.Arch, reg_offset: int, reg_size: int, def_cc: SimCC | None = None) -> bool:
+def is_sane_register_variable(
+    arch: archinfo.Arch, reg_offset: int, reg_size: int, def_cc: SimCC | type[SimCC] | None = None
+) -> bool:
     """
     Filters all registers that are surly not members of function arguments.
     This can be seen as a workaround, since VariableRecoveryFast sometimes gives input variables of cc_ndep (which

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -292,6 +292,7 @@ class CConstruct:
                                 CUnaryOp,
                                 CAssignment,
                                 CFunctionCall,
+                                CLabel,
                             ),
                         )
                         and pos_to_node is not None

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 import logging
 from typing import cast
-from collections.abc import Iterable
+
+from collections.abc import Iterable, Sequence
 from collections import defaultdict
 import contextlib
 
@@ -1130,7 +1131,7 @@ class SimCC:
 
     @staticmethod
     def find_cc(
-        arch: archinfo.Arch, args: list[SimFunctionArgument], sp_delta: int, platform: str = "Linux"
+        arch: archinfo.Arch, args: Sequence[SimFunctionArgument], sp_delta: int, platform: str = "Linux"
     ) -> SimCC | None:
         """
         Pinpoint the best-fit calling convention and return the corresponding SimCC instance, or None if no fit is

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -28,7 +28,7 @@ class SimOS:
     def __init__(self, project: angr.Project, name=None):
         self.arch = project.arch
         self.project = project
-        self.name = name
+        self.name = name if name is not None else self.__class__.__name__
         self.return_deadend = None
         self.unresolvable_jump_target = None
         self.unresolvable_call_target = None

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -23,12 +23,12 @@ class SimOS:
     A class describing OS/arch-level configuration.
     """
 
-    name: str
+    name: str | None
 
-    def __init__(self, project: angr.Project, name=None):
+    def __init__(self, project: angr.Project, name: str | None = None):
         self.arch = project.arch
         self.project = project
-        self.name = name if name is not None else self.__class__.__name__
+        self.name = name
         self.return_deadend = None
         self.unresolvable_jump_target = None
         self.unresolvable_call_target = None

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -23,6 +23,8 @@ class SimOS:
     A class describing OS/arch-level configuration.
     """
 
+    name: str
+
     def __init__(self, project: angr.Project, name=None):
         self.arch = project.arch
         self.project = project

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -4485,7 +4485,16 @@ class TestDecompiler(unittest.TestCase):
         p = angr.Project(bin_path, auto_load_libs=False)
         cfg = p.analyses.CFGFast(normalize=True)
         p.analyses.CompleteCallingConventions()
-        dec = p.analyses.Decompiler(p.kb.functions[p.entry], cfg=cfg, options=decompiler_options)
+
+        # we alter the function prototype of f1 and entry to make this test case work as expected
+        f1 = p.kb.functions["f1"]
+        assert f1 is not None
+        f1.prototype.returnty = SimTypeLongLong(signed=True).with_arch(p.arch)
+        entry = p.kb.functions[p.entry]
+        assert entry is not None
+        entry.prototype.returnty = SimTypeLongLong(signed=True).with_arch(p.arch)
+
+        dec = p.analyses.Decompiler(entry, cfg=cfg, options=decompiler_options)
         assert dec.codegen is not None and isinstance(dec.codegen.text, str)
         text = dec.codegen.text
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -4488,10 +4488,10 @@ class TestDecompiler(unittest.TestCase):
 
         # we alter the function prototype of f1 and entry to make this test case work as expected
         f1 = p.kb.functions["f1"]
-        assert f1 is not None
+        assert f1 is not None and f1.prototype is not None
         f1.prototype.returnty = SimTypeLongLong(signed=True).with_arch(p.arch)
         entry = p.kb.functions[p.entry]
-        assert entry is not None
+        assert entry is not None and entry.prototype is not None
         entry.prototype.returnty = SimTypeLongLong(signed=True).with_arch(p.arch)
 
         dec = p.analyses.Decompiler(entry, cfg=cfg, options=decompiler_options)

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -14,7 +14,15 @@ import ailment
 
 import angr
 from angr.knowledge_plugins.variables.variable_manager import VariableManagerInternal
-from angr.sim_type import SimTypeInt, SimTypePointer, SimTypeBottom, SimTypeLongLong, SimTypeArray, SimTypeChar
+from angr.sim_type import (
+    SimTypeInt,
+    SimTypePointer,
+    SimTypeBottom,
+    SimTypeLongLong,
+    SimTypeArray,
+    SimTypeChar,
+    SimTypeFunction,
+)
 from angr.analyses import (
     VariableRecoveryFast,
     CallingConventionAnalysis,
@@ -4426,7 +4434,15 @@ class TestDecompiler(unittest.TestCase):
         p = angr.Project(bin_path, auto_load_libs=False)
         cfg = p.analyses.CFGFast(normalize=True)
         p.analyses.CompleteCallingConventions()
-        dec = p.analyses.Decompiler(p.kb.functions[p.entry], cfg=cfg, options=decompiler_options)
+        # we alter the function prototype of f1 and entry to make this test case work as expected
+        f1 = p.kb.functions["f1"]
+        assert f1 is not None
+        f1.prototype = SimTypeFunction([], SimTypeLongLong(signed=True)).with_arch(p.arch)
+        entry = p.kb.functions[p.entry]
+        assert entry is not None
+        entry.prototype = SimTypeFunction([], SimTypeLongLong(signed=True)).with_arch(p.arch)
+        # decompile!
+        dec = p.analyses.Decompiler(entry, cfg=cfg, options=decompiler_options)
         assert dec.codegen is not None and isinstance(dec.codegen.text, str)
         text = dec.codegen.text
 


### PR DESCRIPTION
Also move the register consolidation logic to right before calling convention matching. This allows a more accurate register argument size detection during CCA on IR.