### PR TITLE
docs: fix old code, use `CFGModel` api for finding nodes by address

### DIFF
--- a/docs/core-concepts/toplevel.rst
+++ b/docs/core-concepts/toplevel.rst
@@ -319,8 +319,8 @@ construct and use a quick control-flow graph:
    >>> len(cfg.graph.nodes())
    951
 
-   # To get the CFGNode for a given address, use cfg.get_any_node
-   >>> entry_node = cfg.get_any_node(proj.entry)
+   # To get the CFGNode for a given address, use cfg.model.get_any_node
+   >>> entry_node = cfg.model.get_any_node(proj.entry)
    >>> len(list(cfg.graph.successors(entry_node)))
    2
 


### PR DESCRIPTION
old code is invalid and will result in an error on any angr version from recent years.