### PR TITLE
spiller_db: replace deprecated datetime.utcnow() default

### DIFF
--- a/angr/exploration_techniques/spiller_db.py
+++ b/angr/exploration_techniques/spiller_db.py
@@ -18,7 +18,7 @@ try:
         priority = Column(Integer)
         taken = Column(Boolean, default=False)
         stash = Column(String, default="")
-        timestamp = Column(DateTime, default=datetime.datetime.utcnow)
+        timestamp = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC))
 
 except ImportError:
     sqlalchemy = None


### PR DESCRIPTION
`datetime.datetime.utcnow` is deprecated in Python 3.12+ and emits `DeprecationWarning` each time it's called. SQLAlchemy invokes the `default=` callable on every `PickledState` insert in the `Spiller` exploration technique, so any spiller run with sqlalchemy installed accumulates warnings, and crashes under `-W error::DeprecationWarning` / pytest `filterwarnings = ["error"]`.

Switch the default to a timezone-aware `lambda: datetime.datetime.now(datetime.UTC)`. `datetime.UTC` is available unconditionally — `pyproject.toml` already pins `requires-python = ">=3.12"`.
