### PR TITLE
type: state_plugins/plugin.py and misc/ux.py

### DIFF
--- a/angr/misc/ux.py
+++ b/angr/misc/ux.py
@@ -1,22 +1,30 @@
 from __future__ import annotations
+
 import warnings
+from collections.abc import Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
 
-once_set = set()
+once_set: set[str] = set()
 
 
-def once(key):
+def once(key: str) -> bool:
     if key in once_set:
         return False
     once_set.add(key)
     return True
 
 
-already_complained = set()
+already_complained: set[object] = set()
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
-def deprecated(replacement=None):
-    def outer(func):
-        def inner(*args, **kwargs):
+def deprecated(replacement: str | None = None) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def outer(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        def inner(*args: P.args, **kwargs: P.kwargs) -> R:
             if func not in already_complained:
                 if replacement is None:
                     warnings.warn(f"Don't use {func.__name__}", DeprecationWarning, stacklevel=2)

--- a/angr/state_plugins/plugin.py
+++ b/angr/state_plugins/plugin.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
+import logging
+from collections.abc import Callable, Iterable
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, cast
+
+from angr.misc.ux import once
+
+if TYPE_CHECKING:
+    from angr.sim_state import SimState
+
 # pylint: disable=import-outside-toplevel
 
-from typing import Any, Generic, ParamSpec, cast, TypeVar, Protocol
-from collections.abc import Callable
-from functools import wraps
-
-import logging
-
-import angr
-from angr.misc.ux import once
 
 l = logging.getLogger(name=__name__)
 
-T = TypeVar("T")
 S_co = TypeVar("S_co", covariant=True)
-P = ParamSpec("P")
 
 
 class _CopyFunc(Protocol, Generic[S_co]):
@@ -23,8 +23,7 @@ class _CopyFunc(Protocol, Generic[S_co]):
     Function wrapping copy method for memo tracking.
     """
 
-    @staticmethod
-    def __call__(_self: Any, memo: dict[int, Any] | None = None) -> S_co: ...
+    def __call__(self, _self: Any, memo: dict[int, Any] | None = None) -> S_co: ...
 
 
 class SimStatePlugin:
@@ -36,19 +35,19 @@ class SimStatePlugin:
 
     STRONGREF_STATE = False
 
-    def __init__(self):
-        self.state: angr.SimState = cast(angr.SimState, None)
+    def __init__(self) -> None:
+        self.state: SimState[Any, Any] = cast("SimState[Any, Any]", None)
 
-    def set_state(self, state):
+    def set_state(self, state) -> None:
         """
         Sets a new state (for example, if the state has been branched)
         """
         self.state = state._get_weakref()
 
-    def set_strongref_state(self, state):
+    def set_strongref_state(self, state) -> None:
         pass
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         d = dict(self.__dict__)
         d["state"] = None
         return d
@@ -69,12 +68,10 @@ class SimStatePlugin:
             memo[id(self)] = c
             return c
 
-        # Type-checking fails here because we can't express the `self` partial-application with a Protocol
-        # and we can't express the optional `memo` parameter without a Protocol
-        return inner  # type: ignore
+        return cast(_CopyFunc[S_co], inner)
 
     @memo
-    def copy(self, _memo):
+    def copy(self, _memo: dict[int, Any]) -> SimStatePlugin:
         """
         Should return a copy of the plugin without any state attached. Should check the memo first, and add itself to
         memo if it ends up making a new copy.
@@ -131,13 +128,13 @@ class SimStatePlugin:
         """
         raise NotImplementedError(f"merge() not implement for {self.__class__.__name__}")
 
-    def widen(self, others):  # pylint:disable=unused-argument
+    def widen(self, others: Iterable[SimStatePlugin]) -> bool:  # pylint:disable=unused-argument
         """
         The widening operation for plugins. Widening is a special kind of merging that produces a more general state
         from several more specific states. It is used only during intensive static analysis. The same behavior
         regarding copying and mutation from ``merge`` should be followed.
 
-        :param others: the other state plugin
+        :param others: the other state plugins to widen with
 
         :returns: True if the state plugin is actually widened.
         :rtype: bool
@@ -181,7 +178,7 @@ class SimStatePlugin:
 
             SimState.register_default(name, cls, xtr if xtr is not None else "default")
 
-    def init_state(self):
+    def init_state(self) -> None:
         """
         Use this function to perform any initialization on the state at plugin-add time
         """


### PR DESCRIPTION
I continued typing state_plugins/plugin.py (after #6303 ) I did not finish as the States seem quite complex, the function is called from all over the code base with many different types. 

Spent quite a lot of time trying to simplify the decorator `@memo` but did not manage to get something better, only modification is to remove the `@staticmethod` as it is less idiomatic than keeping the `self` (cf [PEP 544](https://peps.python.org/pep-0544/#callback-protocols))

Made it a separate PR so it is easier to review.

Also I did not know if I could delete the `widen` which is referenced at many places but nearly never implemented.

If this PR and the previous #6303 are merged, then developping plugins should now be easier from a IDE integration perspective.