### PR TITLE
VRA: Check existing vars before creating new ones in read_reg.

### DIFF
--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -999,8 +999,10 @@ class SimEngineVRBase(
                         ident=self.state.variable_manager[self.func_addr].next_variable_ident("register"),
                         region=self.func_addr,
                     )
-                    value = self.state.annotate_with_variables(value, [(0, variable)])
                     self.state.variable_manager[self.func_addr].add_variable("register", offset, variable)
+                else:
+                    variable = next(iter(existing_vars))[0]
+                value = self.state.annotate_with_variables(value, [(0, variable)])
             self.state.register_region.store(offset, value)
             value_list = [{value}]
         else:

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -987,14 +987,20 @@ class SimEngineVRBase(
             value = self.state.top(size * self.project.arch.byte_width)
             if create_variable:
                 # create a new variable if necessary
-                variable = SimRegisterVariable(
-                    offset,
-                    size if force_variable_size is None else force_variable_size,
-                    ident=self.state.variable_manager[self.func_addr].next_variable_ident("register"),
-                    region=self.func_addr,
-                )
-                value = self.state.annotate_with_variables(value, [(0, variable)])
-                self.state.variable_manager[self.func_addr].add_variable("register", offset, variable)
+
+                # check if there is an existing variable for the atom at this location already
+                existing_vars: set[tuple[SimVariable, int]] = self.state.variable_manager[
+                    self.func_addr
+                ].find_variables_by_atom(self.block.addr, self.stmt_idx, expr)
+                if not existing_vars:
+                    variable = SimRegisterVariable(
+                        offset,
+                        size if force_variable_size is None else force_variable_size,
+                        ident=self.state.variable_manager[self.func_addr].next_variable_ident("register"),
+                        region=self.func_addr,
+                    )
+                    value = self.state.annotate_with_variables(value, [(0, variable)])
+                    self.state.variable_manager[self.func_addr].add_variable("register", offset, variable)
             self.state.register_region.store(offset, value)
             value_list = [{value}]
         else:

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -934,7 +934,7 @@ class VariableManagerInternal(Serializable):
 
         for var in chain(sorted_stack_variables, sorted_reg_variables, phi_only_vars):
             idx = next(var_ctr)
-            if var.name is not None and not reset:
+            if var.name is not None and var.name != var.ident and not reset:
                 continue
             if isinstance(var, (SimStackVariable, SimRegisterVariable)):
                 var.name = f"v{idx}"
@@ -946,7 +946,7 @@ class VariableManagerInternal(Serializable):
         arg_vars = sorted(arg_vars, key=lambda v: _id_from_varident(v.ident))
         for var in arg_vars:
             idx = next(arg_ctr)
-            if var.name is not None and not reset:
+            if var.name is not None and var.name != var.ident and not reset:
                 continue
             var.name = arg_names[idx] if arg_names else f"a{idx}"
             var._hash = None


### PR DESCRIPTION
Also fix missed variable renaming opportunities in VariableManagerInternal.assign_unified_variable_names.