### PR TITLE
Fix UnboundLocalError on 'sized_amt'

### DIFF
--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -1019,9 +1019,9 @@ def generic_rotate_with_carry(state, left, arg, rot_amt, carry_bit_in, sz):
         sized_amt = (rot_amt & 0x1F) % 9
     elif sz == 2:
         sized_amt = (rot_amt & 0x1F) % 17
-    elif sz == 3:
-        sized_amt = rot_amt & 0x1F
     elif sz == 4:
+        sized_amt = rot_amt & 0x1F
+    elif sz == 8:
         sized_amt = rot_amt & 0x3F
 
     # Ajust the BV size


### PR DESCRIPTION
While playing around with angr, I encountered the following error:

> File "/home/.../.venv/lib/python3.13/site-packages/angr/engines/vex/claripy/ccall.py", line 1030, in generic_rotate_with_carry
>     sized_amt = sized_amt.zero_extend(1) if bits == len(sized_amt) else sized_amt[bits:0]
>                                                         ^^^^^^^^^
> UnboundLocalError: cannot access local variable 'sized_amt' where it is not associated with a value
> 

Taking a look at ccall.py, I can see on line 1009 `bits = sz * 8` so I figure the valid values for sz are 1,2,4 and 8 (giving 8,16, 32 and 64 bits). The modifications in this PR also match the referenced documentation at https://www.felixcloutier.com/x86/rcl:rcr:rol:ror#---rcl-and-rcr-instructions--- .

