### PR TITLE
Propagate is_prototype_guessed tag to Call expression tags.

### DIFF
--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -364,6 +364,8 @@ class CallSiteMaker(Analysis):
 
         tags = call_expr.tags.copy()
         tags.pop("arg_vvars", None)
+        if func is not None:
+            tags["is_prototype_guessed"] = func.is_prototype_guessed
         new_call = Expr.Call(
             call_expr.idx,
             call_expr.target,

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1542,8 +1542,10 @@ class Clinic(Analysis):
             new_last_stmt.expr.calling_convention = cc
             new_last_stmt.expr.prototype = prototype
             new_last_stmt.tags["is_prototype_guessed"] = True
+            new_last_stmt.expr.tags["is_prototype_guessed"] = True
             if func is not None:
                 new_last_stmt.tags["is_prototype_guessed"] = func.is_prototype_guessed
+                new_last_stmt.expr.tags["is_prototype_guessed"] = func.is_prototype_guessed
             block.statements[-1] = new_last_stmt
 
         return ail_graph


### PR DESCRIPTION
After the SideEffectStatement refactor (22bd9f6a), Call expressions can be
folded into Return statements during simplification. When this happens,
variable recovery handles them via _handle_expr_Call which only adds return
type constraints when is_prototype_guessed=False on the expression's tags.
Previously, is_prototype_guessed was only set on the SideEffectStatement's
tags (not the inner Call expression), so the tag was lost after folding.

This caused return types like SimTypeFd to not propagate from callee to
caller (e.g. socket -> __socket wrapper).
