### PR TITLE
Fact collector: Exclude all caller-saved regs from callee-restored set

### DIFF
--- a/tests/analyses/test_fact_collector.py
+++ b/tests/analyses/test_fact_collector.py
@@ -59,7 +59,6 @@ class TestFactCollector(unittest.TestCase):
             ],
         )
 
-
     def test_caller_saved_regs_not_in_input_args(self):
         """Caller-saved registers should not be mistakenly treated as callee-saved input args."""
         binary_path = os.path.join(test_location, "x86_64", "fauxware")

--- a/tests/analyses/test_fact_collector.py
+++ b/tests/analyses/test_fact_collector.py
@@ -59,7 +59,6 @@ class TestFactCollector(unittest.TestCase):
             ],
         )
 
-
     def _check_caller_saved_excluded(self, arch_dir):
         """Helper: no caller-saved register offset may appear in callee_restored_regs."""
         from angr.calling_conventions import default_cc  # pylint:disable=import-outside-toplevel
@@ -83,8 +82,7 @@ class TestFactCollector(unittest.TestCase):
             callee_restored = ffc._analyze_endpoints_for_restored_regs()
             overlap = callee_restored & caller_saved_offsets
             assert not overlap, (
-                f"{func.name} @ {hex(func.addr)}: caller-saved offsets {overlap} "
-                f"leaked into callee_restored_regs"
+                f"{func.name} @ {hex(func.addr)}: caller-saved offsets {overlap} leaked into callee_restored_regs"
             )
 
     def test_caller_saved_regs_excluded_from_callee_restored_armel(self):


### PR DESCRIPTION
- **Fact collector: exclude all caller-saved regs from callee-restored set**
- **Add test for caller-saved register exclusion in fact collector**

Arm does some insane stuff like:
pop {r1, r2, r3, r4, r5, r6, r7, r8, sb, sl, fp, pc}
but r0-r3 are caller-saved so even though r1-r3 are pop'd at the end they still need to be considered as potentially valid candidates for func args.