### PR TITLE
On unconstrained memory read, include symbolic repr

### DIFF
--- a/angr/storage/memory_mixins/address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/address_concretization_mixin.py
@@ -270,13 +270,13 @@ class AddressConcretizationMixin(MemoryMixin):
             )
 
         if self.state.solver.symbolic(addr) and options.AVOID_MULTIVALUED_READS in self.state.options:
-            return self._default_value(None, size, name=f"symbolic_read_unconstrained_({addr})", **kwargs)
+            return self._default_value(None, size, name=f"symbolic_read_unconstrained_{addr}", **kwargs)
 
         try:
             concrete_addrs = self._interleave_ints(sorted(self.concretize_read_addr(addr, condition=condition)))
         except SimMemoryError:
             if options.CONSERVATIVE_READ_STRATEGY in self.state.options:
-                return self._default_value(None, size, name=f"symbolic_read_unconstrained_({addr})", **kwargs)
+                return self._default_value(None, size, name=f"symbolic_read_unconstrained_{addr}", **kwargs)
             raise
 
         # quick optimization so as to not involve the solver if not necessary

--- a/angr/storage/memory_mixins/address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/address_concretization_mixin.py
@@ -270,13 +270,13 @@ class AddressConcretizationMixin(MemoryMixin):
             )
 
         if self.state.solver.symbolic(addr) and options.AVOID_MULTIVALUED_READS in self.state.options:
-            return self._default_value(None, size, name="symbolic_read_unconstrained", **kwargs)
+            return self._default_value(None, size, name=f"symbolic_read_unconstrained_({addr})", **kwargs)
 
         try:
             concrete_addrs = self._interleave_ints(sorted(self.concretize_read_addr(addr, condition=condition)))
         except SimMemoryError:
             if options.CONSERVATIVE_READ_STRATEGY in self.state.options:
-                return self._default_value(None, size, name="symbolic_read_unconstrained", **kwargs)
+                return self._default_value(None, size, name=f"symbolic_read_unconstrained_({addr})", **kwargs)
             raise
 
         # quick optimization so as to not involve the solver if not necessary


### PR DESCRIPTION
Title says it all. I need to be able to see what symbolic address caused a read. This was quick and dirty, I wanted to add a flag in `AddressConcretizationMixin` that would turn on or off this behavior, but found trouble with AttributeErrors I couldn't decipher. If another interface would be better I'd be happy to implement it with some pointers.