### PR TITLE
Structurer: Preserve external jumps

### DIFF
--- a/angr/analyses/decompiler/structuring/recursive_structurer.py
+++ b/angr/analyses/decompiler/structuring/recursive_structurer.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
-import itertools
 from typing import TYPE_CHECKING
 import logging
 
 from angr.analyses import Analysis, register_analysis
 from angr.analyses.decompiler.condition_processor import ConditionProcessor
 from angr.analyses.decompiler.graph_region import GraphRegion
-from angr.analyses.decompiler.jumptable_entry_condition_rewriter import JumpTableEntryConditionRewriter
 from angr.analyses.decompiler.empty_node_remover import EmptyNodeRemover
 from angr.analyses.decompiler.jump_target_collector import JumpTargetCollector
 from angr.analyses.decompiler.redundant_label_remover import RedundantLabelRemover
@@ -116,17 +114,7 @@ class RecursiveStructurer(Analysis):
                         parent_region, current_region, st._region, st.result, st.virtualized_edges
                     )
 
-        if self.structurer_cls is DreamStructurer:
-            # rewrite conditions in the result to remove all jump table entry conditions
-            rewriter = JumpTableEntryConditionRewriter(set(itertools.chain(*self.cond_proc.jump_table_conds.values())))
-            rewriter.walk(self.result)  # update SequenceNodes in-place
-
-            # remove all goto statements
-            # TODO: Properly implement support for multi-entry regions
-            StructurerBase._remove_all_jumps(self.result)
-
-        else:
-            StructurerBase._remove_redundant_jumps(self.result)
+        StructurerBase._remove_redundant_jumps(self.result)
 
         # remove redundant labels
         jtc = JumpTargetCollector(self.result)
@@ -134,10 +122,6 @@ class RecursiveStructurer(Analysis):
 
         # remove empty nodes (if any)
         self.result = EmptyNodeRemover(self.result).result
-
-        if self.structurer_cls is DreamStructurer:
-            # remove conditional jumps
-            StructurerBase._remove_conditional_jumps(self.result)
 
         self.result = self.cond_proc.remove_claripy_bool_asts(self.result)
 

--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -110,34 +110,6 @@ class StructurerBase(Analysis):
         return not networkx.is_directed_acyclic_graph(self._region.graph)
 
     @staticmethod
-    def _remove_conditional_jumps_from_block(block, parent=None, index=0, label=None):
-        block.statements = [stmt for stmt in block.statements if not isinstance(stmt, ailment.Stmt.ConditionalJump)]
-
-    @staticmethod
-    def _remove_conditional_jumps(seq, follow_seq=True):
-        """
-        Remove all conditional jumps.
-
-        :param SequenceNode seq:    The SequenceNode instance to handle.
-        :return:                    A processed SequenceNode.
-        """
-
-        def _handle_Sequence(node, **kwargs):
-            if not follow_seq and node is not seq:
-                return None
-            return walker._handle_Sequence(node, **kwargs)
-
-        handlers = {
-            SequenceNode: _handle_Sequence,
-            ailment.Block: StructurerBase._remove_conditional_jumps_from_block,
-        }
-
-        walker = SequenceWalker(handlers=handlers)
-        walker.walk(seq)
-
-        return seq
-
-    @staticmethod
     def _switch_find_switch_end_addr(
         cases: dict[int, BaseNode], default: BaseNode | ailment.Block | None, region_node_addrs: set[int]
     ) -> int | None:
@@ -246,35 +218,6 @@ class StructurerBase(Analysis):
 
         if default is not None:
             walker.walk(default)
-
-    @staticmethod
-    def _remove_all_jumps(seq):
-        """
-        Remove all constant jumps.
-
-        :param SequenceNode seq:    The SequenceNode instance to handle.
-        :return:                    A processed SequenceNode.
-        """
-
-        def _handle_Block(node: ailment.Block, **kwargs):
-            if (
-                node.statements
-                and isinstance(node.statements[-1], ailment.Stmt.Jump)
-                and isinstance(node.statements[-1].target, ailment.Expr.Const)
-            ):
-                # remove the jump
-                node.statements = node.statements[:-1]
-
-            return node
-
-        handlers = {
-            ailment.Block: _handle_Block,
-        }
-
-        walker = SequenceWalker(handlers=handlers)
-        walker.walk(seq)
-
-        return seq
 
     @staticmethod
     def _remove_redundant_jumps(seq):


### PR DESCRIPTION
Currently using DREAM for structuring will result in indiscriminate removal of jumps, including to external targets which should definitely be preserved.
