### PR TITLE
Add AFL-style edge hitmap support to Icicle engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
 name = "angr"
 version = "0.1.0"
 dependencies = [
+ "icicle-fuzzing",
  "icicle-vm",
  "pcode",
  "pyo3",
@@ -109,6 +110,20 @@ name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "cfg-if"
@@ -277,6 +292,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crepe"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a572c5a5165c71c6a34cd5391521faf590f0e216031574375149fd9666ec5cad"
+dependencies = [
+ "petgraph",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +331,12 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -392,6 +426,26 @@ dependencies = [
  "icicle-mem",
  "object",
  "pcode",
+ "sleigh-runtime",
+ "target-lexicon 0.12.16",
+ "tracing",
+]
+
+[[package]]
+name = "icicle-fuzzing"
+version = "0.1.0"
+source = "git+https://github.com/icicle-emu/icicle-emu.git?rev=4d7ed93254a20b7e5c16bd7b0c6b46db49e1c72e#4d7ed93254a20b7e5c16bd7b0c6b46db49e1c72e"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "bitflags 2.9.1",
+ "bytemuck",
+ "crepe",
+ "icicle-vm",
+ "indexmap",
+ "pcode",
+ "ron",
+ "serde",
  "sleigh-runtime",
  "target-lexicon 0.12.16",
  "tracing",
@@ -569,6 +623,16 @@ version = "0.2.0"
 source = "git+https://github.com/icicle-emu/icicle-emu.git?rev=4d7ed93254a20b7e5c16bd7b0c6b46db49e1c72e#4d7ed93254a20b7e5c16bd7b0c6b46db49e1c72e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +643,30 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -636,7 +724,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -649,7 +737,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -779,7 +867,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -835,6 +923,16 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -873,7 +971,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -966,7 +1064,7 @@ checksum = "db8efb877c9e5e67239d4553bb44dd2a34ae5cfb728f3cf2c5e64439c6ca6ee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1156,5 +1254,5 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]

--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -123,7 +123,7 @@ class IcicleEngine(ConcreteEngine):
         if proj is None:
             raise ValueError("IcicleEngine requires a project to be set")
 
-        emu = Icicle(icicle_arch, PROCESSORS_DIR, True)
+        emu = Icicle(icicle_arch, PROCESSORS_DIR, True, True)
 
         copied_registers = set()
 
@@ -174,6 +174,11 @@ class IcicleEngine(ConcreteEngine):
             initial_cpu_icount=emu.cpu_icount,
         )
 
+        # 3. Copy edge hitmap
+        edge_hitmap = state.history.last_edge_hitmap
+        if edge_hitmap is not None:
+            emu.edge_hitmap = edge_hitmap
+
         return (emu, translation_data)
 
     @staticmethod
@@ -221,8 +226,11 @@ class IcicleEngine(ConcreteEngine):
         # Skip the last block, because it will be added by Successors
         state.history.recent_bbl_addrs.extend([b[0] for b in emu.recent_blocks][:-1])
 
-        # 4. Set history.recent_instruction_count
+        # 3.3. Set history.recent_instruction_count
         state.history.recent_instruction_count = emu.cpu_icount - translation_data.initial_cpu_icount
+
+        # 3.4. Set edge hitmap
+        state.history.edge_hitmap = emu.edge_hitmap
 
         return state
 

--- a/angr/rustylib/icicle.pyi
+++ b/angr/rustylib/icicle.pyi
@@ -82,7 +82,9 @@ class Icicle:
     # Number of instructions executed on the cpu
     cpu_icount: int
 
-    def __init__(self, architecture: str, processors_path: str, enable_tracing: bool) -> None: ...
+    def __init__(
+        self, architecture: str, processors_path: str, enable_tracing: bool, enable_edge_hitmap: bool
+    ) -> None: ...
     @property
     def architecture(self) -> str:
         """The architecture of the VM, e.g., 'x86_64', 'armv7', etc."""
@@ -168,3 +170,11 @@ class Icicle:
     @property
     def recent_blocks(self) -> list[tuple[int, int]]:
         """The addresses of recently executed basic blocks, if available."""
+    
+    @property
+    def edge_hitmap(self) -> bytes | None:
+        """The edge hitmap from the most recent run, if edge hitmap is enabled."""
+
+    @edge_hitmap.setter
+    def edge_hitmap(self, value: bytes | None) -> None:
+        """Set the edge hitmap for the current run."""

--- a/angr/state_plugins/history.py
+++ b/angr/state_plugins/history.py
@@ -59,6 +59,9 @@ class SimStateHistory(SimStatePlugin):
         self.recent_syscall_count = 0 if clone is None else clone.recent_syscall_count
         self.recent_instruction_count = -1 if clone is None else clone.recent_instruction_count
 
+        # afl-style hitmap
+        self.edge_hitmap: bytes | None = None if clone is None else clone.edge_hitmap
+
         # satness stuff
         self._all_constraints = ()
         self._satisfiable = None
@@ -401,6 +404,19 @@ class SimStateHistory(SimStatePlugin):
     @property
     def stack_actions(self):
         return LambdaIterIter(self, operator.attrgetter("recent_stack_actions"))
+
+    @property
+    def last_edge_hitmap(self) -> bytes | None:
+        """
+        Returns the last edge hitmap in the history chain, or None if there is no edge hitmap.
+        """
+        history = self
+        while history is not None:
+            if history.edge_hitmap is not None:
+                return history.edge_hitmap
+            # Traverse to the previous state in the history chain
+            history = history.parent
+        return None
 
     #
     # Merging support

--- a/native/angr/Cargo.toml
+++ b/native/angr/Cargo.toml
@@ -8,6 +8,7 @@ name = "rustylib"
 crate-type = ["cdylib"]
 
 [dependencies]
+icicle-fuzzing = { git = "https://github.com/icicle-emu/icicle-emu.git", rev = "4d7ed93254a20b7e5c16bd7b0c6b46db49e1c72e" }
 icicle-vm = { git = "https://github.com/icicle-emu/icicle-emu.git", rev = "4d7ed93254a20b7e5c16bd7b0c6b46db49e1c72e" }
 pcode = { git = "https://github.com/icicle-emu/icicle-emu.git", rev = "4d7ed93254a20b7e5c16bd7b0c6b46db49e1c72e" }
 pyo3 = { version = "0.24.2", features = ["extension-module", "py-clone", "abi3-py310"] }

--- a/native/angr/src/icicle.rs
+++ b/native/angr/src/icicle.rs
@@ -7,6 +7,7 @@
 /// https://github.com/icicle-emu/icicle-python
 use std::{collections::HashMap, path::PathBuf};
 
+use icicle_fuzzing::coverage::register_afl_hit_counts_all;
 use icicle_vm::{
     cpu::{
         Cpu, ValueSource,
@@ -198,6 +199,7 @@ struct Icicle {
     architecture: String,
     vm: icicle_vm::Vm,
     path_tracer: Option<PathTracerRef>,
+    edge_count_hitmap: Option<Box<[u8]>>,
 }
 
 #[pymethods]
@@ -207,6 +209,7 @@ impl Icicle {
         architecture: String,
         processors_path: String,
         enable_tracing: bool,
+        enable_edge_count: bool,
     ) -> PyResult<Self> {
         let mut config =
             icicle_vm::cpu::Config::from_target_triple(format!("{architecture}-none").as_str());
@@ -249,10 +252,19 @@ impl Icicle {
                 None
             };
 
+        let edge_count_hitmap = if enable_edge_count {
+            let mut hitmap = vec![0u8; 1 << 16].into_boxed_slice();
+            register_afl_hit_counts_all(&mut vm, hitmap.as_mut_ptr(), 16);
+            Some(hitmap)
+        } else {
+            None
+        };
+
         Ok(Self {
             architecture,
             vm,
             path_tracer,
+            edge_count_hitmap,
         })
     }
 
@@ -413,6 +425,24 @@ impl Icicle {
         } else {
             Vec::new()
         }
+    }
+
+    #[getter]
+    pub fn get_edge_hitmap(&mut self) -> Option<&[u8]> {
+        self.edge_count_hitmap.as_deref()
+    }
+
+    #[setter]
+    pub fn set_edge_hitmap(&mut self, new_hitmap: &[u8]) -> PyResult<()> {
+        if let Some(hitmap) = &mut self.edge_count_hitmap {
+            if hitmap.len() != new_hitmap.len() {
+                return Err(PyRuntimeError::new_err("Hitmap size mismatch"));
+            }
+            hitmap.copy_from_slice(new_hitmap);
+        } else {
+            return Err(PyRuntimeError::new_err("Edge hitmap is not enabled"));
+        }
+        Ok(())
     }
 }
 

--- a/tests/sim/test_icicle.py
+++ b/tests/sim/test_icicle.py
@@ -552,3 +552,110 @@ class TestTracing(TestCase):
             0x4007D3,
             0x801058,
         ]
+
+
+class TestEdgeHitmap(TestCase):
+    """Unit tests for the edge_hitmap functionality in the Icicle engine."""
+
+    def test_edge_hitmap_populated(self):
+        """Test that the edge hitmap is populated after execution."""
+
+        project = angr.load_shellcode("je $+2; nop; nop; nop", "x86_64")
+        engine = IcicleEngine(project)
+        init_state = project.factory.blank_state(
+            remove_options={*o.symbolic},
+        )
+        result = engine.process(init_state, num_inst=10)
+        hitmap = result.successors[0].history.edge_hitmap
+
+        assert hitmap is not None
+        assert len(hitmap) == 65536
+        assert any(x > 0 for x in hitmap)
+
+    def test_edge_hitmap_reproducibility(self):
+        project = angr.load_shellcode("nop; nop; nop; nop; nop", "x86_64")
+        engine = IcicleEngine(project)
+
+        state_1 = project.factory.blank_state(remove_options={*o.symbolic})
+        result_1 = engine.process(state_1, num_inst=3)
+        hitmap_1 = result_1.successors[0].history.edge_hitmap
+
+        assert hitmap_1 is not None
+        assert any(x > 0 for x in hitmap_1)
+
+        state_2 = project.factory.blank_state(remove_options={*o.symbolic})
+        result_2 = engine.process(state_2, num_inst=5)
+        hitmap_2 = result_2.successors[0].history.edge_hitmap
+
+        assert hitmap_1 == hitmap_2
+
+    def test_edge_hitmap_multiple_blocks(self):
+        shellcode = "xor rax, rax; inc rax; cmp rax, 5; jne $-8; nop"
+        project = angr.load_shellcode(shellcode, "x86_64")
+        engine = IcicleEngine(project)
+        init_state = project.factory.blank_state(
+            remove_options={*o.symbolic},
+            add_options={o.ZERO_FILL_UNCONSTRAINED_MEMORY, o.ZERO_FILL_UNCONSTRAINED_REGISTERS},
+        )
+
+        # Run a small number of instructions first
+        result1 = engine.process(init_state, num_inst=5)
+        s1 = result1.successors[0]
+        hitmap1 = s1.history.edge_hitmap
+        assert hitmap1 is not None
+        assert any(x > 0 for x in hitmap1)
+        assert s1.history.recent_instruction_count == 5
+        print("Initial hitmap:", hitmap1[:100])
+
+        # Continue execution for more instructions
+        result2 = engine.process(s1, num_inst=45)
+        s2 = result2.successors[0]
+        hitmap2 = s2.history.edge_hitmap
+        assert hitmap2 is not None
+        assert any(x > 0 for x in hitmap2)
+        assert s2.history.recent_instruction_count == 45
+        print("Extended hitmap:", hitmap2[:100])
+
+        # The second hitmap should be additive (all edges from first plus possibly more)
+        bad = []
+        for i in range(65536):
+            if hitmap2[i] < hitmap1[i]:
+                bad.append((i, hitmap1[i], hitmap2[i]))
+
+        assert not bad, f"Edge hitmap values decreased for edges: {bad}"
+
+    def test_fauxware_reproducibility(self):
+        """Test that the edge hitmap is reproducible across runs of the fauxware binary."""
+        project = angr.Project(os.path.join(bin_location, "tests", "x86_64", "fauxware"), auto_load_libs=False)
+        init_state = project.factory.entry_state(
+            stdin=b"username\nSOSNEAKY\n",
+            args=["fauxware"],
+            remove_options={*o.symbolic},
+            add_options={o.ZERO_FILL_UNCONSTRAINED_MEMORY, o.ZERO_FILL_UNCONSTRAINED_REGISTERS},
+        )
+
+        engine = UberIcicleEngine(project)
+
+        state1 = init_state.copy()
+        while state1.history.jumpkind != "Ijk_Exit":
+            successors = engine.process(state1)
+            assert len(successors.successors) == 1
+            assert successors.successors[0].history.jumpkind != "Ijk_SigSEGV"
+            state1 = successors.successors[0]
+
+        hitmap1 = state1.history.last_edge_hitmap
+
+        assert hitmap1 is not None
+        assert any(x > 0 for x in hitmap1)
+
+        # Reset and run again
+        state2 = init_state.copy()
+        while state2.history.jumpkind != "Ijk_Exit":
+            successors = engine.process(state2)
+            assert len(successors.successors) == 1
+            assert successors.successors[0].history.jumpkind != "Ijk_SigSEGV"
+            state2 = successors.successors[0]
+
+        hitmap2 = state2.history.last_edge_hitmap
+
+        assert hitmap1 == hitmap2


### PR DESCRIPTION
When running the Icicle engine, an afl-style hitmap will be tracked for use in fuzzing.