### PR TITLE
Handle __fastfail intrinsic

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1052,7 +1052,11 @@ class Clinic(Analysis):
                 node = self._cfg.get_any_node(block.addr)
                 if node is None:
                     continue
-                successors = self._cfg.get_successors(node, excluding_fakeret=True, jumpkind="Ijk_Call")
+                successors = [
+                    node
+                    for node, jk in self._cfg.get_successors_and_jumpkinds(node)
+                    if jk == "Ijk_Call" or jk.startswith("Ijk_Sys")
+                ]
                 if len(successors) == 1:
                     succ_addr = successors[0].addr
                     if not self.project.is_hooked(succ_addr) or not isinstance(

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1433,7 +1433,7 @@ class SimCCX86LinuxSyscall(SimCCSyscall):
 
 class SimCCX86WindowsSyscall(SimCCSyscall):
     # TODO: Make sure the information is correct
-    ARG_REGS = []
+    ARG_REGS = ["ecx"]
     FP_ARG_REGS = []
     RETURN_VAL = SimRegArg("eax", 4)
     RETURN_ADDR = SimRegArg("ip_at_syscall", 4)
@@ -1673,7 +1673,7 @@ class SimCCAMD64LinuxSyscall(SimCCSyscall):
 
 class SimCCAMD64WindowsSyscall(SimCCSyscall):
     # TODO: Make sure the information is correct
-    ARG_REGS = []
+    ARG_REGS = ["rcx"]
     FP_ARG_REGS = []
     RETURN_VAL = SimRegArg("rax", 8)
     RETURN_ADDR = SimRegArg("ip_at_syscall", 8)

--- a/angr/procedures/definitions/wdk_ntoskrnl.py
+++ b/angr/procedures/definitions/wdk_ntoskrnl.py
@@ -20,6 +20,8 @@ lib.add_all_from_dict(P["win32_kernel"])
 lib.set_library_names("ntoskrnl.exe")
 prototypes = \
     {
+        # int 29h
+        '__fastfail': SimTypeFunction([SimTypeInt(signed=False, label="Int")], SimTypeBottom(label="void"), arg_names=["code"]),
         #
         'NtQueryObject': SimTypeFunction([SimTypePointer(SimTypeInt(signed=True, label="Int"), label="IntPtr", offset=0), SimTypeInt(signed=False, label="OBJECT_INFORMATION_CLASS"), SimTypePointer(SimTypeBottom(label="Void"), offset=0), SimTypeInt(signed=False, label="UInt32"), SimTypePointer(SimTypeInt(signed=False, label="UInt32"), offset=0)], SimTypeInt(signed=True, label="Int32"), arg_names=["Handle", "ObjectInformationClass", "ObjectInformation", "ObjectInformationLength", "ReturnLength"]),
         #

--- a/angr/procedures/win32_kernel/__fastfail.py
+++ b/angr/procedures/win32_kernel/__fastfail.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+import angr
+
+
+class __fastfail(angr.SimProcedure):
+    """
+    Immediately terminates the calling process with minimum overhead.
+
+    https://learn.microsoft.com/en-us/cpp/intrinsics/fastfail?view=msvc-170
+    """
+
+    NO_RET = True
+
+    def run(self, _):  # pylint:disable=arguments-differ
+        self.exit(0xC0000409)

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -3,7 +3,7 @@ import inspect
 import copy
 import itertools
 import logging
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import claripy
 from cle import SymbolType
@@ -339,7 +339,7 @@ class SimProcedure:
     ALT_NAMES = None  # alternative names
     local_vars: tuple[str, ...] = ()
 
-    def run(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def run(self, *args, **kwargs) -> Any:  # pylint: disable=unused-argument
         """
         Implement the actual procedure here!
         """

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 import logging
 import struct
 
@@ -13,6 +14,9 @@ from angr.calling_conventions import default_cc
 from angr.procedures import SIM_PROCEDURES as P
 from angr import sim_options as o
 from angr.storage.file import SimFileStream, SimFileBase
+
+if TYPE_CHECKING:
+    from angr.sim_procedure import SimProcedure
 
 
 _l = logging.getLogger(name=__name__)
@@ -326,22 +330,22 @@ class SimOS:
     # Dummy stuff to allow this API to be used freely
 
     # pylint: disable=unused-argument, no-self-use
-    def syscall(self, state, allow_unsupported=True):
+    def syscall(self, state: SimState, allow_unsupported: bool = True) -> SimProcedure | None:
         return None
 
-    def syscall_abi(self, state) -> str | None:
+    def syscall_abi(self, state: SimState) -> str | None:
         return None
 
-    def syscall_cc(self, state) -> angr.calling_conventions.SimCCSyscall | None:
+    def syscall_cc(self, state: SimState) -> angr.calling_conventions.SimCCSyscall | None:
         raise NotImplementedError
 
-    def is_syscall_addr(self, addr):
+    def is_syscall_addr(self, addr) -> bool:
         return False
 
-    def syscall_from_addr(self, addr, allow_unsupported=True):
+    def syscall_from_addr(self, addr, allow_unsupported=True) -> SimProcedure | None:
         return None
 
-    def syscall_from_number(self, number, allow_unsupported=True, abi=None):
+    def syscall_from_number(self, number, allow_unsupported=True, abi=None) -> SimProcedure | None:
         return None
 
     def setup_gdt(self, state, gdt):

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -76,10 +76,12 @@ class SimWindows(SimOS):
 
         self.project.hook(self.fastfail.addr, self.fastfail)
 
-        self.is_dump = isinstance(self.project.loader.main_object, cle.backends.Minidump)
-
         if not self.is_dump:
             self.project.loader.tls.new_thread()
+
+    @property
+    def is_dump(self) -> bool:
+        return isinstance(self.project.loader.main_object, cle.backends.Minidump)
 
     def _find_or_make(self, name):
         sym = self.project.loader.find_symbol(name)

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -27,6 +27,8 @@ VS_SECURITY_COOKIES = {"AMD64": _VS_Security_Cookie(0x2B992DDFA232, 48), "X86": 
 
 
 class SecurityCookieInit(enum.Enum):
+    """Security cooke initialization value initialization method."""
+
     NONE = 0
     RANDOM = 1
     STATIC = 2

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -4907,6 +4907,17 @@ class TestDecompiler(unittest.TestCase):
         # ensure decompling this function should not take over 30 seconds - it was taking at least two minutes before
         # recent optimizations
 
+    def test_fastfail_intrinsic(self, decompiler_options=None):
+        bin_path = os.path.join(test_location, "x86_64", "windows", "fastfail.exe")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        proj.analyses.CompleteCallingConventions(analyze_callsites=True)
+        dec = proj.analyses.Decompiler(
+            proj.kb.functions["fastfail_with_code_if_lt_10"], cfg=cfg, options=decompiler_options
+        )
+        assert dec.codegen is not None and dec.codegen.text is not None
+        assert "__fastfail(a0)" in dec.codegen.text
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds basic support for the [`__fastfail(code)`](https://learn.microsoft.com/en-us/cpp/intrinsics/fastfail?view=msvc-170) msvc intrinsic, which essentially compiles to `mov ecx, code; int 0x29`:

> Immediately terminates the calling process with minimum overhead. [...] User-mode fast fail requests appear as a second chance non-continuable exception with exception code 0xC0000409, and with at least one exception parameter. The first exception parameter is the code value. [...] no exception handlers are invoked because the program is expected to be in a corrupted state

- Implemented as a syscall, so this intrinsic will actually appear in the CFG and work in simulation, etc.
- Adjusts Clinic to resolve indirect calls with syscall jumpkinds.
   - Other platform syscalls (e.g. `open`/`read` on Linux) will now also be resolved.
   - This behavior may call for a configuration option.

TODO:
- [x] Clean up `get_successors` bit
- [x] Fix x86-32 `int 29h` decode in pyvex (https://github.com/angr/pyvex/pull/455)
- [x] Make CFGFast syscall resolver smarter (will PR separately)