### PR TITLE
Added blob loading options to the angr CLI

### DIFF
--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -276,7 +276,6 @@ def decompile(args):
     if args.entry_point is not None:
         loader_main_opts_kwargs["entry_point"] = args.entry_point
 
-
     # Load binary
     proj = angr.Project(args.binary, auto_load_libs=False, main_opts=loader_main_opts_kwargs)
 
@@ -434,10 +433,10 @@ def _add_common_args(subparser):
         default=None,
     )
     subparser.add_argument(
-          "--blob",
-          help="Treat the input file as a raw binary blob instead of auto-detecting a file format.",
-          action="store_true",
-          default=False,
+        "--blob",
+        help="Treat the input file as a raw binary blob instead of auto-detecting a file format.",
+        action="store_true",
+        default=False,
     )
     subparser.add_argument(
         "--arch",

--- a/angr/__main__.py
+++ b/angr/__main__.py
@@ -186,8 +186,14 @@ def disassemble(args):
         show_status = False
 
     loader_main_opts_kwargs = {}
+    if args.blob:
+        loader_main_opts_kwargs["backend"] = "blob"
     if args.base_addr is not None:
         loader_main_opts_kwargs["base_addr"] = args.base_addr
+    if args.arch is not None:
+        loader_main_opts_kwargs["arch"] = args.arch
+    if args.entry_point is not None:
+        loader_main_opts_kwargs["entry_point"] = args.entry_point
 
     proj = angr.Project(args.binary, auto_load_libs=False, main_opts=loader_main_opts_kwargs)
 
@@ -260,10 +266,16 @@ def decompile(args):
     if not args.pbar:
         show_status = False
 
-    # Resolve loader args
     loader_main_opts_kwargs = {}
+    if args.blob:
+        loader_main_opts_kwargs["backend"] = "blob"
     if args.base_addr is not None:
         loader_main_opts_kwargs["base_addr"] = args.base_addr
+    if args.arch is not None:
+        loader_main_opts_kwargs["arch"] = args.arch
+    if args.entry_point is not None:
+        loader_main_opts_kwargs["entry_point"] = args.entry_point
+
 
     # Load binary
     proj = angr.Project(args.binary, auto_load_libs=False, main_opts=loader_main_opts_kwargs)
@@ -421,6 +433,23 @@ def _add_common_args(subparser):
         type=lambda x: int(x, 0),
         default=None,
     )
+    subparser.add_argument(
+          "--blob",
+          help="Treat the input file as a raw binary blob instead of auto-detecting a file format.",
+          action="store_true",
+          default=False,
+    )
+    subparser.add_argument(
+        "--arch",
+        help="Architecture to use when loading a raw binary blob.",
+        default=None,
+    )
+    subparser.add_argument(
+        "--entry-point",
+        help="Entry point to use when loading a raw binary blob.",
+        type=lambda x: int(x, 0),
+        default=None,
+    )
 
 
 def main():
@@ -513,6 +542,14 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.blob:
+        if args.arch is None:
+            parser.error("--blob requires --arch")
+        if args.base_addr is None:
+            parser.error("--blob requires --base-addr")
+        if args.entry_point is None:
+            parser.error("--blob requires --entry-point")
 
     log_level = max(logging.ERROR - (10 * args.verbose), logging.DEBUG)
     logging.getLogger("angr").setLevel(log_level)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -321,6 +321,80 @@ class TestCommandLineInterface(unittest.TestCase):
         assert stdout == ""
         assert "error decompiling" in stderr.lower()
 
+    def test_blob_requires_required_args(self):
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        with (
+            mock.patch("sys.argv", [sys.executable, "disassemble", bin_path, "--blob"]),
+            mock.patch("sys.stderr", new=io.StringIO()) as fake_err,
+            self.assertRaises(SystemExit) as exc,
+        ):
+            main()
+
+        assert exc.exception.code == 2
+        assert "--blob requires --arch" in fake_err.getvalue()
+
+    def test_disassemble_blob_loader_options(self):
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        fake_proj = mock.Mock()
+        fake_proj.analyses.CFG.return_value = None
+        fake_proj.kb.functions = {}
+
+        with mock.patch("angr.__main__.angr.Project", return_value=fake_proj) as mock_project:
+            output = run_cli(
+                "disassemble",
+                bin_path,
+                "--blob",
+                "--arch",
+                "AMD64",
+                "--base-addr",
+                "0x400000",
+                "--entry-point",
+                "0x400000",
+            )
+
+        assert output == ""
+        _, kwargs = mock_project.call_args
+        assert kwargs["auto_load_libs"] is False
+        assert kwargs["main_opts"] == {
+            "backend": "blob",
+            "arch": "AMD64",
+            "base_addr": 0x400000,
+            "entry_point": 0x400000,
+        }
+
+    def test_decompile_blob_loader_options(self):
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+
+        fake_cfg = mock.Mock()
+        fake_cfg.kb.functions = {}
+        fake_cfg.functions = {}
+
+        fake_proj = mock.Mock()
+        fake_proj.analyses.CFG.return_value = fake_cfg
+
+        with mock.patch("angr.__main__.angr.Project", return_value=fake_proj) as mock_project:
+            output = run_cli(
+                "decompile",
+                bin_path,
+                "--blob",
+                "--arch",
+                "AMD64",
+                "--base-addr",
+                "0x400000",
+                "--entry-point",
+                "0x400000",
+                "--no-colors",
+            )
+
+        assert output == ""
+        _, kwargs = mock_project.call_args
+        assert kwargs["auto_load_libs"] is False
+        assert kwargs["main_opts"] == {
+            "backend": "blob",
+            "arch": "AMD64",
+            "base_addr": 0x400000,
+            "entry_point": 0x400000,
+        }
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -396,5 +396,6 @@ class TestCommandLineInterface(unittest.TestCase):
             "entry_point": 0x400000,
         }
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds raw blob loading support to the angr CLI via `--blob`. Also accepts and validates options like `--arch`, `--base-addr` and `--entry-point`. 

Closes #6035