### PR TITLE
Bypass "AttributeError: 'IRSB' object has no attribute 'is_noop_block'"

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2596,7 +2596,7 @@ class CFGBase(Analysis):
                 if THUMB_NOOPS.issuperset(insns):
                     return True
 
-        return block.vex_nostmt.is_noop_block
+        return getattr(block.vex_nostmt, "is_noop_block", False)
 
     @staticmethod
     def _is_noop_insn(insn):


### PR DESCRIPTION
Sometimes when constructing CFGs, I get an `AttributeError: 'IRSB' object has no attribute 'is_noop_block'`. I think it has something to do with unhandled architecture checks in the base CFG implementation. So here I've replaced the reference to `is_noop_block` with a `getattr` that defaults to `False` (which I think makes sense, treating all blocks as effect-ful, conservatively).