### PR TITLE
fix(cfg): update function transition graph when recovering pending jobs

### DIFF
--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1071,7 +1071,13 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
                     stmt_idx=pending_job_src_exit_stmt_idx,
                     ins_addr=pending_job.src_exit_ins_addr,
                 )
-
+                self._update_function_transition_graph(
+                    pending_job_src_block_id,
+                    pending_job_key,
+                    jumpkind="Ijk_FakeRet",
+                    stmt_idx=pending_job_src_exit_stmt_idx,
+                    confirmed=True,
+                )
                 return None
 
         pending_job_state.history.jumpkind = "Ijk_FakeRet"


### PR DESCRIPTION
Currently, when CFGEmulated fails to find a return path for a function (e.g., due to obfuscation or incorrect non-returning detection), it attempts to recover the "FakeRet" edge in `_get_one_pending_job` to ensure code coverage.

However, while this recovery logic correctly adds the edge to the global `self.graph`, it fails to call `_update_function_transition_graph`. 

This results in an inconsistency where the edge exists in the global CFG but is missing from the individual `function.graph`.

This commit ensures that `_update_function_transition_graph` is invoked during the pending job recovery process, maintaining consistency between the global model and the functional representation.