### PR TITLE
Add __isoc23*scanf SimProcedures

### DIFF
--- a/angr/procedures/glibc/scanf.py
+++ b/angr/procedures/glibc/scanf.py
@@ -6,6 +6,11 @@ from angr.procedures.libc.fscanf import fscanf
 class __isoc99_scanf(scanf):
     pass
 
+class __isoc23_scanf(scanf):
+    pass
 
 class __isoc99_fscanf(fscanf):
+    pass
+
+class __isoc23_fscanf(fscanf):
     pass

--- a/angr/procedures/glibc/scanf.py
+++ b/angr/procedures/glibc/scanf.py
@@ -6,11 +6,14 @@ from angr.procedures.libc.fscanf import fscanf
 class __isoc99_scanf(scanf):
     pass
 
+
 class __isoc23_scanf(scanf):
     pass
 
+
 class __isoc99_fscanf(fscanf):
     pass
+
 
 class __isoc23_fscanf(fscanf):
     pass

--- a/angr/procedures/glibc/sscanf.py
+++ b/angr/procedures/glibc/sscanf.py
@@ -5,5 +5,6 @@ from angr.procedures.libc.sscanf import sscanf
 class __isoc99_sscanf(sscanf):
     pass
 
+
 class __isoc23_sscanf(sscanf):
     pass

--- a/angr/procedures/glibc/sscanf.py
+++ b/angr/procedures/glibc/sscanf.py
@@ -4,3 +4,6 @@ from angr.procedures.libc.sscanf import sscanf
 
 class __isoc99_sscanf(sscanf):
     pass
+
+class __isoc23_sscanf(sscanf):
+    pass


### PR DESCRIPTION
Invokes matching angr.procedures.libc SimProcedures as with __isoc99*scanf functions.

Currently as far as I can tell the only behavior difference for isoc23 scanf functions (SCANF_ISOC23_BIN_CST) in glibc/stdio-common/vfscanf-internal.c seems to be related to the handling of 0b-prefixed binary integer inputs.

Related to issue #5183 