### PR TITLE
Fixed the RCR rotation amount

### DIFF
--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -1013,7 +1013,19 @@ def generic_rotate_with_carry(state, left, arg, rot_amt, carry_bit_in, sz):
     if bits > len(rot_amt):
         raise SimError("Got a rotate instruction for data larger than the provided word size. Panic.")
 
-    sized_amt = (rot_amt & bits_in - 1).zero_extend(1) if bits == len(rot_amt) else (rot_amt & bits_in - 1)[bits:0]
+    # Mask the rotate amount
+    # https://www.felixcloutier.com/x86/rcl:rcr:rol:ror#---rcl-and-rcr-instructions---
+    if sz == 1:
+        sized_amt = (rot_amt & 0x1F) % 9
+    elif sz == 2:
+        sized_amt = (rot_amt & 0x1F) % 17
+    elif sz == 3:
+        sized_amt = rot_amt & 0x1F
+    elif sz == 4:
+        sized_amt = rot_amt & 0x3F
+
+    # Ajust the BV size
+    sized_amt = sized_amt.zero_extend(1) if bits == len(sized_amt) else sized_amt[bits:0]
 
     assert len(sized_amt) == bits + 1
 

--- a/tests/engines/vex/test_vex.py
+++ b/tests/engines/vex/test_vex.py
@@ -115,6 +115,15 @@ class TestVex(unittest.TestCase):
         assert s.solver.is_true(sf == 0)
         assert s.solver.is_true(of == 1)
 
+        l.debug("Testing amd64g_calculate_RCR")
+        l.debug("(64-bit) RCR E6 3E...")
+        arg = claripy.BVV(0xE6, 8)
+        rot_amt = claripy.BVV(0x3E, 8)
+        eflags = claripy.BVV(1, 8)
+        sz = claripy.BVV(1, 8)
+        res = s_ccall.amd64g_calculate_RCR(s, arg, rot_amt, eflags, sz)
+        assert s.solver.is_true(res == claripy.BVV(0xBC, 8))
+
         l.debug("Testing pc_actions_ROR")
         l.debug("(32-bit) ROR -1 1...")
         result = claripy.BVV(-1, 32)  # the result of ror(0xffffffff, 1)


### PR DESCRIPTION
The RCR/RCL instructions mask the rotation value before calculating the rotation amount.
https://www.felixcloutier.com/x86/rcl:rcr:rol:ror
