### PR TITLE
Migrate to pycparser 3.0.

### DIFF
--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -3738,45 +3738,29 @@ def register_types(types):
         ALL_TYPES.update(types)
 
 
-def do_preprocess(defn, include_path=()):
-    """
-    Run a string through the C preprocessor that ships with pycparser but is weirdly inaccessible?
-    """
-    from pycparser.ply import lex, cpp  # pylint:disable=import-outside-toplevel
-
-    lexer = lex.lex(cpp)
-    p = cpp.Preprocessor(lexer)
-    for included in include_path:
-        p.add_path(included)
-    p.parse(defn)
-    return "".join(tok.value for tok in p.parser if tok.type not in p.ignore)
-
-
-def parse_signature(defn, preprocess=True, predefined_types=None, arch=None):
+def parse_signature(defn, predefined_types=None, arch=None):
     """
     Parse a single function prototype and return its type
     """
     try:
-        parsed = parse_file(
-            defn.strip(" \n\t;") + ";", preprocess=preprocess, predefined_types=predefined_types, arch=arch
-        )
+        parsed = parse_file(defn.strip(" \n\t;") + ";", predefined_types=predefined_types, arch=arch)
         return next(iter(parsed[0].values()))
     except StopIteration as e:
         raise ValueError("No declarations found") from e
 
 
-def parse_defns(defn, preprocess=True, predefined_types=None, arch=None):
+def parse_defns(defn, predefined_types=None, arch=None):
     """
     Parse a series of C definitions, returns a mapping from variable name to variable type object
     """
-    return parse_file(defn, preprocess=preprocess, predefined_types=predefined_types, arch=arch)[0]
+    return parse_file(defn, predefined_types=predefined_types, arch=arch)[0]
 
 
-def parse_types(defn, preprocess=True, predefined_types=None, arch=None):
+def parse_types(defn, predefined_types=None, arch=None):
     """
     Parse a series of C definitions, returns a mapping from type name to type object
     """
-    return parse_file(defn, preprocess=preprocess, predefined_types=predefined_types, arch=arch)[1]
+    return parse_file(defn, predefined_types=predefined_types, arch=arch)[1]
 
 
 _include_re = re.compile(r"^\s*#include")
@@ -3784,7 +3768,6 @@ _include_re = re.compile(r"^\s*#include")
 
 def parse_file(
     defn,
-    preprocess=True,
     predefined_types: dict[Any, SimType] | None = None,
     arch=None,
     side_effect_types: dict[Any, SimType] | None = None,
@@ -3798,8 +3781,8 @@ def parse_file(
         raise ImportError("Please install pycparser in order to parse C definitions")
 
     defn = "\n".join(x for x in defn.split("\n") if _include_re.match(x) is None)
-    if preprocess:
-        defn = do_preprocess(defn)
+    # remove comments
+    defn = re.sub(r"/\*.*?\*/", r"", defn, flags=re.DOTALL)
 
     # pylint: disable=unexpected-keyword-arg
     node = pycparser.c_parser.CParser().parse(defn, scope_stack=_make_scope(predefined_types))
@@ -3856,13 +3839,13 @@ def type_parser_singleton() -> pycparser.CParser:
     return _type_parser_singleton
 
 
-def parse_type(defn, preprocess=True, predefined_types=None, arch=None):  # pylint:disable=unused-argument
+def parse_type(defn, predefined_types=None, arch=None):  # pylint:disable=unused-argument
     """
     Parse a simple type expression into a SimType
 
     >>> parse_type('int *')
     """
-    return parse_type_with_name(defn, preprocess=preprocess, predefined_types=predefined_types, arch=arch)[0]
+    return parse_type_with_name(defn, predefined_types=predefined_types, arch=arch)[0]
 
 
 def parse_type_with_name(
@@ -3900,11 +3883,18 @@ def _accepts_scope_stack():
     """
 
     def parse(self, text, filename="", debug=False, scope_stack=None):
-        self.clex.filename = filename
-        self.clex.reset_lineno()
+        self.clex._filename = filename
+        self.clex._lineno = 1
         self._scope_stack = [{}] if scope_stack is None else scope_stack
-        self._last_yielded_token = None
-        return self.cparser.parse(input=text, lexer=self.clex, debug=debug)
+
+        self.clex.input(text, filename)
+        self._tokens = pycparser.c_parser._TokenStream(self.clex)
+
+        ast = self._parse_translation_unit_or_empty()
+        tok = self._peek()
+        if tok is not None:
+            self._parse_error(f"before: {tok.value}", self._tok_coord(tok))
+        return ast
 
     pycparser.CParser.parse = parse
 

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -3862,7 +3862,7 @@ def parse_type_with_name(
         defn = re.sub(r"/\*.*?\*/", r"", defn)
 
     # pylint: disable=unexpected-keyword-arg
-    node = type_parser_singleton().parse_type(text=defn, scope_stack=_make_scope(predefined_types))
+    node = type_parser_singleton().parse_type_with_name(defn, scope_stack=_make_scope(predefined_types))
     if not isinstance(node, c_ast.Typename) and not isinstance(node, c_ast.Decl):
         raise pycparser.c_parser.ParseError("Got an unexpected type out of pycparser")
 
@@ -3892,7 +3892,7 @@ def _accepts_scope_stack():
             self._parse_error(f"before: {tok.value}", self._tok_coord(tok))
         return ast
 
-    def parse_type(self, text, filename="", scope_stack=None) -> c_ast.Typename:
+    def parse_type_with_name(self, text, filename="", scope_stack=None) -> c_ast.Typename:
         self.clex._filename = filename
         self.clex._lineno = 1
         self._scope_stack = [{}] if scope_stack is None else scope_stack
@@ -3900,14 +3900,10 @@ def _accepts_scope_stack():
         self.clex.input(text, filename)
         self._tokens = pycparser.c_parser._TokenStream(self.clex)
 
-        ast = self._parse_type_name()
-        tok = self._peek()
-        if tok is not None:
-            self._parse_error(f"before: {tok.value}", self._tok_coord(tok))
-        return ast
+        return self._parse_type_name()  # ignore all tokens that follow the type name
 
     pycparser.CParser.parse = parse
-    pycparser.CParser.parse_type = parse_type
+    pycparser.CParser.parse_type_with_name = parse_type_with_name
 
 
 def _decl_to_type(

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -3783,6 +3783,7 @@ def parse_file(
     defn = "\n".join(x for x in defn.split("\n") if _include_re.match(x) is None)
     # remove comments
     defn = re.sub(r"/\*.*?\*/", r"", defn, flags=re.DOTALL)
+    defn = re.sub(r"//.*?$", r"", defn, flags=re.MULTILINE)
 
     # pylint: disable=unexpected-keyword-arg
     node = pycparser.c_parser.CParser().parse(defn, scope_stack=_make_scope(predefined_types))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "networkx!=2.8.1,>=2.0",
     "protobuf>=6.33.0",
     "psutil",
-    "pycparser>=2.18,<3.0",
+    "pycparser>=3.0",
     "pydemumble",
     "pyformlang",
     "pypcode>=3.2.1,<4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "networkx!=2.8.1,>=2.0",
     "protobuf>=6.33.0",
     "psutil",
-    "pycparser>=3.0",
+    "pycparser~=3.0",
     "pydemumble",
     "pyformlang",
     "pypcode>=3.2.1,<4.0",


### PR DESCRIPTION
Changes:

- Drop all `preprocess=` parameter from `parse_*` methods in `sim_type.py`. This is because pycparser 3.0 dropped PLY (see https://github.com/eliben/pycparser/commit/01f96fc1b076dfb8602a3d94bc8d215859b9315f).
- Manually remove comments from C snippets using a regex before parsing.
- Reimplement the hack (`_accepts_scope_stack`) that overwrites `pycparser.CParser.parse()` so that it takes `scope_stack` as a parameter.
- Implement `pycparser.CParser.parse_type()` to augment `type_parser_singleton` because `CParser.cparser` no longer exists.