### PR TITLE
use the base knowledge base during decompilation if variable_kb is not provided

### DIFF
--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -104,7 +104,7 @@ class Decompiler(Analysis):
         self._peephole_optimizations = peephole_optimizations
         self._vars_must_struct = vars_must_struct
         self._flavor = flavor
-        self._variable_kb if variable_kb is not None else self.kb
+        self._variable_kb = variable_kb if variable_kb is not None else self.kb
         self._expr_comments = expr_comments
         self._stmt_comments = stmt_comments
         self._ite_exprs = ite_exprs

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -151,7 +151,7 @@ class OptimizationPass(BaseOptimizationPass):
         self._blocks_by_addr: dict[int, set[ailment.Block]] = blocks_by_addr or {}
         self._blocks_by_addr_and_idx: dict[tuple[int, int | None], ailment.Block] = blocks_by_addr_and_idx or {}
         self._graph = graph
-        self._variable_kb if variable_kb is not None else self.kb
+        self._variable_kb = variable_kb if variable_kb is not None else self.kb
         self._ri = region_identifier
         self._rd = reaching_definitions
         self._scratch = scratch if scratch is not None else {}


### PR DESCRIPTION
This aligns with other passes, which uses `self.kb` when `variable_kb` is not provided.
