### PR TITLE
fix(cfg_emulated): ensure input_state and final_states are always from the same execution

### DIFF
--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1245,11 +1245,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
         # Increment tracing count for this block
         self._traced_addrs[job.call_stack_suffix][addr] += 1
 
-        if self._keep_state:
-            # TODO: if we are reusing an existing CFGNode, we will be overwriting the original input state here. we
-            # TODO: should save them all, which, unfortunately, requires some redesigning :-(
-            cfg_node.input_state = sim_successors.initial_state
-
         # See if this job cancels another FakeRet
         # This should be done regardless of whether this job should be skipped or not, otherwise edges will go missing
         # in the CFG or function transition graphs.
@@ -1296,6 +1291,11 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
             # We are good. Raise the exception and leave
             raise AngrSkipJobNotice
 
+        if self._keep_state:
+            # TODO: if we are reusing an existing CFGNode, we will be overwriting the original input state here. we
+            # TODO: should save them all, which, unfortunately, requires some redesigning :-(
+            cfg_node.input_state = sim_successors.initial_state
+        
         self._update_thumb_addrs(sim_successors, job.state)
 
         # We store the function hints first. Function hints will be checked at the end of the analysis to avoid

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -1295,7 +1295,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
             # TODO: if we are reusing an existing CFGNode, we will be overwriting the original input state here. we
             # TODO: should save them all, which, unfortunately, requires some redesigning :-(
             cfg_node.input_state = sim_successors.initial_state
-        
+
         self._update_thumb_addrs(sim_successors, job.state)
 
         # We store the function hints first. Function hints will be checked at the end of the analysis to avoid


### PR DESCRIPTION
Previously, cfg_node.input_state was assigned unconditionally in
_pre_job_handling before the should_skip check. When AngrSkipJobNotice
was raised, input_state would be overwritten with the new job's state
while final_states remained from a previous execution, causing the two
to be mismatched.

The existing TODO note acknowledges that ideally all input states across
multiple traces should be saved. This fix is a minimal step in that
direction: by moving the assignment to after the should_skip check, we
at least guarantee that input_state and final_states always come from
the same execution, even if only the last one is retained.