### PR TITLE
Add definition for Mach-O libSystem library

### DIFF
--- a/angr/procedures/definitions/__init__.py
+++ b/angr/procedures/definitions/__init__.py
@@ -1028,6 +1028,8 @@ COMMON_LIBRARIES = {
     "linux_loader",
     # Windows
     "msvcr",
+    # Mach O
+    "macho_libsystem",
 }
 
 

--- a/angr/procedures/definitions/macho_libsystem.py
+++ b/angr/procedures/definitions/macho_libsystem.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from angr.procedures import SIM_PROCEDURES as P
+from . import SimLibrary
+
+libc = SimLibrary()
+libc.set_library_names(
+    "libSystem.dylib",
+    "libSystem.B.dylib",
+)
+# TODO: add more functions
+libc.add_all_from_dict(P["libc"])
+
+# Mach-O naming convention adds an underscore prefix to function names
+for name, _ in P["libc"].items():
+    libc.add_alias(name, "_" + name)


### PR DESCRIPTION
Add for support Mach-O "libSystem.B.dylib" library.