### PR TITLE
fix: AttributeError in `heap_ptmalloc.realloc` when shrinking the final 

### DIFF
--- a/angr/state_plugins/heap/heap_ptmalloc.py
+++ b/angr/state_plugins/heap/heap_ptmalloc.py
@@ -541,9 +541,10 @@ class SimHeapPTMalloc(SimHeapFreelist):
             # Less space is needed, so just shrink the chunk and create a new free chunk from the freed space
             chunk.set_size(new_size, False)
             new_next_chunk = chunk.next_chunk()
-            new_next_chunk.set_size(old_size - new_size, False)
-            new_next_chunk.set_prev_freeness(False)
-            self.free(new_next_chunk.data_ptr())
+            if new_next_chunk is not None:
+                new_next_chunk.set_size(old_size - new_size, False)
+                new_next_chunk.set_prev_freeness(False)
+                self.free(new_next_chunk.data_ptr())
             return chunk.data_ptr()
         # No changes needed; we're already the right size
         return chunk.data_ptr()


### PR DESCRIPTION
Fixes #6228

`SimHeapPTMalloc.realloc` in `angr/state_plugins/heap/heap_ptmalloc.py` raised an `AttributeError` when shrinking the final heap chunk because `next_chunk()` returns `None` at the heap boundary, and the code unconditionally called methods on the result. Guards the three affected calls with a `None` check so shrinking the last chunk skips the free-chunk creation step.