### PR TITLE
AILBlock: Faster __str__.

### DIFF
--- a/angr/ailment/block.py
+++ b/angr/ailment/block.py
@@ -8,6 +8,10 @@ if TYPE_CHECKING:
 class Block:
     """
     Describes an AIL block.
+
+    __str__ should be fast because Phoenix uses networkx graph filters, and graph filters may print str(block) in some
+    cases, e.g.,
+    https://github.com/networkx/networkx/blob/861718f8aadeed4f742a348f0c437396cacdf180/networkx/classes/coreviews.py#L305
     """
 
     __slots__ = (
@@ -60,8 +64,13 @@ class Block:
         block_str += stmts_str + "\n"
         return block_str
 
+    def pp(self) -> None:
+        print(self.dbg_repr())
+
     def __str__(self):
-        return self.dbg_repr()
+        if self.idx is None:
+            return f"<AILBlock {self.addr:#x}>"
+        return f"<AILBlock {self.addr:#x}.{self.idx}>"
 
     def __eq__(self, other):
         return (


### PR DESCRIPTION
AIL Blocks are used in filtered graphs in Phoenix, and networkx may get the string representation of AIL blocks in FilterAtlas.__getitem__(). As such, Block.__str__ must be fast.

For the original output of AIL blocks, call `Block.dbg_repr()` or `Block.pp()` instead.