### PR TITLE
GraphDephication: Use phivar's category and oident for new vvars.

### DIFF
--- a/angr/analyses/decompiler/dephication/graph_vvar_mapping.py
+++ b/angr/analyses/decompiler/dephication/graph_vvar_mapping.py
@@ -4,14 +4,14 @@ from collections import defaultdict
 
 from angr.ailment import AILBlockWalker
 from angr.ailment.block import Block
-from angr.ailment.expression import Phi, VirtualVariable, VirtualVariableCategory
+from angr.ailment.expression import Phi, VirtualVariable
 from angr.ailment.statement import Assignment, Jump, ConditionalJump, Label
 
 from angr.analyses import Analysis
 from angr.analyses.s_reaching_definitions import SRDAModel
 from angr.knowledge_plugins.functions import Function
 from angr.analyses import register_analysis
-from angr.utils.ssa import is_phi_assignment, DEPHI_VVAR_REG_OFFSET
+from angr.utils.ssa import is_phi_assignment
 
 l = logging.getLogger(name=__name__)
 
@@ -232,14 +232,8 @@ class GraphDephicationVVarMapping(Analysis):  # pylint:disable=abstract-method
                         # we have not yet appended a statement to this block
                         the_block = self._blocks[src]
                         ins_addr = the_block.addr + the_block.original_size - 1
-                        if vvar.category == VirtualVariableCategory.PARAMETER:
-                            # it's a parameter, so we copy the variable into a dummy register vvar
-                            # a parameter vvar should never be assigned to
-                            new_category = VirtualVariableCategory.REGISTER
-                            new_oident = DEPHI_VVAR_REG_OFFSET
-                        else:
-                            new_category = vvar.category
-                            new_oident = vvar.oident
+                        new_category = phi_stmt.dst.category
+                        new_oident = phi_stmt.dst.oident
                         new_vvar = VirtualVariable(
                             None, new_vvar_id, vvar.bits, new_category, oident=new_oident, ins_addr=ins_addr
                         )


### PR DESCRIPTION
This fix allows the newly created vvars to inherit the category of the phivar, which prevents unexpected assignments like `v3.Length = v3.Length;` where the dst is a vvar created from a phi assignment statement like `reg_phi_var = phi(reg_vvar, stack_vvar)`. In this case, the new dst vvar should inherit the category of `reg_phi_var` instead of the category of `stack_vvar`.