### PR TITLE
calling_conventions.py: Fix SimReferenceArgument error in setup_callsite

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -938,9 +938,9 @@ class SimCC:
         for i, (loc, val) in enumerate(zip(arg_locs, vals)):
             if not isinstance(loc, SimReferenceArgument):
                 continue
-            dumped = allocator.dump(val, state, loc=val.main_loc)
+            dumped = allocator.dump(val, state, loc=loc.main_loc)
             vals[i] = dumped
-            arg_locs[i] = val.ptr_loc
+            arg_locs[i] = loc.ptr_loc
 
         # step 1.75 allocate implicit outparam stuff
         if self.return_in_implicit_outparam(prototype.returnty):


### PR DESCRIPTION
Corrected the logic to use `loc`  instead of `val`. The type of `SimFunctionArgument` is `loc`, not `val`.

```bash
  File "/home/jvle/Desktop/works/sec/test/angr-test/examples/angr/simcc/cc_test.py", line 72, in run_test
    state = proj.factory.call_state(target_addr, *args, cc=cc, prototype=proto)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jvle/Desktop/works/sec/angr-dev/angr/angr/factory.py", line 206, in call_state
    return self.project.simos.state_call(addr, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jvle/Desktop/works/sec/angr-dev/angr/angr/simos/simos.py", line 268, in state_call
    cc.setup_callsite(state, ret_addr, args, prototype, stack_base, alloc_base, grow_like_stack)
  File "/home/jvle/Desktop/works/sec/angr-dev/angr/angr/calling_conventions.py", line 941, in setup_callsite
    dumped = allocator.dump(val, state, loc=val.main_loc)
                                            ^^^^^^^^^^^^
  File "/home/jvle/Desktop/works/sec/angr-dev/angr/angr/sim_type.py", line 1816, in __getattr__
    return self[k]
           ~~~~^^^
  File "/home/jvle/Desktop/works/sec/angr-dev/angr/angr/sim_type.py", line 1828, in __getitem__
    raise KeyError(k)
KeyError: 'main_loc'
```