### PR TITLE
fix(propagator): gracefully handle missing Tmp definitions in AIL blocks

### DIFF
--- a/angr/analyses/s_propagator.py
+++ b/angr/analyses/s_propagator.py
@@ -439,6 +439,8 @@ class SPropagatorAnalysis(Analysis):
 
         for block_loc, tmp_and_uses in tmp_uselocs.items():
             for tmp_atom, tmp_uses in tmp_and_uses.items():
+                if tmp_atom not in tmp_deflocs.get(block_loc, {}):
+                    continue
                 # take a look at the definition and propagate the definition if supported
                 block = blocks[block_loc]
                 tmp_def_stmtidx = tmp_deflocs[block_loc][tmp_atom]


### PR DESCRIPTION
When I patched a binary (to include references to functions not included in the binary) then the AIL block simplification would fail : 

```txt
ERROR    | 2026-03-30 18:50:25,859 | angrmanagement.logic.jobmanager | Exception while runningjob "CFG generation":
Traceback (most recent call last):
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/logic/jobmanager.py", line 82, in execute_job
    job.start(ctx)
    ~~~~~~~~~^^^^^
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/data/jobs/job.py", line 89, in start
    self.result = self.run(ctx)
                  ~~~~~~~~^^^^^
  File "/home/jns/git/cloned-repos/angr-management/angrmanagement/data/jobs/cfg_generation.py", line 187, in run
    cfg = self.instance.project.analyses.CFG(
        progress_callback=functools.partial(self._progress_callback, ctx),
    ...<2 lines>...
        **self.cfg_args,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 266, in __call__
    r = w(*args, **kwargs)
  File "/home/jns/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 251, in wrapper
    oself.__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/cfg/cfg.py", line 71, in __init__
    CFGFast.__init__(self, **kwargs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/cfg/cfg_fast.py", line 902, in __init__
    self._analyze()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/forward_analysis/forward_analysis.py", line 277, in _analyze
    self._analysis_core_baremetal()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/forward_analysis/forward_analysis.py", line 400, in _analysis_core_baremetal
    self._job_queue_empty()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/cfg/cfg_fast.py", line 1790, in _job_queue_empty
    self._make_completed_functions()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/cfg/cfg_base.py", line 1584, in _make_completed_functions
    self._function_completed(func_addr)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/cfg/cfg_fast.py", line 1772, in _function_completed
    clinic = self.project.analyses.Clinic(func, mode=ClinicMode.COLLECT_DATA_REFS)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 266, in __call__
    r = w(*args, **kwargs)
  File "/home/jns/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 251, in wrapper
    oself.__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/decompiler/clinic.py", line 281, in __init__
    self._analyze_for_data_refs()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/decompiler/clinic.py", line 980, in _analyze_for_data_refs
    ail_graph = self._simplify_blocks(ail_graph, stack_pointer_tracker=spt, cache=block_simplification_cache)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/utils/timing.py", line 72, in timed_func
    return func(*args, **kwargs)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/decompiler/clinic.py", line 1582, in _simplify_blocks
    simplified = self._simplify_block(
        ail_block,
    ...<3 lines>...
        type_hints=type_hints,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/decompiler/clinic.py", line 1629, in _simplify_block
    simp = self.project.analyses.AILBlockSimplifier(
        ail_block,
    ...<8 lines>...
        type_hints=type_hints,
    )
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 266, in __call__
    r = w(*args, **kwargs)
  File "/home/jns/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 251, in wrapper
    oself.__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/decompiler/block_simplifier.py", line 126, in __init__
    self._analyze()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/decompiler/block_simplifier.py", line 143, in _analyze
    new_block = self._simplify_block_once(block)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/decompiler/block_simplifier.py", line 203, in _simplify_block_once
    propagator = self._compute_propagation(block)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/decompiler/block_simplifier.py", line 162, in _compute_propagation
    self._propagator = self.project.analyses[SPropagatorAnalysis].prep(fail_fast=self._fail_fast)(
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        subject=block,
        ^^^^^^^^^^^^^^
    ...<2 lines>...
        ail_manager=self._ail_manager,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/jns/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/analysis.py", line 251, in wrapper
    oself.__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/s_propagator.py", line 108, in __init__
    self._analyze()
    ~~~~~~~~~~~~~^^
  File "/home/jns/.cache/uv/archive-v0/b8Run-s0qmWkdujrln6xk/lib/python3.13/site-packages/angr/analyses/s_propagator.py", line 444, in _analyze
    tmp_def_stmtidx = tmp_deflocs[block_loc][tmp_atom]
                      ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: <Tmp 3>
```

This patch prevents this from happening, by checking that the Tmp atom exists before accessing it.