### PR TITLE
docs: Fix a broken link in loading.rst

### DIFF
--- a/docs/core-concepts/loading.rst
+++ b/docs/core-concepts/loading.rst
@@ -331,7 +331,7 @@ These builtin procedures are available in the ``angr.SIM_PROCEDURES``
 dictionary, which is two-leveled, keyed first on the package name (libc, posix,
 win32, stubs) and then on the name of the library function. Executing a
 SimProcedure instead of the actual library function that gets loaded from your
-system makes analysis a LOT more tractable, at the cost of `some potential
+system makes analysis a LOT more tractable, at the cost of :ref:`some potential
 inaccuracies <Gotchas when using angr>`.
 
 When no such summary is available for a given function:


### PR DESCRIPTION
This link doesn't render, instead it shows this:

```
at the cost of some potential inaccuracies <Gotchas when using angr>.
```

Please verify this change before merging, I didn't build the docs myself. Is there any CI where I can see the result of this change? (i.e. final html)