### PR TITLE
Flirt: Migrate from nampa to a self-contained implementation.

### DIFF
--- a/angr/analyses/flirt/__init__.py
+++ b/angr/analyses/flirt/__init__.py
@@ -13,7 +13,7 @@ def flirt_arch_to_arch_name(flirt_arch: int, app_types: int) -> str:
     :return: Architecture name.
     """
     try:
-        arches = FLIRT_ARCH_TO_ARCHNAME.get(flirt_arch)
+        arches = FLIRT_ARCH_TO_ARCHNAME[flirt_arch]
     except KeyError:
         return "Unknown"
     if app_types & FlirtAppType.APP_32_BIT and 32 in arches:

--- a/angr/analyses/flirt/__init__.py
+++ b/angr/analyses/flirt/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from .flirt import FlirtAnalysis
+from .flirt_sig import FlirtSignature, FlirtSignatureParsed, FlirtSignatureError
+
+
+__all__ = [
+    "FlirtAnalysis",
+    "FlirtSignature",
+    "FlirtSignatureError",
+    "FlirtSignatureParsed",
+]

--- a/angr/analyses/flirt/__init__.py
+++ b/angr/analyses/flirt/__init__.py
@@ -1,6 +1,40 @@
 from __future__ import annotations
 from .flirt import FlirtAnalysis
 from .flirt_sig import FlirtSignature, FlirtSignatureParsed, FlirtSignatureError
+from .consts import FLIRT_ARCH_TO_ARCHNAME, FLIRT_OS_TO_OSNAME, FlirtAppType, FlirtOSType
+
+
+def flirt_arch_to_arch_name(flirt_arch: int, app_types: int) -> str:
+    """
+    Convert FLIRT architecture ID to architecture name.
+
+    :param flirt_arch: FLIRT architecture ID.
+    :param app_types: FLIRT application types.
+    :return: Architecture name.
+    """
+    try:
+        arches = FLIRT_ARCH_TO_ARCHNAME.get(flirt_arch)
+    except KeyError:
+        return "Unknown"
+    if app_types & FlirtAppType.APP_32_BIT and 32 in arches:
+        return arches[32]
+    if app_types & FlirtAppType.APP_64_BIT and 64 in arches:
+        return arches[64]
+    return "Unknown"
+
+
+def flirt_os_type_to_os_name(os_type: int) -> str:
+    """
+    Convert FLIRT OS type to OS name.
+
+    :param os_type: FLIRT OS type.
+    :return: OS name.
+    """
+    try:
+        v = FlirtOSType(os_type)
+        return FLIRT_OS_TO_OSNAME.get(v, v.name)
+    except ValueError:
+        return "UnknownOS"
 
 
 __all__ = [
@@ -8,4 +42,6 @@ __all__ = [
     "FlirtSignature",
     "FlirtSignatureError",
     "FlirtSignatureParsed",
+    "flirt_arch_to_arch_name",
+    "flirt_os_type_to_os_name",
 ]

--- a/angr/analyses/flirt/consts.py
+++ b/angr/analyses/flirt/consts.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+from enum import Enum
+
+
+class FlirtArch(int, Enum):
+    ARCH_386 = 0  # Intel 80x86
+    ARCH_Z80 = 1  # 8085, Z80
+    ARCH_I860 = 2  # Intel 860
+    ARCH_8051 = 3  # 8051
+    ARCH_TMS = 4  # Texas Instruments TMS320C5x
+    ARCH_6502 = 5  # 6502
+    ARCH_PDP = 6  # PDP11
+    ARCH_68K = 7  # Motorola 680x0
+    ARCH_JAVA = 8  # Java
+    ARCH_6800 = 9  # Motorola 68xx
+    ARCH_ST7 = 10  # SGS-Thomson ST7
+    ARCH_MC6812 = 11  # Motorola 68HC12
+    ARCH_MIPS = 12  # MIPS
+    ARCH_ARM = 13  # Advanced RISC Machines
+    ARCH_TMSC6 = 14  # Texas Instruments TMS320C6x
+    ARCH_PPC = 15  # PowerPC
+    ARCH_80196 = 16  # Intel 80196
+    ARCH_Z8 = 17  # Z8
+    ARCH_SH = 18  # Renesas (formerly Hitachi) SuperH
+    ARCH_NET = 19  # Microsoft Visual Studio.Net
+    ARCH_AVR = 20  # Atmel 8-bit RISC processor(s)
+    ARCH_H8 = 21  # Hitachi H8/300, H8/2000
+    ARCH_PIC = 22  # Microchip's PIC
+    ARCH_SPARC = 23  # SPARC
+    ARCH_ALPHA = 24  # DEC Alpha
+    ARCH_HPPA = 25  # Hewlett-Packard PA-RISC
+    ARCH_H8500 = 26  # Hitachi H8/500
+    ARCH_TRICORE = 27  # Tasking Tricore
+    ARCH_DSP56K = 28  # Motorola DSP5600x
+    ARCH_C166 = 29  # Siemens C166 family
+    ARCH_ST20 = 30  # SGS-Thomson ST20
+    ARCH_IA64 = 31  # Intel Itanium IA64
+    ARCH_I960 = 32  # Intel 960
+    ARCH_F2MC = 33  # Fujitsu F2MC-16
+    ARCH_TMS320C54 = 34  # Texas Instruments TMS320C54xx
+    ARCH_TMS320C55 = 35  # Texas Instruments TMS320C55xx
+    ARCH_TRIMEDIA = 36  # Trimedia
+    ARCH_M32R = 37  # Mitsubishi 32bit RISC
+    ARCH_NEC_78K0 = 38  # NEC 78K0
+    ARCH_NEC_78K0S = 39  # NEC 78K0S
+    ARCH_M740 = 40  # Mitsubishi 8bit
+    ARCH_M7700 = 41  # Mitsubishi 16bit
+    ARCH_ST9 = 42  # ST9+
+    ARCH_FR = 43  # Fujitsu FR Family
+    ARCH_MC6816 = 44  # Motorola 68HC16
+    ARCH_M7900 = 45  # Mitsubishi 7900
+    ARCH_TMS320C3 = 46  # Texas Instruments TMS320C3
+    ARCH_KR1878 = 47  # Angstrem KR1878
+    ARCH_AD218X = 48  # Analog Devices ADSP 218X
+    ARCH_OAKDSP = 49  # Atmel OAK DSP
+    ARCH_TLCS900 = 50  # Toshiba TLCS-900
+    ARCH_C39 = 51  # Rockwell C39
+    ARCH_CR16 = 52  # NSC CR16
+    ARCH_MN102L00 = 53  # Panasonic MN10200
+    ARCH_TMS320C1X = 54  # Texas Instruments TMS320C1x
+    ARCH_NEC_V850X = 55  # NEC V850 and V850ES/E1/E2
+    ARCH_SCR_ADPT = 56  # Processor module adapter for processor modules written in scripting languages
+    ARCH_EBC = 57  # EFI Bytecode
+    ARCH_MSP430 = 58  # Texas Instruments MSP430
+    ARCH_SPU = 59  # Cell Broadband Engine Synergistic Processor Unit
+    ARCH_DALVIK = 60  # Android Dalvik Virtual Machine
+
+
+class FlirtFileType(int, Enum):
+    FILE_DOS_EXE_OLD = 0x00000001
+    FILE_DOS_COM_OLD = 0x00000002
+    FILE_BIN = 0x00000004
+    FILE_DOSDRV = 0x00000008
+    FILE_NE = 0x00000010
+    FILE_INTELHEX = 0x00000020
+    FILE_MOSHEX = 0x00000040
+    FILE_LX = 0x00000080
+    FILE_LE = 0x00000100
+    FILE_NLM = 0x00000200
+    FILE_COFF = 0x00000400
+    FILE_PE = 0x00000800
+    FILE_OMF = 0x00001000
+    FILE_SREC = 0x00002000
+    FILE_ZIP = 0x00004000
+    FILE_OMFLIB = 0x00008000
+    FILE_AR = 0x00010000
+    FILE_LOADER = 0x00020000
+    FILE_ELF = 0x00040000
+    FILE_W32RUN = 0x00080000
+    FILE_AOUT = 0x00100000
+    FILE_PILOT = 0x00200000
+    FILE_DOS_EXE = 0x00400000
+    FILE_DOS_COM = 0x00800000
+    FILE_AIXAR = 0x01000000
+
+
+class FlirtOSType(int, Enum):
+    OS_MSDOS = 0x01
+    OS_WIN = 0x02
+    OS_OS2 = 0x04
+    OS_NETWARE = 0x08
+    OS_UNIX = 0x10
+    OS_OTHER = 0x20
+
+
+class FlirtAppType(int, Enum):
+    APP_CONSOLE = 0x0001
+    APP_GRAPHICS = 0x0002
+    APP_EXE = 0x0004
+    APP_DLL = 0x0008
+    APP_DRV = 0x0010
+    APP_SINGLE_THREADED = 0x0020
+    APP_MULTI_THREADED = 0x0040
+    APP_16_BIT = 0x0080
+    APP_32_BIT = 0x0100
+    APP_64_BIT = 0x0200
+
+
+class FlirtFeatureFlag(int, Enum):
+    FEATURE_STARTUP = 0x1
+    FEATURE_CTYPE_CRC = 0x2
+    FEATURE_2BYTE_CTYPE = 0x4
+    FEATURE_ALT_CTYPE_CRC = 0x8
+    FEATURE_COMPRESSED = 0x10
+
+
+class FlirtParseFlag(int, Enum):
+    PARSE_MORE_PUBLIC_NAMES = 0x1
+    PARSE_READ_TAIL_BYTES = 0x2
+    PARSE_READ_REFERENCED_FUNCTIONS = 0x4
+    PARSE_MORE_MODULES_WITH_SAME_CRC = 0x8
+    PARSE_MORE_MODULES = 0x10
+
+
+class FlirtFunctionFlag(int, Enum):
+    FUNCTION_LOCAL = 0x2
+    FUNCTION_UNRESOLVED_COLLISION = 0x8

--- a/angr/analyses/flirt/consts.py
+++ b/angr/analyses/flirt/consts.py
@@ -67,7 +67,7 @@ class FlirtArch(int, Enum):
     ARCH_DALVIK = 60  # Android Dalvik Virtual Machine
 
 
-FLIRT_ARCH_TO_ARCHNAME = {
+FLIRT_ARCH_TO_ARCHNAME: dict[int, dict[int, str]] = {
     FlirtArch.ARCH_386: {32: "X86", 64: "AMD64"},
     FlirtArch.ARCH_MIPS: {32: "MIPS32", 64: "MIPS64"},
     FlirtArch.ARCH_ARM: {32: "ARM", 64: "AARCH64"},

--- a/angr/analyses/flirt/consts.py
+++ b/angr/analyses/flirt/consts.py
@@ -1,3 +1,4 @@
+# pylint:disable=missing-class-docstring
 from __future__ import annotations
 from enum import Enum
 
@@ -66,6 +67,15 @@ class FlirtArch(int, Enum):
     ARCH_DALVIK = 60  # Android Dalvik Virtual Machine
 
 
+FLIRT_ARCH_TO_ARCHNAME = {
+    FlirtArch.ARCH_386: {32: "X86", 64: "AMD64"},
+    FlirtArch.ARCH_MIPS: {32: "MIPS32", 64: "MIPS64"},
+    FlirtArch.ARCH_ARM: {32: "ARM", 64: "AARCH64"},
+    FlirtArch.ARCH_PPC: {32: "PPC32", 64: "PPC64"},
+    FlirtArch.ARCH_SPARC: {32: "SPARC32", 64: "SPARC64"},
+}
+
+
 class FlirtFileType(int, Enum):
     FILE_DOS_EXE_OLD = 0x00000001
     FILE_DOS_COM_OLD = 0x00000002
@@ -95,12 +105,25 @@ class FlirtFileType(int, Enum):
 
 
 class FlirtOSType(int, Enum):
+    """
+    Actually no longer used in IDA.
+    """
+
     OS_MSDOS = 0x01
     OS_WIN = 0x02
     OS_OS2 = 0x04
     OS_NETWARE = 0x08
     OS_UNIX = 0x10
     OS_OTHER = 0x20
+
+
+FLIRT_OS_TO_OSNAME = {
+    FlirtOSType.OS_MSDOS: "MSDOS",
+    FlirtOSType.OS_WIN: "Win32",
+    FlirtOSType.OS_OS2: "OS/2",
+    FlirtOSType.OS_UNIX: "Linux",
+    FlirtOSType.OS_OTHER: "Other",
+}
 
 
 class FlirtAppType(int, Enum):

--- a/angr/analyses/flirt/flirt.py
+++ b/angr/analyses/flirt/flirt.py
@@ -190,8 +190,8 @@ class FlirtAnalysis(Analysis):
         return caller_funcs
 
     def _get_callee_name(
-        self, func, func_addr: int, call_addr: int, expected_name: str
-    ) -> str | None:  # pylint:disable=unused-argument
+        self, func, func_addr: int, call_addr: int, expected_name: str  # pylint:disable=unused-argument
+    ) -> str | None:
         for block_addr, (call_target, _) in func._call_sites.items():
             block = func.get_block(block_addr)
             call_ins_addr = (

--- a/angr/analyses/flirt/flirt.py
+++ b/angr/analyses/flirt/flirt.py
@@ -92,6 +92,7 @@ class FlirtAnalysis(Analysis):
 
             if max_suggestion_sig_path is not None:
                 sig_ = path_to_sig.get(max_suggestion_sig_path)
+                assert sig_ is not None
                 _l.info("Applying FLIRT signature %s for library %s.", sig_, lib)
                 self._apply_changes(
                     sig_.sig_name if not self._temporary_sig else None, sig_to_suggestions[max_suggestion_sig_path]
@@ -188,7 +189,9 @@ class FlirtAnalysis(Analysis):
                     caller_funcs.add(pred)
         return caller_funcs
 
-    def _get_callee_name(self, func, func_addr: int, call_addr: int, expected_name: str) -> str | None:
+    def _get_callee_name(
+        self, func, func_addr: int, call_addr: int, expected_name: str
+    ) -> str | None:  # pylint:disable=unused-argument
         for block_addr, (call_target, _) in func._call_sites.items():
             block = func.get_block(block_addr)
             call_ins_addr = (
@@ -208,7 +211,6 @@ class FlirtAnalysis(Analysis):
         )
         if func_addr != base_addr and (self._is_arm and func_addr != base_addr + 1):
             # get the correct function
-            func = None
             try:
                 func = self.kb.functions.get_by_addr(func_addr)
             except KeyError:

--- a/angr/analyses/flirt/flirt.py
+++ b/angr/analyses/flirt/flirt.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
-from functools import partial
+
+from collections.abc import Generator
 from collections import defaultdict
+import contextlib
 import logging
 
-import nampa
 from archinfo.arch_arm import is_arm_arch
 
 from angr.analyses import AnalysesHub
+from angr.analyses.analysis import Analysis
 from angr.errors import AngrRuntimeError
-from angr.flirt import FlirtSignature, STRING_TO_LIBRARIES, LIBRARY_TO_SIGNATURES, FLIRT_SIGNATURES_BY_ARCH
-from .analysis import Analysis
-import contextlib
+from .flirt_sig import FlirtSignature, FlirtSignatureParsed
+from .flirt_function import FlirtFunction
+from .flirt_matcher import FlirtMatcher
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.functions import Function
@@ -33,19 +35,22 @@ class FlirtAnalysis(Analysis):
       current binary, and then match all possible signatures for the architecture.
     """
 
-    def __init__(self, sig: FlirtSignature | str | None = None):
+    def __init__(self, sig: FlirtSignature | str | None = None, max_mismatched_bytes: int = 0):
+
+        from angr.flirt import FLIRT_SIGNATURES_BY_ARCH  # pylint:disable=import-outside-toplevel
+
         self._is_arm = is_arm_arch(self.project.arch)
         self._all_suggestions: dict[str, dict[str, dict[int, str]]] = {}
         self._suggestions: dict[int, str] = {}
         self.matched_suggestions: dict[str, tuple[FlirtSignature, dict[int, str]]] = {}
         self._temporary_sig = False
+        self._max_mismatched_bytes = max_mismatched_bytes
 
         if sig:
             if isinstance(sig, str):
                 # this is a file path
-                sig = FlirtSignature(
-                    self.project.arch.name.lower(), self.project.simos.name.lower(), "Temporary", sig, None
-                )
+                simos_name = self.project.arch.name if self.project.simos.name is not None else "UnknownOS"
+                sig = FlirtSignature(simos_name.lower(), simos_name.lower(), "Temporary", sig, None)
 
                 self.signatures = [sig]
                 self._temporary_sig = True
@@ -93,7 +98,10 @@ class FlirtAnalysis(Analysis):
                 )
                 self.matched_suggestions[lib] = (sig_, sig_to_suggestions[max_suggestion_sig_path])
 
-    def _find_hits_by_strings(self, regions: list[bytes]) -> list[FlirtSignature]:
+    def _find_hits_by_strings(self, regions: list[bytes]) -> Generator[FlirtSignature]:
+
+        from angr.flirt import STRING_TO_LIBRARIES, LIBRARY_TO_SIGNATURES  # pylint:disable=import-outside-toplevel
+
         library_hits: dict[str, int] = defaultdict(int)
         for s, libs in STRING_TO_LIBRARIES.items():
             for region in regions:
@@ -117,37 +125,88 @@ class FlirtAnalysis(Analysis):
         # match each function
         self._suggestions = {}
         with open(sig.sig_path, "rb") as sigfile:
-            flirt = nampa.parse_flirt_file(sigfile)
-            for func in self.project.kb.functions.values():
-                func: Function
-                if func.is_simprocedure or func.is_plt:
-                    continue
-                if not func.is_default_name:
-                    # it already has a name. skip
-                    continue
+            flirt = FlirtSignatureParsed.parse(sigfile)
+            tolerances = range(self._max_mismatched_bytes + 1)
+            for tolerance in tolerances:
+                # we iteratively match until we find no new matches
+                updated_funcs = set()
+                while True:
+                    matched = False
 
-                start = func.addr
-                if self._is_arm:
-                    start = start & 0xFFFF_FFFE
+                    funcs = (
+                        self.project.kb.functions.values()
+                        if not updated_funcs
+                        else {self.project.kb.functions.get_by_addr(a) for a in self._get_caller_funcs(updated_funcs)}
+                    )
+                    updated_funcs = set()
 
-                max_block_addr = max(func.block_addrs_set)
-                end_block = func.get_block(max_block_addr)
-                end = max_block_addr + end_block.size
+                    for func in funcs:
+                        func: Function
+                        if func.is_simprocedure or func.is_plt:
+                            continue
+                        if func.addr in self._suggestions:
+                            # we already have a suggestion for this function
+                            continue
+                        if not func.is_default_name:
+                            # it already has a name. skip
+                            continue
 
-                if self._is_arm:
-                    end = end & 0xFFFF_FFFE
+                        # print(tolerance, repr(func))
+                        start = func.addr
+                        if self._is_arm:
+                            start = start & 0xFFFF_FFFE
 
-                # load all bytes
-                func_bytes = self.project.loader.memory.load(start, end - start + 0x100)
-                _callback = partial(self._on_func_matched, func)
-                nampa.match_function(flirt, func_bytes, start, _callback)
+                        max_block_addr = max(func.block_addrs_set)
+                        end_block = func.get_block(max_block_addr)
+                        end = max_block_addr + end_block.size
 
-    def _on_func_matched(self, func: Function, base_addr: int, flirt_func: nampa.FlirtFunction):
+                        if self._is_arm:
+                            end = end & 0xFFFF_FFFE
+
+                        # load all bytes
+                        func_bytes = self.project.loader.memory.load(start, end - start + 0x100)
+                        matcher = FlirtMatcher(
+                            flirt,
+                            func,
+                            self._get_callee_name,
+                            self._on_func_matched,
+                            mismatch_bytes_tolerance=tolerance,
+                        )
+                        func_matched = matcher.match_function(func_bytes, start)
+                        if func_matched:
+                            updated_funcs.add(func.addr)
+                        matched |= func_matched
+
+                    if not matched:
+                        break
+
+    def _get_caller_funcs(self, update_func_addrs: set[int]) -> set[int]:
+        caller_funcs = set()
+        for func_addr in update_func_addrs:
+            for pred in self.kb.functions.callgraph.predecessors(func_addr):
+                if pred != func_addr:
+                    caller_funcs.add(pred)
+        return caller_funcs
+
+    def _get_callee_name(self, func, func_addr: int, call_addr: int, expected_name: str) -> str | None:
+        for block_addr, (call_target, _) in func._call_sites.items():
+            block = func.get_block(block_addr)
+            call_ins_addr = (
+                block.instruction_addrs[-2] if self.project.arch.branch_delay_slot else block.instruction_addrs[-1]
+            )
+            if block_addr <= call_addr < block_addr + block.size and call_ins_addr <= call_addr:
+                if call_target is None or not self.kb.functions.contains_addr(call_target):
+                    return None
+                callee = self.kb.functions.get_by_addr(call_target)
+                return callee.name
+        return None
+
+    def _on_func_matched(self, func: Function, base_addr: int, flirt_func: FlirtFunction):
         func_addr = base_addr + flirt_func.offset
         _l.debug(
             "_on_func_matched() is called with func_addr %#x with a suggested name %s.", func_addr, flirt_func.name
         )
-        if func_addr != base_addr:
+        if func_addr != base_addr and (self._is_arm and func_addr != base_addr + 1):
             # get the correct function
             func = None
             try:

--- a/angr/analyses/flirt/flirt_function.py
+++ b/angr/analyses/flirt/flirt_function.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+
+class FlirtFunction:
+    """
+    Describes a function object in a FLIRT signature.
+    """
+
+    __slots__ = (
+        "collision",
+        "local",
+        "name",
+        "offset",
+    )
+
+    def __init__(self, name: str, offset: int, local: bool, collision: bool):
+        self.name = name
+        self.offset = offset
+        self.local = local
+        self.collision = collision

--- a/angr/analyses/flirt/flirt_matcher.py
+++ b/angr/analyses/flirt/flirt_matcher.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 from .flirt_sig import FlirtSignatureParsed
 from .flirt_node import FlirtNode
 from .flirt_module import FlirtModule
+
+if TYPE_CHECKING:
+    from angr.knowledge_plugins.functions import Function
+    from .flirt_function import FlirtFunction
 
 
 # crc 16 with pre-computed table
@@ -281,7 +287,15 @@ class FlirtMatcher:
     """
 
     def __init__(
-        self, sig: FlirtSignatureParsed, func, get_callee_name, func_matched, mismatch_bytes_tolerance: int = 0
+        self,
+        sig: FlirtSignatureParsed,
+        func: Function,
+        get_callee_name: Callable[
+            [Function, int, int, str],
+            str | None,
+        ],
+        func_matched: Callable[[Function, int, FlirtFunction], None],
+        mismatch_bytes_tolerance: int = 0,
     ):
         self.sig = sig
         self.func = func

--- a/angr/analyses/flirt/flirt_matcher.py
+++ b/angr/analyses/flirt/flirt_matcher.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from .flirt_sig import FlirtSignatureParsed
+from .flirt_node import FlirtNode
+from .flirt_module import FlirtModule
+
+
+# crc 16 with pre-computed table
+crc16_table = [
+    0x0000,
+    0x1189,
+    0x2312,
+    0x329B,
+    0x4624,
+    0x57AD,
+    0x6536,
+    0x74BF,
+    0x8C48,
+    0x9DC1,
+    0xAF5A,
+    0xBED3,
+    0xCA6C,
+    0xDBE5,
+    0xE97E,
+    0xF8F7,
+    0x1081,
+    0x0108,
+    0x3393,
+    0x221A,
+    0x56A5,
+    0x472C,
+    0x75B7,
+    0x643E,
+    0x9CC9,
+    0x8D40,
+    0xBFDB,
+    0xAE52,
+    0xDAED,
+    0xCB64,
+    0xF9FF,
+    0xE876,
+    0x2102,
+    0x308B,
+    0x0210,
+    0x1399,
+    0x6726,
+    0x76AF,
+    0x4434,
+    0x55BD,
+    0xAD4A,
+    0xBCC3,
+    0x8E58,
+    0x9FD1,
+    0xEB6E,
+    0xFAE7,
+    0xC87C,
+    0xD9F5,
+    0x3183,
+    0x200A,
+    0x1291,
+    0x0318,
+    0x77A7,
+    0x662E,
+    0x54B5,
+    0x453C,
+    0xBDCB,
+    0xAC42,
+    0x9ED9,
+    0x8F50,
+    0xFBEF,
+    0xEA66,
+    0xD8FD,
+    0xC974,
+    0x4204,
+    0x538D,
+    0x6116,
+    0x709F,
+    0x0420,
+    0x15A9,
+    0x2732,
+    0x36BB,
+    0xCE4C,
+    0xDFC5,
+    0xED5E,
+    0xFCD7,
+    0x8868,
+    0x99E1,
+    0xAB7A,
+    0xBAF3,
+    0x5285,
+    0x430C,
+    0x7197,
+    0x601E,
+    0x14A1,
+    0x0528,
+    0x37B3,
+    0x263A,
+    0xDECD,
+    0xCF44,
+    0xFDDF,
+    0xEC56,
+    0x98E9,
+    0x8960,
+    0xBBFB,
+    0xAA72,
+    0x6306,
+    0x728F,
+    0x4014,
+    0x519D,
+    0x2522,
+    0x34AB,
+    0x0630,
+    0x17B9,
+    0xEF4E,
+    0xFEC7,
+    0xCC5C,
+    0xDDD5,
+    0xA96A,
+    0xB8E3,
+    0x8A78,
+    0x9BF1,
+    0x7387,
+    0x620E,
+    0x5095,
+    0x411C,
+    0x35A3,
+    0x242A,
+    0x16B1,
+    0x0738,
+    0xFFCF,
+    0xEE46,
+    0xDCDD,
+    0xCD54,
+    0xB9EB,
+    0xA862,
+    0x9AF9,
+    0x8B70,
+    0x8408,
+    0x9581,
+    0xA71A,
+    0xB693,
+    0xC22C,
+    0xD3A5,
+    0xE13E,
+    0xF0B7,
+    0x0840,
+    0x19C9,
+    0x2B52,
+    0x3ADB,
+    0x4E64,
+    0x5FED,
+    0x6D76,
+    0x7CFF,
+    0x9489,
+    0x8500,
+    0xB79B,
+    0xA612,
+    0xD2AD,
+    0xC324,
+    0xF1BF,
+    0xE036,
+    0x18C1,
+    0x0948,
+    0x3BD3,
+    0x2A5A,
+    0x5EE5,
+    0x4F6C,
+    0x7DF7,
+    0x6C7E,
+    0xA50A,
+    0xB483,
+    0x8618,
+    0x9791,
+    0xE32E,
+    0xF2A7,
+    0xC03C,
+    0xD1B5,
+    0x2942,
+    0x38CB,
+    0x0A50,
+    0x1BD9,
+    0x6F66,
+    0x7EEF,
+    0x4C74,
+    0x5DFD,
+    0xB58B,
+    0xA402,
+    0x9699,
+    0x8710,
+    0xF3AF,
+    0xE226,
+    0xD0BD,
+    0xC134,
+    0x39C3,
+    0x284A,
+    0x1AD1,
+    0x0B58,
+    0x7FE7,
+    0x6E6E,
+    0x5CF5,
+    0x4D7C,
+    0xC60C,
+    0xD785,
+    0xE51E,
+    0xF497,
+    0x8028,
+    0x91A1,
+    0xA33A,
+    0xB2B3,
+    0x4A44,
+    0x5BCD,
+    0x6956,
+    0x78DF,
+    0x0C60,
+    0x1DE9,
+    0x2F72,
+    0x3EFB,
+    0xD68D,
+    0xC704,
+    0xF59F,
+    0xE416,
+    0x90A9,
+    0x8120,
+    0xB3BB,
+    0xA232,
+    0x5AC5,
+    0x4B4C,
+    0x79D7,
+    0x685E,
+    0x1CE1,
+    0x0D68,
+    0x3FF3,
+    0x2E7A,
+    0xE70E,
+    0xF687,
+    0xC41C,
+    0xD595,
+    0xA12A,
+    0xB0A3,
+    0x8238,
+    0x93B1,
+    0x6B46,
+    0x7ACF,
+    0x4854,
+    0x59DD,
+    0x2D62,
+    0x3CEB,
+    0x0E70,
+    0x1FF9,
+    0xF78F,
+    0xE606,
+    0xD49D,
+    0xC514,
+    0xB1AB,
+    0xA022,
+    0x92B9,
+    0x8330,
+    0x7BC7,
+    0x6A4E,
+    0x58D5,
+    0x495C,
+    0x3DE3,
+    0x2C6A,
+    0x1EF1,
+    0x0F78,
+]
+
+
+def crc16(data: bytes) -> int:
+    crc = 0xFFFF
+    for byte in data:
+        crc = (crc >> 8) ^ crc16_table[(crc ^ byte) & 0xFF]
+    crc ^= 0xFFFF
+    # swap endianness
+    return ((crc & 0xFF) << 8) | ((crc & 0xFF00) >> 8)
+
+
+class FlirtMatcher:
+    """
+    A class that matches functions in a binary using FLIRT signatures.
+    """
+
+    def __init__(
+        self, sig: FlirtSignatureParsed, func, get_callee_name, func_matched, mismatch_bytes_tolerance: int = 0
+    ):
+        self.sig = sig
+        self.func = func
+        self.get_callee_name = get_callee_name
+        self.func_matched = func_matched
+        self.mismatch_bytes_tolerance: int = mismatch_bytes_tolerance
+
+    def match_function(self, buff: bytes, addr: int) -> bool:
+        return any(self._match_node(node, buff, addr, 0, 0) for node in self.sig.root.children)
+
+    def _match_node(self, node: FlirtNode, buff: bytes, addr: int, offset: int, mismatches: int) -> bool:
+        if len(buff) < offset + len(node.pattern):
+            return False
+        for i in range(len(node.pattern)):
+            if node.pattern[i] != -1 and node.pattern[i] != buff[offset + i]:
+                mismatches += 1
+                if mismatches > self.mismatch_bytes_tolerance:
+                    return False
+        if mismatches <= self.mismatch_bytes_tolerance:
+            # a matching node is found
+            for child in node.children:
+                if self._match_node(child, buff, addr, offset + node.length, mismatches):
+                    return True
+            for module in node.modules:
+                if self._match_module(module, buff, addr, offset + node.length):
+                    return True
+        return False
+
+    def _match_module(self, module: FlirtModule, buff: bytes, addr: int, offset: int) -> bool:
+        offset = max(offset, 32)
+        if module.crc_len > len(buff) - offset:
+            return False
+        crc = crc16(buff[offset : offset + module.crc_len]) if module.crc_len > 0 else 0
+        if crc != module.crc:
+            return False
+
+        # tail bytes
+        for off, b in module.tail_bytes:
+            if len(buff) <= offset + off or buff[offset + off] != b:
+                return False
+
+        # referenced functions
+        for ref_func in module.ref_funcs:
+            call_addr = addr + offset + ref_func.offset
+            callee_name = self.get_callee_name(self.func, addr, call_addr, ref_func.name)
+            if callee_name != ref_func.name:
+                return False
+
+        for func in module.pub_funcs:
+            self.func_matched(self.func, addr, func)
+
+        return True

--- a/angr/analyses/flirt/flirt_matcher.py
+++ b/angr/analyses/flirt/flirt_matcher.py
@@ -290,12 +290,13 @@ class FlirtMatcher:
         self.mismatch_bytes_tolerance: int = mismatch_bytes_tolerance
 
     def match_function(self, buff: bytes, addr: int) -> bool:
+        assert self.sig.root is not None
         return any(self._match_node(node, buff, addr, 0, 0) for node in self.sig.root.children)
 
     def _match_node(self, node: FlirtNode, buff: bytes, addr: int, offset: int, mismatches: int) -> bool:
         if len(buff) < offset + len(node.pattern):
             return False
-        for i in range(len(node.pattern)):
+        for i in range(len(node.pattern)):  # pylint:disable=consider-using-enumerate
             if node.pattern[i] != -1 and node.pattern[i] != buff[offset + i]:
                 mismatches += 1
                 if mismatches > self.mismatch_bytes_tolerance:

--- a/angr/analyses/flirt/flirt_module.py
+++ b/angr/analyses/flirt/flirt_module.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from .flirt_function import FlirtFunction
+
+
+class FlirtModule:
+    """
+    Describes a module in a FLIRT signature.
+    """
+
+    __slots__ = ("crc", "crc_len", "length", "pub_funcs", "ref_funcs", "tail_bytes")
+
+    def __init__(
+        self,
+        length: int,
+        crc_len: int,
+        crc: int,
+        pub_funcs: list[FlirtFunction],
+        ref_funcs: list[FlirtFunction],
+        tail_bytes: list[tuple[int, int]],
+    ):
+        self.length = length
+        self.crc_len = crc_len
+        self.crc = crc  # CRC16
+        self.pub_funcs = pub_funcs
+        self.ref_funcs = ref_funcs
+        self.tail_bytes = tail_bytes
+
+    def __repr__(self) -> str:
+        return (
+            f"<FlirtModule: length={self.length}, crc_len={self.crc_len}, crc={self.crc}, "
+            f"pub_funcs={self.pub_funcs}, ref_funcs={self.ref_funcs}, tail_bytes={self.tail_bytes}>"
+        )

--- a/angr/analyses/flirt/flirt_node.py
+++ b/angr/analyses/flirt/flirt_node.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from .flirt_module import FlirtModule
+
+
+class FlirtNode:
+    """
+    Describes a tree node in the FLIRT signature tree.
+    """
+
+    __slots__ = ("children", "length", "modules", "pattern")
+
+    def __init__(self, children: list[FlirtNode], modules: list[FlirtModule], length: int, pattern: list[int]):
+        self.children = children
+        self.modules = modules
+        self.length = length
+        self.pattern = pattern
+
+    @property
+    def leaf(self) -> bool:
+        return not self.children
+
+    def __repr__(self) -> str:
+        return f"<FlirtNode length={self.length} leaf={self.leaf}>"

--- a/angr/analyses/flirt/flirt_sig.py
+++ b/angr/analyses/flirt/flirt_sig.py
@@ -108,9 +108,13 @@ class FlirtSignatureParsed:
         Parse a FLIRT function tree.
         """
 
-        length = 0 if root else file_obj.read(1)[0]
-        variant_mask = None if root else self.parse_variant_mask(file_obj, length)
-        pattern = None if root else self.parse_node(file_obj, length, variant_mask)
+        if root:
+            length = file_obj.read(1)[0]
+            variant_mask = self.parse_variant_mask(file_obj, length)
+            pattern = self.parse_node(file_obj, length, variant_mask)
+        else:
+            length = 0
+            pattern = []
 
         node_count = read_multiple_bytes(file_obj)
         if node_count > 0:

--- a/angr/analyses/flirt/flirt_sig.py
+++ b/angr/analyses/flirt/flirt_sig.py
@@ -108,7 +108,7 @@ class FlirtSignatureParsed:
         Parse a FLIRT function tree.
         """
 
-        if root:
+        if not root:
             length = file_obj.read(1)[0]
             variant_mask = self.parse_variant_mask(file_obj, length)
             pattern = self.parse_node(file_obj, length, variant_mask)

--- a/angr/analyses/flirt/flirt_sig.py
+++ b/angr/analyses/flirt/flirt_sig.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+import struct
+import zlib
+from io import BytesIO
+
+from angr.errors import AngrError
+from .consts import FlirtParseFlag, FlirtFeatureFlag, FlirtFunctionFlag
+from .flirt_utils import read_max_2_bytes, read_multiple_bytes
+from .flirt_function import FlirtFunction
+from .flirt_module import FlirtModule
+from .flirt_node import FlirtNode
+
+
+class FlirtSignatureError(AngrError):
+    """
+    Describes errors related to FLIRT signatures, especially parsing.
+    """
+
+
+class FlirtSignature:
+    """
+    This class describes a FLIRT signature without any internal data that is only available after parsing.
+    """
+
+    def __init__(
+        self,
+        arch: str,
+        platform: str,
+        sig_name: str,
+        sig_path: str,
+        unique_strings: set[str] | None = None,
+        compiler: str | None = None,
+        compiler_version: str | None = None,
+        os_name: str | None = None,
+        os_version: str | None = None,
+    ):
+        self.arch = arch
+        self.platform = platform
+        self.sig_name = sig_name
+        self.sig_path = sig_path
+        self.unique_strings = unique_strings
+        self.compiler = compiler
+        self.compiler_version = compiler_version
+        self.os_name = os_name
+        self.os_version = os_version
+
+    def __repr__(self):
+        if self.os_name:
+            if self.os_version:
+                return f"<{self.sig_name}@{self.arch}-{self.os_name}-{self.os_version}>"
+            return f"<{self.sig_name}@{self.arch}-{self.os_name}>"
+        return f"<{self.sig_name}@{self.arch}-{self.platform}>"
+
+
+class FlirtSignatureParsed:
+    """
+    Describes a FLIRT signature file after parsing.
+    """
+
+    __slots__ = (
+        "app_types",
+        "arch",
+        "crc",
+        "ctype",
+        "ctypes_crc",
+        "features",
+        "file_types",
+        "libname",
+        "nfuncs",
+        "os_types",
+        "pattern_size",
+        "root",
+        "version",
+    )
+
+    def __init__(
+        self,
+        version: int,
+        arch: int,
+        file_types: int,
+        os_types: int,
+        app_types: int,
+        features: int,
+        crc: int,
+        ctype: int,
+        ctypes_crc: int,
+        nfuncs: int | None,
+        pattern_size: int | None,
+        libname: str,
+        root: FlirtNode | None,
+    ):
+        self.version = version
+        self.arch = arch
+        self.file_types = file_types
+        self.os_types = os_types
+        self.app_types = app_types
+        self.features = features
+        self.crc = crc
+        self.ctype = ctype
+        self.ctypes_crc = ctypes_crc
+        self.nfuncs = nfuncs
+        self.pattern_size = pattern_size
+        self.libname = libname
+        self.root = root
+
+    def parse_tree(self, file_obj, root: bool = False) -> FlirtNode:
+        """
+        Parse a FLIRT function tree.
+        """
+
+        length = 0 if root else file_obj.read(1)[0]
+        variant_mask = None if root else self.parse_variant_mask(file_obj, length)
+        pattern = None if root else self.parse_node(file_obj, length, variant_mask)
+
+        node_count = read_multiple_bytes(file_obj)
+        if node_count > 0:
+            # non-leaf; load its child nodes
+            nodes: list[FlirtNode] = [None] * node_count  # type: ignore
+            for i in range(node_count):
+                nn = self.parse_tree(file_obj)
+                nodes[i] = nn
+            return FlirtNode(nodes, [], length, pattern)
+        # leaf
+        modules = self.parse_modules(file_obj)
+        return FlirtNode([], modules, length, pattern)
+
+    def parse_public_function(self, file_obj, offset: int) -> tuple[FlirtFunction, int, int]:
+        off = read_multiple_bytes(file_obj) if self.version >= 9 else read_max_2_bytes(file_obj)
+        off += offset
+
+        local = False  # is it a local function?
+        collision = False  # is it an unresolved collision?
+
+        flags = file_obj.read(1)[0]
+        if flags < 0x20:
+            local = bool(flags & FlirtFunctionFlag.FUNCTION_LOCAL)
+            collision = bool(flags & FlirtFunctionFlag.FUNCTION_UNRESOLVED_COLLISION)
+            next_byte = file_obj.read(1)[0]
+        else:
+            next_byte = flags
+
+        name_lst = []
+        name_end = False  # in case the function name is too long...
+        for _ in range(1024):  # max length of a function name
+            if next_byte < 0x20:
+                name_end = True
+                break
+            name_lst.append(next_byte)
+            next_byte = file_obj.read(1)[0]
+
+        name = bytes(name_lst).decode("utf-8")
+        if not name_end:
+            name = name + "..."
+        return FlirtFunction(name, off, local, collision), off, next_byte
+
+    def parse_referenced_functions(self, file_obj) -> list[FlirtFunction]:
+        func_count = file_obj.read(1)[0] if self.version >= 8 else 1
+        lst = []
+        for _ in range(func_count):
+            off = read_multiple_bytes(file_obj) if self.version >= 9 else read_max_2_bytes(file_obj)
+            name_len = file_obj.read(1)[0]
+            if name_len == 0:
+                name_len = read_multiple_bytes(file_obj)
+            if name_len > 1024:
+                raise FlirtSignatureError(f"Function name too long: {name_len}")
+            name_bytes = file_obj.read(name_len)
+            if len(name_bytes) < name_len:
+                raise FlirtSignatureError("Unexpected EOF")
+            name = name_bytes.decode("utf-8").rstrip("\x00")
+            lst.append(FlirtFunction(name, off, False, False))
+        return lst
+
+    def parse_tail_bytes(self, file_obj) -> list[tuple[int, int]]:
+        bytes_count = file_obj.read(1)[0] if self.version >= 8 else 1
+        lst = []
+        for _ in range(bytes_count):
+            off = read_multiple_bytes(file_obj) if self.version >= 9 else read_max_2_bytes(file_obj)
+            value = file_obj.read(1)[0]
+            lst.append((off, value))
+        return lst
+
+    def parse_modules(self, file_obj) -> list[FlirtModule]:
+        modules = []
+        while True:
+            crc_len = file_obj.read(1)[0]
+            crc = struct.unpack(">H", file_obj.read(2))[0]
+
+            while True:
+                # parse all modules with the same CRC
+                module, flags = self.parse_module(file_obj)
+                module.crc_len = crc_len
+                module.crc = crc
+                modules.append(module)
+                if flags & FlirtParseFlag.PARSE_MORE_MODULES_WITH_SAME_CRC == 0:
+                    break
+
+            # same crc length but different crc
+            if flags & FlirtParseFlag.PARSE_MORE_MODULES == 0:
+                break
+        return modules
+
+    def parse_module(self, file_obj) -> tuple[FlirtModule, int]:
+        length = read_multiple_bytes(file_obj) if self.version >= 9 else read_max_2_bytes(file_obj)
+        pub_funcs = []
+        off = 0
+        while True:
+            func, off, flags = self.parse_public_function(file_obj, off)
+            pub_funcs.append(func)
+            if flags & FlirtParseFlag.PARSE_MORE_PUBLIC_NAMES == 0:
+                break
+
+        tail_bytes: list[tuple[int, int]] = []
+        if flags & FlirtParseFlag.PARSE_READ_TAIL_BYTES:
+            tail_bytes = self.parse_tail_bytes(file_obj)
+
+        ref_funcs = []
+        if flags & FlirtParseFlag.PARSE_READ_REFERENCED_FUNCTIONS:
+            ref_funcs = self.parse_referenced_functions(file_obj)
+
+        return (
+            FlirtModule(
+                length,
+                0,  # back-filled in its caller
+                0,  # back-filled in its caller
+                pub_funcs,
+                ref_funcs,
+                tail_bytes,
+            ),
+            flags,
+        )
+
+    @staticmethod
+    def parse_variant_mask(file_obj, length: int) -> int:
+        if length < 0x10:
+            return read_max_2_bytes(file_obj)
+        if length <= 0x20:
+            return read_multiple_bytes(file_obj)
+        if length <= 0x40:
+            return (read_multiple_bytes(file_obj) << 32) | read_multiple_bytes(file_obj)
+        raise FlirtSignatureError(f"Unexpected variant mask length: {length}")
+
+    @staticmethod
+    def is_bit_set_be(mask: int, mask_len: int, bit_offset: int) -> bool:
+        assert mask_len > bit_offset
+        return mask & (1 << (mask_len - bit_offset - 1)) != 0
+
+    @staticmethod
+    def parse_node(file_obj, length: int, variant_mask: int) -> list[int]:
+        pattern = [-1] * length
+        for i in range(length):
+            if not FlirtSignatureParsed.is_bit_set_be(variant_mask, length, i):
+                pattern[i] = file_obj.read(1)[0]
+        return pattern
+
+    @classmethod
+    def parse(cls, file_obj) -> FlirtSignatureParsed:
+        """
+        Parse a FLIRT signature file.
+
+        The following struct definitions come from radare2
+
+        // FLIRT v5+
+        ut8 magic[6];
+        ut8 version;
+        ut8 arch;
+        ut32 file_types;
+        ut16 os_types;
+        ut16 app_types;
+        ut16 features;
+        ut16 old_n_functions;
+        ut16 crc16;
+        ut8 ctype[12];
+        ut8 library_name_len;
+        ut16 ctypes_crc16;
+
+        // FLIRT v6+
+        ut32 nfuncs;
+
+        // FLIRT v8+
+        ut16 pattern_size;
+
+        // FLIRT v10
+        ut16 unknown;
+        """
+
+        struct_str = "<6s B B I H H H H H 12s B H".replace(" ", "")
+        sz = struct.calcsize(struct_str)
+        header_bytes = file_obj.read(sz)
+        if len(header_bytes) != sz:
+            raise FlirtSignatureError
+        unpacked = struct.unpack(struct_str, header_bytes)
+
+        # sanity check
+        if unpacked[0] != b"IDASGN":
+            raise FlirtSignatureError("Unexpected magic bytes")
+
+        version = unpacked[1]
+        if version < 5:
+            raise FlirtSignatureError("Unsupported FLIRT signature version")
+
+        if version >= 6:
+            # nfuncs
+            data = file_obj.read(4)
+            if len(data) != 4:
+                raise FlirtSignatureError("Unexpected EOF")
+            nfuncs = struct.unpack("<I", data)[0]
+        else:
+            nfuncs = None
+        if version >= 8:
+            # pattern_size
+            data = file_obj.read(2)
+            if len(data) != 2:
+                raise FlirtSignatureError("Unexpected EOF")
+            pattern_size = struct.unpack("<H", data)[0]
+        else:
+            pattern_size = None
+
+        if version >= 10:
+            # unknown
+            data = file_obj.read(2)
+            if len(data) != 2:
+                raise FlirtSignatureError("Unexpected EOF")
+
+        libname_len = unpacked[10]
+        libname = file_obj.read(libname_len).decode("utf-8")
+
+        obj = cls(
+            version=version,
+            arch=unpacked[2],
+            file_types=unpacked[3],
+            os_types=unpacked[4],
+            app_types=unpacked[5],
+            features=unpacked[6],
+            crc=unpacked[7],
+            ctype=unpacked[8],
+            ctypes_crc=unpacked[11],
+            nfuncs=nfuncs,
+            pattern_size=pattern_size,
+            libname=libname,
+            root=None,
+        )
+
+        # is it compressed?
+        if obj.features & FlirtFeatureFlag.FEATURE_COMPRESSED:
+            data = file_obj.read()
+            decompressed = BytesIO(zlib.decompress(data))
+            file_obj = decompressed
+
+        root = obj.parse_tree(file_obj, root=True)
+
+        obj.root = root
+        return obj

--- a/angr/analyses/flirt/flirt_utils.py
+++ b/angr/analyses/flirt/flirt_utils.py
@@ -1,0 +1,31 @@
+# Util functions that are mostly rewrite of the original code in redare2
+from __future__ import annotations
+import struct
+
+
+def read_short(file_obj) -> int:
+    return struct.unpack(">H", file_obj.read(2))[0]
+
+
+def read_word(file_obj) -> int:
+    return struct.unpack(">I", file_obj.read(4))[0]
+
+
+def read_max_2_bytes(file_obj) -> int:
+    b = file_obj.read(1)[0]
+    if b & 0x80 != 0x80:
+        return b
+    return ((b & 0x7F) << 8) + file_obj.read(1)[0]
+
+
+def read_multiple_bytes(file_obj) -> int:
+    b = file_obj.read(1)[0]
+    if b & 0x80 != 0x80:
+        return b
+    if b & 0xC0 != 0xC0:
+        return ((b & 0x7F) << 8) + file_obj.read(1)[0]
+    if b & 0xE0 != 0xE0:
+        b = ((b & 0x3F) << 24) + (file_obj.read(1)[0] << 16)
+        b += read_short(file_obj)
+        return b
+    return read_word(file_obj)

--- a/angr/flirt/__init__.py
+++ b/angr/flirt/__init__.py
@@ -6,7 +6,13 @@ import json
 from collections import defaultdict
 import logging
 
-from angr.analyses.flirt import FlirtSignature, FlirtSignatureParsed, FlirtSignatureError
+from angr.analyses.flirt import (
+    FlirtSignature,
+    FlirtSignatureParsed,
+    FlirtSignatureError,
+    flirt_arch_to_arch_name,
+    flirt_os_type_to_os_name,
+)
 
 
 _l = logging.getLogger(__name__)
@@ -50,8 +56,8 @@ def load_signatures(path: str) -> None:
                     with open(meta_path) as f:
                         meta = json.load(f)
 
-                    arch = meta.get("arch", None)
-                    platform = meta.get("platform", None)
+                    arch = str(meta.get("arch", "Unknown"))
+                    platform = str(meta.get("platform", "UnknownOS"))
                     os_name = meta.get("os", None)
                     os_version = meta.get("os_version", None)
                     compiler = meta.get("compiler", None)
@@ -60,9 +66,8 @@ def load_signatures(path: str) -> None:
 
                 else:
                     # nope... we need to extract information from the signature file
-                    # TODO: Convert them to angr-specific strings
-                    arch = sig_parsed.arch
-                    platform = sig_parsed.os_types
+                    arch = flirt_arch_to_arch_name(sig_parsed.arch, sig_parsed.app_types)
+                    platform = flirt_os_type_to_os_name(sig_parsed.os_types)
                     os_name = None
                     os_version = None
                     unique_strings = None

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -218,7 +218,7 @@ class Function(Serializable):
             self.is_default_name = False
             self._name = name
         self.previous_names = []
-        self.from_signature = None
+        self.from_signature: str | None = None
 
         # Determine the name the binary where this function is.
         if binary_name is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "claripy==9.2.147.dev0",
     "cle==9.2.147.dev0",
     "mulpyplexer",
-    "nampa",
     "networkx!=2.8.1,>=2.0",
     "protobuf>=5.28.2",
     "psutil",


### PR DESCRIPTION
This is for supporting reference functions as well as fuzzy FLIRT parsing.