### PR TITLE
Caching Icicle State

### DIFF
--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import cast
 
@@ -267,13 +268,11 @@ class IcicleEngine(ConcreteEngine):
 
         # 1. Copy register values
         for register in base_translation_data.registers:
-            try:
+            with suppress(KeyError):
                 emu.reg_write(
                     register,
                     state.solver.eval(state.registers.load(register), cast_to=int),
                 )
-            except KeyError:
-                pass
 
         # Handle thumb/ARM mode
         if IcicleEngine.__is_thumb(state.arch, icicle_arch, state.addr):
@@ -343,9 +342,8 @@ class IcicleEngine(ConcreteEngine):
         if extra_stop_points is not None:
             for addr in extra_stop_points:
                 addr = addr & ~1  # Clear thumb bit if set
-                if emu.pc != addr:
-                    if emu.add_breakpoint(addr):
-                        added_breakpoints.append(addr)
+                if emu.pc != addr and emu.add_breakpoint(addr):
+                    added_breakpoints.append(addr)
 
         # Set the instruction count limit
         if num_inst is not None and num_inst > 0:

--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -327,9 +327,7 @@ class IcicleEngine(ConcreteEngine):
         if self._cached_emu is not None and self._snapshot_mode:
             # Fast path: restore snapshot and sync only changed state
             self._cached_emu.restore_snapshot()
-            translation_data = self.__sync_angr_state_to_icicle(
-                self._cached_emu, state, self._base_translation_data
-            )
+            translation_data = self.__sync_angr_state_to_icicle(self._cached_emu, state, self._base_translation_data)
             emu = self._cached_emu
         else:
             # Full init path

--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -35,6 +35,7 @@ class IcicleStateTranslationData:
     registers: set[str]
     writable_pages: set[int]
     initial_cpu_icount: int
+    icicle_arch: str
 
 
 class IcicleEngine(ConcreteEngine):
@@ -50,13 +51,19 @@ class IcicleEngine(ConcreteEngine):
     This class is the base class for the Icicle engine. It implements execution
     by creating an Icicle instance, copying the state from angr to Icicle, and then
     running the Icicle instance. The results are then copied back to the angr
-    state. It is likely the case that this can be improved by re-using the Icicle
-    instance across multiple runs and only copying the state when necessary.
+    state. When snapshot mode is enabled, the Icicle instance is reused across
+    multiple runs, restoring from a snapshot and only syncing changed state.
 
     For a more complete implementation, use the UberIcicleEngine class, which
     intends to provide a more complete set of features, such as hooks and syscalls.
 
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cached_emu: Icicle | None = None
+        self._base_translation_data: IcicleStateTranslationData | None = None
+        self._snapshot_mode: bool = False
 
     @staticmethod
     def __make_icicle_arch(arch: Arch) -> str | None:
@@ -179,6 +186,7 @@ class IcicleEngine(ConcreteEngine):
             registers=copied_registers,
             writable_pages=writable_pages,
             initial_cpu_icount=emu.cpu_icount,
+            icicle_arch=icicle_arch,
         )
 
         # 3. Copy edge hitmap
@@ -244,6 +252,71 @@ class IcicleEngine(ConcreteEngine):
 
         return state
 
+    @staticmethod
+    def __sync_angr_state_to_icicle(
+        emu: Icicle,
+        state: HeavyConcreteState,
+        base_translation_data: IcicleStateTranslationData,
+    ) -> IcicleStateTranslationData:
+        """
+        Sync only registers and writable pages from an angr state to an existing
+        Icicle VM. This is much faster than a full conversion since it skips VM
+        creation, memory mapping, and read-only page copies.
+        """
+        icicle_arch = base_translation_data.icicle_arch
+
+        # 1. Copy register values
+        for register in base_translation_data.registers:
+            try:
+                emu.reg_write(
+                    register,
+                    state.solver.eval(state.registers.load(register), cast_to=int),
+                )
+            except KeyError:
+                pass
+
+        # Handle thumb/ARM mode
+        if IcicleEngine.__is_thumb(state.arch, icicle_arch, state.addr):
+            emu.pc = state.addr & ~1
+            emu.isa_mode = 1
+        elif "arm" in icicle_arch:
+            emu.pc = state.addr
+
+        # Special case for x86 gs register
+        if state.arch.name == "X86":
+            emu.reg_write("GS_OFFSET", state.registers.load("gs").concrete_value << 16)
+
+        # 2. Copy writable page contents only
+        for page_num in base_translation_data.writable_pages:
+            addr = page_num * state.memory.page_size
+            memory = state.memory.concrete_load(addr, state.memory.page_size)
+            emu.mem_write(addr, memory)
+
+        return IcicleStateTranslationData(
+            base_state=state,
+            registers=base_translation_data.registers,
+            writable_pages=base_translation_data.writable_pages,
+            initial_cpu_icount=emu.cpu_icount,
+            icicle_arch=icicle_arch,
+        )
+
+    def enable_snapshot_mode(self) -> None:
+        """Enable snapshot mode for VM reuse across multiple runs."""
+        self._snapshot_mode = True
+
+    def has_snapshot(self) -> bool:
+        """Check if a snapshot is available for fast restore."""
+        return self._cached_emu is not None and self._cached_emu.has_snapshot()
+
+    def restore_and_sync(self, state: HeavyConcreteState) -> None:
+        """Restore the cached VM from snapshot and sync the given state to it."""
+        if self._cached_emu is None or self._base_translation_data is None:
+            raise ValueError("No cached emulator. Run process_concrete first with snapshot mode enabled.")
+        self._cached_emu.restore_snapshot()
+        self._base_translation_data = self.__sync_angr_state_to_icicle(
+            self._cached_emu, state, self._base_translation_data
+        )
+
     @override
     def process_concrete(
         self,
@@ -251,16 +324,30 @@ class IcicleEngine(ConcreteEngine):
         num_inst: int | None = None,
         extra_stop_points: set[int] | None = None,
     ) -> HeavyConcreteState:
-        emu, translation_data = self.__convert_angr_state_to_icicle(state)
+        if self._cached_emu is not None and self._snapshot_mode:
+            # Fast path: restore snapshot and sync only changed state
+            self._cached_emu.restore_snapshot()
+            translation_data = self.__sync_angr_state_to_icicle(
+                self._cached_emu, state, self._base_translation_data
+            )
+            emu = self._cached_emu
+        else:
+            # Full init path
+            emu, translation_data = self.__convert_angr_state_to_icicle(state)
+            if self._snapshot_mode and self._cached_emu is None:
+                emu.save_snapshot()
+                self._cached_emu = emu
+                self._base_translation_data = translation_data
 
-        # Set extra stop points, skip the current PC. This assumes that if running
-        # with a stop point at the current PC, then the user has already done
-        # the necessary handling and is resuming execution.
+        # Set extra stop points, skip the current PC. Track which ones were
+        # actually added so we can clean them up after the run.
+        added_breakpoints = []
         if extra_stop_points is not None:
             for addr in extra_stop_points:
                 addr = addr & ~1  # Clear thumb bit if set
                 if emu.pc != addr:
-                    emu.add_breakpoint(addr)
+                    if emu.add_breakpoint(addr):
+                        added_breakpoints.append(addr)
 
         # Set the instruction count limit
         if num_inst is not None and num_inst > 0:
@@ -268,6 +355,10 @@ class IcicleEngine(ConcreteEngine):
 
         # Run it
         status = emu.run()
+
+        # Remove extra stop points to prevent accumulation across runs
+        for addr in added_breakpoints:
+            emu.remove_breakpoint(addr)
 
         return IcicleEngine.__convert_icicle_state_to_angr(emu, translation_data, status)
 

--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -12,6 +12,7 @@ import pypcode
 from archinfo import Arch, ArchARMCortexM, ArchPcode, Endness
 from typing_extensions import override
 
+from angr.errors import SimMemoryError
 from angr.engines.concrete import ConcreteEngine, HeavyConcreteState
 from angr.engines.failure import SimEngineFailure
 from angr.engines.hook import HooksMixin
@@ -34,7 +35,9 @@ class IcicleStateTranslationData:
 
     base_state: HeavyConcreteState
     registers: set[str]
+    mapped_pages: set[int]
     writable_pages: set[int]
+    explicit_page_metadata: dict[int, int | None]
     initial_cpu_icount: int
     icicle_arch: str
 
@@ -120,10 +123,32 @@ class IcicleEngine(ConcreteEngine):
                 end = (addr + len(backer) - 1) // page_size
                 pages.update(range(start, end + 1))
 
-        # pages from the memory model
-        pages.update(state.memory._pages)
+        # The paged memory model stores explicit page overrides in _pages.
+        # A None entry means the page was explicitly unmapped and must shadow
+        # loader backers.
+        for page_num, page in state.memory._pages.items():
+            if page is None:
+                pages.discard(page_num)
+            else:
+                pages.add(page_num)
 
         return pages
+
+    @staticmethod
+    def __get_explicit_page_metadata(state: HeavyConcreteState) -> dict[int, int | None]:
+        """
+        Return explicit page overrides from the paged memory model.
+        The key is page number. Value is permission bits, or None when the page
+        is explicitly unmapped.
+        """
+        metadata = {}
+        page_size = state.memory.page_size
+        for page_num, page in state.memory._pages.items():
+            if page is None:
+                metadata[page_num] = None
+            else:
+                metadata[page_num] = state.memory.permissions(page_num * page_size).concrete_value
+        return metadata
 
     @staticmethod
     def __convert_angr_state_to_icicle(state: HeavyConcreteState) -> tuple[Icicle, IcicleStateTranslationData]:
@@ -138,6 +163,7 @@ class IcicleEngine(ConcreteEngine):
         emu = Icicle(icicle_arch, PROCESSORS_DIR, True, True)
 
         copied_registers = set()
+        explicit_page_metadata = IcicleEngine.__get_explicit_page_metadata(state)
 
         # To create a state in Icicle, we need to do the following:
         # 1. Copy the register values
@@ -185,7 +211,9 @@ class IcicleEngine(ConcreteEngine):
         translation_data = IcicleStateTranslationData(
             base_state=state,
             registers=copied_registers,
+            mapped_pages=mapped_pages,
             writable_pages=writable_pages,
+            explicit_page_metadata=explicit_page_metadata,
             initial_cpu_icount=emu.cpu_icount,
             icicle_arch=icicle_arch,
         )
@@ -285,16 +313,62 @@ class IcicleEngine(ConcreteEngine):
         if state.arch.name == "X86":
             emu.reg_write("GS_OFFSET", state.registers.load("gs").concrete_value << 16)
 
-        # 2. Copy writable page contents only
-        for page_num in base_translation_data.writable_pages:
-            addr = page_num * state.memory.page_size
-            memory = state.memory.concrete_load(addr, state.memory.page_size)
+        # 2. Sync only mapping/permission deltas from explicit page changes.
+        page_size = state.memory.page_size
+        explicit_page_metadata = IcicleEngine.__get_explicit_page_metadata(state)
+        base_explicit_page_metadata = base_translation_data.explicit_page_metadata
+
+        candidate_pages = set(base_explicit_page_metadata).symmetric_difference(explicit_page_metadata)
+        for page_num in set(base_explicit_page_metadata).intersection(explicit_page_metadata):
+            if base_explicit_page_metadata[page_num] != explicit_page_metadata[page_num]:
+                candidate_pages.add(page_num)
+
+        mapped_pages = set(base_translation_data.mapped_pages)
+        writable_pages = set()
+        writable_pages.update(base_translation_data.writable_pages)
+
+        for page_num in candidate_pages:
+            addr = page_num * page_size
+            old_mapped = page_num in mapped_pages
+
+            try:
+                perm_bits = state.memory.permissions(addr).concrete_value
+                new_mapped = True
+            except SimMemoryError:
+                perm_bits = 0
+                new_mapped = False
+
+            if old_mapped and not new_mapped:
+                emu.mem_unmap(addr, page_size)
+                mapped_pages.remove(page_num)
+                writable_pages.discard(page_num)
+                continue
+
+            if not old_mapped and new_mapped:
+                emu.mem_map(addr, page_size, perm_bits)
+                mapped_pages.add(page_num)
+            elif old_mapped and new_mapped:
+                base_perm_bits = base_translation_data.base_state.memory.permissions(addr).concrete_value
+                if base_perm_bits != perm_bits:
+                    emu.mem_protect(addr, page_size, perm_bits)
+
+            if perm_bits & 2:
+                writable_pages.add(page_num)
+            else:
+                writable_pages.discard(page_num)
+
+        # 3. Copy writable page contents.
+        for page_num in writable_pages:
+            addr = page_num * page_size
+            memory = state.memory.concrete_load(addr, page_size)
             emu.mem_write(addr, memory)
 
         return IcicleStateTranslationData(
             base_state=state,
             registers=base_translation_data.registers,
-            writable_pages=base_translation_data.writable_pages,
+            mapped_pages=mapped_pages,
+            writable_pages=writable_pages,
+            explicit_page_metadata=explicit_page_metadata,
             initial_cpu_icount=emu.cpu_icount,
             icicle_arch=icicle_arch,
         )
@@ -325,6 +399,8 @@ class IcicleEngine(ConcreteEngine):
     ) -> HeavyConcreteState:
         if self._cached_emu is not None and self._snapshot_mode:
             # Fast path: restore snapshot and sync only changed state
+            if self._base_translation_data is None:
+                raise ValueError("No base translation data. Run process_concrete first with snapshot mode enabled.")
             self._cached_emu.restore_snapshot()
             translation_data = self.__sync_angr_state_to_icicle(self._cached_emu, state, self._base_translation_data)
             emu = self._cached_emu

--- a/angr/rustylib/icicle.pyi
+++ b/angr/rustylib/icicle.pyi
@@ -141,10 +141,11 @@ class Icicle:
         :arg data: The data to write to memory as bytes.
         """
 
-    def add_breakpoint(self, addr: int) -> None:
+    def add_breakpoint(self, addr: int) -> bool:
         """Add a breakpoint at a specific address.
 
         :arg addr: The address where the breakpoint should be set.
+        :returns: True if the breakpoint was added, False if it already exists.
         """
 
     def remove_breakpoint(self, addr: int) -> None:
@@ -178,3 +179,22 @@ class Icicle:
     @edge_hitmap.setter
     def edge_hitmap(self, value: bytes | None) -> None:
         """Set the edge hitmap for the current run."""
+
+    def save_snapshot(self) -> None:
+        """Save a snapshot of the current VM state for later restoration."""
+
+    def restore_snapshot(self) -> None:
+        """Restore the VM to a previously saved snapshot.
+
+        Clears the path tracer and zeros the edge hitmap.
+        Raises RuntimeError if no snapshot has been saved.
+        """
+
+    def has_snapshot(self) -> bool:
+        """Check if a snapshot has been saved.
+
+        :returns: True if a snapshot exists, False otherwise.
+        """
+
+    def clear_path_tracer(self) -> None:
+        """Clear the path tracer's recorded execution trace."""

--- a/native/angr/src/fuzzer/executor.rs
+++ b/native/angr/src/fuzzer/executor.rs
@@ -16,6 +16,7 @@ pub struct PyExecutorInner<S> {
     apply_fn: Py<PyAny>,
     observers: OT,
     timeout: Option<Duration>,
+    cached_engine: Option<Py<PyAny>>,
     phantom: std::marker::PhantomData<S>,
 }
 
@@ -36,6 +37,7 @@ impl<S> PyExecutorInner<S> {
             apply_fn: apply_fn.unbind(),
             observers,
             timeout,
+            cached_engine: None,
             phantom: std::marker::PhantomData,
         })
     }
@@ -61,16 +63,24 @@ impl Executor<EM, I, S, Z> for PyExecutorInner<S> {
                 let apply_fn = self.apply_fn.bind(py);
                 apply_fn.call1((&copied_state, input.as_ref()))?;
 
-                // Step 2: Use an emulator to run the target
-                let project = copied_state.getattr("project")?;
-                let icicle_engine = py
-                    .import("angr.engines.icicle")?
-                    .getattr("UberIcicleEngine")?
-                    .call1((project,))?;
+                // Step 2: Get or create the icicle engine (reuse across iterations)
+                let icicle_engine = if let Some(ref cached) = self.cached_engine {
+                    cached.bind(py).clone()
+                } else {
+                    let project = copied_state.getattr("project")?;
+                    let engine = py
+                        .import("angr.engines.icicle")?
+                        .getattr("UberIcicleEngine")?
+                        .call1((project,))?;
+                    engine.call_method0("enable_snapshot_mode")?;
+                    self.cached_engine = Some(engine.clone().unbind());
+                    engine
+                };
+
                 let emulator = py
                     .import("angr.emulator")?
                     .getattr("Emulator")?
-                    .call1((icicle_engine, &copied_state))?;
+                    .call1((&icicle_engine, &copied_state))?;
 
                 // Step 2.5: Set return address as breakpoint to detect normal returns
                 let calling_convention = self

--- a/native/angr/src/icicle.rs
+++ b/native/angr/src/icicle.rs
@@ -233,6 +233,7 @@ struct Icicle {
     vm: icicle_vm::Vm,
     path_tracer: Option<PathTracerRef>,
     edge_count_hitmap: Option<Hitmap>,
+    snapshot: Option<icicle_vm::Snapshot>,
 }
 
 #[pymethods]
@@ -298,6 +299,7 @@ impl Icicle {
             vm,
             path_tracer,
             edge_count_hitmap,
+            snapshot: None,
         })
     }
 
@@ -398,13 +400,8 @@ impl Icicle {
 
     // Execution
 
-    pub fn add_breakpoint(&mut self, addr: u64) -> PyResult<()> {
-        if !self.vm.add_breakpoint(addr) {
-            return Err(PyRuntimeError::new_err(format!(
-                "Failed to add breakpoint at {addr:#x}"
-            )));
-        }
-        Ok(())
+    pub fn add_breakpoint(&mut self, addr: u64) -> bool {
+        self.vm.add_breakpoint(addr)
     }
 
     pub fn remove_breakpoint(&mut self, addr: u64) -> PyResult<()> {
@@ -478,6 +475,37 @@ impl Icicle {
             return Err(PyRuntimeError::new_err("Edge hitmap is not enabled"));
         }
         Ok(())
+    }
+
+    // Snapshot/restore
+
+    pub fn save_snapshot(&mut self) {
+        self.snapshot = Some(self.vm.snapshot());
+    }
+
+    pub fn restore_snapshot(&mut self) -> PyResult<()> {
+        let snapshot = self
+            .snapshot
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("No snapshot saved"))?;
+        self.vm.restore(snapshot);
+        if let Some(path_tracer) = self.path_tracer {
+            path_tracer.clear(&mut self.vm);
+        }
+        if let Some(hitmap) = &mut self.edge_count_hitmap {
+            hitmap.as_slice_mut().fill(0);
+        }
+        Ok(())
+    }
+
+    pub fn has_snapshot(&self) -> bool {
+        self.snapshot.is_some()
+    }
+
+    pub fn clear_path_tracer(&mut self) {
+        if let Some(path_tracer) = self.path_tracer {
+            path_tracer.clear(&mut self.vm);
+        }
     }
 }
 

--- a/tests/sim/test_icicle.py
+++ b/tests/sim/test_icicle.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from io import BytesIO
+from types import SimpleNamespace
 from unittest import TestCase
 
 import archinfo
@@ -19,8 +20,9 @@ import cle
 
 import angr
 from angr import sim_options as o
+from angr.errors import SimMemoryError
 from angr.emulator import EmulatorStopReason
-from angr.engines.icicle import IcicleEngine, UberIcicleEngine
+from angr.engines.icicle import IcicleEngine, IcicleStateTranslationData, UberIcicleEngine
 from angr.state_plugins.edge_hitmap import SimStateEdgeHitmap
 from tests.common import bin_location
 
@@ -180,6 +182,105 @@ class TestIcicle(TestCase):
         assert successors.successors[0].ip.concrete_value == 0x0
         # Check that the syscall was invoked
         assert successors.successors[0].history.jumpkind == "Ijk_Syscall"
+
+
+class TestSnapshotSync(TestCase):
+    """Unit tests for snapshot sync behavior in the Icicle engine."""
+
+    def test_snapshot_sync_page_set_changes(self):
+        page_size = 0x1000
+        kept_page = 0x20
+        freed_page = 0x21
+        added_page = 0x22
+
+        class FakePerm:
+            def __init__(self, value):
+                self.concrete_value = value
+
+        class FakeMemory:
+            def __init__(self, pages):
+                self.page_size = page_size
+                self._pages = {page_num: object() for page_num in pages}
+                self._perms = {page_num: perm_bits for page_num, (perm_bits, _) in pages.items()}
+                self._contents = {page_num: content for page_num, (_, content) in pages.items()}
+
+            def permissions(self, addr):
+                page_num = addr // self.page_size
+                if page_num not in self._perms:
+                    raise SimMemoryError(f"{addr:#x} is not mapped")
+                return FakePerm(self._perms[page_num])
+
+            def concrete_load(self, addr, size):
+                assert size == self.page_size
+                page_num = addr // self.page_size
+                return self._contents[page_num]
+
+        class FakeState:
+            def __init__(self, pages):
+                self.memory = FakeMemory(pages)
+                self.project = None
+                self.arch = SimpleNamespace(name="AMD64")
+                self.addr = 0
+
+        class FakeEmu:
+            def __init__(self):
+                self.cpu_icount = 1234
+                self.mapped = []
+                self.unmapped = []
+                self.protected = []
+                self.writes = []
+
+            def mem_map(self, addr, size, perm):
+                self.mapped.append((addr, size, perm))
+
+            def mem_unmap(self, addr, size):
+                self.unmapped.append((addr, size))
+
+            def mem_protect(self, addr, size, perm):
+                self.protected.append((addr, size, perm))
+
+            def mem_write(self, addr, data):
+                self.writes.append((addr, data))
+
+        base_state = FakeState(
+            {
+                kept_page: (0b011, b"A" * page_size),
+                freed_page: (0b011, b"B" * page_size),
+            }
+        )
+        new_state = FakeState(
+            {
+                kept_page: (0b011, b"C" * page_size),
+                added_page: (0b011, b"D" * page_size),
+            }
+        )
+        emu = FakeEmu()
+
+        base_translation_data = IcicleStateTranslationData(
+            base_state=base_state,
+            registers=set(),
+            mapped_pages={kept_page, freed_page},
+            writable_pages={kept_page, freed_page},
+            explicit_page_metadata={kept_page: 0b011, freed_page: 0b011},
+            initial_cpu_icount=0,
+            icicle_arch="x86_64",
+        )
+
+        synced_translation_data = IcicleEngine._IcicleEngine__sync_angr_state_to_icicle(
+            emu, new_state, base_translation_data
+        )
+
+        assert {(addr // page_size, size, perm) for addr, size, perm in emu.mapped} == {(added_page, page_size, 0b011)}
+        assert {(addr // page_size, size) for addr, size in emu.unmapped} == {(freed_page, page_size)}
+        assert emu.protected == []
+
+        written_pages = {addr // page_size for addr, _ in emu.writes}
+        written_data = {addr // page_size: data for addr, data in emu.writes}
+        assert written_pages == {kept_page, added_page}
+        assert written_data[kept_page] == b"C" * page_size
+        assert written_data[added_page] == b"D" * page_size
+
+        assert synced_translation_data.writable_pages == {kept_page, added_page}
 
 
 class TestThumb(TestCase):

--- a/tests/sim/test_icicle.py
+++ b/tests/sim/test_icicle.py
@@ -193,10 +193,10 @@ class TestSnapshotSync(TestCase):
         engine = IcicleEngine(project)
         engine.enable_snapshot_mode()
 
-        state_opts = dict(
-            remove_options={*o.symbolic},
-            add_options={o.ZERO_FILL_UNCONSTRAINED_MEMORY, o.ZERO_FILL_UNCONSTRAINED_REGISTERS},
-        )
+        state_opts = {
+            "remove_options": {*o.symbolic},
+            "add_options": {o.ZERO_FILL_UNCONSTRAINED_MEMORY, o.ZERO_FILL_UNCONSTRAINED_REGISTERS},
+        }
 
         # First run: establish snapshot, page at 0x10000
         s1 = project.factory.blank_state(**state_opts)

--- a/tests/sim/test_icicle.py
+++ b/tests/sim/test_icicle.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import os
 from io import BytesIO
-from types import SimpleNamespace
 from unittest import TestCase
 
 import archinfo
@@ -20,9 +19,8 @@ import cle
 
 import angr
 from angr import sim_options as o
-from angr.errors import SimMemoryError
 from angr.emulator import EmulatorStopReason
-from angr.engines.icicle import IcicleEngine, IcicleStateTranslationData, UberIcicleEngine
+from angr.engines.icicle import IcicleEngine, UberIcicleEngine
 from angr.state_plugins.edge_hitmap import SimStateEdgeHitmap
 from tests.common import bin_location
 
@@ -188,107 +186,58 @@ class TestSnapshotSync(TestCase):
     """Unit tests for snapshot sync behavior in the Icicle engine."""
 
     def test_snapshot_sync_page_set_changes(self):
-        page_size = 0x1000
-        kept_page = 0x20
-        freed_page = 0x21
-        added_page = 0x22
+        """Test that snapshot sync correctly handles page additions, removals, and data changes."""
+        # Shellcode: load a 64-bit value from address in x0 into x1
+        shellcode = "ldr x1, [x0]"
+        project = angr.load_shellcode(shellcode, "aarch64")
+        engine = IcicleEngine(project)
+        engine.enable_snapshot_mode()
 
-        class FakePerm:
-            """Minimal permission wrapper matching claripy concrete_value API."""
-
-            def __init__(self, value):
-                self.concrete_value = value
-
-        class FakeMemory:
-            """Small paged-memory stand-in for snapshot sync tests."""
-
-            def __init__(self, pages):
-                self.page_size = page_size
-                self._pages = {page_num: object() for page_num in pages}
-                self._perms = {page_num: perm_bits for page_num, (perm_bits, _) in pages.items()}
-                self._contents = {page_num: content for page_num, (_, content) in pages.items()}
-
-            def permissions(self, addr):
-                page_num = addr // self.page_size
-                if page_num not in self._perms:
-                    raise SimMemoryError(f"{addr:#x} is not mapped")
-                return FakePerm(self._perms[page_num])
-
-            def concrete_load(self, addr, size):
-                assert size == self.page_size
-                page_num = addr // self.page_size
-                return self._contents[page_num]
-
-        class FakeState:
-            """State shim exposing only fields needed by sync code."""
-
-            def __init__(self, pages):
-                self.memory = FakeMemory(pages)
-                self.project = None
-                self.arch = SimpleNamespace(name="AMD64")
-                self.addr = 0
-
-        class FakeEmu:
-            """Icicle emulator shim recording memory operation calls."""
-
-            def __init__(self):
-                self.cpu_icount = 1234
-                self.mapped = []
-                self.unmapped = []
-                self.protected = []
-                self.writes = []
-
-            def mem_map(self, addr, size, perm):
-                self.mapped.append((addr, size, perm))
-
-            def mem_unmap(self, addr, size):
-                self.unmapped.append((addr, size))
-
-            def mem_protect(self, addr, size, perm):
-                self.protected.append((addr, size, perm))
-
-            def mem_write(self, addr, data):
-                self.writes.append((addr, data))
-
-        base_state = FakeState(
-            {
-                kept_page: (0b011, b"A" * page_size),
-                freed_page: (0b011, b"B" * page_size),
-            }
-        )
-        new_state = FakeState(
-            {
-                kept_page: (0b011, b"C" * page_size),
-                added_page: (0b011, b"D" * page_size),
-            }
-        )
-        emu = FakeEmu()
-
-        base_translation_data = IcicleStateTranslationData(
-            base_state=base_state,
-            registers=set(),
-            mapped_pages={kept_page, freed_page},
-            writable_pages={kept_page, freed_page},
-            explicit_page_metadata={kept_page: 0b011, freed_page: 0b011},
-            initial_cpu_icount=0,
-            icicle_arch="x86_64",
+        state_opts = dict(
+            remove_options={*o.symbolic},
+            add_options={o.ZERO_FILL_UNCONSTRAINED_MEMORY, o.ZERO_FILL_UNCONSTRAINED_REGISTERS},
         )
 
-        synced_translation_data = IcicleEngine._IcicleEngine__sync_angr_state_to_icicle(
-            emu, new_state, base_translation_data
-        )
+        # First run: establish snapshot, page at 0x10000
+        s1 = project.factory.blank_state(**state_opts)
+        s1.regs.x0 = 0x10000
+        s1.memory.map_region(0x10000, 0x1000, 0b111)
+        s1.memory.store(0x10000, 0xAA, size=8, endness="Iend_LE")
 
-        assert {(addr // page_size, size, perm) for addr, size, perm in emu.mapped} == {(added_page, page_size, 0b011)}
-        assert {(addr // page_size, size) for addr, size in emu.unmapped} == {(freed_page, page_size)}
-        assert not emu.protected
+        result1 = engine.process(s1, num_inst=1)
+        assert len(result1.successors) == 1
+        assert result1[0].regs.x1.concrete_value == 0xAA
 
-        written_pages = {addr // page_size for addr, _ in emu.writes}
-        written_data = {addr // page_size: data for addr, data in emu.writes}
-        assert written_pages == {kept_page, added_page}
-        assert written_data[kept_page] == b"C" * page_size
-        assert written_data[added_page] == b"D" * page_size
+        # Second run: same page, updated data — tests writable page sync
+        s2 = project.factory.blank_state(**state_opts)
+        s2.regs.x0 = 0x10000
+        s2.memory.map_region(0x10000, 0x1000, 0b111)
+        s2.memory.store(0x10000, 0xBB, size=8, endness="Iend_LE")
 
-        assert synced_translation_data.writable_pages == {kept_page, added_page}
+        result2 = engine.process(s2, num_inst=1)
+        assert len(result2.successors) == 1
+        assert result2[0].regs.x1.concrete_value == 0xBB
+
+        # Third run: add new page at 0x20000, read from it — tests page addition
+        s3 = project.factory.blank_state(**state_opts)
+        s3.regs.x0 = 0x20000
+        s3.memory.map_region(0x10000, 0x1000, 0b111)
+        s3.memory.map_region(0x20000, 0x1000, 0b111)
+        s3.memory.store(0x20000, 0xCC, size=8, endness="Iend_LE")
+
+        result3 = engine.process(s3, num_inst=1)
+        assert len(result3.successors) == 1
+        assert result3[0].regs.x1.concrete_value == 0xCC
+
+        # Fourth run: remove 0x10000, read from 0x20000 — tests page removal
+        s4 = project.factory.blank_state(**state_opts)
+        s4.regs.x0 = 0x20000
+        s4.memory.map_region(0x20000, 0x1000, 0b111)
+        s4.memory.store(0x20000, 0xDD, size=8, endness="Iend_LE")
+
+        result4 = engine.process(s4, num_inst=1)
+        assert len(result4.successors) == 1
+        assert result4[0].regs.x1.concrete_value == 0xDD
 
 
 class TestThumb(TestCase):

--- a/tests/sim/test_icicle.py
+++ b/tests/sim/test_icicle.py
@@ -194,10 +194,14 @@ class TestSnapshotSync(TestCase):
         added_page = 0x22
 
         class FakePerm:
+            """Minimal permission wrapper matching claripy concrete_value API."""
+
             def __init__(self, value):
                 self.concrete_value = value
 
         class FakeMemory:
+            """Small paged-memory stand-in for snapshot sync tests."""
+
             def __init__(self, pages):
                 self.page_size = page_size
                 self._pages = {page_num: object() for page_num in pages}
@@ -216,6 +220,8 @@ class TestSnapshotSync(TestCase):
                 return self._contents[page_num]
 
         class FakeState:
+            """State shim exposing only fields needed by sync code."""
+
             def __init__(self, pages):
                 self.memory = FakeMemory(pages)
                 self.project = None
@@ -223,6 +229,8 @@ class TestSnapshotSync(TestCase):
                 self.addr = 0
 
         class FakeEmu:
+            """Icicle emulator shim recording memory operation calls."""
+
             def __init__(self):
                 self.cpu_icount = 1234
                 self.mapped = []
@@ -272,7 +280,7 @@ class TestSnapshotSync(TestCase):
 
         assert {(addr // page_size, size, perm) for addr, size, perm in emu.mapped} == {(added_page, page_size, 0b011)}
         assert {(addr // page_size, size) for addr, size in emu.unmapped} == {(freed_page, page_size)}
-        assert emu.protected == []
+        assert not emu.protected
 
         written_pages = {addr // page_size for addr, _ in emu.writes}
         written_data = {addr // page_size: data for addr, data in emu.writes}


### PR DESCRIPTION
Caches icicle state at fuzzer initialization, then only updates registers/writable memory in subsequent fuzzer iterations.