### PR TITLE
Fix _is_noop_block function to handle RISC-V arch

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2595,6 +2595,10 @@ class CFGBase(Analysis):
                 insns = {block.bytes[i : i + 2] for i in range(0, block.size, 2)}
                 if THUMB_NOOPS.issuperset(insns):
                     return True
+        elif arch.name.startswith("RISC"):
+            RISC_NOOP = b"\x13"  # ADDI x0, x0, 0 or NOP
+            # Return systematically since VEX still does not support RISC-V
+            return set(block.bytes) == {RISC_NOOP}
 
         return block.vex_nostmt.is_noop_block
 


### PR DESCRIPTION
angr fails to generate a CFGFast for RISC-V binaries. The error is caused by the _is_noop_block of cfg_base.py function that checks the attribute is_noop_block of an IRSB object. Since pyvex does not seem to support RISC for the moment, an AttributeError occurs.

I fix this by adding a case test for the RISC arch that returns systematically.
