### PR TITLE
cfg_fast: use Function._remove_fakeret (mark dirty) instead of direct transition_graph.remove_edge

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2345,8 +2345,8 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                             # Mark this edge as confirmed
                             f._confirm_fakeret(src, dst)
 
-                for edge in edges_to_remove:
-                    f.transition_graph.remove_edge(*edge)
+                for src, dst in edges_to_remove:
+                    f._remove_fakeret(src, dst)
 
                 # Clear the cache
                 f._local_transition_graph = None

--- a/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
+++ b/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring
+"""Regression test for the missing mark_dirty on fake_return cleanup.
+
+Before the fix, CFGFast._post_analysis removed unconfirmed fake_return
+edges via `f.transition_graph.remove_edge(*edge)`, bypassing the
+@dirty_func-decorated Function._remove_fakeret. If the function was
+just loaded from LMDB (so f._dirty was False) the mutation didn't
+flip the dirty flag, and the cleanup was silently lost on the next
+eviction/reload cycle through SpillingFunctionDict.
+"""
+from __future__ import annotations
+
+__package__ = __package__ or "tests.knowledge_plugins.functions"
+
+import tempfile
+import unittest
+
+import angr
+from angr.codenode import BlockNode
+from angr.knowledge_plugins.functions.function import Function
+
+
+class TestFunctionPostAnalysisDirty(unittest.TestCase):
+    def test_fakeret_cleanup_marks_dirty(self):
+        # 14-byte AMD64 block ending in a `call rel32` — the exact
+        # instruction pattern that produces unconfirmed fake_return
+        # edges to external blocks during CFGFast.
+        blob = bytes.fromhex("ffc86b060000000000e86b060001")
+        addr = 0x100077547
+        fakeret_dst_addr = addr + 14  # byte past the 5-byte call
+
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+            f.write(blob)
+            blob_path = f.name
+
+        proj = angr.Project(
+            blob_path,
+            main_opts={
+                "backend": "blob",
+                "base_addr": addr,
+                "arch": "AMD64",
+                "entry_point": addr,
+            },
+            auto_load_libs=False,
+        )
+
+        fm = proj.kb.functions
+        func = fm.function(addr=addr, create=True)
+        local_block = BlockNode(addr, 14, bytestr=blob[:14])
+        ext_block = BlockNode(fakeret_dst_addr, 4, bytestr=b"\x00" * 4)
+
+        func._register_node(True, local_block)
+        # CFGFast leaves an unconfirmed fake_return edge to an external
+        # block when the call's return target is later determined to
+        # belong to a non-returning function. Build that exact shape.
+        func.transition_graph.add_node(ext_block)
+        func.transition_graph.add_edge(
+            local_block, ext_block, type="fake_return", outside=False,
+        )
+
+        # Round-trip through the parser to set _dirty=False, mimicking
+        # a normal SpillingFunctionDict reload.
+        cmsg = func.serialize_to_cmessage()
+        loaded = Function.parse_from_cmessage(
+            cmsg, function_manager=fm, project=proj,
+        )
+        self.assertFalse(
+            loaded._dirty,
+            "test setup: parse_from_cmessage should reset _dirty=False",
+        )
+
+        # Find the fake_return edge that CFGFast._post_analysis would
+        # decide to remove. (We simulate that decision directly instead
+        # of running the full CFGFast pipeline.)
+        fakeret_edges = [
+            (s, d)
+            for s, d, data in loaded.transition_graph.edges(data=True)
+            if data.get("type") == "fake_return"
+        ]
+        self.assertEqual(len(fakeret_edges), 1)
+        src, dst = fakeret_edges[0]
+
+        # Operation under test. After the fix _post_analysis routes
+        # this through Function._remove_fakeret (@dirty_func); before
+        # the fix it was a direct graph mutation that left _dirty
+        # untouched.
+        loaded._remove_fakeret(src, dst)
+
+        self.assertTrue(
+            loaded._dirty,
+            "Function must be marked dirty after fake_return edge removal so "
+            "that SpillingFunctionDict._evict_n persists the cleanup to LMDB.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
+++ b/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
@@ -62,36 +62,21 @@ class TestFunctionPostAnalysisDirty(unittest.TestCase):
             outside=False,
         )
 
-        # Round-trip through the parser to set _dirty=False, mimicking
-        # a normal SpillingFunctionDict reload.
-        cmsg = func.serialize_to_cmessage()
-        loaded = Function.parse_from_cmessage(
-            cmsg,
-            function_manager=fm,
-            project=proj,
-        )
-        self.assertFalse(
-            loaded._dirty,
-            "test setup: parse_from_cmessage should reset _dirty=False",
-        )
-
-        # Find the fake_return edge that CFGFast._post_analysis would
-        # decide to remove. (We simulate that decision directly instead
-        # of running the full CFGFast pipeline.)
-        fakeret_edges = [
-            (s, d) for s, d, data in loaded.transition_graph.edges(data=True) if data.get("type") == "fake_return"
-        ]
-        self.assertEqual(len(fakeret_edges), 1)
-        src, dst = fakeret_edges[0]
+        # Reset _dirty to mimic a function freshly loaded from LMDB
+        # via parse_from_cmessage (which sets _dirty=False at exit).
+        # This is the state CFGFast._post_analysis encounters when a
+        # bad function was spilled then reloaded before the fakeret
+        # cleanup loop runs.
+        func._dirty = False
 
         # Operation under test. After the fix _post_analysis routes
         # this through Function._remove_fakeret (@dirty_func); before
         # the fix it was a direct graph mutation that left _dirty
         # untouched.
-        loaded._remove_fakeret(src, dst)
+        func._remove_fakeret(local_block, ext_block)
 
         self.assertTrue(
-            loaded._dirty,
+            func._dirty,
             "Function must be marked dirty after fake_return edge removal so "
             "that SpillingFunctionDict._evict_n persists the cleanup to LMDB.",
         )

--- a/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
+++ b/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
@@ -9,6 +9,7 @@ just loaded from LMDB (so f._dirty was False) the mutation didn't
 flip the dirty flag, and the cleanup was silently lost on the next
 eviction/reload cycle through SpillingFunctionDict.
 """
+
 from __future__ import annotations
 
 __package__ = __package__ or "tests.knowledge_plugins.functions"
@@ -56,14 +57,19 @@ class TestFunctionPostAnalysisDirty(unittest.TestCase):
         # belong to a non-returning function. Build that exact shape.
         func.transition_graph.add_node(ext_block)
         func.transition_graph.add_edge(
-            local_block, ext_block, type="fake_return", outside=False,
+            local_block,
+            ext_block,
+            type="fake_return",
+            outside=False,
         )
 
         # Round-trip through the parser to set _dirty=False, mimicking
         # a normal SpillingFunctionDict reload.
         cmsg = func.serialize_to_cmessage()
         loaded = Function.parse_from_cmessage(
-            cmsg, function_manager=fm, project=proj,
+            cmsg,
+            function_manager=fm,
+            project=proj,
         )
         self.assertFalse(
             loaded._dirty,
@@ -74,9 +80,7 @@ class TestFunctionPostAnalysisDirty(unittest.TestCase):
         # decide to remove. (We simulate that decision directly instead
         # of running the full CFGFast pipeline.)
         fakeret_edges = [
-            (s, d)
-            for s, d, data in loaded.transition_graph.edges(data=True)
-            if data.get("type") == "fake_return"
+            (s, d) for s, d, data in loaded.transition_graph.edges(data=True) if data.get("type") == "fake_return"
         ]
         self.assertEqual(len(fakeret_edges), 1)
         src, dst = fakeret_edges[0]

--- a/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
+++ b/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
@@ -17,7 +17,6 @@ import unittest
 
 import angr
 from angr.codenode import BlockNode
-from angr.knowledge_plugins.functions.function import Function
 
 
 class TestFunctionPostAnalysisDirty(unittest.TestCase):

--- a/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
+++ b/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
@@ -48,6 +48,7 @@ class TestFunctionPostAnalysisDirty(unittest.TestCase):
 
         fm = proj.kb.functions
         func = fm.function(addr=addr, create=True)
+        assert func is not None
         local_block = BlockNode(addr, 14, bytestr=blob[:14])
         ext_block = BlockNode(fakeret_dst_addr, 4, bytestr=b"\x00" * 4)
 

--- a/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
+++ b/tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py
@@ -12,8 +12,6 @@ eviction/reload cycle through SpillingFunctionDict.
 
 from __future__ import annotations
 
-__package__ = __package__ or "tests.knowledge_plugins.functions"
-
 import tempfile
 import unittest
 


### PR DESCRIPTION
Fixes #6414.

## Summary

`CFGFast._post_analysis`'s fake_return cleanup loop called
`f.transition_graph.remove_edge(*edge)` directly, bypassing the
`@dirty_func`-decorated `Function._remove_fakeret`. Because the
dirty flag was never set after the in-memory mutation, the cleanup
was silently lost on the next `SpillingFunctionDict` eviction-then-
reload cycle of the affected function: the eviction was "clean" so
`_save_to_lmdb` was skipped, the LMDB record kept the edge, and the
next `parse_from_cmessage` rebuild reinstated it. See #6414 for the
full sequence-of-events breakdown.

## Fix

Replace the direct `transition_graph.remove_edge` call with the
existing `_remove_fakeret` API, which already does the same
`transition_graph.remove_edge` plus the `_local_transition_graph`
cache invalidation, with `@dirty_func` wrapping it. The parallel
`f._confirm_fakeret(src, dst)` call a few lines above already uses
the Function API on the other branch of the same `if`, so this just
makes the two arms symmetric.

The post-loop `f._local_transition_graph = None` becomes redundant
(`_remove_fakeret` does it). Left in place to keep the diff minimal
and because it's harmless.

## Test

`tests/knowledge_plugins/functions/test_function_post_analysis_dirty.py`
constructs a Function with a `fake_return` edge to an external
block, round-trips it through `parse_from_cmessage` to reset
`_dirty=False` (mimicking an SFD reload), runs the equivalent of the
post-analysis cleanup (`f._remove_fakeret(src, dst)`), and asserts
the function is marked dirty afterwards.

## Compatibility

- `_remove_fakeret` is the existing Function-public API for this
  operation; no new surface.
- Behavior change: affected functions are now correctly marked dirty
  after cleanup, so `_save_to_lmdb` will write the cleaned-up state
  back. This means slightly more LMDB writes on binaries that hit
  this path, but produces deterministic output instead of
  LRU-cache-state-dependent output.
- `CFGFast` output on small binaries that fit entirely in
  `SpillingFunctionDict`'s default `cache_limit` (1000) is
  unchanged — those never round-trip through the parser, so the bug
  wasn't visible there.
