### PR TITLE
Use abi3 for wheels

### DIFF
--- a/native/angr/Cargo.toml
+++ b/native/angr/Cargo.toml
@@ -15,7 +15,7 @@ libafl = { version = "=0.15.4" }
 libafl_bolts = { version = "=0.15.4" }
 pcode = { git = "https://github.com/angr/icicle-emu.git", rev = "fac77d41c845f91ba85fc072ad87bf7c3f4a28cc" }
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
-pyo3 = { version = "0.28.3", features = ["py-clone"] }
+pyo3 = { version = "0.28.3", features = ["abi3-py312", "py-clone"] }
 rangemap = "1.7.1"
 send_wrapper = "0.6.0"
 indexmap = "2.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ target = "angr.rustylib"
 path = "native/angr/Cargo.toml"
 debug = false
 
+[tool.distutils.bdist_wheel]
+py_limited_api = "cp312"
+
 [tool.uv]
 default-groups = ["dev", "extras"]
 


### PR DESCRIPTION
Our wheel sizes have gotten large, and the motivation for changing away from abi3 previously is no longer relevant (pyo3 has improved).