### PR TITLE
Fix get_nearest_pos returns an error result #4513

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/base.py
+++ b/angr/analyses/decompiler/structured_codegen/base.py
@@ -118,7 +118,7 @@ class InstructionMapping:
     def get_nearest_pos(self, ins_addr: int) -> int | None:
         try:
             pre_max = next(self._insmap.irange(maximum=ins_addr, reverse=True))
-            pre_min = next(self._insmap.irange(minimum=ins_addr, reverse=True))
+            pre_min = next(self._insmap.irange(minimum=ins_addr, reverse=False))
         except StopIteration:
             return None
 


### PR DESCRIPTION
This fixes issue #4513. Due to the reverse order `pre_min` is always the highest address for that function.
Resulting in nearest pos usually returning the nearest lower address.