### PR TITLE
Make pypcode required

### DIFF
--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -6,12 +6,13 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any
 
-import pyvex
 import archinfo
+import pypcode
+import pyvex
 
 from . import Analysis
-
 from angr.analyses import AnalysesHub
+from angr.engines import pcode
 from angr.errors import AngrTypeError
 from angr.knowledge_plugins import Function
 from angr.utils.library import get_cpp_function_name
@@ -20,16 +21,9 @@ from angr.block import DisassemblerInsn, CapstoneInsn, SootBlockNode
 from angr.codenode import BlockNode
 from .disassembly_utils import decode_instruction
 
-try:
-    from angr.engines import pcode
-    import pypcode
 
-    IRSBType = pyvex.IRSB | pcode.lifter.IRSB
-    IROpObjType = pyvex.stmt.IRStmt | pypcode.PcodeOp
-except ImportError:
-    pcode = None
-    IRSBType = pyvex.IRSB
-    IROpObjType = pyvex.stmt
+IRSBType = pyvex.IRSB | pcode.lifter.IRSB
+IROpObjType = pyvex.stmt.IRStmt | pypcode.PcodeOp
 
 l = logging.getLogger(name=__name__)
 

--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -7,10 +7,12 @@ import re
 import logging
 from collections import defaultdict
 
-from archinfo.arch_arm import is_arm_arch
+import pypcode
 import pyvex
+from archinfo.arch_arm import is_arm_arch
 
 from angr.analyses import ForwardAnalysis, visitors
+from angr.engines import pcode
 from angr.utils.constants import is_alignment_mask
 from angr.analyses import AnalysesHub
 from angr.knowledge_plugins import Function
@@ -21,12 +23,6 @@ from angr.utils.types import dereference_simtype_by_lib
 
 from .analysis import Analysis
 
-try:
-    import pypcode
-    from angr.engines import pcode
-except ImportError:
-    pypcode = None
-    pcode = None
 
 if TYPE_CHECKING:
     from angr.block import Block

--- a/angr/engines/pcode/behavior.py
+++ b/angr/engines/pcode/behavior.py
@@ -4,13 +4,10 @@ from collections.abc import Callable, Iterable
 
 import claripy
 from claripy.ast.bv import BV
+from pypcode import OpCode
 
 from angr.errors import AngrError
 
-try:
-    from pypcode import OpCode
-except ImportError:
-    OpCode = None
 
 # pylint:disable=abstract-method
 

--- a/angr/engines/pcode/emulate.py
+++ b/angr/engines/pcode/emulate.py
@@ -3,6 +3,7 @@ import logging
 
 import claripy
 from claripy.ast.bv import BV
+from pypcode import OpCode, Varnode, PcodeOp
 
 from angr.engines.engine import SimEngine
 from angr.utils.constants import DEFAULT_STATEMENT
@@ -10,10 +11,6 @@ from .lifter import IRSB
 from .behavior import OpBehavior
 from angr.errors import AngrError
 from angr.state_plugins.inspect import BP_BEFORE, BP_AFTER
-import contextlib
-
-with contextlib.suppress(ImportError):
-    from pypcode import OpCode, Varnode, PcodeOp
 
 
 l = logging.getLogger(__name__)

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -11,8 +11,9 @@ from typing import Any, TYPE_CHECKING
 from collections.abc import Iterable, Sequence
 
 import archinfo
-from archinfo import ArchARM, ArchPcode
 import cle
+import pypcode
+from archinfo import ArchARM, ArchPcode
 from cachetools import LRUCache
 
 # FIXME: Reusing these errors from pyvex for compatibility. Eventually these
@@ -28,16 +29,7 @@ from angr.errors import SimEngineError, SimTranslationError, SimError
 from angr import sim_options as o
 from angr.block import DisassemblerBlock, DisassemblerInsn
 
-
-try:
-    import pypcode
-except ImportError:
-    pypcode = None
-
-
 if TYPE_CHECKING:
-    # this is to make pyright happy; otherwise it believes pypcode is None
-    import pypcode
     from pypcode import PcodeOp, Context
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pycparser>=2.18",
     "pydemumble",
     "pyformlang",
-    "pypcode>=3.2.1;<4.0",
+    "pypcode>=3.2.1,<4.0",
     "pyvex==9.2.157.dev0",
     "rich>=13.1.0",
     "sortedcontainers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pycparser>=2.18",
     "pydemumble",
     "pyformlang",
+    "pypcode>=3.2.1;<4.0",
     "pyvex==9.2.157.dev0",
     "rich>=13.1.0",
     "sortedcontainers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ Repository = "https://github.com/angr/angr"
 
 [project.optional-dependencies]
 angrdb = ["sqlalchemy"]
-pcode = ["pypcode~=3.0"]
 keystone = ["keystone-engine"]
 telemetry = ["opentelemetry-api"]
 unicorn = ["unicorn==2.0.1.post1"]
@@ -72,7 +71,7 @@ dev = [
     "ruff>=0.11.7",
 ]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-autodoc-typehints"]
-extras = ["angr[angrdb,keystone,pcode]"]
+extras = ["angr[angrdb,keystone]"]
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/engines/pcode/test_emulate.py
+++ b/tests/engines/pcode/test_emulate.py
@@ -1,23 +1,19 @@
 from __future__ import annotations
+
 import logging
-import unittest
 import operator
+import unittest
 from dataclasses import dataclass
 
 import claripy
+import pypcode
+from pypcode import OpCode
 
 import angr
 from angr.engines.pcode.behavior import BehaviorFactory
 from angr.engines.pcode.emulate import PcodeEmulatorMixin
 from angr.sim_state import SimState
 from angr.engines import SimSuccessors
-
-
-try:
-    import pypcode
-    from pypcode import OpCode
-except ImportError:
-    pypcode = None
 
 
 log = logging.getLogger(__name__)

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-from unittest import TestCase, skipUnless, main
+
 import os
+from unittest import TestCase, skipUnless, main
 
 import archinfo
+import pypcode
+
 import angr
 
-try:
-    import pypcode
-except ModuleNotFoundError:
-    pypcode = None
 
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "..", "binaries", "tests")

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -10,7 +10,6 @@ import pypcode
 import angr
 
 
-
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "..", "binaries", "tests")
 
 


### PR DESCRIPTION
Preparing for the icicle engine (sans icicle-python), I will need a copy of the sleigh files somewhere. Since we already have a copy with pypcode, I would like to just make pypcode a hard dependency.