### PR TITLE
Split type string and variable name from right

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -230,7 +230,7 @@ def type_to_c_repr_chunks(ty: SimType, name=None, name_type=None, full=False, in
         raw_type_str = ty.c_repr(name=name)
         assert name in raw_type_str
 
-        type_pre, type_post = raw_type_str.split(name, 1)
+        type_pre, type_post = raw_type_str.rsplit(name, 1)
 
         if type_pre.endswith(" "):
             type_pre_spaces = " " * (len(type_pre) - len(type_pre.rstrip(" ")))


### PR DESCRIPTION
Switch from `split` to `rsplit`, resolving issue where the `raw_type_str` was being incorrectly split when type name contained the variable name.
- also fixes angr/angr-management#1566