### PR TITLE
Highlight syntax by default on angr decompile CLI

### DIFF
--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -12,14 +12,8 @@ from angr.analyses.decompiler.structuring import STRUCTURER_CLASSES, DEFAULT_STR
 from angr.analyses.decompiler.utils import decompile_functions
 from angr.utils.formatting import ansi_color_enabled
 
-try:
-    from rich.syntax import Syntax
-    from rich.console import Console
-
-    HAS_RICH_SYNTAX = True
-except ImportError:
-    HAS_RICH_SYNTAX = False
-
+from rich.syntax import Syntax
+from rich.console import Console
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.functions import Function
@@ -93,7 +87,7 @@ def decompile(args):
     )
 
     # Determine if we should use syntax highlighting
-    should_highlight = HAS_RICH_SYNTAX and ansi_color_enabled and not getattr(args, "no_colors", False)
+    should_highlight = ansi_color_enabled and not args.no_colors
 
     if should_highlight:
         try:

--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -6,14 +6,14 @@ import re
 from typing import TYPE_CHECKING
 from collections.abc import Generator
 
+from rich.syntax import Syntax
+from rich.console import Console
+
 import angr
 from angr.analyses.decompiler import DECOMPILATION_PRESETS
 from angr.analyses.decompiler.structuring import STRUCTURER_CLASSES, DEFAULT_STRUCTURER
 from angr.analyses.decompiler.utils import decompile_functions
 from angr.utils.formatting import ansi_color_enabled
-
-from rich.syntax import Syntax
-from rich.console import Console
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.functions import Function

--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -100,7 +100,9 @@ def decompile(args):
             console = Console()
             syntax = Syntax(decompilation, "c", theme=args.theme, line_numbers=False)
             console.print(syntax)
-        except Exception:
+        # pylint: disable=broad-exception-caught
+        except Exception as e:
+            log.warning("Syntax highlighting failed: %s", e)
             # Fall back to plain text if syntax highlighting fails
             print(decompilation)
     else:

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -989,7 +989,7 @@ def decompile_functions(
     show_casts: bool = True,
     base_address: int | None = None,
     preset: str | None = None,
-) -> str | None:
+) -> str:
     """
     Decompile a binary into a set of functions.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,11 +110,9 @@ class TestCommandLineInterface(unittest.TestCase):
             assert s in disasm
 
     def test_syntax_highlighting_no_colors_flag(self):
-        """Test that --no-colors flag disables syntax highlighting"""
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "sailr_motivating_example")
         f1 = "main"
 
-        # Test with --no-colors flag - should get plain text output
         no_colors_output = run_cli(bin_path, "decompile", "--functions", f1, "--no-colors")
         expected_output = decompile_functions(bin_path, [f1]) + "\n"
 
@@ -124,7 +122,6 @@ class TestCommandLineInterface(unittest.TestCase):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "sailr_motivating_example")
         f1 = "main"
 
-        # Test with --no-colors flag - should get plain text output
         colors_output = run_cli(bin_path, "decompile", "--functions", f1)
         expected_output = decompile_functions(bin_path, [f1]) + "\n"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,16 +116,8 @@ class TestCommandLineInterface(unittest.TestCase):
         no_colors_output = run_cli(bin_path, "decompile", "--functions", f1, "--no-colors")
         expected_output = decompile_functions(bin_path, [f1]) + "\n"
 
+        # it should maintain that no ANSI color codes are present
         assert no_colors_output == expected_output
-
-    def test_syntax_highlighting(self):
-        bin_path = os.path.join(test_location, "x86_64", "decompiler", "sailr_motivating_example")
-        f1 = "main"
-
-        colors_output = run_cli(bin_path, "decompile", "--functions", f1)
-        expected_output = decompile_functions(bin_path, [f1]) + "\n"
-
-        assert colors_output != expected_output
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,10 +34,16 @@ class TestCommandLineInterface(unittest.TestCase):
         f2 = "main"
 
         # test a single function
-        assert run_cli(bin_path, "decompile", "--functions", f1) == decompile_functions(bin_path, [f1]) + "\n"
+        assert (
+            run_cli(bin_path, "decompile", "--functions", f1, "--no-color")
+            == decompile_functions(bin_path, [f1]) + "\n"
+        )
 
         # test multiple functions
-        assert run_cli(bin_path, "decompile", "--functions", f1, f2) == decompile_functions(bin_path, [f1, f2]) + "\n"
+        assert (
+            run_cli(bin_path, "decompile", "--functions", f1, f2, "--no-color")
+            == decompile_functions(bin_path, [f1, f2]) + "\n"
+        )
 
     def test_structuring(self):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "sailr_motivating_example")
@@ -57,12 +63,14 @@ class TestCommandLineInterface(unittest.TestCase):
         f1_offset = f1_default_addr - default_base_addr
 
         # function resolving is based on symbol
-        sym_based_dec = run_cli(bin_path, "decompile", "--functions", f1, "--preset", "full")
+        sym_based_dec = run_cli(bin_path, "decompile", "--functions", f1, "--preset", "full", "--no-color")
         # function resolving is based on the address (with default angr loading)
-        base_addr_dec = run_cli(bin_path, "decompile", "--functions", hex(f1_default_addr), "--preset", "full")
+        base_addr_dec = run_cli(
+            bin_path, "decompile", "--functions", hex(f1_default_addr), "--preset", "full", "--no-color"
+        )
         # function resolving is based on the address (with base address specified)
         offset_dec = run_cli(
-            bin_path, "--base-addr", "0x0", "decompile", "--functions", hex(f1_offset), "--preset", "full"
+            bin_path, "--base-addr", "0x0", "decompile", "--functions", hex(f1_offset), "--preset", "full", "--no-color"
         )
 
         # since the externs can be unpredictable, we only check the function name down
@@ -100,6 +108,27 @@ class TestCommandLineInterface(unittest.TestCase):
 
         for s in substrs:
             assert s in disasm
+
+    def test_syntax_highlighting_no_colors_flag(self):
+        """Test that --no-colors flag disables syntax highlighting"""
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "sailr_motivating_example")
+        f1 = "main"
+
+        # Test with --no-colors flag - should get plain text output
+        no_colors_output = run_cli(bin_path, "decompile", "--functions", f1, "--no-colors")
+        expected_output = decompile_functions(bin_path, [f1]) + "\n"
+
+        assert no_colors_output == expected_output
+
+    def test_syntax_highlighting(self):
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "sailr_motivating_example")
+        f1 = "main"
+
+        # Test with --no-colors flag - should get plain text output
+        colors_output = run_cli(bin_path, "decompile", "--functions", f1)
+        expected_output = decompile_functions(bin_path, [f1]) + "\n"
+
+        assert colors_output != expected_output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [X] Syntax highlight angr decompilation by default
- [X] Disable (using Rich) if terminal does not support colors (also off in redirection)
- [X] Have an option for no colors

Looks like the following:
<img width="1015" height="574" alt="image" src="https://github.com/user-attachments/assets/a044a34b-eb79-4917-b6ca-060faec9667b" />