### PR TITLE
Type inference speed improvements: Strike 1.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -218,6 +218,9 @@ class Clinic(Analysis):
 
         self._new_block_addrs = set()
 
+        # a reference to the Typehoon type inference engine; useful for debugging and loading stats post decompilation
+        self.typehoon = None
+
         # sanity checks
         if not self.kb.functions:
             l.warning("No function is available in kb.functions. It will lead to a suboptimal conversion result.")
@@ -1888,6 +1891,7 @@ class Clinic(Analysis):
                         if isinstance(v, SimMemoryVariable) and not isinstance(v, SimStackVariable)
                     },
                 )
+                self.typehoon = tp
             except Exception:  # pylint:disable=broad-except
                 if self._fail_fast:
                     raise

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -25,6 +25,7 @@ from .typevars import (
     FuncIn,
     FuncOut,
     ConvertTo,
+    new_dtv,
 )
 from .typeconsts import (
     BottomType,
@@ -710,9 +711,8 @@ class SimpleSolver:
                 else:
                     raise TypeError("Unexpected")
                 labels += (label,)
-                succ_derived_typevar = DerivedTypeVariable(
+                succ_derived_typevar = new_dtv(
                     base_typevar,
-                    None,
                     labels=labels,
                 )
                 succ_node = SketchNode(succ_derived_typevar)

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -440,14 +440,23 @@ class SimpleSolver:
         for src, dst in self._base_lattice.edges:
             self._base_lattice_inverted.add_edge(dst, src)
 
+        # statistics
+        self.processed_constraints_count: int = 0
+        self.simplified_constraints_count: int = 0
+        self.eqclass_constraints_count: list[int] = []
+
         #
         # Solving state
         #
         self._equivalence = defaultdict(dict)
         for typevar in list(self._constraints):
             if self._constraints[typevar]:
+                self.processed_constraints_count += len(self._constraints[typevar])
+
                 self._constraints[typevar] |= self._eq_constraints_from_add(typevar)
                 self._constraints[typevar] = self._handle_equivalence(typevar)
+
+                self.simplified_constraints_count += len(self._constraints[typevar])
 
         self.solution = {}
         for tv, sol in self._equivalence.items():
@@ -518,6 +527,7 @@ class SimpleSolver:
                 idx + 1,
                 len(constraintset2tvs),
             )
+            self.eqclass_constraints_count.append(len(constraint_subset))
 
             while True:
                 base_constraint_graph = self._generate_constraint_graph(constraint_subset, tvs | PRIMITIVE_TYPES)

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -241,6 +241,10 @@ class Sketch:
             for data in self.graph.get_edge_data(src, dst).values():
                 if "label" in data and data["label"] == label:
                     return
+        if isinstance(src, SketchNode) and src.typevar not in self.node_mapping:
+            self.node_mapping[src.typevar] = src
+        if isinstance(dst, SketchNode) and dst.typevar not in self.node_mapping:
+            self.node_mapping[dst.typevar] = dst
         self.graph.add_edge(src, dst, label=label)
 
     def add_constraint(self, constraint: TypeConstraint) -> None:

--- a/angr/analyses/typehoon/typehoon.py
+++ b/angr/analyses/typehoon/typehoon.py
@@ -63,6 +63,10 @@ class Typehoon(Analysis):
         self.structs = None
         self.simtypes_solution = None
 
+        # stats
+        self.processed_constraints_count: int = 0
+        self.eqclass_constraints_count: list[int] = []
+
         # import pprint
         # pprint.pprint(self._var_mapping)
         # pprint.pprint(self._constraints)
@@ -209,6 +213,8 @@ class Typehoon(Analysis):
 
         solver = SimpleSolver(self.bits, self._constraints, typevars, stackvar_max_sizes=self._stackvar_max_sizes)
         self.solution = solver.solution
+        self.processed_constraints_count = solver.processed_constraints_count
+        self.eqclass_constraints_count = solver.eqclass_constraints_count
 
     def _specialize(self):
         """

--- a/angr/analyses/typehoon/typevars.py
+++ b/angr/analyses/typehoon/typevars.py
@@ -315,7 +315,7 @@ class TypeVariable:
 class DerivedTypeVariable(TypeVariable):
     __slots__ = ("labels", "type_var")
 
-    typevar: TypeVariable
+    type_var: TypeVariable
     labels: tuple[BaseLabel, ...]
 
     def __init__(

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -166,7 +166,7 @@ class SimEngineVRAIL(
             # this is a dynamically calculated call target
             target_expr = self._expr(target)
             funcaddr_typevar = target_expr.typevar
-            if funcaddr_typevar is not None:
+            if isinstance(funcaddr_typevar, typevars.TypeVariable):
                 load_typevar = self._create_access_typevar(funcaddr_typevar, False, self.arch.bytes, 0)
                 self.state.add_type_constraint(typevars.Subtype(funcaddr_typevar, load_typevar))
 
@@ -229,7 +229,7 @@ class SimEngineVRAIL(
             # this is a dynamically calculated call target
             target_expr = self._expr(target)
             funcaddr_typevar = target_expr.typevar
-            if funcaddr_typevar is not None:
+            if isinstance(funcaddr_typevar, typevars.TypeVariable):
                 load_typevar = self._create_access_typevar(funcaddr_typevar, False, self.arch.bytes, 0)
                 self.state.add_type_constraint(typevars.Subtype(funcaddr_typevar, load_typevar))
 

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -407,7 +407,7 @@ class SimEngineVRAIL(
             ):
                 # there is already a reinterpretas - overwrite it
                 typevar = typevars.new_dtv(r.typevar.type_var, label=typevars.ReinterpretAs(expr.to_type, expr.to_bits))
-            else:
+            elif isinstance(r.typevar, typevars.TypeVariable):
                 typevar = typevars.new_dtv(r.typevar, label=typevars.ReinterpretAs(expr.to_type, expr.to_bits))
 
         return RichR(self.state.top(expr.to_bits), typevar=typevar)
@@ -475,9 +475,11 @@ class SimEngineVRAIL(
         # create a new type variable and add constraints accordingly
         r0_typevar = r0.typevar if r0.typevar is not None else typevars.TypeVariable()
 
+        typevar = None
         if r1.data.concrete:
             # addition with constants. create a derived type variable
-            typevar = typevars.new_dtv(r0_typevar, label=typevars.AddN(r1.data.concrete_value))
+            if isinstance(r0_typevar, typevars.TypeVariable):
+                typevar = typevars.new_dtv(r0_typevar, label=typevars.AddN(r1.data.concrete_value))
         elif r1.typevar is not None:
             typevar = typevars.TypeVariable()
             type_constraints.add(typevars.Add(r0_typevar, r1.typevar, typevar))
@@ -492,7 +494,8 @@ class SimEngineVRAIL(
         compute = r0.data - r1.data  # type: ignore
 
         type_constraints = set()
-        if r0.typevar is not None and r1.data.concrete:
+        typevar = None
+        if r0.typevar is not None and r1.data.concrete and isinstance(r0.typevar, typevars.TypeVariable):
             typevar = typevars.new_dtv(r0.typevar, label=typevars.SubN(r1.data.concrete_value))
         else:
             typevar = typevars.TypeVariable()

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -614,7 +614,7 @@ class SimEngineVRAIL(
             tc = typevars.Subtype(r0.typevar, typeconsts.int_type(r0.data.size()))
             self.state.add_type_constraint(tc)
         if isinstance(r1.typevar, typevars.TypeVariable):
-            tc = typevars.Subtype(r1.typevar, typeconsts.int_type(r0.data.size()))
+            tc = typevars.Subtype(r1.typevar, typeconsts.int_type(r1.data.size()))
             self.state.add_type_constraint(tc)
 
         r = self.state.top(expr.bits)

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -456,7 +456,7 @@ class SimEngineVRBase(
                 # optimization: if richr.typevar is a derived typevar, we simply carry it over instead of creating a
                 # new typevar here
                 # this is because the solver does not support constraints like tv_1 <: tv_2.+1; we replace it with
-                # tv_1 = tv_2 + 1
+                # tv_1 = tv_2.+1
                 if isinstance(richr.typevar, typevars.DerivedTypeVariable):
                     typevar = richr.typevar
                 else:
@@ -884,8 +884,8 @@ class SimEngineVRBase(
         else:
             richr_addr_typevar = richr_addr.typevar
 
-        if richr_addr_typevar is not None:
-            # create a type constraint
+        if isinstance(richr_addr_typevar, typevars.TypeVariable):
+            # ensure it's not a type constant, and then we create a type constraint for this typevar
             typevar = self._create_access_typevar(richr_addr_typevar, False, size, offset)
             self.state.add_type_constraint(typevars.Subtype(typevar, typeconsts.TopType()))
 

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -453,15 +453,21 @@ class SimEngineVRBase(
 
         if richr.typevar is not None:
             if not self.state.typevars.has_type_variable_for(variable):
-                # assign a new type variable to it
-                typevar = typevars.TypeVariable()
+                # optimization: if richr.typevar is a derived typevar, we simply carry it over instead of creating a
+                # new typevar here
+                # this is because the solver does not support constraints like tv_1 <: tv_2.+1; we replace it with
+                # tv_1 = tv_2 + 1
+                if isinstance(richr.typevar, typevars.DerivedTypeVariable):
+                    typevar = richr.typevar
+                else:
+                    typevar = typevars.TypeVariable()
                 self.state.typevars.add_type_variable(variable, typevar)
             else:
                 typevar = self.state.typevars.get_type_variable(variable)
 
             # create constraints accordingly
-
-            self.state.add_type_constraint(typevars.Subtype(richr.typevar, typevar))
+            if richr.typevar is not typevar:
+                self.state.add_type_constraint(typevars.Subtype(richr.typevar, typevar))
             if vvar.varid in self.vvar_type_hints:
                 # handle type hints
                 self.state.add_type_constraint(typevars.Subtype(typevar, self.vvar_type_hints[vvar.varid]))

--- a/angr/analyses/variable_recovery/engine_base.py
+++ b/angr/analyses/variable_recovery/engine_base.py
@@ -694,7 +694,7 @@ class SimEngineVRBase(
 
         typevar = typevars.TypeVariable() if richr_addr.typevar is None else richr_addr.typevar
 
-        if typevar is not None:
+        if isinstance(typevar, typevars.TypeVariable):
             if isinstance(typevar, typevars.DerivedTypeVariable) and isinstance(typevar.one_label, typevars.AddN):
                 base_typevar = typevar.type_var
                 field_offset = typevar.one_label.n
@@ -1158,7 +1158,7 @@ class SimEngineVRBase(
 
     def _create_access_typevar(
         self,
-        typevar: typeconsts.TypeConstant | TypeVariable | DerivedTypeVariable,
+        typevar: TypeVariable | DerivedTypeVariable,
         is_store: bool,
         size: int | None,
         offset: int,
@@ -1169,13 +1169,13 @@ class SimEngineVRBase(
                 if len(typevar.labels) == 1:
                     typevar = typevar.type_var
                 else:
-                    typevar = DerivedTypeVariable(typevar.type_var, None, labels=typevar.labels[:-1])
+                    typevar = typevars.new_dtv(typevar.type_var, labels=typevar.labels[:-1])
             elif isinstance(typevar.labels[-1], SubN):
                 offset -= typevar.labels[-1].n
                 if len(typevar.labels) == 1:
                     typevar = typevar.type_var
                 else:
-                    typevar = DerivedTypeVariable(typevar.type_var, None, labels=typevar.labels[:-1])
+                    typevar = typevars.new_dtv(typevar.type_var, labels=typevar.labels[:-1])
         lbl = Store() if is_store else Load()
         bits = size * self.project.arch.byte_width if size is not None else MAX_POINTSTO_BITS
         return DerivedTypeVariable(

--- a/tests/analyses/test_typehoon.py
+++ b/tests/analyses/test_typehoon.py
@@ -60,6 +60,7 @@ class TestTypehoon(unittest.TestCase):
         proj.analyses.CompleteCallingConventions()
 
         dec = proj.analyses.Decompiler(main_func)
+        assert dec.codegen is not None and dec.codegen.text is not None
         assert "->field_0 = 10;" in dec.codegen.text
         assert "->field_4 = 20;" in dec.codegen.text
         assert "->field_8 = 808464432;" in dec.codegen.text
@@ -74,6 +75,7 @@ class TestTypehoon(unittest.TestCase):
         proj.analyses.CompleteCallingConventions()
 
         dec = proj.analyses.Decompiler(main_func, cfg=cfg.model)
+        assert dec.codegen is not None and dec.codegen.text is not None
         assert dec.codegen.text.count("UNICODE_STRING v") == 2
 
     def test_type_inference_basic_case_0(self):
@@ -172,9 +174,12 @@ class TestTypehoon(unittest.TestCase):
         p.analyses.CompleteCallingConventions()
         dec = p.analyses.Decompiler(func, cfg=cfg.model)
         assert dec.codegen is not None and dec.codegen.text is not None
-        # print(dec.codegen.text)
+        print(dec.codegen.text)
 
-        assert dec.clinic.typehoon is not None
+        # no masking should exist in the decompilation; all redundant variable type casts are removed
+        assert "& 0x" not in dec.codegen.text
+
+        assert dec.clinic is not None and dec.clinic.typehoon is not None
         assert 0 < max(dec.clinic.typehoon.eqclass_constraints_count) < 350
 
 

--- a/tests/analyses/test_typehoon.py
+++ b/tests/analyses/test_typehoon.py
@@ -164,6 +164,19 @@ class TestTypehoon(unittest.TestCase):
         assert isinstance(sol.basetype.fields[8], Pointer64)
         assert sol.basetype.fields[8].basetype == sol.basetype
 
+    def test_solving_cascading_type_constraints(self):
+        p = angr.Project(os.path.join(test_location, "x86_64", "decompiler", "tiny_aes_test.elf"), auto_load_libs=False)
+        cfg = p.analyses.CFG(data_references=True, normalize=True)
+
+        func = cfg.kb.functions["Cipher"]
+        p.analyses.CompleteCallingConventions()
+        dec = p.analyses.Decompiler(func, cfg=cfg.model)
+        assert dec.codegen is not None and dec.codegen.text is not None
+        # print(dec.codegen.text)
+
+        assert dec.clinic.typehoon is not None
+        assert 0 < max(dec.clinic.typehoon.eqclass_constraints_count) < 350
+
 
 class TestTypeTranslator(unittest.TestCase):
     def test_tc2simtype(self):

--- a/tests/analyses/test_typehoon.py
+++ b/tests/analyses/test_typehoon.py
@@ -173,11 +173,6 @@ class TestTypehoon(unittest.TestCase):
         func = cfg.kb.functions["Cipher"]
         p.analyses.CompleteCallingConventions()
         dec = p.analyses.Decompiler(func, cfg=cfg.model)
-        assert dec.codegen is not None and dec.codegen.text is not None
-        print(dec.codegen.text)
-
-        # no masking should exist in the decompilation; all redundant variable type casts are removed
-        assert "& 0x" not in dec.codegen.text
 
         assert dec.clinic is not None and dec.clinic.typehoon is not None
         assert 0 < max(dec.clinic.typehoon.eqclass_constraints_count) < 350


### PR DESCRIPTION
- AIL: Xor no longer passes on typevars from operands.

- Do not create subtype constraints between typevars and dtv.+/-N. Directly use the rhs dtv instead at lhs.

- Implement eager evaluation for +/-N when creating dtvs.