### PR TITLE
distribute rustylib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ exclude = ["tests*"]
 namespaces = false
 
 [tool.setuptools.package-data]
-angr = ["py.typed", "lib/*"]
+angr = ["py.typed", "lib/*", "rustylib.*"]
 
 [tool.setuptools.dynamic]
 version = { attr = "angr.__version__" }


### PR DESCRIPTION
For me, this manifests with being unable to use angr in an editable install, but it probably affects wheels as well.