### PR TITLE
pthread_mutex_lock and unlock always to return Success

### DIFF
--- a/angr/procedures/posix/pthread.py
+++ b/angr/procedures/posix/pthread.py
@@ -52,20 +52,20 @@ class pthread_cond_signal(angr.SimProcedure):
 
 class pthread_mutex_lock(angr.SimProcedure):
     """
-    A no-op.
+    Always returns 0 (SUCCESS).
     """
 
     def run(self, arg):
-        pass
+        return 0
 
 
 class pthread_mutex_unlock(angr.SimProcedure):
     """
-    A no-op.
+    Always returns 0 (SUCCESS).
     """
 
     def run(self, arg):
-        pass
+        return 0
 
 
 class pthread_once(angr.SimProcedure):


### PR DESCRIPTION
In the program I'm analyzing there is a following sequence of opcodes:
```
push    rax {var_18}
call    pthread_mutex_lock
test    eax, eax
jne     0x55555562d705
```

But since the exisisting SimProcedure for `pthread_mutex_lock`  is no-op it is impossible for solver to solve `test eax, eax` as it is never zero.

Judging by online docs `pthread_mutex_lock` should return 0 in case of successful mutex aquisition. The same for `unlock`.

This commit fixes just that.