### PR TITLE
utils: Fix parsing issues with get_cpp_function_name

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -581,7 +581,7 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
         yield " ", None
         # function name
         if self.demangled_name and self.show_demangled_name:
-            normalized_name = get_cpp_function_name(self.demangled_name, specialized=False, qualified=True)
+            normalized_name = get_cpp_function_name(self.demangled_name)
         else:
             normalized_name = self.name
         yield normalized_name, self
@@ -1357,7 +1357,7 @@ class CFunctionCall(CStatement, CExpression):
 
         if self.callee_func is not None:
             if self.callee_func.demangled_name and self.show_demangled_name:
-                func_name = get_cpp_function_name(self.callee_func.demangled_name, specialized=False, qualified=True)
+                func_name = get_cpp_function_name(self.callee_func.demangled_name)
             else:
                 func_name = self.callee_func.name
             if (
@@ -2240,7 +2240,7 @@ class CConstant(CExpression):
                     yield CConstant.str_to_c_str(v.content.decode("utf-8")), self
                     return
                 elif isinstance(v, Function):
-                    yield get_cpp_function_name(v.demangled_name, specialized=False, qualified=True), self
+                    yield get_cpp_function_name(v.demangled_name), self
                     return
                 elif isinstance(v, str):
                     yield CConstant.str_to_c_str(v), self

--- a/angr/analyses/disassembly.py
+++ b/angr/analyses/disassembly.py
@@ -922,7 +922,7 @@ class Value(OperandPiece):
             if func is not None and lbl == func.name and func.name != func.demangled_name:
                 # see if lbl == func.name and func.demangled_name != func.name. if so, we prioritize the
                 # demangled name
-                normalized_name = get_cpp_function_name(func.demangled_name, specialized=False, qualified=True)
+                normalized_name = get_cpp_function_name(func.demangled_name)
                 return [normalized_name]
             return [("+" if self.render_with_sign else "") + lbl]
         if func is not None:

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1666,7 +1666,7 @@ class Function(Serializable):
         if self.is_rust_function():
             ast = pydemumble.demangle(self.name)
             return Function._rust_fmt_node(ast.split("::")[-2])
-        func_name = get_cpp_function_name(self.demangled_name, specialized=False, qualified=True)
+        func_name = get_cpp_function_name(self.demangled_name)
         return func_name.split("::")[-1]
 
     def get_unambiguous_name(self, display_name: str | None = None) -> str:

--- a/angr/utils/library.py
+++ b/angr/utils/library.py
@@ -195,7 +195,7 @@ def cprotos2py(cprotos: list[str], fd_spots=frozenset(), remove_sys_prefix=False
     return parsedcprotos2py(parsed_cprotos, fd_spots=fd_spots, remove_sys_prefix=remove_sys_prefix)
 
 
-def get_cpp_function_name(demangled_name):
+def get_cpp_function_name(demangled_name: str) -> str:
     # remove "<???>"s
     name = normalize_cpp_function_name(demangled_name)
 

--- a/angr/utils/library.py
+++ b/angr/utils/library.py
@@ -195,14 +195,13 @@ def cprotos2py(cprotos: list[str], fd_spots=frozenset(), remove_sys_prefix=False
     return parsedcprotos2py(parsed_cprotos, fd_spots=fd_spots, remove_sys_prefix=remove_sys_prefix)
 
 
-def get_cpp_function_name(demangled_name, specialized=True, qualified=True):
+def get_cpp_function_name(demangled_name):
     # remove "<???>"s
-    name = normalize_cpp_function_name(demangled_name) if not specialized else demangled_name
+    name = normalize_cpp_function_name(demangled_name)
 
-    if not qualified:
-        # remove leading namespaces
-        chunks = name.split("::")
-        name = "::".join(chunks[2:])
+    # remove leading namespaces
+    chunks = name.split("::")
+    name = "::".join(chunks[2:])
 
     # remove arguments
     if "(" in name:

--- a/angr/utils/library.py
+++ b/angr/utils/library.py
@@ -196,15 +196,7 @@ def cprotos2py(cprotos: list[str], fd_spots=frozenset(), remove_sys_prefix=False
 
 
 def get_cpp_function_name(demangled_name: str) -> str:
-    # remove "<???>"s
-    name = normalize_cpp_function_name(demangled_name)
-
-    # remove leading namespaces
-    chunks = name.split("::")
-    name = "::".join(chunks[2:])
-
-    # remove arguments
-    if "(" in name:
-        name = name[: name.find("(")]
-
-    return name
+    func_decls, _ = parse_cpp_file(demangled_name)
+    if func_decls and len(func_decls) == 1:
+        return next(iter(func_decls))
+    return normalize_cpp_function_name(demangled_name)

--- a/angr/utils/library.py
+++ b/angr/utils/library.py
@@ -196,6 +196,16 @@ def cprotos2py(cprotos: list[str], fd_spots=frozenset(), remove_sys_prefix=False
 
 
 def get_cpp_function_name(demangled_name: str) -> str:
+    """
+    Parse a demangled C++ declaration into a function name.
+
+    Note that the extracted name may include template instantiation, for example:
+
+        example_func<int>
+
+    :param demangled_name: The demangled C++ function name.
+    :return:               The qualified function name, excluding return type and parameters.
+    """
     func_decls, _ = parse_cpp_file(demangled_name)
     if func_decls and len(func_decls) == 1:
         return next(iter(func_decls))

--- a/tests/utils/test_library.py
+++ b/tests/utils/test_library.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import unittest
+
+from angr.utils.library import get_cpp_function_name
+
+
+class TestLibrary(unittest.TestCase):
+    """
+    Test functions in angr.utils.library.
+    """
+
+    # pylint: disable=no-self-use
+
+    def test_get_cpp_function_name(self):
+        input_and_expected = [
+            ("", ""),
+            ("func", "func"),
+            ("func(char*, int)", "func"),
+            ("int __cdecl Fxi(int (__cdecl *)(int))", "Fxi"),
+            ("public: __cdecl S::S(struct S &&)", "S::S"),
+            ("printTwice<int>(int x)", "printTwice<int>"),
+        ]
+
+        for input_, expected in input_and_expected:
+            with self.subTest(input_=input_):
+                assert get_cpp_function_name(input_) == expected


### PR DESCRIPTION
Before:

```cpp
long  static long __cdecl _tlgWriteTemplate<long __cdecl(unsigned long this, unsigned long long unknown_0, unsigned long unknown_1, unsigned long unknown_2, unsigned long long *unknown_3, unsigned long long unknown_4, unsigned long unknown_5)
```

After:

```cpp
long _tlgWriteTemplate<long __cdecl (struct _tlgProvider_t const *, void const *, struct _GUID const *, struct _GUID const *, unsigned int, struct _EVENT_DATA_DESCRIPTOR *), & long __cdecl _tlgWriteTransfer_EventWriteTransfer (struct _tlgProvider_t const *, void const *, struct _GUID const *, struct _GUID const *, unsigned int, struct _EVENT_DATA_DESCRIPTOR *), const struct _GUID*, const struct _GUID*>::Write<struct _tlgWrapperByRef<16>, struct _tlgWrapperByVal<8>>(unsigned long this, unsigned long long unknown_0, unsigned long unknown_1, unsigned long unknown_2, unsigned long long *unknown_3, unsigned long long unknown_4, unsigned long unknown_5)
```

https://github.com/angr/angr-management/issues/1431