### PR TITLE
ci: Install older CMake on macOS nightly

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -53,6 +53,11 @@ jobs:
           repository: angr/binaries
           path: binaries
       - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v6
+      # XXX: Install CMake<4 to build pinned unicorn==2.0.1.post1 for now
+      - name: Install CMake
+        uses: ssrobins/install-cmake@c54bb968401dd4ff9e6c9d697df5b843ee3b783b # v1
+        with:
+          version: 3.31.9
       - name: Sync dependencies
         run: uv --directory angr sync -p 3.10
       - name: Run pytest


### PR DESCRIPTION
unicorn==2.0.1.post1 no longer builds with recent CMake. Pin to an older version for testing for now.

* Once Unicorn is updated (#5161) (or dropped), remove this pin.