### PR TITLE
Clinic: Implement type joining in callee prototype constraining.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -66,6 +66,7 @@ from angr.procedures.stubs.UnresolvableJumpTarget import UnresolvableJumpTarget
 from angr.analyses import Analysis, register_analysis
 from angr.analyses.cfg.cfg_base import CFGBase
 from angr.analyses.typehoon import Typehoon
+from angr.analyses.typehoon.simple_solver import SimpleSolver
 from angr.analyses.s_liveness import SLivenessAnalysis
 from angr.ailment.expression import Struct, Array, RustEnum, Let, FunctionLikeMacro
 from .ail_simplifier import AILSimplifier
@@ -229,6 +230,7 @@ class Clinic(Analysis):
         static_vvars: dict | None = None,
         static_buffers: dict | None = None,
         flatten_args=False,
+        constrain_callee_prototypes: bool = False,
         semvar_naming: bool = True,
         flavor: str = "pseudocode",
     ):
@@ -318,6 +320,8 @@ class Clinic(Analysis):
         self.edges_to_remove: list[tuple[ailment.Address, ailment.Address]] = []
         self.copied_var_ids: set[int] = set()
 
+        self._constrain_callee_prototypes = constrain_callee_prototypes
+
         self._new_block_addrs: set[int] = set()
 
         # a reference to the Typehoon type inference engine; useful for debugging and loading stats post decompilation
@@ -341,8 +345,12 @@ class Clinic(Analysis):
 
         if self._mode == ClinicMode.DECOMPILE:
             self._analyze_for_decompiling()
-            if self._end_stage >= ClinicStage.MAKE_CALLSITES and self.variable_kb is not None:
-                self._constrain_callee_prototypes()
+            if (
+                self._end_stage >= ClinicStage.MAKE_CALLSITES
+                and self.variable_kb is not None
+                and self._constrain_callee_prototypes
+            ):
+                self.constrain_callee_prototypes()
         elif self._mode == ClinicMode.COLLECT_DATA_REFS:
             self._analyze_for_data_refs()
         else:
@@ -3922,7 +3930,23 @@ class Clinic(Analysis):
 
         return dict(func_proto_candidates)
 
-    def _constrain_callee_prototypes(self):
+    @staticmethod
+    def _flatten_pointer_to_array(ty: SimType) -> SimType:
+        """
+        Convert a pointer-to-array type (``type[N]*``) into a plain pointer type (``type*``). This normalizes argument
+        types observed at call sites so that pointers to arrays of different lengths can be joined together.
+        """
+        if isinstance(ty, SimTypePointer) and isinstance(ty.pts_to, SimTypeArray):
+            return SimTypePointer(ty.pts_to.elem_type)
+        return ty
+
+    def constrain_callee_prototypes(self):
+        """
+        Constrain the types of callee function arguments based on facts that are observed at call sites. Note that this
+        function will change the prototypes of (callee) functions in the knowledge base, which means it may affect
+        the decompilation output of the current function if it is decompiled again.
+        """
+
         func_proto_candidates = self._collect_callsite_prototypes()
 
         default_arg_type = SimTypeLongLong if self.project.arch.bits == 64 else SimTypeInt
@@ -3949,13 +3973,21 @@ class Clinic(Analysis):
                 ]
                 if not all_args:
                     continue
-                # TODO: Implement a better logic to find the precise type
-                precise_types = []
-                for a in all_args:
-                    if isinstance(a, (SimTypePointer, SimStruct, SimTypeArray, SimCppClass)):
-                        precise_types.append(a)
-                if len(precise_types) == 1:
-                    arg_result[arg_i] = precise_types[0]
+                # Among the observed argument types, keep the precise (informative) ones and merge them by computing
+                # their join on the type lattice. A single precise type joins to itself; multiple precise types are
+                # merged into their least general common supertype. We ignore the result when the join degrades to a
+                # bottom type, i.e., the observations have no meaningful common supertype.
+                precise_types = [
+                    self._flatten_pointer_to_array(a).with_arch(self.project.arch)
+                    for a in all_args
+                    if isinstance(a, (SimTypePointer, SimStruct, SimTypeArray, SimCppClass))
+                ]
+                if precise_types:
+                    joined = precise_types[0]
+                    for a in precise_types[1:]:
+                        joined = SimpleSolver.join_simtypes(joined, a, self.project.arch)
+                    if not isinstance(joined, SimTypeBottom):
+                        arg_result[arg_i] = joined
 
             if arg_result:
                 # build a new function prototype

--- a/angr/analyses/decompiler/decompilation_options.py
+++ b/angr/analyses/decompiler/decompilation_options.py
@@ -322,6 +322,20 @@ options = [
         default_value=False,
         clears_cache=False,
     ),
+    O(
+        "Constrain and improve callee function prototypes based on call site information",
+        "When enabled, the decompiler will analyze call sites and constrain the types of callee function arguments "
+        "based on facts observed at the call sites. This may improve the accuracy of callee function prototypes and "
+        "consequently enhance the decompilation output of the current function. Note that enabling this option may "
+        "change the prototypes of callee functions in the knowledge base, which could affect subsequent decompilation "
+        "results.",
+        bool,
+        "clinic",
+        "constrain_callee_prototypes",
+        category="Types",
+        default_value=True,
+        clears_cache=True,
+    ),
 ]
 
 # NOTE: if you add a codegen option here, please add it to reapply_options

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -1,5 +1,6 @@
 # pylint:disable=missing-class-docstring,too-many-boolean-expressions
 from __future__ import annotations
+from typing import TYPE_CHECKING
 import enum
 from collections import defaultdict
 from contextlib import suppress
@@ -66,6 +67,11 @@ from .typeconsts import (
 )
 from .variance import Variance
 from .dfa import DFAConstraintSolver, EmptyEpsilonNFAError
+
+if TYPE_CHECKING:
+    import archinfo
+
+    from angr.sim_type import SimType
 
 _l = logging.getLogger(__name__)
 
@@ -216,6 +222,16 @@ BASE_LATTICES = {
     32: BASE_LATTICE_32,
     64: BASE_LATTICE_64,
 }
+
+
+def _invert_lattice(lattice: networkx.DiGraph) -> networkx.DiGraph:
+    inverted = networkx.DiGraph()
+    for src, dst in lattice.edges:
+        inverted.add_edge(dst, src)
+    return inverted
+
+
+BASE_LATTICES_INVERTED = {bits: _invert_lattice(lattice) for bits, lattice in BASE_LATTICES.items()}
 
 
 #
@@ -1792,11 +1808,26 @@ class SimpleSolver:
     # Type lattice
     #
 
-    def join(self, t1: TypeConstant | TypeVariable, t2: TypeConstant | TypeVariable) -> TypeConstant:
-        abstract_t1 = self.abstract(t1)
-        abstract_t2 = self.abstract(t2)
-        if abstract_t1 in self._base_lattice and abstract_t2 in self._base_lattice:
-            ancestor = networkx.lowest_common_ancestor(self._base_lattice, abstract_t1, abstract_t2)
+    @staticmethod
+    def _lattice_op(
+        t1: TypeConstant,
+        t2: TypeConstant,
+        lattice: networkx.DiGraph,
+        unit: TypeConstant,
+    ) -> TypeConstant:
+        """
+        The shared core of :meth:`join` and :meth:`meet`. Walk ``lattice`` to find the lowest common ancestor of the
+        two (abstracted) type constants.
+
+        :param lattice: The lattice to walk: the base lattice for join, or the inverted base lattice for meet.
+        :param unit:    The unit element of the operation: ``BottomType`` for join and ``TopType`` for meet. It acts as
+                        the identity element and is returned when the two types have no common ancestor in the lattice.
+        """
+
+        abstract_t1 = SimpleSolver.abstract(t1)
+        abstract_t2 = SimpleSolver.abstract(t2)
+        if abstract_t1 in lattice and abstract_t2 in lattice:
+            ancestor = networkx.lowest_common_ancestor(lattice, abstract_t1, abstract_t2)
 
             if (
                 isinstance(ancestor, Pointer)
@@ -1805,7 +1836,7 @@ class SimpleSolver:
                 and isinstance(t1, Pointer)
                 and isinstance(t2, Pointer)
             ):
-                return ancestor.__class__(self.join(t1.basetype, t2.basetype))
+                return ancestor.__class__(SimpleSolver._lattice_op(t1.basetype, t2.basetype, lattice, unit))  # type: ignore
 
             if ancestor == abstract_t1:
                 return t1
@@ -1814,39 +1845,62 @@ class SimpleSolver:
             return ancestor
         if isinstance(abstract_t1, Struct) and isinstance(abstract_t2, Struct) and abstract_t1 == abstract_t2:
             return t1
-        if t1 == Bottom_:
+        if t1 == unit:
             return t2
-        if t2 == Bottom_:
+        if t2 == unit:
             return t1
-        return Bottom_
+        return unit
 
-    def meet(self, t1: TypeConstant | TypeVariable, t2: TypeConstant | TypeVariable) -> TypeConstant:
-        abstract_t1 = self.abstract(t1)
-        abstract_t2 = self.abstract(t2)
-        if abstract_t1 in self._base_lattice_inverted and abstract_t2 in self._base_lattice_inverted:
-            ancestor = networkx.lowest_common_ancestor(self._base_lattice_inverted, abstract_t1, abstract_t2)
+    def join(self, t1: TypeConstant, t2: TypeConstant) -> TypeConstant:
+        return self._lattice_op(t1, t2, self._base_lattice, Bottom_)
 
-            if (
-                isinstance(ancestor, Pointer)
-                and isinstance(abstract_t1, Pointer)
-                and isinstance(abstract_t2, Pointer)
-                and isinstance(t1, Pointer)
-                and isinstance(t2, Pointer)
-            ):
-                return ancestor.__class__(self.meet(t1.basetype, t2.basetype))
+    def meet(self, t1: TypeConstant, t2: TypeConstant) -> TypeConstant:
+        return self._lattice_op(t1, t2, self._base_lattice_inverted, Top_)
 
-            if ancestor == abstract_t1:
-                return t1
-            if ancestor == abstract_t2:
-                return t2
-            return ancestor
-        if isinstance(abstract_t1, Struct) and isinstance(abstract_t2, Struct) and abstract_t1 == abstract_t2:
-            return t1
-        if t1 == Top_:
-            return t2
-        if t2 == Top_:
-            return t1
-        return Top_
+    @classmethod
+    def join_simtypes(cls, t1: SimType, t2: SimType, arch: archinfo.Arch) -> SimType:
+        """
+        Compute the join (the least general common supertype) of two SimTypes on the type lattice.
+
+        The two types are lifted to internal type constants, joined on the base lattice for ``arch.bits``, and the
+        result is translated back into a SimType. When the two types have no meaningful common supertype, the result is
+        a ``SimTypeBottom``.
+
+        :param t1:      The first SimType.
+        :param t2:      The second SimType.
+        :param arch:    The architecture, used to determine the pointer size and to build the resulting SimType.
+        :return:        The join of ``t1`` and ``t2`` as a SimType.
+        """
+
+        return cls._simtype_lattice_op(t1, t2, arch, BASE_LATTICES, Bottom_)
+
+    @classmethod
+    def meet_simtypes(cls, t1: SimType, t2: SimType, arch: archinfo.Arch) -> SimType:
+        """
+        Compute the meet (the greatest common subtype) of two SimTypes on the type lattice.
+
+        See :meth:`join_simtypes` for details. When the two types have no meaningful common subtype, the result is a
+        ``SimTypeBottom``.
+        """
+
+        return cls._simtype_lattice_op(t1, t2, arch, BASE_LATTICES_INVERTED, Top_)
+
+    @classmethod
+    def _simtype_lattice_op(
+        cls, t1: SimType, t2: SimType, arch: archinfo.Arch, lattices: dict[int, networkx.DiGraph], unit: TypeConstant
+    ) -> SimType:
+        # delayed import to avoid a circular import at module load time
+        from .translator import TypeTranslator  # pylint:disable=import-outside-toplevel
+
+        if arch.bits not in lattices:
+            raise ValueError(f"Pointer size {arch.bits} is not supported. Expect 32 or 64.")
+
+        translator = TypeTranslator(arch)
+        tc1 = translator.simtype2tc(t1)
+        tc2 = translator.simtype2tc(t2)
+        result_tc = cls._lattice_op(tc1, tc2, lattices[arch.bits], unit)
+        result_simtype, _ = translator.tc2simtype(result_tc)
+        return result_simtype
 
     @staticmethod
     def abstract(t: TypeConstant | TypeVariable) -> TypeConstant | TypeVariable:

--- a/tests/analyses/decompiler/test_output_nondeterminism.py
+++ b/tests/analyses/decompiler/test_output_nondeterminism.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+import angr
+import difflib
+
+from tests.common import bin_location
+
+
+class TestVariableNondeterminism(unittest.TestCase):
+    def test_deterministic_decompilation_output_upon_multiple_attempts(self):
+        """Regression test for https://github.com/angr/angr/issues/6440."""
+
+        binary_path = os.path.join(bin_location, "tests", "x86_64", "fauxware")
+        project = angr.Project(binary_path)
+        project.analyses.CFGFast(normalize=True)
+        project.analyses.CompleteCallingConventions(analyze_callsites=False)
+        output = []
+        for i in range(20):
+            dec = project.analyses.Decompiler("main", options=[("constrain_callee_prototypes", False)])
+            assert dec.codegen is not None and dec.codegen.text is not None
+            output.append(dec.codegen.text)
+
+            if i > 0 and output[0] != output[i]:
+                diff = difflib.unified_diff(
+                    output[0].splitlines(keepends=True),
+                    output[i].splitlines(keepends=True),
+                    fromfile="output[0]",
+                    tofile=f"output[{i}]",
+                )
+                print("Diff:")
+                print("".join(diff))
+                print("=======")
+                print("Output[0]:")
+                print(output[0])
+                print("-------")
+                print(f"Output[{i}]:")
+                print(output[i])
+                print("=======")
+                assert False, f"Output differs at iteration {i}"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/test_typehoon.py
+++ b/tests/analyses/test_typehoon.py
@@ -111,7 +111,9 @@ class TestTypehoon(unittest.TestCase):
         assert func_phase2.prototype_source == PrototypeSource.CCA_LOW
         func_read6numbers = cfg.kb.functions["read_six_numbers"]
         assert func_read6numbers.prototype_source == PrototypeSource.CCA_LOW
-        dec_phase2 = proj.analyses.Decompiler(func_phase2, fail_fast=True)
+        dec_phase2 = proj.analyses.Decompiler(
+            func_phase2, fail_fast=True, options=[("constrain_callee_prototypes", True)]
+        )
         print_decompilation_result(dec_phase2)
         assert dec_phase2.codegen is not None and dec_phase2.codegen.text is not None
         assert func_phase2.prototype_source == PrototypeSource.CCA_DECOMPILER
@@ -129,7 +131,9 @@ class TestTypehoon(unittest.TestCase):
         )
 
         # decompile read_six_numbers, and its prototype should be updated to (char*, uint32_t*)
-        dec_read6numbers = proj.analyses.Decompiler(func_read6numbers, fail_fast=True)
+        dec_read6numbers = proj.analyses.Decompiler(
+            func_read6numbers, fail_fast=True, options=[("constrain_callee_prototypes", True)]
+        )
         assert dec_read6numbers.codegen is not None and dec_read6numbers.codegen.text is not None
         print_decompilation_result(dec_read6numbers)
         assert func_read6numbers.prototype_source == PrototypeSource.CCA_DECOMPILER
@@ -145,7 +149,9 @@ class TestTypehoon(unittest.TestCase):
         )
 
         # decompile phase_2 again, and we should see an unsigned int [6] on the stack
-        dec_phase2 = proj.analyses.Decompiler(func_phase2, fail_fast=True)
+        dec_phase2 = proj.analyses.Decompiler(
+            func_phase2, fail_fast=True, options=[("constrain_callee_prototypes", True)]
+        )
         assert dec_phase2.codegen is not None and dec_phase2.codegen.text is not None
         print_decompilation_result(dec_phase2)
         assert re.search(r"  int v\d+\[6];", dec_phase2.codegen.text) is not None

--- a/tests/analyses/test_typehoon.py
+++ b/tests/analyses/test_typehoon.py
@@ -12,6 +12,7 @@ from collections import OrderedDict
 import archinfo
 
 import angr
+from angr.analyses.decompiler.clinic import Clinic
 from angr.knowledge_plugins.functions.function import PrototypeSource
 from angr.sim_type import (
     SimTypeFloat,
@@ -21,6 +22,7 @@ from angr.sim_type import (
     SimTypeBottom,
     SimTypeFunction,
     SimTypeChar,
+    SimTypeArray,
 )
 from angr.analyses.typehoon.typevars import (
     TypeVariable,
@@ -34,6 +36,7 @@ from angr.analyses.typehoon.typevars import (
 )
 from angr.analyses.typehoon.typeconsts import Int32, Struct, Pointer64, Float32, Float64
 from angr.analyses.typehoon.translator import TypeTranslator
+from angr.analyses.typehoon.simple_solver import SimpleSolver
 
 from tests.common import bin_location, print_decompilation_result
 
@@ -446,6 +449,113 @@ class TestTypeTranslator(unittest.TestCase):
         assert isinstance(tc.fields[0], Pointer64)
         assert 0 in tc.field_names
         assert tc.field_names[0] == "ptr"
+
+
+class TestSimpleSolverLatticeOps(unittest.TestCase):
+    """Tests for the SimType-level lattice operations SimpleSolver.join_simtypes / meet_simtypes."""
+
+    arch = archinfo.arch_from_id("amd64")
+
+    def test_join_signed_unsigned_int(self):
+        # join(signed int, unsigned int) -> int (their common Int32 supertype)
+        joined = SimpleSolver.join_simtypes(
+            SimTypeInt(signed=True).with_arch(self.arch),
+            SimTypeInt(signed=False).with_arch(self.arch),
+            self.arch,
+        )
+        assert isinstance(joined, SimTypeInt)
+
+    def test_join_same_pointer(self):
+        # join(char *, char *) -> char *
+        joined = SimpleSolver.join_simtypes(
+            SimTypePointer(SimTypeChar()).with_arch(self.arch),
+            SimTypePointer(SimTypeChar()).with_arch(self.arch),
+            self.arch,
+        )
+        assert isinstance(joined, SimTypePointer)
+        assert isinstance(joined.pts_to, SimTypeChar)
+
+    def test_join_same_struct_pointer_preserves_struct(self):
+        # join(struct A *, struct A *) -> struct A *
+        s = SimStruct({"a": SimTypeInt()}, name="A").with_arch(self.arch)
+        joined = SimpleSolver.join_simtypes(
+            SimTypePointer(s).with_arch(self.arch),
+            SimTypePointer(s).with_arch(self.arch),
+            self.arch,
+        )
+        assert isinstance(joined, SimTypePointer)
+        assert isinstance(joined.pts_to, SimStruct)
+        assert joined.pts_to.name == "A"
+
+    def test_join_distinct_struct_pointers_to_void(self):
+        # join(struct A *, struct B *) -> void * (no common struct supertype)
+        sa = SimStruct({"a": SimTypeInt()}, name="A").with_arch(self.arch)
+        sb = SimStruct({"b": SimTypeInt()}, name="B").with_arch(self.arch)
+        joined = SimpleSolver.join_simtypes(
+            SimTypePointer(sa).with_arch(self.arch),
+            SimTypePointer(sb).with_arch(self.arch),
+            self.arch,
+        )
+        assert isinstance(joined, SimTypePointer)
+        assert isinstance(joined.pts_to, SimTypeBottom)
+
+    def test_join_incompatible_scalars_is_bottom(self):
+        # join(char, int): the only common supertype is the generic Int, which has no precise SimType -> bottom
+        joined = SimpleSolver.join_simtypes(
+            SimTypeChar().with_arch(self.arch),
+            SimTypeInt().with_arch(self.arch),
+            self.arch,
+        )
+        assert isinstance(joined, SimTypeBottom)
+
+    def test_meet_identical_type(self):
+        # meet(char, char) -> char
+        met = SimpleSolver.meet_simtypes(
+            SimTypeChar(signed=True).with_arch(self.arch),
+            SimTypeChar(signed=True).with_arch(self.arch),
+            self.arch,
+        )
+        assert isinstance(met, SimTypeChar)
+
+    def test_meet_incompatible_is_bottom(self):
+        # meet(signed int, unsigned int): no common subtype on the lattice -> bottom
+        met = SimpleSolver.meet_simtypes(
+            SimTypeInt(signed=True).with_arch(self.arch),
+            SimTypeInt(signed=False).with_arch(self.arch),
+            self.arch,
+        )
+        assert isinstance(met, SimTypeBottom)
+
+
+class TestFunctionArgTypeNormalization(unittest.TestCase):
+    """Tests for Clinic._flatten_pointer_to_array, the call-site argument type normalization filter."""
+
+    arch = archinfo.arch_from_id("amd64")
+
+    def test_pointer_to_array_becomes_pointer(self):
+        # type[N] * -> type *
+        ty = SimTypePointer(SimTypeArray(SimTypeInt(), 4)).with_arch(self.arch)
+        flattened = Clinic._flatten_pointer_to_array(ty)
+        assert isinstance(flattened, SimTypePointer)
+        assert isinstance(flattened.pts_to, SimTypeInt)
+
+    def test_plain_pointer_unchanged(self):
+        ty = SimTypePointer(SimTypeChar()).with_arch(self.arch)
+        flattened = Clinic._flatten_pointer_to_array(ty)
+        assert flattened is ty
+
+    def test_non_pointer_unchanged(self):
+        ty = SimTypeInt().with_arch(self.arch)
+        flattened = Clinic._flatten_pointer_to_array(ty)
+        assert flattened is ty
+
+    def test_array_pointers_of_different_lengths_join_after_filter(self):
+        # int[4] * and int[8] * normalize to int *, which then join to int *
+        t1 = Clinic._flatten_pointer_to_array(SimTypePointer(SimTypeArray(SimTypeInt(), 4)).with_arch(self.arch))
+        t2 = Clinic._flatten_pointer_to_array(SimTypePointer(SimTypeArray(SimTypeInt(), 8)).with_arch(self.arch))
+        joined = SimpleSolver.join_simtypes(t1, t2, self.arch)
+        assert isinstance(joined, SimTypePointer)
+        assert isinstance(joined.pts_to, SimTypeInt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also,

- Make callee prototype constraining disabled by default.

- Refactor simple_solver.py so that join and meet are usable without creating a SimpleSolver instance first.

Fix #6440.