### PR TITLE
Swap arg order to be angr [command] [binary]

### DIFF
--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -107,14 +107,10 @@ def decompile(args):
         print(decompilation)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="The angr CLI allows you to decompile and analyze binaries.")
-    parser.add_argument("--version", action="version", version=angr.__version__)
-    parser.add_argument(
-        "-v", "--verbose", action="count", default=0, help="Increase verbosity level (can be used multiple times)."
-    )
-    parser.add_argument("binary", help="The path to the binary to analyze.")
-    parser.add_argument(
+def _add_common_args(subparser):
+    """Add arguments common to all subcommands."""
+    subparser.add_argument("binary", help="The path to the binary to analyze.")
+    subparser.add_argument(
         "--catch-exceptions",
         help="""
         Catch exceptions during analysis. The scope of error handling may depend on the command used for analysis.
@@ -122,7 +118,7 @@ def main():
         action="store_true",
         default=False,
     )
-    parser.add_argument(
+    subparser.add_argument(
         "--base-addr",
         help="""
         The base address of the binary. This is useful when the binary is loaded at a different address than the one
@@ -130,10 +126,19 @@ def main():
         type=lambda x: int(x, 0),
         default=None,
     )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="The angr CLI allows you to decompile and analyze binaries.")
+    parser.add_argument("--version", action="version", version=angr.__version__)
+    parser.add_argument(
+        "-v", "--verbose", action="count", default=0, help="Increase verbosity level (can be used multiple times)."
+    )
     subparsers = parser.add_subparsers(metavar="command", required=True)
 
     decompile_cmd_parser = subparsers.add_parser("decompile", aliases=["dec"], help=decompile.__doc__)
     decompile_cmd_parser.set_defaults(func=decompile)
+    _add_common_args(decompile_cmd_parser)
     decompile_cmd_parser.add_argument(
         "--structurer",
         help="The structuring algorithm to use for decompilation.",
@@ -201,6 +206,7 @@ def main():
 
     disassemble_cmd_parser = subparsers.add_parser("disassemble", aliases=["dis"], help=disassemble.__doc__)
     disassemble_cmd_parser.set_defaults(func=disassemble)
+    _add_common_args(disassemble_cmd_parser)
     disassemble_cmd_parser.add_argument(
         "--functions",
         help="""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,15 @@ class TestCommandLineInterface(unittest.TestCase):
         )
         # function resolving is based on the address (with base address specified)
         offset_dec = run_cli(
-            "decompile", bin_path, "--base-addr", "0x0", "--functions", hex(f1_offset), "--preset", "full", "--no-colors"
+            "decompile",
+            bin_path,
+            "--base-addr",
+            "0x0",
+            "--functions",
+            hex(f1_offset),
+            "--preset",
+            "full",
+            "--no-colors",
         )
 
         # since the externs can be unpredictable, we only check the function name down

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,13 +34,13 @@ class TestCommandLineInterface(unittest.TestCase):
 
         # test a single function
         assert (
-            run_cli(bin_path, "decompile", "--functions", f1, "--no-color")
+            run_cli("decompile", bin_path, "--functions", f1, "--no-colors")
             == decompile_functions(bin_path, [f1]) + "\n"
         )
 
         # test multiple functions
         assert (
-            run_cli(bin_path, "decompile", "--functions", f1, f2, "--no-color")
+            run_cli("decompile", bin_path, "--functions", f1, f2, "--no-colors")
             == decompile_functions(bin_path, [f1, f2]) + "\n"
         )
 
@@ -48,8 +48,8 @@ class TestCommandLineInterface(unittest.TestCase):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "sailr_motivating_example")
         f1 = "schedule_job"
 
-        dream_cli = run_cli(bin_path, "decompile", "--no-casts", "--functions", f1, "--structurer", "dream")
-        sailr_cli = run_cli(bin_path, "decompile", "--functions", f1, "--structurer", "sailr")
+        dream_cli = run_cli("decompile", bin_path, "--no-casts", "--functions", f1, "--structurer", "dream")
+        sailr_cli = run_cli("decompile", bin_path, "--functions", f1, "--structurer", "sailr")
         assert dream_cli.count("goto") == 0
         assert dream_cli != sailr_cli
 
@@ -62,14 +62,14 @@ class TestCommandLineInterface(unittest.TestCase):
         f1_offset = f1_default_addr - default_base_addr
 
         # function resolving is based on symbol
-        sym_based_dec = run_cli(bin_path, "decompile", "--functions", f1, "--preset", "full", "--no-color")
+        sym_based_dec = run_cli("decompile", bin_path, "--functions", f1, "--preset", "full", "--no-colors")
         # function resolving is based on the address (with default angr loading)
         base_addr_dec = run_cli(
-            bin_path, "decompile", "--functions", hex(f1_default_addr), "--preset", "full", "--no-color"
+            "decompile", bin_path, "--functions", hex(f1_default_addr), "--preset", "full", "--no-colors"
         )
         # function resolving is based on the address (with base address specified)
         offset_dec = run_cli(
-            bin_path, "--base-addr", "0x0", "decompile", "--functions", hex(f1_offset), "--preset", "full", "--no-color"
+            "decompile", bin_path, "--base-addr", "0x0", "--functions", hex(f1_offset), "--preset", "full", "--no-colors"
         )
 
         # since the externs can be unpredictable, we only check the function name down
@@ -86,7 +86,7 @@ class TestCommandLineInterface(unittest.TestCase):
 
     def test_disassembly(self):
         bin_path = os.path.join(test_location, "x86_64", "fauxware")
-        disasm = run_cli(bin_path, "disassemble")
+        disasm = run_cli("disassemble", bin_path)
         funcs = {
             "_init",
             "_start",
@@ -112,7 +112,7 @@ class TestCommandLineInterface(unittest.TestCase):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "sailr_motivating_example")
         f1 = "main"
 
-        no_colors_output = run_cli(bin_path, "decompile", "--functions", f1, "--no-colors")
+        no_colors_output = run_cli("decompile", bin_path, "--functions", f1, "--no-colors")
         expected_output = decompile_functions(bin_path, [f1]) + "\n"
 
         # it should maintain that no ANSI color codes are present


### PR DESCRIPTION
My LLM managed to do this without implementing a caching layer, so we'll want to add that feature separately later.