### PR TITLE
JumpTableResolver: stop using deprecated BP(condition=...)

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -2108,16 +2108,27 @@ class JumpTableResolver(IndirectJumpResolver):
         :return:                            None
         """
 
+        def _scratch_gated(hook, block_addr, stmt_idx):
+            def _action(_s):
+                if _s.scratch.bbl_addr == block_addr and _s.scratch.stmt_idx == stmt_idx:
+                    hook(_s)
+
+            return _action
+
+        def _statement_gated(hook, block_addr, stmt_idx):
+            def _action(_s):
+                if _s.scratch.bbl_addr == block_addr and _s.inspect.attrs.statement == stmt_idx:
+                    hook(_s)
+
+            return _action
+
         for sort, block_addr, stmt_idx in stmts_to_instrument:
             l.debug("Add a %s hook to overwrite memory/register values at %#x:%d.", sort, block_addr, stmt_idx)
             if sort == "mem_write":
                 bp = BP(
                     when=BP_BEFORE,
                     enabled=True,
-                    action=StoreHook.hook,
-                    condition=lambda _s, a=block_addr, idx=stmt_idx: (
-                        _s.scratch.bbl_addr == a and _s.scratch.stmt_idx == idx
-                    ),
+                    action=_scratch_gated(StoreHook.hook, block_addr, stmt_idx),
                 )
                 state.inspect.add_breakpoint("mem_write", bp)
             elif sort == "mem_read":
@@ -2125,38 +2136,26 @@ class JumpTableResolver(IndirectJumpResolver):
                 bp0 = BP(
                     when=BP_BEFORE,
                     enabled=True,
-                    action=hook.hook_before,
-                    condition=lambda _s, a=block_addr, idx=stmt_idx: (
-                        _s.scratch.bbl_addr == a and _s.scratch.stmt_idx == idx
-                    ),
+                    action=_scratch_gated(hook.hook_before, block_addr, stmt_idx),
                 )
                 state.inspect.add_breakpoint("mem_read", bp0)
                 bp1 = BP(
                     when=BP_AFTER,
                     enabled=True,
-                    action=hook.hook_after,
-                    condition=lambda _s, a=block_addr, idx=stmt_idx: (
-                        _s.scratch.bbl_addr == a and _s.scratch.stmt_idx == idx
-                    ),
+                    action=_scratch_gated(hook.hook_after, block_addr, stmt_idx),
                 )
                 state.inspect.add_breakpoint("mem_read", bp1)
             elif sort == "reg_write":
                 bp = BP(
                     when=BP_BEFORE,
                     enabled=True,
-                    action=PutHook.hook,
-                    condition=lambda _s, a=block_addr, idx=stmt_idx: (
-                        _s.scratch.bbl_addr == a and _s.scratch.stmt_idx == idx
-                    ),
+                    action=_scratch_gated(PutHook.hook, block_addr, stmt_idx),
                 )
                 state.inspect.add_breakpoint("reg_write", bp)
             else:
                 raise NotImplementedError(f"Unsupported sort {sort} in stmts_to_instrument.")
 
         reg_val = 0x13370000
-
-        def bp_condition(block_addr, stmt_idx, _s):
-            return _s.scratch.bbl_addr == block_addr and _s.inspect.attrs.statement == stmt_idx
 
         for block_addr, stmt_idx, reg_offset, reg_bits in regs_to_initialize:
             l.debug(
@@ -2168,8 +2167,11 @@ class JumpTableResolver(IndirectJumpResolver):
             bp = BP(
                 when=BP_BEFORE,
                 enabled=True,
-                action=RegisterInitializerHook(reg_offset, reg_bits, reg_val).hook,
-                condition=functools.partial(bp_condition, block_addr, stmt_idx),
+                action=_statement_gated(
+                    RegisterInitializerHook(reg_offset, reg_bits, reg_val).hook,
+                    block_addr,
+                    stmt_idx,
+                ),
             )
             state.inspect.add_breakpoint("statement", bp)
             reg_val += 16


### PR DESCRIPTION
`BP.__init__` deprecates the `condition=` kwarg, but `JumpTableResolver._instrument_statements` was still passing it at five call sites. Every `CFGFast` run that hits a jumptable emits a `DeprecationWarning`, and consumers that promote that warning to an error (pytest `filterwarnings = ["error"]`, `-W error::DeprecationWarning`) crash on the first jumptable.

This change wraps each hook in a small gating closure that checks the same scratch/statement predicate the old `condition=` lambda checked, and drops `condition=` from all five `BP(...)` calls.

### Verification

- The repro from #6466 against `binaries/tests/x86_64/cfg_switches` now completes without raising.
- Per-function decompilation of `cfg_switches` is byte-identical before and after the change (zero-line `diff` across all 238 lines of output).
- `tests/analyses/cfg/test_jumptables.py`: 25 passed, 24 subtests passed.
- `ruff check` clean on the modified file.

Fixes #6466.
