### PR TITLE
Improve fuzzer test time

### DIFF
--- a/angr/rustylib/fuzzer.pyi
+++ b/angr/rustylib/fuzzer.pyi
@@ -98,6 +98,7 @@ class Fuzzer:
         apply_fn: Callable[[SimState, bytes], None],
         timeout: int = 0,
         seed: int | None = None,
+        max_mutations: int | None = None,
     ):
         """
         Initialize the fuzzer with the given parameters.

--- a/native/angr/src/fuzzer.rs
+++ b/native/angr/src/fuzzer.rs
@@ -2,6 +2,7 @@ pub mod corpus;
 pub mod executor;
 pub mod monitor;
 
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use libafl::{
@@ -58,6 +59,7 @@ struct Fuzzer {
 #[pymethods]
 impl Fuzzer {
     #[new]
+    #[pyo3(signature = (base_state, corpus, solutions, apply_fn, timeout=None, seed=0, max_mutations=None))]
     fn py_new(
         base_state: Bound<PyAny>,
         corpus: Bound<PyAny>,
@@ -65,6 +67,7 @@ impl Fuzzer {
         apply_fn: Bound<PyAny>,
         timeout: Option<u64>,
         seed: u64,
+        max_mutations: Option<u64>,
     ) -> PyResult<Self> {
         if !apply_fn.is_callable() {
             return Err(PyTypeError::new_err("Expected a callable harness function"));
@@ -125,9 +128,15 @@ impl Fuzzer {
             CrashFeedback,
         > = StdFuzzer::new(QueueScheduler::new(), feedback, objective);
 
-        let stages = tuple_list!(StdMutationalStage::new(HavocScheduledMutator::new(
-            havoc_mutations()
-        )),);
+        let mutator = HavocScheduledMutator::new(havoc_mutations());
+        let stage = if let Some(max_iter) = max_mutations {
+            let max_iter = NonZeroUsize::new(max_iter as usize)
+                .ok_or_else(|| PyRuntimeError::new_err("max_mutations must be > 0"))?;
+            StdMutationalStage::with_max_iterations(mutator, max_iter)
+        } else {
+            StdMutationalStage::new(mutator)
+        };
+        let stages = tuple_list!(stage);
 
         let executor = PyExecutorInner::new(
             base_state,

--- a/tests/test_fuzzer.py
+++ b/tests/test_fuzzer.py
@@ -1,159 +1,108 @@
 from __future__ import annotations
 
 import os.path
+import tempfile
 
 import angr
 from angr.rustylib.fuzzer import Fuzzer, InMemoryCorpus, OnDiskCorpus
 
-from tests.common import bin_location
-
 # pylint: disable=missing-class-docstring,no-self-use
+
+SHELLCODE = """
+cmp al, 0x41
+je path_a
+cmp al, 0x42
+je path_b
+ret
+path_a:
+nop
+ret
+path_b:
+nop
+nop
+ret
+"""
+
+
+def _apply_fn(state: angr.SimState, input: bytes):  # pylint: disable=redefined-builtin
+    # Feed the fuzzed byte into rax so the binary can branch on it.
+    state.regs.rax = input[0] if input else 0
+    # Set the return address to the entry so the breakpoint is at a mapped addr.
+    cc = state.project.factory.cc()
+    cc.return_addr.set_value(state, state.project.entry)
 
 
 class TestFuzzer:
     def test_fuzzer(self):
-        project = angr.Project(
-            os.path.join(bin_location, "tests", "x86_64", "fauxware"), auto_load_libs=True, use_sim_procedures=False
-        )
-        stdin = angr.SimFile(content=b"", concrete=True)
-        base_state = project.factory.entry_state(stdin=stdin, add_options={angr.options.STRICT_PAGE_ACCESS})
-
-        def apply_fn(state: angr.SimState, input: bytes):  # pylint: disable=redefined-builtin
-            print("Apply function called with input:", input, flush=True)
-            assert state.project is not None
-            cc = state.project.factory.cc()
-            assert cc.return_addr is not None
-            cc.return_addr.set_value(state, 0xDEADBEEF)
-            state.posix.stdin.write(0, b"usernameN")
-            state.posix.stdin.write(0, input)
-            print("Done")
-
-        corpus = InMemoryCorpus.from_list([b"S", b"SO", b"SOS", b"SOSN"])
+        project = angr.load_shellcode(SHELLCODE, "amd64")
+        base_state = project.factory.entry_state()
+        corpus = InMemoryCorpus.from_list([b"\x00", b"A", b"B", b"C"])
         solutions = InMemoryCorpus()
 
-        fuzzer = Fuzzer(base_state, corpus, solutions, apply_fn, 0, 0)
+        fuzzer = Fuzzer(base_state, corpus, solutions, _apply_fn, 0, 0, max_mutations=2)
 
         new_corpus_entry = fuzzer.run_once()
-        print("New corpus entry:", new_corpus_entry, flush=True)
         live_corpus = fuzzer.corpus()
         assert isinstance(live_corpus, InMemoryCorpus)
         assert 0 <= new_corpus_entry < len(live_corpus)
-        print("Value: ", live_corpus[new_corpus_entry], flush=True)
-        print("Fuzzer run completed", flush=True)
 
-        new_corpus_entry = fuzzer.run_once()
-        print("New corpus entry:", new_corpus_entry, flush=True)
-        live_corpus = fuzzer.corpus()
-        assert isinstance(live_corpus, InMemoryCorpus)
-        assert 0 <= new_corpus_entry < len(live_corpus)
-        print("Value: ", live_corpus[new_corpus_entry], flush=True)
-        print("Fuzzer run completed", flush=True)
+    def test_fuzzer_ondisk(self):
+        project = angr.load_shellcode(SHELLCODE, "amd64")
+        base_state = project.factory.entry_state()
 
-    def test_fuzzer_ondisk(self, tmp_path):
-        print("Running test: ondisk", flush=True)
-        project = angr.Project(
-            os.path.join(bin_location, "tests", "x86_64", "fauxware"), auto_load_libs=True, use_sim_procedures=False
-        )
-        stdin = angr.SimFile(content=b"", concrete=True)
-        base_state = project.factory.entry_state(stdin=stdin, add_options={angr.options.STRICT_PAGE_ACCESS})
+        with tempfile.TemporaryDirectory() as tmp_path:
+            corpus_dir = os.path.join(tmp_path, "corpus")
+            os.makedirs(corpus_dir)
+            corpus = OnDiskCorpus(corpus_dir)
+            for seed in [b"\x00", b"A", b"B", b"C"]:
+                corpus.add(seed)
+            solutions_dir = os.path.join(tmp_path, "solutions")
+            os.makedirs(solutions_dir)
+            solutions = OnDiskCorpus(solutions_dir)
 
-        def apply_fn(state: angr.SimState, input: bytes):  # pylint: disable=redefined-builtin
-            print("Apply function called with input:", input, flush=True)
-            assert state.project is not None
-            cc = state.project.factory.cc()
-            assert cc.return_addr is not None
-            cc.return_addr.set_value(state, 0xDEADBEEF)
-            state.posix.stdin.write(0, b"usernameN")
-            state.posix.stdin.write(0, input)
-            print("Done")
+            fuzzer = Fuzzer(base_state, corpus, solutions, _apply_fn, 0, 0, max_mutations=2)
 
-        corpus_dir = str(tmp_path / "corpus")
-        os.makedirs(corpus_dir, exist_ok=True)
-        corpus = OnDiskCorpus(corpus_dir)
-        for seed in [b"S", b"SO", b"SOS", b"SOSN"]:
-            corpus.add(seed)
-        solutions_dir = str(tmp_path / "solutions")
-        os.makedirs(solutions_dir, exist_ok=True)
-        solutions = OnDiskCorpus(solutions_dir)
+            new_corpus_entry = fuzzer.run_once()
+            live_corpus = fuzzer.corpus()
+            assert isinstance(live_corpus, OnDiskCorpus)
+            assert 0 <= new_corpus_entry < len(live_corpus)
+            live_solutions = fuzzer.solutions()
+            assert isinstance(live_solutions, OnDiskCorpus)
 
-        fuzzer = Fuzzer(base_state, corpus, solutions, apply_fn, 0, 0)
+    def test_fuzzer_mixed_inmem_corpus_ondisk_solutions(self):
+        project = angr.load_shellcode(SHELLCODE, "amd64")
+        base_state = project.factory.entry_state()
 
-        new_corpus_entry = fuzzer.run_once()
-        print("New corpus entry:", new_corpus_entry, flush=True)
-        live_corpus = fuzzer.corpus()
-        assert isinstance(live_corpus, OnDiskCorpus)
-        assert 0 <= new_corpus_entry < len(live_corpus)
-        print("Value: ", live_corpus[new_corpus_entry], flush=True)
-        print("Fuzzer run completed", flush=True)
-        live_solutions = fuzzer.solutions()
-        assert isinstance(live_solutions, OnDiskCorpus)
+        with tempfile.TemporaryDirectory() as tmp_path:
+            corpus = InMemoryCorpus.from_list([b"\x00", b"A", b"B", b"C"])
+            solutions_dir = os.path.join(tmp_path, "solutions_mixed1")
+            os.makedirs(solutions_dir)
+            solutions = OnDiskCorpus(solutions_dir)
 
-    def test_fuzzer_mixed_inmem_corpus_ondisk_solutions(self, tmp_path):
-        print("Running test: mixed_inmem_corpus_ondisk_solutions", flush=True)
-        project = angr.Project(
-            os.path.join(bin_location, "tests", "x86_64", "fauxware"), auto_load_libs=True, use_sim_procedures=False
-        )
-        stdin = angr.SimFile(content=b"", concrete=True)
-        base_state = project.factory.entry_state(stdin=stdin, add_options={angr.options.STRICT_PAGE_ACCESS})
+            fuzzer = Fuzzer(base_state, corpus, solutions, _apply_fn, 0, 0, max_mutations=2)
+            new_corpus_entry = fuzzer.run_once()
+            live_corpus = fuzzer.corpus()
+            assert isinstance(live_corpus, InMemoryCorpus)
+            assert 0 <= new_corpus_entry < len(live_corpus)
+            live_solutions = fuzzer.solutions()
+            assert isinstance(live_solutions, OnDiskCorpus)
 
-        def apply_fn(state: angr.SimState, input: bytes):  # pylint: disable=redefined-builtin
-            print("Apply function called with input:", input, flush=True)
-            assert state.project is not None
-            cc = state.project.factory.cc()
-            assert cc.return_addr is not None
-            cc.return_addr.set_value(state, 0xDEADBEEF)
-            state.posix.stdin.write(0, b"usernameN")
-            state.posix.stdin.write(0, input)
-            print("Done")
+    def test_fuzzer_mixed_ondisk_corpus_inmem_solutions(self):
+        project = angr.load_shellcode(SHELLCODE, "amd64")
+        base_state = project.factory.entry_state()
 
-        corpus = InMemoryCorpus.from_list([b"S", b"SO", b"SOS", b"SOSN"])
-        solutions_dir = str(tmp_path / "solutions_mixed1")
-        os.makedirs(solutions_dir, exist_ok=True)
-        solutions = OnDiskCorpus(solutions_dir)
+        with tempfile.TemporaryDirectory() as tmp_path:
+            corpus_dir = os.path.join(tmp_path, "corpus_mixed2")
+            os.makedirs(corpus_dir)
+            corpus = OnDiskCorpus(corpus_dir)
+            for seed in [b"\x00", b"A", b"B", b"C"]:
+                corpus.add(seed)
+            solutions = InMemoryCorpus()
 
-        fuzzer = Fuzzer(base_state, corpus, solutions, apply_fn, 0, 0)
-        new_corpus_entry = fuzzer.run_once()
-        print("New corpus entry:", new_corpus_entry, flush=True)
-        live_corpus = fuzzer.corpus()
-        assert isinstance(live_corpus, InMemoryCorpus)
-        assert 0 <= new_corpus_entry < len(live_corpus)
-        print("Value: ", live_corpus[new_corpus_entry], flush=True)
-        print("Fuzzer run completed", flush=True)
-        live_solutions = fuzzer.solutions()
-        assert isinstance(live_solutions, OnDiskCorpus)
-
-    def test_fuzzer_mixed_ondisk_corpus_inmem_solutions(self, tmp_path):
-        print("Running test: mixed_ondisk_corpus_inmem_solutions", flush=True)
-        project = angr.Project(
-            os.path.join(bin_location, "tests", "x86_64", "fauxware"), auto_load_libs=True, use_sim_procedures=False
-        )
-        stdin = angr.SimFile(content=b"", concrete=True)
-        base_state = project.factory.entry_state(stdin=stdin, add_options={angr.options.STRICT_PAGE_ACCESS})
-
-        def apply_fn(state: angr.SimState, input: bytes):  # pylint: disable=redefined-builtin
-            print("Apply function called with input:", input, flush=True)
-            assert state.project is not None
-            cc = state.project.factory.cc()
-            assert cc.return_addr is not None
-            cc.return_addr.set_value(state, 0xDEADBEEF)
-            state.posix.stdin.write(0, b"usernameN")
-            state.posix.stdin.write(0, input)
-            print("Done")
-
-        corpus_dir = str(tmp_path / "corpus_mixed2")
-        os.makedirs(corpus_dir, exist_ok=True)
-        corpus = OnDiskCorpus(corpus_dir)
-        for seed in [b"S", b"SO", b"SOS", b"SOSN"]:
-            corpus.add(seed)
-        solutions = InMemoryCorpus()
-
-        fuzzer = Fuzzer(base_state, corpus, solutions, apply_fn, 0, 0)
-        new_corpus_entry = fuzzer.run_once()
-        print("New corpus entry:", new_corpus_entry, flush=True)
-        live_corpus = fuzzer.corpus()
-        assert isinstance(live_corpus, OnDiskCorpus)
-        assert 0 <= new_corpus_entry < len(live_corpus)
-        print("Value: ", live_corpus[new_corpus_entry], flush=True)
-        print("Fuzzer run completed", flush=True)
-        live_solutions = fuzzer.solutions()
-        assert isinstance(live_solutions, InMemoryCorpus)
+            fuzzer = Fuzzer(base_state, corpus, solutions, _apply_fn, 0, 0, max_mutations=2)
+            new_corpus_entry = fuzzer.run_once()
+            live_corpus = fuzzer.corpus()
+            assert isinstance(live_corpus, OnDiskCorpus)
+            assert 0 <= new_corpus_entry < len(live_corpus)
+            live_solutions = fuzzer.solutions()
+            assert isinstance(live_solutions, InMemoryCorpus)


### PR DESCRIPTION
This reduces the fuzzer test time primarily by reducing the number of cycles afl uses. It also uses shellcode so that the results are easier to make quick sense of.