### PR TITLE
AngrDB: Support loading Loader with multiple objects

### DIFF
--- a/angr/angrdb/serializers/loader.py
+++ b/angr/angrdb/serializers/loader.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 from typing import Any
-from io import BytesIO
+from pathlib import Path
 import json
 import binascii
 import logging
+import tempfile
 
 import cle
 
@@ -132,33 +133,36 @@ class LoaderSerializer:
 
     @staticmethod
     def load(session):
-        all_objects = {}  # path to object
-        main_object = None
+        main_path = None
+        lib_paths = []
 
         db_objects: list[DbObject] = session.query(DbObject)
-        load_args = {}
+        main_opts = None
+        lib_opts = {}
 
         decoder = LoadArgsJSONDecoder()
 
-        for db_o in db_objects:
-            all_objects[db_o.path] = db_o
-            if db_o.main_object:
-                main_object = db_o
-            load_args[db_o] = decoder.decode(db_o.backend_args) if db_o.backend_args else {}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for db_o in db_objects:
+                load_opts = decoder.decode(db_o.backend_args) if db_o.backend_args else {}
+                path = Path(db_o.path)
 
-        if main_object is None:
-            raise AngrCorruptDBError("Corrupt database: No main object.")
+                if not path.exists():
+                    # dump the content to a temporary file if the
+                    # original file does not exist anymore
+                    tmp_path = Path(tmpdir) / path.name
+                    with open(tmp_path, "wb") as f:
+                        f.write(db_o.content)
+                    path = tmp_path
 
-        # build params
-        # FIXME: Load other objects
+                if db_o.main_object:
+                    main_opts = load_opts
+                    main_path = str(path)
+                else:
+                    lib_opts[path.name] = load_opts
+                    lib_paths.append(str(path))
 
-        loader = cle.Loader(BytesIO(main_object.content), main_opts=load_args[main_object])
+            if main_path is None:
+                raise AngrCorruptDBError("Corrupt database: No main object.")
 
-        skip_mainbin, _ = LoaderSerializer.should_skip_main_binary(loader)
-
-        loader._main_binary_path = main_object.path
-        if not skip_mainbin:
-            # fix the binary name of the main binary
-            loader.main_object.binary = main_object.path
-
-        return loader
+            return cle.Loader(main_path, preload_libs=lib_paths, main_opts=main_opts, lib_opts=lib_opts)

--- a/tests/serialization/test_db.py
+++ b/tests/serialization/test_db.py
@@ -335,6 +335,30 @@ class TestDb(unittest.TestCase):
 
             _proj = AngrDB(nullpool=True).load(out_db)
 
+    def test_angrdb_loader_multi_object(self):
+        """Verify that a Loader with multiple objects can be dumped and loaded correctly."""
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        lib_path = os.path.join(test_location, "x86_64", "libc.so.6")
+        proj = angr.Project(bin_path, preload_libs=[lib_path], auto_load_libs=False)
+
+        objects = proj.loader.all_elf_objects
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = os.path.join(td, "test.adb")
+            AngrDB(proj, nullpool=True).dump(db_file)
+            proj2 = AngrDB(nullpool=True).load(db_file)
+
+        objects2 = proj2.loader.all_elf_objects
+
+        assert len(objects) == len(objects2), f"number of objects mismatch: {len(objects)} vs {len(objects2)}"
+
+        for o1, o2 in zip(objects, objects2):
+            name1 = os.path.basename(o1.binary) if o1.binary else None
+            name2 = os.path.basename(o2.binary) if o2.binary else None
+            assert name1 == name2, f"object binary name mismatch: {name1} vs {name2}"
+            assert o1.min_addr == o2.min_addr
+            assert o1.max_addr == o2.max_addr
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The current `AngrDB` implementation only loads the main object for dumped `Project`s. When working with a `Project` with multiple loaded objects, this may cause various exceptions (e.g., when reconstructing `CFGModel`'s memory data, it may attempt to load memory from the `Loader` in `MemoryData.fill_content` which belongs to an object that is not loaded).

This PR extends the `LoaderSerializer` to support loading all objects that were serialized to the database, allowing the loader state to be reconstructed correctly.