### PR TITLE
Add is_noop_block property to pcode IRSB

### DIFF
--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -432,7 +432,7 @@ class IRSB:
         """
         Returns True if this block is a no-op block (i.e. it has no instructions and no jumps).
         """
-        return len(self._ops) == 0
+        return not any(op.opcode != pypcode.OpCode.IMARK for op in self._ops)
 
     #
     # private methods

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -427,6 +427,13 @@ class IRSB:
 
         return exits
 
+    @property
+    def is_noop_block(self) -> bool:
+        """
+        Returns True if this block is a no-op block (i.e. it has no instructions and no jumps).
+        """
+        return len(self._ops) == 0
+
     #
     # private methods
     #


### PR DESCRIPTION
This is an attempt at a somewhat more generalized fix to #5395 and #5411 by implementing this property on the pcode block. If we wanted to take this a step further, we should actually define this in the BlockProtocol, however right now that's literally just an address so I don't want to turn this into a Block API definition task.