### PR TITLE
Fix AngrDB().load() failing when importing decompiled projects (#5990)

### DIFF
--- a/angr/knowledge_plugins/variables/variable_access.py
+++ b/angr/knowledge_plugins/variables/variable_access.py
@@ -108,6 +108,6 @@ class VariableAccess(Serializable):
             variable,
             access_type,
             location,
-            cmsg.offset if cmsg.HasField("offset") else None,
+            cmsg.offset if hasattr(cmsg, "offset") else None,
             atom_hash=cmsg.atom_hash if cmsg.HasField("atom_hash") else None,
         )


### PR DESCRIPTION
Fixes a bug in `VariableAccess.parse_from_cmessage()` where `offset == 0` is incorrectly treated as “field not present” during protobuf deserialization. This caused exported/decompiled projects to fail to reload via `AngrDB().load()` because variable access offsets were parsed as `None` and later assertions in the variable manager triggered.