### PR TITLE
improve return value size detection and riscv64 support

### DIFF
--- a/angr/analyses/calling_convention/utils.py
+++ b/angr/analyses/calling_convention/utils.py
@@ -55,9 +55,9 @@ def is_sane_register_variable(
 
     if arch_name == "X86":
         return 8 <= reg_offset < 24 or 160 <= reg_offset < 288  # eax, ebx, ecx, edx  # xmm0-xmm7
-    
+
     if arch_name == "RISCV64":
-        return 96 <= reg_offset < 160 # a0-a7
+        return 96 <= reg_offset < 160  # a0-a7
 
     l.critical("Unsupported architecture %s.", arch.name)
     return True

--- a/angr/analyses/calling_convention/utils.py
+++ b/angr/analyses/calling_convention/utils.py
@@ -55,6 +55,9 @@ def is_sane_register_variable(
 
     if arch_name == "X86":
         return 8 <= reg_offset < 24 or 160 <= reg_offset < 288  # eax, ebx, ecx, edx  # xmm0-xmm7
+    
+    if arch_name == "RISCV64":
+        return 96 <= reg_offset < 160 # a0-a7
 
     l.critical("Unsupported architecture %s.", arch.name)
     return True

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -595,9 +595,7 @@ class TestCallingConventionAnalysis(unittest.TestCase):
 
     def test_return_typecheck(self):
         for arch in ["x86_64", "riscv64", "aarch64"]:
-            binary_path = os.path.join(
-                test_location, arch, f"test_return_type_{arch}.elf"
-            )
+            binary_path = os.path.join(test_location, arch, f"test_return_type_{arch}.elf")
             proj = angr.Project(binary_path, auto_load_libs=False)
             cfg = proj.analyses.CFG(normalize=True)
             proj.analyses.CompleteCallingConventions(recover_variables=True, cfg=cfg)

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -332,13 +332,11 @@ class TestCallingConventionAnalysis(unittest.TestCase):
             proj.analyses.CompleteCallingConventions(mode=mode, recover_variables=True)
 
             for func in ["target", "direct", "plt"]:
-                # expected prototype: (int) -> long long
-                # technically should be (int) -> int, but the compiler loads all 64 bits and then truncates
                 proto = proj.kb.functions[func].prototype
                 assert proto is not None
                 assert len(proto.args) == 1
                 assert isinstance(proto.args[0], SimTypeInt)
-                assert isinstance(proto.returnty, SimTypeLongLong)
+                assert isinstance(proto.returnty, SimTypeInt)
 
     def test_ls_gcc_O0_timespec_cmp(self):
         binary_path = os.path.join(test_location, "x86_64", "decompiler", "ls_gcc_O0")


### PR DESCRIPTION
**this PR depend on #5981 and https://github.com/angr/binaries/pull/155**

1. riscv64: add general rigisters to is_sane_register_variable
2. fact_collector: fix 32-bit return type detection on 64-bit architectures
    - this will solve e7c15d3619116081a11ba475867b12b0b99317bf in x86_64
4. fact_collector: improve return value size detection logic
    - mainly designed for arm/arm64 suche as `int ret_cast_int(long long a) { return (int)a; }`
    - first arg: x0. ret value: x0.
    - this will cause `retval_sizes` be none and return a `void`
6. tests: fix test_tails_calls type check
7. tests/analyses: add new test for return type check