### PR TITLE
Fix IndexError in ultra_page.py merge() and changed_bytes() due to missing page boundary checks

### DIFF
--- a/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
@@ -305,6 +305,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
                 # get the size that we can merge easily. This is the minimum of
                 # the size of all memory objects and unallocated spaces.
                 min_size = min(mo.length - (page_addr + b - mo.base) for mo, _ in memory_objects)
+                min_size = min(min_size, max(0, len(self.symbolic_bitmap) - b))
                 for um, _ in unconstrained_in:
                     for i in range(min_size):
                         if um._contains(b + i, page_addr):
@@ -368,6 +369,9 @@ class UltraPage(MemoryObjectMixin, PageBase):
             changed_candidates = self._ultra_changed_candidates(other)
 
         changes: set[int] = set()
+
+        addr_limit_len = min(len(self.symbolic_bitmap), len(other.symbolic_bitmap))
+        changed_candidates.intersection_update(range(addr_limit_len))
 
         for addr in changed_candidates:
             if self.symbolic_bitmap[addr] != other.symbolic_bitmap[addr]:


### PR DESCRIPTION
This patch may address the issues reported in #6314 and #3807

In `changed_bytes()`, candidate addresses from `changed_candidates` are first used as indices into `self.symbolic_bitmap` and `other.symbolic_bitmap` to determine whether the corresponding bytes are symbolic. However, if a candidate address itself exceeds the **page boundary** (example 0x1000), accessing the bitmap will raise an IndexError.

I found that `changed_candidates` is typically derived from `_ultra_changed_candidates()`. The root cause is that symbolic objects may span multiple pages depending on their base address and size.

Further inspection shows that for symbolic objects spanning multiple pages, each involved page maintains its own corresponding record (i.e., the object appears in the `symbolic_data` of each page it overlaps). Based on this observation, it is safe to ignore candidate addresses that fall outside the current page. This does not compromise correctness, as the portions belonging to other pages will still be handled when those pages are processed.

test:
```python
import angr
import claripy

proj = angr.Project("whilesp.exe", use_sim_procedures=True, auto_load_libs=False)

s1 = proj.factory.blank_state()
s2 = s1.copy()

BASE = 3 * 4096

sym1 = claripy.BVS("uusym1", 9 * 8, explicit_name = True)
s1.memory.store(BASE + 4094, sym1)

sym2 = claripy.BVS("uusym2", 25 * 8, explicit_name = True)
s2.memory.store(BASE + 4080, sym2)

merged, m, anything_merged = s1.merge(s2)

for i in range(30):
    off = 4078 + i
    addr = BASE + off
    pageno = int(addr / merged.memory.page_size)
    print(f"[BASE + {off}] [pageno.{pageno}]: {merged.mem[addr].uint8_t.resolved}")
```

---

In `merge()`, `min_size` is intended to determine the maximum safely mergeable length. However, it similarly ignores page boundaries. Consider the case where, after b, there exists a contiguous unconstrained region that extends up to the page boundary, and `min_size` exceeds the length of this region. In this situation, the expression `b + i` may go out of bounds, causing an IndexError inside the `_contains` check used in the loop that finalizes the value of `min_size`.

test:
```python
import angr
import claripy

proj = angr.Project("whilesp.exe", use_sim_procedures=True, auto_load_libs=False)
st1 = proj.factory.entry_state(remove_options={angr.options.SYMBOLIC_INITIAL_VALUES})
st2 = st1.copy()

umsym = claripy.BVS('umsym', 0x100 * 8, explicit_name = True)

st2.memory.store(0x40006f30, umsym)
for i in range(0x100): # i in [0x00, 0xff]
    st2.solver.add(st2.mem[0x40006f30 + i].uint8_t.resolved == i)

merged, m, anything_merged = st1.merge(st2)

for i in range(0x100): # i in [0x00, 0xff]
    validSet = set({0, i})
    assert(set(merged.solver.eval_upto(merged.mem[0x40006f30 + i].uint8_t.resolved, 10000)) == validSet)
```