### PR TITLE
LRU cache eviction addr_type mismatch fix & better LMDB packing strategy

### DIFF
--- a/angr/knowledge_plugins/cfg/spilling_digraph.py
+++ b/angr/knowledge_plugins/cfg/spilling_digraph.py
@@ -258,7 +258,7 @@ class SpillingAdjDict(MutableMapping):
             match self.addr_type:
                 case "int":
                     key_bytes = struct.pack("<Q", dst_key[0]) + struct.pack("<H", dst_key[1])
-                
+
                 case "block_id":
                     # dst_key: CFGENODE_K
                     assert isinstance(dst_key, tuple) and len(dst_key) == 3 and isinstance(dst_key[0], BlockID)
@@ -545,7 +545,7 @@ class SpillingDiGraph(networkx.DiGraph):
         if self._adj or self._pred:
             raise ValueError("You shouldn't change addr_type once the first adjlist_outer_dict has been created.")
         self._addr_type = value
-        self._adj = self.adjlist_outer_dict_factory() # There should be a better way to do this instead
+        self._adj = self.adjlist_outer_dict_factory()  # There should be a better way to do this instead
         self._pred = self.adjlist_outer_dict_factory()
 
     #

--- a/angr/knowledge_plugins/cfg/spilling_digraph.py
+++ b/angr/knowledge_plugins/cfg/spilling_digraph.py
@@ -258,7 +258,7 @@ class SpillingAdjDict(MutableMapping):
             match self.addr_type:
                 case "int":
                     key_bytes = struct.pack("<Q", dst_key[0]) + struct.pack("<H", dst_key[1])
-
+                
                 case "block_id":
                     # dst_key: CFGENODE_K
                     assert isinstance(dst_key, tuple) and len(dst_key) == 3 and isinstance(dst_key[0], BlockID)
@@ -272,7 +272,7 @@ class SpillingAdjDict(MutableMapping):
                                 entry.has_value = True
                                 entry.value = val
                     key_bytes = (
-                        struct.pack("<I", dst_key[1]) + struct.pack("<H", dst_key[2]) + block_id.SerializeToString()
+                        struct.pack("<i", dst_key[1]) + struct.pack("<H", dst_key[2]) + block_id.SerializeToString()
                     )
 
                 case "soot":
@@ -320,11 +320,11 @@ class SpillingAdjDict(MutableMapping):
                 case "block_id":
                     if key_len <= 6:
                         raise ValueError(f"Invalid key length for block_id addr_type: {key_len}")
-                    size = struct.unpack_from("<I", key_bytes, 0)[0]
+                    size = struct.unpack_from("<i", key_bytes, 0)[0]
                     looping_times = struct.unpack_from("<H", key_bytes, 4)[0]
                     block_id = cfg_pb2.BlockIDProto()  # type:ignore
                     block_id.ParseFromString(key_bytes[6:])
-                    if block_id.HasField("callsite_tuples"):
+                    if block_id.callsite_tuples:
                         callsite_tuples = tuple(
                             entry.value if entry.has_value else None for entry in block_id.callsite_tuples
                         )
@@ -542,7 +542,11 @@ class SpillingDiGraph(networkx.DiGraph):
         # you shouldn't change addr_type once the first adjlist_outer_dict has been created.
         if value not in ("int", "block_id", "soot"):
             raise ValueError(f"Invalid addr_type {value}, must be 'int', 'block_id', or 'soot'")
+        if self._adj or self._pred:
+            raise ValueError("You shouldn't change addr_type once the first adjlist_outer_dict has been created.")
         self._addr_type = value
+        self._adj = self.adjlist_outer_dict_factory() # There should be a better way to do this instead
+        self._pred = self.adjlist_outer_dict_factory()
 
     #
     #  Spilling helpers


### PR DESCRIPTION
At first, i will talk about LMDB related issue.
1- On CFGENODE_K entries, which are tuples:
```py
def get_block_key(node: CFGNode | CFGENode) -> K:
    """
    Get the unique identifier for a CFGNode. Typically this unique identifier contains the address of the block and
    the looping_times of the block (in case there are multiple blocks with the same address, which may happen after
    loop unrolling in a CFGEmulated instance).

    :param node:    The CFGNode or CFGENode instance to get the block key for.
    :return:        The unique identifier.
    """

    if isinstance(node.addr, SootAddressDescriptor):
        return node.addr

    block_id = node.block_id
    if block_id is None:
        block_id = node.addr
    block_key = block_id, node.size if node.size is not None else -1 # <== node.size is between -1 <= sz < ...

    if isinstance(node, CFGENode):
        return *block_key, node.looping_times if node.looping_times is not None else 0
    return block_key
```
considering this piece of code, node.size can be negative, so it must be represented by a signed integer. `struct.pack("<I...` is for unsigned integers, so I replaced it with `struct.pack("<i...` instead.

2- callsite_tuples field of protobuf must be checked through `.callsite_tuples` because it's a `repeated` field. I am not expert at this context but it seems `.HasField("callsite_tuples")` check is wrong and throws an error. `.callsite_tuples` check is safe and working fine.

Now let's talk about LRU cache thing.
During my task I got a really complex error. When I've made some researchs, I've figured out that it's just because `.addr_type` field is shared with lots of subclasses of `CFGModel`, just like `SpillingCFG`, `SpillingDiGraph`, etc. but in the end of this chain, there is a mismatch because of this piece of code:
```py
class SpillingDiGraph(networkx.DiGraph):
...
    @addr_type.setter
    def addr_type(self, value: str) -> None:
        # you shouldn't change addr_type once the first adjlist_outer_dict has been created.
        if value not in ("int", "block_id", "soot"):
            raise ValueError(f"Invalid addr_type {value}, must be 'int', 'block_id', or 'soot'")
        self._addr_type = value
```

As you can see, it's not being propagated to the subclasses anymore. This causes the mismatch that I told:
```py
    def adjlist_outer_dict_factory(self) -> SpillingAdjDict:  # type:ignore
        return SpillingAdjDict(self.addr_type, self._rtdb, self._edge_cache_limit, self._edge_db_batch_size)
```
This function is called from base class of `SpillingDiGraph(networkx.DiGraph`, which is `networkx.DiGraph`, at initialization; so it doesn't get affected by the changes on `addr_type` field.
I think a solution for this problem is already found by you, there's just a reminder comment line in the beginning of the 'SpillingDiGraph._addr_type.setter` function but it seems it's not even considered:
```py
class CFGManager(KnowledgeBasePlugin):
...
    def new_model(self, prefix, addr_type: CFG_ADDR_TYPES = "int"):
        if prefix not in self.cfgs:
            model = self[prefix]
            model.addr_type = addr_type # look at this line
            return model

        # find a unique ident
        i = 0
        while True:
            ident = f"{prefix}_{i}"
            if ident not in self.cfgs:
                break
            i += 1
        model = self[ident]
        model.addr_type = addr_type # look at this line
        return model
```
`model.addr_type` changes the `addr_type` field, but indeed, it's the old one (which is `int`) on `_adj` and `_pred` fields of DiGraph instance. It's because of they are defined on initialization, so they are having the initial `addr_type` value, not the current. So my idea was updating them if there's really no touch on those fields, like what your comment line says, but I'm sure that this is not the cleanest way to do it (but works fine).