### PR TITLE
riscv64: add disassembly branch classification

### DIFF
--- a/angr/analyses/disassembly_utils.py
+++ b/angr/analyses/disassembly_utils.py
@@ -111,5 +111,5 @@ def decode_instruction(arch, instr):
                 instr.branch_type = "indirect"
             else:
                 instr.branch_type = "direct"
-            
+
             instr.branch_target_operand = len(instr.insn.operands) - 1

--- a/angr/analyses/disassembly_utils.py
+++ b/angr/analyses/disassembly_utils.py
@@ -26,6 +26,11 @@ INS_GROUP_INFO = {
         cs.arm.ARM_GRP_BRANCH_RELATIVE: "branch",
         cs.arm.ARM_GRP_JUMP: "branch",
     },
+    "RISCV64": {
+        cs.riscv.RISCV_GRP_CALL: "call",
+        cs.riscv.RISCV_GRP_JUMP: "branch",
+        cs.riscv.RISCV_GRP_RET: "return",
+    },
 }
 
 INS_GROUP_INFO["ARMEL"] = INS_GROUP_INFO["ARM"]
@@ -98,4 +103,13 @@ def decode_instruction(arch, instr):
                 instr.branch_type = "indirect"
             else:
                 instr.branch_type = "direct"
+            instr.branch_target_operand = len(instr.insn.operands) - 1
+
+        elif arch_name == "RISCV64":
+            mnemonic = instr.insn.insn.mnemonic.lower()
+            if "r" in mnemonic:
+                instr.branch_type = "indirect"
+            else:
+                instr.branch_type = "direct"
+            
             instr.branch_target_operand = len(instr.insn.operands) - 1

--- a/tests/analyses/test_disassembly.py
+++ b/tests/analyses/test_disassembly.py
@@ -204,11 +204,7 @@ c  lw      $t9, -0x7ee0($gp)
         # 0x10: e7 00 05 00    jalr    ra, 0(a0)      ; Indirect Call
 
         proj = angr.load_shellcode(
-            b"\xef\x02\x40\x06"
-            b"\x63\x00\x10\x00"
-            b"\x67\x00\x25\x00"
-            b"\x67\x80\x00\x00"
-            b"\xe7\x00\x05\x00",
+            b"\xef\x02\x40\x06" b"\x63\x00\x10\x00" b"\x67\x00\x25\x00" b"\x67\x80\x00\x00" b"\xe7\x00\x05\x00",
             "RISCV64",
             0,
         )
@@ -232,6 +228,7 @@ c  lw      $t9, -0x7ee0($gp)
         assert insns[3].branch_type == "indirect"
         # jalr ra, 0(a0)
         assert insns[4].branch_type == "indirect"
+
 
 if __name__ == "__main__":
     main()

--- a/tests/analyses/test_disassembly.py
+++ b/tests/analyses/test_disassembly.py
@@ -204,7 +204,7 @@ c  lw      $t9, -0x7ee0($gp)
         # 0x10: e7 00 05 00    jalr    ra, 0(a0)      ; Indirect Call
 
         proj = angr.load_shellcode(
-            b"\xef\x02\x40\x06" b"\x63\x00\x10\x00" b"\x67\x00\x25\x00" b"\x67\x80\x00\x00" b"\xe7\x00\x05\x00",
+            b"\xef\x02\x40\x06\x63\x00\x10\x00\x67\x00\x25\x00\x67\x80\x00\x00\xe7\x00\x05\x00",
             "RISCV64",
             0,
         )


### PR DESCRIPTION
Hello maintainers,

I support `riscv64` to `disassembly.py` to check for direct jumps and indirect jumps.