### PR TITLE
feat: add proper support for 16-bit architecture in stack pointer initialization

### DIFF
--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -172,11 +172,9 @@ class ReachingDefinitionsState:
         return None
 
     def _initial_stack_pointer(self):
-        if self.arch.bits == 32:
-            return claripy.BVS("stack_base", 32, explicit_name=True)
-        if self.arch.bits == 64:
-            return claripy.BVS("stack_base", 64, explicit_name=True)
-        raise ValueError(f"Unsupported architecture word size {self.arch.bits}")
+        if self.arch.bits not in (16, 32, 64):
+            raise ValueError(f"Unsupported architecture word size {self.arch.bits}")
+        return claripy.BVS("stack_base", self.arch.bits, explicit_name=True)
 
     def _to_signed(self, n):
         if n >= 2 ** (self.arch.bits - 1):

--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -86,6 +86,7 @@ class LiveDefinitions:
     uncovered during the analysis.
     """
 
+    INITIAL_SP_16BIT = 0x7F00
     INITIAL_SP_32BIT = 0x7FFF0000
     INITIAL_SP_64BIT = 0x7FFFFFFF0000
     _tops = {}
@@ -438,6 +439,9 @@ class LiveDefinitions:
         elif self.arch.bits == 64:
             base_v = self.INITIAL_SP_64BIT
             mask = 0xFFFF_FFFF_FFFF_FFFF
+        elif self.arch.bits == 16:
+            base_v = self.INITIAL_SP_16BIT
+            mask = 0xFFFF
         else:
             raise ValueError(f"Unsupported architecture word size {self.arch.bits}")
         return (base_v + offset) & mask


### PR DESCRIPTION
When i triggered an analysis of a 16 bit program (for z80) I would get loads of errors : 

```txt
ERROR    | 2026-03-30 18:50:25,873 | angrmanagement.logic.jobmanager | Exception while runningjob "Calling Convention Recovery":
Traceback (most recent call last):
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/logic/jobmanager.py", line 82, in execute_job
    job.start(ctx)
    ~~~~~~~~~^^^^^
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/data/jobs/job.py", line 89, in start
    self.result = self.run(ctx)
                  ~~~~~~~~^^^^^
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/data/jobs/calling_convention_recovery.py", line 144, in run
    self.ccc.work()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/complete_calling_conventions.py", line 218, in work
    cc, proto, proto_libname, proto_guessed, _ = self._analyze_core(func_addr)
                                                 ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/complete_calling_conventions.py", line 406, in _analyze_core
    cc_analysis = self.project.analyses[CallingConventionAnalysis].prep(kb=self.kb)(
        func,
    ...<4 lines>...
        collect_facts_arg_passthru=self.mode == CallingConventionAnalysisMode.FASTISH,
    )
  File "/home/jns/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 251, in wrapper
    oself.__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/calling_convention/calling_convention.py", line 158, in __init__
    self._analyze()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/calling_convention/calling_convention.py", line 229, in _analyze
    callsite_facts = self._extract_and_analyze_callsites(
        max_analyzing_callsites=1,
        include_callsite_preds=include_callsite_preds,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/calling_convention/calling_convention.py", line 595, in _extract_and_analyze_callsites
    fact = self._analyze_callsite(
        caller.addr,
    ...<2 lines>...
        include_preds=include_callsite_preds,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/calling_convention/calling_convention.py", line 526, in _analyze_callsite
    rda = self.project.analyses[ReachingDefinitionsAnalysis].prep()(
        func,
        func_graph=subgraph,
        observation_points=observation_points,
    )
  File "/home/jns/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 251, in wrapper
    oself.__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/reaching_definitions.py", line 203, in __init__
    self._analyze()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/forward_analysis/forward_analysis.py", line 282, in _analyze
    self._analysis_core_graph()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/forward_analysis/forward_analysis.py", line 298, in _analysis_core_graph
    job_state = self._initial_abstract_state(n)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/reaching_definitions.py", line 452, in _initial_abstract_state
    return ReachingDefinitionsState(
        CodeLocation(node.addr, stmt_idx=0, ins_addr=node.addr, context=self._init_context),
    ...<8 lines>...
        merge_into_tops=self._merge_into_tops,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_state.py", line 134, in __init__
    self._set_initialization_values(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        subject, rtoc_value, initializer=initializer, project=self.live_definitions.project
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_state.py", line 294, in _set_initialization_values
    initializer.initialize_function_state(self, subject.cc, subject.content.addr, rtoc_value)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_initializer.py", line 55, in initialize_function_state
    self.initialize_stack_pointer(state, func_addr, ex_loc)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_initializer.py", line 129, in initialize_stack_pointer
    sp = state.annotate_with_def(state._initial_stack_pointer(), sp_def)
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_state.py", line 179, in _initial_stack_pointer
    raise ValueError(f"Unsupported architecture word size {self.arch.bits}")
ValueError: Unsupported architecture word size 16
WARNING  | 2026-03-30 18:50:25,880 | angr.analyses.calling_convention.calling_convention | <Function _GetKey (0x4972)> is not in the CFG. Skip calling convention analysis at call sites.
ERROR    | 2026-03-30 18:50:25,881 | angrmanagement.logic.jobmanager | Exception while runningjob "Variable Recovery":
Traceback (most recent call last):
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/logic/jobmanager.py", line 82, in execute_job
    job.start(ctx)
    ~~~~~~~~~^^^^^
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/data/jobs/job.py", line 89, in start
    self.result = self.run(ctx)
                  ~~~~~~~~^^^^^
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/data/jobs/variable_recovery.py", line 152, in run
    self.ccc.work()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/complete_calling_conventions.py", line 218, in work
    cc, proto, proto_libname, proto_guessed, _ = self._analyze_core(func_addr)
                                                 ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/complete_calling_conventions.py", line 406, in _analyze_core
    cc_analysis = self.project.analyses[CallingConventionAnalysis].prep(kb=self.kb)(
        func,
    ...<4 lines>...
        collect_facts_arg_passthru=self.mode == CallingConventionAnalysisMode.FASTISH,
    )
  File "/home/jns/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 251, in wrapper
    oself.__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/calling_convention/calling_convention.py", line 158, in __init__
    self._analyze()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/calling_convention/calling_convention.py", line 229, in _analyze
    callsite_facts = self._extract_and_analyze_callsites(
        max_analyzing_callsites=1,
        include_callsite_preds=include_callsite_preds,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/calling_convention/calling_convention.py", line 595, in _extract_and_analyze_callsites
    fact = self._analyze_callsite(
        caller.addr,
    ...<2 lines>...
        include_preds=include_callsite_preds,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/calling_convention/calling_convention.py", line 526, in _analyze_callsite
    rda = self.project.analyses[ReachingDefinitionsAnalysis].prep()(
        func,
        func_graph=subgraph,
        observation_points=observation_points,
    )
  File "/home/jns/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 251, in wrapper
    oself.__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/reaching_definitions.py", line 203, in __init__
    self._analyze()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/forward_analysis/forward_analysis.py", line 282, in _analyze
    self._analysis_core_graph()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/forward_analysis/forward_analysis.py", line 298, in _analysis_core_graph
    job_state = self._initial_abstract_state(n)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/reaching_definitions.py", line 452, in _initial_abstract_state
    return ReachingDefinitionsState(
        CodeLocation(node.addr, stmt_idx=0, ins_addr=node.addr, context=self._init_context),
    ...<8 lines>...
        merge_into_tops=self._merge_into_tops,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_state.py", line 134, in __init__
    self._set_initialization_values(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        subject, rtoc_value, initializer=initializer, project=self.live_definitions.project
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_state.py", line 294, in _set_initialization_values
    initializer.initialize_function_state(self, subject.cc, subject.content.addr, rtoc_value)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_initializer.py", line 55, in initialize_function_state
    self.initialize_stack_pointer(state, func_addr, ex_loc)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_initializer.py", line 129, in initialize_stack_pointer
    sp = state.annotate_with_def(state._initial_stack_pointer(), sp_def)
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/reaching_definitions/rd_state.py", line 179, in _initial_stack_pointer
    raise ValueError(f"Unsupported architecture word size {self.arch.bits}")
ValueError: Unsupported architecture word size 16
```

This PR solves the errors that were 16-bit related