### PR TITLE
arg_session: Ensure created void* types have arch.

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -725,7 +725,7 @@ class SimCC:
         """
         session = self.ArgSession(self)
         if self.return_in_implicit_outparam(ret_ty):
-            self.next_arg(session, SimTypePointer(SimTypeBottom()))
+            self.next_arg(session, SimTypePointer(SimTypeBottom()).with_arch(self.arch))
         return session
 
     def return_in_implicit_outparam(self, ty) -> bool:  # pylint:disable=unused-argument
@@ -762,7 +762,7 @@ class SimCC:
                 assert self.RETURN_VAL is not None
                 ptr_loc = self.RETURN_VAL
             else:
-                ptr_loc = self.next_arg(self.ArgSession(self), SimTypePointer(SimTypeBottom()))
+                ptr_loc = self.next_arg(self.ArgSession(self), SimTypePointer(SimTypeBottom()).with_arch(self.arch))
             return SimReferenceArgument(
                 ptr_loc, SimStackArg(0, ty.size // self.arch.byte_width, is_fp=isinstance(ty, SimTypeFloat))
             )
@@ -1445,7 +1445,7 @@ class SimCCMicrosoftAMD64(SimCC):
                     size = subty.size
             if chosen is None:
                 # fallback to void*
-                chosen = SimTypePointer(SimTypeBottom())
+                chosen = SimTypePointer(SimTypeBottom()).with_arch(self.arch)
             return self.return_val(chosen, perspective_returned=perspective_returned)
 
         if not isinstance(ty, SimStruct):


### PR DESCRIPTION
This PR fixes the following exception:

```python
File F:\angr\angr\angr\calling_conventions.py:878, in SimCC.arg_locs(self, prototype)
    876 if prototype._arch is None:
    877     prototype = prototype.with_arch(self.arch)
--> 878 session = self.arg_session(prototype.returnty)
    879 return [self.next_arg(session, arg_ty) for arg_ty in prototype.args]

File F:\angr\angr\angr\calling_conventions.py:728, in SimCC.arg_session(self, ret_ty)
    726 session = self.ArgSession(self)
    727 if self.return_in_implicit_outparam(ret_ty):
--> 728     self.next_arg(session, SimTypePointer(SimTypeBottom()))
    729 return session

File F:\angr\angr\angr\calling_conventions.py:1614, in SimCCSystemVAMD64.next_arg(self, session, arg_type)
   1612     arg_type = SimTypePointer(arg_type.elem_type).with_arch(self.arch)
   1613 state = session.getstate()
-> 1614 classification = self._classify(arg_type)
   1615 try:
   1616     mapped_classes = []

File F:\angr\angr\angr\calling_conventions.py:1678, in SimCCSystemVAMD64._classify(self, ty, chunksize)
   1676     chunksize = self.arch.bytes
   1677 # treat BOT as INTEGER
-> 1678 nchunks = 1 if isinstance(ty, SimTypeBottom) else (ty.size // self.arch.byte_width + chunksize - 1) // chunksize
   1679 if isinstance(ty, (SimTypeFloat,)):
   1680     return ["SSE"] + ["SSEUP"] * (nchunks - 1)

File F:\angr\angr\angr\sim_type.py:778, in SimTypePointer.size(self)
    775 @property
    776 def size(self):
    777     if self._arch is None:
--> 778         raise ValueError("Can't tell my size without an arch!")
    779     return self._arch.bits

ValueError: Can't tell my size without an arch!
```