### PR TITLE
Fix fread ClaripyZeroDivisionError for size==0 and concrete values

### DIFF
--- a/angr/procedures/libc/fread.py
+++ b/angr/procedures/libc/fread.py
@@ -18,7 +18,9 @@ class fread(angr.SimProcedure):
             return -1
 
         ret = simfd.read(dst, size * nm)
-        return claripy.If(claripy.Or(size == 0, nm == 0), 0, ret // size)
+
+        # avoid ClaripyZeroDivisionError for size == 0 (If will yield 0 either way)
+        return claripy.If(claripy.Or(size == 0, nm == 0), 0, ret // (size + (size == 0)))
 
 
 fread_unlocked = fread


### PR DESCRIPTION
Calling `fread` with `size==0` and concrete values currently leads to a `ClaripyZeroDivisionError`, due to the evaluation of the last `If` argument value
(I can make this somewhat cleaner if preferable)