### PR TITLE
function_parser: derive fake_return is_outside from cmsg.blocks membership (defense-in-depth for #6414)

### DIFF
--- a/angr/knowledge_plugins/functions/function_parser.py
+++ b/angr/knowledge_plugins/functions/function_parser.py
@@ -354,10 +354,7 @@ class FunctionParser:
                         dst_addr,
                     )
                 else:
-                    fakeret_is_outside = (
-                        fake_ret_edge is None
-                        or fake_ret_edge[1].addr not in blocks
-                    )
+                    fakeret_is_outside = fake_ret_edge is None or fake_ret_edge[1].addr not in blocks
                     if isinstance(dst, (FuncNode, HookNode)):
                         obj._call_to(
                             src,
@@ -376,10 +373,7 @@ class FunctionParser:
                             fakeret_src,
                             fakeret_dst,
                             confirmed=fakeret_data.get("confirmed"),
-                            to_outside=(
-                                fakeret_data.get("outside", None)
-                                or fakeret_is_outside
-                            ),
+                            to_outside=(fakeret_data.get("outside", None) or fakeret_is_outside),
                             update_func_block_count=False,  # we will update the block count at the end of this function
                         )
             elif edge_type == "return":

--- a/angr/knowledge_plugins/functions/function_parser.py
+++ b/angr/knowledge_plugins/functions/function_parser.py
@@ -354,6 +354,10 @@ class FunctionParser:
                         dst_addr,
                     )
                 else:
+                    fakeret_is_outside = (
+                        fake_ret_edge is None
+                        or fake_ret_edge[1].addr not in blocks
+                    )
                     if isinstance(dst, (FuncNode, HookNode)):
                         obj._call_to(
                             src,
@@ -361,7 +365,7 @@ class FunctionParser:
                             None if fake_ret_edge is None else fake_ret_edge[1],
                             stmt_idx=stmt_idx,
                             ins_addr=ins_addr,
-                            return_to_outside=fake_ret_edge is None,
+                            return_to_outside=fakeret_is_outside,
                             syscall=edge_type == "syscall",
                             update_func_block_count=False,  # we will update the block count at the end of this function
                         )
@@ -372,7 +376,10 @@ class FunctionParser:
                             fakeret_src,
                             fakeret_dst,
                             confirmed=fakeret_data.get("confirmed"),
-                            to_outside=fakeret_data.get("outside", None),
+                            to_outside=(
+                                fakeret_data.get("outside", None)
+                                or fakeret_is_outside
+                            ),
                             update_func_block_count=False,  # we will update the block count at the end of this function
                         )
             elif edge_type == "return":

--- a/tests/knowledge_plugins/functions/test_function_parser_fakeret.py
+++ b/tests/knowledge_plugins/functions/test_function_parser_fakeret.py
@@ -19,6 +19,7 @@ outside=False but does NOT call _register_node for the to_node
 cmsg.external_blocks; the edge keeps is_outside=False; the loader
 then disagrees.
 """
+
 from __future__ import annotations
 
 __package__ = __package__ or "tests.knowledge_plugins.functions"
@@ -36,7 +37,7 @@ class TestFunctionParserFakeret(unittest.TestCase):
         blob = bytes.fromhex("ffc86b060000000000e86b060001")
         addr = 0x100077547
         fakeret_dst_addr = addr + 14
-        call_dst_addr = 0x101077bc0
+        call_dst_addr = 0x101077BC0
 
         with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
             f.write(blob)
@@ -65,14 +66,22 @@ class TestFunctionParserFakeret(unittest.TestCase):
         call_target = FuncNode(call_dst_addr)
         func.transition_graph.add_node(call_target)
         func.transition_graph.add_edge(
-            local_block, call_target,
-            type="call", outside=False, ins_addr=addr + 9, stmt_idx=None,
+            local_block,
+            call_target,
+            type="call",
+            outside=False,
+            ins_addr=addr + 9,
+            stmt_idx=None,
         )
         func.transition_graph.add_node(ext_block)
         func.transition_graph.add_edge(
-            local_block, ext_block,
-            type="fake_return", outside=False, confirmed=True,
-            ins_addr=addr + 9, stmt_idx=None,
+            local_block,
+            ext_block,
+            type="fake_return",
+            outside=False,
+            confirmed=True,
+            ins_addr=addr + 9,
+            stmt_idx=None,
         )
 
         pre = set(func._local_block_addrs)
@@ -80,10 +89,7 @@ class TestFunctionParserFakeret(unittest.TestCase):
 
         # Sanity: cmsg shape that exposes the bug.
         self.assertEqual([b.ea for b in cmsg.blocks], [addr])
-        fakeret_edges = [
-            e for e in cmsg.graph.edges
-            if e.dst_ea == fakeret_dst_addr
-        ]
+        fakeret_edges = [e for e in cmsg.graph.edges if e.dst_ea == fakeret_dst_addr]
         self.assertEqual(len(fakeret_edges), 1)
         self.assertFalse(
             bool(fakeret_edges[0].is_outside),
@@ -91,13 +97,15 @@ class TestFunctionParserFakeret(unittest.TestCase):
         )
 
         loaded = Function.parse_from_cmessage(
-            cmsg, function_manager=fm, project=proj,
+            cmsg,
+            function_manager=fm,
+            project=proj,
         )
         post = set(loaded._local_block_addrs)
         self.assertEqual(
-            pre, post,
-            f"round-trip is not idempotent: pre={sorted(hex(a) for a in pre)} "
-            f"post={sorted(hex(a) for a in post)}",
+            pre,
+            post,
+            f"round-trip is not idempotent: pre={sorted(hex(a) for a in pre)} post={sorted(hex(a) for a in post)}",
         )
 
 

--- a/tests/knowledge_plugins/functions/test_function_parser_fakeret.py
+++ b/tests/knowledge_plugins/functions/test_function_parser_fakeret.py
@@ -22,8 +22,6 @@ then disagrees.
 
 from __future__ import annotations
 
-__package__ = __package__ or "tests.knowledge_plugins.functions"
-
 import tempfile
 import unittest
 

--- a/tests/knowledge_plugins/functions/test_function_parser_fakeret.py
+++ b/tests/knowledge_plugins/functions/test_function_parser_fakeret.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring
+"""Regression test for serialize/parse round-trip non-idempotence
+when a Function has a fake_return edge whose destination is external
+(in cmsg.external_blocks at save time) but whose edge attribute
+outside=False.
+
+Before the fix, parse_from_cmessage's call-edge handler trusted the
+saved edge attribute and called _call_to(return_to_outside=False),
+which made _call_to register the destination as a local block via
+_register_node. Each roundtrip added one entry to
+_local_block_addrs.
+
+This shape arises organically when CFGFast calls
+kb.functions._add_fakeret_to(..., confirmed=None) -- the underlying
+Function._fakeret_to(confirmed=None) adds the edge with
+outside=False but does NOT call _register_node for the to_node
+(the `if confirmed:` branch is skipped). At save the dst goes to
+cmsg.external_blocks; the edge keeps is_outside=False; the loader
+then disagrees.
+"""
+from __future__ import annotations
+
+__package__ = __package__ or "tests.knowledge_plugins.functions"
+
+import tempfile
+import unittest
+
+import angr
+from angr.codenode import BlockNode, FuncNode
+from angr.knowledge_plugins.functions.function import Function
+
+
+class TestFunctionParserFakeret(unittest.TestCase):
+    def test_serialize_parse_roundtrip_with_external_fakeret(self):
+        blob = bytes.fromhex("ffc86b060000000000e86b060001")
+        addr = 0x100077547
+        fakeret_dst_addr = addr + 14
+        call_dst_addr = 0x101077bc0
+
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+            f.write(blob)
+            blob_path = f.name
+
+        proj = angr.Project(
+            blob_path,
+            main_opts={
+                "backend": "blob",
+                "base_addr": addr,
+                "arch": "AMD64",
+                "entry_point": addr,
+            },
+            auto_load_libs=False,
+        )
+
+        fm = proj.kb.functions
+        func = fm.function(addr=addr, create=True)
+        local_block = BlockNode(addr, 14, bytestr=blob[:14])
+        ext_block = BlockNode(fakeret_dst_addr, 4, bytestr=b"\x00" * 4)
+
+        func._register_node(True, local_block)
+
+        # Synthesize the call + fake_return edge pair that CFGFast can
+        # leave behind via _add_fakeret_to(confirmed=None).
+        call_target = FuncNode(call_dst_addr)
+        func.transition_graph.add_node(call_target)
+        func.transition_graph.add_edge(
+            local_block, call_target,
+            type="call", outside=False, ins_addr=addr + 9, stmt_idx=None,
+        )
+        func.transition_graph.add_node(ext_block)
+        func.transition_graph.add_edge(
+            local_block, ext_block,
+            type="fake_return", outside=False, confirmed=True,
+            ins_addr=addr + 9, stmt_idx=None,
+        )
+
+        pre = set(func._local_block_addrs)
+        cmsg = func.serialize_to_cmessage()
+
+        # Sanity: cmsg shape that exposes the bug.
+        self.assertEqual([b.ea for b in cmsg.blocks], [addr])
+        fakeret_edges = [
+            e for e in cmsg.graph.edges
+            if e.dst_ea == fakeret_dst_addr
+        ]
+        self.assertEqual(len(fakeret_edges), 1)
+        self.assertFalse(
+            bool(fakeret_edges[0].is_outside),
+            "test setup: edge must have is_outside=False",
+        )
+
+        loaded = Function.parse_from_cmessage(
+            cmsg, function_manager=fm, project=proj,
+        )
+        post = set(loaded._local_block_addrs)
+        self.assertEqual(
+            pre, post,
+            f"round-trip is not idempotent: pre={sorted(hex(a) for a in pre)} "
+            f"post={sorted(hex(a) for a in post)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge_plugins/functions/test_function_parser_fakeret.py
+++ b/tests/knowledge_plugins/functions/test_function_parser_fakeret.py
@@ -56,6 +56,7 @@ class TestFunctionParserFakeret(unittest.TestCase):
 
         fm = proj.kb.functions
         func = fm.function(addr=addr, create=True)
+        assert func is not None
         local_block = BlockNode(addr, 14, bytestr=blob[:14])
         ext_block = BlockNode(fakeret_dst_addr, 4, bytestr=b"\x00" * 4)
 


### PR DESCRIPTION
Defense-in-depth follow-up to #6416 (which fixed #6414).

## Background

#6416 fixed the primary cache-coherence bug in
`CFGFast._post_analysis`: the fake_return cleanup loop now marks the
function dirty, so the cleanup persists across `SpillingFunctionDict`
eviction/reload. With that fix, on-disk records produced by the
patched `CFGFast` no longer contain stale fake_return edges.

However, two issues remain that this PR addresses:

1. **Pre-existing LMDB records** (written by older angr / between
   eviction and the fix landing) still contain the stale fake_return
   edges. When a user loads those, the parser still hits the
   amplifier described below and produces inflated function block
   sets.

2. **Other call sites** can produce the same inconsistent state in
   memory: an edge with attribute `outside=False` whose destination
   is NOT in `_local_block_addrs`. The most direct example is
   `Function._fakeret_to(confirmed=None, to_outside=False)`, which
   adds the edge to `transition_graph` (with `outside=False`) without
   registering the destination as local (the `if confirmed:` branch
   that calls `_register_node` is skipped when `confirmed` is None).
   `FunctionManager._add_fakeret_to` is called this way from
   `CFGFast._function_add_fakeret_to`.

## The amplifier in the parser

`parse_from_cmessage`'s call-edge handler called:

```python
obj._call_to(
    src, dst,
    None if fake_ret_edge is None else fake_ret_edge[1],
    ...,
    return_to_outside=fake_ret_edge is None,
)
```

That `return_to_outside=fake_ret_edge is None` only checks edge
*existence*, not whether the destination was external at save time.
`_call_to` then calls `_register_node(is_local=return_to_outside is False, ret_node, ...)`,
which adds the fakeret target to `_local_block_addrs` as a local
block — even when the destination was serialized into
`cmsg.external_blocks` (which is the authoritative "this was external
at save time" signal).

Net effect: on every load of an affected function, the block set
grows by one. With `SpillingFunctionDict` eviction pressure this
compounds, and `CFGFast.drop_bad_functions`'s per-block heuristic
sees a larger block set on each pass.

## Fix

Derive the `return_to_outside` / `to_outside` flags from
`cmsg.blocks` membership (authoritative for what was local at save
time) rather than trusting the edge attribute.

## Test

`tests/knowledge_plugins/functions/test_function_parser_fakeret.py`:
serialize a function with the inconsistent in-memory edge shape
described above, parse it back, and assert `_local_block_addrs` is
unchanged.

## Compatibility

- No API change.
- Loader behaviour: stricter — edges saved with `is_outside=False`
  whose dst is in `cmsg.external_blocks` are now treated as outside.
  Previously the parser would expand them into local blocks. With
  #6416 landed and a clean re-save, no such records should exist
  going forward, but legacy records benefit from this fix
  immediately on load.
- Output: functions reloaded from those legacy records will now have
  the same `_local_block_addrs` they had at save time. This may
  change a downstream `drop_bad_functions` decision per affected
  function — that's the bug being fixed.
