### PR TITLE
Fix Icicle breakpoints not reliably working in thumb mode

### DIFF
--- a/angr/emulator.py
+++ b/angr/emulator.py
@@ -95,7 +95,8 @@ class Emulator:
         num_inst_executed: int = 0
         while self._state.history.jumpkind != "Ijk_Exit":
             # Check if there is a breakpoint at the current address
-            if completed_engine_execs > 0 and self._state.addr in self._engine.get_breakpoints():
+            addr_with_lower_bit_cleared = self._state.addr & ~1
+            if completed_engine_execs > 0 and addr_with_lower_bit_cleared in self._engine.get_breakpoints():
                 return EmulatorStopReason.BREAKPOINT
 
             # Check if we've already executed the requested number of instructions

--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing_extensions import override
 
 import pypcode
-from archinfo import Arch, Endness, ArchARMCortexM
+from archinfo import Arch, ArchPcode, Endness, ArchARMCortexM
 
 from angr.engines.concrete import ConcreteEngine, HeavyConcreteState
 from angr.engines.failure import SimEngineFailure
@@ -72,6 +72,8 @@ class IcicleEngine(ConcreteEngine):
         accurate, just a set of heuristics to get the right architecture. When
         adding a new architecture, this function may need to be updated.
         """
+        if isinstance(arch, ArchARMCortexM) or (isinstance(arch, ArchPcode) and arch.pcode_arch == "ARM:LE:32:Cortex"):
+            return "armv7m"
         if arch.linux_name == "arm":
             return "armv7a" if arch.memory_endness == Endness.LE else "armeb"
         return arch.linux_name
@@ -84,11 +86,20 @@ class IcicleEngine(ConcreteEngine):
         return icicle_arch.startswith(("arm", "thumb"))
 
     @staticmethod
+    def __is_cortex_m(angr_arch: Arch, icicle_arch: str) -> bool:
+        """
+        Check if the architecture is cortex-m based on the address.
+        """
+        return isinstance(angr_arch, ArchARMCortexM) or icicle_arch == "armv7m"
+
+    @staticmethod
     def __is_thumb(angr_arch: Arch, icicle_arch: str, addr: int) -> bool:
         """
         Check if the architecture is thumb based on the address.
         """
-        return isinstance(angr_arch, ArchARMCortexM) or (IcicleEngine.__is_arm(icicle_arch) and addr & 1 == 1)
+        return IcicleEngine.__is_cortex_m(angr_arch, icicle_arch) or (
+            IcicleEngine.__is_arm(icicle_arch) and addr & 1 == 1
+        )
 
     @staticmethod
     def __get_pages(state: HeavyConcreteState) -> set[int]:
@@ -132,7 +143,10 @@ class IcicleEngine(ConcreteEngine):
         for register in state.arch.register_list:
             register = register.vex_name.lower() if register.vex_name is not None else register.name
             try:
-                emu.reg_write(register, state.solver.eval(state.registers.load(register), cast_to=int))
+                emu.reg_write(
+                    register,
+                    state.solver.eval(state.registers.load(register), cast_to=int),
+                )
                 copied_registers.add(register)
             except KeyError:
                 log.debug("Register %s not found in icicle", register)
@@ -242,11 +256,13 @@ class IcicleEngine(ConcreteEngine):
     @override
     def add_breakpoint(self, addr: int) -> None:
         """Add a breakpoint at the given address."""
+        addr = addr & ~1  # Clear thumb bit if set
         self.breakpoints.add(addr)
 
     @override
     def remove_breakpoint(self, addr: int) -> None:
         """Remove a breakpoint at the given address, if present."""
+        addr = addr & ~1  # Clear thumb bit if set
         self.breakpoints.discard(addr)
 
     @override


### PR DESCRIPTION
Icicle does not set the thumb bit when considering to break for a breakpoint. So for instance, if a breakpoint is set at 0x1001, Icicle will never hit this, it would instead hit 0x1000. Since angr prefers to pretend the thumb bit is set in the pc this makes sure it is always unset before being communicated to Icicle.