### PR TITLE
fix - check if function is empty before applying signature matching

### DIFF
--- a/angr/analyses/flirt/flirt.py
+++ b/angr/analyses/flirt/flirt.py
@@ -152,6 +152,9 @@ class FlirtAnalysis(Analysis):
 
                     for func in funcs:
                         func: Function
+                        if not func._local_block_addrs:
+                            # empty function
+                            continue
                         if func.is_simprocedure or func.is_plt:
                             continue
                         if func.addr in self._suggestions:

--- a/angr/analyses/flirt/flirt.py
+++ b/angr/analyses/flirt/flirt.py
@@ -152,7 +152,7 @@ class FlirtAnalysis(Analysis):
 
                     for func in funcs:
                         func: Function
-                        if not func._local_block_addrs:
+                        if not func.block_addrs_set:
                             # empty function
                             continue
                         if func.is_simprocedure or func.is_plt:


### PR DESCRIPTION
While running analyses on `angr-management` tool, I have encountered an error:
```
ERROR    | 2026-05-21 13:31:43,348 | angrmanagement.logic.jobmanager | Exception while running job "Applying FLIRT signatures":
Traceback (most recent call last):
  File "/home/unex/Dev/re-fivem/.venv/lib/python3.12/site-packages/angrmanagement/logic/jobmanager.py", line 82, in execute_job
    job.start(ctx)
  File "/home/unex/Dev/re-fivem/.venv/lib/python3.12/site-packages/angrmanagement/data/jobs/job.py", line 89, in start
    self.result = self.run(ctx)
                  ^^^^^^^^^^^^^
  File "/home/unex/Dev/re-fivem/.venv/lib/python3.12/site-packages/angrmanagement/data/jobs/flirt_signature_recognition.py", line 43, in run
    self.instance.project.analyses.Flirt()
  File "/home/unex/Dev/re-fivem/.venv/lib/python3.12/site-packages/angr/analyses/analysis.py", line 264, in __call__
    r = w(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^
  File "/home/unex/Dev/re-fivem/.venv/lib/python3.12/site-packages/angr/analyses/analysis.py", line 249, in wrapper
    oself.__init__(*args, **kwargs)
  File "/home/unex/Dev/re-fivem/.venv/lib/python3.12/site-packages/angr/analyses/flirt/flirt.py", line 83, in __init__
    self._match_all_against_one_signature(sig_)
  File "/home/unex/Dev/re-fivem/.venv/lib/python3.12/site-packages/angr/analyses/flirt/flirt.py", line 169, in _match_all_against_one_signature
    max_block_addr = max(func.block_addrs_set)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: max() iterable argument is empty
```
According to the error, I dig into the source code and see no validation for function emptiness.
I don't know if this is 'really' an edge-case - maybe you have an assumption that functions are never empty before running analyses - but indeed, they can be. 