### PR TITLE
Add HTTP transport for angr MCP server

### DIFF
--- a/angr/mcp/__init__.py
+++ b/angr/mcp/__init__.py
@@ -11,6 +11,9 @@ Usage:
     # Run with SSE transport
     python -m angr.mcp --transport sse --port 8080
 
+    # Run with HTTP transport
+    python -m angr.mcp --transport http --host 0.0.0.0 --port 8080 --path /mcp
+
     # Programmatic usage
     from angr.mcp import create_server
     server = create_server()

--- a/angr/mcp/__main__.py
+++ b/angr/mcp/__main__.py
@@ -9,12 +9,12 @@ import sys
 from .server import mcp
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """Entry point for running the angr MCP server."""
     parser = argparse.ArgumentParser(description="angr MCP Server - Binary analysis via Model Context Protocol")
     parser.add_argument(
         "--transport",
-        choices=["stdio", "sse"],
+        choices=["stdio", "sse", "http"],
         default="stdio",
         help="Transport mechanism (default: stdio)",
     )
@@ -27,16 +27,24 @@ def main() -> None:
     parser.add_argument(
         "--host",
         default="localhost",
-        help="Host for SSE transport (default: localhost)",
+        help="Host for HTTP/SSE transport (default: localhost)",
     )
     parser.add_argument(
         "--port",
         type=int,
         default=8000,
-        help="Port for SSE transport (default: 8000)",
+        help="Port for HTTP/SSE transport (default: 8000)",
+    )
+    parser.add_argument(
+        "--path",
+        default="/mcp",
+        help="Path for HTTP transport (default: /mcp)",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    if args.transport == "http" and not args.path.startswith("/"):
+        parser.error("--path must start with '/'")
 
     # Configure logging
     logging.basicConfig(
@@ -57,6 +65,8 @@ def main() -> None:
         mcp.run(transport="stdio")
     elif args.transport == "sse":
         mcp.run(transport="sse", host=args.host, port=args.port)
+    elif args.transport == "http":
+        mcp.run(transport="http", host=args.host, port=args.port, path=args.path)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Repository = "https://github.com/angr/angr"
 angrdb = ["sqlalchemy"]
 keystone = ["keystone-engine"]
 telemetry = ["opentelemetry-api"]
-llm = ["pydantic-ai", "mcp>=1.0.0", "fastmcp"]
+llm = ["pydantic-ai", "mcp>=1.0.0", "fastmcp>=2.3.0"]
 unicorn = ["unicorn==2.1.4"]
 
 [project.scripts]

--- a/tests/mcp/test_cli.py
+++ b/tests/mcp/test_cli.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from angr.mcp import __main__ as mcp_main
+
+
+class DummyMCP:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def run(self, **kwargs: object) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        ([], {"transport": "stdio"}),
+        (
+            ["--transport", "sse", "--host", "0.0.0.0", "--port", "8123"],
+            {"transport": "sse", "host": "0.0.0.0", "port": 8123},
+        ),
+        (
+            ["--transport", "http", "--host", "0.0.0.0", "--port", "8123", "--path", "/custom"],
+            {"transport": "http", "host": "0.0.0.0", "port": 8123, "path": "/custom"},
+        ),
+    ],
+)
+def test_main_dispatches_transport(monkeypatch, argv: list[str], expected: dict[str, object]) -> None:
+    dummy_mcp = DummyMCP()
+    monkeypatch.setattr(mcp_main, "mcp", dummy_mcp)
+
+    mcp_main.main(argv)
+
+    assert dummy_mcp.calls == [expected]
+
+
+def test_http_path_must_be_absolute(monkeypatch) -> None:
+    dummy_mcp = DummyMCP()
+    monkeypatch.setattr(mcp_main, "mcp", dummy_mcp)
+
+    with pytest.raises(SystemExit) as exc_info:
+        mcp_main.main(["--transport", "http", "--path", "mcp"])
+
+    assert exc_info.value.code == 2
+    assert dummy_mcp.calls == []

--- a/tests/mcp/test_cli.py
+++ b/tests/mcp/test_cli.py
@@ -6,6 +6,8 @@ from angr.mcp import __main__ as mcp_main
 
 
 class DummyMCP:
+    """Test double for the MCP server object."""
+
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
@@ -44,4 +46,4 @@ def test_http_path_must_be_absolute(monkeypatch) -> None:
         mcp_main.main(["--transport", "http", "--path", "mcp"])
 
     assert exc_info.value.code == 2
-    assert dummy_mcp.calls == []
+    assert not dummy_mcp.calls


### PR DESCRIPTION
## Summary
- add `--transport http` to the angr MCP CLI
- pass host, port, and path through to FastMCP's Streamable HTTP transport
- document the HTTP invocation and require a FastMCP version with HTTP support
- add focused CLI dispatch coverage

## Testing
- `python -m pytest tests/mcp/test_cli.py`
- `python -m pytest tests/mcp` (77 passed)
