### PR TITLE
Type inference speed improvements: Strike 2.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -143,7 +143,8 @@ class Clinic(Analysis):
         desired_variables: set[str] | None = None,
         force_loop_single_exit: bool = True,
         complete_successors: bool = False,
-        max_type_constraints: int = 4000,
+        max_type_constraints: int = 100_000,
+        type_constraint_set_degradation_threshold: int = 150,
         ail_graph: networkx.DiGraph | None = None,
         arg_vvars: dict[int, tuple[ailment.Expr.VirtualVariable, SimVariable]] | None = None,
         start_stage: ClinicStage | None = ClinicStage.INITIALIZATION,
@@ -185,6 +186,7 @@ class Clinic(Analysis):
         self._cache = cache
         self._mode = mode
         self._max_type_constraints = max_type_constraints
+        self._type_constraint_set_degradation_threshold = type_constraint_set_degradation_threshold
         self.vvar_id_start = vvar_id_start
         self.vvar_to_vvar: dict[int, int] | None = None
         # during SSA conversion, we create secondary stack variables because they overlap and are larger than the
@@ -1871,6 +1873,7 @@ class Clinic(Analysis):
                     must_struct=must_struct,
                     ground_truth=groundtruth,
                     stackvar_max_sizes=tv_max_sizes,
+                    constraint_set_degradation_threshold=self._type_constraint_set_degradation_threshold,
                 )
                 # tp.pp_constraints()
                 # tp.pp_solution()

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -1,4 +1,4 @@
-# pylint:disable=missing-class-docstring
+# pylint:disable=missing-class-docstring,too-many-boolean-expressions
 from __future__ import annotations
 import enum
 from collections import defaultdict
@@ -588,16 +588,19 @@ class SimpleSolver:
                 solutions = {}
                 self.determine(sketches, tvs_with_primitive_constraints, solutions)
                 _l.debug("Determined solutions for %d type variable(s).", len(tvs_with_primitive_constraints))
-                if not solutions:
-                    break
 
                 leaf_solutions = 0
                 for tv_, ub_tv in ub_subtypes.items():
                     if ub_tv in solutions:
                         solutions[tv_] = solutions[ub_tv]
                         leaf_solutions += 1
+                    elif isinstance(ub_tv, TypeConstant):
+                        solutions[tv_] = ub_tv
+                        leaf_solutions += 1
                 _l.debug("Determined solutions for %d leaf type variable(s).", leaf_solutions)
 
+                if not solutions:
+                    break
                 self.solution |= solutions
 
                 tvs = {tv for tv in tvs if tv not in tvs_with_primitive_constraints}
@@ -1009,7 +1012,7 @@ class SimpleSolver:
             if len(components) == 1:
                 continue
             if any(tv in tv_to_degrade for tv in components):
-                components_lst = sorted(components, key=lambda x: str(x))
+                components_lst = sorted(components, key=str)
                 representative = components_lst[0]
                 for tv in components_lst[1:]:
                     replacements[tv] = representative

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -633,10 +633,7 @@ class SimEngineVRAIL(
         if not r1.data.concrete:
             # we don't support symbolic shiftamount
             r = self.state.top(result_size)
-            return RichR(
-                r,
-                typevar=r0.typevar,
-            )
+            return RichR(r)
 
         shiftamount = r1.data.concrete_value
         return RichR(r0.data << shiftamount, typevar=typeconsts.int_type(result_size), type_constraints=None)
@@ -651,10 +648,7 @@ class SimEngineVRAIL(
         if not r1.data.concrete:
             # we don't support symbolic shiftamount
             r = self.state.top(result_size)
-            return RichR(
-                r,
-                typevar=r0.typevar,
-            )
+            return RichR(r)
 
         shiftamount = r1.data.concrete_value
 
@@ -672,10 +666,7 @@ class SimEngineVRAIL(
         if not r1.data.concrete:
             # we don't support symbolic shiftamount
             r = self.state.top(result_size)
-            return RichR(
-                r,
-                typevar=r0.typevar,
-            )
+            return RichR(r)
 
         shiftamount = r1.data.concrete_value
 
@@ -691,10 +682,7 @@ class SimEngineVRAIL(
         if not r1.data.concrete:
             # we don't support symbolic shiftamount
             r = self.state.top(result_size)
-            return RichR(
-                r,
-                typevar=r0.typevar,
-            )
+            return RichR(r)
 
         shiftamount = r1.data.concrete_value
 
@@ -761,22 +749,22 @@ class SimEngineVRAIL(
     def _handle_binop_Rol(self, expr):
         arg0, arg1 = expr.operands
 
-        r0 = self._expr_bv(arg0)
+        _ = self._expr_bv(arg0)
         _ = self._expr_bv(arg1)
         result_size = arg0.bits
 
         r = self.state.top(result_size)
-        return RichR(r, typevar=r0.typevar)
+        return RichR(r)
 
     def _handle_binop_Ror(self, expr):
         arg0, arg1 = expr.operands
 
-        r0 = self._expr_bv(arg0)
+        _ = self._expr_bv(arg0)
         _ = self._expr_bv(arg1)
         result_size = arg0.bits
 
         r = self.state.top(result_size)
-        return RichR(r, typevar=r0.typevar)
+        return RichR(r)
 
     def _handle_binop_Concat(self, expr):
         arg0, arg1 = expr.operands


### PR DESCRIPTION
- Degrade large type constraint sets before saturation.

- Filter constraint sets in SimpleSolver before saturation.

- Speed up type constraint subset generation; Reduce redundant analysis iterations.

- Drop leaf typevars before saturation.

- Drop typevar propagation for bitwise arithmetic operations.