### PR TITLE
Fixed angrdb loader for raw blobs and HEX backend files

### DIFF
--- a/angr/angrdb/serializers/loader.py
+++ b/angr/angrdb/serializers/loader.py
@@ -5,6 +5,7 @@ import json
 import binascii
 import logging
 import tempfile
+import archinfo
 
 import cle
 
@@ -25,6 +26,13 @@ class LoadArgsJSONEncoder(json.JSONEncoder):
                 "__custom_type__": "bytes",
                 "__v__": binascii.hexlify(o).decode("ascii"),
             }
+        if isinstance(o, archinfo.Arch):
+            return {
+                "__custom_type__": "arch",
+                "name": o.name,
+                "endness": o.memory_endness,
+                "bits": o.bits
+            }
         return super().default(o)
 
 
@@ -42,6 +50,12 @@ class LoadArgsJSONDecoder(json.JSONDecoder):
                 case "bytes":
                     if "__v__" in d:
                         return binascii.unhexlify(d["__v__"])
+                case "arch":
+                    return archinfo.arch_from_id(
+                          d["name"],
+                          d.get("endness", ""),
+                        d.get("bits", ""),
+                )
         return d
 
 
@@ -145,11 +159,15 @@ class LoaderSerializer:
         with tempfile.TemporaryDirectory() as tmpdir:
             for db_o in db_objects:
                 load_opts = decoder.decode(db_o.backend_args) if db_o.backend_args else {}
+
+                if db_o.backend is not None:
+                    load_opts["backend"] = db_o.backend
+
+                load_opts = {k: v for k, v in load_opts.items() if v is not None}
+
                 path = Path(db_o.path)
 
                 if not path.exists():
-                    # dump the content to a temporary file if the
-                    # original file does not exist anymore
                     tmp_path = Path(tmpdir) / path.name
                     with open(tmp_path, "wb") as f:
                         f.write(db_o.content)

--- a/angr/angrdb/serializers/loader.py
+++ b/angr/angrdb/serializers/loader.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 from typing import Any
 from pathlib import Path
-from io import BytesIO
 import json
 import binascii
 import logging
 import tempfile
 import archinfo
-import tempfile
 
 import cle
 
@@ -29,12 +27,7 @@ class LoadArgsJSONEncoder(json.JSONEncoder):
                 "__v__": binascii.hexlify(o).decode("ascii"),
             }
         if isinstance(o, archinfo.Arch):
-            return {
-                "__custom_type__": "arch",
-                "name": o.name,
-                "endness": o.memory_endness,
-                "bits": o.bits
-            }
+            return {"__custom_type__": "arch", "name": o.name, "endness": o.memory_endness, "bits": o.bits}
         return super().default(o)
 
 
@@ -54,10 +47,10 @@ class LoadArgsJSONDecoder(json.JSONDecoder):
                         return binascii.unhexlify(d["__v__"])
                 case "arch":
                     return archinfo.arch_from_id(
-                          d["name"],
-                          d.get("endness", ""),
-                          d.get("bits", ""),
-                )
+                        d["name"],
+                        d.get("endness", ""),
+                        d.get("bits", ""),
+                    )
         return d
 
 

--- a/angr/angrdb/serializers/loader.py
+++ b/angr/angrdb/serializers/loader.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 from typing import Any
 from pathlib import Path
+from io import BytesIO
 import json
 import binascii
 import logging
 import tempfile
 import archinfo
+import tempfile
 
 import cle
 
@@ -54,7 +56,7 @@ class LoadArgsJSONDecoder(json.JSONDecoder):
                     return archinfo.arch_from_id(
                           d["name"],
                           d.get("endness", ""),
-                        d.get("bits", ""),
+                          d.get("bits", ""),
                 )
         return d
 
@@ -168,6 +170,8 @@ class LoaderSerializer:
                 path = Path(db_o.path)
 
                 if not path.exists():
+                    # dump the content to a temporary file if the
+                    # original file does not exist anymore
                     tmp_path = Path(tmpdir) / path.name
                     with open(tmp_path, "wb") as f:
                         f.write(db_o.content)

--- a/tests/serialization/test_db.py
+++ b/tests/serialization/test_db.py
@@ -446,5 +446,6 @@ class TestDb(unittest.TestCase):
             assert o1.min_addr == o2.min_addr
             assert o1.max_addr == o2.max_addr
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/serialization/test_db.py
+++ b/tests/serialization/test_db.py
@@ -346,30 +346,6 @@ class TestDb(unittest.TestCase):
 
             _proj = AngrDB(nullpool=True).load(out_db)
 
-    def test_angrdb_loader_multi_object(self):
-        """Verify that a Loader with multiple objects can be dumped and loaded correctly."""
-        bin_path = os.path.join(test_location, "x86_64", "fauxware")
-        lib_path = os.path.join(test_location, "x86_64", "libc.so.6")
-        proj = angr.Project(bin_path, preload_libs=[lib_path], auto_load_libs=False)
-
-        objects = proj.loader.all_elf_objects
-
-        with tempfile.TemporaryDirectory() as td:
-            db_file = os.path.join(td, "test.adb")
-            AngrDB(proj, nullpool=True).dump(db_file)
-            proj2 = AngrDB(nullpool=True).load(db_file)
-
-        objects2 = proj2.loader.all_elf_objects
-
-        assert len(objects) == len(objects2), f"number of objects mismatch: {len(objects)} vs {len(objects2)}"
-
-        for o1, o2 in zip(objects, objects2):
-            name1 = os.path.basename(o1.binary) if o1.binary else None
-            name2 = os.path.basename(o2.binary) if o2.binary else None
-            assert name1 == name2, f"object binary name mismatch: {name1} vs {name2}"
-            assert o1.min_addr == o2.min_addr
-            assert o1.max_addr == o2.max_addr
-
     def test_angrdb_blob_loader_options_roundtrip(self):
         with tempfile.TemporaryDirectory() as td:
             blob_path = os.path.join(td, "sample.bin")
@@ -445,6 +421,30 @@ class TestDb(unittest.TestCase):
 
             loaded_2 = self._roundtrip_angrdb(loaded, db_file_2)
             self._assert_loader_state(loaded_2, cle.backends.Hex, "ARMHF")
+
+    def test_angrdb_loader_multi_object(self):
+        """Verify that a Loader with multiple objects can be dumped and loaded correctly."""
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        lib_path = os.path.join(test_location, "x86_64", "libc.so.6")
+        proj = angr.Project(bin_path, preload_libs=[lib_path], auto_load_libs=False)
+
+        objects = proj.loader.all_elf_objects
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = os.path.join(td, "test.adb")
+            AngrDB(proj, nullpool=True).dump(db_file)
+            proj2 = AngrDB(nullpool=True).load(db_file)
+
+        objects2 = proj2.loader.all_elf_objects
+
+        assert len(objects) == len(objects2), f"number of objects mismatch: {len(objects)} vs {len(objects2)}"
+
+        for o1, o2 in zip(objects, objects2):
+            name1 = os.path.basename(o1.binary) if o1.binary else None
+            name2 = os.path.basename(o2.binary) if o2.binary else None
+            assert name1 == name2, f"object binary name mismatch: {name1} vs {name2}"
+            assert o1.min_addr == o2.min_addr
+            assert o1.max_addr == o2.max_addr
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/serialization/test_db.py
+++ b/tests/serialization/test_db.py
@@ -9,6 +9,7 @@ import tempfile
 import shutil
 import unittest
 
+import archinfo
 import cle
 
 import angr
@@ -21,6 +22,16 @@ test_location = os.path.join(bin_location, "tests")
 
 
 class TestDb(unittest.TestCase):
+    @staticmethod
+    def _roundtrip_angrdb(proj, db_file):
+        AngrDB(proj, nullpool=True).dump(db_file)
+        return AngrDB(nullpool=True).load(db_file)
+
+    @staticmethod
+    def _assert_loader_state(proj, backend_cls, arch_name):
+        assert isinstance(proj.loader.main_object, backend_cls)
+        assert proj.arch.name == arch_name
+
     def test_angrdb_fauxware(self):
         bin_path = os.path.join(test_location, "x86_64", "fauxware")
 
@@ -359,6 +370,81 @@ class TestDb(unittest.TestCase):
             assert o1.min_addr == o2.min_addr
             assert o1.max_addr == o2.max_addr
 
+    def test_angrdb_blob_loader_options_roundtrip(self):
+        with tempfile.TemporaryDirectory() as td:
+            blob_path = os.path.join(td, "sample.bin")
+            db_file = os.path.join(td, "sample.adb")
+
+            with open(blob_path, "wb") as f:
+                f.write(b"\x01\x02\x03\x04")
+
+            proj = angr.Project(
+                blob_path,
+                auto_load_libs=False,
+                main_opts={"backend": "blob", "arch": "ARMHF"},
+            )
+
+            loaded = self._roundtrip_angrdb(proj, db_file)
+            self._assert_loader_state(loaded, cle.backends.Blob, "ARMHF")
+
+    def test_angrdb_blob_loader_options_roundtrip_with_arch_object(self):
+        with tempfile.TemporaryDirectory() as td:
+            blob_path = os.path.join(td, "sample.bin")
+            db_file = os.path.join(td, "sample.adb")
+            db_file_2 = os.path.join(td, "sample_2.adb")
+
+            with open(blob_path, "wb") as f:
+                f.write(b"\x01\x02\x03\x04")
+
+            proj = angr.Project(
+                blob_path,
+                auto_load_libs=False,
+                main_opts={"backend": "blob", "arch": archinfo.arch_from_id("ARMHF")},
+            )
+
+            loaded = self._roundtrip_angrdb(proj, db_file)
+            self._assert_loader_state(loaded, cle.backends.Blob, "ARMHF")
+
+            loaded_2 = self._roundtrip_angrdb(loaded, db_file_2)
+            self._assert_loader_state(loaded_2, cle.backends.Blob, "ARMHF")
+
+    def test_angrdb_ihex_loader_options_roundtrip(self):
+        with tempfile.TemporaryDirectory() as td:
+            hex_path = os.path.join(td, "sample.ihex")
+            db_file = os.path.join(td, "sample.adb")
+
+            with open(hex_path, "wb") as f:
+                f.write(b":0400000001020304F2\n:00000001FF\n")
+
+            proj = angr.Project(
+                hex_path,
+                auto_load_libs=False,
+                main_opts={"backend": "hex", "arch": "ARMHF"},
+            )
+
+            loaded = self._roundtrip_angrdb(proj, db_file)
+            self._assert_loader_state(loaded, cle.backends.Hex, "ARMHF")
+
+    def test_angrdb_ihex_loader_options_roundtrip_with_arch_object(self):
+        with tempfile.TemporaryDirectory() as td:
+            hex_path = os.path.join(td, "sample.ihex")
+            db_file = os.path.join(td, "sample.adb")
+            db_file_2 = os.path.join(td, "sample_2.adb")
+
+            with open(hex_path, "wb") as f:
+                f.write(b":0400000001020304F2\n:00000001FF\n")
+
+            proj = angr.Project(
+                hex_path,
+                auto_load_libs=False,
+                main_opts={"backend": "hex", "arch": archinfo.arch_from_id("ARMHF")},
+            )
+
+            loaded = self._roundtrip_angrdb(proj, db_file)
+            self._assert_loader_state(loaded, cle.backends.Hex, "ARMHF")
+
+            loaded_2 = self._roundtrip_angrdb(loaded, db_file_2)
+            self._assert_loader_state(loaded_2, cle.backends.Hex, "ARMHF")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes the issue which causes a corrupted angrdb to get saved because of a loader bug in serialization/deserialization in `angr`. 

The bug was caused by: 

- `archinfo.Arch` objects in loader not being serialized correctly when trying to dump `.adb` file in angr-management. 
- the saved backend name was not replayed when reconstructing the loader when loading the `.adb` file.

This caused `.adb` reopen failures for raw blob-backed inputs and Intel HEX inputs.

## Fix

- Added serialization/deserialization support for `archinfo.Arch` object in angrdb loader args.
- Restored the saved backend into `main_opts` during angrdb load
- Additionally filtered out `NoneType` valued loader options when `base_addr` or `entry_point` options are not passed before recreating the CLE loader.

This closes the issue raised on angr/angr-management at: https://github.com/angr/angr-management/issues/1500