### PR TITLE
CI: Disable cancel-in-progress for the master branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   ci:


### PR DESCRIPTION
This is a stop-gap solution. @mborgerson Please feel free to do it in a different way.