### PR TITLE
Use a new solver instead of modifying constraints in existing solver

### DIFF
--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -2967,10 +2967,13 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
                 new_state.options.add(o.DO_RET_EMULATION)
                 # Remove bad constraints
                 # FIXME: This is so hackish...
-                new_state.solver._solver.constraints = [
+                preserved_constraints = [
                     c for c in new_state.solver.constraints if c.op != "BoolV" or c.args[0] is not False
                 ]
-                new_state.solver._solver._result = None
+                new_solver = new_state.solver.blank_copy()
+                new_solver.add(preserved_constraints)
+                new_state.solver._solver = new_solver
+
                 # Swap them
                 saved_state, job.state = job.state, new_state
                 sim_successors, exception_info, _ = self._get_simsuccessors(addr, job)

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -2972,7 +2972,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
                 ]
                 new_solver = new_state.solver._solver.blank_copy()
                 new_solver.add(preserved_constraints)
-                new_state.solver._solver = new_solver
+                new_state.solver._stored_solver = new_solver
 
                 # Swap them
                 saved_state, job.state = job.state, new_state

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -2970,7 +2970,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
                 preserved_constraints = [
                     c for c in new_state.solver.constraints if c.op != "BoolV" or c.args[0] is not False
                 ]
-                new_solver = new_state.solver.blank_copy()
+                new_solver = new_state.solver._solver.blank_copy()
                 new_solver.add(preserved_constraints)
                 new_state.solver._solver = new_solver
 


### PR DESCRIPTION
Still a bit of a hack, but at least now the hacky-ness is self contained within angr instead of crossing library boundaries.