### PR TITLE
Typehoon: Fix transitive type inference

### DIFF
--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -315,7 +315,7 @@ class ConstraintGraphNode:
             tag_str = "R"
         else:
             tag_str = "U"
-        forgotten_str = "PRE" if FORGOTTEN.PRE_FORGOTTEN else "POST"
+        forgotten_str = "PRE" if self.forgotten == FORGOTTEN.PRE_FORGOTTEN else "POST"
         s = f"{self.typevar}#{variance_str}.{tag_str}.{forgotten_str}"
         if ":" in s:
             return '"' + s + '"'

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -4211,10 +4211,7 @@ class TestDecompiler(unittest.TestCase):
         assert isinstance(arg0_type, SimTypePointer)
         assert isinstance(arg0_type.pts_to, SimTypeBottom)
         assert isinstance(arg1_type, SimTypePointer)
-        if isinstance(arg1_type.pts_to, SimTypeArray):
-            assert isinstance(arg1_type.pts_to.elem_type, SimTypeChar)
-        else:
-            assert isinstance(arg1_type.pts_to, SimTypeChar)
+        assert isinstance(arg1_type.pts_to, SimTypeBottom)
         assert isinstance(arg2_type, SimTypeLongLong)
         assert arg2_type.signed is False
 


### PR DESCRIPTION
This patch series fixes an issue with transitive type resolving, i.e. `a <: b`, `b <: c` &rarr; `a <: c` via `S-TRANS` rule in retypd paper. ~~To do this I've added a transitive edge to constraint graph nodes e.g. adding `{(b.r, c.r)}` to `{(a.l, b.r), (b.l, c.r)}` so the DFS solver can resolve the path `(a.l, b.r, c.r)`. I'm not sure if there's a different mechanism in the design that's supposed to do this, so I'd appreciate your review @ltfish~~

Also fixes an issue when populating the base type variables set from constraints (e.g. in test cases) when the base type does not appear in the constraint set in a subtype relationship (that is, only it's derived type is present in a constraint).
