### PR TITLE
Merging sub-function definitions into parent all_definitions

### DIFF
--- a/angr/analyses/reaching_definitions/function_handler.py
+++ b/angr/analyses/reaching_definitions/function_handler.py
@@ -584,6 +584,7 @@ class FunctionHandler:
         # migrate data from sub_rda to its parent
         state.analysis.function_calls.update(sub_rda.function_calls)
         state.analysis.model.observed_results.update(sub_rda.model.observed_results)
+        state.all_definitions |= sub_rda.all_definitions
 
         sub_ld = get_exit_livedefinitions(data.function, sub_rda.model)
         if sub_ld is not None:


### PR DESCRIPTION
Previously, when running ReachingDefinitions with interfunction_level > 0, definitions generated inside sub-functions were not propagated back into the top-level rda.all_definitions. Only the first instruction of each sub-function appeared in the final result.

This commit updates recurse_analysis() to union sub_rda.all_definitions into state.all_definitions after each recursive call. As a result, all definitions produced by every instruction in every sub-function are preserved.

