### PR TITLE
Add pysoot to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dev = [
     "ruff>=0.11.7",
 ]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-autodoc-typehints"]
-extras = ["angr[angrdb,keystone,unicorn,llm]"]
+extras = ["angr[angrdb,keystone,unicorn,llm]", "pysoot"]
 
 [tool.setuptools]
 include-package-data = true
@@ -104,6 +104,7 @@ archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
 pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
 cle = { git = "https://github.com/angr/cle.git", branch = "master" }
 claripy = { git = "https://github.com/angr/claripy.git", branch = "master" }
+pysoot = { git = "https://github.com/angr/pysoot.git", branch = "master" }
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
pysoot now works on more platforms. The new version has not yet been published to pypi. For now, this will allow us to have pysoot in the uv env. A future next step will be to update the PyPI package to the new version and then enabling it as an optional dependency or hard dependency.