### PR TITLE
CFGFast: Reduce segment list fragmentation for ARMCortexM binaries.

### DIFF
--- a/tests/utils/test_segment_list.py
+++ b/tests/utils/test_segment_list.py
@@ -111,3 +111,7 @@ class TestSegmentList(unittest.TestCase):
         assert seg_list[1].start == 11
         assert seg_list[1].end == 30
         assert seg_list[1].sort == "code"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Scan for long repeating byte patterns and mark them as no-decode.
- Reuse the previous segment's segment sort when finding aligned addresses.
- Mark nodecode when an address cannot be lifted as ARM or THUMB code.