### PR TITLE
Add uv CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,14 @@ jobs:
     steps:
       - name: Checkout angr
         uses: actions/checkout@v4
+        with:
+          path: angr
+
       - name: Checkout binaries
         uses: actions/checkout@v4
         with:
           repository: angr/binaries
+          path: binaries
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,37 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+        group: [1, 2, 3, 4, 5]
+      fail-fast: false
+    name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout angr
+        uses: actions/checkout@v4
+      - name: Checkout binaries
+        uses: actions/checkout@v4
+        with:
+          repository: angr/binaries
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: cd angr && uv sync --dev
+      - name: Run tests
+        run: cd angr && uv run pytest -nauto --splits 5 --group ${{ matrix.group }}
+
+  ecosystem:
+    name: angr Ecosystem
     uses: angr/ci-settings/.github/workflows/angr-ci.yml@master
+    with:
+      include_self: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: cd angr && uv sync --dev
       - name: Run tests
-        run: cd angr && uv run pytest -nauto --splits 5 --group ${{ matrix.group }}
+        run: cd angr && uv run pytest -nauto --splits 5 --group ${{ matrix.group }} tests
 
   ecosystem:
     name: angr Ecosystem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: ["3.10"]
         group: [1, 2, 3, 4, 5]
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,23 +58,24 @@ docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
 ]
+keystone = ["keystone-engine"]
 pcode = ["pypcode~=3.0"]
 telemetry = ["opentelemetry-api"]
-testing = [
-    "keystone-engine",
-    "pypcode~=3.0",
-    "pytest",
-    "pytest-split",
-    "pytest-xdist",
-    "sqlalchemy",
-    "unicorn==2.0.1.post1",
-]
-unicorn = [
-    "unicorn==2.0.1.post1",
-]
+unicorn = ["unicorn==2.0.1.post1"]
 
 [project.scripts]
 angr = "angr.__main__:main"
+
+[dependency-groups]
+dev = [
+    "pytest",
+    "pytest-split",
+    "pytest-xdist",
+    "keystone-engine",
+    "pypcode~=3.0",
+    "sqlalchemy",
+    "unicorn==2.0.1.post1",
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/regression/test_regression_memcmp_definite_size.py
+++ b/tests/regression/test_regression_memcmp_definite_size.py
@@ -15,7 +15,7 @@ from tests.common import bin_location, slow_test
 class TestMemcmpDefiniteSize(unittest.TestCase):
     @slow_test
     def test_memcmp_strlen_simprocedure_interaction(self):
-        bin_path = os.path.join(bin_location, "i386", "cpp_regression_test_ch25")
+        bin_path = os.path.join(bin_location, "tests", "i386", "cpp_regression_test_ch25")
 
         p = angr.Project(bin_path, auto_load_libs=True)  # this binary requires the loading of libstdc++.so.6
         argv1 = claripy.Concat(*[claripy.BVS(f"argv{i}", 8) for i in range(48)])


### PR DESCRIPTION
This adds a new job to test angr installed using `uv`, and disables it from running in the "ecosystem ci". The rest of the ecosystem is still tested in the container as usual. The idea here is to decrease the latency between opening a PR and getting feedback from the CI. In the future I want to convert the ecosystem ci to use uv too, and this is a first step in that direction.