### PR TITLE
Decompiler: Fix long multi-statement expressions.

### DIFF
--- a/angr/analyses/decompiler/counters/call_counter.py
+++ b/angr/analyses/decompiler/counters/call_counter.py
@@ -37,8 +37,10 @@ class AILCallCounter(SequenceWalker):
         }
         super().__init__(handlers)
         self.calls = 0
+        self.stmts = 0
 
     def _handle_Block(self, node: Block, **kwargs):  # pylint:disable=unused-argument
         ctr = AILBlockCallCounter()
         ctr.walk(node)
         self.calls += ctr.calls
+        self.stmts += len(node.statements)

--- a/angr/analyses/decompiler/counters/call_counter.py
+++ b/angr/analyses/decompiler/counters/call_counter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ailment import Block
+from ailment.statement import Label
 from ailment.block_walker import AILBlockWalkerBase
 
 from angr.analyses.decompiler.sequence_walker import SequenceWalker
@@ -37,10 +38,10 @@ class AILCallCounter(SequenceWalker):
         }
         super().__init__(handlers)
         self.calls = 0
-        self.stmts = 0
+        self.non_label_stmts = 0
 
     def _handle_Block(self, node: Block, **kwargs):  # pylint:disable=unused-argument
         ctr = AILBlockCallCounter()
         ctr.walk(node)
         self.calls += ctr.calls
-        self.stmts += len(node.statements)
+        self.non_label_stmts += sum(1 for stmt in node.statements if not isinstance(stmt, Label))

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
@@ -164,6 +164,20 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                                 **expr.tags,
                             )
 
+        # simpler cases
+        # (A & mask) & mask  ==>  A & mask
+        if (
+            expr.op == "And"
+            and isinstance(expr.operands[1], Const)
+            and isinstance(expr.operands[0], BinaryOp)
+            and expr.operands[0].op == "And"
+        ):
+            inner_op0, inner_op1 = expr.operands[0].operands
+            if (isinstance(inner_op0, Const) and inner_op0.value == expr.operands[1].value) or (
+                isinstance(inner_op1, Const) and inner_op1.value == expr.operands[1].value
+            ):
+                return expr.operands[0]
+
         return None
 
     @staticmethod

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -90,6 +90,7 @@ class PhoenixStructurer(StructurerBase):
         parent_region=None,
         improve_algorithm=False,
         use_multistmtexprs: MultiStmtExprMode = MultiStmtExprMode.MAX_ONE_CALL,
+        multistmtexpr_stmt_threshold: int = 5,
         **kwargs,
     ):
         super().__init__(
@@ -126,6 +127,7 @@ class PhoenixStructurer(StructurerBase):
         self._edge_virtualization_hints = []
 
         self._use_multistmtexprs = use_multistmtexprs
+        self._multistmtexpr_stmt_threshold = multistmtexpr_stmt_threshold
         self._analyze()
 
     @staticmethod
@@ -540,7 +542,7 @@ class PhoenixStructurer(StructurerBase):
                             ):
                                 stmts = self._build_multistatementexpr_statements(succ)
                                 assert stmts is not None
-                                if stmts:
+                                if stmts and len(stmts) <= self._multistmtexpr_stmt_threshold:
                                     edge_cond_succhead = MultiStatementExpression(
                                         None,
                                         stmts,
@@ -2612,12 +2614,14 @@ class PhoenixStructurer(StructurerBase):
         if self._use_multistmtexprs == MultiStmtExprMode.NEVER:
             return False
         if self._use_multistmtexprs == MultiStmtExprMode.ALWAYS:
-            return True
+            ctr = AILCallCounter()
+            ctr.walk(node)
+            return ctr.stmts <= self._multistmtexpr_stmt_threshold
         if self._use_multistmtexprs == MultiStmtExprMode.MAX_ONE_CALL:
             # count the number of calls
             ctr = AILCallCounter()
             ctr.walk(node)
-            return ctr.calls <= 1
+            return ctr.calls <= 1 and ctr.stmts <= self._multistmtexpr_stmt_threshold
         l.warning("Unsupported enum value for _use_multistmtexprs: %s", self._use_multistmtexprs)
         return False
 

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -542,7 +542,11 @@ class PhoenixStructurer(StructurerBase):
                             ):
                                 stmts = self._build_multistatementexpr_statements(succ)
                                 assert stmts is not None
-                                if stmts and len(stmts) <= self._multistmtexpr_stmt_threshold:
+                                if (
+                                    stmts
+                                    and sum(1 for stmt in stmts if not isinstance(stmt, Label))
+                                    <= self._multistmtexpr_stmt_threshold
+                                ):
                                     edge_cond_succhead = MultiStatementExpression(
                                         None,
                                         stmts,
@@ -2616,12 +2620,12 @@ class PhoenixStructurer(StructurerBase):
         if self._use_multistmtexprs == MultiStmtExprMode.ALWAYS:
             ctr = AILCallCounter()
             ctr.walk(node)
-            return ctr.stmts <= self._multistmtexpr_stmt_threshold
+            return ctr.non_label_stmts <= self._multistmtexpr_stmt_threshold
         if self._use_multistmtexprs == MultiStmtExprMode.MAX_ONE_CALL:
             # count the number of calls
             ctr = AILCallCounter()
             ctr.walk(node)
-            return ctr.calls <= 1 and ctr.stmts <= self._multistmtexpr_stmt_threshold
+            return ctr.calls <= 1 and ctr.non_label_stmts <= self._multistmtexpr_stmt_threshold
         l.warning("Unsupported enum value for _use_multistmtexprs: %s", self._use_multistmtexprs)
         return False
 


### PR DESCRIPTION
Also remove redundant masking operations (& 0xff) in decompilation output.