### PR TITLE
SegSelectorRewriter: Ensure seg_selector is a VVar before accessing .was_reg.

### DIFF
--- a/angr/analyses/decompiler/ccall_rewriters/x86_ccalls.py
+++ b/angr/analyses/decompiler/ccall_rewriters/x86_ccalls.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from angr.ailment import Expr
 
-from angr.ailment.expression import Convert
+from angr.ailment.expression import Convert, VirtualVariable
 from angr.ailment.statement import Call
 from angr.engines.vex.claripy.ccall import data
 from angr.procedures.definitions import SIM_LIBRARIES
@@ -311,6 +311,7 @@ class X86CCallRewriter(CCallRewriterBase):
                 seg_selector = seg_selector.operands[0]
             if (
                 self.project.simos.name == "Win32"
+                and isinstance(seg_selector, VirtualVariable)
                 and seg_selector.was_reg
                 and self.project.arch.register_names.get(seg_selector.reg_offset, "") == "fs"
                 and isinstance(virtual_addr, Expr.Const)


### PR DESCRIPTION
This PR fixes the following exception:

```
  File "/home/ubuntu/projects/angr-dev/angr/angr/ailment/block_walker.py", line 314, in _handle_expr
    expr = handler(expr_idx, expr, stmt_idx, stmt, block)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/projects/angr-dev/angr/angr/ailment/block_walker.py", line 701, in _handle_Convert
    new_operand = self._handle_expr(expr_idx, expr.operand, stmt_idx, stmt, block)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/projects/angr-dev/angr/angr/ailment/block_walker.py", line 314, in _handle_expr
    expr = handler(expr_idx, expr, stmt_idx, stmt, block)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/projects/angr-dev/angr/angr/analyses/decompiler/ail_simplifier.py", line 2111, in _handle_VEXCCallExpression
    rewriter = rewriter_cls(r_expr, self.project, rename_ccalls=self._should_rename_ccalls)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/projects/angr-dev/angr/angr/analyses/decompiler/ccall_rewriters/rewriter_base.py", line 17, in __init__
    self.result: ailment.Expr.Expression | None = self._rewrite(ccall)
                                                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/projects/angr-dev/angr/angr/analyses/decompiler/ccall_rewriters/x86_ccalls.py", line 314, in _rewrite
    and seg_selector.was_reg
        ^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/projects/angr-dev/angr/angr/ailment/tagged_object.py", line 31, in __getattr__
    return super().__getattribute__(item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Const' object has no attribute 'was_reg'
```