### PR TITLE
chore: Make SIM_LIBRARIES a dict of list of lib instead of a dict of lib

### DIFF
--- a/angr/analyses/calling_convention/fact_collector.py
+++ b/angr/analyses/calling_convention/fact_collector.py
@@ -445,10 +445,11 @@ class FactCollector(Analysis):
                             if func_succ.prototype_libname is not None:
                                 # we need to deref the prototype in case it uses SimTypeRef internally
                                 type_collections = []
-                                prototype_lib = SIM_LIBRARIES[func_succ.prototype_libname]
-                                if prototype_lib.type_collection_names:
-                                    for typelib_name in prototype_lib.type_collection_names:
-                                        type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+                                for prototype_lib in SIM_LIBRARIES[func_succ.prototype_libname]:
+                                    if prototype_lib.type_collection_names:
+                                        for typelib_name in prototype_lib.type_collection_names:
+                                            type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+                                if type_collections:
                                     proto = dereference_simtype(proto, type_collections)
 
                             assert isinstance(proto, SimTypeFunction) and proto.returnty is not None

--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -111,10 +111,10 @@ class CallSiteMaker(Analysis):
             prototype_libname = func.prototype_libname
             type_collections = []
             if prototype_libname is not None:
-                prototype_lib = SIM_LIBRARIES[prototype_libname]
-                if prototype_lib.type_collection_names:
-                    for typelib_name in prototype_lib.type_collection_names:
-                        type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+                for prototype_lib in SIM_LIBRARIES[prototype_libname]:
+                    if prototype_lib.type_collection_names:
+                        for typelib_name in prototype_lib.type_collection_names:
+                            type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
             if type_collections:
                 prototype = dereference_simtype(prototype, type_collections).with_arch(  # type: ignore
                     self.project.arch

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1197,10 +1197,10 @@ class Clinic(Analysis):
                 prototype_libname = func.prototype_libname
                 type_collections = []
                 if prototype_libname is not None:
-                    prototype_lib = SIM_LIBRARIES[prototype_libname]
-                    if prototype_lib.type_collection_names:
-                        for typelib_name in prototype_lib.type_collection_names:
-                            type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+                    for prototype_lib in SIM_LIBRARIES[prototype_libname]:
+                        if prototype_lib.type_collection_names:
+                            for typelib_name in prototype_lib.type_collection_names:
+                                type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
                 if type_collections:
                     prototype = dereference_simtype(prototype, type_collections).with_arch(  # type: ignore
                         self.project.arch

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1281,11 +1281,11 @@ class CFunctionCall(CStatement, CExpression):
             if self.callee_func.prototype_libname is not None:
                 # we need to deref the prototype in case it uses SimTypeRef internally
                 type_collections = []
-                prototype_lib = SIM_LIBRARIES[self.callee_func.prototype_libname]
-                if prototype_lib.type_collection_names:
-                    for typelib_name in prototype_lib.type_collection_names:
-                        type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
-                    proto = dereference_simtype(proto, type_collections)
+                for prototype_lib in SIM_LIBRARIES[self.callee_func.prototype_libname]:
+                    if prototype_lib.type_collection_names:
+                        for typelib_name in prototype_lib.type_collection_names:
+                            type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+                proto = dereference_simtype(proto, type_collections)
             return proto
         returnty = SimTypeInt(signed=False)
         return SimTypeFunction([arg.type for arg in self.args], returnty).with_arch(self.codegen.project.arch)

--- a/angr/analyses/deobfuscator/api_obf_finder.py
+++ b/angr/analyses/deobfuscator/api_obf_finder.py
@@ -315,7 +315,11 @@ class APIObfuscationFinder(Analysis):
 
     @staticmethod
     def is_apiname(name: str) -> bool:
-        return any(not isinstance(lib, SimSyscallLibrary) and lib.has_prototype(name) for lib in SIM_LIBRARIES.values())
+        return any(
+            not isinstance(lib, SimSyscallLibrary) and lib.has_prototype(name)
+            for libs in SIM_LIBRARIES.values()
+            for lib in libs
+        )
 
 
 AnalysesHub.register_default("APIObfuscationFinder", APIObfuscationFinder)

--- a/angr/analyses/deobfuscator/api_obf_peephole_optimizer.py
+++ b/angr/analyses/deobfuscator/api_obf_peephole_optimizer.py
@@ -30,7 +30,7 @@ class APIObfType1PeepholeOptimizer(PeepholeOptimizationExprBase):
                 # assign a new function on-demand
                 symbol = self.project.loader.extern_object.make_extern(funcname)
                 hook_addr = self.project.hook_symbol(
-                    symbol.rebased_addr, SIM_LIBRARIES["linux"].get_stub(funcname, self.project.arch)
+                    symbol.rebased_addr, SIM_LIBRARIES["linux"][0].get_stub(funcname, self.project.arch)
                 )
                 func = self.kb.functions.function(addr=hook_addr, name=funcname, create=True)
                 func.is_simprocedure = True

--- a/angr/analyses/identifier/runner.py
+++ b/angr/analyses/identifier/runner.py
@@ -29,7 +29,7 @@ assert len(FLAG_DATA) == 0x1000
 class Runner:
     def __init__(self, project, cfg):
         # this is kind of fucked up
-        project.simos.syscall_library.update(SIM_LIBRARIES["cgcabi_tracer"])
+        project.simos.syscall_library.update(SIM_LIBRARIES["cgcabi_tracer"][0])
 
         self.project = project
         self.cfg = cfg

--- a/angr/analyses/reaching_definitions/function_handler.py
+++ b/angr/analyses/reaching_definitions/function_handler.py
@@ -401,10 +401,10 @@ class FunctionHandler:
             )
             type_collections = []
             if prototype_libname is not None and prototype_libname in SIM_LIBRARIES:
-                prototype_lib = SIM_LIBRARIES[prototype_libname]
-                if prototype_lib.type_collection_names:
-                    for typelib_name in prototype_lib.type_collection_names:
-                        type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+                for prototype_lib in SIM_LIBRARIES[prototype_libname]:
+                    if prototype_lib.type_collection_names:
+                        for typelib_name in prototype_lib.type_collection_names:
+                            type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
             if type_collections:
                 prototype = dereference_simtype(data.prototype, type_collections).with_arch(state.arch)
                 data.prototype = cast(SimTypeFunction, prototype)

--- a/angr/analyses/static_hooker.py
+++ b/angr/analyses/static_hooker.py
@@ -21,7 +21,7 @@ class StaticHooker(Analysis):
     def __init__(self, library, binary=None):
         self.results = {}
         try:
-            lib = SIM_LIBRARIES[library]
+            libs = SIM_LIBRARIES[library]
         except KeyError as err:
             raise AngrValueError(f"No such library {library}") from err
 
@@ -36,14 +36,16 @@ class StaticHooker(Analysis):
                 l.debug("Skipping %s at %#x, already hooked", func.name, func.rebased_addr)
                 continue
 
-            if lib.has_implementation(func.name):
-                proc = lib.get(func.name, self.project.arch)
-                self.results[func.rebased_addr] = proc
-                if self.project.is_hooked(func.rebased_addr):
-                    l.debug("Skipping %s at %#x, already hooked", func.name, func.rebased_addr)
-                else:
-                    self.project.hook(func.rebased_addr, proc)
-                    l.info("Hooked %s at %#x", func.name, func.rebased_addr)
+            for lib in libs:
+                if lib.has_implementation(func.name):
+                    proc = lib.get(func.name, self.project.arch)
+                    self.results[func.rebased_addr] = proc
+                    if self.project.is_hooked(func.rebased_addr):
+                        l.debug("Skipping %s at %#x, already hooked", func.name, func.rebased_addr)
+                    else:
+                        self.project.hook(func.rebased_addr, proc)
+                        l.info("Hooked %s at %#x", func.name, func.rebased_addr)
+                    break
             else:
                 l.debug("Failed to hook %s at %#x", func.name, func.rebased_addr)
 

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -169,10 +169,10 @@ class SimEngineVRAIL(
 
             type_collections = []
             if prototype_libname is not None:
-                prototype_lib = SIM_LIBRARIES[prototype_libname]
-                if prototype_lib.type_collection_names:
-                    for typelib_name in prototype_lib.type_collection_names:
-                        type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+                for prototype_lib in SIM_LIBRARIES[prototype_libname]:
+                    if prototype_lib.type_collection_names:
+                        for typelib_name in prototype_lib.type_collection_names:
+                            type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
 
             for arg, arg_type in zip(args, prototype.args):
                 if arg.typevar is not None:
@@ -262,10 +262,10 @@ class SimEngineVRAIL(
 
             type_collections = []
             if prototype_libname is not None:
-                prototype_lib = SIM_LIBRARIES[prototype_libname]
-                if prototype_lib.type_collection_names:
-                    for typelib_name in prototype_lib.type_collection_names:
-                        type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+                for prototype_lib in SIM_LIBRARIES[prototype_libname]:
+                    if prototype_lib.type_collection_names:
+                        for typelib_name in prototype_lib.type_collection_names:
+                            type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
 
             for arg, arg_type in zip(args, prototype.args):
                 if arg.typevar is not None:

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1511,20 +1511,21 @@ class Function(Serializable):
             lib = SIM_LIBRARIES.get(binary_name, None)
             libraries = set()
             if lib is not None:
-                libraries.add(lib)
+                libraries.update(lib)
 
         else:
             # try all libraries or all libraries that match the given library name hint
             libraries = set()
-            for lib_name, lib in SIM_LIBRARIES.items():
+            for lib_name, libs in SIM_LIBRARIES.items():
                 # TODO: Add support for syscall libraries. Note that syscall libraries have different function
                 #  prototypes for .has_prototype() and .get_prototype()...
-                if not isinstance(lib, SimSyscallLibrary):
-                    if binary_name_hint:
-                        if binary_name_hint.lower() in lib_name.lower():
+                for lib in libs:
+                    if not isinstance(lib, SimSyscallLibrary):
+                        if binary_name_hint:
+                            if binary_name_hint.lower() in lib_name.lower():
+                                libraries.add(lib)
+                        else:
                             libraries.add(lib)
-                    else:
-                        libraries.add(lib)
 
         if not libraries:
             return False

--- a/angr/procedures/definitions/__init__.py
+++ b/angr/procedures/definitions/__init__.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 l = logging.getLogger(name=__name__)
-SIM_LIBRARIES: dict[str, SimLibrary] = {}
+SIM_LIBRARIES: dict[str, list[SimLibrary]] = {}
 SIM_TYPE_COLLECTIONS: dict[str, SimTypeCollection] = {}
 
 
@@ -147,7 +147,10 @@ class SimLibrary:
         """
         for name in names:
             self.names.append(name)
-            SIM_LIBRARIES[name] = self
+            if name in SIM_LIBRARIES:
+                SIM_LIBRARIES[name].append(self)
+            else:
+                SIM_LIBRARIES[name] = [self]
 
     def set_default_cc(self, arch_name, cc_cls):
         """

--- a/angr/project.py
+++ b/angr/project.py
@@ -18,6 +18,7 @@ from .misc.ux import deprecated
 from .errors import AngrNoPluginError
 
 l = logging.getLogger(name=__name__)
+l.setLevel("DEBUG")
 
 
 def load_shellcode(shellcode: bytes | str, arch, start_offset=0, load_address=0, thumb=False, **kwargs):
@@ -300,16 +301,17 @@ class Project:
         missing_libs = []
         for lib_name in self.loader.missing_dependencies:
             try:
-                missing_libs.append(SIM_LIBRARIES[lib_name])
+                missing_libs.extend(SIM_LIBRARIES[lib_name])
             except KeyError:
                 l.info("There are no simprocedures for missing library %s :(", lib_name)
         # additionally provide libraries we _have_ loaded as a fallback fallback
         # this helps in the case that e.g. CLE picked up a linux arm libc to satisfy an android arm binary
         for lib in self.loader.all_objects:
             if lib.provides is not None and lib.provides in SIM_LIBRARIES:
-                simlib = SIM_LIBRARIES[lib.provides]
-                if simlib not in missing_libs:
-                    missing_libs.append(simlib)
+                simlibs = SIM_LIBRARIES[lib.provides]
+                for simlib in simlibs:
+                    if simlib not in missing_libs:
+                        missing_libs.append(simlib)
 
         # Step 2: Categorize every "import" symbol in each object.
         # If it's IGNORED, mark it for stubbing
@@ -362,11 +364,13 @@ class Project:
                     owner_name = owner_name.lower()
                 if owner_name not in SIM_LIBRARIES:
                     continue
-                sim_lib = SIM_LIBRARIES[owner_name]
-                if not sim_lib.has_implementation(export.name):
-                    continue
-                l.info("Using builtin SimProcedure for %s from %s", export.name, sim_lib.name)
-                self.hook_symbol(export.rebased_addr, sim_lib.get(export.name, sim_proc_arch))
+                sim_libs = SIM_LIBRARIES[owner_name]
+                for sim_lib in sim_libs:
+                    if not sim_lib.has_implementation(export.name):
+                        continue
+                    l.info("Using builtin SimProcedure for %s from %s", export.name, sim_lib.name)
+                    self.hook_symbol(export.rebased_addr, sim_lib.get(export.name, sim_proc_arch))
+                    break
 
             # Step 2.3: If 2.2 didn't work, check if the symbol wants to be resolved
             # by a library we already know something about. Resolve it appropriately.
@@ -375,7 +379,7 @@ class Project:
             # we still want to try as hard as we can to figure out where it comes from
             # so we can get the calling convention as close to right as possible.
             elif reloc.resolvewith is not None and reloc.resolvewith in SIM_LIBRARIES:
-                sim_lib = SIM_LIBRARIES[reloc.resolvewith]
+                sim_lib = sorted(SIM_LIBRARIES[reloc.resolvewith], key=lambda lib: lib.has_prototype(export.name))[-1]
                 if self._check_user_blacklists(export.name):
                     if not func.is_weak:
                         l.info("Using stub SimProcedure for unresolved %s from %s", func.name, sim_lib.name)
@@ -407,7 +411,7 @@ class Project:
                         if export.name and export.name.startswith("_Z"):
                             # GNU C++ name. Use a C++ library to create the stub
                             if "libstdc++.so" in SIM_LIBRARIES:
-                                the_lib = SIM_LIBRARIES["libstdc++.so"]
+                                the_lib = SIM_LIBRARIES["libstdc++.so"][0]
                             else:
                                 l.critical(
                                     "Does not find any C++ library in SIM_LIBRARIES. We may not correctly "
@@ -442,11 +446,12 @@ class Project:
             hinted_libs = filter(lambda lib: lib if ".so" in lib else None, SIM_LIBRARIES)
 
         for lib in hinted_libs:
-            if SIM_LIBRARIES[lib].has_implementation(f.name):
-                l.debug("Found implementation for %s in %s", f, lib)
-                hook_at = f.resolvedby.rebased_addr if f.resolvedby else f.relative_addr  # ????
-                self.hook_symbol(hook_at, (SIM_LIBRARIES[lib].get(f.name, self.arch)))
-                return True
+            for simlib in SIM_LIBRARIES[lib]:
+                if simlib.has_implementation(f.name):
+                    l.debug("Found implementation for %s in %s", f, lib)
+                    hook_at = f.resolvedby.rebased_addr if f.resolvedby else f.relative_addr  # ????
+                    self.hook_symbol(hook_at, (simlib.get(f.name, self.arch)))
+                    return True
 
         l.debug("Could not find matching SimProcedure for %s, ignoring.", f.name)
         return False

--- a/angr/simos/cgc.py
+++ b/angr/simos/cgc.py
@@ -18,7 +18,7 @@ class SimCGC(SimUserland):
     """
 
     def __init__(self, project, **kwargs):
-        super().__init__(project, syscall_library=L["cgcabi"], syscall_addr_alignment=1, name="CGC", **kwargs)
+        super().__init__(project, syscall_library=L["cgcabi"][0], syscall_addr_alignment=1, name="CGC", **kwargs)
 
     # pylint: disable=arguments-differ
     def state_blank(self, flag_page=None, allocate_stack_page_count=0x100, **kwargs):

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -29,7 +29,7 @@ class SimLinux(SimUserland):
     def __init__(self, project, **kwargs):
         super().__init__(
             project,
-            syscall_library=L["linux"],
+            syscall_library=L["linux"][0],
             syscall_addr_alignment=project.arch.instruction_alignment,
             name="Linux",
             **kwargs,
@@ -66,12 +66,12 @@ class SimLinux(SimUserland):
             self.project.hook(self.vsyscall_addr, P["linux_kernel"]["_vsyscall"]())
 
             # there are some functions we MUST use the simprocedures for, regardless of what the user wants
-            self._weak_hook_symbol("__tls_get_addr", L["ld.so"].get("__tls_get_addr", self.arch))  # ld
-            self._weak_hook_symbol("___tls_get_addr", L["ld.so"].get("___tls_get_addr", self.arch))  # ld
+            self._weak_hook_symbol("__tls_get_addr", L["ld.so"][0].get("__tls_get_addr", self.arch))  # ld
+            self._weak_hook_symbol("___tls_get_addr", L["ld.so"][0].get("___tls_get_addr", self.arch))  # ld
             self._weak_hook_symbol(
-                "_dl_get_tls_static_info", L["ld.so"].get("_dl_get_tls_static_info", self.arch)
+                "_dl_get_tls_static_info", L["ld.so"][0].get("_dl_get_tls_static_info", self.arch)
             )  # ld
-            self._weak_hook_symbol("_dl_vdso_vsym", L["libc.so.6"].get("_dl_vdso_vsym", self.arch))  # libc
+            self._weak_hook_symbol("_dl_vdso_vsym", L["libc.so.6"][0].get("_dl_vdso_vsym", self.arch))  # libc
 
             # set up some static data in the loader object...
             _rtld_global = self.project.loader.find_symbol("_rtld_global")

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -51,7 +51,7 @@ class SimWindows(SimOS):
         self.acmdln_ptr = None
         self.wcmdln_ptr = None
 
-        self.fastfail = L["ntoskrnl.exe"].get("__fastfail", self.arch)
+        self.fastfail = L["ntoskrnl.exe"][0].get("__fastfail", self.arch)
         self.fastfail.addr = self._find_or_make(self.fastfail.display_name)
         self.fastfail.cc = SYSCALL_CC[self.arch.name]["Win32"](self.arch)
         self._syscall_handlers = {self.fastfail.addr: self.fastfail}
@@ -60,13 +60,13 @@ class SimWindows(SimOS):
         super().configure_project()
 
         # here are some symbols which we MUST hook, regardless of what the user wants
-        self._weak_hook_symbol("GetProcAddress", L["kernel32.dll"].get("GetProcAddress", self.arch))
-        self._weak_hook_symbol("LoadLibraryA", L["kernel32.dll"].get("LoadLibraryA", self.arch))
-        self._weak_hook_symbol("LoadLibraryExW", L["kernel32.dll"].get("LoadLibraryExW", self.arch))
+        self._weak_hook_symbol("GetProcAddress", L["kernel32.dll"][0].get("GetProcAddress", self.arch))
+        self._weak_hook_symbol("LoadLibraryA", L["kernel32.dll"][0].get("LoadLibraryA", self.arch))
+        self._weak_hook_symbol("LoadLibraryExW", L["kernel32.dll"][0].get("LoadLibraryExW", self.arch))
 
         self._exception_handler = self._find_or_make("KiUserExceptionDispatcher")
         self.project.hook(
-            self._exception_handler, L["ntdll.dll"].get("KiUserExceptionDispatcher", self.arch), replace=True
+            self._exception_handler, L["ntdll.dll"][0].get("KiUserExceptionDispatcher", self.arch), replace=True
         )
 
         self.fmode_ptr = self._find_or_make("_fmode")

--- a/docs/extending-angr/environment.rst
+++ b/docs/extending-angr/environment.rst
@@ -76,8 +76,8 @@ each of their common names. For example,
 ``angr/procedures/definitions/linux_loader.py`` contains ``lib = SimLibrary();
 lib.set_library_names('ld.so', 'ld-linux.so', 'ld.so.2', 'ld-linux.so.2',
 'ld-linux-x86_64.so.2')``, so you can access it via
-``angr.SIM_LIBRARIES['ld.so']`` or ``angr.SIM_LIBRARIES['ld-linux.so']`` or any
-of the other names.
+``angr.SIM_LIBRARIES['ld.so'][0]`` or ``angr.SIM_LIBRARIES['ld-linux.so'][0]``
+or any of the other names.
 
 At load time, all the dynamic library dependencies are looked up in
 ``SIM_LIBRARIES`` and their procedures (or stubs!) are hooked into the project's
@@ -96,7 +96,7 @@ Case 2, out-of-tree development, tight integration
 
 If you'd like to implement your procedures outside the angr repository, you can
 do that. You effectively do this by just manually adding your procedures to the
-appropriate SimLibrary. Just call ``angr.SIM_LIBRARIES[libname].add(name,
+appropriate SimLibrary. Just call ``angr.SIM_LIBRARIES[libname][0].add(name,
 proc_cls)`` to do the registration.
 
 Note that this will only work if you do this before the project is loaded with
@@ -196,7 +196,7 @@ Case 2, out-of-tree development, tight integration
 
 You can add syscalls to a SimSyscallLibrary the same way you can add functions
 to a normal SimLibrary, by tweaking the entries in ``angr.SIM_LIBRARIES``. If
-you're this for linux you want ``angr.SIM_LIBRARIES['linux'].add(name,
+you're this for linux you want ``angr.SIM_LIBRARIES['linux'][0].add(name,
 proc_cls)``.
 
 You can register a SimOS with angr from out-of-tree as well - the same

--- a/tests/exploration_techniques/test_tracer.py
+++ b/tests/exploration_techniques/test_tracer.py
@@ -29,7 +29,7 @@ def tracer_cgc(
     symbolic_stdin=True,
 ):
     p = angr.Project(filename)
-    p.simos.syscall_library.update(angr.SIM_LIBRARIES["cgcabi_tracer"])
+    p.simos.syscall_library.update(angr.SIM_LIBRARIES["cgcabi_tracer"][0])
 
     trace, magic, crash_mode, crash_addr = do_trace(p, test_name, stdin)
     s = p.factory.entry_state(

--- a/tests/knowledge_plugins/functions/test_prototypes.py
+++ b/tests/knowledge_plugins/functions/test_prototypes.py
@@ -22,7 +22,7 @@ class TestPrototypes(unittest.TestCase):
         proj = angr.Project(os.path.join(test_location, "x86_64", "all"), auto_load_libs=False)
 
         func = angr.knowledge_plugins.Function(proj.kb.functions, 0x100000, name="strcmp")
-        func.prototype = angr.SIM_LIBRARIES["libc.so.6"].prototypes[func.name]
+        func.prototype = angr.SIM_LIBRARIES["libc.so.6"][0].prototypes[func.name]
         func.calling_convention = angr.calling_conventions.default_cc(proj.arch.name, platform="Linux")(proj.arch)
 
     def test_find_prototype(self):

--- a/tests/procedures/libc/test_string.py
+++ b/tests/procedures/libc/test_string.py
@@ -28,7 +28,7 @@ def make_state_with_stdin(content):
 
 def make_func(name):
     return (
-        lambda state, arguments: SIM_LIBRARIES["libc.so.6"]
+        lambda state, arguments: SIM_LIBRARIES["libc.so.6"][0]
         .get(name, "AMD64")
         .execute(state, arguments=arguments)
         .ret_expr

--- a/tests/procedures/libc/test_strtol.py
+++ b/tests/procedures/libc/test_strtol.py
@@ -53,7 +53,7 @@ class TestStrtol(unittest.TestCase):
 
         state.libc.max_strtol_len = 11
 
-        strtol = angr.SIM_LIBRARIES["libc.so.6"].get("strtol", arch=b.arch)
+        strtol = angr.SIM_LIBRARIES["libc.so.6"][0].get("strtol", arch=b.arch)
         strtol.state = state.copy()
         ret = strtol.run(0x500000, 0, 0)
 


### PR DESCRIPTION
Fixes issues with gdi32.dll being actually two separate libraries depending on whether you're in userspace or a kernel driver