### PR TITLE
Phoenix: Fix bad fullgraphs after cyclic refinement.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -142,6 +142,7 @@ class Clinic(Analysis):
         optimization_scratch: dict[str, Any] | None = None,
         desired_variables: set[str] | None = None,
         force_loop_single_exit: bool = True,
+        refine_loops_with_single_successor: bool = False,
         complete_successors: bool = False,
         max_type_constraints: int = 100_000,
         type_constraint_set_degradation_threshold: int = 150,
@@ -212,6 +213,7 @@ class Clinic(Analysis):
         self._inlining_parents = inlining_parents or ()
         self._desired_variables = desired_variables
         self._force_loop_single_exit = force_loop_single_exit
+        self._refine_loops_with_single_successor = refine_loops_with_single_successor
         self._complete_successors = complete_successors
 
         self._register_save_areas_removed: bool = False
@@ -1550,6 +1552,7 @@ class Clinic(Analysis):
                 entry_node_addr=self.entry_node_addr,
                 scratch=self.optimization_scratch,
                 force_loop_single_exit=self._force_loop_single_exit,
+                refine_loops_with_single_successor=self._refine_loops_with_single_successor,
                 complete_successors=self._complete_successors,
                 stack_pointer_tracker=stack_pointer_tracker,
                 **kwargs,

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -247,7 +247,10 @@ class ConditionProcessor:
                 )
                 assert last_stmt is not None
             else:
-                last_stmt = self.get_last_statement(src)
+                try:
+                    last_stmt = self.get_last_statement(src)
+                except EmptyBlockNotice:
+                    last_stmt = None
 
             if isinstance(last_stmt, ailment.Stmt.ConditionalJump):
                 return True

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -239,6 +239,24 @@ class ConditionProcessor:
         condition translation if possible.
         """
 
+        if isinstance(src, SequenceNode) and src.nodes and isinstance(src.nodes[-1], ConditionNode):
+            cond_node = src.nodes[-1]
+            if (
+                isinstance(cond_node.true_node, ailment.Block)
+                and isinstance(cond_node.false_node, ailment.Block)
+                and cond_node.true_node.statements
+                and cond_node.false_node.statements
+            ):
+                last_stmt_true = self.get_last_statement(cond_node.true_node)
+                last_stmt_false = self.get_last_statement(cond_node.false_node)
+                if (
+                    isinstance(last_stmt_true, ailment.Stmt.Jump)
+                    and isinstance(last_stmt_false, ailment.Stmt.Jump)
+                    and isinstance(last_stmt_true.target, ailment.Expr.Const)
+                    and isinstance(last_stmt_false.target, ailment.Expr.Const)
+                ):
+                    return {last_stmt_true.target.value, last_stmt_false.target.value} == {dst0.addr, dst1.addr}
+
         if src in graph and graph.out_degree[src] == 2 and graph.has_edge(src, dst0) and graph.has_edge(src, dst1):
             # sometimes the last statement is the conditional jump. sometimes it's the first statement of the block
             if isinstance(src, ailment.Block) and src.statements and is_head_controlled_loop_block(src):
@@ -261,6 +279,28 @@ class ConditionProcessor:
         return claripy.is_true(claripy.Not(edge_cond_left) == edge_cond_right)  # type: ignore
 
     def recover_edge_condition(self, graph: networkx.DiGraph, src, dst):
+
+        def _check_condnode_and_get_condition(cond_node: ConditionNode) -> claripy.ast.Bool | None:
+            for cond_block, negate in [(cond_node.true_node, False), (cond_node.false_node, True)]:
+                if isinstance(cond_block, ailment.Block) and cond_block.statements:
+                    last_stmt = self.get_last_statement(cond_block)
+                    if (
+                        isinstance(last_stmt, ailment.Stmt.Jump)
+                        and isinstance(last_stmt.target, ailment.Expr.Const)
+                        and last_stmt.target.value == dst.addr
+                    ):
+                        return claripy.Not(cond_node.condition) if negate else cond_node.condition
+            return None
+
+        if isinstance(src, SequenceNode) and src.nodes and isinstance(src.nodes[-1], ConditionNode):
+            predicate = _check_condnode_and_get_condition(src.nodes[-1])
+            if predicate is not None:
+                return predicate
+        if isinstance(src, ConditionNode):
+            predicate = _check_condnode_and_get_condition(src)
+            if predicate is not None:
+                return predicate
+
         edge = src, dst
         edge_data = graph.get_edge_data(*edge)
         edge_type = edge_data.get("type", "transition") if edge_data is not None else "transition"

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -222,6 +222,7 @@ class Decompiler(Analysis):
         # determine a few arguments according to the structuring algorithm
         fold_callexprs_into_conditions = False
         self._force_loop_single_exit = True
+        self._refine_loops_with_single_successor = False
         self._complete_successors = False
         self._recursive_structurer_params = self.options_to_params(self.options_by_class["recursive_structurer"])
         if "structurer_cls" not in self._recursive_structurer_params:
@@ -229,6 +230,7 @@ class Decompiler(Analysis):
         # is the algorithm based on Phoenix (a schema-based algorithm)?
         if issubclass(self._recursive_structurer_params["structurer_cls"], PhoenixStructurer):
             self._force_loop_single_exit = False
+            self._refine_loops_with_single_successor = True
             self._complete_successors = True
             fold_callexprs_into_conditions = True
 
@@ -261,6 +263,7 @@ class Decompiler(Analysis):
                 desired_variables=self._desired_variables,
                 optimization_scratch=self._optimization_scratch,
                 force_loop_single_exit=self._force_loop_single_exit,
+                refine_loops_with_single_successor=self._refine_loops_with_single_successor,
                 complete_successors=self._complete_successors,
                 ail_graph=self._clinic_graph,
                 arg_vvars=self._clinic_arg_vvars,
@@ -396,6 +399,7 @@ class Decompiler(Analysis):
             cond_proc=condition_processor,
             update_graph=update_graph,
             force_loop_single_exit=self._force_loop_single_exit,
+            refine_loops_with_single_successor=self._refine_loops_with_single_successor,
             complete_successors=self._complete_successors,
             entry_node_addr=self.clinic.entry_node_addr,
             **self.options_to_params(self.options_by_class["region_identifier"]),
@@ -444,6 +448,7 @@ class Decompiler(Analysis):
                 entry_node_addr=self.clinic.entry_node_addr,
                 scratch=self._optimization_scratch,
                 force_loop_single_exit=self._force_loop_single_exit,
+                refine_loops_with_single_successor=self._refine_loops_with_single_successor,
                 complete_successors=self._complete_successors,
                 **kwargs,
             )
@@ -507,6 +512,7 @@ class Decompiler(Analysis):
                 entry_node_addr=self.clinic.entry_node_addr,
                 scratch=self._optimization_scratch,
                 force_loop_single_exit=self._force_loop_single_exit,
+                refine_loops_with_single_successor=self._refine_loops_with_single_successor,
                 complete_successors=self._complete_successors,
                 peephole_optimizations=self._peephole_optimizations,
                 avoid_vvar_ids=self._copied_var_ids,

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -230,7 +230,7 @@ class Decompiler(Analysis):
         # is the algorithm based on Phoenix (a schema-based algorithm)?
         if issubclass(self._recursive_structurer_params["structurer_cls"], PhoenixStructurer):
             self._force_loop_single_exit = False
-            self._refine_loops_with_single_successor = True
+            # self._refine_loops_with_single_successor = True
             self._complete_successors = True
             fold_callexprs_into_conditions = True
 

--- a/angr/analyses/decompiler/node_replacer.py
+++ b/angr/analyses/decompiler/node_replacer.py
@@ -15,7 +15,7 @@ class NodeReplacer(SequenceWalker):
 
         self.root = root
         self.replacements = replacements
-        self.result: BaseNode = self.walk(self.root)
+        self.result: BaseNode = self.walk(self.root)  # type:ignore
 
     def _handle(self, node: BaseNode, **kwargs):
         return self.replacements[node] if node in self.replacements else super()._handle(node, **kwargs)

--- a/angr/analyses/decompiler/node_replacer.py
+++ b/angr/analyses/decompiler/node_replacer.py
@@ -15,7 +15,7 @@ class NodeReplacer(SequenceWalker):
 
         self.root = root
         self.replacements = replacements
-        self.result = self.walk(self.root)
+        self.result: BaseNode = self.walk(self.root)
 
     def _handle(self, node: BaseNode, **kwargs):
         return self.replacements[node] if node in self.replacements else super()._handle(node, **kwargs)

--- a/angr/analyses/decompiler/node_replacer.py
+++ b/angr/analyses/decompiler/node_replacer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from angr.ailment import Block
+from .sequence_walker import SequenceWalker
+from .structuring.structurer_nodes import BaseNode, SequenceNode, MultiNode
+
+
+class NodeReplacer(SequenceWalker):
+    """
+    Replaces nodes in a node with new nodes based on a mapping.
+    """
+
+    def __init__(self, root: BaseNode, replacements: dict) -> None:
+        super().__init__(update_seqnode_in_place=False)
+
+        self.root = root
+        self.replacements = replacements
+        self.result = self.walk(self.root)
+
+    def _handle(self, node: BaseNode, **kwargs):
+        return self.replacements[node] if node in self.replacements else super()._handle(node, **kwargs)
+
+    def _handle_MultiNode(self, node: MultiNode, **kwargs):
+        changed = False
+        nodes_copy = list(node.nodes)
+
+        i = len(nodes_copy) - 1
+        has_non_block = False
+        while i > -1:
+            node_ = nodes_copy[i]
+            new_node = self._handle(node_, parent=node, index=i)
+            if new_node is not None:
+                changed = True
+                nodes_copy[i] = new_node
+                if not isinstance(new_node, Block):
+                    has_non_block = True
+            i -= 1
+        if not changed:
+            return None
+        if has_non_block:
+            return SequenceNode(node.addr, nodes=nodes_copy)
+        return MultiNode(nodes_copy, addr=node.addr, idx=node.idx)

--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -163,7 +163,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
             require_gotos=False,
             prevent_new_gotos=False,
             simplify_ail=False,
-            must_improve_rel_quality=True,
+            must_improve_rel_quality=False,
             **kwargs,
         )
 

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -135,6 +135,7 @@ class OptimizationPass(BaseOptimizationPass):
         entry_node_addr=None,
         scratch: dict[str, Any] | None = None,
         force_loop_single_exit: bool = True,
+        refine_loops_with_single_successor: bool = False,
         complete_successors: bool = False,
         avoid_vvar_ids: set[int] | None = None,
         arg_vvars: set[int] | None = None,
@@ -158,6 +159,7 @@ class OptimizationPass(BaseOptimizationPass):
             entry_node_addr if entry_node_addr is not None else (func.addr, None)
         )
         self._force_loop_single_exit = force_loop_single_exit
+        self._refine_loops_with_single_successor = refine_loops_with_single_successor
         self._complete_successors = complete_successors
         self._avoid_vvar_ids = avoid_vvar_ids or set()
         self._peephole_optimizations = peephole_optimizations
@@ -397,6 +399,7 @@ class OptimizationPass(BaseOptimizationPass):
             cond_proc=condition_processor or ConditionProcessor(self.project.arch),
             update_graph=update_graph,
             force_loop_single_exit=self._force_loop_single_exit,
+            refine_loops_with_single_successor=self._refine_loops_with_single_successor,
             complete_successors=self._complete_successors,
             entry_node_addr=self.entry_node_addr,
         )

--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_low.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_low.py
@@ -6,7 +6,7 @@ from typing import Any
 import networkx
 
 from angr.ailment import Block
-from angr.ailment.statement import ConditionalJump, Label
+from angr.ailment.statement import ConditionalJump
 
 from .return_duplicator_base import ReturnDuplicatorBase
 from .optimization_pass import StructuringOptimizationPass
@@ -154,79 +154,6 @@ class ReturnDuplicatorLow(StructuringOptimizationPass, ReturnDuplicatorBase):
                     return True
                 # keep testing the next edge
                 node = succ
-
-            # Special case 3: In Phoenix, regions full of only if-stmts can be collapsed and moved. This causes
-            # the goto manager to report gotos that are at the top of the region instead of ones in the middle of it.
-            # Because of this, we need to gather all the nodes above the original src and check if any of them
-            # go to the destination. Additionally, we need to do this on the supergraph to get rid of
-            # goto edges that are removed by Phoenix.
-            # This case is observed in the test case `TestDecompiler.test_tail_tail_bytes_ret_dup`.
-            if self._supergraph is None:
-                return False
-
-            super_to_og_nodes = {n: self._supergraph.nodes[n]["original_nodes"] for n in self._supergraph.nodes}
-            og_to_super_nodes = {og: super_n for super_n, ogs in super_to_og_nodes.items() for og in ogs}
-            super_src = og_to_super_nodes.get(src)
-            super_dst = og_to_super_nodes.get(dst)
-            if super_src is None or super_dst is None:
-                return False
-
-            # collect all nodes which have only an if-stmt in them that are ancestors of super_src
-            check_blks = {super_src}
-            level_blocks = {super_src}
-            for _ in range(10):
-                done = False
-                if_blks = set()
-                for lblock in level_blocks:
-                    preds = list(self._supergraph.predecessors(lblock))
-                    for pred in preds:
-                        only_cond_jump = all(isinstance(s, (ConditionalJump, Label)) for s in pred.statements)
-                        if only_cond_jump:
-                            if_blks.add(pred)
-
-                    done = len(if_blks) == 0
-
-                if done:
-                    break
-
-                check_blks |= if_blks
-                level_blocks = if_blks
-
-            # convert all the found if-only super-blocks back into their original blocks
-            og_check_blocks = set()
-            for blk in check_blks:
-                og_check_blocks |= set(super_to_og_nodes[blk])
-
-            # check if any of the original blocks are gotos to the destination
-            goto_hits = 0
-            for block in og_check_blocks:
-                if self._goto_manager.is_goto_edge(block, dst):
-                    goto_hits += 1
-
-            # Although it is good to find a goto in the if-only block region, having more than a single goto
-            # existing that goes to the same dst is a bad sign. This can be seen in the the following test:
-            # TestDecompiler.test_dd_iread_ret_dup_region
-            #
-            # It occurs when you have something like:
-            # ```
-            # if (a || c)
-            #     goto target;
-            # target:
-            # return 0;
-            # ```
-            #
-            #
-            # This looks like an edge from (a, target) and (c, target) but it is actually a single edge.
-            # If you allow both to duplicate you get the following:
-            # ```
-            # if (a):
-            #    return
-            # if (c):
-            #    return
-            # ```
-            # This is not the desired behavior.
-            # So we need to check if there is only a single goto that goes to the destination.
-            return goto_hits == 1
 
         return False
 

--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_low.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_low.py
@@ -53,7 +53,7 @@ class ReturnDuplicatorLow(StructuringOptimizationPass, ReturnDuplicatorBase):
         prevent_new_gotos: bool = True,
         minimize_copies_for_regions: bool = True,
         region_identifier=None,
-        vvar_id_start: int | None = None,
+        vvar_id_start: int = 0,
         scratch: dict[str, Any] | None = None,
         max_func_blocks: int = 500,
         **kwargs,
@@ -91,8 +91,9 @@ class ReturnDuplicatorLow(StructuringOptimizationPass, ReturnDuplicatorBase):
         self,
         src: Block,
         dst: Block,
-        graph: networkx.DiGraph = None,
         max_level_check=1,
+        *,
+        graph: networkx.DiGraph,
     ):
         """
         TODO: Implement a more principled way of checking if an edge is a goto edge with Phoenix's structuring info
@@ -100,6 +101,7 @@ class ReturnDuplicatorLow(StructuringOptimizationPass, ReturnDuplicatorBase):
         above a goto edge as the goto src.
         """
         # Do a simple and fast check first
+        assert self._goto_manager is not None
         is_simple_goto = self._goto_manager.is_goto_edge(src, dst)
         if is_simple_goto:
             return True

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -280,9 +280,6 @@ class RegionIdentifier(Analysis):
         return set(loop_subgraph)
 
     def _refine_loop(self, graph: networkx.DiGraph, head, initial_loop_nodes, initial_exit_nodes):
-        if len(initial_exit_nodes) <= 1:
-            return initial_loop_nodes, initial_exit_nodes
-
         refined_loop_nodes = initial_loop_nodes.copy()
         refined_exit_nodes = initial_exit_nodes.copy()
 

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -43,6 +43,7 @@ class RegionIdentifier(Analysis):
         update_graph=True,
         largest_successor_tree_outside_loop=True,
         force_loop_single_exit=True,
+        refine_loops_with_single_successor=False,
         complete_successors=False,
         entry_node_addr: tuple[int, int | None] | None = None,
     ):
@@ -70,6 +71,7 @@ class RegionIdentifier(Analysis):
         self.regions_by_block_addrs = []
         self._largest_successor_tree_outside_loop = largest_successor_tree_outside_loop
         self._force_loop_single_exit = force_loop_single_exit
+        self._refine_loops_with_single_successor = refine_loops_with_single_successor
         self._complete_successors = complete_successors
         # we keep a dictionary of node and their traversal order in a quasi-topological traversal and update this
         # dictionary as we update the graph
@@ -280,6 +282,11 @@ class RegionIdentifier(Analysis):
         return set(loop_subgraph)
 
     def _refine_loop(self, graph: networkx.DiGraph, head, initial_loop_nodes, initial_exit_nodes):
+        if (self._refine_loops_with_single_successor and len(initial_exit_nodes) == 0) or (
+            not self._refine_loops_with_single_successor and len(initial_exit_nodes) <= 1
+        ):
+            return initial_loop_nodes, initial_exit_nodes
+
         refined_loop_nodes = initial_loop_nodes.copy()
         refined_exit_nodes = initial_exit_nodes.copy()
 

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -717,7 +717,7 @@ class RegionIdentifier(Analysis):
 
         # visit the nodes in post-order
         region_created = False
-        for node in list(networkx.dfs_postorder_nodes(graph_copy, source=head)):
+        for node in list(GraphUtils.dfs_postorder_nodes_deterministic(graph_copy, head)):
             if node is dummy_endnode:
                 # skip the dummy endnode
                 continue

--- a/angr/analyses/decompiler/sequence_walker.py
+++ b/angr/analyses/decompiler/sequence_walker.py
@@ -110,24 +110,28 @@ class SequenceWalker:
 
     def _handle_MultiNode(self, node, **kwargs):
         changed = False
-        nodes_copy = list(node.nodes)
+        nodes = node.nodes if self._update_seqnode_in_place else list(node.nodes)
 
         if self._force_forward_scan:
-            for i, node_ in enumerate(nodes_copy):
+            for i, node_ in enumerate(nodes):
                 new_node = self._handle(node_, parent=node, index=i)
                 if new_node is not None:
                     changed = True
-                    node.nodes[i] = new_node
+                    nodes[i] = new_node
         else:
-            i = len(nodes_copy) - 1
+            i = len(nodes) - 1
             while i > -1:
-                node_ = nodes_copy[i]
+                node_ = nodes[i]
                 new_node = self._handle(node_, parent=node, index=i)
                 if new_node is not None:
                     changed = True
-                    node.nodes[i] = new_node
+                    nodes[i] = new_node
                 i -= 1
-        return None if not changed else node
+        if not changed:
+            return None
+        if self._update_seqnode_in_place:
+            return node
+        return MultiNode(nodes, addr=node.addr, idx=node.idx)
 
     def _handle_SwitchCase(self, node, **kwargs):
         self._handle(node.switch_expr, parent=node, label="switch_expr")

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -1008,6 +1008,13 @@ class PhoenixStructurer(StructurerBase):
             if node in graph and networkx.has_path(graph, node, loop_head):
                 loop_body.add(node)
 
+        # does it form a natural loop already?
+        for node in loop_body:
+            succs_in_loop_body = [succ for succ in fullgraph.successors(node) if succ in loop_body]
+            if len(succs_in_loop_body) > 1:
+                # it has multiple successors in the loop body, so it is not a natural loop
+                return False, None
+
         # extend the loop body if possible
         while True:
             loop_body_updated = False

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -994,9 +994,8 @@ class PhoenixStructurer(StructurerBase):
                     return True, (continue_edges, outgoing_edges, continue_node, successor)
         return False, None
 
-    def _refine_cyclic_make_natural_loop(
-        self, graph, fullgraph, loop_head
-    ) -> tuple[bool, tuple[list, list, Any] | None]:
+    @staticmethod
+    def _refine_cyclic_make_natural_loop(graph, fullgraph, loop_head) -> tuple[bool, tuple[list, list, Any] | None]:
         continue_edges = []
         outgoing_edges = []
 

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -850,6 +850,15 @@ class PhoenixStructurer(StructurerBase):
                 # give up because there is a parent region
                 return False
 
+            # sanity check: if removing outgoing edges would create dangling nodes, then it means we are not ready for
+            # cyclic refinement yet.
+            outgoing_edges_by_dst = defaultdict(list)
+            for src, dst in outgoing_edges:
+                outgoing_edges_by_dst[dst].append(src)
+            for dst, srcs in outgoing_edges_by_dst.items():
+                if dst in graph and graph.in_degree[dst] == len(srcs):
+                    return False
+
             outgoing_edges = sorted(outgoing_edges, key=lambda edge: (edge[0].addr, edge[1].addr))
 
             if successor is None:

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -1008,6 +1008,17 @@ class PhoenixStructurer(StructurerBase):
             if node in graph and networkx.has_path(graph, node, loop_head):
                 loop_body.add(node)
 
+        # extend the loop body if possible
+        while True:
+            loop_body_updated = False
+            for node in list(loop_body):
+                for succ in graph.successors(node):
+                    if succ not in loop_body and all(pred in loop_body for pred in graph.predecessors(succ)):
+                        loop_body.add(succ)
+                        loop_body_updated = True
+            if not loop_body_updated:
+                break
+
         # determine successor candidates using the loop body
         successor_candidates = set()
         for node in loop_body:

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -2612,6 +2612,14 @@ class PhoenixStructurer(StructurerBase):
                 continue
             if src not in graph:
                 continue
+            if (
+                isinstance(src, Block)
+                and src.statements
+                and isinstance(src.statements[-1], IncompleteSwitchCaseHeadStatement)
+            ):
+                # this is a head of an incomplete switch-case construct (that we will definitely be structuring later),
+                # so we do not want to remove any edges going out of this block
+                continue
             if not dominates(idoms, src, dst) and not dominates(idoms, dst, src):
                 if (src.addr, dst.addr) not in self.whitelist_edges:
                     all_edges_wo_dominance.append((src, dst))

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -342,7 +342,7 @@ class PhoenixStructurer(StructurerBase):
                         seq_node = SequenceNode(node.addr, nodes=[node]) if not isinstance(node, SequenceNode) else node
                         loop_node = LoopNode(loop_type, edge_cond_left, seq_node, addr=seq_node.addr)
                         self.replace_nodes(graph, node, loop_node, self_loop=False)
-                        self.replace_nodes(full_graph, node, loop_node, self_loop=False)
+                        self.replace_nodes(full_graph, node, loop_node, self_loop=False, update_node_order=True)
 
                         # ensure the loop has only one successor: the right node
                         self._remove_edges_except(graph, loop_node, right)
@@ -371,7 +371,9 @@ class PhoenixStructurer(StructurerBase):
                             # on the original graph
                             self.replace_nodes(graph, node, loop_node, old_node_1=left, self_loop=False)
                             # on the graph with successors
-                            self.replace_nodes(full_graph, node, loop_node, old_node_1=left, self_loop=False)
+                            self.replace_nodes(
+                                full_graph, node, loop_node, old_node_1=left, self_loop=False, update_node_order=True
+                            )
 
                             # ensure the loop has only one successor: the right node
                             self._remove_edges_except(graph, loop_node, right)
@@ -396,7 +398,9 @@ class PhoenixStructurer(StructurerBase):
                         # on the original graph
                         self.replace_nodes(graph, node, loop_node, old_node_1=left, self_loop=False)
                         # on the graph with successors
-                        self.replace_nodes(full_graph, node, loop_node, old_node_1=left, self_loop=False)
+                        self.replace_nodes(
+                            full_graph, node, loop_node, old_node_1=left, self_loop=False, update_node_order=True
+                        )
 
                         # ensure the loop has only one successor: the right node
                         self._remove_edges_except(graph, loop_node, right)
@@ -419,7 +423,9 @@ class PhoenixStructurer(StructurerBase):
                             # on the original graph
                             self.replace_nodes(graph, node, loop_node, old_node_1=left, self_loop=False)
                             # on the graph with successors
-                            self.replace_nodes(full_graph, node, loop_node, old_node_1=left, self_loop=False)
+                            self.replace_nodes(
+                                full_graph, node, loop_node, old_node_1=left, self_loop=False, update_node_order=True
+                            )
 
                             # ensure the loop has only one successor: the right node
                             self._remove_edges_except(graph, loop_node, right)
@@ -505,7 +511,7 @@ class PhoenixStructurer(StructurerBase):
         for node_ in seq_node.nodes:
             if node_ is not node_copy:
                 full_graph.remove_node(node_)
-        self.replace_nodes(full_graph, node, loop_node, self_loop=False)
+        self.replace_nodes(full_graph, node, loop_node, self_loop=False, update_node_order=True)
         full_graph.add_edge(loop_node, successor_node)
 
         if self._node_order is not None:
@@ -571,7 +577,9 @@ class PhoenixStructurer(StructurerBase):
                             # on the original graph
                             self.replace_nodes(graph, node, loop_node, old_node_1=succ, self_loop=False)
                             # on the graph with successors
-                            self.replace_nodes(full_graph, node, loop_node, old_node_1=succ, self_loop=False)
+                            self.replace_nodes(
+                                full_graph, node, loop_node, old_node_1=succ, self_loop=False, update_node_order=True
+                            )
 
                             return True, loop_node, out_node
         elif ((node is head and len(preds) >= 1) or len(preds) >= 2) and len(succs) == 2 and node in succs:
@@ -590,7 +598,7 @@ class PhoenixStructurer(StructurerBase):
                     # on the original graph
                     self.replace_nodes(graph, node, loop_node, self_loop=False)
                     # on the graph with successors
-                    self.replace_nodes(full_graph, node, loop_node, self_loop=False)
+                    self.replace_nodes(full_graph, node, loop_node, self_loop=False, update_node_order=True)
 
                     return True, loop_node, succ
         return False, None, None
@@ -635,7 +643,7 @@ class PhoenixStructurer(StructurerBase):
         for node_ in seq_node.nodes:
             if node_ is not node:
                 full_graph.remove_node(node_)
-        self.replace_nodes(full_graph, node, loop_node, self_loop=False)
+        self.replace_nodes(full_graph, node, loop_node, self_loop=False, update_node_order=True)
 
         return True, loop_node
 
@@ -844,7 +852,7 @@ class PhoenixStructurer(StructurerBase):
                         else:
                             # directly replace the node in graph
                             self.replace_nodes(graph, src, new_node)
-                            self.replace_nodes(fullgraph, src, new_node)
+                            self.replace_nodes(fullgraph, src, new_node, update_node_order=True)
                             if src is loop_head:
                                 loop_head = new_node
                             if src is continue_node:
@@ -929,7 +937,7 @@ class PhoenixStructurer(StructurerBase):
                             self._remove_last_statement_if_jump(cont_block)
                             new_node = SequenceNode(src.addr, nodes=[src, new_cont_node])
                             self.replace_nodes(graph, src, new_node)
-                            self.replace_nodes(fullgraph, src, new_node)
+                            self.replace_nodes(fullgraph, src, new_node, update_node_order=True)
 
         if loop_type == "do-while":
             self.dowhile_known_tail_nodes.add(continue_node)
@@ -1688,7 +1696,7 @@ class PhoenixStructurer(StructurerBase):
                 if out_nodes and out_nodes[0] in graph:
                     graph.add_edge(new_node, out_nodes[0])
                 full_graph.remove_nodes_from(successors)
-                self.replace_nodes(full_graph, node, new_node)
+                self.replace_nodes(full_graph, node, new_node, update_node_order=True)
                 if out_nodes:
                     full_graph.add_edge(new_node, out_nodes[0])
                 if self._node_order:
@@ -1718,7 +1726,7 @@ class PhoenixStructurer(StructurerBase):
             # make the default node a SequenceNode so that we can insert Break and Continue nodes into it later
             new_node = SequenceNode(node_default.addr, nodes=[node_default])
             self.replace_nodes(graph, node_default, new_node)
-            self.replace_nodes(full_graph, node_default, new_node)
+            self.replace_nodes(full_graph, node_default, new_node, update_node_order=True)
             node_default = new_node
 
         converted_nodes: dict[tuple[int, int | None], Any] = {}
@@ -1985,7 +1993,7 @@ class PhoenixStructurer(StructurerBase):
                 # on the original graph
                 self.replace_nodes(graph, start_node, new_seq, old_node_1=end_node if end_node in graph else None)
                 # on the graph with successors
-                self.replace_nodes(full_graph, start_node, new_seq, old_node_1=end_node)
+                self.replace_nodes(full_graph, start_node, new_seq, old_node_1=end_node, update_node_order=True)
                 return True
         return False
 
@@ -2045,7 +2053,9 @@ class PhoenixStructurer(StructurerBase):
                             self.replace_nodes(graph, start_node, new_node, old_node_1=right)
                             # on the graph with successors
                             full_graph.remove_node(left)
-                            self.replace_nodes(full_graph, start_node, new_node, old_node_1=right)
+                            self.replace_nodes(
+                                full_graph, start_node, new_node, old_node_1=right, update_node_order=True
+                            )
                         else:
                             # on the original graph
                             if right in graph:
@@ -2053,7 +2063,9 @@ class PhoenixStructurer(StructurerBase):
                             self.replace_nodes(graph, start_node, new_node, old_node_1=left)
                             # on the graph with successors
                             full_graph.remove_node(right)
-                            self.replace_nodes(full_graph, start_node, new_node, old_node_1=left)
+                            self.replace_nodes(
+                                full_graph, start_node, new_node, old_node_1=left, update_node_order=True
+                            )
 
                         return True
 
@@ -2082,7 +2094,7 @@ class PhoenixStructurer(StructurerBase):
                         # on the original graph
                         self.replace_nodes(graph, start_node, new_node, old_node_1=left)
                         # on the graph with successors
-                        self.replace_nodes(full_graph, start_node, new_node, old_node_1=left)
+                        self.replace_nodes(full_graph, start_node, new_node, old_node_1=left, update_node_order=True)
 
                         return True
 
@@ -2114,7 +2126,7 @@ class PhoenixStructurer(StructurerBase):
                     # on the original graph
                     self.replace_nodes(graph, start_node, new_node, old_node_1=left)
                     # on the graph with successors
-                    self.replace_nodes(full_graph, start_node, new_node, old_node_1=left)
+                    self.replace_nodes(full_graph, start_node, new_node, old_node_1=left, update_node_order=True)
 
                     return True
 
@@ -2168,7 +2180,7 @@ class PhoenixStructurer(StructurerBase):
                     # on the original graph
                     self.replace_nodes(graph, start_node, new_node, old_node_1=left)
                     # on the graph with successors
-                    self.replace_nodes(full_graph, start_node, new_node, old_node_1=left)
+                    self.replace_nodes(full_graph, start_node, new_node, old_node_1=left, update_node_order=True)
 
                     return True
 
@@ -2304,7 +2316,7 @@ class PhoenixStructurer(StructurerBase):
             new_node = SequenceNode(start_node.addr, nodes=[start_node, new_cond_node])
 
             self.replace_nodes(graph, start_node, new_node, old_node_1=left if left in graph else None)
-            self.replace_nodes(full_graph, start_node, new_node, old_node_1=left)
+            self.replace_nodes(full_graph, start_node, new_node, old_node_1=left, update_node_order=True)
 
             return True
 
@@ -2338,7 +2350,7 @@ class PhoenixStructurer(StructurerBase):
             new_node = SequenceNode(start_node.addr, nodes=[start_node, new_cond_node])
 
             self.replace_nodes(graph, start_node, new_node, old_node_1=right if right in graph else None)
-            self.replace_nodes(full_graph, start_node, new_node, old_node_1=right)
+            self.replace_nodes(full_graph, start_node, new_node, old_node_1=right, update_node_order=True)
 
             return True
 
@@ -2373,7 +2385,7 @@ class PhoenixStructurer(StructurerBase):
             new_node = SequenceNode(start_node.addr, nodes=[start_node, new_cond_node])
 
             self.replace_nodes(graph, start_node, new_node, old_node_1=left if left in graph else None)
-            self.replace_nodes(full_graph, start_node, new_node, old_node_1=left)
+            self.replace_nodes(full_graph, start_node, new_node, old_node_1=left, update_node_order=True)
             return True
 
         r = self._match_acyclic_short_circuit_conditions_type_d(graph, full_graph, start_node)
@@ -2406,7 +2418,7 @@ class PhoenixStructurer(StructurerBase):
             new_node = SequenceNode(start_node.addr, nodes=[start_node, new_cond_node])
 
             self.replace_nodes(graph, start_node, new_node, old_node_1=left if left in graph else None)
-            self.replace_nodes(full_graph, start_node, new_node, old_node_1=left)
+            self.replace_nodes(full_graph, start_node, new_node, old_node_1=left, update_node_order=True)
             return True
 
         return False
@@ -2729,7 +2741,7 @@ class PhoenixStructurer(StructurerBase):
             self.virtualized_edges.add((src, dst))
             full_graph.remove_edge(src, dst)
             if new_src is not None:
-                self.replace_nodes(full_graph, src, new_src)
+                self.replace_nodes(full_graph, src, new_src, update_node_order=True)
         if remove_src_last_stmt:
             remove_last_statements(src)
 
@@ -3049,9 +3061,11 @@ class PhoenixStructurer(StructurerBase):
         )
         self._node_order = {n: i for i, n in enumerate(ordered_nodes)}
 
-    def replace_nodes(self, graph, old_node_0, new_node, old_node_1=None, self_loop=True):
+    def replace_nodes(
+        self, graph, old_node_0, new_node, old_node_1=None, self_loop=True, update_node_order: bool = False
+    ):
         super().replace_nodes(graph, old_node_0, new_node, old_node_1=old_node_1, self_loop=self_loop)
-        if self._node_order is not None and graph is self._region.graph_with_successors:
+        if self._node_order is not None and update_node_order:
             if old_node_1 is not None:
                 self._node_order[new_node] = min(self._node_order[old_node_0], self._node_order[old_node_1])
             else:

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -1009,11 +1009,8 @@ class PhoenixStructurer(StructurerBase):
         outgoing_edges = []
 
         # determine the loop body: all nodes that have paths going to loop_head
-        loop_body = set()
-        for node in fullgraph:
-            if node is loop_head:
-                loop_body.add(loop_head)
-                continue
+        loop_body = {loop_head}
+        for node in networkx.descendants(fullgraph, loop_head):
             if node in graph and networkx.has_path(graph, node, loop_head):
                 loop_body.add(node)
 

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -948,6 +948,8 @@ class PhoenixStructurer(StructurerBase):
                 else:
                     self.virtualized_edges.add((src, dst))
                     fullgraph_raw.remove_edge(src, dst)
+                    if graph.has_edge(src, dst):
+                        graph_raw.remove_edge(src, dst)
                     if fullgraph.in_degree[dst] == 0:
                         # drop this node
                         fullgraph_raw.remove_node(dst)

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -937,7 +937,7 @@ class PhoenixStructurer(StructurerBase):
         return bool(outgoing_edges or len(continue_edges) > 1)
 
     @staticmethod
-    def _refine_cyclic_is_while_loop_check_loop_head_successors(graph, loop_head, head_succs) -> tuple[bool, Any]:
+    def _refine_cyclic_is_while_loop_check_loop_head_successors(graph, head_succs) -> tuple[bool, Any]:
         assert len(head_succs) == 2
         a, b = head_succs
         a_in_graph = a in graph
@@ -950,7 +950,7 @@ class PhoenixStructurer(StructurerBase):
         self, graph, fullgraph, loop_head, head_succs
     ) -> tuple[bool, tuple[list, list, BaseNode, BaseNode] | None]:
         if len(head_succs) == 2:
-            r, successor = self._refine_cyclic_is_while_loop_check_loop_head_successors(graph, loop_head, head_succs)
+            r, successor = self._refine_cyclic_is_while_loop_check_loop_head_successors(graph, head_succs)
             if r:
                 # make sure the head_pred is not already structured
                 _, _, head_block_0 = self._find_node_going_to_dst(loop_head, head_succs[0])

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -1017,21 +1017,22 @@ class PhoenixStructurer(StructurerBase):
             if node in graph and networkx.has_path(graph, node, loop_head):
                 loop_body.add(node)
 
-        # does it form a natural loop already?
-        for node in loop_body:
-            succs_in_loop_body = [succ for succ in fullgraph.successors(node) if succ in loop_body]
-            if len(succs_in_loop_body) > 1:
-                # it has multiple successors in the loop body, so it is not a natural loop
-                return False, None
-
         # extend the loop body if possible
         while True:
             loop_body_updated = False
             for node in list(loop_body):
-                for succ in graph.successors(node):
-                    if succ not in loop_body and all(pred in loop_body for pred in graph.predecessors(succ)):
-                        loop_body.add(succ)
-                        loop_body_updated = True
+                new_nodes = set()
+                succ_not_in_loop_body = False
+                for succ in fullgraph.successors(node):
+                    if succ not in loop_body:
+                        if all(pred in loop_body for pred in fullgraph.predecessors(succ)):
+                            new_nodes.add(succ)
+                        else:
+                            # one of the predecessors of this successor is not in the loop body
+                            succ_not_in_loop_body = True
+                if new_nodes and not succ_not_in_loop_body:
+                    loop_body |= new_nodes
+                    loop_body_updated = True
             if not loop_body_updated:
                 break
 

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -769,7 +769,7 @@ class PhoenixStructurer(StructurerBase):
                     # block in src may not be the actual block that has a direct jump or a conditional jump to dst. as
                     # a result, we should walk all blocks in src to find the jump to dst, then extract the condition
                     # and augment the corresponding block with a ConditionalBreak.
-                    _, src_parent, src_block = self._find_node_going_to_dst(src, dst)
+                    _, _, src_block = self._find_node_going_to_dst(src, dst)
                     if src_block is None:
                         l.warning(
                             "Cannot find the source block jumping to the destination block at %#x. "

--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -912,6 +912,24 @@ class StructurerBase(Analysis):
         return None
 
     @staticmethod
+    def _copy_and_remove_last_statement_if_jump(node: ailment.Block | MultiNode) -> ailment.Block | MultiNode:
+        if isinstance(node, MultiNode):
+            if node.nodes:
+                last_block = StructurerBase._copy_and_remove_last_statement_if_jump(node.nodes[-1])
+                nodes = [*node.nodes[:-1], last_block]
+            else:
+                nodes = []
+            return MultiNode(nodes, addr=node.addr, idx=node.idx)
+
+        assert isinstance(node, ailment.Block)
+        if node.statements and isinstance(node.statements[-1], (ailment.Stmt.Jump, ailment.Stmt.ConditionalJump)):
+            # copy the block and remove the last statement
+            stmts = node.statements[:-1]
+        else:
+            stmts = node.statements[::]
+        return ailment.Block(node.addr, node.original_size, statements=stmts, idx=node.idx)
+
+    @staticmethod
     def _merge_nodes(node_0, node_1):
         addr = node_0.addr if node_0.addr is not None else node_1.addr
 

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -163,7 +163,7 @@ def switch_extract_cmp_bounds_from_condition(cond: ailment.Expr.Expression) -> t
     # TODO: Add more operations
     if isinstance(cond, ailment.Expr.BinaryOp):
         if cond.op in {"CmpLE", "CmpLT"}:
-            if not isinstance(cond.operands[1], ailment.Expr.Const):
+            if not (isinstance(cond.operands[1], ailment.Expr.Const) and isinstance(cond.operands[1].value, int)):
                 return None
             cmp_ub = cond.operands[1].value if cond.op == "CmpLE" else cond.operands[1].value - 1
             cmp_lb = 0
@@ -172,6 +172,7 @@ def switch_extract_cmp_bounds_from_condition(cond: ailment.Expr.Expression) -> t
                 isinstance(cmp, ailment.Expr.BinaryOp)
                 and cmp.op == "Sub"
                 and isinstance(cmp.operands[1], ailment.Expr.Const)
+                and isinstance(cmp.operands[1].value, int)
             ):
                 cmp_ub += cmp.operands[1].value
                 cmp_lb += cmp.operands[1].value
@@ -182,7 +183,7 @@ def switch_extract_cmp_bounds_from_condition(cond: ailment.Expr.Expression) -> t
             # We got the negated condition here
             #  CmpGE -> CmpLT
             #  CmpGT -> CmpLE
-            if not isinstance(cond.operands[1], ailment.Expr.Const):
+            if not (isinstance(cond.operands[1], ailment.Expr.Const) and isinstance(cond.operands[1].value, int)):
                 return None
             cmp_ub = cond.operands[1].value if cond.op == "CmpGT" else cond.operands[1].value - 1
             cmp_lb = 0
@@ -191,6 +192,7 @@ def switch_extract_cmp_bounds_from_condition(cond: ailment.Expr.Expression) -> t
                 isinstance(cmp, ailment.Expr.BinaryOp)
                 and cmp.op == "Sub"
                 and isinstance(cmp.operands[1], ailment.Expr.Const)
+                and isinstance(cmp.operands[1].value, int)
             ):
                 cmp_ub += cmp.operands[1].value
                 cmp_lb += cmp.operands[1].value
@@ -334,7 +336,7 @@ def switch_extract_bitwiseand_jumptable_info(last_stmt: ailment.Stmt.Jump) -> tu
     coeff = None
     index_expr = None
     lb = None
-    ub = None
+    ub: int | None = None
     while expr is not None:
         if isinstance(expr, ailment.Expr.BinaryOp):
             if expr.op == "Mul":
@@ -350,12 +352,12 @@ def switch_extract_bitwiseand_jumptable_info(last_stmt: ailment.Stmt.Jump) -> tu
                 masks = {0x1, 0x3, 0x7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, 0x1FF, 0x3FF}
                 if isinstance(expr.operands[1], ailment.Expr.Const) and expr.operands[1].value in masks:
                     lb = 0
-                    ub = expr.operands[1].value
+                    ub = expr.operands[1].value  # type:ignore
                     index_expr = expr
                     break
                 if isinstance(expr.operands[0], ailment.Expr.Const) and expr.operands[1].value in masks:
                     lb = 0
-                    ub = expr.operands[0].value
+                    ub = expr.operands[0].value  # type:ignore
                     index_expr = expr
                     break
                 return None
@@ -385,7 +387,7 @@ def get_ast_subexprs(claripy_ast):
             yield ast
 
 
-def insert_node(parent, insert_location: str, node, node_idx: int | tuple[int] | None, label=None):
+def insert_node(parent, insert_location: str, node, node_idx: int, label=None):
     if insert_location not in {"before", "after"}:
         raise ValueError('"insert_location" must be either "before" or "after"')
 
@@ -557,12 +559,13 @@ def is_empty_or_label_only_node(node) -> bool:
 
 
 def has_nonlabel_statements(block: ailment.Block) -> bool:
-    return block.statements and any(not isinstance(stmt, ailment.Stmt.Label) for stmt in block.statements)
+    return bool(block.statements and any(not isinstance(stmt, ailment.Stmt.Label) for stmt in block.statements))
 
 
 def has_nonlabel_nonphi_statements(block: ailment.Block) -> bool:
-    return block.statements and any(
-        not (isinstance(stmt, ailment.Stmt.Label) or is_phi_assignment(stmt)) for stmt in block.statements
+    return bool(
+        block.statements
+        and any(not (isinstance(stmt, ailment.Stmt.Label) or is_phi_assignment(stmt)) for stmt in block.statements)
     )
 
 
@@ -704,7 +707,9 @@ def _find_node_in_graph(node: ailment.Block, graph: networkx.DiGraph) -> ailment
     return None
 
 
-def structured_node_has_multi_predecessors(node: SequenceNode | MultiNode, graph: networkx.DiGraph) -> bool:
+def structured_node_has_multi_predecessors(
+    node: SequenceNode | MultiNode | ailment.Block, graph: networkx.DiGraph
+) -> bool:
     if graph is None:
         return False
 
@@ -760,6 +765,7 @@ def structured_node_is_simple_return(
     if valid_last_stmt:
         # note that the block may not be the same block in the AIL graph post dephication. we must find the block again
         # in the graph.
+        assert isinstance(last_block, ailment.Block)
         last_graph_block = _find_node_in_graph(last_block, graph)
         if last_graph_block is not None:
             succs = list(graph.successors(last_graph_block))
@@ -959,6 +965,7 @@ def peephole_optimize_multistmts(block, stmt_opts):
                         break
 
                 if matched:
+                    assert stmt_seq_len is not None
                     matched_stmts = statements[stmt_idx : stmt_idx + stmt_seq_len]
                     r = opt.optimize(matched_stmts, stmt_idx=stmt_idx, block=block)
                     if r is not None:
@@ -1068,7 +1075,11 @@ def decompile_functions(
             _l.critical("Failed to decompile %s because %s", repr(f), exception_string)
             decompilation += f"// [error: {func} | {exception_string}]\n"
         else:
-            decompilation += dec.codegen.text + "\n"
+            if dec is not None and dec.codegen is not None and dec.codegen.text is not None:
+                decompilation += dec.codegen.text
+            else:
+                decompilation += "Invalid decompilation output"
+            decompilation += "\n"
 
     return decompilation
 

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -589,6 +589,19 @@ def last_nonlabel_statement(block: ailment.Block) -> ailment.Stmt.Statement | No
     return None
 
 
+def last_node(node: BaseNode) -> BaseNode | ailment.Block | None:
+    """
+    Get the last node in a sequence or code node.
+    """
+    if isinstance(node, CodeNode):
+        return last_node(node.node)
+    if isinstance(node, SequenceNode):
+        if not node.nodes:
+            return None
+        return last_node(node.nodes[-1])
+    return node
+
+
 def first_nonlabel_node(seq: SequenceNode) -> BaseNode | ailment.Block | None:
     for node in seq.nodes:
         inner_node = node.node if isinstance(node, CodeNode) else node

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -813,6 +813,10 @@ class GraphUtils:
                 graph_copy.add_node(node)
 
         class NodeWithAddr:
+            """
+            Temporary node class.
+            """
+
             def __init__(self, addr: int):
                 self.addr = addr
 

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -777,11 +777,11 @@ class GraphUtils:
         # find all strongly connected components in the graph
         sccs = sorted(
             (scc for scc in networkx.strongly_connected_components(graph) if len(scc) > 1),
-            key=lambda x: min(node.addr for node in x),
+            key=lambda x: (len(x), min(node.addr if hasattr(node, "addr") else node for node in x)),
         )
         comp_indices = {}
         for i, scc in enumerate(sccs):
-            scc_addr = min(node.addr for node in scc)
+            scc_addr = min(node.addr if hasattr(node, "addr") else node for node in scc)
             for node in scc:
                 if node not in comp_indices:
                     comp_indices[node] = (i, scc_addr)

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -118,7 +118,7 @@ def dfs_back_edges(graph, start_node, *, visit_all_nodes: bool = False, visited:
     if visit_all_nodes:
         while len(visited) < len(graph):
             # If we need to visit all nodes, we can start from unvisited nodes
-            node = next(iter(sorted(set(graph) - visited, key=GraphUtils._sort_node)))
+            node = sorted(set(graph) - visited, key=GraphUtils._sort_node)[0]
             yield from dfs_back_edges(graph, node, visited=visited)
 
 

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -766,7 +766,10 @@ class GraphUtils:
         """
 
         # fast path for single node graphs
-        if graph.number_of_nodes() == 1:
+        number_of_nodes = graph.number_of_nodes()
+        if number_of_nodes == 0:
+            return []
+        if number_of_nodes == 1:
             if nodes is None:
                 return list(graph.nodes)
             return [n for n in graph.nodes() if n in nodes]

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -85,7 +85,7 @@ def to_acyclic_graph(
     return acyclic_graph
 
 
-def dfs_back_edges(graph, start_node):
+def dfs_back_edges(graph, start_node, *, visit_all_nodes: bool = False, visited: set | None = None):
     """
     Perform an iterative DFS traversal of the graph, returning back edges.
 
@@ -96,7 +96,7 @@ def dfs_back_edges(graph, start_node):
     if start_node not in graph:
         return  # Ensures that the start node is in the graph
 
-    visited = set()  # Tracks visited nodes
+    visited = set() if visited is None else visited  # Tracks visited nodes
     finished = set()  # Tracks nodes whose descendants are fully explored
     stack = [(start_node, iter(sorted(graph[start_node], key=GraphUtils._sort_node)))]
 
@@ -114,6 +114,12 @@ def dfs_back_edges(graph, start_node):
         except StopIteration:
             stack.pop()  # Done with this node's children
             finished.add(node)  # Mark this node as finished
+
+    if visit_all_nodes:
+        while len(visited) < len(graph):
+            # If we need to visit all nodes, we can start from unvisited nodes
+            node = next(iter(sorted(set(graph) - visited, key=GraphUtils._sort_node)))
+            yield from dfs_back_edges(graph, node, visited=visited)
 
 
 def subgraph_between_nodes(graph, source, frontier, include_frontier=False):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -4578,6 +4578,7 @@ class TestDecompiler(unittest.TestCase):
         # decompile!
         dec = p.analyses.Decompiler(entry, cfg=cfg, options=decompiler_options)
         assert dec.codegen is not None and isinstance(dec.codegen.text, str)
+        print_decompilation_result(dec)
         text = dec.codegen.text
 
         # Ensure call to f1 is not moved out of loop

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3831,7 +3831,7 @@ class TestDecompiler(unittest.TestCase):
         )
         print_decompilation_result(d)
 
-        assert d.codegen.text.count("break;") == 2
+        assert d.codegen.text.count("break;") == 2 or d.codegen.text.count("goto LABEL_402417;") == 1
 
     @structuring_algo("sailr")
     def test_ternary_expression_over_propagation(self, decompiler_options=None):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2680,9 +2680,11 @@ class TestDecompiler(unittest.TestCase):
         d = proj.analyses[Decompiler].prep(fail_fast=True)(
             f, cfg=cfg.model, options=decompiler_options, optimization_passes=all_optimization_passes
         )
+        assert d.codegen is not None and d.codegen.text is not None
         print_decompilation_result(d)
 
         assert d.codegen.text.count("switch") == 1
+        assert d.codegen.text.count("while ") == 2, "Expect two loops"
 
     @for_all_structuring_algos
     def test_no_switch_case_touch_touch(self, decompiler_options=None):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1501,8 +1501,8 @@ class TestDecompiler(unittest.TestCase):
 
         print_decompilation_result(d)
 
-        assert re.search(r"if \([^v]*v1 == 32\)", d.codegen.text) is not None
-        assert re.search(r"else if \([^v]*v1 == 9\)", d.codegen.text) is not None
+        assert re.search(r"if \([^v]*v1 [=!]= 32\)", d.codegen.text) is not None
+        assert re.search(r"if \([^v]*v1 [=!]= 9\)", d.codegen.text) is not None
         assert d.codegen.text.count("return v1;") == 1
 
     @for_all_structuring_algos


### PR DESCRIPTION
Also:

- Fix some problems in deterministic post-order node sorting and dfs_back_edges. These problems were causing non-determinism during structuring.

- Fix a bug in deterministic post-order node sorting where the same node may be yielded multiple times.

- Reimplementation and many fixes regarding how Phoenix refines cycles.

- Deterministically visit nodes in a graph in RegionIdentifier.

- Fix an overly broad heuristic in loop body identification in RegionIdentifier.