### PR TITLE
Add dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist
 *.db
 *.dylib
 docs/_build
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,17 @@ unicorn = [
 [project.scripts]
 angr = "angr.__main__:main"
 
+[dependency-groups]
+dev = [
+    "keystone-engine>=0.9.2",
+    "pytest>=8.3.5",
+    "pytest-durations>=1.4.0",
+    "pytest-profiling>=1.8.1",
+    "pytest-timeout>=2.3.1",
+    "pytest-xdist>=3.6.1",
+    "sqlalchemy>=2.0.40",
+]
+
 [tool.setuptools]
 include-package-data = true
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,13 +78,13 @@ angr = "angr.__main__:main"
 
 [dependency-groups]
 dev = [
-    "keystone-engine>=0.9.2",
+    "black>=25.1.0",
     "pytest>=8.3.5",
     "pytest-durations>=1.4.0",
     "pytest-profiling>=1.8.1",
     "pytest-timeout>=2.3.1",
     "pytest-xdist>=3.6.1",
-    "sqlalchemy>=2.0.40",
+    "ruff>=0.11.7",
 ]
 
 [tool.setuptools]
@@ -103,6 +103,9 @@ angr = [
 
 [tool.setuptools.dynamic]
 version = {attr = "angr.__version__"}
+
+[tool.uv]
+default-groups = ["angrdb", "pcode", "unicorn"]
 
 [tool.uv.sources]
 archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }


### PR DESCRIPTION
Ever since we added uv sources, I've been deving angr by simply cloning it (next to a binaries checkout) and running `uv sync`, and then manually `uv pip install`ing optional dependencies and pytest. This allows doing `uv sync --dev`, and activating the venv, pytest is ready to go. Also adding uv.lock to the gitignore. 