### PR TITLE
Fix the check on guard that incorrectly checks the False condition

### DIFF
--- a/angr/exploration_techniques/driller_core.py
+++ b/angr/exploration_techniques/driller_core.py
@@ -94,7 +94,7 @@ class DrillerCore(ExplorationTechnique):
     @staticmethod
     def _has_false(state):
         # Check if the state is unsat even if we remove preconstraints.
-        if state.scratch.guard.identical(claripy.false()) or claripy.is_false(state.scratch.guard):
+        if claripy.is_false(state.scratch.guard):
             return True
 
-        return any((c.identical(claripy.false()) or claripy.is_false(c)) for c in state.solver.constraints)
+        return any(claripy.is_false(c) for c in state.solver.constraints)

--- a/angr/exploration_techniques/driller_core.py
+++ b/angr/exploration_techniques/driller_core.py
@@ -94,7 +94,7 @@ class DrillerCore(ExplorationTechnique):
     @staticmethod
     def _has_false(state):
         # Check if the state is unsat even if we remove preconstraints.
-        if state.scratch.guard.identical(claripy.false()):
+        if state.scratch.guard.identical(claripy.false()) or claripy.is_false(state.scratch.guard):
             return True
 
-        return any(c.identical(claripy.false()) for c in state.solver.constraints)
+        return any((c.identical(claripy.false()) or claripy.is_false(c)) for c in state.solver.constraints)


### PR DESCRIPTION
In the check of the guard condition, state.scratch.guard.identical(claripy.false()) evaluates to False even when state.scratch.guard is <Bool False>. Therefore the states are considered valid even if the guard prevents reaching them. As a result, symbolic inputs are concretized for path that are unreachable and/or don't depend on the symbolic inputs.
The correct way is claripy.is_false(state.scratch.guard).
The same goes for state contraints.