### PR TITLE
Refactor inspect attributes to use dataclass

### DIFF
--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -2662,12 +2662,12 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
 
                 :param SimSuccessors state_: state to update registers for
                 """
-                if state_.inspect.address is None:
-                    l.error("state.inspect.address is None. It will be fixed by Yan later.")
+                if state_.inspect.attrs.address is None:
+                    l.error("state.inspect.attrs.address is None. It will be fixed by Yan later.")
                     return
 
                 if state_.registers.load(self._reg_offset).symbolic:
-                    current_run = state_.inspect.address
+                    current_run = state_.inspect.attrs.address
                     if current_run in self._info_collection and not state_.solver.symbolic(
                         self._info_collection[current_run][self._reg_offset]
                     ):

--- a/angr/analyses/cfg/indirect_jump_resolvers/constant_value_manager.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/constant_value_manager.py
@@ -45,15 +45,15 @@ class ConstantValueManager:
 
         codeloc = CodeLocation(state.scratch.bbl_addr, state.scratch.stmt_idx, ins_addr=state.scratch.ins_addr)
         if codeloc in self.mapping:
-            reg_read_offset = state.inspect.reg_read_offset
+            reg_read_offset = state.inspect.attrs.reg_read_offset
             if isinstance(reg_read_offset, claripy.ast.BV) and reg_read_offset.op == "BVV":
                 reg_read_offset = reg_read_offset.args[0]
-            variable = VEXReg(reg_read_offset, state.inspect.reg_read_length)
+            variable = VEXReg(reg_read_offset, state.inspect.attrs.reg_read_length)
             if variable in self.mapping[codeloc]:
                 v = self.mapping[codeloc][variable]
                 if isinstance(v, int):
-                    v = claripy.BVV(v, state.inspect.reg_read_length * state.arch.byte_width)
-                state.inspect.reg_read_expr = v
+                    v = claripy.BVV(v, state.inspect.attrs.reg_read_length * state.arch.byte_width)
+                state.inspect.attrs.reg_read_expr = v
 
     def _build_mapping(self):
         # constant propagation

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -616,12 +616,12 @@ class StoreHook:
 
     @staticmethod
     def hook(state):
-        write_length = state.inspect.mem_write_length
+        write_length = state.inspect.attrs.mem_write_length
         if write_length is None:
-            write_length = len(state.inspect.mem_write_expr)
+            write_length = len(state.inspect.attrs.mem_write_expr)
         else:
             write_length = write_length * state.arch.byte_width
-        state.inspect.mem_write_expr = claripy.BVS("instrumented_store", write_length)
+        state.inspect.attrs.mem_write_expr = claripy.BVS("instrumented_store", write_length)
 
 
 class LoadHook:
@@ -633,13 +633,13 @@ class LoadHook:
         self._var = None
 
     def hook_before(self, state):
-        addr = state.inspect.mem_read_address
-        size = state.solver.eval(state.inspect.mem_read_length)
+        addr = state.inspect.attrs.mem_read_address
+        size = state.solver.eval(state.inspect.attrs.mem_read_length)
         self._var = claripy.BVS("instrumented_load", size * 8)
         state.memory.store(addr, self._var, endness=state.arch.memory_endness)
 
     def hook_after(self, state):
-        state.inspect.mem_read_expr = self._var
+        state.inspect.attrs.mem_read_expr = self._var
 
 
 class PutHook:
@@ -649,8 +649,8 @@ class PutHook:
 
     @staticmethod
     def hook(state):
-        state.inspect.reg_write_expr = claripy.BVS(
-            "instrumented_put", state.solver.eval(state.inspect.reg_write_length) * 8
+        state.inspect.attrs.reg_write_expr = claripy.BVS(
+            "instrumented_put", state.solver.eval(state.inspect.attrs.reg_write_length) * 8
         )
 
 
@@ -682,8 +682,8 @@ class BSSHook:
         if not self._bss_regions:
             return
 
-        read_addr = state.inspect.mem_read_address
-        read_length = state.inspect.mem_read_length
+        read_addr = state.inspect.attrs.mem_read_address
+        read_length = state.inspect.attrs.mem_read_length
 
         if not isinstance(read_addr, int) and read_addr.symbolic:
             # don't touch it
@@ -714,16 +714,16 @@ class BSSHook:
         if not self._bss_regions:
             return
 
-        write_addr = state.inspect.mem_write_address
+        write_addr = state.inspect.attrs.mem_write_address
 
         if not isinstance(write_addr, int) and write_addr.symbolic:
             return
 
         concrete_write_addr = state.solver.eval(write_addr)
         concrete_write_length = (
-            state.solver.eval(state.inspect.mem_write_length)
-            if state.inspect.mem_write_length is not None
-            else len(state.inspect.mem_write_expr) // state.arch.byte_width
+            state.solver.eval(state.inspect.attrs.mem_write_length)
+            if state.inspect.attrs.mem_write_length is not None
+            else len(state.inspect.attrs.mem_write_expr) // state.arch.byte_width
         )
 
         for start, size in self._bss_regions:
@@ -751,16 +751,16 @@ class MIPSGPHook:
         self.gp = gp
 
     def gp_register_read_hook(self, state):
-        read_offset = state.inspect.reg_read_offset
-        read_length = state.inspect.reg_read_length
+        read_offset = state.inspect.attrs.reg_read_offset
+        read_length = state.inspect.attrs.reg_read_length
         if state.solver.eval(read_offset) == self.gp_offset and read_length == 4:
-            state.inspect.reg_read_expr = claripy.BVV(self.gp, size=32)
+            state.inspect.attrs.reg_read_expr = claripy.BVV(self.gp, size=32)
 
     def gp_register_write_hook(self, state):
-        write_offset = state.inspect.reg_write_offset
-        write_length = state.inspect.reg_write_length
+        write_offset = state.inspect.attrs.reg_write_offset
+        write_length = state.inspect.attrs.reg_write_length
         if state.solver.eval(write_offset) == self.gp_offset and write_length == 4:
-            state.inspect.reg_write_expr = claripy.BVV(self.gp, size=32)
+            state.inspect.attrs.reg_write_expr = claripy.BVV(self.gp, size=32)
 
 
 #
@@ -2154,7 +2154,7 @@ class JumpTableResolver(IndirectJumpResolver):
         reg_val = 0x13370000
 
         def bp_condition(block_addr, stmt_idx, _s):
-            return _s.scratch.bbl_addr == block_addr and _s.inspect.statement == stmt_idx
+            return _s.scratch.bbl_addr == block_addr and _s.inspect.attrs.statement == stmt_idx
 
         for block_addr, stmt_idx, reg_offset, reg_bits in regs_to_initialize:
             l.debug(
@@ -2184,17 +2184,17 @@ class JumpTableResolver(IndirectJumpResolver):
 
     def _init_registers_on_demand(self, state):
         # for uninitialized read using a register as the source address, we replace them in memory on demand
-        read_addr = state.inspect.mem_read_address
-        cond = state.inspect.mem_read_condition
+        read_addr = state.inspect.attrs.mem_read_address
+        cond = state.inspect.attrs.mem_read_condition
 
         if not isinstance(read_addr, int) and read_addr.has_annotation_type(UninitializedAnnotation) and cond is None:
             # if this AST has been initialized before, just use the cached addr
             cached_addr = self._cached_memread_addrs.get(read_addr, None)
             if cached_addr is not None:
-                state.inspect.mem_read_address = cached_addr
+                state.inspect.attrs.mem_read_address = cached_addr
                 return
 
-            read_length = state.inspect.mem_read_length
+            read_length = state.inspect.attrs.mem_read_length
             if not isinstance(read_length, int):
                 read_length = read_length.args[3]  # max
             if read_length > 16:
@@ -2209,7 +2209,7 @@ class JumpTableResolver(IndirectJumpResolver):
             # address again.
             self._cached_memread_addrs[read_addr] = new_read_addr
 
-            state.inspect.mem_read_address = new_read_addr
+            state.inspect.attrs.mem_read_address = new_read_addr
 
             # job done :-)
 

--- a/angr/analyses/identifier/runner.py
+++ b/angr/analyses/identifier/runner.py
@@ -147,7 +147,7 @@ class Runner:
     def syscall_hook(state):
         # FIXME maybe we need to fix transmit/receive to handle huge vals properly
         # kill path that try to read/write large amounts
-        syscall_name = state.inspect.syscall_name
+        syscall_name = state.inspect.attrs.syscall_name
         if syscall_name == "transmit":
             count = state.solver.eval(state.regs.edx)
             if count > 0x10000:
@@ -168,7 +168,7 @@ class Runner:
     def syscall_hook_concrete_rand(state):
         # FIXME maybe we need to fix transmit/receive to handle huge vals properly
         # kill path that try to read/write large amounts
-        syscall_name = state.inspect.syscall_name
+        syscall_name = state.inspect.attrs.syscall_name
         if syscall_name == "random":
             count = state.solver.eval(state.regs.ecx)
             if count > 100:

--- a/angr/analyses/smc.py
+++ b/angr/analyses/smc.py
@@ -39,10 +39,10 @@ class TraceClassifier:
         """
         SimInspect callback for memory writes.
         """
-        addr = state.solver.eval(state.inspect.mem_write_address)
-        length = state.inspect.mem_write_length
+        addr = state.solver.eval(state.inspect.attrs.mem_write_address)
+        length = state.inspect.attrs.mem_write_length
         if length is None:
-            length = len(state.inspect.mem_write_expr) // state.arch.byte_width
+            length = len(state.inspect.attrs.mem_write_expr) // state.arch.byte_width
         if not isinstance(length, int):
             length = state.solver.eval(length)
         self.map.add(addr, length, TraceActions.WRITE)
@@ -51,7 +51,7 @@ class TraceClassifier:
         """
         SimInspect callback for instruction execution.
         """
-        addr = state.inspect.instruction
+        addr = state.inspect.attrs.instruction
         if addr is None:
             log.warning("Symbolic addr")
             return

--- a/angr/analyses/variable_recovery/variable_recovery.py
+++ b/angr/analyses/variable_recovery/variable_recovery.py
@@ -172,15 +172,15 @@ class VariableRecoveryState(VariableRecoveryStateBase):
     #
 
     def _hook_register_read(self, state):
-        reg_read_offset = state.inspect.reg_read_offset
+        reg_read_offset = state.inspect.attrs.reg_read_offset
         if isinstance(reg_read_offset, claripy.ast.BV):
             if reg_read_offset.multivalued:
                 # Multi-valued register offsets are not supported
                 l.warning("Multi-valued register offsets are not supported.")
                 return
             reg_read_offset = state.solver.eval(reg_read_offset)
-        reg_read_length = state.inspect.reg_read_length
-        reg_read_expr = state.inspect.reg_read_expr
+        reg_read_length = state.inspect.attrs.reg_read_length
+        reg_read_expr = state.inspect.attrs.reg_read_expr
 
         if reg_read_offset == state.arch.sp_offset and reg_read_length == state.arch.bytes:
             # TODO: make sure the sp is not overwritten by something that we are not tracking
@@ -204,7 +204,7 @@ class VariableRecoveryState(VariableRecoveryStateBase):
             self.variable_manager[self.func_addr].add_variable("register", var_offset, variable)
 
     def _hook_register_write(self, state):
-        reg_write_offset = state.inspect.reg_write_offset
+        reg_write_offset = state.inspect.attrs.reg_write_offset
         if isinstance(reg_write_offset, claripy.ast.BV):
             if reg_write_offset.multivalued:
                 # Multi-valued register offsets are not supported
@@ -216,13 +216,13 @@ class VariableRecoveryState(VariableRecoveryStateBase):
             # it's updating stack pointer. skip
             return
 
-        reg_write_expr = state.inspect.reg_write_expr
+        reg_write_expr = state.inspect.attrs.reg_write_expr
         reg_write_length = len(reg_write_expr) // 8
 
         # annotate it
         # reg_write_expr = reg_write_expr.annotate(VariableSourceAnnotation.from_state(state))
 
-        state.inspect.reg_write_expr = reg_write_expr
+        state.inspect.attrs.reg_write_expr = reg_write_expr
 
         existing_vars = self.variable_manager[self.func_addr].find_variables_by_stmt(
             state.scratch.bbl_addr, state.scratch.stmt_idx, "register"
@@ -282,10 +282,10 @@ class VariableRecoveryState(VariableRecoveryStateBase):
                 self.variable_manager[self.func_addr].reference_at(var, offset, self._codeloc_from_state(state))
 
     def _hook_memory_read(self, state):
-        mem_read_address = state.inspect.mem_read_address
-        mem_read_expr = state.inspect.mem_read_expr
-        mem_read_length = state.inspect.mem_read_length
-        endness = state.inspect.mem_read_endness
+        mem_read_address = state.inspect.attrs.mem_read_address
+        mem_read_expr = state.inspect.attrs.mem_read_expr
+        mem_read_length = state.inspect.attrs.mem_read_length
+        endness = state.inspect.attrs.mem_read_endness
 
         stack_offset = self._addr_to_stack_offset(mem_read_address)
 
@@ -336,10 +336,10 @@ class VariableRecoveryState(VariableRecoveryStateBase):
                 self.variable_manager[self.func_addr].read_from(variable, offset, self._codeloc_from_state(state))
 
     def _hook_memory_write(self, state):
-        mem_write_address = state.inspect.mem_write_address
-        mem_write_expr = state.inspect.mem_write_expr
+        mem_write_address = state.inspect.attrs.mem_write_address
+        mem_write_expr = state.inspect.attrs.mem_write_expr
         mem_write_length = len(mem_write_expr) // 8
-        endness = state.inspect.mem_write_endness
+        endness = state.inspect.attrs.mem_write_endness
 
         stack_offset = self._addr_to_stack_offset(mem_write_address)
 

--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -426,16 +426,16 @@ class IcicleEngine(SuccessorsEngine):
             if not isinstance(plugin, SimStateIcicle):
                 return
             solver = state.solver
-            addr = state.inspect.mem_write_address
+            addr = state.inspect.attrs.mem_write_address
             if addr is None or solver.symbolic(addr):
                 return
             addr = solver.eval(addr, cast_to=int)
             # length is often None because `state.memory.store(addr, bvv)`
             # is called without an explicit size — fall back to the value's
             # bit width.
-            length = state.inspect.mem_write_length
+            length = state.inspect.attrs.mem_write_length
             if length is None:
-                expr = state.inspect.mem_write_expr
+                expr = state.inspect.attrs.mem_write_expr
                 if expr is None:
                     return
                 length = expr.size() // 8

--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -321,7 +321,9 @@ class SimEngineUnicorn(SuccessorsEngine):
             mem_read_val += next_val["value"]
 
         assert state.inspect.attrs.mem_read_length == mem_read_size
-        state.inspect.attrs.mem_read_address = claripy.BVV(mem_read_address, state.inspect.attrs.mem_read_address.size())
+        state.inspect.attrs.mem_read_address = claripy.BVV(
+            mem_read_address, state.inspect.attrs.mem_read_address.size()
+        )
         if mem_read_taint_map.count(-1) != mem_read_size:
             # Since read is might need bitmap adjustment, insert breakpoint to return the correct concrete value
             self.state.inspect.b(

--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -303,7 +303,7 @@ class SimEngineUnicorn(SuccessorsEngine):
         mem_read_size = 0
         mem_read_address = None
         mem_read_taint_map = []
-        while mem_read_size != state.inspect.mem_read_length and self._instr_mem_reads:
+        while mem_read_size != state.inspect.attrs.mem_read_length and self._instr_mem_reads:
             next_val = self._instr_mem_reads.pop(0)
             if not mem_read_address:
                 mem_read_address = next_val["address"]
@@ -320,8 +320,8 @@ class SimEngineUnicorn(SuccessorsEngine):
             mem_read_size += 1
             mem_read_val += next_val["value"]
 
-        assert state.inspect.mem_read_length == mem_read_size
-        state.inspect.mem_read_address = claripy.BVV(mem_read_address, state.inspect.mem_read_address.size())
+        assert state.inspect.attrs.mem_read_length == mem_read_size
+        state.inspect.attrs.mem_read_address = claripy.BVV(mem_read_address, state.inspect.attrs.mem_read_address.size())
         if mem_read_taint_map.count(-1) != mem_read_size:
             # Since read is might need bitmap adjustment, insert breakpoint to return the correct concrete value
             self.state.inspect.b(
@@ -334,16 +334,16 @@ class SimEngineUnicorn(SuccessorsEngine):
 
     def _set_correct_mem_read_val(self, state, value, taint_map):  # pylint: disable=no-self-use
         state.inspect._breakpoints["mem_read"].pop()
-        if taint_map.count(0) == state.inspect.mem_read_length:
+        if taint_map.count(0) == state.inspect.attrs.mem_read_length:
             # The value is completely concrete
             if state.arch.memory_endness == archinfo.Endness.LE:
-                state.inspect.mem_read_expr = claripy.BVV(value[::-1])
+                state.inspect.attrs.mem_read_expr = claripy.BVV(value[::-1])
             else:
-                state.inspect.mem_read_expr = claripy.BVV(value)
+                state.inspect.attrs.mem_read_expr = claripy.BVV(value)
         else:
             # The value may be partially concrete. Set the symbolic bitmap to read correct value and restore it
-            mem_read_addr = state.solver.eval(state.inspect.mem_read_address)
-            mem_read_len = state.inspect.mem_read_length
+            mem_read_addr = state.solver.eval(state.inspect.attrs.mem_read_address)
+            mem_read_len = state.inspect.attrs.mem_read_length
             saved_taints = []
             for offset in range(mem_read_len):
                 page_num, page_off = state.memory._divide_addr(mem_read_addr + offset)
@@ -384,11 +384,11 @@ class SimEngineUnicorn(SuccessorsEngine):
 
                 curr_value = claripy.Concat(*curr_value_bytes)
 
-            state.inspect.mem_read_expr = curr_value
+            state.inspect.attrs.mem_read_expr = curr_value
 
     def _save_mem_write_addrs(self, state):
-        mem_write_addr = state.solver.eval(state.inspect.mem_write_address)
-        self._instr_mem_write_addrs.update(range(mem_write_addr, mem_write_addr + state.inspect.mem_write_length))
+        mem_write_addr = state.solver.eval(state.inspect.attrs.mem_write_address)
+        self._instr_mem_write_addrs.update(range(mem_write_addr, mem_write_addr + state.inspect.attrs.mem_write_length))
 
     def process_successors(self, successors, **kwargs):
         state = self.state

--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -1054,8 +1054,8 @@ class Tracer(ExplorationTechnique):
         """
         # only grab ones that match the constrained addrs
         if cls._should_add_constraints(state):
-            addr = state.inspect.address_concretization_expr
-            result = state.inspect.address_concretization_result
+            addr = state.inspect.attrs.address_concretization_expr
+            result = state.inspect.attrs.address_concretization_result
             if result is None:
                 l.warning("addr concretization result is None")
                 return
@@ -1068,7 +1068,7 @@ class Tracer(ExplorationTechnique):
         """
         # for each constrained addrs check to see if the variables match,
         # if so keep the constraints
-        state.inspect.address_concretization_add_constraints = cls._should_add_constraints(state)
+        state.inspect.attrs.address_concretization_add_constraints = cls._should_add_constraints(state)
 
     @classmethod
     def _should_add_constraints(cls, state):
@@ -1076,7 +1076,7 @@ class Tracer(ExplorationTechnique):
         Check to see if the current address concretization variable is any of the registered
         constrained_addrs we want to allow concretization for
         """
-        expr = state.inspect.address_concretization_expr
+        expr = state.inspect.attrs.address_concretization_expr
         hit_indices = cls._to_indices(state, expr)
 
         for action in state.preconstrainer._constrained_addrs:

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -426,12 +426,9 @@ class SimState[IPTypeConc, IPTypeSym](PluginHub[SimStatePlugin]):
         if self.supports_inspect:
             self.inspect.action(*args, **kwargs)
 
-    T = TypeVar("T")
-
-    def _inspect_getattr(self, attr: str, default_value: T):
-        if self.supports_inspect and hasattr(self.inspect, attr):
-            return getattr(self.inspect, attr)
-
+    def _inspect_getattr[T](self, attr: str, default_value: T):
+        if self.supports_inspect:
+            return getattr(self.inspect.attrs, attr)
         return default_value
 
     #

--- a/angr/state_plugins/__init__.py
+++ b/angr/state_plugins/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .plugin import SimStatePlugin
 from .libc import SimStateLibc
-from .inspect import SimInspector, NO_OVERRIDE, BP_BEFORE, BP_AFTER, BP_BOTH, BP_IPDB, BP_IPYTHON
+from .inspect import InspectAttrs, SimInspector, NO_OVERRIDE, BP_BEFORE, BP_AFTER, BP_BOTH, BP_IPDB, BP_IPYTHON
 from .posix import PosixDevFS, PosixProcFS, SimSystemPosix
 from .solver import SimSolver
 from .light_registers import SimLightRegisters
@@ -39,6 +39,7 @@ __all__ = (
     "GDB",
     "NO_OVERRIDE",
     "CallStack",
+    "InspectAttrs",
     "PTChunk",
     "PTChunkIterator",
     "PosixDevFS",

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, fields
 from typing import Any
@@ -394,6 +395,30 @@ class SimInspector(SimStatePlugin):
     def set_state(self, state):
         super().set_state(state)
         state.supports_inspect = True
+
+    # Backwards compatibility: allow access to inspect attributes directly on SimInspector, but warn about it.
+
+    def __getattr__(self, item):
+        if item in inspect_attributes:
+            warnings.warn(
+                f"Accessing inspect attribute '{item}' via SimInspector is deprecated. Use state.inspect.attrs.{item} instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return getattr(self.attrs, item)
+        return super().__getattr__(item)
+
+    def __setattr__(self, key, value):
+        if key in inspect_attributes:
+            warnings.warn(
+                f"Setting inspect attribute '{key}' via SimInspector is deprecated. Use state.inspect.attrs.{key} instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            setattr(self.attrs, key, value)
+            self.action_attrs_set = True
+        else:
+            super().__setattr__(key, value)
 
 
 SimState.register_default("inspect", SimInspector)

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass, fields
 from typing import Any
 
 from angr.sim_state import SimState
@@ -39,89 +40,101 @@ event_types = {
     "memory_page_map",
 }
 
-inspect_attributes = {
+
+@dataclass
+class InspectAttrs:
+    """
+    Per-event attributes published by the inspect machinery while a breakpoint is firing.
+
+    Each field is set on the active state before any matching breakpoint is checked, then
+    cleared (back to ``None``) after the event completes. Breakpoint actions read and write
+    these fields through ``state.inspect.attrs`` to observe or override the in-flight event.
+    """
+
     # vex_lift
-    "vex_lift_addr",
-    "vex_lift_size",
-    "vex_lift_buff",
+    vex_lift_addr: Any = None
+    vex_lift_size: Any = None
+    vex_lift_buff: Any = None
     # mem_read
-    "mem_read_address",
-    "mem_read_expr",
-    "mem_read_length",
-    "mem_read_condition",
-    "mem_read_endness",
+    mem_read_address: Any = None
+    mem_read_expr: Any = None
+    mem_read_length: Any = None
+    mem_read_condition: Any = None
+    mem_read_endness: Any = None
     # mem_write
-    "mem_write_address",
-    "mem_write_expr",
-    "mem_write_length",
-    "mem_write_condition",
-    "mem_write_endness",
+    mem_write_address: Any = None
+    mem_write_expr: Any = None
+    mem_write_length: Any = None
+    mem_write_condition: Any = None
+    mem_write_endness: Any = None
     # reg_read
-    "reg_read_offset",
-    "reg_read_expr",
-    "reg_read_length",
-    "reg_read_condition",
-    "reg_read_endness",
+    reg_read_offset: Any = None
+    reg_read_expr: Any = None
+    reg_read_length: Any = None
+    reg_read_condition: Any = None
+    reg_read_endness: Any = None
     # reg_write
-    "reg_write_offset",
-    "reg_write_expr",
-    "reg_write_length",
-    "reg_write_condition",
-    "reg_write_endness",
+    reg_write_offset: Any = None
+    reg_write_expr: Any = None
+    reg_write_length: Any = None
+    reg_write_condition: Any = None
+    reg_write_endness: Any = None
     # tmp_read
-    "tmp_read_num",
-    "tmp_read_expr",
+    tmp_read_num: Any = None
+    tmp_read_expr: Any = None
     # tmp_write
-    "tmp_write_num",
-    "tmp_write_expr",
+    tmp_write_num: Any = None
+    tmp_write_expr: Any = None
     # expr
-    "expr",
-    "expr_result",
+    expr: Any = None
+    expr_result: Any = None
     # statement
-    "statement",
+    statement: Any = None
     # instruction
-    "instruction",
+    instruction: Any = None
     # irsb
-    "address",
+    address: Any = None
     # constraints
-    "added_constraints",
+    added_constraints: Any = None
     # call
-    "function_address",
+    function_address: Any = None
     # exit
-    "exit_target",
-    "exit_guard",
-    "exit_jumpkind",
-    "backtrace",  # unused?
+    exit_target: Any = None
+    exit_guard: Any = None
+    exit_jumpkind: Any = None
+    backtrace: Any = None  # unused?
     # symbolic_variable
-    "symbolic_name",
-    "symbolic_size",
-    "symbolic_expr",
+    symbolic_name: Any = None
+    symbolic_size: Any = None
+    symbolic_expr: Any = None
     # address_concretization
-    "address_concretization_strategy",
-    "address_concretization_action",
-    "address_concretization_memory",
-    "address_concretization_expr",
-    "address_concretization_result",
-    "address_concretization_add_constraints",
+    address_concretization_strategy: Any = None
+    address_concretization_action: Any = None
+    address_concretization_memory: Any = None
+    address_concretization_expr: Any = None
+    address_concretization_result: Any = None
+    address_concretization_add_constraints: Any = None
     # syscall
-    "syscall_name",
+    syscall_name: Any = None
     # simprocedure
-    "simprocedure_name",
-    "simprocedure_addr",
-    "simprocedure_result",
-    "simprocedure",
+    simprocedure_name: Any = None
+    simprocedure_addr: Any = None
+    simprocedure_result: Any = None
+    simprocedure: Any = None
     # dirty
-    "dirty_name",
-    "dirty_handler",
-    "dirty_args",
-    "dirty_result",
+    dirty_name: Any = None
+    dirty_handler: Any = None
+    dirty_args: Any = None
+    dirty_result: Any = None
     # engine_process
-    "sim_engine",
-    "sim_successors",
+    sim_engine: Any = None
+    sim_successors: Any = None
     # memory mapping
-    "mapped_page",
-    "mapped_address",
-}
+    mapped_page: Any = None
+    mapped_address: Any = None
+
+
+inspect_attributes: frozenset[str] = frozenset(f.name for f in fields(InspectAttrs))
 
 NO_OVERRIDE = object()
 
@@ -172,7 +185,7 @@ class BP:
         l.debug("... after enabled and when: %s", ok)
 
         for a in [_ for _ in self.kwargs if not _.endswith("_unique")]:
-            current_expr = getattr(state.inspect, a)
+            current_expr = getattr(state.inspect.attrs, a)
             needed = self.kwargs.get(a, None)
 
             l.debug("... checking condition %s", a)
@@ -254,17 +267,13 @@ class SimInspector(SimStatePlugin):
         self.action_attrs_set = False  # action() will set it to True if the kwargs passed in have been set as
         # attributes to self.
 
-        for i in inspect_attributes:
-            setattr(self, i, None)
-
-    def __dir__(self):
-        return sorted(set(dir(super()) + dir(inspect_attributes) + dir(self.__class__)))
+        self.attrs = InspectAttrs()
 
     def _set_inspect_attrs(self, **kwargs: dict[str, Any]) -> None:
         for k, v in kwargs.items():
             if k not in inspect_attributes:
                 raise ValueError(f"Invalid inspect attribute {k} passed in. Should be one of: {inspect_attributes}")
-            setattr(self, k, v)
+            setattr(self.attrs, k, v)
 
     def action(self, event_type: str, when: str, **kwargs: dict[str, Any]) -> None:
         """
@@ -345,7 +354,7 @@ class SimInspector(SimStatePlugin):
     def copy(self, memo):  # pylint: disable=unused-argument
         c = SimInspector()
         for i in inspect_attributes:
-            setattr(c, i, getattr(self, i))
+            setattr(c.attrs, i, getattr(self.attrs, i))
 
         for t, a in self._breakpoints.items():
             c._breakpoints[t].extend(a)
@@ -353,20 +362,18 @@ class SimInspector(SimStatePlugin):
 
     def downsize(self):
         """
-        Remove previously stored attributes from this plugin instance to save memory.
-        This method is supposed to be called by breakpoint implementors. A typical workflow looks like the following :
+        Reset event-specific attributes on this plugin instance to save memory.
+        This method is supposed to be called by breakpoint implementors. A typical workflow looks like the following:
 
-        >>> # Add `attr0` and `attr1` to `self.state.inspect`
+        >>> # Add `attr0` and `attr1` via the inspect machinery
         >>> self.state.inspect(xxxxxx, attr0=yyyy, attr1=zzzz)
         >>> # Get new attributes out of SimInspect in case they are modified by the user
-        >>> new_attr0 = self.state._inspect.attr0
-        >>> new_attr1 = self.state._inspect.attr1
-        >>> # Remove them from SimInspect
-        >>> self.state._inspect.downsize()
+        >>> new_attr0 = self.state.inspect.attrs.attr0
+        >>> new_attr1 = self.state.inspect.attrs.attr1
+        >>> # Reset them
+        >>> self.state.inspect.downsize()
         """
-        for k in inspect_attributes:
-            if hasattr(self, k):
-                setattr(self, k, None)
+        self.attrs = InspectAttrs()
 
     def _combine(self, others):
         for t in event_types:

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -180,7 +180,7 @@ class BP:
         :param when:    Whether the check is happening before or after the event.
         :return:        A boolean representing whether the checkpoint should fire.
         """
-        ok = self.enabled and (when == self.when or self.when == BP_BOTH)
+        ok = self.enabled and self.when in (when, BP_BOTH)
         if not ok:
             return ok
         l.debug("... after enabled and when: %s", ok)
@@ -401,17 +401,19 @@ class SimInspector(SimStatePlugin):
     def __getattr__(self, item):
         if item in inspect_attributes:
             warnings.warn(
-                f"Accessing inspect attribute '{item}' via SimInspector is deprecated. Use state.inspect.attrs.{item} instead.",
+                f"Accessing inspect attribute '{item}' via SimInspector is deprecated. "
+                f"Use state.inspect.attrs.{item} instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
             return getattr(self.attrs, item)
-        return super().__getattr__(item)
+        return super().__getattribute__(item)
 
     def __setattr__(self, key, value):
         if key in inspect_attributes:
             warnings.warn(
-                f"Setting inspect attribute '{key}' via SimInspector is deprecated. Use state.inspect.attrs.{key} instead.",
+                f"Setting inspect attribute '{key}' via SimInspector is deprecated. "
+                f"Use state.inspect.attrs.{key} instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/angr/state_plugins/symbolizer.py
+++ b/angr/state_plugins/symbolizer.py
@@ -59,44 +59,46 @@ class SimSymbolizer(SimStatePlugin):  # pylint:disable=abstract-method
 
     def _page_map_callback(self):
         if self._symbolize_all:
-            page_id, _ = self.state.memory._divide_addr(self.state.inspect.mapped_address)
+            page_id, _ = self.state.memory._divide_addr(self.state.inspect.attrs.mapped_address)
             self.symbolization_target_pages.add(page_id)
 
     def _mem_write_callback(self):
-        if not isinstance(self.state.inspect.mem_write_expr, int) and self.state.inspect.mem_write_expr.symbolic:
+        attrs = self.state.inspect.attrs
+        if not isinstance(attrs.mem_write_expr, int) and attrs.mem_write_expr.symbolic:
             return
-        mem_write_length = self.state.inspect.mem_write_length
+        mem_write_length = attrs.mem_write_length
         if mem_write_length is not None and not isinstance(mem_write_length, int) and mem_write_length.symbolic:
             return
 
-        # length = self.state.solver.eval_one(self.state.inspect.mem_write_length)
+        # length = self.state.solver.eval_one(attrs.mem_write_length)
         # if length != self.state.arch.bytes:
         #   return
 
-        write_expr = self.state.inspect.mem_write_expr
+        write_expr = attrs.mem_write_expr
         byte_expr = self.state.solver.eval_one(write_expr, cast_to=bytes).rjust(
             write_expr.length // self.state.arch.byte_width
         )
         replacement_expr = self._resymbolize_data(byte_expr)
         if replacement_expr is not None:
             assert replacement_expr.length == write_expr.length
-            self.state.inspect.mem_write_expr = replacement_expr
+            attrs.mem_write_expr = replacement_expr
 
     def _reg_write_callback(self):
-        if not isinstance(self.state.inspect.reg_write_expr, int) and self.state.inspect.reg_write_expr.symbolic:
+        attrs = self.state.inspect.attrs
+        if not isinstance(attrs.reg_write_expr, int) and attrs.reg_write_expr.symbolic:
             return
-        if not isinstance(self.state.inspect.reg_write_length, int) and self.state.inspect.reg_write_length.symbolic:
+        if not isinstance(attrs.reg_write_length, int) and attrs.reg_write_length.symbolic:
             return
-        if self.state.inspect.reg_write_offset == self.state.arch.ip_offset:
+        if attrs.reg_write_offset == self.state.arch.ip_offset:
             return
 
-        length = self.state.solver.eval_one(self.state.inspect.reg_write_length)
+        length = self.state.solver.eval_one(attrs.reg_write_length)
         if length != self.state.arch.bytes:
             return
 
-        expr = self.state.solver.eval_one(self.state.inspect.reg_write_expr)
+        expr = self.state.solver.eval_one(attrs.reg_write_expr)
         if self._should_symbolize(expr):
-            self.state.inspect.reg_write_expr = self._preconstrain(expr)
+            attrs.reg_write_expr = self._preconstrain(expr)
 
     def init_state(self):
         super().init_state()

--- a/angr/state_plugins/trace_additions.py
+++ b/angr/state_plugins/trace_additions.py
@@ -259,7 +259,7 @@ def exit_hook(state):
     if not state.has_plugin("chall_resp_info"):
         return
 
-    guard = state.inspect.exit_guard
+    guard = state.inspect.attrs.exit_guard
 
     # track the amount of stdout we had when a constraint was first added to a byte of stdin
     chall_resp_plugin = state.get_plugin("chall_resp_info")
@@ -277,7 +277,7 @@ def syscall_hook(state):
         return
 
     # here we detect how much stdout we have when a byte is first read in
-    syscall_name = state.inspect.syscall_name
+    syscall_name = state.inspect.attrs.syscall_name
     if syscall_name == "receive":
         # track the amount of stdout we had when we first read the byte
         stdin_min_stdout_reads = state.get_plugin("chall_resp_info").stdin_min_stdout_reads
@@ -305,7 +305,7 @@ def constraint_hook(state):
     # here we prevent adding constraints if there's a pending thing
     chall_resp_plugin = state.get_plugin("chall_resp_info")
     if chall_resp_plugin.pending_info is not None and angr.options.REPLACEMENT_SOLVER in state.options:
-        state.inspect.added_constraints = []
+        state.inspect.attrs.added_constraints = []
 
 
 class ChallRespInfo(angr.state_plugins.SimStatePlugin):
@@ -609,17 +609,17 @@ def zen_hook(state, expr):
 
 
 def zen_memory_write(state):
-    mem_write_expr = state.inspect.mem_write_expr
+    mem_write_expr = state.inspect.attrs.mem_write_expr
     new_expr = zen_hook(state, mem_write_expr)
     if new_expr is not None:
-        state.inspect.mem_write_expr = new_expr
+        state.inspect.attrs.mem_write_expr = new_expr
 
 
 def zen_register_write(state):
-    reg_write_expr = state.inspect.reg_write_expr
+    reg_write_expr = state.inspect.attrs.reg_write_expr
     new_expr = zen_hook(state, reg_write_expr)
     if new_expr is not None:
-        state.inspect.reg_write_expr = new_expr
+        state.inspect.attrs.reg_write_expr = new_expr
 
 
 class ZenPlugin(angr.state_plugins.SimStatePlugin):

--- a/docs/appendix/cheatsheet.rst
+++ b/docs/appendix/cheatsheet.rst
@@ -268,7 +268,7 @@ Set Breakpoint at every Memory read/write:
 
    new_state.inspect.b('mem_read', when=angr.BP_AFTER, action=debug_funcRead)
    def debug_funcRead(state):
-       print 'Read', state.inspect.mem_read_expr, 'from', state.inspect.mem_read_address
+       print 'Read', state.inspect.attrs.mem_read_expr, 'from', state.inspect.attrs.mem_read_address
 
 Set Breakpoint at specific Memory location:
 

--- a/docs/core-concepts/simulation.rst
+++ b/docs/core-concepts/simulation.rst
@@ -387,14 +387,14 @@ These events expose different attributes:
      - The SimSuccessors object defining the result of the engine.
 
 
-These attributes can be accessed as members of ``state.inspect`` during the
+These attributes can be accessed as members of ``state.inspect.attrs`` during the
 appropriate breakpoint callback to access the appropriate values. You can even
 modify these value to modify further uses of the values!
 
 .. code-block:: python
 
    >>> def track_reads(state):
-   ...     print('Read', state.inspect.mem_read_expr, 'from', state.inspect.mem_read_address)
+   ...     print('Read', state.inspect.attrs.mem_read_expr, 'from', state.inspect.attrs.mem_read_address)
    ...
    >>> s.inspect.b('mem_read', when=angr.BP_AFTER, action=track_reads)
 
@@ -419,7 +419,7 @@ Cool stuff! In fact, we can even specify a function as a condition:
    # this is a complex condition that could do anything! In this case, it makes sure that RAX is 0x41414141 and
    # that the basic block starting at 0x8004 was executed sometime in this path's history
    >>> def cond(state):
-   ...     return state.eval(state.regs.rax, cast_to=str) == 'AAAA' and 0x8004 in state.inspect.backtrace
+   ...     return state.eval(state.regs.rax, cast_to=str) == 'AAAA' and 0x8004 in state.inspect.attrs.backtrace
 
    >>> s.inspect.b('mem_write', condition=cond)
 

--- a/tests/state_plugins/inspect/test_inspect.py
+++ b/tests/state_plugins/inspect/test_inspect.py
@@ -237,7 +237,9 @@ class TestInspect(unittest.TestCase):
                 self.state = state
 
         def abort_unconstrained(state):
-            print(state.inspect.attrs.address_concretization_strategy, state.inspect.attrs.address_concretization_result)
+            print(
+                state.inspect.attrs.address_concretization_strategy, state.inspect.attrs.address_concretization_result
+            )
             if (
                 isinstance(
                     state.inspect.attrs.address_concretization_strategy,

--- a/tests/state_plugins/inspect/test_inspect.py
+++ b/tests/state_plugins/inspect/test_inspect.py
@@ -68,7 +68,7 @@ class TestInspect(unittest.TestCase):
             counts.instruction += 1
 
         def act_variables(state):  # pylint:disable=unused-argument
-            # print "CREATING:", state.inspect.symbolic_name
+            # print "CREATING:", state.inspect.attrs.symbolic_name
             counts.variables += 1
 
         #   def act_constraints(state): #pylint:disable=unused-argument
@@ -136,12 +136,12 @@ class TestInspect(unittest.TestCase):
 
         def handle_exit_before(state):
             counts.exit_before += 1
-            exit_target = state.inspect.exit_target
+            exit_target = state.inspect.attrs.exit_target
             assert state.solver.eval(exit_target) == 0x3F8
             # change exit target
-            state.inspect.exit_target = 0x41414141
-            assert state.inspect.exit_jumpkind == "Ijk_Boring"
-            assert state.inspect.exit_guard.is_true()
+            state.inspect.attrs.exit_target = 0x41414141
+            assert state.inspect.attrs.exit_jumpkind == "Ijk_Boring"
+            assert state.inspect.attrs.exit_guard.is_true()
 
         def handle_exit_after(state):  # pylint:disable=unused-argument
             counts.exit_after += 1
@@ -169,12 +169,12 @@ class TestInspect(unittest.TestCase):
 
         def handle_syscall_before(state):
             counts.exit_before += 1
-            syscall_name = state.inspect.syscall_name
+            syscall_name = state.inspect.attrs.syscall_name
             assert syscall_name == "close"
 
         def handle_syscall_after(state):
             counts.exit_after += 1
-            syscall_name = state.inspect.syscall_name
+            syscall_name = state.inspect.attrs.syscall_name
             assert syscall_name == "close"
 
         p = load_shellcode(b"\xc3", arch="AMD64")
@@ -205,8 +205,8 @@ class TestInspect(unittest.TestCase):
         #
 
         def change_symbolic_target(state):
-            if state.inspect.address_concretization_action == "store":
-                state.inspect.address_concretization_expr = claripy.BVV(0x1000, state.arch.bits)
+            if state.inspect.attrs.address_concretization_action == "store":
+                state.inspect.attrs.address_concretization_expr = claripy.BVV(0x1000, state.arch.bits)
 
         s = SimState(arch="AMD64")
         s.inspect.b("address_concretization", BP_BEFORE, action=change_symbolic_target)
@@ -219,7 +219,7 @@ class TestInspect(unittest.TestCase):
         #
 
         def dont_add_constraints(state):
-            state.inspect.address_concretization_add_constraints = False
+            state.inspect.attrs.address_concretization_add_constraints = False
 
         s = SimState(arch="AMD64")
         s.inspect.b("address_concretization", BP_BEFORE, action=dont_add_constraints)
@@ -237,13 +237,13 @@ class TestInspect(unittest.TestCase):
                 self.state = state
 
         def abort_unconstrained(state):
-            print(state.inspect.address_concretization_strategy, state.inspect.address_concretization_result)
+            print(state.inspect.attrs.address_concretization_strategy, state.inspect.attrs.address_concretization_result)
             if (
                 isinstance(
-                    state.inspect.address_concretization_strategy,
+                    state.inspect.attrs.address_concretization_strategy,
                     concretization_strategies.SimConcretizationStrategyRange,
                 )
-                and state.inspect.address_concretization_result is None
+                and state.inspect.attrs.address_concretization_result is None
             ):
                 raise UnconstrainedAbort("uh oh", state)
 
@@ -267,7 +267,7 @@ class TestInspect(unittest.TestCase):
         p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
 
         def check_first_symbolic_fork(state):
-            succs = state.inspect.sim_successors.successors
+            succs = state.inspect.attrs.sim_successors.successors
             succ_addr = [hex(s.addr) for s in succs]
             assert len(succ_addr) == 2
             assert "0x400692L" in succ_addr
@@ -276,7 +276,7 @@ class TestInspect(unittest.TestCase):
             print("Successors:", succ_addr)
 
         def check_second_symbolic_fork(state):
-            succs = state.inspect.sim_successors.successors
+            succs = state.inspect.attrs.sim_successors.successors
             succ_addr = [hex(s.addr) for s in succs]
             assert len(succ_addr) == 2
             assert "0x4006dfL" in succ_addr
@@ -285,14 +285,14 @@ class TestInspect(unittest.TestCase):
             print("Successors:", succ_addr)
 
         def first_symbolic_fork(state):
-            return hex(state.addr) == "0x40068eL" and isinstance(state.inspect.sim_engine, HeavyVEXMixin)
+            return hex(state.addr) == "0x40068eL" and isinstance(state.inspect.attrs.sim_engine, HeavyVEXMixin)
             # TODO: I think this latter check is meaningless with the eleventh hour refactor
 
         def second_symbolic_fork(state):
-            return hex(state.addr) == "0x4006dbL" and isinstance(state.inspect.sim_engine, HeavyVEXMixin)
+            return hex(state.addr) == "0x4006dbL" and isinstance(state.inspect.attrs.sim_engine, HeavyVEXMixin)
 
         def check_state(state):
-            assert hex(state.inspect.sim_successors.addr) in ("0x40068eL", "0x4006dbL")
+            assert hex(state.inspect.attrs.sim_successors.addr) in ("0x40068eL", "0x4006dbL")
 
         state = p.factory.entry_state(addr=p.loader.find_symbol("main").rebased_addr)
         pg = p.factory.simulation_manager(state)

--- a/tests/state_plugins/inspect/test_syscall_override.py
+++ b/tests/state_plugins/inspect/test_syscall_override.py
@@ -50,13 +50,13 @@ class TestSyscallOverride(unittest.TestCase):
         queued_syscall_returns.append(0)  # password \n input
 
         def syscall_hook(state):
-            if not state.inspect.simprocedure.is_syscall:
+            if not state.inspect.attrs.simprocedure.is_syscall:
                 return
             try:
                 f = queued_syscall_returns.pop(0)
                 if f is None:
                     return
-                state.inspect.simprocedure_result = f(state) if callable(f) else f
+                state.inspect.attrs.simprocedure_result = f(state) if callable(f) else f
             except IndexError:
                 return
 


### PR DESCRIPTION
This doesn't fully type attributes, they are still typed as `Any`. However, it separates them into a different namespace