### PR TITLE
SimCCSystemVAMD64: Support bools and string_ts in _classify().

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1656,10 +1656,10 @@ class SimCCSystemVAMD64(SimCC):
             chunksize = self.arch.bytes
         # treat BOT as INTEGER
         nchunks = 1 if isinstance(ty, SimTypeBottom) else (ty.size // self.arch.byte_width + chunksize - 1) // chunksize
-        if isinstance(ty, (SimTypeInt, SimTypeChar, SimTypePointer, SimTypeNum, SimTypeBottom, SimTypeReference)):
-            return ["INTEGER"] * nchunks
         if isinstance(ty, (SimTypeFloat,)):
             return ["SSE"] + ["SSEUP"] * (nchunks - 1)
+        if isinstance(ty, (SimTypeReg, SimTypeNum, SimTypeBottom)):
+            return ["INTEGER"] * nchunks
         if isinstance(ty, (SimStruct, SimTypeFixedSizeArray, SimUnion)):
             assert ty.size is not None
             if ty.size > 512:


### PR DESCRIPTION
The stack backtrace of the crash that this PR fixes:

```python
NotImplementedError: Ummmmm... not sure what goes here. report bug to @rhelmot
> f:\angr\angr\angr\calling_conventions.py(1688)_classify()
   1686                     result[i] = "SSE"
   1687             return result
-> 1688         raise NotImplementedError("Ummmmm... not sure what goes here. report bug to @rhelmot")
   1689
   1690     def _flatten(self, ty) -> dict[int, list[SimType]] | None:
ipdb> pp ty
bool
ipdb> up
> f:\angr\angr\angr\calling_conventions.py(1595)next_arg()
   1593             arg_type = SimTypePointer(arg_type.elem_type).with_arch(self.arch)
   1594         state = session.getstate()
-> 1595         classification = self._classify(arg_type)
   1596         try:
   1597             mapped_classes = []

ipdb> pp arg_type
bool
ipdb> pp arg_type.__class__
<class 'angr.sim_type.SimTypeBool'>
```