### PR TITLE
Improve handling of phi var-involving constant propagation.

### DIFF
--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -819,6 +819,7 @@ class AILSimplifier(Analysis):
                     isinstance(stmt, Assignment)
                     and isinstance(stmt.dst, VirtualVariable)
                     and isinstance(stmt.src, Const)
+                    and isinstance(stmt.src.value, int)
                 ):
                     vvar_values[stmt.dst.varid] = stmt.src.value, stmt.src.bits
 
@@ -855,6 +856,7 @@ class AILSimplifier(Analysis):
             for expr, use_loc in srda.all_vvar_uses[vvar_id]:
                 if expr is None:
                     continue
+                assert use_loc.block_addr is not None
                 key = use_loc.block_addr, use_loc.block_idx
                 stmt = blocks_dict[key].statements[use_loc.stmt_idx]
                 if is_phi_assignment(stmt):

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -226,6 +226,15 @@ class AILSimplifier(Analysis):
             # reaching definition analysis results are no longer reliable
             self._clear_cache()
 
+        _l.debug("Rewriting constant expressions with phi variables")
+        phi_const_rewritten = self._rewrite_phi_const_exprs()
+        self.simplified |= phi_const_rewritten
+        if phi_const_rewritten:
+            _l.debug("... constant expressions with phi variables rewritten")
+            self._rebuild_func_graph()
+            # reaching definition analysis results are no longer reliable
+            self._clear_cache()
+
         if self._only_consts:
             return
 
@@ -698,6 +707,11 @@ class AILSimplifier(Analysis):
         if not replacements_by_block_addrs_and_idx:
             return False
 
+        return self._replace_exprs_in_blocks(replacements_by_block_addrs_and_idx)
+
+    def _replace_exprs_in_blocks(
+        self, replacements: dict[tuple[int, int | None], dict[CodeLocation, dict[Expression, Expression]]]
+    ) -> bool:
         blocks_by_addr_and_idx = {(node.addr, node.idx): node for node in self.func_graph.nodes()}
 
         if self._stack_arg_offsets:
@@ -706,7 +720,7 @@ class AILSimplifier(Analysis):
             insn_addrs_using_stack_args = None
 
         replaced = False
-        for (block_addr, block_idx), reps in replacements_by_block_addrs_and_idx.items():
+        for (block_addr, block_idx), reps in replacements.items():
             block = blocks_by_addr_and_idx[(block_addr, block_idx)]
 
             # only replace loads if there are stack arguments in this block
@@ -786,6 +800,66 @@ class AILSimplifier(Analysis):
                     changed = True
 
         return changed
+
+    #
+    # Rewriting constant expressions with phi variables
+    #
+
+    def _rewrite_phi_const_exprs(self) -> bool:
+        """
+        Rewrite phi variables that are definitely constant expressions to constants.
+        """
+
+        # gather constant assignments
+
+        vvar_values: dict[int, tuple[int, int]] = {}
+        for block in self.func_graph:
+            for stmt in block.statements:
+                if (
+                    isinstance(stmt, Assignment)
+                    and isinstance(stmt.dst, VirtualVariable)
+                    and isinstance(stmt.src, Const)
+                ):
+                    vvar_values[stmt.dst.varid] = stmt.src.value, stmt.src.bits
+
+        srda = self._compute_reaching_definitions()
+        # compute vvar reachability for phi variables
+        g = networkx.Graph()
+        for phi_vvar_id, vvar_ids in srda.phivarid_to_varids.items():
+            for vvar_id in vvar_ids:
+                g.add_edge(phi_vvar_id, vvar_id)
+
+        phi_vvar_ids = srda.phi_vvar_ids
+        to_replace = {}
+        for cc in networkx.algorithms.connected_components(g):
+            normal_vvar_ids = cc.difference(phi_vvar_ids)
+            # ensure there is at least one phi variable and all remaining vvars are constant non-phi variables
+            if len(normal_vvar_ids) < len(cc) and len(normal_vvar_ids.intersection(vvar_values)) == len(
+                normal_vvar_ids
+            ):
+                all_values = {vvar_values[vvar_id] for vvar_id in normal_vvar_ids}
+                if len(all_values) == 1:
+                    # found it!
+                    value, bits = next(iter(all_values))
+                    for var_id in cc:
+                        to_replace[var_id] = value, bits
+
+        # build the replacement dictionary
+        blocks_dict = {(node.addr, node.idx): node for node in self.func_graph.nodes()}
+        replacements: dict[tuple[int, int | None], dict[CodeLocation, dict[Expression, Expression]]] = defaultdict(dict)
+        for vvar_id, (value, bits) in to_replace.items():
+            for expr, use_loc in srda.all_vvar_uses[vvar_id]:
+                if expr is None:
+                    continue
+                key = use_loc.block_addr, use_loc.block_idx
+                stmt = blocks_dict[key].statements[use_loc.stmt_idx]
+                if is_phi_assignment(stmt):
+                    continue
+                if use_loc not in replacements[key]:
+                    replacements[key][use_loc] = {}
+                replacements[key][use_loc][expr] = Const(None, None, value, bits, **expr.tags)
+
+        return self._replace_exprs_in_blocks(replacements) if replacements else False
 
     #
     # Unifying local variables

--- a/angr/analyses/s_reaching_definitions/s_rda_model.py
+++ b/angr/analyses/s_reaching_definitions/s_rda_model.py
@@ -25,6 +25,7 @@ class SRDAModel:
         self.all_tmp_definitions: dict[CodeLocation, dict[atoms.Tmp, int]] = defaultdict(dict)
         self.all_tmp_uses: dict[CodeLocation, dict[atoms.Tmp, set[tuple[Tmp, int]]]] = defaultdict(dict)
         self.phi_vvar_ids: set[int] = set()
+        self.phivarid_to_varids_with_unknown: dict[int, set[int | None]] = {}
         self.phivarid_to_varids: dict[int, set[int]] = {}
         self.vvar_uses_by_loc: dict[CodeLocation, list[int]] = {}
 

--- a/angr/analyses/s_reaching_definitions/s_reaching_definitions.py
+++ b/angr/analyses/s_reaching_definitions/s_reaching_definitions.py
@@ -63,7 +63,7 @@ class SReachingDefinitionsAnalysis(Analysis):
             case _:
                 raise NotImplementedError
 
-        phi_vvars: dict[int, set[int]] = {}
+        phi_vvars: dict[int, set[int | None]] = {}
         # find all vvar definitions
         vvar_deflocs = get_vvar_deflocs(blocks.values(), phi_vvars=phi_vvars)
         # find all explicit vvar uses
@@ -88,7 +88,7 @@ class SReachingDefinitionsAnalysis(Analysis):
         self.model.phivarid_to_varids = {}
         for vvar_id, src_vvars in phi_vvars.items():
             self.model.phivarid_to_varids_with_unknown[vvar_id] = src_vvars
-            self.model.phivarid_to_varids[vvar_id] = (
+            self.model.phivarid_to_varids[vvar_id] = (  # type: ignore
                 {vvar_id for vvar_id in src_vvars if vvar_id is not None} if None in src_vvars else src_vvars
             )
 

--- a/angr/analyses/s_reaching_definitions/s_reaching_definitions.py
+++ b/angr/analyses/s_reaching_definitions/s_reaching_definitions.py
@@ -87,7 +87,10 @@ class SReachingDefinitionsAnalysis(Analysis):
         self.model.phi_vvar_ids = set(phi_vvars)
         self.model.phivarid_to_varids = {}
         for vvar_id, src_vvars in phi_vvars.items():
-            self.model.phivarid_to_varids[vvar_id] = src_vvars
+            self.model.phivarid_to_varids_with_unknown[vvar_id] = src_vvars
+            self.model.phivarid_to_varids[vvar_id] = (
+                {vvar_id for vvar_id in src_vvars if vvar_id is not None} if None in src_vvars else src_vvars
+            )
 
         if self.mode == "function":
 

--- a/angr/utils/ssa/__init__.py
+++ b/angr/utils/ssa/__init__.py
@@ -89,7 +89,7 @@ def get_reg_offset_base(reg_offset, arch, size=None, resilient=True):
 
 
 def get_vvar_deflocs(
-    blocks, phi_vvars: dict[int, set[int]] | None = None
+    blocks, phi_vvars: dict[int, set[int | None]] | None = None
 ) -> dict[int, tuple[VirtualVariable, CodeLocation]]:
     vvar_to_loc: dict[int, tuple[VirtualVariable, CodeLocation]] = {}
     for block in blocks:
@@ -161,7 +161,7 @@ def get_tmp_uselocs(blocks) -> dict[CodeLocation, dict[atoms.Tmp, set[tuple[Tmp,
     return tmp_to_loc
 
 
-def is_const_assignment(stmt: Statement) -> tuple[bool, Const | None]:
+def is_const_assignment(stmt: Statement) -> tuple[bool, Const | StackBaseOffset | None]:
     if isinstance(stmt, Assignment) and isinstance(stmt.src, (Const, StackBaseOffset)):
         return True, stmt.src
     return False, None

--- a/angr/utils/ssa/__init__.py
+++ b/angr/utils/ssa/__init__.py
@@ -100,7 +100,7 @@ def get_vvar_deflocs(
                 )
                 if phi_vvars is not None and isinstance(stmt.src, Phi):
                     phi_vvars[stmt.dst.varid] = {
-                        vvar_.varid for src, vvar_ in stmt.src.src_and_vvars if vvar_ is not None
+                        vvar_.varid if vvar_ is not None else None for src, vvar_ in stmt.src.src_and_vvars
                     }
             elif isinstance(stmt, Call):
                 if isinstance(stmt.ret_expr, VirtualVariable):


### PR DESCRIPTION
I skip implementing a test case because a future test case that tests strncpy and wstrncpy rewrites for `NPInit` in `notepad.exe` will cover this PR.