### PR TITLE
Dirty Page Tracking for Icicle Engine

### DIFF
--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -239,10 +239,13 @@ class IcicleEngine(ConcreteEngine):
         if IcicleEngine.__is_arm(emu.architecture):  # Hack to work around us calling it r15t
             state.registers.store("pc", (emu.pc | 1) if emu.isa_mode == 1 else emu.pc)
 
-        # 2. Copy the memory contents
+        # 2. Copy only memory pages that were actually modified during execution
+        modified_addrs = set(emu.modified_pages)
+        page_size = state.memory.page_size
         for page_num in translation_data.writable_pages:
-            addr = page_num * state.memory.page_size
-            state.memory.store(addr, emu.mem_read(addr, state.memory.page_size))
+            addr = page_num * page_size
+            if addr in modified_addrs:
+                state.memory.store(addr, emu.mem_read(addr, page_size))
 
         # 3. Set history
         # 3.1 history.jumpkind
@@ -424,6 +427,15 @@ class IcicleEngine(ConcreteEngine):
         # Set the instruction count limit
         if num_inst is not None and num_inst > 0:
             emu.icount_limit = num_inst
+
+        # Reset page modification tracking so only writes during execution
+        # are recorded.  This clears per-page modified flags and the global
+        # modified set, allowing __convert_icicle_state_to_angr to skip
+        # pages that were not touched.
+        page_size = state.memory.page_size
+        emu.reset_page_modification_tracking(
+            [page_num * page_size for page_num in translation_data.writable_pages]
+        )
 
         # Run it
         status = emu.run()

--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -433,9 +433,7 @@ class IcicleEngine(ConcreteEngine):
         # modified set, allowing __convert_icicle_state_to_angr to skip
         # pages that were not touched.
         page_size = state.memory.page_size
-        emu.reset_page_modification_tracking(
-            [page_num * page_size for page_num in translation_data.writable_pages]
-        )
+        emu.reset_page_modification_tracking([page_num * page_size for page_num in translation_data.writable_pages])
 
         # Run it
         status = emu.run()

--- a/angr/rustylib/icicle.pyi
+++ b/angr/rustylib/icicle.pyi
@@ -198,3 +198,18 @@ class Icicle:
 
     def clear_path_tracer(self) -> None:
         """Clear the path tracer's recorded execution trace."""
+
+    @property
+    def modified_pages(self) -> list[int]:
+        """Page-aligned virtual addresses modified since the last tracking reset."""
+
+    def reset_page_modification_tracking(self, page_addresses: list[int]) -> None:
+        """Reset page modification tracking.
+
+        Clears per-page modified flags for the given addresses, then flushes
+        the global modified set and TLB write cache so only subsequent writes
+        are recorded.
+
+        :arg page_addresses: Page-aligned virtual addresses whose per-page
+            modified flags should be cleared.
+        """

--- a/native/angr/src/icicle.rs
+++ b/native/angr/src/icicle.rs
@@ -507,6 +507,28 @@ impl Icicle {
             path_tracer.clear(&mut self.vm);
         }
     }
+
+    // Dirty page tracking
+
+    /// Get the set of page-aligned virtual addresses that have been modified
+    /// since the last call to reset_page_modification_tracking.
+    #[getter]
+    pub fn get_modified_pages(&self) -> Vec<u64> {
+        self.vm.cpu.mem.modified.iter().copied().collect()
+    }
+
+    /// Reset page modification tracking so that only writes occurring after
+    /// this call are recorded.  For each given page address, the per-page
+    /// `modified` flag on the underlying physical page is cleared.  Then the
+    /// global modified-address set and TLB write cache are flushed.
+    pub fn reset_page_modification_tracking(&mut self, page_addresses: Vec<u64>) {
+        for addr in page_addresses {
+            if let Some(index) = self.vm.cpu.mem.get_physical_index(addr) {
+                self.vm.cpu.mem.get_physical_mut(index).modified = false;
+            }
+        }
+        self.vm.cpu.mem.clear_page_modification_log();
+    }
 }
 
 fn get_reg_varnode(vm: &icicle_vm::Vm, name: &str) -> PyResult<pcode::VarNode> {

--- a/tests/sim/test_icicle.py
+++ b/tests/sim/test_icicle.py
@@ -240,6 +240,76 @@ class TestSnapshotSync(TestCase):
         assert result4[0].regs.x1.concrete_value == 0xDD
 
 
+class TestDirtyPageTracking(TestCase):
+    """Unit tests for dirty page tracking optimization in the Icicle engine."""
+
+    def test_only_written_pages_are_dirty(self):
+        """Test that modified_pages reports only pages actually written during execution."""
+        # Shellcode: store x0 to [x1], leaving other mapped pages untouched
+        shellcode = "str x0, [x1]"
+        project = angr.load_shellcode(shellcode, "aarch64")
+
+        engine = IcicleEngine(project)
+        state = project.factory.blank_state(
+            remove_options={*o.symbolic},
+            add_options={o.ZERO_FILL_UNCONSTRAINED_MEMORY, o.ZERO_FILL_UNCONSTRAINED_REGISTERS},
+        )
+
+        # Map three writable pages; only one will be written to
+        state.memory.map_region(0x10000, 0x1000, 0b111)
+        state.memory.map_region(0x20000, 0x1000, 0b111)
+        state.memory.map_region(0x30000, 0x1000, 0b111)
+        state.regs.x0 = 0xDEADBEEF
+        state.regs.x1 = 0x20000  # write target
+
+        result = engine.process(state, num_inst=1)
+        assert len(result.successors) == 1
+        out = result.successors[0]
+
+        # The written value must be correct
+        assert out.memory.load(0x20000, 8, endness="Iend_LE").concrete_value == 0xDEADBEEF
+
+        # Pages that were not written should still read as zero-filled
+        assert out.memory.load(0x10000, 8, endness="Iend_LE").concrete_value == 0
+        assert out.memory.load(0x30000, 8, endness="Iend_LE").concrete_value == 0
+
+    def test_dirty_tracking_across_snapshot_restore(self):
+        """Test that dirty page tracking works correctly across snapshot restore cycles."""
+        # Shellcode: store x0 to [x1]
+        shellcode = "str x0, [x1]"
+        project = angr.load_shellcode(shellcode, "aarch64")
+
+        engine = IcicleEngine(project)
+        engine.enable_snapshot_mode()
+
+        state_opts = {
+            "remove_options": {*o.symbolic},
+            "add_options": {o.ZERO_FILL_UNCONSTRAINED_MEMORY, o.ZERO_FILL_UNCONSTRAINED_REGISTERS},
+        }
+
+        # First run: establish snapshot, write to page 0x10000
+        s1 = project.factory.blank_state(**state_opts)
+        s1.memory.map_region(0x10000, 0x1000, 0b111)
+        s1.memory.map_region(0x20000, 0x1000, 0b111)
+        s1.regs.x0 = 0xAA
+        s1.regs.x1 = 0x10000
+
+        r1 = engine.process(s1, num_inst=1)
+        assert r1[0].memory.load(0x10000, 8, endness="Iend_LE").concrete_value == 0xAA
+
+        # Second run (snapshot restore path): write to different page
+        s2 = project.factory.blank_state(**state_opts)
+        s2.memory.map_region(0x10000, 0x1000, 0b111)
+        s2.memory.map_region(0x20000, 0x1000, 0b111)
+        s2.regs.x0 = 0xBB
+        s2.regs.x1 = 0x20000
+
+        r2 = engine.process(s2, num_inst=1)
+        assert r2[0].memory.load(0x20000, 8, endness="Iend_LE").concrete_value == 0xBB
+        # Page 0x10000 should be unchanged (zero-filled from the fresh angr state copy)
+        assert r2[0].memory.load(0x10000, 8, endness="Iend_LE").concrete_value == 0
+
+
 class TestThumb(TestCase):
     """Thumb-specific tests for the Icicle engine."""
 


### PR DESCRIPTION
In __convert_icicle_state_to_angr, we only write modified pages from icicle's execution to angr state.
