### PR TITLE
Typehoon: Solution cache considers equivalence classes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,6 @@ repos:
     rev: v1.10.0
     hooks:
     # Python
-    -   id: python-use-type-annotations
     -   id: python-no-log-warn
     # Documentation
     -   id: rst-backticks

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -704,8 +704,8 @@ class SimpleSolver:
         out_graph = networkx.MultiDiGraph()  # there can be multiple edges between two nodes, each edge is associated
         # with a different label
         for src, dst, data in g.edges(data=True):
-            src_cls = equivalence_classes[src]
-            dst_cls = equivalence_classes[dst]
+            src_cls = equivalence_classes.get(src, src)
+            dst_cls = equivalence_classes.get(dst, dst)
             label = None if not data else data["label"]
             if label is not None and out_graph.has_edge(src_cls, dst_cls):
                 # do not add the same edge twice
@@ -808,8 +808,8 @@ class SimpleSolver:
         graph: networkx.DiGraph,
     ) -> None:
         # first convert cls0 and cls1 to their equivalence classes
-        cls0 = equivalence_classes[cls0]
-        cls1 = equivalence_classes[cls1]
+        cls0 = equivalence_classes.get(cls0, cls0)
+        cls1 = equivalence_classes.get(cls1, cls1)
 
         # unify if needed
         if cls0 != cls1:
@@ -837,7 +837,10 @@ class SimpleSolver:
                             isinstance(data0["label"], Load) and isinstance(data1["label"], Store)
                         ):
                             SimpleSolver._unify(
-                                equivalence_classes, equivalence_classes[dst0], equivalence_classes[dst1], graph
+                                equivalence_classes,
+                                equivalence_classes.get(dst0, dst0),
+                                equivalence_classes.get(dst1, dst1),
+                                graph,
                             )
 
     def _eq_constraints_from_add(self, typevar: TypeVariable):


### PR DESCRIPTION
Also removes pre-commit no type annotation as comments check because it conflicts with "# typedef xxx" (it should have been implemented better but it's not our problem).