### PR TITLE
typehoon: stabilize two more order-sensitive set iterations in SimpleSolver

### DIFF
--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -773,7 +773,8 @@ class SimpleSolver:
                 constraint_subset = self._filter_constraints(new_constraint_subset)
 
         # set the solution for missing type vars to TOP
-        self.determine(sketches, set(sketches).difference(set(self.solution)), equiv_classes, self.solution)
+        pending = sorted(set(sketches).difference(set(self.solution)), key=repr)
+        self.determine(sketches, pending, equiv_classes, self.solution)
 
         # set solutions for non-representative type variables
         for tv, reptv in equiv_classes.items():
@@ -1089,12 +1090,11 @@ class SimpleSolver:
             elif not isinstance(cls1, (DerivedTypeVariable, TypeConstant)):
                 rep_cls = cls1
             else:
-                rep_cls = next(
-                    iter(
-                        elem for elem in existing_elements if not isinstance(elem, (DerivedTypeVariable, TypeConstant))
-                    ),
-                    cls0,
+                candidates = sorted(
+                    (elem for elem in existing_elements if not isinstance(elem, (DerivedTypeVariable, TypeConstant))),
+                    key=repr,
                 )
+                rep_cls = candidates[0] if candidates else cls0
             for elem in existing_elements:
                 equivalence_classes[elem] = rep_cls
             # the logic below refers to the retypd reference implementation. it is different from Algorithm E.1


### PR DESCRIPTION
Follow-up to #6438. Two more places in `simple_solver.py` where iteration over a set leaks process-global `TypeVariable.idx` values into the solver's output.

## 1. Equivalence-class representative selection (line ~1092)

```python
rep_cls = next(
    iter(
        elem for elem in existing_elements if not isinstance(elem, (DerivedTypeVariable, TypeConstant))
    ),
    cls0,
)
```

`existing_elements` is a `set` of typevars whose hashes depend on the global `TypeVariable` counter. `next(iter(...))` picks an arbitrary element and elevates it to the equivalence class representative, which then becomes a dict key used downstream. Different decompilations of the same function in the same process can pick different representatives.

Fix: sort candidates by `repr` and take the first.

```python
candidates = sorted(
    (elem for elem in existing_elements if not isinstance(elem, (DerivedTypeVariable, TypeConstant))),
    key=repr,
)
rep_cls = candidates[0] if candidates else cls0
```

## 2. `determine(...)` over remaining sketches (line ~776)

```python
self.determine(sketches, set(sketches).difference(set(self.solution)), equiv_classes, self.solution)
```

`determine` iterates its `tvs` argument and mutates `self.solution` per typevar. The post-loop fixup at lines 1897–1899 propagates equivalence-class solutions back, so the order in which pending typevars are resolved can affect the final solution.

Fix: sort before passing.

```python
pending = sorted(set(sketches).difference(set(self.solution)), key=repr)
self.determine(sketches, pending, equiv_classes, self.solution)
```

## Scope

These are mechanical, narrowly scoped sorts using `repr` as the key — the same approach as #6438. Together with #6438 they close the three set-iteration sites identified as direct causes of decompiler output nondeterminism in the Typehoon solver.

Two additional latent sites (the `constraintset2tvs` insertion order at ~685 and the `sketches` dict construction at ~793) sort by `lambda x: x.idx` already or are dict-key-ordered; while their input ordering is also process-global-dependent in spirit, they were not observed to leak into output in the repro and are left for a separate PR.

No regression test in this PR.
