### PR TITLE
Phoenix: Prefer do-while over while(true) when latch has a condition

### DIFF
--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -813,7 +813,15 @@ class PhoenixStructurer(StructurerBase):
             assert result_while is not None and result_dowhile is not None
             succ_while = result_while[-1]
             succ_dowhile = result_dowhile[-1]
-            if succ_while in self._parent_region.graph and succ_dowhile in self._parent_region.graph:
+            # Check if the while matcher would produce while(true): if the
+            # do-while's latch appears as a source in the while's outgoing
+            # edges, the latch's condition is wasted as a break.  Prefer
+            # do-while so the latch's condition becomes the loop condition.
+            dowhile_latch = result_dowhile[2]  # continue_node = latch
+            while_outgoing_srcs = {src for src, _ in result_while[1]}
+            if dowhile_latch in while_outgoing_srcs:
+                is_while = False
+            elif succ_while in self._parent_region.graph and succ_dowhile in self._parent_region.graph:
                 sorted_nodes = GraphUtils.quasi_topological_sort_nodes(
                     self._parent_region.graph, loop_heads=[self._parent_region.head]
                 )
@@ -901,15 +909,6 @@ class PhoenixStructurer(StructurerBase):
                         if graph.has_edge(src, dst):
                             graph_raw[src][dst]["cyclic_refinement_outgoing"] = True
                     else:
-                        has_continue = False
-                        # at the same time, examine if there is an edge that goes from src to the continue node. if so,
-                        # we deal with it here as well.
-                        continue_node_going_edge = src, continue_node
-                        if continue_node_going_edge in continue_edges:
-                            has_continue = True
-                            # do not remove the edge from continue_edges since we want to process them later in this
-                            # function.
-
                         # create the "break" node. in fact, we create a jump or a conditional jump, which will be
                         # rewritten to break nodes after (if possible). directly creating break nodes may lead to
                         # unwanted results, e.g., inserting a break (that's intended to break out of the loop) inside a
@@ -985,40 +984,6 @@ class PhoenixStructurer(StructurerBase):
                             )
                         new_src_block = self._copy_and_remove_last_statement_if_jump(src_block)
                         new_node = SequenceNode(src_block.addr, nodes=[new_src_block, break_node])
-                        if has_continue:
-                            assert continue_node is not None
-
-                            if continue_node.addr is not None and self.is_a_jump_target(
-                                last_src_stmt, continue_node.addr
-                            ):
-                                # instead of a conditional break node, we should insert a condition node instead
-                                break_stmt = Jump(
-                                    None,
-                                    Const(None, None, successor.addr, self.project.arch.bits),
-                                    target_idx=successor.idx if isinstance(successor, Block) else None,
-                                    ins_addr=last_src_stmt.tags["ins_addr"],
-                                )
-                                break_node = Block(last_src_stmt.tags["ins_addr"], None, statements=[break_stmt])
-                                cont_node = ContinueNode(
-                                    last_src_stmt.tags["ins_addr"],
-                                    Const(None, None, continue_node.addr, self.project.arch.bits),
-                                )
-                                cond_node = ConditionNode(
-                                    last_src_stmt.tags["ins_addr"],
-                                    None,
-                                    break_cond,
-                                    break_node,
-                                )
-                                new_node.nodes[-1] = cond_node
-                                new_node.nodes.append(cont_node)
-
-                                # we don't remove the edge (src, continue_node) from the graph or full graph. we will
-                                # process them later in this function.
-                            else:
-                                # the last statement in src_block is not the conditional jump whose one branch goes to
-                                # the loop head. it probably goes to another block that ends up going to the loop head.
-                                # we don't handle it here.
-                                pass
 
                         # we cannot modify the original src_block because loop refinement may fail and we must restore
                         # the original graph

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -597,9 +597,9 @@ class TestDecompiler(unittest.TestCase):
         assert "fflush(stdout);" in code.lower()
 
         access_count = code.count("access(")
-        assert access_count == 2, (
-            f"The decompilation should contain 2 calls to access(), but instead {access_count} calls are present."
-        )
+        assert (
+            access_count == 2
+        ), f"The decompilation should contain 2 calls to access(), but instead {access_count} calls are present."
 
         m = re.search(r"if \([\S]*access\([\S]+, [\S]+\) == -1\)", code)
         if m is None:
@@ -613,9 +613,9 @@ class TestDecompiler(unittest.TestCase):
             if "convert(" in line:
                 # the previous line must be a curly brace
                 assert i > 0
-                assert code_lines[i - 1] == "{", (
-                    "Some arguments to convert() are probably not folded into this call statement."
-                )
+                assert (
+                    code_lines[i - 1] == "{"
+                ), "Some arguments to convert() are probably not folded into this call statement."
                 break
         else:
             assert False, "Call to convert() is not found in decompilation output."
@@ -718,9 +718,9 @@ class TestDecompiler(unittest.TestCase):
         code = dec.codegen.text
         # Make sure argument a0 is correctly typed to char*
         lines = code.split("\n")
-        assert "local_strcat(char *a0, char *a1)" in lines[0], (
-            f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
-        )
+        assert (
+            "local_strcat(char *a0, char *a1)" in lines[0]
+        ), f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
 
     @for_all_structuring_algos
     def test_decompiling_strings_local_strcat_with_local_strlen(self, decompiler_options=None):
@@ -749,9 +749,9 @@ class TestDecompiler(unittest.TestCase):
         code = dec.codegen.text
         # Make sure argument a0 is correctly typed to char*
         lines = code.split("\n")
-        assert "local_strcat(char *a0, char *a1)" in lines[0], (
-            f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
-        )
+        assert (
+            "local_strcat(char *a0, char *a1)" in lines[0]
+        ), f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
 
     @for_all_structuring_algos
     def test_decompilation_call_expr_folding(self, decompiler_options=None):
@@ -772,9 +772,9 @@ class TestDecompiler(unittest.TestCase):
 
         code = dec.codegen.text
         m = re.search(r"v(\d+) = (\(.*\))?strlen\(&v(\d+)\);", code)  # e.g., s_428 = (int)strlen(&s_418);
-        assert m is not None, (
-            "The result of strlen() should be directly assigned to a stack variable because of call-expression folding."
-        )
+        assert (
+            m is not None
+        ), "The result of strlen() should be directly assigned to a stack variable because of call-expression folding."
         assert m.group(1) != m.group(2)
 
         func_1 = cfg.functions["strlen_should_not_fold"]
@@ -1565,7 +1565,6 @@ class TestDecompiler(unittest.TestCase):
         cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
 
         f = proj.kb.functions[0x403C78]
-        proj.analyses.VariableRecoveryFast(f)
         cca = proj.analyses.CallingConvention(f)
         f.prototype = cca.prototype
         f.calling_convention = cca.cc

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -597,9 +597,9 @@ class TestDecompiler(unittest.TestCase):
         assert "fflush(stdout);" in code.lower()
 
         access_count = code.count("access(")
-        assert (
-            access_count == 2
-        ), f"The decompilation should contain 2 calls to access(), but instead {access_count} calls are present."
+        assert access_count == 2, (
+            f"The decompilation should contain 2 calls to access(), but instead {access_count} calls are present."
+        )
 
         m = re.search(r"if \([\S]*access\([\S]+, [\S]+\) == -1\)", code)
         if m is None:
@@ -613,9 +613,9 @@ class TestDecompiler(unittest.TestCase):
             if "convert(" in line:
                 # the previous line must be a curly brace
                 assert i > 0
-                assert (
-                    code_lines[i - 1] == "{"
-                ), "Some arguments to convert() are probably not folded into this call statement."
+                assert code_lines[i - 1] == "{", (
+                    "Some arguments to convert() are probably not folded into this call statement."
+                )
                 break
         else:
             assert False, "Call to convert() is not found in decompilation output."
@@ -718,9 +718,9 @@ class TestDecompiler(unittest.TestCase):
         code = dec.codegen.text
         # Make sure argument a0 is correctly typed to char*
         lines = code.split("\n")
-        assert (
-            "local_strcat(char *a0, char *a1)" in lines[0]
-        ), f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
+        assert "local_strcat(char *a0, char *a1)" in lines[0], (
+            f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
+        )
 
     @for_all_structuring_algos
     def test_decompiling_strings_local_strcat_with_local_strlen(self, decompiler_options=None):
@@ -749,9 +749,9 @@ class TestDecompiler(unittest.TestCase):
         code = dec.codegen.text
         # Make sure argument a0 is correctly typed to char*
         lines = code.split("\n")
-        assert (
-            "local_strcat(char *a0, char *a1)" in lines[0]
-        ), f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
+        assert "local_strcat(char *a0, char *a1)" in lines[0], (
+            f"Argument a0 and a1 seem to be incorrectly typed: {lines[0]}"
+        )
 
     @for_all_structuring_algos
     def test_decompilation_call_expr_folding(self, decompiler_options=None):
@@ -772,9 +772,9 @@ class TestDecompiler(unittest.TestCase):
 
         code = dec.codegen.text
         m = re.search(r"v(\d+) = (\(.*\))?strlen\(&v(\d+)\);", code)  # e.g., s_428 = (int)strlen(&s_418);
-        assert (
-            m is not None
-        ), "The result of strlen() should be directly assigned to a stack variable because of call-expression folding."
+        assert m is not None, (
+            "The result of strlen() should be directly assigned to a stack variable because of call-expression folding."
+        )
         assert m.group(1) != m.group(2)
 
         func_1 = cfg.functions["strlen_should_not_fold"]

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1556,6 +1556,32 @@ class TestDecompiler(unittest.TestCase):
             r"(\w+) = __errno_location\(\);\s*error\(1, \*\(\1\), \"%s\"\);", last_lines
         )
 
+    @structuring_algo("phoenix")
+    def test_decompiling_fmt_paragraph_dowhile(self, decompiler_options=None):
+        """Test that a while(true) with two breaks to the same exit is structured as do-while with break."""
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "fmt_O0")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+
+        f = proj.kb.functions[0x403C78]
+        proj.analyses.VariableRecoveryFast(f)
+        cca = proj.analyses.CallingConvention(f)
+        f.prototype = cca.prototype
+        f.calling_convention = cca.cc
+
+        d = proj.analyses.Decompiler(f, cfg=cfg.model, options=decompiler_options)
+        assert d.codegen is not None and isinstance(d.codegen.text, str)
+
+        code = d.codegen.text
+
+        # the inner loop should be a do-while, not while(true)
+        assert "} while (" in code, "Inner loop should be structured as do-while"
+        # there should be a break inside the do-while for the mid-loop exit
+        assert "break;" in code, "do-while should contain a break for the mid-loop exit"
+        # there should be no spurious continue that makes code unreachable
+        assert "\n            continue;\n" not in code, "No spurious continue should appear in the do-while body"
+
     @for_all_structuring_algos
     def test_decompiling_fmt0_main(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "fmt_0")
@@ -5253,14 +5279,14 @@ class TestDecompiler(unittest.TestCase):
             if m is not None:
                 v1, v2 = m.groups()
                 assert v1 != v2, f"Found a redundant assignment: {line}"
-        # we expect two equivalence checks like v3[1] == 7
+        # we expect two comparisons against v3[1] and 7 (== or != depending on structuring)
         var_ids = []
         for line in lines:
-            m = re.search(r"v(\d+)\[1] == 7", line)
+            m = re.search(r"v(\d+)\[1] [!=]= 7", line)
             if m is not None:
                 var_ids.append(m.group(1))
-        assert len(var_ids) == 2, f"Expected two equivalence checks, found {len(var_ids)}: {var_ids}"
-        assert len(set(var_ids)) == 1, f"Expected the same variable in both equivalence checks, found {var_ids}"
+        assert len(var_ids) == 2, f"Expected two comparisons with [1] and 7, found {len(var_ids)}: {var_ids}"
+        assert len(set(var_ids)) == 1, f"Expected the same variable in both comparisons, found {var_ids}"
 
     def test_decompiling_fauxware_wide_scrt_release_startup_lock(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "windows", "fauxware-wide.exe")


### PR DESCRIPTION
## Summary

Two fixes in `_refine_cyclic_core`:

**Fix 1: Prefer do-while over while(true).** When both `_refine_cyclic_is_while_loop` and `_refine_cyclic_is_dowhile_loop` match, detect when the while matcher would produce `while(true)` by checking if the do-while's latch appears as a source in the while's outgoing edges. If so, the latch's condition is being wasted as a conditional break — prefer do-while so it becomes the loop condition. This turns `while(true) { ... if (cond1) break; ... if (cond2) break; }` into `do { ... if (cond1) break; ... } while (cond2);`.

**Fix 2: Remove `has_continue` special case.** This code inserted an explicit `ContinueNode` when a `ConditionalJump` had both a break edge and an edge to the continue target. It was redundant — continue edges are already handled by the continue-edges processing phase and `_rewrite_jumps_to_continues` at the schema level. Removing it also fixes a bug where do-while loops got a spurious `continue;` that made subsequent loop body code unreachable.

**Test update:** `test_decompiling_budgit_cgc_recvline` regex updated to match both `==` and `!=` comparisons, since do-while structuring converts `if (v[1] == 7) break;` into `} while (v[1] != 7);`.

## Test plan

- [x] New `test_decompiling_fmt_paragraph_dowhile` (Phoenix-only) — verifies `} while (` present, `break;` exists, no spurious `continue;`
- [x] Updated `test_decompiling_budgit_cgc_recvline` to accept do-while output
- [x] Existing decompiler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)