### PR TITLE
fix test case based on cle #647

### DIFF
--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -5392,6 +5392,21 @@ class TestDecompiler(unittest.TestCase):
         proto_str = callee.prototype.c_repr("G_DoLoadLevel")
         assert "(void)" in proto_str, f"Callee prototype should have (void), got: {proto_str}"
 
+    @for_all_structuring_algos
+    def test_decompiling_extern_size_hints(self, decompiler_options=None):
+        bin_path = os.path.join(test_location, "x86_64", "f_finale.o")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        proj.analyses.CompleteCallingConventions()
+
+        func = proj.kb.functions["F_CastResponder"]
+        dec = proj.analyses.Decompiler(func, cfg=cfg, options=decompiler_options)
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+
+        # Check that extern variables with proper size hints are resolved
+        assert "g_5000e0" in dec.codegen.text, "Extern variable g_5000e0 should be present"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3472,9 +3472,9 @@ class TestDecompiler(unittest.TestCase):
         assert second_good_if is not None
         assert second_good_if.start() == all_if_stmts[1].start()
 
-        # ensure the constant memory read exists
-        const_mem_read = re.search(r"\*\(\(int \*\)0x501380\) == 1", text)
-        assert const_mem_read is not None
+        # ensure the memory read exists
+        mem_read = re.search(r"\*\(\(int \*\)&g_501380\) == 1", text)
+        assert mem_read is not None
 
     @structuring_algo("sailr")
     def test_ifelseflatten_certtool_common(self, decompiler_options=None):


### PR DESCRIPTION
Update test case based on https://github.com/angr/cle/pull/647
cle PR fixes extern symbol sizing for relocatable objects using relocation addends. 