### PR TITLE
Remove linux platform tag override in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,10 @@ import glob
 import importlib
 import importlib.resources
 import os
-import platform
 import shutil
 import subprocess
 import sys
 from distutils.command.build import build as st_build
-from distutils.util import get_platform
 
 from setuptools import Command, setup
 from setuptools.command.develop import develop as st_develop

--- a/setup.py
+++ b/setup.py
@@ -120,13 +120,4 @@ except ModuleNotFoundError:
     pass
 
 
-if "bdist_wheel" in sys.argv and "--plat-name" not in sys.argv:
-    sys.argv.append("--plat-name")
-    name = get_platform()
-    if "linux" in name:
-        sys.argv.append("manylinux2014_" + platform.machine())
-    else:
-        # https://www.python.org/dev/peps/pep-0425/
-        sys.argv.append(name.replace(".", "_").replace("-", "_"))
-
 setup(cmdclass=cmdclass)


### PR DESCRIPTION
This should no longer be necessary, as auditwheel will properly set the platform tag in the release pipeline.