### PR TITLE
docs: Disambiguate narrative cross-references

### DIFF
--- a/docs/advanced-topics/speed.rst
+++ b/docs/advanced-topics/speed.rst
@@ -32,7 +32,7 @@ General speed tips
   function you're jumping into. If there's no autonomy requirement for this
   project, you can often isolate individual problem spots where analysis hangs
   up and summarize them with a hook.
-* *Use SimInspect*. :ref:`SimInspect <Breakpoints>` is the most underused and
+* *Use SimInspect*. :ref:`SimInspect <core-concepts/simulation:Breakpoints>` is the most underused and
   one of the most powerful features of angr. You can hook and modify almost any
   behavior of angr, including memory index resolution (which is often the
   slowest part of any angr analysis).

--- a/docs/appendix/changelog.rst
+++ b/docs/appendix/changelog.rst
@@ -92,7 +92,7 @@ angr 8.18.10.1
 
 Welcome to angr 8!
 The biggest change for this major version bump is the transition to Python 3.
-You can read about this, as well as a few other breaking changes, in the :ref:`Migrating to angr 8`.
+You can read about this, as well as a few other breaking changes, in the :ref:`Migrating to angr 8 <appendix/migration-8:Migrating to angr 8>`.
 
 
 * Switch to Python 3
@@ -169,7 +169,7 @@ angr 7.7.9.8
 
 Welcome to angr 7!
 We worked long and hard all summer to make this release the best ever.
-It introduces several breaking changes, so for a quick guide on the most common ways you'll need to update your scripts, take a look at the :ref:`Migrating to angr 7`.
+It introduces several breaking changes, so for a quick guide on the most common ways you'll need to update your scripts, take a look at the :ref:`Migrating to angr 7 <appendix/migration-7:Migrating to angr 7>`.
 
 
 * SimuVEX has been removed and its components have been integrated into angr

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,13 @@ extensions = [
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+# -- Options for autosectionlabel --------------------------------------------
+# Prefix every auto-generated section label with the document path so labels
+# in different files (e.g. "Core Concepts" appearing in two docs) don't
+# collide. References must spell out the document path:
+# ``:ref:`text <path/to/doc:Heading>```.
+autosectionlabel_prefix_document = True
+
 # -- Options for autodoc -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration
 autoclass_content = "class"

--- a/docs/core-concepts/analyses.rst
+++ b/docs/core-concepts/analyses.rst
@@ -4,7 +4,7 @@ Analyses
 angr's goal is to make it easy to carry out useful analyses on binary programs.
 To this end, angr allows you to package analysis code in a common format that
 can be easily applied to any project. We will cover writing your own analyses
-:ref:`Writing Analyses`, but the idea is that all the analyses appear under
+:ref:`Writing Analyses <extending-angr/analysis_writing:Writing Analyses>`, but the idea is that all the analyses appear under
 ``project.analyses`` (for example, ``project.analyses.CFGFast()``) and can be
 called as functions, returning analysis result instances.
 

--- a/docs/core-concepts/pathgroups.rst
+++ b/docs/core-concepts/pathgroups.rst
@@ -213,7 +213,7 @@ Now, we can get the flag out of that state!
 
 Pretty simple, isn't it?
 
-Other examples can be found by browsing the :ref:`examples <angr examples>`.
+Other examples can be found by browsing the :ref:`examples <examples:angr examples>`.
 
 Exploration Techniques
 ----------------------

--- a/docs/core-concepts/states.rst
+++ b/docs/core-concepts/states.rst
@@ -223,7 +223,7 @@ analyzed can be found as ``arch.memory_endness`` - for instance
 
 There is also a low-level interface for register access, ``state.registers``,
 that uses the exact same API as ``state.memory``, but explaining its behavior
-involves a :ref:`dive <Intermediate Representation>` into the abstractions that
+involves a :ref:`dive <advanced-topics/ir:Intermediate Representation>` into the abstractions that
 angr uses to seamlessly work with multiple architectures. The short version is
 that it is simply a register file, with the mapping between registers and
 offsets defined in `archinfo <https://github.com/angr/archinfo>`_.
@@ -239,7 +239,7 @@ On each SimState object, there is a set (``state.options``) of all its enabled
 options. Each option (really just a string) controls the behavior of angr's
 execution engine in some minute way. A listing of the full domain of options,
 along with the defaults for different state types, can be found in :ref:`the
-appendix <List of State Options>`. You can access an individual option for
+appendix <appendix/options:List of State Options>`. You can access an individual option for
 adding to a state through ``angr.options``. The individual options are named
 with CAPITAL_LETTERS, but there are also common groupings of objects that you
 might want to use bundled together, named with lowercase_letters.
@@ -268,7 +268,7 @@ SimState is actually stored in a *plugin* attached to the state. Almost every
 property on the state we've discussed so far is a plugin - ``memory``,
 ``registers``, ``mem``, ``regs``, ``solver``, etc. This design allows for code
 modularity as well as the ability to easily :ref:`implement new kinds of data
-storage <State Plugins>` for other aspects of an emulated state, or the ability
+storage <extending-angr/state_plugins:State Plugins>` for other aspects of an emulated state, or the ability
 to provide alternate implementations of plugins.
 
 For example, the normal ``memory`` plugin simulates a flat memory space, but
@@ -355,7 +355,7 @@ topmost frame, this is ``state.callstack``.
 More about I/O: Files, file systems, and network sockets
 --------------------------------------------------------
 
-Please refer to :ref:`Working with File System, Sockets, and Pipes` for a more
+Please refer to :ref:`Working with File System, Sockets, and Pipes <advanced-topics/file_system:Working with File System, Sockets, and Pipes>` for a more
 complete and detailed documentation of how I/O is modeled in angr.
 
 Copying and Merging

--- a/docs/core-concepts/toplevel.rst
+++ b/docs/core-concepts/toplevel.rst
@@ -70,7 +70,7 @@ Loading
 Getting from a binary file to its representation in a virtual address space is
 pretty complicated! We have a module called CLE to handle that. CLE's result,
 called the loader, is available in the ``.loader`` property. We'll get into
-detail on how to use this :ref:`soon <Loading a Binary>`, but for now just know
+detail on how to use this :ref:`soon <core-concepts/loading:Loading a Binary>`, but for now just know
 that you can use it to see the shared libraries that angr loaded alongside your
 program and perform basic queries about the loaded address space.
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -12,10 +12,10 @@ by `Florent Bordignon <https://github.com/bordig-f>`_.
 
 To jump to a specific category:
 
-* :ref:`Introduction` - examples showing off the very basics of angr's functionality
-* :ref:`Reversing` - examples showing angr being used in reverse engineering tasks
-* :ref:`Vulnerability Discovery` - examples of angr being used to search for vulnerabilities
-* :ref:`Exploitation` - examples of angr being used as an exploitation assistance tool
+* :ref:`Introduction <examples:Introduction>` - examples showing off the very basics of angr's functionality
+* :ref:`Reversing <examples:Reversing>` - examples showing angr being used in reverse engineering tasks
+* :ref:`Vulnerability Discovery <examples:Vulnerability Discovery>` - examples of angr being used to search for vulnerabilities
+* :ref:`Exploitation <examples:Exploitation>` - examples of angr being used as an exploitation assistance tool
 
 Introduction
 ------------

--- a/docs/extending-angr/environment.rst
+++ b/docs/extending-angr/environment.rst
@@ -8,7 +8,7 @@ rare cases, loader artifacts. angr provides a convenient interface to do most of
 these things!
 
 Everything discussed here involves writing SimProcedures, so :ref:`make sure you
-know how to do that! <Hooks and SimProcedures>`.
+know how to do that! <extending-angr/simprocedures:Hooks and SimProcedures>`.
 
 Note that this page should be treated as a narrative document, not a reference
 document, so you should read it at least once start to end.

--- a/docs/extending-angr/simprocedures.rst
+++ b/docs/extending-angr/simprocedures.rst
@@ -38,8 +38,7 @@ Now, let's talk about what happens on the edge of this function! When entering
 the function, where do the values that go into the arguments come from? You can
 define your ``run()`` function with however many arguments you like, and the
 SimProcedure runtime will automatically extract from the program state those
-arguments for you, via a :ref:`calling convention <Working with Calling
-Conventions>`, and call your run function with them. Similarly, when you return
+arguments for you, via a :ref:`calling convention <advanced-topics/structured_data:Working with Calling Conventions>`, and call your run function with them. Similarly, when you return
 a value from the run function, it is placed into the state (again, according to
 the calling convention), and the actual control-flow action of returning from a
 function is performed, which depending on the architecture may involve jumping
@@ -55,7 +54,7 @@ Implementation Context
 
 On a ``Project`` class, the dict ``project._sim_procedures`` is a mapping from
 address to ``SimProcedure`` instances. When the :ref:`execution pipeline
-<Understanding the Execution Pipeline>` reaches an address that is present in
+<advanced-topics/pipeline:Understanding the Execution Pipeline>` reaches an address that is present in
 that dict, that is, an address that is hooked, it will execute
 ``project._sim_procedures[address].execute(state)``. This will consult the
 calling convention to extract the arguments, make a copy of itself in order to
@@ -281,8 +280,7 @@ Otherwise, use a user hook.
 Hooking Symbols
 ---------------
 
-As you should recall from the :ref:`section on loading a binary <Loading a
-Binary>`, dynamically linked programs have a list of symbols that they must
+As you should recall from the :ref:`section on loading a binary <core-concepts/loading:Loading a Binary>`, dynamically linked programs have a list of symbols that they must
 import from the libraries they have listed as dependencies, and angr will make
 sure, rain or shine, that every import symbol gets resolved by *some* address,
 whether it's a real implementation of the function or just a dummy address hooked

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -5,8 +5,7 @@ This is a collection of commonly-asked "how do I do X?" questions and other
 general questions about angr, for those too lazy to read this whole document.
 
 If your question is of the form "how do I fix X issue after installing", see
-also the Troubleshooting section of the :ref:`install instructions <Installing
-angr>`.
+also the Troubleshooting section of the :ref:`install instructions <getting-started/installing:Installing angr>`.
 
 Why is it named angr?
 ---------------------
@@ -71,7 +70,7 @@ well as all other analyses, log at the INFO level.
 Why is angr so slow?
 --------------------
 
-It's complicated! :ref:`Optimization considerations`
+It's complicated! :ref:`Optimization considerations <advanced-topics/speed:Optimization considerations>`
 
 How do I find bugs using angr?
 ------------------------------


### PR DESCRIPTION
Turn on ``autosectionlabel_prefix_document = True`` so that auto-generated section labels are prefixed with the document path. This silences the duplicate-label warnings between narrative pages where the same H1 text appears in more than one file (e.g. "State Plugins" in ``core-concepts/states.rst`` and ``extending-angr/state_plugins.rst``, "Core Concepts" in ``core-concepts/index.rst`` and ``core-concepts/toplevel.rst``).

Update the existing bare-label ``:ref:`` links to use the prefixed form (e.g. ``:ref:`text <core-concepts/loading:Loading a Binary>```), and at the same time collapse the line-wrapped links that were already brittle.