### PR TITLE
Fix analyses cfg cfgemulated callless ret

### DIFF
--- a/angr/engines/pcode/engine.py
+++ b/angr/engines/pcode/engine.py
@@ -217,7 +217,7 @@ class HeavyPcodeMixin(
                 exit_state.scratch.target = claripy.BVV(
                     successors.addr + self.state.scratch.irsb.size, exit_state.arch.bits
                 )
-                exit_state.history.jumpkind = "Ijk_Ret"
+                exit_state.history.jumpkind = "Ijk_FakeRet"
                 exit_state.regs.ip = exit_state.scratch.target
                 if exit_state.arch.call_pushes_ret:
                     exit_state.regs.sp = exit_state.regs.sp + exit_state.arch.bytes

--- a/angr/engines/vex/heavy/heavy.py
+++ b/angr/engines/vex/heavy/heavy.py
@@ -195,7 +195,7 @@ class HeavyVEXMixin(SuccessorsEngine, ClaripyDataMixin, SimStateStorageMixin, VE
                     exit_state.arch.ret_offset, exit_state.solver.Unconstrained("fake_ret_value", exit_state.arch.bits)
                 )
                 exit_state.scratch.target = claripy.BVV(successors.addr + irsb.size, exit_state.arch.bits)
-                exit_state.history.jumpkind = "Ijk_Ret"
+                exit_state.history.jumpkind = "Ijk_FakeRet"
                 exit_state.regs.ip = exit_state.scratch.target
                 if exit_state.arch.call_pushes_ret:
                     exit_state.regs.sp = exit_state.regs.sp + exit_state.arch.bytes

--- a/tests/analyses/cfg/test_cfgemulated.py
+++ b/tests/analyses/cfg/test_cfgemulated.py
@@ -619,6 +619,36 @@ class TestCfgemulate(unittest.TestCase):
                 f"CFG node 0x{node_addr:x} has incorrect final states."
             )
 
+    def test_callless_function_graph_consistency(self):
+        binary_path = os.path.join(test_location, "x86_64", "fauxware")
+        proj = angr.Project(binary_path, load_options={"auto_load_libs": False})
+        cfg = proj.analyses.CFGEmulated(
+            keep_state=True,
+            fail_fast=True,
+            starts=[0x400664],  # authenticate
+            state_add_options={o.CALLLESS},
+        )
+        # For each node in cfg.graph that has outgoing edges,
+        # verify that the corresponding node in function.graph also has outgoing edges.
+        # A node with successors in cfg.graph but none in function.graph indicates
+        # the bug where CALLLESS converts Ijk_Call to Ijk_Ret, causing
+        # _update_function_transition_graph to invoke _add_return_from instead of
+        # _add_fakeret_to, leaving call blocks disconnected in function.graph.
+        for cfg_node in cfg.graph.nodes():
+            cfg_out = cfg.graph.out_degree(cfg_node)
+            if cfg_out == 0:
+                continue
+            # look up the function this node belongs to
+            func = cfg.kb.functions.get_by_addr(cfg_node.function_address)
+            if func is None:
+                continue
+            # find the corresponding node in function.graph
+            func_node = next((n for n in func.graph.nodes() if n.addr == cfg_node.addr), None)
+            if func_node is None:
+                continue
+            func_out = func.graph.out_degree(func_node)
+            assert func_out > 0
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -98,6 +98,53 @@ class TestPcodeEngine(TestCase):
         assert simgr.active[0].regs.t6.concrete
         assert simgr.active[0].regs.t6.concrete_value == 1
 
+    def test_callless_function_graph_consistency(self):
+        binary_path = os.path.join(test_location, "x86_64", "fauxware")
+        proj = angr.Project(
+            binary_path,
+            load_options={"auto_load_libs": False},
+            engine=angr.engines.UberEnginePcode,
+        )
+
+        # Address 400550: ff 25 ca 0a 20 00 jmp *0x200aca(%rip) # 601020 <strcmp@GLIBC_2.2.5>
+        # This is a PLT stub. Current limitations in the P-Code engine cause it to
+        # misidentify this indirect jump as 'Ijk_Boring', leading to a disconnected
+        # function graph that creates a false negative in this test.
+        #
+        # Since the purpose of this test is specifically to verify the CALLLESS logic
+        # and not P-Code's jumpkind resolution, we manually hook this address with
+        # a SimProcedure. This bypasses the engine's parsing limitations and ensures
+        # the CALLLESS mechanism can correctly generate the expected FakeRet edge.
+        proj.hook(0x400550, angr.SimProcedure(return_value=0), length=6)
+
+        cfg = proj.analyses.CFGEmulated(
+            keep_state=True,
+            fail_fast=True,
+            starts=[0x400664],  # authenticate
+            state_add_options={angr.options.CALLLESS},
+        )
+
+        # For each node in cfg.graph that has outgoing edges,
+        # verify that the corresponding node in function.graph also has outgoing edges.
+        # A node with successors in cfg.graph but none in function.graph indicates
+        # the bug where CALLLESS converts Ijk_Call to Ijk_Ret, causing
+        # _update_function_transition_graph to invoke _add_return_from instead of
+        # _add_fakeret_to, leaving call blocks disconnected in function.graph.
+        for cfg_node in cfg.graph.nodes():
+            cfg_out = cfg.graph.out_degree(cfg_node)
+            if cfg_out == 0:
+                continue
+            # look up the function this node belongs to
+            func = cfg.kb.functions.get_by_addr(cfg_node.function_address)
+            if func is None:
+                continue
+            # find the corresponding node in function.graph
+            func_node = next((n for n in func.graph.nodes() if n.addr == cfg_node.addr), None)
+            if func_node is None:
+                continue
+            func_out = func.graph.out_degree(func_node)
+            assert func_out > 0
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Problem Description:
In the CALLLESS handling logic within angr/engines/vex/heavy/heavy.py and angr/engines/engine.py, when a successor with Ijk_Call jumpkind is encountered, the code modifies its jumpkind to Ijk_Ret to simulate the behavior of skipping the call and returning immediately.
However, Ijk_Ret in CFGEmulated's _update_function_transition_graph represents a real cross-function return, which invokes _add_return_from instead of _add_fakeret_to. This causes a divergence between em_ret.graph and function.graph:

CFGEmulate.graph remains correct because _graph_add_edge is jumpkind-agnostic and unconditionally adds the edge.
function.graph is broken because _add_return_from does not create an intra-function edge from the call block to its successor, leaving call blocks with no predecessors or successors in function.graph.

The correct jumpkind for this case is Ijk_FakeRet, which semantically means "assume this function will return, continue execution after the call site" — exactly what CALLLESS intends to do. Using Ijk_FakeRet causes _update_function_transition_graph to invoke _add_fakeret_to, which correctly builds the intra-function edge and keeps function.graph consistent with em_ret.graph.