### PR TITLE
Function: Only count local blocks toward size

### DIFF
--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -612,7 +612,7 @@ class Function(Serializable):
 
     @property
     def size(self):
-        return sum(self._block_sizes.values())
+        return sum(self._block_sizes[addr] for addr in self._local_blocks)
 
     @property
     def binary(self):


### PR DESCRIPTION
Non-local block sizes may be cached in `self._block_sizes`, e.g. via` _register_node`. Count only the local block sizes towards total function size in `Function::size`. Resolves a discrepancy in size of a Function created via CFGFast and that function after being restored from adb.