### PR TITLE
type: misc/plugins.py

### DIFF
--- a/angr/misc/plugins.py
+++ b/angr/misc/plugins.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from typing import TypeVar, Generic
-
-from angr.errors import AngrNoPluginError
 
 import logging
+from typing import Generic, TypeVar
+
+from angr.errors import AngrNoPluginError
 
 l = logging.getLogger(name=__name__)
 
@@ -25,27 +25,27 @@ class PluginHub(Generic[P]):
     defaults.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._active_plugins: dict[str, P] = {}
-        self._active_preset: PluginPreset | None = None
+        self._active_preset: PluginPreset[P] | None = None
         self._provided_by_preset: list[int] = []
 
     #
     #   Class methods for registration
     #
 
-    _presets: dict[str, type[P]]
+    _presets: dict[str, PluginPreset[P]]
 
     @classmethod
-    def register_default(cls, name, plugin_cls, preset="default"):
+    def register_default(cls, name: str, plugin_cls: type, preset: str = "default") -> None:
         if not hasattr(cls, "_presets") or preset not in cls._presets:
             l.error("Preset %s does not exist yet...", preset)
             return
         cls._presets[preset].add_default_plugin(name, plugin_cls)
 
     @classmethod
-    def register_preset(cls, name, preset):
+    def register_preset(cls, name: str, preset: PluginPreset[P]) -> None:
         """
         Register a preset instance with the class of the hub it corresponds to. This allows individual plugin objects to
         automatically register themselves with a preset by using a classmethod of their own with only the name of the
@@ -59,10 +59,10 @@ class PluginHub(Generic[P]):
     #   Python magic methods
     #
 
-    def __getstate__(self):
+    def __getstate__(self) -> tuple[dict[str, P], PluginPreset[P] | None, list[int]]:
         return self._active_plugins, self._active_preset, self._provided_by_preset
 
-    def __setstate__(self, s):
+    def __setstate__(self, s: tuple[dict[str, P], PluginPreset[P] | None, list[int]]) -> None:
         plugins, preset, provided = s
         self._active_preset = preset
         self._active_plugins = {}
@@ -78,10 +78,10 @@ class PluginHub(Generic[P]):
         except AngrNoPluginError as err:
             raise AttributeError(name) from err
 
-    def __dir__(self):
+    def __dir__(self) -> list[str]:
         out = set(self.__dict__)
         out.update(self._active_plugins)
-        if self.has_plugin_preset:
+        if self._active_preset is not None:
             out.update(self._active_preset.list_default_plugins())
 
         q = [type(self)]
@@ -99,7 +99,7 @@ class PluginHub(Generic[P]):
     #
 
     @property
-    def plugin_preset(self):
+    def plugin_preset(self) -> PluginPreset[P] | None:
         """
         Get the current active plugin preset
         """
@@ -112,7 +112,7 @@ class PluginHub(Generic[P]):
         """
         return self._active_preset is not None
 
-    def use_plugin_preset(self, preset):
+    def use_plugin_preset(self, preset: str | PluginPreset[P]) -> None:
         """
         Apply a preset to the hub. If there was a previously active preset, discard it.
 
@@ -120,25 +120,24 @@ class PluginHub(Generic[P]):
         """
         if isinstance(preset, str):
             try:
-                preset = self._presets[preset]
+                preset_obj = self._presets[preset]
             except (AttributeError, KeyError) as err:
                 raise AngrNoPluginError(f"There is no preset named {preset}") from err
-
-        elif not isinstance(preset, PluginPreset):
-            raise ValueError(f"Argument must be an instance of PluginPreset: {preset}")
+        else:
+            preset_obj = preset
 
         if self._active_preset:
-            l.warning("Overriding active preset %s with %s", self._active_preset, preset)
+            l.warning("Overriding active preset %s with %s", self._active_preset, preset_obj)
             self.discard_plugin_preset()
 
-        preset.activate(self)
-        self._active_preset = preset
+        preset_obj.activate(self)
+        self._active_preset = preset_obj
 
-    def discard_plugin_preset(self):
+    def discard_plugin_preset(self) -> None:
         """
         Discard the current active preset. Will release any active plugins that could have come from the old preset.
         """
-        if self.has_plugin_preset:
+        if self._active_preset is not None:
             for name, plugin in list(self._active_plugins.items()):
                 if id(plugin) in self._provided_by_preset:
                     self.release_plugin(name)
@@ -177,13 +176,13 @@ class PluginHub(Generic[P]):
         """
         return plugin_cls()
 
-    def has_plugin(self, name):
+    def has_plugin(self, name: str) -> bool:
         """
         Return whether or not a plugin with the name ``name`` is currently active.
         """
         return name in self._active_plugins
 
-    def register_plugin(self, name: str, plugin):
+    def register_plugin(self, name: str, plugin: P) -> P:
         """
         Add a new plugin ``plugin`` with name ``name`` to the active plugins.
         """
@@ -193,7 +192,7 @@ class PluginHub(Generic[P]):
         setattr(self, name, plugin)
         return plugin
 
-    def release_plugin(self, name):
+    def release_plugin(self, name: str) -> None:
         """
         Deactivate and remove the plugin with name ``name``.
         """
@@ -205,7 +204,7 @@ class PluginHub(Generic[P]):
         delattr(self, name)
 
 
-class PluginPreset:
+class PluginPreset(Generic[P]):
     """
     A plugin preset object contains a mapping from name to a plugin class.
     A preset can be active on a hub, which will cause it to handle requests for plugins which are not already present
@@ -216,32 +215,30 @@ class PluginPreset:
     an explicit reference to the preset itself.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._default_plugins: dict[str, type[P]] = {}
 
-    def activate(self, hub):  # pylint:disable=no-self-use,unused-argument
+    def activate(self, hub: PluginHub[P]) -> None:  # pylint:disable=no-self-use,unused-argument
         """
         This method is called when the preset becomes active on a hub.
         """
-        return
 
-    def deactivate(self, hub):  # pylint:disable=no-self-use,unused-argument
+    def deactivate(self, hub: PluginHub[P]) -> None:  # pylint:disable=no-self-use,unused-argument
         """
         This method is called when the preset is discarded from the hub.
         """
-        return
 
-    def add_default_plugin(self, name, plugin_cls):
+    def add_default_plugin(self, name: str, plugin_cls: type[P]) -> None:
         """
         Add a plugin to the preset.
         """
         self._default_plugins[name] = plugin_cls
 
-    def list_default_plugins(self):
+    def list_default_plugins(self) -> list[str]:
         """
         Return a list of the names of available default plugins.
         """
-        return self._default_plugins.keys()
+        return list(self._default_plugins.keys())
 
     def request_plugin(self, name: str) -> type[P]:
         """
@@ -253,7 +250,7 @@ class PluginPreset:
         except KeyError as err:
             raise AngrNoPluginError(f"There is no plugin named {name}") from err
 
-    def copy(self):
+    def copy(self) -> PluginPreset[P]:
         """
         Return a copy of self.
         """
@@ -269,13 +266,19 @@ class PluginVendor(Generic[P], PluginHub[P]):
     It will directly return the plugins provided by the preset instead of instantiating them.
     """
 
-    def release_plugin(self, name):
-        pass
+    def release_plugin(self, name: str) -> None:
+        """
+        This hub doesn't actually have any active plugins, so this is a no-op.
+        """
 
-    def register_plugin(self, name, plugin):
-        pass
+    def register_plugin(self, name: str, plugin: P) -> P:
+        """
+        This hub doesn't actually have any active plugins, so this is a no-op.
+        We just return the plugin that was passed in to satisfy the return type of PluginHub.register_plugin.
+        """
+        return plugin
 
-    def __dir__(self):
+    def __dir__(self) -> list[str]:
         x = super().__dir__()
         x.remove("release_plugin")
         x.remove("register_plugin")
@@ -283,7 +286,7 @@ class PluginVendor(Generic[P], PluginHub[P]):
         return x
 
 
-class VendorPreset(PluginPreset):
+class VendorPreset(PluginPreset[P]):
     """
     A specialized preset class for use with the PluginVendor.
     """

--- a/angr/state_plugins/plugin.py
+++ b/angr/state_plugins/plugin.py
@@ -145,12 +145,18 @@ class SimStatePlugin:
         raise NotImplementedError(f"widen() not implemented for {self.__class__.__name__}")
 
     @classmethod
-    def register_default(cls, name, xtr=None):
+    def register_default(cls, name: str, xtr: type[SimStatePlugin] | str | None = None) -> None:
         if cls is SimStatePlugin:
             if once("simstateplugin_register_default deprecation"):
                 l.critical(
                     "SimStatePlugin.register_default(name, cls) is deprecated, "
                     "please use SimState.register_default(name)"
+                )
+
+            if xtr is None or isinstance(xtr, str):
+                raise TypeError(
+                    "When calling SimStatePlugin.register_default, "
+                    "the plugin class must be provided as the second argument."
                 )
 
             from angr.sim_state import SimState
@@ -165,6 +171,11 @@ class SimStatePlugin:
                         "please use cls.register_default(name)"
                     )
                 xtr = None
+            elif not isinstance(xtr, str) and xtr is not None:
+                raise TypeError(
+                    "When calling a plugin subclass's register_default, "
+                    "the second argument must be completely omitted or a preset string."
+                )
 
             from angr.sim_state import SimState
 


### PR DESCRIPTION
I checked all the call hierarchy of `register_default` as this is the function that is called everywhere else.

The only interrogation that remained was for the `preset` argument of `register_default` : this argument is never used except in this line https://github.com/angr/angr/blob/9cd7c6cab4cd5789cf7d54ec3072fcdebaf4a306/angr/state_plugins/plugin.py#L148-L171 and this function is only called once by https://github.com/angr/angr/blob/9cd7c6cab4cd5789cf7d54ec3072fcdebaf4a306/angr/state_plugins/filesystem.py#L257 So I was not sure if I could change the signature of the function (especially if third party plugins depend on the deprecated feature (since 8 years))

When running pyright in strict mode 
```sh
$ uv run pyright angr/misc/plugins.py
      Built angr @ file:///home/jns/git/cloned-repos/angr
Uninstalled 1 package in 3ms
Installed 1 package in 3ms
0 errors, 0 warnings, 0 informations
```

Other modifications are : 
- replacing `has_preset` calls by `is not None` I can revert if you prefer the old method
- made `PluginPreset` a `Generic[P]` as I needed to use `P` in the type hints
- let ruff reorder the imports
- rename `preset` to `preset_obj` as we were using the same variable for two different things