### PR TITLE
FunctionManager: Fix two serialization bugs

### DIFF
--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -505,6 +505,7 @@ class FunctionManager(KnowledgeBasePlugin, collections.abc.Mapping):
 
     def rebuild_callgraph(self):
         self.callgraph = networkx.MultiDiGraph()
+        cfg = self._kb.cfgs.get_most_accurate()
         for func_addr in self._function_map:
             self.callgraph.add_node(func_addr)
         for func in self._function_map.values():
@@ -512,6 +513,14 @@ class FunctionManager(KnowledgeBasePlugin, collections.abc.Mapping):
                 for node in func.transition_graph.nodes():
                     if isinstance(node, Function):
                         self.callgraph.add_edge(func.addr, node.addr)
+                    else:
+                        cfgnode = cfg.get_any_node(node.addr)
+                        if (
+                            cfgnode is not None
+                            and cfgnode.function_address is not None
+                            and cfgnode.function_address != func.addr
+                        ):
+                            self.callgraph.add_edge(func.addr, cfgnode.function_address)
 
 
 KnowledgeBasePlugin.register_default("functions", FunctionManager)

--- a/angr/knowledge_plugins/functions/function_parser.py
+++ b/angr/knowledge_plugins/functions/function_parser.py
@@ -113,7 +113,7 @@ class FunctionParser:
             binary_name=None if not cmsg.binary_name else cmsg.binary_name,
             calling_convention=pickle.loads(cmsg.calling_convention),
             prototype=pickle.loads(cmsg.prototype),
-            prototype_libname=cmsg.prototype_libname,
+            prototype_libname=cmsg.prototype_libname if cmsg.prototype_libname else None,
             is_prototype_guessed=cmsg.is_prototype_guessed,
         )
         obj._project = project


### PR DESCRIPTION
- preserve the None-ness of prototype_libname
- preserve odd edges of the callgraph