### PR TITLE
ci: Use macos-15-intel runner for smoketest for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test installation
     strategy:
       matrix:
-        os: [windows-2022, macos-15]
+        os: [windows-2022, macos-15-intel]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
In #5763 I selected macos-15, which will run on ARM. This was a change from macos-13 which runs on x86. Move to macos-15-intel to get things passing again incrementally and fix the problems with macos-15 (unicorn) in a follow up.