### PR TITLE
PurityAnalysis: be more aggressive in killing source taints

### DIFF
--- a/angr/analyses/forward_analysis/forward_analysis.py
+++ b/angr/analyses/forward_analysis/forward_analysis.py
@@ -598,8 +598,8 @@ class ForwardAnalysisForClinic(
                     assert isinstance(stmt.dst, ailment.expression.VirtualVariable)
                     for pred, vvar in stmt.src.src_and_vvars:
                         if pred == (node.addr, node.idx):
-                            assert vvar is not None
-                            self._handle_phi(node, succ, result, stmt.dst, vvar)
+                            if vvar is not None:
+                                self._handle_phi(node, succ, result, stmt.dst, vvar)
                             break
                     else:
                         raise AngrForwardAnalysisError("Failed to find appropriate predecessor")

--- a/angr/analyses/purity/engine.py
+++ b/angr/analyses/purity/engine.py
@@ -11,6 +11,7 @@ from typing_extensions import Self
 import angr
 from angr.engines.light import SimEngineLightAIL
 from angr import ailment
+from angr.knowledge_plugins.functions.function import Function
 
 
 @dataclass
@@ -42,7 +43,7 @@ class DataSource:
 
     constant_value: int | None = None
     function_arg: int | None = None
-    callee_return: int | None = None
+    callee_return: Function | None = None
     reference_to: int | None = None
 
 
@@ -70,7 +71,7 @@ class ResultType:
 
     uses: MutableMapping[DataSource, DataUsage] = field(default_factory=lambda: defaultdict(DataUsage))
     # keyed as: block addr, block idx, stmt idx, call addr, call arg
-    call_args: MutableMapping[tuple[int, int | None, int, int, int], DataType_co] = field(
+    call_args: MutableMapping[tuple[int, int | None, int, Function | None, int], DataType_co] = field(
         default_factory=lambda: defaultdict(frozenset)
     )
     ret_vals: MutableMapping[int, DataType_co] = field(default_factory=lambda: defaultdict(frozenset))
@@ -98,9 +99,12 @@ class PurityEngineAIL(SimEngineLightAIL[StateType, DataType_co, StmtDataType, Re
     A use is arithmetic, store, or load.
     """
 
-    def __init__(self, project: angr.Project, clinic: angr.analyses.decompiler.Clinic):
+    def __init__(
+        self, project: angr.Project, clinic: angr.analyses.decompiler.Clinic, recurse: Callable[[Function], ResultType]
+    ):
         self.clinic = clinic
         self.result = ResultType()
+        self.recurse = recurse
         super().__init__(project)
 
     def initial_state(self, node: ailment.Block):
@@ -165,9 +169,7 @@ class PurityEngineAIL(SimEngineLightAIL[StateType, DataType_co, StmtDataType, Re
     def _handle_stmt_WeakAssignment(self, stmt: ailment.statement.WeakAssignment) -> StmtDataType:
         raise NotImplementedError
 
-    def _handle_stmt_Store(self, stmt: ailment.statement.Store) -> StmtDataType:
-        val = self._expr(stmt.data)
-        ptr = self._expr(stmt.addr)
+    def _do_store(self, ptr: DataType_co, val: DataType_co):
         for src in ptr:
             if src.reference_to is not None:
                 self.state.vars[src.reference_to] = val
@@ -175,6 +177,11 @@ class PurityEngineAIL(SimEngineLightAIL[StateType, DataType_co, StmtDataType, Re
                 self.result.uses[src].ptr_store = True
                 if val:
                     self.result.other_storage[src] |= val
+
+    def _handle_stmt_Store(self, stmt: ailment.statement.Store) -> StmtDataType:
+        val = self._expr(stmt.data)
+        ptr = self._expr(stmt.addr)
+        self._do_store(ptr, val)
 
     def _handle_stmt_Jump(self, stmt: ailment.statement.Jump) -> StmtDataType:
         self._expr_single(stmt.target)
@@ -187,21 +194,15 @@ class PurityEngineAIL(SimEngineLightAIL[StateType, DataType_co, StmtDataType, Re
             self._expr_single(stmt.false_target)
 
     def _handle_stmt_Call(self, stmt: ailment.statement.Call) -> StmtDataType:
-        assert isinstance(stmt.target, ailment.Expression)
-        target = self._expr_single(stmt.target)
-        target_int = target.constant_value or 0
-        result = frozenset((DataSource(callee_return=target_int),))
-        for i, arg in enumerate(stmt.args or []):
-            val = self._expr(arg)
-            self.result.call_args[(self.block.addr, self.block.idx, self.stmt_idx, target_int, i)] |= val
-        # recursive processing...?
+        results = self._do_call(stmt)
         if stmt.ret_expr is not None:
-            self._do_assign(stmt.ret_expr, result)
+            assert 0 in results
+            self._do_assign(stmt.ret_expr, results[0])
         if stmt.fp_ret_expr is not None:
-            self._do_assign(stmt.fp_ret_expr, result)
+            assert 0 in results
+            self._do_assign(stmt.fp_ret_expr, results[0])
 
     def _handle_stmt_Return(self, stmt: ailment.statement.Return) -> StmtDataType:
-        # recursive processing...?
         for i, expr in enumerate(stmt.ret_exprs):
             r = self._expr(expr)
             self.result.ret_vals[i] |= r
@@ -221,13 +222,19 @@ class PurityEngineAIL(SimEngineLightAIL[StateType, DataType_co, StmtDataType, Re
         return self.tmps[expr.tmp_idx]
 
     def _handle_expr_VirtualVariable(self, expr: ailment.expression.VirtualVariable) -> DataType_co:
+        # allow registers to be uninitialized since callee-save is a thing
+        assert (
+            self.clinic.function.name == "_security_check_cookie"
+            or expr.category == ailment.expression.VirtualVariableCategory.REGISTER
+            or expr.varid in self.state.vars
+        )
         return self.state.vars[expr.varid]
 
     def _handle_expr_Phi(self, expr: ailment.expression.Phi) -> DataType_co:
         assert False, "Unreachable"
 
     def _handle_expr_Convert(self, expr):
-        return self._expr(expr.operand)
+        return frozenset(x for x in self._expr(expr.operand) if x.constant_value is not None)
 
     def _handle_expr_Reinterpret(self, expr: ailment.expression.Reinterpret) -> DataType_co:
         return self._expr(expr.operand)
@@ -244,7 +251,8 @@ class PurityEngineAIL(SimEngineLightAIL[StateType, DataType_co, StmtDataType, Re
                 result.extend(self.state.vars[src.reference_to])
             elif self._is_valid_pointer(src):
                 self.result.uses[src].ptr_load = True
-                result.append(src)
+                if src.constant_value is None:
+                    result.append(src)
         return frozenset(result)
 
     def _handle_expr_Load(self, expr: ailment.expression.Load) -> DataType_co:
@@ -257,14 +265,52 @@ class PurityEngineAIL(SimEngineLightAIL[StateType, DataType_co, StmtDataType, Re
         self._expr(expr.condition)
         return self._expr(expr.iftrue) | self._expr(expr.iffalse)
 
-    def _handle_expr_Call(self, expr: ailment.statement.Call) -> DataType_co:
+    def _do_call(self, expr: ailment.statement.Call) -> MutableMapping[int, DataType_co]:
         assert isinstance(expr.target, ailment.Expression)
+        args = [self._expr(arg) for arg in expr.args or []]
         target = self._expr_single(expr.target)
-        target_int = target.constant_value or 0
-        for i, arg in enumerate(expr.args or []):
-            val = self._expr(arg)
-            self.result.call_args[(self.block.addr, self.block.idx, self.stmt_idx, target_int, i)] |= val
-        return frozenset((DataSource(callee_return=target_int),))
+        seen = None
+        func = None
+        if target.constant_value:
+            func = self.clinic.project.kb.functions[target.constant_value]
+            if not func.is_plt and not func.is_simprocedure:
+                seen = ResultType() if func.name == "_security_check_cookie" else self.recurse(func)
+
+        if seen is not None:
+
+            def subst(v: DataSource) -> DataType_co:
+                if v.function_arg is not None:
+                    return args[v.function_arg]
+                if v.reference_to is not None:
+                    return frozenset()
+                return frozenset((v,))
+
+            def substall(v: DataType_co) -> DataType_co:
+                result = []
+                for vv in v:
+                    result.extend(subst(vv))
+                return frozenset(result)
+
+            for srcs, val in seen.other_storage.items():
+                if not val:
+                    continue
+                self._do_store(subst(srcs), substall(val))
+            for srcs, kind in seen.uses.items():
+                for src in subst(srcs):
+                    self.result.uses[src] |= kind
+            for callsite, vals in seen.call_args.items():
+                self.result.call_args[callsite] |= substall(vals)
+
+            return {i: substall(v) for i, v in seen.ret_vals.items()}
+        for i, val in enumerate(args):
+            self.result.call_args[(self.block.addr, self.block.idx, self.stmt_idx, func, i)] |= val
+        # ummmm need to rearrange data model
+        return {idx: frozenset((DataSource(callee_return=func),)) for idx in range(0 if expr.ret_expr is None else 1)}
+
+    def _handle_expr_Call(self, expr: ailment.statement.Call) -> DataType_co:
+        r = self._do_call(expr)
+        assert 0 in r
+        return r[0]
 
     def _handle_expr_DirtyExpression(self, expr: ailment.expression.DirtyExpression) -> DataType_co:
         for arg in expr.operands:

--- a/tests/analyses/test_purity.py
+++ b/tests/analyses/test_purity.py
@@ -27,8 +27,8 @@ class TestAILPurityAnalysis(unittest.TestCase):
             ),
             # malloc - no flow from arg0 to malloc since it is a pointer-destroying op
             "e": AILPurityResultType(
-                uses={AILPurityDataSource(callee_return=4198448): AILPurityDataUsage(ptr_store=True)},
-                call_args={(4199008, None, 2, 4198448, 0): frozenset()},
+                uses={AILPurityDataSource(callee_return=p.kb.functions[4198448]): AILPurityDataUsage(ptr_store=True)},
+                call_args={(4199008, None, 2, p.kb.functions[4198448], 0): frozenset()},
             ),
         }
 
@@ -36,6 +36,8 @@ class TestAILPurityAnalysis(unittest.TestCase):
             func = p.kb.functions[name]
             clinic = p.analyses.Clinic(func)
             pure = p.analyses[AILPurityAnalysis].prep()(clinic)
+            pure.result.ret_vals = {}
+            pure.result.other_storage = {}
             assert pure.result == desired_result
 
 


### PR DESCRIPTION
Prevents many spurious dataflows from appearing

also fixes a really silly bug preventing non-constant dataflows from being propagated through binops

also makes this analysis recursive