### PR TITLE
CLI: Report version with --version

### DIFF
--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -87,6 +87,7 @@ def decompile(args):
 
 def main():
     parser = argparse.ArgumentParser(description="The angr CLI allows you to decompile and analyze binaries.")
+    parser.add_argument("--version", action="version", version=angr.__version__)
     parser.add_argument("binary", help="The path to the binary to analyze.")
     parser.add_argument(
         "--catch-exceptions",


### PR DESCRIPTION
Report angr version with `angr --version`

We should probably migrate bug_report to the CLI interface as well..