### PR TITLE
unify_local_variables: Fix premature vvar replacements.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1826,7 +1826,13 @@ class Clinic(Analysis):
 
         # Unify SSA variables
         tmp_kb.variables.global_manager.assign_variable_names(labels=self.kb.labels, types={SimMemoryVariable})
-        var_manager.unify_variables()
+        liveness = self.project.analyses.SLiveness(
+            self.function,
+            func_graph=ail_graph,
+            entry=next(iter(bb for bb in ail_graph if (bb.addr, bb.idx) == self.entry_node_addr)),
+            arg_vvars=[vvar for vvar, _ in arg_vvars.values()],
+        )
+        var_manager.unify_variables(interference=liveness.interference_graph())
         var_manager.assign_unified_variable_names(
             labels=self.kb.labels,
             arg_names=self.function.prototype.arg_names if self.function.prototype else None,

--- a/angr/analyses/decompiler/dephication/graph_vvar_mapping.py
+++ b/angr/analyses/decompiler/dephication/graph_vvar_mapping.py
@@ -174,13 +174,13 @@ class GraphDephicationVVarMapping(Analysis):  # pylint:disable=abstract-method
             # update phi_congruence_class
             (phidef_block_addr, phidef_block_idx), phidef_stmt_idx = self._vvar_defloc[phi_id]
             phi_block = self._blocks[(phidef_block_addr, phidef_block_idx)]
+            # phi_stmt is the newly created phi statement with variables replaced
             phi_stmt = phi_block.statements[phidef_stmt_idx]
-
+            phi_src_vvar_ids = {src_vvar.varid for _, src_vvar in phi_stmt.src.src_and_vvars if src_vvar is not None}
             new_class = phi_congruence_class[phi_stmt.dst.varid]
-            for _, vvar in phi_stmt.src.src_and_vvars:
-                if vvar is not None:
-                    new_class |= phi_congruence_class[vvar.varid]
-                    phi_congruence_class[vvar.varid] = new_class
+            for src_vvar_id in phi_src_vvar_ids:
+                new_class |= phi_congruence_class[src_vvar_id]
+                phi_congruence_class[src_vvar_id] = new_class
 
         # append statements that were recorded for prepending
         for block, stmts in self._stmts_to_prepend.items():

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -1144,7 +1144,7 @@ class VariableManagerInternal(Serializable):
             # merge stack variables at the same offsets only if their corresponding vvars do not interfere
             stack_vars_by_offset: dict[int, list[SimStackVariable]] = defaultdict(list)
             for v in stack_vars:
-                stack_vars_by_offset[(v.offset, v.size)].append(v)
+                stack_vars_by_offset[v.offset].append(v)
             for vs in stack_vars_by_offset.values():
                 # split vs into disjoint sets based on variable interference relations
                 congruence_classes = {v: {v} for v in vs}

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -1090,14 +1090,8 @@ class VariableManagerInternal(Serializable):
         for v in sorted(reg_vars, key=lambda v: v.ident):
             self.set_unified_variable(v, v)
 
-        stack_vars_by_offset: dict[int, list[SimStackVariable]] = defaultdict(list)
-        for v in stack_vars:
-            stack_vars_by_offset[v.offset].append(v)
-        for vs in stack_vars_by_offset.values():
-            vs = sorted(vs, key=lambda v: v.ident)
-            unified = vs[0].copy()
-            for v in vs:
-                self.set_unified_variable(v, unified)
+        for v in sorted(stack_vars, key=lambda v: v.ident):
+            self.set_unified_variable(v, v)
 
     def set_unified_variable(self, variable: SimVariable, unified: SimVariable) -> None:
         """

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1294,6 +1294,9 @@ class TestDecompiler(unittest.TestCase):
         assert stmts[1].lhs.unified_variable == stmts[4].rhs.unified_variable
         assert stmts[2].lhs.operand.variable == stmts[4].lhs.variable
         assert stmts[2].rhs.operand.variable == stmts[3].lhs.variable
+        # v0 = v0; is incorrect
+        assert stmts[3].lhs.unified_variable != stmts[3].rhs.unified_variable, "Variable unification went wrong."
+        assert stmts[4].lhs.unified_variable != stmts[4].rhs.unified_variable, "Variable unification went wrong."
         assert dw.condition.lhs.operand.variable == stmts[2].lhs.operand.variable
 
     @for_all_structuring_algos

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1280,11 +1280,21 @@ class TestDecompiler(unittest.TestCase):
         assert isinstance(dw, angr.analyses.decompiler.structured_codegen.c.CDoWhileLoop)
         stmts = dw.body.statements
         assert len(stmts) == 5
-        assert stmts[1].lhs.unified_variable == stmts[0].rhs.unified_variable
-        assert stmts[3].lhs.unified_variable == stmts[2].rhs.unified_variable
-        assert stmts[4].lhs.operand.variable == stmts[2].lhs.variable
-        assert stmts[4].rhs.operand.variable == stmts[0].lhs.variable
-        assert dw.condition.lhs.operand.variable == stmts[2].lhs.variable
+        # Current decompilation output:
+        #   do
+        #   {
+        #       v1 = v0 + 1;
+        #       v3 = v2 + 1;
+        #       *(v2) = *(v0);
+        #       v0 = v1;
+        #       v2 = v3;
+        #   } while (*(v2))
+        # We can improve it by re-arranging the first three statements; we leave it as future work
+        assert stmts[0].lhs.unified_variable == stmts[3].rhs.unified_variable
+        assert stmts[1].lhs.unified_variable == stmts[4].rhs.unified_variable
+        assert stmts[2].lhs.operand.variable == stmts[4].lhs.variable
+        assert stmts[2].rhs.operand.variable == stmts[3].lhs.variable
+        assert dw.condition.lhs.operand.variable == stmts[2].lhs.operand.variable
 
     @for_all_structuring_algos
     def test_decompiling_nl_i386_pie(self, decompiler_options=None):


### PR DESCRIPTION
TODO:

- [x] Add a test case (`fmt_rust`).