### PR TITLE
Lazily import litellm.

### DIFF
--- a/angr/llm_client.py
+++ b/angr/llm_client.py
@@ -5,8 +5,10 @@ import logging
 import os
 import re
 
+from angr.utils.lazy_import import lazy_import
+
 try:
-    import litellm  # type: ignore
+    lazy_import("litellm")  # type: ignore
 except ImportError:
     litellm = None
 


### PR DESCRIPTION
LiteLLM takes too much RAM and is slow to import.