### PR TITLE
fix deprecation warning for simgr.step()

### DIFF
--- a/angr/analyses/smc.py
+++ b/angr/analyses/smc.py
@@ -146,7 +146,7 @@ class SelfModifyingCodeAnalysis(Analysis):
 
         for n in range(100):
             self._update_progress(n)
-            simgr.step(n=3)
+            simgr.run(n=3)
             random.shuffle(simgr.active)
             simgr.split(from_stash="active", to_stash=simgr.DROP, limit=10)
 


### PR DESCRIPTION
This mitigates the warning: "Deprecation warning: the use of `n` and `until` arguments is deprecated. Consider using simgr.run() with the same arguments if you want to specify a number of steps or an additional condition on when to stop the execution"
