### PR TITLE
typehoon: sort primitive constraints before folding into sketches

### DIFF
--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -737,7 +737,7 @@ class SimpleSolver:
                         tvs, filtered_constraint_subset, primitive_constraints
                     )
                 tvs_with_primitive_constraints = set()
-                for primitive_constraint in primitive_constraints:
+                for primitive_constraint in sorted(primitive_constraints, key=repr):
                     tv = self._typevar_from_primitive_constraint(primitive_constraint)
                     tvs_with_primitive_constraints.add(tv)
                     assert tv is not None, f"Cannot find type variable in primitive constraint {primitive_constraint}"


### PR DESCRIPTION
## Problem

Decompiling the same function twice in the same Python process can produce different C output. The difference is small — typically a single local's inferred type flipping (e.g. `int` vs `struct UNICODE_STRING`), occasionally pulling an extra typedef into the file — but it breaks any workflow that hashes or diffs decompiler output.

The cause is in the Typehoon solver. In `simple_solver.py` around line 740:

```python
for primitive_constraint in primitive_constraints:
    tv = self._typevar_from_primitive_constraint(primitive_constraint)
    tvs_with_primitive_constraints.add(tv)
    sketches[tv].add_constraint(primitive_constraint)
```

`primitive_constraints` is a `set` of `Subtype` objects. `Subtype.__hash__` reduces to `TypeVariable.__hash__`, which is `hash((TypeVariable, self.idx))`, and `TypeVariable.idx` comes from a process-global monotonic counter in `typevars.py`. Each successive decompilation gets fresh `idx` values for the same logical typevars, which reshuffles set iteration order. `Sketch.add_constraint` folds each incoming constraint into a node's bounds via `join`/`meet`, and those operations are not order-invariant when alternative types collide on the same node.

`PYTHONHASHSEED=0` does not fix it — this is object-identity driven, not string-hash randomization.

## Fix

Sort the constraint set by `repr` before iterating it. Within a single solver invocation all typevars share the same global `idx` baseline, so the relative ordering of constraint reprs is stable.

Verified on a Windows driver reproducer: 30/30 identical decompilations across 3 fresh Python processes, vs. ~2/10 diverging before the patch.

## Scope

Smallest possible change — a one-line `sorted(..., key=repr)`. This does not address the broader root cause (global `TypeVariable` counter leaking into hashes) or other unsorted set iterations elsewhere in `simple_solver.py`; those are worth a follow-up but kept out of this PR.

No regression test included in this PR.
