### PR TITLE
pyproject.toml: Bump protobuf requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "msgspec",
     "mulpyplexer",
     "networkx!=2.8.1,>=2.0",
-    "protobuf>=6.32.0",
+    "protobuf>=6.33.0",
     "psutil",
     "pycparser>=2.18",
     "pydemumble",


### PR DESCRIPTION
Fixes

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading angr/protos/primitives.proto: gencode 6.33.0 runtime 6.32.0. Ru...
```