### PR TITLE
pyproject.toml: Align with current license metadata guidance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "angr"
 description = "A multi-architecture binary analysis toolkit, with the ability to perform dynamic symbolic execution and various static analyses on binaries"
 license = "BSD-2-Clause"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
@@ -79,7 +80,6 @@ extras = ["angr[angrdb,keystone,unicorn]"]
 
 [tool.setuptools]
 include-package-data = true
-license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 exclude = ["tests*"]


### PR DESCRIPTION
```
DEBUG         ********************************************************************************
DEBUG         Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
DEBUG 
DEBUG         By 2026-Feb-18, you need to update your project and remove deprecated calls
DEBUG         or your builds will no longer be supported.
DEBUG 
DEBUG         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
DEBUG         ********************************************************************************
```