### PR TITLE
GraphUtils: Fix quasi_topological_sort_nodes panic mode

### DIFF
--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -673,6 +673,15 @@ class GraphUtils:
         return sorted(nodes, key=lambda n: addrs_to_index[n.addr], reverse=True)
 
     @staticmethod
+    def _sort_node(node):
+        """
+        A sorter to make a deterministic order of nodes.
+        """
+        if hasattr(node, "addr"):
+            return node.addr
+        return node
+
+    @staticmethod
     def _sort_edge(edge):
         """
         A sorter to make a deterministic order of edges.
@@ -832,8 +841,8 @@ class GraphUtils:
                     break
 
         if loop_head is None:
-            # randomly pick one
-            loop_head = next(iter(scc))
+            # pick the first one
+            loop_head = sorted(scc, key=GraphUtils._sort_node)[0]
 
         subgraph: networkx.DiGraph = graph.subgraph(scc).copy()
         for src, _ in list(subgraph.in_edges(loop_head)):

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -829,7 +829,7 @@ class GraphUtils:
         # panic mode that will aggressively remove edges
 
         if len(subgraph) > 3000 and len(subgraph.edges) > len(subgraph) * 1.4:
-            for n0, n1 in sorted(dfs_back_edges(subgraph, loop_head), key=lambda x: (x[0].addr, x[0].addr)):
+            for n0, n1 in sorted(dfs_back_edges(subgraph, loop_head), key=GraphUtils._sort_edge):
                 subgraph.remove_edge(n0, n1)
                 if len(subgraph.edges) <= len(subgraph) * 1.4:
                     break

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 import unittest
 import networkx as nx
-from angr.utils.graph import Dominators, TemporaryNode
+from ailment.block import Block
+from angr.utils.graph import Dominators, TemporaryNode, GraphUtils
 
 
 class TestGraph(unittest.TestCase):
@@ -36,6 +37,25 @@ class TestGraph(unittest.TestCase):
             end_node: {},
         }
         assert d.dom.succ == idom_succ
+
+    def test_quasi_topological_sort_nodes_panic_mode_int_nodes(self):
+        G = nx.DiGraph()
+        num_nodes = 100
+        for src in range(num_nodes):
+            for dst in range(num_nodes):
+                G.add_edge(src, dst)
+        G_sorted = GraphUtils.quasi_topological_sort_nodes(G, panic_mode_threshold=num_nodes // 2)
+        assert G_sorted == list(range(num_nodes))
+
+    def test_quasi_topological_sort_nodes_panic_mode_ail_block_nodes(self):
+        G = nx.DiGraph()
+        num_nodes = 100
+        nodes = [Block(i, 20) for i in range(num_nodes)]
+        for src in range(num_nodes):
+            for dst in range(num_nodes):
+                G.add_edge(nodes[src], nodes[dst])
+        G_sorted = GraphUtils.quasi_topological_sort_nodes(G, panic_mode_threshold=num_nodes // 2)
+        assert G_sorted == nodes
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Use `_sort_edge` in panic mode to support both integer node types and nodes with `.addr` property
   * We should probably refactor this to take generic comparison delegates for generalized sorting when the object is not naturally comparable, but it is deferred to a future PR
* Fix a source of non-determinism
* Make panic mode threshold comparable (mostly for faster testing)
* Add some test cases for panic mode with different node types