### PR TITLE
Decompiler: Use VariableMap to track Atom-Variable mapping.

### DIFF
--- a/angr/ailment/block_walker.py
+++ b/angr/ailment/block_walker.py
@@ -686,8 +686,6 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
                 stmt.size,
                 stmt.endness,
                 guard=guard,
-                variable=stmt.variable,
-                offset=stmt.offset,
                 **stmt.tags,
             )
         return stmt

--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -298,7 +298,6 @@ class PCodeIRSBConverter(Converter):
             offset = self._map_register_name(varnode)
             return Register(
                 self._manager.next_atom(),
-                None,
                 offset,
                 size,
                 reg_name=varnode.getRegisterName(),
@@ -563,7 +562,7 @@ class PCodeIRSBConverter(Converter):
         ret_expr = (
             None
             if ret_reg_offset is None
-            else Register(None, None, ret_reg_offset, self._manager.arch.bits, ins_addr=self._manager.ins_addr)
+            else Register(None, ret_reg_offset, self._manager.arch.bits, ins_addr=self._manager.ins_addr)
         )  # ???
         if self._irsb.next is not None:
             dest = Const(self._manager.next_atom(), self._irsb.next.con.value, self._manager.arch.bits)
@@ -591,7 +590,7 @@ class PCodeIRSBConverter(Converter):
         Convert a p-code indirect call operation
         """
         ret_reg_offset = self._manager.arch.ret_offset
-        ret_expr = Register(None, None, ret_reg_offset, self._manager.arch.bits, ins_addr=self._manager.ins_addr)  # ???
+        ret_expr = Register(None, ret_reg_offset, self._manager.arch.bits, ins_addr=self._manager.ins_addr)  # ???
         dest = self._get_value(self._current_op.inputs[0])
         call_expr = Call(
             self._manager.next_atom(),

--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -293,7 +293,7 @@ class PCodeIRSBConverter(Converter):
         size = varnode.size * 8
 
         if space_name == "const":
-            return Const(self._manager.next_atom(), None, varnode.offset, size)
+            return Const(self._manager.next_atom(), varnode.offset, size)
         if space_name == "register":
             offset = self._map_register_name(varnode)
             return Register(
@@ -323,7 +323,7 @@ class PCodeIRSBConverter(Converter):
                     t = BinaryOp(
                         self._manager.next_atom(),
                         "Shr",
-                        [t, Const(self._manager.next_atom(), None, right_shift_amount * 8, 8)],
+                        [t, Const(self._manager.next_atom(), right_shift_amount * 8, 8)],
                         False,
                         ins_addr=self._manager.ins_addr,
                     )
@@ -332,7 +332,7 @@ class PCodeIRSBConverter(Converter):
             return Tmp(self._manager.next_atom(), None, offset, size)
         if space_name in ["ram", "mem"]:
             assert not is_write
-            addr = Const(self._manager.next_atom(), None, varnode.offset, self._manager.arch.bits)
+            addr = Const(self._manager.next_atom(), varnode.offset, self._manager.arch.bits)
             # Note: Load takes bytes, not bits, for size
             return Load(
                 self._manager.next_atom(),
@@ -361,7 +361,7 @@ class PCodeIRSBConverter(Converter):
                 self._statement_idx, self._convert_varnode(varnode, True), value, ins_addr=self._manager.ins_addr
             )
         if space_name in ["ram", "mem"]:
-            addr = Const(self._manager.next_atom(), None, varnode.offset, self._manager.arch.bits)
+            addr = Const(self._manager.next_atom(), varnode.offset, self._manager.arch.bits)
             return Store(
                 self._statement_idx,
                 addr,
@@ -430,7 +430,7 @@ class PCodeIRSBConverter(Converter):
         out = self._current_op.output
         inp = self._get_value(self._current_op.inputs[0])
 
-        cval = Const(self._manager.next_atom(), None, 0, self._current_op.inputs[0].size * 8)
+        cval = Const(self._manager.next_atom(), 0, self._current_op.inputs[0].size * 8)
 
         expr = BinaryOp(self._manager.next_atom(), "CmpEQ", [inp, cval], signed=False, ins_addr=self._manager.ins_addr)
 
@@ -500,7 +500,7 @@ class PCodeIRSBConverter(Converter):
 
         # special handling: if the previous statement is a ConditionalJump with a None destination address, then we
         # back-patch the previous statement
-        dest = Const(self._manager.next_atom(), None, dest_addr, self._manager.arch.bits)
+        dest = Const(self._manager.next_atom(), dest_addr, self._manager.arch.bits)
         if self._statements:
             last_stmt = self._statements[-1]
             if isinstance(last_stmt, ConditionalJump) and last_stmt.false_target is None:
@@ -518,14 +518,13 @@ class PCodeIRSBConverter(Converter):
             raise NotImplementedError("p-code relative branch not supported yet")
         dest_addr = self._current_op.inputs[0].offset
         cond = self._get_value(self._current_op.inputs[1])
-        cval = Const(self._manager.next_atom(), None, 0, cond.bits)
+        cval = Const(self._manager.next_atom(), 0, cond.bits)
         condition = BinaryOp(self._manager.next_atom(), "CmpNE", [cond, cval], signed=False)
-        dest = Const(self._manager.next_atom(), None, dest_addr, self._manager.arch.bits)
+        dest = Const(self._manager.next_atom(), dest_addr, self._manager.arch.bits)
         if self._irsb._ops[-1] is self._current_op:
             # if the cbranch op is the last op, then we need to generate a fallthru target
             fallthru = Const(
                 self._manager.next_atom(),
-                None,
                 self._next_ins_addr,
                 self._manager.arch.bits,
             )
@@ -567,7 +566,7 @@ class PCodeIRSBConverter(Converter):
             else Register(None, None, ret_reg_offset, self._manager.arch.bits, ins_addr=self._manager.ins_addr)
         )  # ???
         if self._irsb.next is not None:
-            dest = Const(self._manager.next_atom(), None, self._irsb.next.con.value, self._manager.arch.bits)
+            dest = Const(self._manager.next_atom(), self._irsb.next.con.value, self._manager.arch.bits)
         else:
             dest = None
         call_expr = Call(

--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -316,7 +316,7 @@ class PCodeIRSBConverter(Converter):
                 assert unique_offset is not None, "Cannot find the source unique variable"
                 # TODO: Check size
                 _, ori_tmp_size = self._unique_tracker[unique_offset]
-                t = Tmp(self._manager.next_atom(), None, unique_offset, ori_tmp_size * 8)
+                t = Tmp(self._manager.next_atom(), unique_offset, ori_tmp_size * 8)
                 # FIXME: Asserting BE
                 right_shift_amount = varnode.offset + varnode.size - (unique_offset + ori_tmp_size)
                 if right_shift_amount != 0:
@@ -329,7 +329,7 @@ class PCodeIRSBConverter(Converter):
                     )
                 return Convert(self._manager.next_atom(), t.bits, size, False, t, ins_addr=self._manager.ins_addr)
 
-            return Tmp(self._manager.next_atom(), None, offset, size)
+            return Tmp(self._manager.next_atom(), offset, size)
         if space_name in ["ram", "mem"]:
             assert not is_write
             addr = Const(self._manager.next_atom(), varnode.offset, self._manager.arch.bits)

--- a/angr/ailment/converter_vex.py
+++ b/angr/ailment/converter_vex.py
@@ -166,7 +166,6 @@ class VEXExprConverter:
                             inner,
                             Const(
                                 manager.next_atom(),
-                                None,
                                 simop._to_size,
                                 8,
                                 ins_addr=manager.ins_addr,
@@ -225,7 +224,7 @@ class VEXExprConverter:
             # convert it to a sub
             op_name = "Sub"
             op1_val, op1_bits = operands[1].value, operands[1].bits
-            operands[1] = Const(operands[1].idx, None, (1 << op1_bits) - op1_val, op1_bits)
+            operands[1] = Const(operands[1].idx, (1 << op1_bits) - op1_val, op1_bits)
 
         signed = False
         vector_count = None
@@ -415,7 +414,6 @@ class VEXExprConverter:
         # pyvex.IRExpr.Const
         return Const(
             manager.next_atom(),
-            None,
             expr.con.value,
             expr.result_size(manager.tyenv),
             ins_addr=manager.ins_addr,
@@ -428,7 +426,6 @@ class VEXExprConverter:
         # pyvex.const.xxx
         return Const(
             manager.next_atom(),
-            None,
             expr.value,
             expr.size,
             ins_addr=manager.ins_addr,

--- a/angr/ailment/converter_vex.py
+++ b/angr/ailment/converter_vex.py
@@ -95,7 +95,6 @@ class VEXExprConverter:
         reg_name = manager.arch.translate_register_name(offset, reg_size)
         return Register(
             manager.next_atom(),
-            None,
             offset,
             bits,
             reg_name=reg_name,
@@ -756,7 +755,6 @@ class VEXIRSBConverter(Converter):
             ret_reg_offset = manager.arch.ret_offset
             ret_expr = Register(
                 manager.next_atom(),
-                None,
                 ret_reg_offset,
                 manager.arch.bits,
                 reg_name=manager.arch.translate_register_name(ret_reg_offset, size=manager.arch.bits),
@@ -768,7 +766,6 @@ class VEXIRSBConverter(Converter):
             if fp_ret_reg_offset is not None and fp_ret_reg_offset != ret_reg_offset:
                 fp_ret_expr = Register(
                     manager.next_atom(),
-                    None,
                     fp_ret_reg_offset,
                     manager.arch.bits,
                     reg_name=manager.arch.translate_register_name(fp_ret_reg_offset, size=manager.arch.bits),

--- a/angr/ailment/converter_vex.py
+++ b/angr/ailment/converter_vex.py
@@ -30,7 +30,7 @@ from .statement import CAS, Assignment, ConditionalJump, DirtyStatement, Jump, R
 log = logging.getLogger(name=__name__)
 
 
-class VEXExprConverter(Converter):
+class VEXExprConverter:
     @staticmethod
     def simop_from_vexop(vex_op):
         return vexop_to_simop(vex_op)
@@ -481,7 +481,7 @@ EXPRESSION_MAPPINGS = {
 }
 
 
-class VEXStmtConverter(Converter):
+class VEXStmtConverter:
     @staticmethod
     def convert(stmt, manager):  # pylint:disable=arguments-differ
         """

--- a/angr/ailment/converter_vex.py
+++ b/angr/ailment/converter_vex.py
@@ -108,7 +108,6 @@ class VEXExprConverter:
     def tmp(tmp_idx, bits, manager):
         return Tmp(
             manager.next_atom(),
-            None,
             tmp_idx,
             bits,
             ins_addr=manager.ins_addr,

--- a/angr/ailment/converter_vex.py
+++ b/angr/ailment/converter_vex.py
@@ -483,10 +483,9 @@ EXPRESSION_MAPPINGS = {
 
 class VEXStmtConverter(Converter):
     @staticmethod
-    def convert(idx, stmt, manager):  # pylint:disable=arguments-differ
+    def convert(stmt, manager):  # pylint:disable=arguments-differ
         """
 
-        :param idx:
         :param stmt:
         :param manager:
         :return:
@@ -505,22 +504,22 @@ class VEXStmtConverter(Converter):
                 vex_stmt_idx=manager.vex_stmt_idx,
             )
             return DirtyStatement(
-                idx,
+                manager.next_atom(),
                 dirty,
                 ins_addr=manager.ins_addr,
                 vex_block_addr=manager.block_addr,
                 vex_stmt_idx=manager.vex_stmt_idx,
             )
 
-        return func(idx, stmt, manager)
+        return func(stmt, manager)
 
     @staticmethod
-    def WrTmp(idx, stmt, manager):
+    def WrTmp(stmt, manager):
         var = VEXExprConverter.tmp(stmt.tmp, stmt.data.result_size(manager.tyenv), manager)
         reg = VEXExprConverter.convert(stmt.data, manager)
 
         return Assignment(
-            idx,
+            manager.next_atom(),
             var,
             reg,
             ins_addr=manager.ins_addr,
@@ -529,11 +528,11 @@ class VEXStmtConverter(Converter):
         )
 
     @staticmethod
-    def Put(idx, stmt, manager):
+    def Put(stmt, manager):
         data = VEXExprConverter.convert(stmt.data, manager)
         reg = VEXExprConverter.register(stmt.offset, data.bits, manager)
         return Assignment(
-            idx,
+            manager.next_atom(),
             reg,
             data,
             ins_addr=manager.ins_addr,
@@ -542,9 +541,9 @@ class VEXStmtConverter(Converter):
         )
 
     @staticmethod
-    def Store(idx, stmt, manager):
+    def Store(stmt, manager):
         return Store(
-            idx,
+            manager.next_atom(),
             VEXExprConverter.convert(stmt.addr, manager),
             VEXExprConverter.convert(stmt.data, manager),
             stmt.data.result_size(manager.tyenv) // 8,
@@ -555,7 +554,7 @@ class VEXStmtConverter(Converter):
         )
 
     @staticmethod
-    def Exit(idx, stmt, manager):
+    def Exit(stmt, manager):
         if stmt.jumpkind in {
             "Ijk_EmWarn",
             "Ijk_NoDecode",
@@ -569,7 +568,7 @@ class VEXStmtConverter(Converter):
             raise SkipConversionNotice
 
         return ConditionalJump(
-            idx,
+            manager.next_atom(),
             VEXExprConverter.convert(stmt.guard, manager),
             VEXExprConverter.convert(stmt.dst, manager),
             None,  # it will be filled in right afterwards
@@ -579,7 +578,7 @@ class VEXStmtConverter(Converter):
         )
 
     @staticmethod
-    def LoadG(idx, stmt: pyvex.IRStmt.LoadG, manager):
+    def LoadG(stmt: pyvex.IRStmt.LoadG, manager):
         sizes = {
             "ILGop_Ident32": (32, 32, False),
             "ILGop_Ident64": (64, 64, False),
@@ -604,7 +603,7 @@ class VEXStmtConverter(Converter):
             src = Convert(manager.next_atom(), load_bits, convert_bits, signed, src)
 
         return Assignment(
-            idx,
+            manager.next_atom(),
             dst,
             src,
             ins_addr=manager.ins_addr,
@@ -613,9 +612,9 @@ class VEXStmtConverter(Converter):
         )
 
     @staticmethod
-    def StoreG(idx, stmt: pyvex.IRStmt.StoreG, manager):
+    def StoreG(stmt: pyvex.IRStmt.StoreG, manager):
         return Store(
-            idx,
+            manager.next_atom(),
             VEXExprConverter.convert(stmt.addr, manager),
             VEXExprConverter.convert(stmt.data, manager),
             stmt.data.result_size(manager.tyenv) // 8,
@@ -627,7 +626,7 @@ class VEXStmtConverter(Converter):
         )
 
     @staticmethod
-    def CAS(idx, stmt: pyvex.IRStmt.CAS, manager):
+    def CAS(stmt: pyvex.IRStmt.CAS, manager):
         # addr
         addr = VEXExprConverter.convert(stmt.addr, manager)
         data_lo = VEXExprConverter.convert(stmt.dataLo, manager)
@@ -641,11 +640,20 @@ class VEXStmtConverter(Converter):
             else None
         )
         return CAS(
-            idx, addr, data_lo, data_hi, expd_lo, expd_hi, old_lo, old_hi, stmt.endness, ins_addr=manager.ins_addr
+            manager.next_atom(),
+            addr,
+            data_lo,
+            data_hi,
+            expd_lo,
+            expd_hi,
+            old_lo,
+            old_hi,
+            stmt.endness,
+            ins_addr=manager.ins_addr,
         )
 
     @staticmethod
-    def Dirty(idx, stmt: pyvex.IRStmt.Dirty, manager):
+    def Dirty(stmt: pyvex.IRStmt.Dirty, manager):
         # we translate it into tmp = DirtyExpression() if possible
 
         operands = [VEXExprConverter.convert(op, manager) for op in stmt.args]
@@ -668,7 +676,7 @@ class VEXStmtConverter(Converter):
 
         if stmt.tmp == 0xFFFFFFFF:
             return DirtyStatement(
-                idx,
+                manager.next_atom(),
                 dirty_expr,
                 ins_addr=manager.ins_addr,
                 vex_block_addr=manager.block_addr,
@@ -677,7 +685,7 @@ class VEXStmtConverter(Converter):
 
         tmp = VEXExprConverter.tmp(stmt.tmp, bits, manager)
         return Assignment(
-            idx,
+            manager.next_atom(),
             tmp,
             dirty_expr,
             ins_addr=manager.ins_addr,
@@ -710,7 +718,6 @@ class VEXIRSBConverter(Converter):
 
         # convert each VEX statement into an AIL statement
         statements = []
-        idx = 0
 
         manager.tyenv = irsb.tyenv
         manager.block_addr = irsb.addr
@@ -734,17 +741,15 @@ class VEXIRSBConverter(Converter):
 
             manager.vex_stmt_idx = vex_stmt_idx
             try:
-                converted = VEXStmtConverter.convert(idx, stmt, manager)
+                converted = VEXStmtConverter.convert(stmt, manager)
                 if isinstance(converted, list):
                     # got multiple statements
                     statements.extend(converted)
-                    idx += len(converted)
                 else:
                     # got one statement
                     statements.append(converted)
                     if type(converted) is ConditionalJump:
                         conditional_jumps.append(converted)
-                    idx += 1
             except SkipConversionNotice:
                 pass
 

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -216,8 +216,8 @@ class Register(Atom):
 
 
 class ComboRegister(Atom):
-    def __init__(self, idx, variable, registers: list[Register | VirtualVariable], **kwargs):
-        super().__init__(idx, variable, **kwargs)
+    def __init__(self, idx, registers: list[Register | VirtualVariable], **kwargs):
+        super().__init__(idx, **kwargs)
         self.registers = registers
         self.bits = sum(reg.bits for reg in registers)
 
@@ -245,7 +245,7 @@ class ComboRegister(Atom):
         return stable_hash(("combo_reg", tuple(self.registers), self.bits, self.idx))
 
     def copy(self) -> ComboRegister:
-        return ComboRegister(self.idx, None, self.registers, **self.tags)
+        return ComboRegister(self.idx, self.registers, **self.tags)
 
 
 class VirtualVariableCategory(IntEnum):

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -155,8 +155,8 @@ class Const(Atom):
 class Tmp(Atom):
     __slots__ = ("tmp_idx",)
 
-    def __init__(self, idx: int, variable, tmp_idx: int, bits, **kwargs):
-        super().__init__(idx, variable, **kwargs)
+    def __init__(self, idx: int, tmp_idx: int, bits, **kwargs):
+        super().__init__(idx, **kwargs)
 
         self.tmp_idx = tmp_idx
         self.bits = bits
@@ -176,10 +176,10 @@ class Tmp(Atom):
         return stable_hash(("tmp", self.tmp_idx, self.bits))
 
     def copy(self) -> Tmp:
-        return Tmp(self.idx, None, self.tmp_idx, self.bits, **self.tags)
+        return Tmp(self.idx, self.tmp_idx, self.bits, **self.tags)
 
     def deep_copy(self, manager) -> Tmp:
-        return self._transfer_varmap(Tmp(manager.next_atom(), None, self.tmp_idx, self.bits, **self.tags), manager)
+        return self._transfer_varmap(Tmp(manager.next_atom(), self.tmp_idx, self.bits, **self.tags), manager)
 
 
 class Register(Atom):

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -93,8 +93,8 @@ class Atom(Expression):
 class Const(Atom):
     __slots__ = ("value",)
 
-    def __init__(self, idx: int, variable, value: int | float, bits: int, **kwargs):
-        super().__init__(idx, variable, **kwargs)
+    def __init__(self, idx: int, value: int | float, bits: int, **kwargs):
+        super().__init__(idx, **kwargs)
 
         self.value = value
         self.bits = bits
@@ -142,10 +142,10 @@ class Const(Atom):
         return self.value >> (self.bits - 1)
 
     def copy(self) -> Const:
-        return Const(self.idx, None, self.value, self.bits, **self.tags)
+        return Const(self.idx, self.value, self.bits, **self.tags)
 
     def deep_copy(self, manager) -> Const:
-        return self._transfer_varmap(Const(manager.next_atom(), None, self.value, self.bits, **self.tags), manager)
+        return self._transfer_varmap(Const(manager.next_atom(), self.value, self.bits, **self.tags), manager)
 
     @property
     def is_int(self) -> bool:

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -78,15 +78,13 @@ class Expression(TaggedObject, ABC):
 
 
 class Atom(Expression):
-    __slots__ = (
-        "variable",
-        "variable_offset",
-    )
+    # NOTE: variable/variable_offset are no longer stored on AIL atoms; that information now lives in a side
+    # VariableMap (see angr.analyses.decompiler.variable_map). The constructor still accepts (and ignores) the
+    # `variable`/`variable_offset` arguments for backwards compatibility with existing call sites.
+    __slots__ = ()
 
-    def __init__(self, idx: int, variable=None, variable_offset=0, **kwargs):
+    def __init__(self, idx: int, variable=None, variable_offset=0, **kwargs):  # pylint:disable=unused-argument
         super().__init__(idx, 0, **kwargs)
-        self.variable = variable
-        self.variable_offset = variable_offset
 
     def __repr__(self) -> str:
         return f"Atom ({self.idx})"
@@ -144,10 +142,10 @@ class Const(Atom):
         return self.value >> (self.bits - 1)
 
     def copy(self) -> Const:
-        return Const(self.idx, self.variable, self.value, self.bits, **self.tags)
+        return Const(self.idx, None, self.value, self.bits, **self.tags)
 
     def deep_copy(self, manager) -> Const:
-        return Const(manager.next_atom(), self.variable, self.value, self.bits, **self.tags)
+        return self._transfer_varmap(Const(manager.next_atom(), None, self.value, self.bits, **self.tags), manager)
 
     @property
     def is_int(self) -> bool:
@@ -178,10 +176,10 @@ class Tmp(Atom):
         return stable_hash(("tmp", self.tmp_idx, self.bits))
 
     def copy(self) -> Tmp:
-        return Tmp(self.idx, self.variable, self.tmp_idx, self.bits, **self.tags)
+        return Tmp(self.idx, None, self.tmp_idx, self.bits, **self.tags)
 
     def deep_copy(self, manager) -> Tmp:
-        return Tmp(manager.next_atom(), self.variable, self.tmp_idx, self.bits, **self.tags)
+        return self._transfer_varmap(Tmp(manager.next_atom(), None, self.tmp_idx, self.bits, **self.tags), manager)
 
 
 class Register(Atom):
@@ -203,9 +201,7 @@ class Register(Atom):
         reg_name = self.tags.get("reg_name", None)
         if reg_name is not None:
             return f"{reg_name}<{self.bits // 8}>"
-        if self.variable is None:
-            return f"reg_{self.reg_offset}<{self.bits // 8}>"
-        return f"{self.variable.name!s}"
+        return f"reg_{self.reg_offset}<{self.bits // 8}>"
 
     matches = likes
 
@@ -213,10 +209,12 @@ class Register(Atom):
         return stable_hash(("reg", self.reg_offset, self.bits, self.idx))
 
     def copy(self) -> Register:
-        return Register(self.idx, self.variable, self.reg_offset, self.bits, **self.tags)
+        return Register(self.idx, None, self.reg_offset, self.bits, **self.tags)
 
     def deep_copy(self, manager) -> Register:
-        return Register(manager.next_atom(), self.variable, self.reg_offset, self.bits, **self.tags)
+        return self._transfer_varmap(
+            Register(manager.next_atom(), None, self.reg_offset, self.bits, **self.tags), manager
+        )
 
 
 class ComboRegister(Atom):
@@ -249,7 +247,7 @@ class ComboRegister(Atom):
         return stable_hash(("combo_reg", tuple(self.registers), self.bits, self.idx))
 
     def copy(self) -> ComboRegister:
-        return ComboRegister(self.idx, self.variable, self.registers, **self.tags)
+        return ComboRegister(self.idx, None, self.registers, **self.tags)
 
 
 class VirtualVariableCategory(IntEnum):
@@ -403,21 +401,20 @@ class VirtualVariable(Atom):
             self.bits,
             self.category,
             oident=self.oident,
-            variable=self.variable,
-            variable_offset=self.variable_offset,
             **self.tags,
         )
 
     def deep_copy(self, manager) -> VirtualVariable:
-        return VirtualVariable(
-            manager.next_atom(),
-            self.varid,
-            self.bits,
-            self.category,
-            oident=self.oident,
-            variable=self.variable,
-            variable_offset=self.variable_offset,
-            **self.tags,
+        return self._transfer_varmap(
+            VirtualVariable(
+                manager.next_atom(),
+                self.varid,
+                self.bits,
+                self.category,
+                oident=self.oident,
+                **self.tags,
+            ),
+            manager,
         )
 
 
@@ -484,19 +481,18 @@ class Phi(Atom):
             self.idx,
             self.bits,
             self.src_and_vvars[::],
-            variable=self.variable,
-            variable_offset=self.variable_offset,
             **self.tags,
         )
 
     def deep_copy(self, manager) -> Phi:
-        return Phi(
-            manager.next_atom(),
-            self.bits,
-            [(s, vvar.deep_copy(manager) if vvar is not None else None) for s, vvar in self.src_and_vvars],
-            variable=self.variable,
-            variable_offset=self.variable_offset,
-            **self.tags,
+        return self._transfer_varmap(
+            Phi(
+                manager.next_atom(),
+                self.bits,
+                [(s, vvar.deep_copy(manager) if vvar is not None else None) for s, vvar in self.src_and_vvars],
+                **self.tags,
+            ),
+            manager,
         )
 
     def replace(self, old_expr, new_expr):
@@ -514,8 +510,6 @@ class Phi(Atom):
                 self.idx,
                 self.bits,
                 new_src_and_vvars,
-                variable=self.variable,
-                variable_offset=self.variable_offset,
                 **self.tags,
             )
         return False, self
@@ -544,11 +538,7 @@ class Op(Expression):
 
 
 class UnaryOp(Op):
-    __slots__ = (
-        "operand",
-        "variable",
-        "variable_offset",
-    )
+    __slots__ = ("operand",)
 
     def __init__(
         self,
@@ -564,8 +554,6 @@ class UnaryOp(Op):
 
         self.operand = operand
         self.bits = operand.bits if bits is None else bits
-        self.variable = variable
-        self.variable_offset = variable_offset
 
     def __str__(self):
         return f"({self.op} {self.operand!s})"
@@ -612,21 +600,20 @@ class UnaryOp(Op):
             self.idx,
             self.op,
             self.operand,
-            variable=self.variable,
-            variable_offset=self.variable_offset,
             bits=self.bits,
             **self.tags,
         )
 
     def deep_copy(self, manager) -> UnaryOp:
-        return UnaryOp(
-            manager.next_atom(),
-            self.op,
-            self.operand.deep_copy(manager),
-            variable=self.variable,
-            variable_offset=self.variable_offset,
-            bits=self.bits,
-            **self.tags,
+        return self._transfer_varmap(
+            UnaryOp(
+                manager.next_atom(),
+                self.op,
+                self.operand.deep_copy(manager),
+                bits=self.bits,
+                **self.tags,
+            ),
+            manager,
         )
 
     def has_atom(self, atom, identity=True):
@@ -877,8 +864,6 @@ class BinaryOp(Op):
         "operands",
         "rounding_mode",
         "signed",
-        "variable",
-        "variable_offset",
         "vector_count",
         "vector_size",
     )
@@ -983,8 +968,6 @@ class BinaryOp(Op):
         else:
             self.bits = get_bits(operands[0]) if not isinstance(operands[0], int) else get_bits(operands[1])
         self.signed = signed
-        self.variable = variable
-        self.variable_offset = variable_offset
         self.floating_point = floating_point
         self.rounding_mode: str | None = rounding_mode
         self.vector_count = vector_count
@@ -1099,9 +1082,7 @@ class BinaryOp(Op):
             self.idx,
             self.op,
             self.operands[::],
-            variable=self.variable,
             signed=self.signed,
-            variable_offset=self.variable_offset,
             bits=self.bits,
             floating_point=self.floating_point,
             rounding_mode=self.rounding_mode,
@@ -1109,17 +1090,18 @@ class BinaryOp(Op):
         )
 
     def deep_copy(self, manager) -> BinaryOp:
-        return BinaryOp(
-            manager.next_atom(),
-            self.op,
-            [op.deep_copy(manager) for op in self.operands],
-            variable=self.variable,
-            signed=self.signed,
-            variable_offset=self.variable_offset,
-            bits=self.bits,
-            floating_point=self.floating_point,
-            rounding_mode=self.rounding_mode,
-            **self.tags,
+        return self._transfer_varmap(
+            BinaryOp(
+                manager.next_atom(),
+                self.op,
+                [op.deep_copy(manager) for op in self.operands],
+                signed=self.signed,
+                bits=self.bits,
+                floating_point=self.floating_point,
+                rounding_mode=self.rounding_mode,
+                **self.tags,
+            ),
+            manager,
         )
 
 
@@ -1129,8 +1111,6 @@ class Load(Expression):
         "alt",
         "endness",
         "guard",
-        "variable",
-        "variable_offset",
     )
 
     def __init__(
@@ -1153,8 +1133,6 @@ class Load(Expression):
         self.endness = endness
         self.guard = guard
         self.alt = alt
-        self.variable = variable
-        self.variable_offset = variable_offset
         self.bits = self.size * 8
 
     def __repr__(self):
@@ -1222,24 +1200,23 @@ class Load(Expression):
             self.addr,
             self.size,
             self.endness,
-            variable=self.variable,
-            variable_offset=self.variable_offset,
             guard=self.guard,
             alt=self.alt,
             **self.tags,
         )
 
     def deep_copy(self, manager) -> Load:
-        return Load(
-            manager.next_atom(),
-            self.addr.deep_copy(manager),
-            self.size,
-            self.endness,
-            variable=self.variable,
-            variable_offset=self.variable_offset,
-            guard=self.guard.deep_copy(manager) if self.guard is not None else None,
-            alt=self.alt,
-            **self.tags,
+        return self._transfer_varmap(
+            Load(
+                manager.next_atom(),
+                self.addr.deep_copy(manager),
+                self.size,
+                self.endness,
+                guard=self.guard.deep_copy(manager) if self.guard is not None else None,
+                alt=self.alt,
+                **self.tags,
+            ),
+            manager,
         )
 
 
@@ -1248,8 +1225,6 @@ class ITE(Expression):
         "cond",
         "iffalse",
         "iftrue",
-        "variable",
-        "variable_offset",
     )
 
     def __init__(
@@ -1276,8 +1251,6 @@ class ITE(Expression):
         self.iffalse = iffalse
         self.iftrue = iftrue
         self.bits = iftrue.bits
-        self.variable = variable
-        self.variable_offset = variable_offset
 
     def __repr__(self):
         return str(self)
@@ -1345,12 +1318,15 @@ class ITE(Expression):
         return ITE(self.idx, self.cond, self.iffalse, self.iftrue, **self.tags)
 
     def deep_copy(self, manager) -> ITE:
-        return ITE(
-            manager.next_atom(),
-            self.cond.deep_copy(manager),
-            self.iffalse.deep_copy(manager),
-            self.iftrue.deep_copy(manager),
-            **self.tags,
+        return self._transfer_varmap(
+            ITE(
+                manager.next_atom(),
+                self.cond.deep_copy(manager),
+                self.iffalse.deep_copy(manager),
+                self.iftrue.deep_copy(manager),
+                **self.tags,
+            ),
+            manager,
         )
 
 
@@ -1665,8 +1641,6 @@ class BasePointerOffset(Expression):
     __slots__ = (
         "base",
         "offset",
-        "variable",
-        "variable_offset",
     )
 
     def __init__(
@@ -1683,8 +1657,6 @@ class BasePointerOffset(Expression):
         self.bits = bits
         self.base = base
         self.offset = offset
-        self.variable = variable
-        self.variable_offset = variable_offset
 
     def __repr__(self):
         if self.offset is None:
@@ -1729,7 +1701,9 @@ class BasePointerOffset(Expression):
         return BasePointerOffset(self.idx, self.bits, self.base, self.offset, **self.tags)
 
     def deep_copy(self, manager) -> BasePointerOffset:
-        return BasePointerOffset(manager.next_atom(), self.bits, self.base, self.offset, **self.tags)
+        return self._transfer_varmap(
+            BasePointerOffset(manager.next_atom(), self.bits, self.base, self.offset, **self.tags), manager
+        )
 
 
 class StackBaseOffset(BasePointerOffset):

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -543,8 +543,6 @@ class UnaryOp(Op):
         idx: int,
         op: str,
         operand: Expression,
-        variable=None,  # pylint:disable=unused-argument
-        variable_offset: int | None = None,  # pylint:disable=unused-argument
         bits=None,
         **kwargs,
     ):

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -545,8 +545,8 @@ class UnaryOp(Op):
         idx: int,
         op: str,
         operand: Expression,
-        variable=None,
-        variable_offset: int | None = None,
+        variable=None,  # pylint:disable=unused-argument
+        variable_offset: int | None = None,  # pylint:disable=unused-argument
         bits=None,
         **kwargs,
     ):
@@ -923,8 +923,8 @@ class BinaryOp(Op):
         operands: Sequence[Expression],
         signed: bool = False,
         *,
-        variable=None,
-        variable_offset=None,
+        variable=None,  # pylint:disable=unused-argument
+        variable_offset=None,  # pylint:disable=unused-argument
         bits=None,
         floating_point=False,
         rounding_mode=None,
@@ -1119,8 +1119,8 @@ class Load(Expression):
         addr: Expression,
         size: int,
         endness: str,
-        variable=None,
-        variable_offset=None,
+        variable=None,  # pylint:disable=unused-argument
+        variable_offset=None,  # pylint:disable=unused-argument
         guard=None,
         alt=None,
         **kwargs,
@@ -1233,8 +1233,8 @@ class ITE(Expression):
         cond: Expression,
         iffalse: Expression,
         iftrue: Expression,
-        variable=None,
-        variable_offset=None,
+        variable=None,  # pylint:disable=unused-argument
+        variable_offset=None,  # pylint:disable=unused-argument
         **kwargs,
     ):
         depth = (
@@ -1649,8 +1649,8 @@ class BasePointerOffset(Expression):
         bits: int,
         base: Expression | str,
         offset: int,
-        variable=None,
-        variable_offset=None,
+        variable=None,  # pylint:disable=unused-argument
+        variable_offset=None,  # pylint:disable=unused-argument
         **kwargs,
     ):
         super().__init__(idx, (offset.depth if isinstance(offset, Expression) else 0) + 1, **kwargs)

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -1639,8 +1639,6 @@ class BasePointerOffset(Expression):
         bits: int,
         base: Expression | str,
         offset: int,
-        variable=None,  # pylint:disable=unused-argument
-        variable_offset=None,  # pylint:disable=unused-argument
         **kwargs,
     ):
         super().__init__(idx, (offset.depth if isinstance(offset, Expression) else 0) + 1, **kwargs)

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -1225,8 +1225,6 @@ class ITE(Expression):
         cond: Expression,
         iffalse: Expression,
         iftrue: Expression,
-        variable=None,  # pylint:disable=unused-argument
-        variable_offset=None,  # pylint:disable=unused-argument
         **kwargs,
     ):
         depth = (

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -1113,8 +1113,6 @@ class Load(Expression):
         addr: Expression,
         size: int,
         endness: str,
-        variable=None,  # pylint:disable=unused-argument
-        variable_offset=None,  # pylint:disable=unused-argument
         guard=None,
         alt=None,
         **kwargs,

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -919,8 +919,6 @@ class BinaryOp(Op):
         operands: Sequence[Expression],
         signed: bool = False,
         *,
-        variable=None,  # pylint:disable=unused-argument
-        variable_offset=None,  # pylint:disable=unused-argument
         bits=None,
         floating_point=False,
         rounding_mode=None,

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -79,11 +79,10 @@ class Expression(TaggedObject, ABC):
 
 class Atom(Expression):
     # NOTE: variable/variable_offset are no longer stored on AIL atoms; that information now lives in a side
-    # VariableMap (see angr.analyses.decompiler.variable_map). The constructor still accepts (and ignores) the
-    # `variable`/`variable_offset` arguments for backwards compatibility with existing call sites.
+    # VariableMap (see angr.analyses.decompiler.variable_map).
     __slots__ = ()
 
-    def __init__(self, idx: int, variable=None, variable_offset=0, **kwargs):  # pylint:disable=unused-argument
+    def __init__(self, idx: int, **kwargs):
         super().__init__(idx, 0, **kwargs)
 
     def __repr__(self) -> str:

--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -185,8 +185,8 @@ class Tmp(Atom):
 class Register(Atom):
     __slots__ = ("reg_offset",)
 
-    def __init__(self, idx: int, variable, reg_offset: int, bits: int, **kwargs):
-        super().__init__(idx, variable, **kwargs)
+    def __init__(self, idx: int, reg_offset: int, bits: int, **kwargs):
+        super().__init__(idx, **kwargs)
 
         self.reg_offset = reg_offset
         self.bits = bits
@@ -209,12 +209,10 @@ class Register(Atom):
         return stable_hash(("reg", self.reg_offset, self.bits, self.idx))
 
     def copy(self) -> Register:
-        return Register(self.idx, None, self.reg_offset, self.bits, **self.tags)
+        return Register(self.idx, self.reg_offset, self.bits, **self.tags)
 
     def deep_copy(self, manager) -> Register:
-        return self._transfer_varmap(
-            Register(manager.next_atom(), None, self.reg_offset, self.bits, **self.tags), manager
-        )
+        return self._transfer_varmap(Register(manager.next_atom(), self.reg_offset, self.bits, **self.tags), manager)
 
 
 class ComboRegister(Atom):

--- a/angr/ailment/manager.py
+++ b/angr/ailment/manager.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 import itertools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from angr.analyses.decompiler.variable_map import VariableMap
 
 
 class Manager:
+    """
+    AIL manager class used during AIL generation and simplification.
+    """
+
     _block_addr: int
 
     def __init__(self, name: str | None = None, arch=None):
@@ -12,11 +20,9 @@ class Manager:
 
         self.atom_ctr = itertools.count()
 
-        # An optional side container (analyses.decompiler.VariableMap) that maps atom .idx values to variable-related
-        # information. It is attached by Clinic so that optimization passes, peephole optimizations, and region
-        # simplifiers (all of which hold a reference to this Manager) can read and update variable information without
-        # storing it on the AIL atoms themselves. Kept untyped here to avoid an ailment->angr import dependency.
-        self.variable_map = None
+        # Attached by Clinic so that optimization passes, peephole optimizations, and region
+        # simplifiers can use VariableMap.
+        self.variable_map: VariableMap | None = None
 
         self._ins_addr: int | None = None
 

--- a/angr/ailment/manager.py
+++ b/angr/ailment/manager.py
@@ -12,6 +12,12 @@ class Manager:
 
         self.atom_ctr = itertools.count()
 
+        # An optional side container (analyses.decompiler.VariableMap) that maps atom .idx values to variable-related
+        # information. It is attached by Clinic so that optimization passes, peephole optimizations, and region
+        # simplifiers (all of which hold a reference to this Manager) can read and update variable information without
+        # storing it on the AIL atoms themselves. Kept untyped here to avoid an ailment->angr import dependency.
+        self.variable_map = None
+
         self._ins_addr: int | None = None
 
         ###

--- a/angr/ailment/statement.py
+++ b/angr/ailment/statement.py
@@ -187,9 +187,6 @@ class Store(Statement):
     Store statement: ``*addr = data``
     """
 
-    # NOTE: variable/offset (the variable and its offset) are no longer stored on Store; that information now lives
-    # in a side VariableMap. The constructor still accepts (and ignores) `variable`/`offset` for backwards
-    # compatibility with existing call sites.
     __slots__ = (
         "addr",
         "data",

--- a/angr/ailment/statement.py
+++ b/angr/ailment/statement.py
@@ -203,8 +203,6 @@ class Store(Statement):
         size: int,
         endness: str,
         guard: Expression | None = None,
-        variable=None,  # pylint:disable=unused-argument
-        offset=None,  # pylint:disable=unused-argument
         **kwargs,
     ):
         super().__init__(idx, **kwargs)

--- a/angr/ailment/statement.py
+++ b/angr/ailment/statement.py
@@ -187,14 +187,15 @@ class Store(Statement):
     Store statement: ``*addr = data``
     """
 
+    # NOTE: variable/offset (the variable and its offset) are no longer stored on Store; that information now lives
+    # in a side VariableMap. The constructor still accepts (and ignores) `variable`/`offset` for backwards
+    # compatibility with existing call sites.
     __slots__ = (
         "addr",
         "data",
         "endness",
         "guard",
-        "offset",
         "size",
-        "variable",
     )
 
     def __init__(
@@ -205,8 +206,8 @@ class Store(Statement):
         size: int,
         endness: str,
         guard: Expression | None = None,
-        variable=None,
-        offset=None,
+        variable=None,  # pylint:disable=unused-argument
+        offset=None,  # pylint:disable=unused-argument
         **kwargs,
     ):
         super().__init__(idx, **kwargs)
@@ -215,9 +216,7 @@ class Store(Statement):
         self.data = data
         self.size = size
         self.endness = endness
-        self.variable = variable
         self.guard = guard
-        self.offset = offset  # variable_offset
 
     def likes(self, other):
         return (
@@ -246,13 +245,8 @@ class Store(Statement):
         return f"Store ({self.addr}, {self.data}[{self.size}])" + ("" if self.guard is None else f"[{self.guard}]")
 
     def __str__(self):
-        if self.variable is None:
-            return (
-                f"STORE(addr={self.addr}, data={self.data!s}, size={self.size},"
-                f" endness={self.endness}, guard={self.guard})"
-            )
-        return f"{self.variable.name} ={'L' if self.endness == 'Iend_LE' else 'B'} {self.data}<{self.size}>" + (
-            "" if self.guard is None else f"[{self.guard}]"
+        return (
+            f"STORE(addr={self.addr}, data={self.data!s}, size={self.size}, endness={self.endness}, guard={self.guard})"
         )
 
     def replace(self, old_expr, new_expr):
@@ -284,7 +278,6 @@ class Store(Statement):
                 self.size,
                 self.endness,
                 guard=replaced_guard,
-                variable=self.variable,
                 **self.tags,
             )
         return False, self
@@ -301,22 +294,21 @@ class Store(Statement):
             self.size,
             self.endness,
             guard=self.guard,
-            variable=self.variable,
-            offset=self.offset,
             **self.tags,
         )
 
     def deep_copy(self, manager) -> Store:
-        return Store(
-            manager.next_atom(),
-            self.addr.deep_copy(manager),
-            self.data.deep_copy(manager),
-            self.size,
-            self.endness,
-            guard=self.guard.deep_copy(manager) if self.guard is not None else None,
-            variable=self.variable,
-            offset=self.offset,
-            **self.tags,
+        return self._transfer_varmap(
+            Store(
+                manager.next_atom(),
+                self.addr.deep_copy(manager),
+                self.data.deep_copy(manager),
+                self.size,
+                self.endness,
+                guard=self.guard.deep_copy(manager) if self.guard is not None else None,
+                **self.tags,
+            ),
+            manager,
         )
 
 

--- a/angr/ailment/tagged_object.py
+++ b/angr/ailment/tagged_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Self, TypedDict
+from typing import TYPE_CHECKING, Self, TypedDict
 
 from angr.ailment.manager import Manager
 
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
     from typing import Unpack
 
     from angr.sim_type import SimType
-    from angr.sim_variable import SimVariable
 
 
 class TagDict(TypedDict, total=False):
@@ -18,7 +17,6 @@ class TagDict(TypedDict, total=False):
 
     always_propagate: bool
     block_idx: int
-    custom_string: bool
     deref_src_addr: int
     extra_def: bool
     extra_defs: list[int]
@@ -26,9 +24,6 @@ class TagDict(TypedDict, total=False):
     is_prototype_guessed: bool
     keep_in_slice: bool
     orig_ins_addr: int
-    reference_values: dict[SimType, Any]
-    reference_variable_offset: int
-    reference_variable: SimVariable
     reg_name: str
     type: dict[str, SimType]
     uninitialized: bool
@@ -66,3 +61,13 @@ class TaggedObject:
 
     def deep_copy(self, manager: Manager) -> Self:
         raise NotImplementedError
+
+    def _transfer_varmap(self, new, manager: Manager):
+        """
+        Helper for deep_copy: when a manager carries a VariableMap, transfer this object's variable information to the
+        freshly deep-copied object ``new`` (which has a new .idx). Returns ``new`` for convenient chaining.
+        """
+        variable_map = getattr(manager, "variable_map", None)
+        if variable_map is not None:
+            variable_map.transfer(self, new)
+        return new

--- a/angr/ailment/tagged_object.py
+++ b/angr/ailment/tagged_object.py
@@ -62,12 +62,11 @@ class TaggedObject:
     def deep_copy(self, manager: Manager) -> Self:
         raise NotImplementedError
 
-    def _transfer_varmap(self, new, manager: Manager):
+    def _transfer_varmap(self, new: TaggedObject, manager: Manager):
         """
         Helper for deep_copy: when a manager carries a VariableMap, transfer this object's variable information to the
         freshly deep-copied object ``new`` (which has a new .idx). Returns ``new`` for convenient chaining.
         """
-        variable_map = getattr(manager, "variable_map", None)
-        if variable_map is not None:
-            variable_map.transfer(self, new)
+        if manager.variable_map is not None:
+            manager.variable_map.transfer(self, new)
         return new

--- a/angr/analyses/decompiler/__init__.py
+++ b/angr/analyses/decompiler/__init__.py
@@ -14,6 +14,7 @@ from .presets import DECOMPILATION_PRESETS
 from .region_identifier import RegionIdentifier
 from .region_simplifiers import RegionSimplifier
 from .ssailification import Ssailification
+from .variable_map import VariableMap
 from .structured_codegen import BaseStructuredCodeGenerator, CStructuredCodeGenerator, ImportSourceCode
 
 StructuredCodeGenerator = CStructuredCodeGenerator
@@ -38,6 +39,7 @@ __all__ = (
     "SeqNodeDephication",
     "Ssailification",
     "StructuredCodeGenerator",
+    "VariableMap",
     "optimization_passes",
     "options",
     "options_by_category",

--- a/angr/analyses/decompiler/__init__.py
+++ b/angr/analyses/decompiler/__init__.py
@@ -14,8 +14,8 @@ from .presets import DECOMPILATION_PRESETS
 from .region_identifier import RegionIdentifier
 from .region_simplifiers import RegionSimplifier
 from .ssailification import Ssailification
-from .variable_map import VariableMap
 from .structured_codegen import BaseStructuredCodeGenerator, CStructuredCodeGenerator, ImportSourceCode
+from .variable_map import VariableMap
 
 StructuredCodeGenerator = CStructuredCodeGenerator
 

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -150,7 +150,7 @@ class PartialConstantExprRewriter(AILBlockRewriter):
                 return expr
             if new_mask == 0:
                 return Const(expr_idx, None, 0, expr.bits, **expr.tags)
-            new_mask_expr = Const(mask_expr.idx, mask_expr.variable, new_mask, mask_expr.bits, **mask_expr.tags)
+            new_mask_expr = Const(mask_expr.idx, None, new_mask, mask_expr.bits, **mask_expr.tags)
             return BinaryOp(expr_idx, expr.op, [vvar, new_mask_expr], bits=expr.bits, **expr.tags)
         return super()._handle_BinaryOp(expr_idx, expr, stmt_idx, stmt, block)
 

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -149,8 +149,8 @@ class PartialConstantExprRewriter(AILBlockRewriter):
             if new_mask == mask:
                 return expr
             if new_mask == 0:
-                return Const(expr_idx, None, 0, expr.bits, **expr.tags)
-            new_mask_expr = Const(mask_expr.idx, None, new_mask, mask_expr.bits, **mask_expr.tags)
+                return Const(expr_idx, 0, expr.bits, **expr.tags)
+            new_mask_expr = Const(mask_expr.idx, new_mask, mask_expr.bits, **mask_expr.tags)
             return BinaryOp(expr_idx, expr.op, [vvar, new_mask_expr], bits=expr.bits, **expr.tags)
         return super()._handle_BinaryOp(expr_idx, expr, stmt_idx, stmt, block)
 
@@ -1027,7 +1027,7 @@ class AILSimplifier(Analysis):
                     continue
                 if use_loc not in replacements[key]:
                     replacements[key][use_loc] = {}
-                replacements[key][use_loc][expr] = Const(self._ail_manager.next_atom(), None, value, bits, **expr.tags)
+                replacements[key][use_loc][expr] = Const(self._ail_manager.next_atom(), value, bits, **expr.tags)
 
         return self._replace_exprs_in_blocks(replacements) if replacements else False
 
@@ -1280,7 +1280,6 @@ class AILSimplifier(Analysis):
                         new_idx,
                         Const(
                             self._ail_manager.next_atom(),
-                            None,
                             eq.atom0.addr,
                             self.project.arch.bits,
                         ),

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -2206,7 +2206,7 @@ class AILSimplifier(Analysis):
             stmt_idx: int, stmt: DirtyStatement, block: Block | None
         ) -> Statement:
             # we do not want to trigger _handle_DirtyExpression, which is why we do not call the superclass method
-            rewriter = rewriter_cls(stmt, self.project.arch)
+            rewriter = rewriter_cls(stmt, self.project.arch, self._ail_manager)
             if rewriter.result is not None:
                 _any_update.v = True
                 if walker._update_block and block is not None:
@@ -2220,7 +2220,7 @@ class AILSimplifier(Analysis):
         ):
             r_expr = AILBlockRewriter._handle_DirtyExpression(walker, expr_idx, expr, stmt_idx, stmt, block)
             assert isinstance(r_expr, DirtyExpression)
-            rewriter = rewriter_cls(r_expr, self.project.arch)
+            rewriter = rewriter_cls(r_expr, self.project.arch, self._ail_manager)
             if rewriter.result is not None:
                 _any_update.v = True
                 assert isinstance(rewriter.result, Expression)

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -393,7 +393,7 @@ class BlockSimplifier(Analysis):
 
                     if type(stmt.dst) is Tmp and isinstance(stmt.src, Call):
                         # eliminate the assignment and replace it with the call
-                        stmt = SideEffectStatement(stmt.idx, stmt.src, **stmt.tags)
+                        stmt = SideEffectStatement(self._ail_manager.next_atom(), stmt.src, **stmt.tags)
 
                 if isinstance(stmt, Assignment) and stmt.src == stmt.dst:
                     continue

--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -227,7 +227,6 @@ class CallSiteMaker(Analysis):
                     else:
                         reg = Expr.Register(
                             self._atom_idx(),
-                            None,
                             offset,
                             size * 8,
                             reg_name=arg_loc.reg_name,

--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -207,7 +207,6 @@ class CallSiteMaker(Analysis):
                                     vvar_use,
                                     Expr.Const(
                                         self._ail_manager.next_atom(),
-                                        None,
                                         (offset - vvar_def_reg_offset) * 8,
                                         8,
                                     ),

--- a/angr/analyses/decompiler/ccall_rewriters/amd64_ccalls.py
+++ b/angr/analyses/decompiler/ccall_rewriters/amd64_ccalls.py
@@ -208,7 +208,7 @@ class AMD64CCallRewriter(CCallRewriterBase):
                         r = Expr.BinaryOp(
                             ccall.idx,
                             expr_op,
-                            (dep_1, Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits)),
+                            (dep_1, Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits)),
                             False,
                             **ccall.tags,
                         )
@@ -231,7 +231,7 @@ class AMD64CCallRewriter(CCallRewriterBase):
                         )
                         expr_op = "CmpEQ" if cond_v == AMD64_CondTypes["CondZ"] else "CmpNE"
 
-                        zero = Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits)
+                        zero = Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits)
                         r = Expr.BinaryOp(ccall.idx, expr_op, (dep_1, zero), False, **ccall.tags)
                         return Expr.Convert(self.ail_manager.next_atom(), r.bits, ccall.bits, False, r, **ccall.tags)
                     if op_v == AMD64_OpTypes["G_CC_OP_COPY"]:
@@ -239,11 +239,11 @@ class AMD64CCallRewriter(CCallRewriterBase):
 
                         bitmask = AMD64_CondBitMasks["G_CC_MASK_Z"]
                         assert isinstance(bitmask, int)
-                        flag = Expr.Const(self.ail_manager.next_atom(), None, bitmask, dep_1.bits)
+                        flag = Expr.Const(self.ail_manager.next_atom(), bitmask, dep_1.bits)
                         masked_dep = Expr.BinaryOp(
                             self.ail_manager.next_atom(), "And", [dep_1, flag], False, **ccall.tags
                         )
-                        zero = Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits)
+                        zero = Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits)
                         expr_op = "CmpEQ" if cond_v == AMD64_CondTypes["CondZ"] else "CmpNE"
 
                         r = Expr.BinaryOp(ccall.idx, expr_op, (masked_dep, zero), False, **ccall.tags)
@@ -265,7 +265,7 @@ class AMD64CCallRewriter(CCallRewriterBase):
                         )
                         expr_op = "CmpEQ" if cond_v == AMD64_CondTypes["CondZ"] else "CmpNE"
 
-                        zero = Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits)
+                        zero = Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits)
                         r = Expr.BinaryOp(ccall.idx, expr_op, (dep_1, zero), False, **ccall.tags)
                         return Expr.Convert(self.ail_manager.next_atom(), r.bits, ccall.bits, False, r, **ccall.tags)
                 elif cond_v == AMD64_CondTypes["CondL"]:
@@ -314,7 +314,7 @@ class AMD64CCallRewriter(CCallRewriterBase):
                             AMD64_OpTypes["G_CC_OP_LOGICL"],
                             ccall.tags,
                         )
-                        zero = Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits)
+                        zero = Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits)
                         r = Expr.BinaryOp(ccall.idx, "CmpLT", (dep_1, zero), True, **ccall.tags)
                         return Expr.Convert(self.ail_manager.next_atom(), r.bits, ccall.bits, False, r, **ccall.tags)
 
@@ -536,8 +536,8 @@ class AMD64CCallRewriter(CCallRewriterBase):
                             ],
                             False,
                         ),
-                        Expr.Const(self.ail_manager.next_atom(), None, 0, ccall.bits),
-                        Expr.Const(self.ail_manager.next_atom(), None, 1, ccall.bits),
+                        Expr.Const(self.ail_manager.next_atom(), 0, ccall.bits),
+                        Expr.Const(self.ail_manager.next_atom(), 1, ccall.bits),
                         **ccall.tags,
                     )
 
@@ -596,10 +596,10 @@ class AMD64CCallRewriter(CCallRewriterBase):
                             Expr.BinaryOp(
                                 self.ail_manager.next_atom(),
                                 "And",
-                                [ndep, Expr.Const(self.ail_manager.next_atom(), None, bitmask, 64)],
+                                [ndep, Expr.Const(self.ail_manager.next_atom(), bitmask, 64)],
                                 False,
                             ),
-                            Expr.Const(self.ail_manager.next_atom(), None, bitmask_1, 64),
+                            Expr.Const(self.ail_manager.next_atom(), bitmask_1, 64),
                         ],
                         False,
                         **ccall.tags,
@@ -618,6 +618,6 @@ class AMD64CCallRewriter(CCallRewriterBase):
             bits = 64
         if bits < 64:
             if isinstance(expr, Expr.Const):
-                return Expr.Const(expr.idx, None, expr.value_int & ((1 << bits) - 1), bits, **tags)
+                return Expr.Const(expr.idx, expr.value_int & ((1 << bits) - 1), bits, **tags)
             return Expr.Convert(self.ail_manager.next_atom(), 64, bits, False, expr, **tags)
         return expr

--- a/angr/analyses/decompiler/ccall_rewriters/arm_ccalls.py
+++ b/angr/analyses/decompiler/ccall_rewriters/arm_ccalls.py
@@ -99,9 +99,9 @@ class ARMCCallRewriter(CCallRewriterBase):
 
         # AL (always) / NV (never) — independent of operation
         if cond_v == ARMCondAL:
-            return Expr.Const(ccall.idx, None, 1, ccall.bits, **ccall.tags)
+            return Expr.Const(ccall.idx, 1, ccall.bits, **ccall.tags)
         if cond_v == ARMCondNV:
-            return Expr.Const(ccall.idx, None, 0, ccall.bits, **ccall.tags)
+            return Expr.Const(ccall.idx, 0, ccall.bits, **ccall.tags)
 
         if op_v == ARMG_CC_OP_SUB:
             return self._rewrite_sub(ccall, cond_v, inv, dep_1, dep_2)
@@ -158,7 +158,7 @@ class ARMCCallRewriter(CCallRewriterBase):
         op_v = cc_op.value_int
         dep_1 = ccall.operands[1]
         dep_2 = ccall.operands[2]
-        zero = Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits, **ccall.tags)
+        zero = Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits, **ccall.tags)
 
         if op_v == ARMG_CC_OP_SUB:
             # N = sign(dep_1 - dep_2) → (dep_1 - dep_2) <s 0 → dep_1 <s dep_2
@@ -184,7 +184,7 @@ class ARMCCallRewriter(CCallRewriterBase):
         op_v = cc_op.value_int
         dep_1 = ccall.operands[1]
         dep_2 = ccall.operands[2]
-        zero = Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits, **ccall.tags)
+        zero = Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits, **ccall.tags)
 
         if op_v == ARMG_CC_OP_SUB:
             # Z = (dep_1 == dep_2)
@@ -285,7 +285,7 @@ class ARMCCallRewriter(CCallRewriterBase):
         ADD: flags from ``dep_1 + dep_2``.
         """
         add_expr = Expr.BinaryOp(self.ail_manager.next_atom(), "Add", (dep_1, dep_2), signed=False, **ccall.tags)
-        zero = Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits, **ccall.tags)
+        zero = Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits, **ccall.tags)
 
         # EQ/NE — Z flag: (dep_1 + dep_2) == 0
         if cond_v in {ARMCondEQ, ARMCondNE}:
@@ -314,7 +314,7 @@ class ARMCCallRewriter(CCallRewriterBase):
         LOGIC: flags from AND/OR/XOR result (dep_1 = result).
         MUL:   flags from multiply result (dep_1 = result).
         """
-        zero = Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits, **ccall.tags)
+        zero = Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits, **ccall.tags)
 
         # EQ/NE — Z flag: dep_1 == 0
         if cond_v in {ARMCondEQ, ARMCondNE}:

--- a/angr/analyses/decompiler/ccall_rewriters/x86_ccalls.py
+++ b/angr/analyses/decompiler/ccall_rewriters/x86_ccalls.py
@@ -90,7 +90,6 @@ class X86CCallRewriter(CCallRewriterBase):
                         )
                         max_signed = Expr.Const(
                             self.ail_manager.next_atom(),
-                            None,
                             (1 << (dep_1.bits - 1)),
                             bits=dep_1.bits * 2,
                             **ccall.tags,
@@ -113,7 +112,6 @@ class X86CCallRewriter(CCallRewriterBase):
                         )
                         max_signed = Expr.Const(
                             self.ail_manager.next_atom(),
-                            None,
                             (1 << (dep_1.bits - 1)),
                             bits=dep_1.bits,
                             **ccall.tags,
@@ -129,7 +127,6 @@ class X86CCallRewriter(CCallRewriterBase):
                         # dep_1 is the result
                         overflowed = Expr.Const(
                             self.ail_manager.next_atom(),
-                            None,
                             1 << (dep_1.bits - 1),
                             dep_1.bits,
                             **ccall.tags,
@@ -147,8 +144,8 @@ class X86CCallRewriter(CCallRewriterBase):
                         return Expr.ITE(
                             ccall.idx,
                             ret_cond,
-                            Expr.Const(self.ail_manager.next_atom(), None, 0, ccall.bits, **ccall.tags),
-                            Expr.Const(self.ail_manager.next_atom(), None, 1, ccall.bits, **ccall.tags),
+                            Expr.Const(self.ail_manager.next_atom(), 0, ccall.bits, **ccall.tags),
+                            Expr.Const(self.ail_manager.next_atom(), 1, ccall.bits, **ccall.tags),
                             **ccall.tags,
                         )
                 elif cond_v == X86_CondTypes["CondZ"]:
@@ -168,7 +165,6 @@ class X86CCallRewriter(CCallRewriterBase):
                         )
                         zero = Expr.Const(
                             self.ail_manager.next_atom(),
-                            None,
                             0,
                             dep_1.bits,
                             **ccall.tags,
@@ -210,7 +206,7 @@ class X86CCallRewriter(CCallRewriterBase):
                         cmp = Expr.BinaryOp(
                             ccall.idx,
                             "CmpEQ",
-                            (dep_1, Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits, **ccall.tags)),
+                            (dep_1, Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits, **ccall.tags)),
                             True,
                             bits=1,
                             **ccall.tags,
@@ -246,7 +242,7 @@ class X86CCallRewriter(CCallRewriterBase):
                         cmp = Expr.BinaryOp(
                             ccall.idx,
                             "CmpLT",
-                            (dep_1, Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits, **ccall.tags)),
+                            (dep_1, Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits, **ccall.tags)),
                             True,
                             **ccall.tags,
                         )
@@ -275,7 +271,6 @@ class X86CCallRewriter(CCallRewriterBase):
                         )
                         zero = Expr.Const(
                             self.ail_manager.next_atom(),
-                            None,
                             0,
                             dep_1.bits,
                             **ccall.tags,
@@ -316,7 +311,7 @@ class X86CCallRewriter(CCallRewriterBase):
                         cmp = Expr.BinaryOp(
                             ccall.idx,
                             "CmpLE" if cond_v == X86_CondTypes["CondBE"] else "CmpLT",
-                            (dep_1, Expr.Const(self.ail_manager.next_atom(), None, 0, dep_1.bits, **ccall.tags)),
+                            (dep_1, Expr.Const(self.ail_manager.next_atom(), 0, dep_1.bits, **ccall.tags)),
                             False,
                             bits=1,
                             **ccall.tags,
@@ -370,6 +365,6 @@ class X86CCallRewriter(CCallRewriterBase):
             bits = 32
         if bits < 32:
             if isinstance(expr, Expr.Const):
-                return Expr.Const(expr.idx, None, expr.value & ((1 << bits) - 1), bits, **tags)
+                return Expr.Const(expr.idx, expr.value & ((1 << bits) - 1), bits, **tags)
             return Expr.Convert(self.ail_manager.next_atom(), 32, bits, False, expr, **tags)
         return expr

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -403,6 +403,8 @@ class Clinic(Analysis):
     def _analyze_for_decompiling(self):
         # initialize the AIL conversion manager
         self._ail_manager = ailment.Manager(arch=self.project.arch)
+        # attach the VariableMap so passes/peephole-opts/region-simplifiers that hold the manager can reach it
+        self._ail_manager.variable_map = self.variable_map
 
         ail_graph = self._init_ail_graph if self._init_ail_graph is not None else self._decompilation_graph_recovery()
         if not ail_graph:
@@ -989,7 +991,9 @@ class Clinic(Analysis):
         assert entry_node is not None
 
         # Run all semantic naming patterns via the orchestrator
-        orchestrator = SemanticNamingOrchestrator(self._ail_graph, var_manager, self.kb.functions, entry_node)
+        orchestrator = SemanticNamingOrchestrator(
+            self._ail_graph, var_manager, self.kb.functions, entry_node, self.variable_map
+        )
         var_name_mapping = orchestrator.analyze()
         l.debug("Semantic naming renamed %d variables", len(var_name_mapping))
 
@@ -1007,6 +1011,7 @@ class Clinic(Analysis):
 
         # initialize the AIL conversion manager
         self._ail_manager = ailment.Manager(arch=self.project.arch)
+        self._ail_manager.variable_map = self.variable_map
 
         # Track stack pointers
         self._update_progress(15.0, text="Tracking stack pointers")
@@ -2648,7 +2653,7 @@ class Clinic(Analysis):
 
         elif isinstance(expr, ailment.Expr.Const) and expr.is_int:
             # custom string?
-            if expr.tags.get("custom_string", False):
+            if self.variable_map.custom_string(expr):
                 s = self.kb.custom_strings[expr.value]
                 ty = (
                     expr.tags["type"]

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -2414,24 +2414,15 @@ class Clinic(Analysis):
         return tmp_kb
 
     def _set_expr_variable(self, expr, variable, offset) -> None:
-        # dual-write: keep the legacy attributes on the AIL object and update the side VariableMap. The legacy
-        # attributes will be removed once all consumers read from the VariableMap.
-        expr.variable = variable
-        expr.variable_offset = offset
         self.variable_map.set_variable(expr, variable, offset)
 
     def _set_store_variable(self, stmt, variable, offset) -> None:
-        stmt.variable = variable
-        stmt.offset = offset
         self.variable_map.set_variable(stmt, variable, offset)
 
     def _set_reference_variable(self, expr, variable, offset) -> None:
-        expr.tags["reference_variable"] = variable
-        expr.tags["reference_variable_offset"] = offset
         self.variable_map.set_reference_variable(expr, variable, offset)
 
     def _set_reference_values(self, expr, reference_values) -> None:
-        expr.tags["reference_values"] = reference_values
         self.variable_map.set_reference_values(expr, reference_values)
 
     def _link_variables_on_block(self, block, kb):

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -83,6 +83,7 @@ from .return_maker import ReturnMaker
 from .semantic_naming import SemanticNamingOrchestrator
 from .ssailification.ssailification import Ssailification
 from .stack_item import StackItem, StackItemType
+from .variable_map import VariableMap
 
 if TYPE_CHECKING:
     from angr.analyses.s_reaching_definitions import SRDAModel
@@ -235,6 +236,7 @@ class Clinic(Analysis):
         constrain_callee_prototypes: bool = False,
         semvar_naming: bool = True,
         flavor: str = "pseudocode",
+        variable_map: VariableMap | None = None,
     ):
         if not func.normalized and mode == ClinicMode.DECOMPILE:
             raise ValueError("Decompilation must work on normalized function graphs.")
@@ -250,6 +252,10 @@ class Clinic(Analysis):
         self.func_args = None
         self.func_ret_var = SimVariable(0, "__retvar", "__retvar")
         self.variable_kb = variable_kb
+        # VariableMap is a side container that holds variable/variable_offset/custom_string/reference_values and the
+        # sibling reference_variable/reference_variable_offset for AIL atoms, keyed by their .idx. It supersedes
+        # storing this information directly on AIL Statement/Expression objects.
+        self.variable_map: VariableMap = variable_map if variable_map is not None else VariableMap()
         self.externs: set[SimMemoryVariable] = set()
         self.data_refs: dict[int, list[DataRefDesc]] = {}  # data address to data reference description
         self.optimization_scratch = optimization_scratch if optimization_scratch is not None else {}
@@ -988,7 +994,7 @@ class Clinic(Analysis):
         l.debug("Semantic naming renamed %d variables", len(var_name_mapping))
 
     def _stage_collect_externs(self) -> None:
-        self.externs = self._collect_externs(self._ail_graph, self.variable_kb)
+        self.externs = self._collect_externs(self._ail_graph, self.variable_kb, self.variable_map)
 
     def _analyze_for_data_refs(self):
         # Remove alignment blocks
@@ -2391,6 +2397,7 @@ class Clinic(Analysis):
             self._link_variables_on_block(block, tmp_kb)
 
         if self._cache is not None:
+            self._cache.variable_map = self.variable_map
             self._cache.arg_vvars = arg_vvars
             self._cache.type_constraints = vr.type_constraints
             self._cache.func_typevar = vr.func_typevar
@@ -2400,6 +2407,27 @@ class Clinic(Analysis):
             self._cache.max_tv_id = vr.tv_manager.max_tv_id
 
         return tmp_kb
+
+    def _set_expr_variable(self, expr, variable, offset) -> None:
+        # dual-write: keep the legacy attributes on the AIL object and update the side VariableMap. The legacy
+        # attributes will be removed once all consumers read from the VariableMap.
+        expr.variable = variable
+        expr.variable_offset = offset
+        self.variable_map.set_variable(expr, variable, offset)
+
+    def _set_store_variable(self, stmt, variable, offset) -> None:
+        stmt.variable = variable
+        stmt.offset = offset
+        self.variable_map.set_variable(stmt, variable, offset)
+
+    def _set_reference_variable(self, expr, variable, offset) -> None:
+        expr.tags["reference_variable"] = variable
+        expr.tags["reference_variable_offset"] = offset
+        self.variable_map.set_reference_variable(expr, variable, offset)
+
+    def _set_reference_values(self, expr, reference_values) -> None:
+        expr.tags["reference_values"] = reference_values
+        self.variable_map.set_reference_values(expr, reference_values)
 
     def _link_variables_on_block(self, block, kb):
         """
@@ -2418,7 +2446,8 @@ class Clinic(Analysis):
                 # find a memory variable
                 mem_vars = variable_manager.find_variables_by_atom(block.addr, stmt_idx, stmt, block_idx=block.idx)
                 if len(mem_vars) == 1:
-                    stmt.variable, stmt.offset = next(iter(mem_vars))
+                    var, offset = next(iter(mem_vars))
+                    self._set_store_variable(stmt, var, offset)
                 else:
                     # check if the dest address is a variable
                     stmt: ailment.Stmt.Store
@@ -2428,8 +2457,7 @@ class Clinic(Analysis):
                         variables = global_variables.get_global_variables(stmt.addr.value)
                         if variables:
                             var = next(iter(variables))
-                            stmt.variable = var
-                            stmt.offset = 0
+                            self._set_store_variable(stmt, var, 0)
                     else:
                         self._link_variables_on_expr(
                             variable_manager, global_variables, block, stmt_idx, stmt, stmt.addr
@@ -2519,15 +2547,13 @@ class Clinic(Analysis):
                 final_reg_vars = reg_vars
             if len(final_reg_vars) >= 1:
                 reg_var, offset = next(iter(final_reg_vars))
-                expr.variable = reg_var
-                expr.variable_offset = offset
+                self._set_expr_variable(expr, reg_var, offset)
 
         elif type(expr) is ailment.Expr.VirtualVariable:
             vars_ = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr, block_idx=block.idx)
             if len(vars_) >= 1:
                 var, offset = next(iter(vars_))
-                expr.variable = var
-                expr.variable_offset = offset
+                self._set_expr_variable(expr, var, offset)
 
             if expr.was_combo_reg:
                 for reg_vvar in expr.reg_vvars:
@@ -2546,33 +2572,37 @@ class Clinic(Analysis):
                 # if we are accessing the variable directly (offset == 0), we link the variable onto this expression
                 if (
                     offset == 0 or (isinstance(offset, ailment.Expr.Const) and offset.value == 0)
-                ) and "reference_variable" in base_addr.tags:
-                    expr.variable = base_addr.tags["reference_variable"]
-                    expr.variable_offset = base_addr.tags["reference_variable_offset"]
+                ) and self.variable_map.reference_variable(base_addr) is not None:
+                    self._set_expr_variable(
+                        expr,
+                        self.variable_map.reference_variable(base_addr),
+                        self.variable_map.reference_variable_offset(base_addr),
+                    )
 
                 if base_addr is None and offset is None:
                     # this is a local variable
                     self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt, expr.addr)
-                    if "reference_variable" in expr.addr.tags and expr.addr.tags["reference_variable"] is not None:
+                    if self.variable_map.reference_variable(expr.addr) is not None:
                         # copy over the variable to this expr since the variable on a constant is supposed to be a
                         # reference variable.
-                        expr.variable = expr.addr.tags["reference_variable"]
-                        expr.variable_offset = expr.addr.tags["reference_variable_offset"]
+                        self._set_expr_variable(
+                            expr,
+                            self.variable_map.reference_variable(expr.addr),
+                            self.variable_map.reference_variable_offset(expr.addr),
+                        )
             else:
                 if len(variables) > 1:
                     l.error(
                         "More than one variable are available for atom %s. Consider fixing it using phi nodes.", expr
                     )
                 var, offset = next(iter(variables))
-                expr.variable = var
-                expr.variable_offset = offset
+                self._set_expr_variable(expr, var, offset)
 
         elif type(expr) is ailment.Expr.BinaryOp:
             variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr, block_idx=block.idx)
             if len(variables) >= 1:
                 var, offset = next(iter(variables))
-                expr.variable = var
-                expr.variable_offset = offset
+                self._set_expr_variable(expr, var, offset)
             else:
                 self._link_variables_on_expr(
                     variable_manager, global_variables, block, stmt_idx, stmt, expr.operands[0]
@@ -2585,8 +2615,7 @@ class Clinic(Analysis):
             variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr, block_idx=block.idx)
             if len(variables) >= 1:
                 var, offset = next(iter(variables))
-                expr.variable = var
-                expr.variable_offset = offset
+                self._set_expr_variable(expr, var, offset)
             else:
                 self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt, expr.operand)
 
@@ -2605,8 +2634,7 @@ class Clinic(Analysis):
             variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr, block_idx=block.idx)
             if len(variables) >= 1:
                 var, offset = next(iter(variables))
-                expr.variable = var
-                expr.variable_offset = offset
+                self._set_expr_variable(expr, var, offset)
             else:
                 self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt, expr.cond)
                 self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt, expr.iftrue)
@@ -2616,8 +2644,7 @@ class Clinic(Analysis):
             variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr, block_idx=block.idx)
             if len(variables) >= 1:
                 var, offset = next(iter(variables))
-                expr.variable = var
-                expr.variable_offset = offset
+                self._set_expr_variable(expr, var, offset)
 
         elif isinstance(expr, ailment.Expr.Const) and expr.is_int:
             # custom string?
@@ -2628,9 +2655,7 @@ class Clinic(Analysis):
                     if "type" in expr.tags
                     else SimTypePointer(SimTypeChar()).with_arch(self.project.arch)
                 )
-                expr.tags["reference_values"] = {
-                    ty: s,
-                }
+                self._set_reference_values(expr, {ty: s})
             else:
                 # global variable?
                 global_vars = global_variables.get_global_variables(expr.value_int)
@@ -2647,15 +2672,13 @@ class Clinic(Analysis):
                             global_vars = {global_var}
                 if global_vars:
                     global_var = next(iter(global_vars))
-                    expr.tags["reference_variable"] = global_var
-                    expr.tags["reference_variable_offset"] = 0
+                    self._set_reference_variable(expr, global_var, 0)
                 else:
                     # is there a related constant variable?
                     variables = variable_manager.find_variables_by_atom(block.addr, stmt_idx, expr, block_idx=block.idx)
                     if len(variables) >= 1:
                         var, offset = next(iter(variables))
-                        expr.variable = var
-                        expr.variable_offset = offset
+                        self._set_expr_variable(expr, var, offset)
 
         elif isinstance(expr, ailment.Expr.Call):
             self._link_variables_on_call(variable_manager, global_variables, block, stmt_idx, stmt, expr)
@@ -3436,7 +3459,7 @@ class Clinic(Analysis):
             node.statements.insert(0, lbl)
 
     @staticmethod
-    def _collect_externs(ail_graph, variable_kb):
+    def _collect_externs(ail_graph, variable_kb, variable_map: VariableMap):
         global_vars = variable_kb.variables.global_manager.get_variables()
         walker = ailment.AILBlockRewriter()
         variables = set()
@@ -3449,16 +3472,17 @@ class Clinic(Analysis):
             block: ailment.Block | None,
         ):
             for v in [
-                getattr(expr, "variable", None),
-                expr.tags.get("reference_variable", None) if hasattr(expr, "tags") else None,
+                variable_map.variable(expr),
+                variable_map.reference_variable(expr),
             ]:
                 if v and v in global_vars:
                     variables.add(v)
             return ailment.AILBlockRewriter._handle_expr(walker, expr_idx, expr, stmt_idx, stmt, block)
 
         def handle_Store(stmt_idx: int, stmt: ailment.statement.Store, block: ailment.Block | None):
-            if stmt.variable and stmt.variable in global_vars:
-                variables.add(stmt.variable)
+            store_var = variable_map.variable(stmt)
+            if store_var and store_var in global_vars:
+                variables.add(store_var)
             return ailment.AILBlockRewriter._handle_Store(walker, stmt_idx, stmt, block)
 
         walker.stmt_handlers[ailment.statement.Store] = handle_Store
@@ -3884,7 +3908,7 @@ class Clinic(Analysis):
                 arg_types = []
                 for arg_expr in expr.args:
                     arg_type = None
-                    if hasattr(arg_expr, "variable") and arg_expr.variable is not None:
+                    if self.variable_map.variable(arg_expr) is not None:
                         # the type is type(a)
                         t = None
                         if isinstance(arg_expr, ailment.Expr.VirtualVariable):
@@ -3904,7 +3928,7 @@ class Clinic(Analysis):
 
                         if t is None:
                             # maybe not a function arg
-                            v = arg_expr.variable
+                            v = self.variable_map.variable(arg_expr)
                             if v is not None:
                                 t = variables.get_variable_type(v)
 
@@ -3913,7 +3937,7 @@ class Clinic(Analysis):
                     elif isinstance(arg_expr, ailment.Expr.UnaryOp) and arg_expr.op == "Reference":
                         # &a; the type becomes a pointer to type(a)
                         inner = arg_expr.operand
-                        v = inner.variable
+                        v = self.variable_map.variable(inner)
                         if v is not None:
                             t = variables.get_variable_type(v)
                             if t is not None:

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -169,7 +169,7 @@ class ComboRegReferenceWalker(AILBlockRewriter):
                 offset += reg_vvar.size
             addr = ailment.Expr.UnaryOp(self._ail_manager.next_atom(), "Reference", combo_reg)
             if offset != 0:
-                offset_expr = ailment.Expr.Const(self._ail_manager.next_atom(), None, offset, self.project.arch.bits)
+                offset_expr = ailment.Expr.Const(self._ail_manager.next_atom(), offset, self.project.arch.bits)
                 addr = ailment.Expr.BinaryOp(
                     self._ail_manager.next_atom(),
                     "Add",
@@ -1386,7 +1386,7 @@ class Clinic(Analysis):
                 ins_addr=block.addr,
             )
             forward = ailment.Expr.Const(
-                self._ail_manager.next_atom(), None, 1, dflag_size * self.project.arch.byte_width, ins_addr=block.addr
+                self._ail_manager.next_atom(), 1, dflag_size * self.project.arch.byte_width, ins_addr=block.addr
             )
             dflag_assignment = ailment.Stmt.Assignment(
                 self._ail_manager.next_atom(), dflag, forward, ins_addr=block.addr
@@ -1452,7 +1452,7 @@ class Clinic(Analysis):
                         new_last_stmt = last_stmt.copy()
                         assert isinstance(successors[0].addr, int)
                         new_last_stmt.expr.target = ailment.Expr.Const(
-                            self._ail_manager.next_atom(), None, successors[0].addr, last_stmt.expr.target.bits
+                            self._ail_manager.next_atom(), successors[0].addr, last_stmt.expr.target.bits
                         )
                         block.statements[-1] = new_last_stmt
 
@@ -1470,7 +1470,7 @@ class Clinic(Analysis):
                     new_last_stmt = last_stmt.copy()
                     assert isinstance(successors[0].addr, int)
                     new_last_stmt.target = ailment.Expr.Const(
-                        self._ail_manager.next_atom(), None, successors[0].addr, last_stmt.target.bits
+                        self._ail_manager.next_atom(), successors[0].addr, last_stmt.target.bits
                     )
                     block.statements[-1] = new_last_stmt
 
@@ -2891,10 +2891,10 @@ class Clinic(Analysis):
             ite_expr_stmt.idx,
             ite_expr.cond,
             ailment.Expr.Const(
-                self._ail_manager.next_atom(), None, true_block_addr, self.project.arch.bits, **ite_expr_stmt.tags
+                self._ail_manager.next_atom(), true_block_addr, self.project.arch.bits, **ite_expr_stmt.tags
             ),
             ailment.Expr.Const(
-                self._ail_manager.next_atom(), None, false_block_addr, self.project.arch.bits, **ite_expr_stmt.tags
+                self._ail_manager.next_atom(), false_block_addr, self.project.arch.bits, **ite_expr_stmt.tags
             ),
             **ite_expr_stmt.tags,
         )
@@ -3299,9 +3299,7 @@ class Clinic(Analysis):
                 # the head is removed - let's replace it with a jump to the target
                 jump_stmt = ailment.Stmt.Jump(
                     self._ail_manager.next_atom(),
-                    ailment.Expr.Const(
-                        self._ail_manager.next_atom(), None, intended_head_1.addr, self.project.arch.bits
-                    ),
+                    ailment.Expr.Const(self._ail_manager.next_atom(), intended_head_1.addr, self.project.arch.bits),
                     target_idx=intended_head_1.idx,
                     ins_addr=o.addr,
                 )
@@ -3315,9 +3313,7 @@ class Clinic(Analysis):
                     # update the jump target
                     new_head.statements[-1] = ailment.Stmt.Jump(
                         new_head.statements[-1].idx,
-                        ailment.Expr.Const(
-                            self._ail_manager.next_atom(), None, intended_head_1.addr, self.project.arch.bits
-                        ),
+                        ailment.Expr.Const(self._ail_manager.next_atom(), intended_head_1.addr, self.project.arch.bits),
                         target_idx=intended_head_1.idx,
                         **new_head.statements[-1].tags,
                     )

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -591,7 +591,6 @@ class Clinic(Analysis):
                             self._ail_manager.next_atom(),
                             ailment.Expr.Register(
                                 self._ail_manager.next_atom(),
-                                None,
                                 self.project.arch.ret_offset,
                                 self.project.arch.bits,
                             ),
@@ -641,7 +640,6 @@ class Clinic(Analysis):
                         param_vvar,
                         ailment.Expr.Register(
                             self._ail_manager.next_atom(),
-                            None,
                             reg_offset,
                             reg_arg.bits,
                             ins_addr=caller_block.addr + caller_block.original_size,
@@ -1260,7 +1258,6 @@ class Clinic(Analysis):
                                 reg_offset, reg_size = self.project.arch.registers[cc.cc.RETURN_VAL.reg_name]
                                 last_stmt.ret_expr = ailment.Expr.Register(
                                     self._ail_manager.next_atom(),
-                                    None,
                                     reg_offset,
                                     reg_size * 8,
                                     ins_addr=callsite_ins_addr,
@@ -1380,7 +1377,6 @@ class Clinic(Analysis):
             dflag_offset, dflag_size = self.project.arch.registers["d"]
             dflag = ailment.Expr.Register(
                 self._ail_manager.next_atom(),
-                None,
                 dflag_offset,
                 dflag_size * self.project.arch.byte_width,
                 ins_addr=block.addr,
@@ -1507,7 +1503,6 @@ class Clinic(Analysis):
                     tags.pop("reg_name", None)
                     ret_expr = ailment.Expr.Register(
                         self._ail_manager.next_atom(),
-                        None,
                         ret_reg_offset,
                         self.project.arch.bits,
                         reg_name=self.project.arch.translate_register_name(ret_reg_offset, size=self.project.arch.bits),
@@ -1566,7 +1561,6 @@ class Clinic(Analysis):
                 arg_offset, arg_bits = self.project.arch.registers[arg.reg_name]
                 arg_expr = ailment.Expr.Register(
                     self._ail_manager.next_atom(),
-                    None,
                     arg_offset,
                     arg_bits * self.project.arch.byte_width,
                     **last_stmt.tags,
@@ -2820,7 +2814,6 @@ class Clinic(Analysis):
                         call_stmt = last_stmt.copy()
                         call_stmt.expr.target = ailment.Expr.Register(
                             self._ail_manager.next_atom(),
-                            None,
                             self.project.arch.registers["rax"][0],
                             64,
                             ins_addr=call_stmt.tags["ins_addr"],
@@ -3845,7 +3838,6 @@ class Clinic(Analysis):
                             [
                                 ailment.Expr.Register(
                                     self._ail_manager.next_atom(),
-                                    None,
                                     self.project.arch.sp_offset,
                                     self.project.arch.bits,
                                 ),

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -758,7 +758,7 @@ class ConditionProcessor:
                     self.ail_manager.next_atom(),
                     "CmpEQ",
                     (
-                        ailment.Expr.Register(self.ail_manager.next_atom(), None, self.EXC_COUNTER, 64),
+                        ailment.Expr.Register(self.ail_manager.next_atom(), self.EXC_COUNTER, 64),
                         ailment.Expr.Const(self.ail_manager.next_atom(), self.EXC_COUNTER, 64),
                     ),
                     False,

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -759,7 +759,7 @@ class ConditionProcessor:
                     "CmpEQ",
                     (
                         ailment.Expr.Register(self.ail_manager.next_atom(), None, self.EXC_COUNTER, 64),
-                        ailment.Expr.Const(self.ail_manager.next_atom(), None, self.EXC_COUNTER, 64),
+                        ailment.Expr.Const(self.ail_manager.next_atom(), self.EXC_COUNTER, 64),
                     ),
                     False,
                 ),
@@ -845,7 +845,7 @@ class ConditionProcessor:
             return cond
 
         if cond.op in {"BoolS", "BoolV"} and claripy.is_true(claripy.simplify(cond)):
-            return ailment.Expr.Const(self.ail_manager.next_atom(), None, True, 1)
+            return ailment.Expr.Const(self.ail_manager.next_atom(), True, 1)
         if cond in self._condition_mapping:
             return self._condition_mapping[cond]
         if cond.op in {"BVS", "BoolS"} and cond.args[0] in self._condition_mapping:
@@ -903,12 +903,12 @@ class ConditionProcessor:
             "__mod__": lambda cond_, tags: _binary_op_reduce("Mod", cond_.args, tags),
             "LShR": lambda cond_, tags: _binary_op_reduce("Shr", cond_.args, tags),
             "BVV": lambda cond_, tags: ailment.Expr.Const(
-                self.ail_manager.next_atom(), None, cond_.args[0], cond_.size(), **tags
+                self.ail_manager.next_atom(), cond_.args[0], cond_.size(), **tags
             ),
             "BoolV": lambda cond_, tags: (
-                ailment.Expr.Const(self.ail_manager.next_atom(), None, True, 1, **tags)
+                ailment.Expr.Const(self.ail_manager.next_atom(), True, 1, **tags)
                 if cond_.args[0] is True
-                else ailment.Expr.Const(self.ail_manager.next_atom(), None, False, 1, **tags)
+                else ailment.Expr.Const(self.ail_manager.next_atom(), False, 1, **tags)
             ),
             "Extract": lambda cond_, tags: self._convert_extract(*cond_.args, tags, memo=memo),
             "ZeroExt": lambda cond_, tags: _binary_op_reduce(

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -949,15 +949,16 @@ class ConditionProcessor:
             )
         if isinstance(condition, (ailment.Expr.Load, ailment.Expr.Register, ailment.Expr.VirtualVariable)):
             # does it have a variable associated?
-            if condition.variable is not None:
+            condition_var = self.ail_manager.variable_map.variable(condition)
+            if condition_var is not None:
                 if condition.bits == 1:
                     var = claripy.BoolS(
-                        f"ailexpr_{condition!r}-{condition.variable.ident}-{ins_addr:x}",
+                        f"ailexpr_{condition!r}-{condition_var.ident}-{ins_addr:x}",
                         explicit_name=True,
                     )
                 else:
                     var = claripy.BVS(
-                        f"ailexpr_{condition!r}-{condition.variable.ident}-{ins_addr:x}",
+                        f"ailexpr_{condition!r}-{condition_var.ident}-{ins_addr:x}",
                         condition.bits,
                         explicit_name=True,
                     )

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -18,7 +18,6 @@ from angr.utils.graph import GraphUtils, dominates, inverted_idoms
 
 from .graph_region import GraphRegion
 from .peephole_optimizations import InvertNegatedLogicalConjunctionsAndDisjunctions, RemoveRedundantNots
-from .variable_map import variable_map_of
 from .structurer_nodes import (
     BreakNode,
     CascadingConditionNode,
@@ -34,6 +33,7 @@ from .structurer_nodes import (
     SwitchCaseNode,
 )
 from .utils import peephole_optimize_expr
+from .variable_map import variable_map_of
 
 if TYPE_CHECKING:
     from angr.ailment import Manager

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -18,6 +18,7 @@ from angr.utils.graph import GraphUtils, dominates, inverted_idoms
 
 from .graph_region import GraphRegion
 from .peephole_optimizations import InvertNegatedLogicalConjunctionsAndDisjunctions, RemoveRedundantNots
+from .variable_map import variable_map_of
 from .structurer_nodes import (
     BreakNode,
     CascadingConditionNode,
@@ -949,7 +950,7 @@ class ConditionProcessor:
             )
         if isinstance(condition, (ailment.Expr.Load, ailment.Expr.Register, ailment.Expr.VirtualVariable)):
             # does it have a variable associated?
-            condition_var = self.ail_manager.variable_map.variable(condition)
+            condition_var = variable_map_of(self.ail_manager).variable(condition)
             if condition_var is not None:
                 if condition.bits == 1:
                     var = claripy.BoolS(

--- a/angr/analyses/decompiler/decompilation_cache.py
+++ b/angr/analyses/decompiler/decompilation_cache.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from angr.analyses.typehoon.typevars import TypeConstraint, TypeVariable
 
     from .structured_codegen import BaseStructuredCodeGenerator
+    from .variable_map import VariableMap
 
 
 class DecompilationCache:
@@ -33,6 +34,7 @@ class DecompilationCache:
         "stackvar_max_sizes",
         "type_constraints",
         "var_to_typevar",
+        "variable_map",
     )
 
     def __init__(self, addr):
@@ -46,6 +48,7 @@ class DecompilationCache:
         self.stack_offset_typevars: dict | None = None
         self.codegen: BaseStructuredCodeGenerator | None = None
         self.clinic: Clinic | None = None
+        self.variable_map: VariableMap | None = None
         self.ite_exprs: set[tuple[int, Any]] | None = None
         self.binop_operators: dict[OpDescriptor, str] | None = None
         self.errors: list[str] = []

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -484,6 +484,7 @@ class Decompiler(Analysis):
                     flavor=self._flavor,
                     func_args=clinic.arg_list,
                     variable_kb=clinic.variable_kb,
+                    variable_map=clinic.variable_map,
                     expr_comments=old_codegen.expr_comments if old_codegen is not None else None,
                     stmt_comments=old_codegen.stmt_comments if old_codegen is not None else None,
                     const_formats=old_codegen.const_formats if old_codegen is not None else None,

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -37,9 +37,9 @@ from .structured_codegen.c import CStructuredCodeGenerator
 from .structured_codegen.rust import RustStructuredCodeGenerator
 from .structurer_nodes import SequenceNode
 from .structuring import DEFAULT_STRUCTURER, PhoenixStructurer, RecursiveStructurer
-from .variable_map import VariableMap
 from .structuring.phoenix import MultiStmtExprMode
 from .utils import remove_edges_in_ailgraph
+from .variable_map import VariableMap
 
 if TYPE_CHECKING:
     from angr.analyses.typehoon.typevars import TypeConstraint, TypeVariable

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -370,6 +370,7 @@ class Decompiler(Analysis):
         # Clinic run, or the reuse-cached-Clinic path, may not repopulate cache.variable_map during linking).
         cache.variable_map = clinic.variable_map
         self._variable_kb = clinic.variable_kb
+        self._variable_map = clinic.variable_map
         self._update_progress(70.0, text="Identifying regions")
         self.vvar_id_start = clinic.vvar_id_start
         self._copied_var_ids = clinic.copied_var_ids
@@ -869,14 +870,26 @@ class Decompiler(Analysis):
         """
         variable_kb = self._variable_kb
         dephication = self.project.analyses.GraphDephication(
-            self.func, ail_graph, rewrite=True, variable_kb=variable_kb, kb=self.kb, fail_fast=self._fail_fast
+            self.func,
+            ail_graph,
+            rewrite=True,
+            variable_kb=variable_kb,
+            variable_map=self._variable_map,
+            kb=self.kb,
+            fail_fast=self._fail_fast,
         )
         return dephication.output
 
     def transform_seqnode_from_ssa(self, seq_node: SequenceNode) -> SequenceNode:
         variable_kb = self._variable_kb
         dephication = self.project.analyses.SeqNodeDephication(
-            self.func, seq_node, rewrite=True, variable_kb=variable_kb, kb=self.kb, fail_fast=self._fail_fast
+            self.func,
+            seq_node,
+            rewrite=True,
+            variable_kb=variable_kb,
+            variable_map=self._variable_map,
+            kb=self.kb,
+            fail_fast=self._fail_fast,
         )
         return dephication.output
 

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -37,6 +37,7 @@ from .structured_codegen.c import CStructuredCodeGenerator
 from .structured_codegen.rust import RustStructuredCodeGenerator
 from .structurer_nodes import SequenceNode
 from .structuring import DEFAULT_STRUCTURER, PhoenixStructurer, RecursiveStructurer
+from .variable_map import VariableMap
 from .structuring.phoenix import MultiStmtExprMode
 from .utils import remove_edges_in_ailgraph
 
@@ -314,6 +315,11 @@ class Decompiler(Analysis):
         cache.ite_exprs = ite_exprs
         cache.binop_operators = binop_operators
 
+        # The Decompiler owns the VariableMap. A fresh map is created before launching a new Clinic (re-linking
+        # populates it from scratch over freshly-allocated atom idx values). When a cached Clinic is reused without
+        # re-linking, its existing map is carried over below.
+        variable_map = VariableMap()
+
         # convert function blocks to AIL blocks
         def progress_callback(p, **kwargs):
             return self._update_progress(p * (70 - 5) / 100.0 + 5, **kwargs)
@@ -349,6 +355,7 @@ class Decompiler(Analysis):
                 static_vvars=self._static_vvars,
                 static_buffers=self._static_buffers,
                 flavor=self._flavor,
+                variable_map=variable_map,
                 **self.options_to_params(self.options_by_class["clinic"]),
             )
         else:
@@ -359,6 +366,9 @@ class Decompiler(Analysis):
 
         self.clinic = clinic
         self.cache = cache
+        # Make the VariableMap available on the cache regardless of whether Clinic re-linked variables (a partial
+        # Clinic run, or the reuse-cached-Clinic path, may not repopulate cache.variable_map during linking).
+        cache.variable_map = clinic.variable_map
         self._variable_kb = clinic.variable_kb
         self._update_progress(70.0, text="Identifying regions")
         self.vvar_id_start = clinic.vvar_id_start

--- a/angr/analyses/decompiler/dephication/dephication_base.py
+++ b/angr/analyses/decompiler/dephication/dephication_base.py
@@ -8,6 +8,7 @@ from angr.analyses.analysis import Analysis
 
 if TYPE_CHECKING:
     from angr import KnowledgeBase
+    from angr.analyses.decompiler.variable_map import VariableMap
 
 l = logging.getLogger(name=__name__)
 
@@ -24,6 +25,7 @@ class DephicationBase(Analysis):
         vvar_to_vvar_mapping: dict[int, int] | None = None,
         rewrite: bool = False,
         variable_kb: KnowledgeBase | None = None,
+        variable_map: VariableMap | None = None,
     ):
         if isinstance(func, str):
             self._function = self.kb.functions[func]
@@ -32,6 +34,7 @@ class DephicationBase(Analysis):
 
         self.variable_kb = variable_kb
         self.vvar_to_vvar_mapping = vvar_to_vvar_mapping if vvar_to_vvar_mapping is not None else None
+        self.variable_map = variable_map
         self.rewrite = rewrite
         self.output = None
 

--- a/angr/analyses/decompiler/dephication/graph_dephication.py
+++ b/angr/analyses/decompiler/dephication/graph_dephication.py
@@ -16,6 +16,7 @@ from .graph_rewriting import GraphRewritingAnalysis
 
 if TYPE_CHECKING:
     from angr import KnowledgeBase
+    from angr.analyses.decompiler.variable_map import VariableMap
 
 
 l = logging.getLogger(name=__name__)
@@ -34,6 +35,7 @@ class GraphDephication(DephicationBase):  # pylint:disable=abstract-method
         vvar_to_vvar_mapping: dict[int, int] | None = None,
         rewrite: bool = False,
         variable_kb: KnowledgeBase | None = None,
+        variable_map: VariableMap | None = None,
     ):
         """
         :param func:                            The subject of the analysis: a function, or a single basic block
@@ -42,7 +44,13 @@ class GraphDephication(DephicationBase):  # pylint:disable=abstract-method
 
         self._graph = ail_graph
 
-        super().__init__(func, vvar_to_vvar_mapping=vvar_to_vvar_mapping, rewrite=rewrite, variable_kb=variable_kb)
+        super().__init__(
+            func,
+            vvar_to_vvar_mapping=vvar_to_vvar_mapping,
+            rewrite=rewrite,
+            variable_kb=variable_kb,
+            variable_map=variable_map,
+        )
 
         self._analyze()
 
@@ -64,7 +72,12 @@ class GraphDephication(DephicationBase):  # pylint:disable=abstract-method
     def _rewrite_container(self) -> networkx.DiGraph:
         # replace all vvars with phi variables in the graph
         rewriter = GraphRewritingAnalysis(
-            self.project, self._function, self._graph, self.vvar_to_vvar_mapping, variable_kb=self.variable_kb
+            self.project,
+            self._function,
+            self._graph,
+            self.vvar_to_vvar_mapping,
+            variable_kb=self.variable_kb,
+            variable_map=self.variable_map,
         )
         return rewriter.out_graph
 

--- a/angr/analyses/decompiler/dephication/graph_rewriting.py
+++ b/angr/analyses/decompiler/dephication/graph_rewriting.py
@@ -20,11 +20,20 @@ class GraphRewritingAnalysis(ForwardAnalysis[None, NodeType, object, object, obj
     This analysis traverses the AIL graph and rewrites virtual variables accordingly.
     """
 
-    def __init__(self, project, func, ail_graph, vvar_to_vvar: dict[int, int], variable_kb=None):
+    def __init__(
+        self,
+        project,
+        func,
+        ail_graph,
+        vvar_to_vvar: dict[int, int],
+        variable_kb=None,
+        variable_map=None,
+    ):
         self.project = project
         self._function = func
         self._graph_visitor = FunctionGraphVisitor(self._function, ail_graph)
         self.variable_kb = variable_kb
+        self.variable_map = variable_map
 
         ForwardAnalysis.__init__(
             self, order_jobs=False, allow_merging=False, allow_widening=False, graph_visitor=self._graph_visitor
@@ -32,7 +41,11 @@ class GraphRewritingAnalysis(ForwardAnalysis[None, NodeType, object, object, obj
         self._graph = ail_graph
         self._vvar_to_vvar = vvar_to_vvar
         self._engine_ail = SimEngineDephiRewriting(
-            self.project, self._vvar_to_vvar, func_addr=self._function.addr, variable_kb=self.variable_kb
+            self.project,
+            self._vvar_to_vvar,
+            func_addr=self._function.addr,
+            variable_kb=self.variable_kb,
+            variable_map=self.variable_map,
         )
 
         self._visited_blocks: set[Any] = set()

--- a/angr/analyses/decompiler/dephication/rewriting_engine.py
+++ b/angr/analyses/decompiler/dephication/rewriting_engine.py
@@ -105,8 +105,6 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 stmt.dst.bits,
                 stmt.dst.category,
                 oident=stmt.dst.oident,
-                variable=stmt.dst.variable,
-                variable_offset=stmt.dst.variable_offset,
                 **stmt.dst.tags,
             )
 
@@ -195,7 +193,6 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 stmt.data if new_data is None else new_data,
                 stmt.size,
                 stmt.endness,
-                variable=stmt.variable,
                 guard=stmt.guard,
                 **stmt.tags,
             )
@@ -303,8 +300,6 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 expr.bits,
                 expr.category,
                 oident=expr.oident,
-                variable=expr.variable,
-                variable_offset=expr.variable_offset,
                 **expr.tags,
             )
         return None

--- a/angr/analyses/decompiler/dephication/rewriting_engine.py
+++ b/angr/analyses/decompiler/dephication/rewriting_engine.py
@@ -37,6 +37,7 @@ from angr.engines.light import SimEngineNostmtAIL
 
 if TYPE_CHECKING:
     from angr import KnowledgeBase
+    from angr.analyses.decompiler.variable_map import VariableMap
 
 
 _l = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
         vvar_to_vvar: dict[int, int],
         func_addr: int | None = None,
         variable_kb: KnowledgeBase | None = None,
+        variable_map: VariableMap | None = None,
     ):
         super().__init__(project)
 
@@ -63,6 +65,7 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
         self.out_block = None
         self.func_addr = func_addr
         self.variable_kb = variable_kb
+        self.variable_map = variable_map
 
         self._stmt_handlers["IncompleteSwitchCaseHeadStatement"] = self._handle_stmt_IncompleteSwitchCaseHeadStatement
 
@@ -120,9 +123,10 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 self.func_addr is not None
                 and self.variable_kb is not None
                 and self.func_addr in self.variable_kb.variables
+                and self.variable_map is not None
             ):
-                dst_var = getattr(dst, "variable", None)
-                src_var = getattr(src, "variable", None)
+                dst_var = self.variable_map.variable(dst)
+                src_var = self.variable_map.variable(src)
                 var_manager = self.variable_kb.variables[self.func_addr]
                 if (
                     dst_var is not None

--- a/angr/analyses/decompiler/dephication/seqnode_dephication.py
+++ b/angr/analyses/decompiler/dephication/seqnode_dephication.py
@@ -19,6 +19,7 @@ from .rewriting_engine import SimEngineDephiRewriting
 
 if TYPE_CHECKING:
     from angr import KnowledgeBase
+    from angr.analyses.decompiler.variable_map import VariableMap
 
 
 l = logging.getLogger(__name__)
@@ -64,6 +65,7 @@ class SeqNodeRewriter(SequenceWalker):
         project: angr.Project,
         variable_kb: KnowledgeBase | None = None,
         func_addr: int | None = None,
+        variable_map: VariableMap | None = None,
     ):
         super().__init__(
             handlers={
@@ -77,7 +79,10 @@ class SeqNodeRewriter(SequenceWalker):
         )
 
         self.vvar_to_vvar = vvar_to_vvar
-        self.engine = SimEngineDephiRewriting(project, self.vvar_to_vvar, func_addr=func_addr, variable_kb=variable_kb)
+        self.variable_map = variable_map
+        self.engine = SimEngineDephiRewriting(
+            project, self.vvar_to_vvar, func_addr=func_addr, variable_kb=variable_kb, variable_map=self.variable_map
+        )
 
         self.output = self.walk(seq_node)
         if self.output is None:
@@ -130,8 +135,15 @@ class SeqNodeDephication(DephicationBase):
         vvar_to_vvar_mapping: dict[int, int] | None = None,
         rewrite: bool = False,
         variable_kb: KnowledgeBase | None = None,
+        variable_map: VariableMap | None = None,
     ):
-        super().__init__(func, vvar_to_vvar_mapping=vvar_to_vvar_mapping, rewrite=rewrite, variable_kb=variable_kb)
+        super().__init__(
+            func,
+            vvar_to_vvar_mapping=vvar_to_vvar_mapping,
+            rewrite=rewrite,
+            variable_kb=variable_kb,
+            variable_map=variable_map,
+        )
 
         self._seq_node = seq_node
 
@@ -149,6 +161,7 @@ class SeqNodeDephication(DephicationBase):
             self.project,
             func_addr=self._function.addr,
             variable_kb=self.variable_kb,
+            variable_map=self.variable_map,
         )
         return rewriter.output
 

--- a/angr/analyses/decompiler/dirty_rewriters/amd64_dirty.py
+++ b/angr/analyses/decompiler/dirty_rewriters/amd64_dirty.py
@@ -19,7 +19,7 @@ class AMD64DirtyRewriter(DirtyRewriterBase):
         call_expr = self._rewrite_expr_to_call(dirty.dirty)
         if call_expr is None:
             return None
-        return SideEffectStatement(dirty.idx, call_expr, **dirty.tags)
+        return SideEffectStatement(self.manager.next_atom(), call_expr, **dirty.tags)
 
     def _rewrite_expr(self, dirty: DirtyExpression) -> Expression | None:
         return self._rewrite_expr_to_call(dirty)
@@ -34,7 +34,7 @@ class AMD64DirtyRewriter(DirtyRewriterBase):
                     return None
                 bits = size.value_int * self.arch.byte_width
                 return Call(
-                    idx=dirty.idx,
+                    self.manager.next_atom(),
                     target=f"__in{self._inout_intrinsic_suffix(bits)}",
                     calling_convention=None,
                     prototype=sim_type.SimTypeFunction(
@@ -52,7 +52,7 @@ class AMD64DirtyRewriter(DirtyRewriterBase):
                     return None
                 bits = size.value_int * self.arch.byte_width
                 return Call(
-                    dirty.idx,
+                    self.manager.next_atom(),
                     target=f"__out{self._inout_intrinsic_suffix(bits)}",
                     calling_convention=None,
                     prototype=sim_type.SimTypeFunction(

--- a/angr/analyses/decompiler/dirty_rewriters/rewriter_base.py
+++ b/angr/analyses/decompiler/dirty_rewriters/rewriter_base.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from angr.ailment.expression import DirtyExpression, Expression
 from angr.ailment.statement import DirtyStatement, Statement
+
+if TYPE_CHECKING:
+    from angr.ailment.manager import Manager
 
 
 class DirtyRewriterBase:
@@ -11,11 +16,13 @@ class DirtyRewriterBase:
 
     __slots__ = (
         "arch",
+        "manager",
         "result",
     )
 
-    def __init__(self, dirty: DirtyExpression | DirtyStatement, arch):
+    def __init__(self, dirty: DirtyExpression | DirtyStatement, arch, manager: Manager):
         self.arch = arch
+        self.manager = manager
         self.result: Expression | Statement | None = (
             self._rewrite_expr(dirty) if isinstance(dirty, DirtyExpression) else self._rewrite_stmt(dirty)
         )

--- a/angr/analyses/decompiler/optimization_passes/condition_constprop.py
+++ b/angr/analyses/decompiler/optimization_passes/condition_constprop.py
@@ -67,7 +67,7 @@ class CCondPropBlockWalker(AILBlockRewriter):
         if expr.varid == self.vvar_id and not (
             isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable) and stmt.dst.varid == self.vvar_id
         ):
-            return Const(expr.idx, None, self.const_value.value, self.const_value.bits, **expr.tags)
+            return Const(expr.idx, self.const_value.value, self.const_value.bits, **expr.tags)
         return expr
 
 

--- a/angr/analyses/decompiler/optimization_passes/const_derefs.py
+++ b/angr/analyses/decompiler/optimization_passes/const_derefs.py
@@ -89,8 +89,6 @@ class BlockWalker(AILBlockRewriter):
                         Const(self.manager.next_atom(), None, w, expr.addr.size, **expr.addr.addr.tags),
                         expr.size,
                         expr.endness,
-                        variable=expr.variable,
-                        variable_offset=expr.variable_offset,
                         guard=expr.guard,
                         alt=expr.alt,
                         **expr.tags,

--- a/angr/analyses/decompiler/optimization_passes/const_derefs.py
+++ b/angr/analyses/decompiler/optimization_passes/const_derefs.py
@@ -67,7 +67,7 @@ class BlockWalker(AILBlockRewriter):
                     w = None
                 if w is not None and not (is_got and w == 0):
                     # nice! replace it with the actual value
-                    return Const(self.manager.next_atom(), None, w, expr.bits, **expr.tags)
+                    return Const(self.manager.next_atom(), w, expr.bits, **expr.tags)
         elif (
             isinstance(expr.addr, Load)
             and expr.addr.bits == self._project.arch.bits
@@ -86,7 +86,7 @@ class BlockWalker(AILBlockRewriter):
                     # nice! replace it with a load from that address
                     return Load(
                         expr.idx,
-                        Const(self.manager.next_atom(), None, w, expr.addr.size, **expr.addr.addr.tags),
+                        Const(self.manager.next_atom(), w, expr.addr.size, **expr.addr.addr.tags),
                         expr.size,
                         expr.endness,
                         guard=expr.guard,

--- a/angr/analyses/decompiler/optimization_passes/deadblock_remover.py
+++ b/angr/analyses/decompiler/optimization_passes/deadblock_remover.py
@@ -71,7 +71,7 @@ class DeadblockRemover(OptimizationPass):
                 other_successor = next(s for s in self._graph.successors(p) if s != b)
                 p.statements[-1] = Jump(
                     self.manager.next_atom(),
-                    Const(self.manager.next_atom(), None, other_successor.addr, self.project.arch.bits),
+                    Const(self.manager.next_atom(), other_successor.addr, self.project.arch.bits),
                     other_successor.idx,
                     **p.statements[-1].tags,
                 )

--- a/angr/analyses/decompiler/optimization_passes/div_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/div_simplifier.py
@@ -53,7 +53,7 @@ class DivSimplifierAILEngine(SimplifierAILEngine):
                 divisor = self._check_divisor(pow(2, 64 + Y), C)
                 if divisor:
                     X = operand_expr.operands[0].operands[0]
-                    new_const = Expr.Const(expr.idx, None, divisor, 64)
+                    new_const = Expr.Const(expr.idx, divisor, 64)
                     return Expr.BinaryOp(expr.idx, "Div", [X, new_const], expr.signed, **expr.tags)
 
         return expr
@@ -232,21 +232,19 @@ class DivSimplifierAILEngine(SimplifierAILEngine):
                 divisor = self._check_divisor(pow(2, Y), C)
 
         if divisor and X:
-            new_const = Expr.Const(expr.idx, None, divisor, 64)
+            new_const = Expr.Const(expr.idx, divisor, 64)
             return Expr.BinaryOp(expr.idx, "Div", [X, new_const], expr.signed, **expr.tags)
 
         if isinstance(operand_1, Expr.Const):
             if isinstance(operand_0, Expr.VirtualVariable) and operand_0.was_reg:
-                new_operand = Expr.Const(operand_1.idx, None, 2**operand_1.value, operand_0.bits)
+                new_operand = Expr.Const(operand_1.idx, 2**operand_1.value, operand_0.bits)
                 return Expr.BinaryOp(expr.idx, "Div", [operand_0, new_operand], expr.signed)
             if (
                 isinstance(operand_0, Expr.BinaryOp)
                 and operand_0.op == "Shr"
                 and isinstance(operand_0.operands[1], Expr.Const)
             ):
-                new_const = Expr.Const(
-                    operand_1.idx, None, operand_0.operands[1].value + operand_1.value, operand_1.bits
-                )
+                new_const = Expr.Const(operand_1.idx, operand_0.operands[1].value + operand_1.value, operand_1.bits)
                 return Expr.BinaryOp(expr.idx, "Shr", [operand_0.operands[0], new_const], expr.signed, **expr.tags)
 
         if (operand_0, operand_1) != (expr.operands[0], expr.operands[1]):
@@ -273,7 +271,7 @@ class DivSimplifierAILEngine(SimplifierAILEngine):
                 V = X.from_bits - X.to_bits
             ndigits = 5 if V == 32 else 6
             if (divisor := self._check_divisor(pow(2, V + Y), C, ndigits)) and X:
-                new_const = Expr.Const(expr.idx, None, divisor, 64)
+                new_const = Expr.Const(expr.idx, divisor, 64)
                 return Expr.BinaryOp(expr.idx, "Div", [X, new_const], expr.signed, **expr.tags)
         if (
             isinstance(operand_1, Expr.Const)
@@ -293,7 +291,7 @@ class DivSimplifierAILEngine(SimplifierAILEngine):
             V = operand_0.from_bits - operand_0.to_bits
             ndigits = 5 if V == 32 else 6
             if (divisor := self._check_divisor(pow(2, V + Y), C, ndigits)) and X:
-                new_const = Expr.Const(expr.idx, None, divisor, 64)
+                new_const = Expr.Const(expr.idx, divisor, 64)
                 return Expr.BinaryOp(expr.idx, "Div", [X, new_const], expr.signed, **expr.tags)
         return expr
 
@@ -308,7 +306,7 @@ class DivSimplifierAILEngine(SimplifierAILEngine):
             and isinstance(operand_0.operands[1], Expr.Const)
         ):
             new_const_value = operand_1.value * operand_0.operands[1].value
-            new_const = Expr.Const(operand_1.idx, None, new_const_value, operand_1.bits)
+            new_const = Expr.Const(operand_1.idx, new_const_value, operand_1.bits)
             return Expr.BinaryOp(expr.idx, "Div", [operand_0.operands[0], new_const], expr.signed, **expr.tags)
 
         if (operand_0, operand_1) != (expr.operands[0], expr.operands[1]):
@@ -380,7 +378,7 @@ class DivSimplifierAILEngine(SimplifierAILEngine):
                 assert isinstance(C, int)
                 divisor = self._check_divisor(pow(2, V), C, ndigits)
                 if divisor is not None and X:
-                    new_const = Expr.Const(self.manager.next_atom(), None, divisor, V)
+                    new_const = Expr.Const(self.manager.next_atom(), divisor, V)
                     new_expr = Expr.BinaryOp(inner.idx, "Div", [X, new_const], inner.signed, **inner.tags)
                     return True, new_expr
 

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -395,9 +395,7 @@ class DuplicationReverter(StructuringOptimizationPass):
                     if last_stmt.target.value != successor.addr:
                         new_last_stmt = deepcopy_ail_anyjump(last_stmt, idx=last_stmt.idx)
                         last_stmt.target_idx = successor.idx
-                        new_last_stmt.target = Const(
-                            self.manager.next_atom(), None, successor.addr, self.project.arch.bits
-                        )
+                        new_last_stmt.target = Const(self.manager.next_atom(), successor.addr, self.project.arch.bits)
                         new_node = node.copy()
                         new_node.statements[-1] = new_last_stmt
                 # the last statement is not a jump, but this node should have one, so add it
@@ -405,7 +403,7 @@ class DuplicationReverter(StructuringOptimizationPass):
                     new_node = node.copy()
                     new_last_stmt = Jump(
                         self.manager.next_atom(),
-                        Const(self.manager.next_atom(), None, successor.addr, self.project.arch.bits),
+                        Const(self.manager.next_atom(), successor.addr, self.project.arch.bits),
                         target_idx=successor.idx,
                     )
                     # TODO: improve addressing here
@@ -469,8 +467,8 @@ class DuplicationReverter(StructuringOptimizationPass):
         cond_jump = ConditionalJump(
             1,
             best_condition.copy() if best_condition is not None else None,
-            Const(self.manager.next_atom(), None, 0, self.project.arch.bits),
-            Const(self.manager.next_atom(), None, 0, self.project.arch.bits),
+            Const(self.manager.next_atom(), 0, self.project.arch.bits),
+            Const(self.manager.next_atom(), 0, self.project.arch.bits),
             **old_stmt_tags,
         )
         cond_block.statements = [cond_jump]
@@ -783,7 +781,7 @@ class DuplicationReverter(StructuringOptimizationPass):
                 nop_blk = Block(
                     self.new_block_addr(),
                     0,
-                    statements=[Jump(0, Const(0, 0, 0, self.project.arch.bits), 0, ins_addr=self.new_block_addr())],
+                    statements=[Jump(0, Const(0, 0, self.project.arch.bits), 0, ins_addr=self.new_block_addr())],
                 )
                 # point src -> nop -> dst
                 graph.add_edge(src, nop_blk)

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/utils.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/utils.py
@@ -111,7 +111,7 @@ def deepcopy_ail_jump(stmt: Jump, idx=1):
     target: Const = stmt.target
     tags = stmt.tags.copy()
 
-    return Jump(idx, Const(1, target.variable, target.value, target.bits, **target.tags.copy()), **tags)
+    return Jump(idx, Const(1, None, target.value, target.bits, **target.tags.copy()), **tags)
 
 
 def deepcopy_ail_condjump(stmt: ConditionalJump, idx=1):
@@ -122,8 +122,8 @@ def deepcopy_ail_condjump(stmt: ConditionalJump, idx=1):
     return ConditionalJump(
         idx,
         stmt.condition.copy(),
-        Const(1, true_target.variable, true_target.value, true_target.bits, **true_target.tags.copy()),
-        Const(1, false_target.variable, false_target.value, false_target.bits, **false_target.tags.copy()),
+        Const(1, None, true_target.value, true_target.bits, **true_target.tags.copy()),
+        Const(1, None, false_target.value, false_target.bits, **false_target.tags.copy()),
         **tags,
     )
 

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/utils.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/utils.py
@@ -111,7 +111,7 @@ def deepcopy_ail_jump(stmt: Jump, idx=1):
     target: Const = stmt.target
     tags = stmt.tags.copy()
 
-    return Jump(idx, Const(1, None, target.value, target.bits, **target.tags.copy()), **tags)
+    return Jump(idx, Const(1, target.value, target.bits, **target.tags.copy()), **tags)
 
 
 def deepcopy_ail_condjump(stmt: ConditionalJump, idx=1):
@@ -122,8 +122,8 @@ def deepcopy_ail_condjump(stmt: ConditionalJump, idx=1):
     return ConditionalJump(
         idx,
         stmt.condition.copy(),
-        Const(1, None, true_target.value, true_target.bits, **true_target.tags.copy()),
-        Const(1, None, false_target.value, false_target.bits, **false_target.tags.copy()),
+        Const(1, true_target.value, true_target.bits, **true_target.tags.copy()),
+        Const(1, false_target.value, false_target.bits, **false_target.tags.copy()),
         **tags,
     )
 

--- a/angr/analyses/decompiler/optimization_passes/eager_std_string_concatenation.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_std_string_concatenation.py
@@ -146,7 +146,7 @@ class EagerStdStringConcatenationPass(OptimizationPass):
             assert old_block is not None
             block = old_block.copy()
             old_stmt = block.statements[last_stmt_idx]
-            str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
+            str_const = Const(self.manager.next_atom(), str_id, self.project.arch.bits)
             self.manager.variable_map.set_custom_string(str_const)
             block.statements[last_stmt_idx] = WeakAssignment(
                 old_stmt.idx,

--- a/angr/analyses/decompiler/optimization_passes/eager_std_string_concatenation.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_std_string_concatenation.py
@@ -146,12 +146,14 @@ class EagerStdStringConcatenationPass(OptimizationPass):
             assert old_block is not None
             block = old_block.copy()
             old_stmt = block.statements[last_stmt_idx]
+            str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
+            self.manager.variable_map.set_custom_string(str_const)
             block.statements[last_stmt_idx] = WeakAssignment(
                 old_stmt.idx,
                 old_stmt.dst,
                 Load(
                     self.manager.next_atom(),
-                    Const(self.manager.next_atom(), None, str_id, self.project.arch.bits, custom_string=True),
+                    str_const,
                     len(final_str),
                     Endness.BE,
                 ),

--- a/angr/analyses/decompiler/optimization_passes/eager_std_string_eval.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_std_string_eval.py
@@ -41,7 +41,7 @@ class RewriteStdStringCallWalker(AILBlockRewriter):
                     if varid in self._str_defs:
                         s = self._str_defs[varid]
                         if s is not None:
-                            return Const(self.manager.next_atom(), None, len(s), expr.bits, **expr.tags)
+                            return Const(self.manager.next_atom(), len(s), expr.bits, **expr.tags)
                 if (
                     func.short_name == "c_str"
                     and len(expr.args) == 1
@@ -54,7 +54,7 @@ class RewriteStdStringCallWalker(AILBlockRewriter):
                         s = self._str_defs[varid]
                         if s is not None:
                             idx = self.kb.custom_strings.allocate(s)
-                            const = Const(self.manager.next_atom(), None, idx, expr.bits, **expr.tags)
+                            const = Const(self.manager.next_atom(), idx, expr.bits, **expr.tags)
                             self.manager.variable_map.set_custom_string(const)
                             return const
 

--- a/angr/analyses/decompiler/optimization_passes/eager_std_string_eval.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_std_string_eval.py
@@ -54,9 +54,9 @@ class RewriteStdStringCallWalker(AILBlockRewriter):
                         s = self._str_defs[varid]
                         if s is not None:
                             idx = self.kb.custom_strings.allocate(s)
-                            return Const(
-                                self.manager.next_atom(), None, idx, expr.bits, custom_string=True, **expr.tags
-                            )
+                            const = Const(self.manager.next_atom(), None, idx, expr.bits, **expr.tags)
+                            self.manager.variable_map.set_custom_string(const)
+                            return const
 
         return super()._handle_CallExpr(expr_idx, expr, stmt_idx, stmt, block)
 
@@ -164,7 +164,7 @@ class EagerStdStringEvalPass(OptimizationPass):
             if isinstance(stmt.src, Load) and isinstance(stmt.src.addr, Const):
                 src_ty = stmt.tags["type"]["src"]
                 if self._is_std_string_type_or_charptr(src_ty):
-                    if isinstance(stmt.src.addr, Const) and stmt.src.addr.tags.get("custom_string", False):
+                    if isinstance(stmt.src.addr, Const) and self.manager.variable_map.custom_string(stmt.src.addr):
                         try:
                             s = self.kb.custom_strings[stmt.src.addr.value_int]
                         except KeyError:

--- a/angr/analyses/decompiler/optimization_passes/engine_base.py
+++ b/angr/analyses/decompiler/optimization_passes/engine_base.py
@@ -97,9 +97,7 @@ class SimplifierAILEngine(
 
         # replace
         if (addr, data) != (stmt.addr, stmt.data):
-            return ailment.statement.Store(
-                stmt.idx, addr, data, stmt.size, stmt.endness, variable=stmt.variable, **stmt.tags
-            )
+            return ailment.statement.Store(stmt.idx, addr, data, stmt.size, stmt.endness, **stmt.tags)
 
         return stmt
 
@@ -251,7 +249,7 @@ class SimplifierAILEngine(
             value = operand_expr.value
             mask = (2**expr.to_bits) - 1
             value &= mask
-            return ailment.expression.Const(expr.idx, operand_expr.variable, value, expr.to_bits, **expr.tags)
+            return ailment.expression.Const(expr.idx, None, value, expr.to_bits, **expr.tags)
         if type(operand_expr) is ailment.expression.BinaryOp and operand_expr.op in {
             "Mul",
             "Shl",
@@ -270,7 +268,7 @@ class SimplifierAILEngine(
                     )
                     converted_const = ailment.expression.Const(
                         operand_expr.operands[1].idx,
-                        operand_expr.operands[1].variable,
+                        None,
                         operand_expr.operands[1].value,
                         expr.to_bits,
                         **operand_expr.operands[1].tags,
@@ -337,8 +335,6 @@ class SimplifierAILEngine(
             self._expr(expr.cond),
             self._expr(expr.iffalse),
             self._expr(expr.iftrue),
-            variable=expr.variable,
-            variable_offset=expr.variable_offset,
             **expr.tags,
         )
 
@@ -380,9 +376,7 @@ class SimplifierAILEngine(
     def _handle_unop_Default(self, expr):
         operand = self._expr(expr.operand)
         if operand != expr.operand:
-            return ailment.expression.UnaryOp(
-                expr.idx, expr.op, operand, variable=expr.variable, variable_offset=expr.variable_offset, **expr.tags
-            )
+            return ailment.expression.UnaryOp(expr.idx, expr.op, operand, **expr.tags)
         return expr
 
     _handle_unop_Not = _handle_unop_Default
@@ -406,8 +400,6 @@ class SimplifierAILEngine(
                 expr.op,
                 (lhs, rhs),
                 expr.signed,
-                variable=expr.variable,
-                variable_offset=expr.variable_offset,
                 bits=expr.bits,
                 floating_point=expr.floating_point,
                 rounding_mode=expr.rounding_mode,

--- a/angr/analyses/decompiler/optimization_passes/engine_base.py
+++ b/angr/analyses/decompiler/optimization_passes/engine_base.py
@@ -249,7 +249,7 @@ class SimplifierAILEngine(
             value = operand_expr.value
             mask = (2**expr.to_bits) - 1
             value &= mask
-            return ailment.expression.Const(expr.idx, None, value, expr.to_bits, **expr.tags)
+            return ailment.expression.Const(expr.idx, value, expr.to_bits, **expr.tags)
         if type(operand_expr) is ailment.expression.BinaryOp and operand_expr.op in {
             "Mul",
             "Shl",
@@ -268,7 +268,6 @@ class SimplifierAILEngine(
                     )
                     converted_const = ailment.expression.Const(
                         operand_expr.operands[1].idx,
-                        None,
                         operand_expr.operands[1].value,
                         expr.to_bits,
                         **operand_expr.operands[1].tags,

--- a/angr/analyses/decompiler/optimization_passes/inlined_memcpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_memcpy_simplifier.py
@@ -96,7 +96,7 @@ class InlinedMemcpySimplifier(OptimizationPass):
                     args=[
                         StackBaseOffset(self.manager.next_atom(), self.project.arch.bits, dst_offset),
                         StackBaseOffset(self.manager.next_atom(), self.project.arch.bits, src_offset),
-                        Const(self.manager.next_atom(), None, store_size, self.project.arch.bits),
+                        Const(self.manager.next_atom(), store_size, self.project.arch.bits),
                     ],
                     prototype=SIM_LIBRARIES["libc.so"][0].get_prototype("memcpy", arch=self.project.arch),
                     bits=None,

--- a/angr/analyses/decompiler/optimization_passes/inlined_memcpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_memcpy_simplifier.py
@@ -88,9 +88,9 @@ class InlinedMemcpySimplifier(OptimizationPass):
         if should_replace:
             assert dst_offset is not None and src_offset is not None and store_size is not None
             return SideEffectStatement(
-                stmt.idx,
+                self.manager.next_atom(),
                 Call(
-                    stmt.idx,
+                    self.manager.next_atom(),
                     "memcpy",
                     calling_convention=None,
                     args=[

--- a/angr/analyses/decompiler/optimization_passes/inlined_memset_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_memset_simplifier.py
@@ -117,14 +117,14 @@ class InlinedMemsetSimplifier(OptimizationPass):
                             # Creating memsets on the stack is a recipe to screw up variable identification.
                             base_expr = None
                         case "global":
-                            base_expr = Const(self.manager.next_atom(), None, candidate.offset, self.project.arch.bits)
+                            base_expr = Const(self.manager.next_atom(), candidate.offset, self.project.arch.bits)
                         case "heap":
                             base_expr = BinaryOp(
                                 self.manager.next_atom(),
                                 "Add",
                                 [
                                     candidate.base,
-                                    Const(self.manager.next_atom(), None, candidate.offset, self.project.arch.bits),
+                                    Const(self.manager.next_atom(), candidate.offset, self.project.arch.bits),
                                 ],
                                 False,
                                 bits=self.project.arch.bits,
@@ -145,8 +145,8 @@ class InlinedMemsetSimplifier(OptimizationPass):
                             "memset",
                             args=[
                                 base_expr,
-                                Const(self.manager.next_atom(), None, candidate.value, 8),
-                                Const(self.manager.next_atom(), None, candidate.count, self.project.arch.bits),
+                                Const(self.manager.next_atom(), candidate.value, 8),
+                                Const(self.manager.next_atom(), candidate.count, self.project.arch.bits),
                             ],
                             prototype=SIM_LIBRARIES["libc.so"][0].get_prototype("memset", arch=self.project.arch),
                             **ref_stmt.tags,

--- a/angr/analyses/decompiler/optimization_passes/inlined_memset_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_memset_simplifier.py
@@ -139,9 +139,9 @@ class InlinedMemsetSimplifier(OptimizationPass):
 
                     ref_stmt = statements[start_stmt_idx]
                     call_stmt = SideEffectStatement(
-                        ref_stmt.idx,
+                        self.manager.next_atom(),
                         Call(
-                            ref_stmt.idx,
+                            self.manager.next_atom(),
                             "memset",
                             args=[
                                 base_expr,

--- a/angr/analyses/decompiler/optimization_passes/inlined_strcpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_strcpy_simplifier.py
@@ -130,6 +130,8 @@ class InlinedStrcpySimplifier(OptimizationPass):
             if r:
                 assert s is not None
                 str_id = self.kb.custom_strings.allocate(s.encode("ascii"))
+                str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
+                self.manager.variable_map.set_custom_string(str_const)
                 return SideEffectStatement(
                     stmt.idx,
                     Call(
@@ -138,7 +140,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
                         calling_convention=None,
                         args=[
                             strcpy_dst,
-                            Const(self.manager.next_atom(), None, str_id, self.project.arch.bits, custom_string=True),
+                            str_const,
                             Const(self.manager.next_atom(), None, len(s), self.project.arch.bits),
                         ],
                         prototype=SIM_LIBRARIES["libc.so"][0].get_prototype("strncpy", arch=self.project.arch),
@@ -187,6 +189,8 @@ class InlinedStrcpySimplifier(OptimizationPass):
                         statements[sidx] = None
 
                     str_id = self.kb.custom_strings.allocate(s.encode("ascii"))
+                    str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
+                    self.manager.variable_map.set_custom_string(str_const)
                     return SideEffectStatement(
                         stmt.idx,
                         Call(
@@ -195,9 +199,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
                             calling_convention=None,
                             args=[
                                 strcpy_dst,
-                                Const(
-                                    self.manager.next_atom(), None, str_id, self.project.arch.bits, custom_string=True
-                                ),
+                                str_const,
                                 Const(self.manager.next_atom(), None, len(s), self.project.arch.bits),
                             ],
                             prototype=SIM_LIBRARIES["libc.so"][0].get_prototype("strncpy", arch=self.project.arch),
@@ -262,17 +264,21 @@ class InlinedStrcpySimplifier(OptimizationPass):
             if new_str.endswith(b"\x00"):
                 call_name = "strcpy"
                 new_str_idx = self.kb.custom_strings.allocate(new_str[:-1])
+                str_const = Const(self.manager.next_atom(), None, new_str_idx, last_stmt.expr.args[0].bits)
+                self.manager.variable_map.set_custom_string(str_const)
                 args = [
                     last_stmt.expr.args[0],
-                    Const(self.manager.next_atom(), None, new_str_idx, last_stmt.expr.args[0].bits, custom_string=True),
+                    str_const,
                 ]
                 prototype = SIM_LIBRARIES["libc.so"][0].get_prototype("strcpy")
             else:
                 call_name = "strncpy"
                 new_str_idx = self.kb.custom_strings.allocate(new_str)
+                str_const = Const(self.manager.next_atom(), None, new_str_idx, last_stmt.expr.args[0].bits)
+                self.manager.variable_map.set_custom_string(str_const)
                 args = [
                     last_stmt.expr.args[0],
-                    Const(self.manager.next_atom(), None, new_str_idx, last_stmt.expr.args[0].bits, custom_string=True),
+                    str_const,
                     Const(self.manager.next_atom(), None, len(new_str), self.project.arch.bits),
                 ]
                 prototype = SIM_LIBRARIES["libc.so"][0].get_prototype("strncpy")
@@ -378,8 +384,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
             return True, "".join(chars)
         return False, None
 
-    @staticmethod
-    def is_inlined_strcpy(stmt):
+    def is_inlined_strcpy(self, stmt):
         return (
             isinstance(stmt, SideEffectStatement)
             and isinstance(stmt.expr.target, str)
@@ -387,7 +392,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
             and stmt.expr.args is not None
             and len(stmt.expr.args) == 3
             and isinstance(stmt.expr.args[1], Const)
-            and "custom_string" in stmt.expr.args[1].tags
+            and self.manager.variable_map.custom_string(stmt.expr.args[1])
         )
 
     @staticmethod

--- a/angr/analyses/decompiler/optimization_passes/inlined_strcpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_strcpy_simplifier.py
@@ -130,7 +130,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
             if r:
                 assert s is not None
                 str_id = self.kb.custom_strings.allocate(s.encode("ascii"))
-                str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
+                str_const = Const(self.manager.next_atom(), str_id, self.project.arch.bits)
                 self.manager.variable_map.set_custom_string(str_const)
                 return SideEffectStatement(
                     self.manager.next_atom(),
@@ -141,7 +141,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
                         args=[
                             strcpy_dst,
                             str_const,
-                            Const(self.manager.next_atom(), None, len(s), self.project.arch.bits),
+                            Const(self.manager.next_atom(), len(s), self.project.arch.bits),
                         ],
                         prototype=SIM_LIBRARIES["libc.so"][0].get_prototype("strncpy", arch=self.project.arch),
                         bits=None,
@@ -189,7 +189,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
                         statements[sidx] = None
 
                     str_id = self.kb.custom_strings.allocate(s.encode("ascii"))
-                    str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
+                    str_const = Const(self.manager.next_atom(), str_id, self.project.arch.bits)
                     self.manager.variable_map.set_custom_string(str_const)
                     return SideEffectStatement(
                         self.manager.next_atom(),
@@ -200,7 +200,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
                             args=[
                                 strcpy_dst,
                                 str_const,
-                                Const(self.manager.next_atom(), None, len(s), self.project.arch.bits),
+                                Const(self.manager.next_atom(), len(s), self.project.arch.bits),
                             ],
                             prototype=SIM_LIBRARIES["libc.so"][0].get_prototype("strncpy", arch=self.project.arch),
                             bits=None,
@@ -264,7 +264,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
             if new_str.endswith(b"\x00"):
                 call_name = "strcpy"
                 new_str_idx = self.kb.custom_strings.allocate(new_str[:-1])
-                str_const = Const(self.manager.next_atom(), None, new_str_idx, last_stmt.expr.args[0].bits)
+                str_const = Const(self.manager.next_atom(), new_str_idx, last_stmt.expr.args[0].bits)
                 self.manager.variable_map.set_custom_string(str_const)
                 args = [
                     last_stmt.expr.args[0],
@@ -274,12 +274,12 @@ class InlinedStrcpySimplifier(OptimizationPass):
             else:
                 call_name = "strncpy"
                 new_str_idx = self.kb.custom_strings.allocate(new_str)
-                str_const = Const(self.manager.next_atom(), None, new_str_idx, last_stmt.expr.args[0].bits)
+                str_const = Const(self.manager.next_atom(), new_str_idx, last_stmt.expr.args[0].bits)
                 self.manager.variable_map.set_custom_string(str_const)
                 args = [
                     last_stmt.expr.args[0],
                     str_const,
-                    Const(self.manager.next_atom(), None, len(new_str), self.project.arch.bits),
+                    Const(self.manager.next_atom(), len(new_str), self.project.arch.bits),
                 ]
                 prototype = SIM_LIBRARIES["libc.so"][0].get_prototype("strncpy")
 

--- a/angr/analyses/decompiler/optimization_passes/inlined_strcpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_strcpy_simplifier.py
@@ -133,9 +133,9 @@ class InlinedStrcpySimplifier(OptimizationPass):
                 str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
                 self.manager.variable_map.set_custom_string(str_const)
                 return SideEffectStatement(
-                    stmt.idx,
+                    self.manager.next_atom(),
                     Call(
-                        stmt.idx,
+                        self.manager.next_atom(),
                         "strncpy",
                         calling_convention=None,
                         args=[
@@ -192,9 +192,9 @@ class InlinedStrcpySimplifier(OptimizationPass):
                     str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
                     self.manager.variable_map.set_custom_string(str_const)
                     return SideEffectStatement(
-                        stmt.idx,
+                        self.manager.next_atom(),
                         Call(
-                            stmt.idx,
+                            self.manager.next_atom(),
                             "strncpy",
                             calling_convention=None,
                             args=[
@@ -293,7 +293,11 @@ class InlinedStrcpySimplifier(OptimizationPass):
                 tags.pop("extra_defs", None)
 
             return [
-                SideEffectStatement(stmt.idx, Call(stmt.idx, call_name, args=args, prototype=prototype, **tags), **tags)
+                SideEffectStatement(
+                    self.manager.next_atom(),
+                    Call(self.manager.next_atom(), call_name, args=args, prototype=prototype, **tags),
+                    **tags,
+                )
             ]
 
         return None

--- a/angr/analyses/decompiler/optimization_passes/inlined_string_transformation_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_string_transformation_simplifier.py
@@ -567,9 +567,7 @@ class InlinedStringTransformationSimplifier(OptimizationPass):
             for off, stack_accesses in enumerate(desc.stack_accesses):
                 # the last element is the final storing statement
                 new_value_ast = stack_accesses[-1][2]
-                new_value = Const(
-                    self.manager.next_atom(), None, new_value_ast.concrete_value, self.project.arch.byte_width
-                )
+                new_value = Const(self.manager.next_atom(), new_value_ast.concrete_value, self.project.arch.byte_width)
                 stmt = Store(
                     self.manager.next_atom(),
                     StackBaseOffset(
@@ -601,7 +599,7 @@ class InlinedStringTransformationSimplifier(OptimizationPass):
             if pred.statements and isinstance(pred.statements[-1], ConditionalJump):
                 pred.statements[-1] = Jump(
                     self.manager.next_atom(),
-                    Const(self.manager.next_atom(), None, succ.addr, self.project.arch.bits),
+                    Const(self.manager.next_atom(), succ.addr, self.project.arch.bits),
                     succ.idx,
                     **pred.statements[-1].tags,
                 )

--- a/angr/analyses/decompiler/optimization_passes/inlined_wcscpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_wcscpy_simplifier.py
@@ -143,9 +143,9 @@ class InlinedWcscpySimplifier(OptimizationPass):
         )
         self.manager.variable_map.set_custom_string(str_const)
         return SideEffectStatement(
-            stmt.idx,
+            self.manager.next_atom(),
             Call(
-                stmt.idx,
+                self.manager.next_atom(),
                 "wcsncpy",
                 args=[
                     dst,
@@ -411,7 +411,9 @@ class InlinedWcscpySimplifier(OptimizationPass):
                     tags.pop("extra_defs", None)
                 return [
                     SideEffectStatement(
-                        stmt.idx, Call(stmt.idx, call_name, args=args, prototype=prototype, **tags), **tags
+                        self.manager.next_atom(),
+                        Call(self.manager.next_atom(), call_name, args=args, prototype=prototype, **tags),
+                        **tags,
                     )
                 ]
 

--- a/angr/analyses/decompiler/optimization_passes/inlined_wcscpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_wcscpy_simplifier.py
@@ -136,7 +136,6 @@ class InlinedWcscpySimplifier(OptimizationPass):
         wstr_type_out = SimTypePointer(SimTypeWideChar(), disposition=PointerDisposition.OUT)
         str_const = Const(
             self.manager.next_atom(),
-            None,
             str_id,
             self.project.arch.bits,
             type=wstr_type,
@@ -150,7 +149,7 @@ class InlinedWcscpySimplifier(OptimizationPass):
                 args=[
                     dst,
                     str_const,
-                    Const(self.manager.next_atom(), None, len(s) // 2, self.project.arch.bits),
+                    Const(self.manager.next_atom(), len(s) // 2, self.project.arch.bits),
                 ],
                 prototype=SimTypeFunction([wstr_type_out, wstr_type, SimTypeLong(signed=False)], wstr_type).with_arch(
                     self.project.arch
@@ -374,7 +373,6 @@ class InlinedWcscpySimplifier(OptimizationPass):
                     new_str_idx = self.kb.custom_strings.allocate(new_str[:-2])
                     str_const = Const(
                         self.manager.next_atom(),
-                        None,
                         new_str_idx,
                         last_stmt.expr.args[0].bits,
                         type=wstr_type,
@@ -389,7 +387,6 @@ class InlinedWcscpySimplifier(OptimizationPass):
                     new_str_idx = self.kb.custom_strings.allocate(new_str)
                     str_const = Const(
                         self.manager.next_atom(),
-                        None,
                         new_str_idx,
                         last_stmt.expr.args[0].bits,
                         type=wstr_type,
@@ -398,7 +395,7 @@ class InlinedWcscpySimplifier(OptimizationPass):
                     args = [
                         last_stmt.expr.args[0],
                         str_const,
-                        Const(self.manager.next_atom(), None, len(new_str) // 2, self.project.arch.bits),
+                        Const(self.manager.next_atom(), len(new_str) // 2, self.project.arch.bits),
                     ]
 
                 tags = TagDict(stmt.tags)

--- a/angr/analyses/decompiler/optimization_passes/inlined_wcscpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_wcscpy_simplifier.py
@@ -134,6 +134,14 @@ class InlinedWcscpySimplifier(OptimizationPass):
         str_id = self.kb.custom_strings.allocate(s)
         wstr_type = SimTypePointer(SimTypeWideChar()).with_arch(self.project.arch)
         wstr_type_out = SimTypePointer(SimTypeWideChar(), disposition=PointerDisposition.OUT)
+        str_const = Const(
+            self.manager.next_atom(),
+            None,
+            str_id,
+            self.project.arch.bits,
+            type=wstr_type,
+        )
+        self.manager.variable_map.set_custom_string(str_const)
         return SideEffectStatement(
             stmt.idx,
             Call(
@@ -141,14 +149,7 @@ class InlinedWcscpySimplifier(OptimizationPass):
                 "wcsncpy",
                 args=[
                     dst,
-                    Const(
-                        self.manager.next_atom(),
-                        None,
-                        str_id,
-                        self.project.arch.bits,
-                        custom_string=True,
-                        type=wstr_type,
-                    ),
+                    str_const,
                     Const(self.manager.next_atom(), None, len(s) // 2, self.project.arch.bits),
                 ],
                 prototype=SimTypeFunction([wstr_type_out, wstr_type, SimTypeLong(signed=False)], wstr_type).with_arch(
@@ -371,30 +372,32 @@ class InlinedWcscpySimplifier(OptimizationPass):
                 if new_str.endswith(b"\x00\x00"):
                     call_name = "wcsncpy"
                     new_str_idx = self.kb.custom_strings.allocate(new_str[:-2])
+                    str_const = Const(
+                        self.manager.next_atom(),
+                        None,
+                        new_str_idx,
+                        last_stmt.expr.args[0].bits,
+                        type=wstr_type,
+                    )
+                    self.manager.variable_map.set_custom_string(str_const)
                     args = [
                         last_stmt.expr.args[0],
-                        Const(
-                            self.manager.next_atom(),
-                            None,
-                            new_str_idx,
-                            last_stmt.expr.args[0].bits,
-                            custom_string=True,
-                            type=wstr_type,
-                        ),
+                        str_const,
                     ]
                 else:
                     call_name = "wcsncpy"
                     new_str_idx = self.kb.custom_strings.allocate(new_str)
+                    str_const = Const(
+                        self.manager.next_atom(),
+                        None,
+                        new_str_idx,
+                        last_stmt.expr.args[0].bits,
+                        type=wstr_type,
+                    )
+                    self.manager.variable_map.set_custom_string(str_const)
                     args = [
                         last_stmt.expr.args[0],
-                        Const(
-                            self.manager.next_atom(),
-                            None,
-                            new_str_idx,
-                            last_stmt.expr.args[0].bits,
-                            custom_string=True,
-                            type=wstr_type,
-                        ),
+                        str_const,
                         Const(self.manager.next_atom(), None, len(new_str) // 2, self.project.arch.bits),
                     ]
 
@@ -543,8 +546,7 @@ class InlinedWcscpySimplifier(OptimizationPass):
             return True, bytes(chars)
         return False, None
 
-    @staticmethod
-    def is_inlined_wcsncpy(stmt):
+    def is_inlined_wcsncpy(self, stmt):
         return (
             isinstance(stmt, SideEffectStatement)
             and isinstance(stmt.expr.target, str)
@@ -552,7 +554,7 @@ class InlinedWcscpySimplifier(OptimizationPass):
             and stmt.expr.args is not None
             and len(stmt.expr.args) == 3
             and isinstance(stmt.expr.args[1], Const)
-            and "custom_string" in stmt.expr.args[1].tags
+            and self.manager.variable_map.custom_string(stmt.expr.args[1])
         )
 
     @staticmethod

--- a/angr/analyses/decompiler/optimization_passes/ite_region_converter.py
+++ b/angr/analyses/decompiler/optimization_passes/ite_region_converter.py
@@ -239,7 +239,7 @@ class ITERegionConverter(OptimizationPass):
         # transitioning statement in the future
         goto_stmt = Jump(
             self.manager.next_atom(),
-            Const(self.manager.next_atom(), None, region_tail.addr, self.project.arch.bits),
+            Const(self.manager.next_atom(), region_tail.addr, self.project.arch.bits),
             region_tail.idx,
             **conditional_jump.tags,
         )

--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -10,6 +10,7 @@ from angr.ailment import AILBlockViewer, Block
 from angr.ailment.expression import BinaryOp, Const, Expression, Load, VirtualVariable
 from angr.ailment.statement import Assignment, ConditionalJump, Jump, Label
 from angr.analyses.decompiler.region_simplifiers.switch_cluster_simplifier import SwitchClusterFinder
+from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.analyses.decompiler.structurer_nodes import (
     IncompleteSwitchCaseHeadStatement,
     MultiNode,
@@ -212,7 +213,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
 
     def _analyze_simplified_region(self, region, initial=False):
         super()._analyze_simplified_region(region, initial=initial)
-        finder = SwitchClusterFinder(region, self.manager.variable_map)
+        finder = SwitchClusterFinder(region, variable_map_of(self.manager))
         self._switches_present_in_code = len(finder.var2switches.values())
 
     def _check(self):
@@ -413,15 +414,15 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
         sorted_nodes = GraphUtils.quasi_topological_sort_nodes(self._graph)
         variable_comparisons = OrderedDict()
         for node in sorted_nodes:
-            r = self._find_switch_variable_comparison_type_a(node, self.manager.variable_map)
+            r = self._find_switch_variable_comparison_type_a(node, variable_map_of(self.manager))
             if r is not None:
                 variable_comparisons[node] = ("a", *r)
                 continue
-            r = self._find_switch_variable_comparison_type_b(node, self.manager.variable_map)
+            r = self._find_switch_variable_comparison_type_b(node, variable_map_of(self.manager))
             if r is not None:
                 variable_comparisons[node] = ("b", *r)
                 continue
-            r = self._find_switch_variable_comparison_type_c(node, self.manager.variable_map)
+            r = self._find_switch_variable_comparison_type_c(node, variable_map_of(self.manager))
             if r is not None:
                 variable_comparisons[node] = ("c", *r)
                 continue

--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -10,13 +10,13 @@ from angr.ailment import AILBlockViewer, Block
 from angr.ailment.expression import BinaryOp, Const, Expression, Load, VirtualVariable
 from angr.ailment.statement import Assignment, ConditionalJump, Jump, Label
 from angr.analyses.decompiler.region_simplifiers.switch_cluster_simplifier import SwitchClusterFinder
-from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.analyses.decompiler.structurer_nodes import (
     IncompleteSwitchCaseHeadStatement,
     MultiNode,
     SequenceNode,
 )
 from angr.analyses.decompiler.utils import first_nonlabel_nonphi_statement, remove_last_statement
+from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.utils.graph import GraphUtils
 
 from .optimization_pass import MultipleBlocksException, StructuringOptimizationPass

--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -304,7 +304,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         statements.append(
                             Jump(
                                 self.manager.next_atom(),
-                                Const(self.manager.next_atom(), None, case.target, self.project.arch.bits),
+                                Const(self.manager.next_atom(), case.target, self.project.arch.bits),
                                 ins_addr=case.original_node.addr,
                             )
                         )

--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -103,17 +103,19 @@ class StableVarExprHasher(AILBlockViewer):
     Obtain a stable hash of an AIL expression with respect to all variables and all operations applied on variables.
     """
 
-    def __init__(self, expr: Expression):
+    def __init__(self, expr: Expression, variable_map):
         super().__init__()
         self.expr = expr
+        self._variable_map = variable_map
         self._hash_lst = []
 
         self.walk_expression(expr)
         self.hash = hash(tuple(self._hash_lst))
 
     def _handle_expr(self, expr_idx: int, expr: Expression, stmt_idx: int, stmt, block: Block | None):
-        if hasattr(expr, "variable") and expr.variable is not None:
-            self._hash_lst.append(expr.variable)
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            self._hash_lst.append(expr_var)
         else:
             super()._handle_expr(expr_idx, expr, stmt_idx, stmt, block)
 
@@ -210,7 +212,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
 
     def _analyze_simplified_region(self, region, initial=False):
         super()._analyze_simplified_region(region, initial=initial)
-        finder = SwitchClusterFinder(region)
+        finder = SwitchClusterFinder(region, self.manager.variable_map)
         self._switches_present_in_code = len(finder.var2switches.values())
 
     def _check(self):
@@ -411,15 +413,15 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
         sorted_nodes = GraphUtils.quasi_topological_sort_nodes(self._graph)
         variable_comparisons = OrderedDict()
         for node in sorted_nodes:
-            r = self._find_switch_variable_comparison_type_a(node)
+            r = self._find_switch_variable_comparison_type_a(node, self.manager.variable_map)
             if r is not None:
                 variable_comparisons[node] = ("a", *r)
                 continue
-            r = self._find_switch_variable_comparison_type_b(node)
+            r = self._find_switch_variable_comparison_type_b(node, self.manager.variable_map)
             if r is not None:
                 variable_comparisons[node] = ("b", *r)
                 continue
-            r = self._find_switch_variable_comparison_type_c(node)
+            r = self._find_switch_variable_comparison_type_c(node, self.manager.variable_map)
             if r is not None:
                 variable_comparisons[node] = ("c", *r)
                 continue
@@ -684,6 +686,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
     @staticmethod
     def _find_switch_variable_comparison_type_a(
         node,
+        variable_map,
     ) -> tuple[int, str, Expression, int, int, int | None, int, int | None] | None:
         # the type a is the last statement is a var == constant comparison, but
         # there is more than one non-label statement in the block
@@ -705,7 +708,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                     and isinstance(cond.operands[0], VirtualVariable)
                     and isinstance(cond.operands[1], Const)
                 ):
-                    variable_hash = StableVarExprHasher(cond.operands[0]).hash
+                    variable_hash = StableVarExprHasher(cond.operands[0], variable_map).hash
                     value = cond.operands[1].value
                     if cond.op == "CmpEQ":
                         target = stmt.true_target.value
@@ -735,6 +738,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
     @staticmethod
     def _find_switch_variable_comparison_type_b(
         node,
+        variable_map,
     ) -> tuple[int, str, Expression, int, int, int | None, int, int | None] | None:
         # the type b is the last statement is a var == constant comparison, and
         # there is only one non-label statement
@@ -756,7 +760,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                     and isinstance(cond.operands[0], VirtualVariable)
                     and isinstance(cond.operands[1], Const)
                 ):
-                    variable_hash = StableVarExprHasher(cond.operands[0]).hash
+                    variable_hash = StableVarExprHasher(cond.operands[0], variable_map).hash
                     value = cond.operands[1].value
                     if cond.op == "CmpEQ":
                         target = stmt.true_target.value
@@ -786,6 +790,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
     @staticmethod
     def _find_switch_variable_comparison_type_c(
         node,
+        variable_map,
     ) -> tuple[int, str, Expression, int, int, int | None, int, int | None] | None:
         # the type c is where the last statement is a var < or > constant comparison, and
         # there is only one non-label statement
@@ -807,7 +812,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                     and isinstance(cond.operands[0], VirtualVariable)
                     and isinstance(cond.operands[1], Const)
                 ):
-                    variable_hash = StableVarExprHasher(cond.operands[0]).hash
+                    variable_hash = StableVarExprHasher(cond.operands[0], variable_map).hash
                     value = cond.operands[1].value
                     op = cond.op
                     if stmt.true_target.value == stmt.false_target.value:

--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_base.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_base.py
@@ -44,8 +44,6 @@ class FreshVirtualVariableRewriter(AILBlockRewriter):
                 dst.bits,
                 dst.category,
                 dst.oident,
-                variable=dst.variable,
-                variable_offset=dst.variable_offset,
                 **dst.tags,
             )
 
@@ -63,8 +61,6 @@ class FreshVirtualVariableRewriter(AILBlockRewriter):
                 expr.bits,
                 expr.category,
                 expr.oident,
-                variable=expr.variable,
-                variable_offset=expr.variable_offset,
                 **expr.tags,
             )
         return expr

--- a/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
@@ -150,7 +150,7 @@ class StackCanarySimplifier(OptimizationPass):
                 pred_copy = pred.copy()
                 pred_copy.statements[-1] = ailment.Stmt.Jump(
                     len(pred_copy.statements) - 1,
-                    ailment.Expr.Const(self.manager.next_atom(), None, ret_node.addr, self.project.arch.bits),
+                    ailment.Expr.Const(self.manager.next_atom(), ret_node.addr, self.project.arch.bits),
                     ins_addr=pred_copy.statements[-1].tags["ins_addr"],
                 )
 

--- a/angr/analyses/decompiler/optimization_passes/static_vvar_rewriter.py
+++ b/angr/analyses/decompiler/optimization_passes/static_vvar_rewriter.py
@@ -160,9 +160,9 @@ class VVarRewritingVisitor(AILBlockRewriter):
                                 None,
                                 str_id,
                                 arg.bits,
-                                custom_string=True,
                                 **arg.tags,
                             )
+                            self.manager.variable_map.set_custom_string(str_id_arg)
                             if new_args is None:
                                 new_args = expr.args[:arg_idx]
                             new_args.append(str_id_arg)
@@ -186,9 +186,9 @@ class VVarRewritingVisitor(AILBlockRewriter):
                                 None,
                                 str_id,
                                 arg.bits,
-                                custom_string=True,
                                 **arg.tags,
                             )
+                            self.manager.variable_map.set_custom_string(str_id_arg)
                             if new_args is None:
                                 new_args = expr.args[:arg_idx]
                             new_args.append(str_id_arg)
@@ -252,7 +252,7 @@ class VVarAliasVisitor(AILBlockViewer):
             # got a new memcpy call that we can handle
             dst, src, size = call.args
             if dst.varid not in self._static_vvars:
-                if src.tags.get("custom_string", False):
+                if self.manager.variable_map.custom_string(src):
                     ident = f"static_buf_{stmt.tags['ins_addr']}"
                     buf = self.kb.custom_strings[src.value_int]
                     fixed_buffer = FixedBuffer(ident, size.value_int, buf)

--- a/angr/analyses/decompiler/optimization_passes/static_vvar_rewriter.py
+++ b/angr/analyses/decompiler/optimization_passes/static_vvar_rewriter.py
@@ -108,7 +108,7 @@ class VVarRewritingVisitor(AILBlockRewriter):
                     return expr
                 data = buffer.content[v.offset : v.offset + expr.size]
                 value = int.from_bytes(data, byteorder="little" if expr.endness == "Iend_LE" else "big")
-                return Const(self.manager.next_atom(), None, value, expr.bits, **expr.tags)
+                return Const(self.manager.next_atom(), value, expr.bits, **expr.tags)
 
         return super()._handle_Load(expr_idx, expr, stmt_idx, stmt, block)
 
@@ -131,7 +131,7 @@ class VVarRewritingVisitor(AILBlockRewriter):
                         and data[str_len * word_size : str_len * word_size + word_size] != b"\x00" * word_size
                     ):
                         str_len += 1
-                    return Const(self.manager.next_atom(), None, str_len, expr.bits, **expr.tags)
+                    return Const(self.manager.next_atom(), str_len, expr.bits, **expr.tags)
 
         elif expr.args and expr.prototype is not None:
             new_args: list | None = None
@@ -157,7 +157,6 @@ class VVarRewritingVisitor(AILBlockRewriter):
                             str_id = self.kb.custom_strings.allocate(bytes(str_bytes))
                             str_id_arg = Const(
                                 self.manager.next_atom(),
-                                None,
                                 str_id,
                                 arg.bits,
                                 **arg.tags,
@@ -183,7 +182,6 @@ class VVarRewritingVisitor(AILBlockRewriter):
                             str_id = self.kb.custom_strings.allocate(bytes(str_bytes))
                             str_id_arg = Const(
                                 self.manager.next_atom(),
-                                None,
                                 str_id,
                                 arg.bits,
                                 **arg.tags,

--- a/angr/analyses/decompiler/optimization_passes/static_vvar_rewriter.py
+++ b/angr/analyses/decompiler/optimization_passes/static_vvar_rewriter.py
@@ -216,11 +216,18 @@ class VVarAliasVisitor(AILBlockViewer):
     The visitor that discovers const assignments and aliases of existing static vvars.
     """
 
-    def __init__(self, static_buffers: dict[str, FixedBuffer], static_vvars: dict[int, FixedBufferPtr | Const], kb):
+    def __init__(
+        self,
+        static_buffers: dict[str, FixedBuffer],
+        static_vvars: dict[int, FixedBufferPtr | Const],
+        kb,
+        manager: Manager,
+    ):
         super().__init__()
         self._static_buffers = static_buffers
         self._static_vvars = static_vvars
         self.kb = kb
+        self.manager = manager
 
     def _handle_Assignment(self, stmt_idx: int, stmt: Assignment, block: Block | None):
         src = self._handle_expr(1, stmt.src, stmt_idx, stmt, block)
@@ -252,7 +259,7 @@ class VVarAliasVisitor(AILBlockViewer):
             # got a new memcpy call that we can handle
             dst, src, size = call.args
             if dst.varid not in self._static_vvars:
-                if self.manager.variable_map.custom_string(src):
+                if self.manager.variable_map is not None and self.manager.variable_map.custom_string(src):
                     ident = f"static_buf_{stmt.tags['ins_addr']}"
                     buf = self.kb.custom_strings[src.value_int]
                     fixed_buffer = FixedBuffer(ident, size.value_int, buf)
@@ -315,7 +322,7 @@ class StaticVVarRewriter(OptimizationPass):
 
     def _check(self):
         # discover aliases
-        alias_visitor = VVarAliasVisitor(self._static_buffers, self._static_vvars, self.kb)
+        alias_visitor = VVarAliasVisitor(self._static_buffers, self._static_vvars, self.kb, self.manager)
         head = {(node.addr, node.idx): node for node in self._graph}[self.entry_node_addr]
         for block in reversed(list(GraphUtils.dfs_postorder_nodes_deterministic(self._graph, head))):
             alias_visitor.walk(block)
@@ -343,7 +350,7 @@ class StaticVVarRewriter(OptimizationPass):
             # discover more aliases
             old_static_buffers = dict(self._static_buffers)
             old_static_vvars = dict(self._static_vvars)
-            alias_visitor = VVarAliasVisitor(self._static_buffers, self._static_vvars, self.kb)
+            alias_visitor = VVarAliasVisitor(self._static_buffers, self._static_vvars, self.kb, self.manager)
             head = {(node.addr, node.idx): node for node in g}[self.entry_node_addr]
             for block in reversed(list(GraphUtils.dfs_postorder_nodes_deterministic(g, head))):
                 alias_visitor.walk(block)

--- a/angr/analyses/decompiler/optimization_passes/switch_default_case_duplicator.py
+++ b/angr/analyses/decompiler/optimization_passes/switch_default_case_duplicator.py
@@ -91,9 +91,7 @@ class SwitchDefaultCaseDuplicator(OptimizationPass):
                     switch_head_node = self._get_block(switch_head_addr)
                     goto_stmt = Jump(
                         self.manager.next_atom(),
-                        Const(
-                            self.manager.next_atom(), None, default_addr, self.project.arch.bits, ins_addr=default_addr
-                        ),
+                        Const(self.manager.next_atom(), default_addr, self.project.arch.bits, ins_addr=default_addr),
                         target_idx=None,  # I'm assuming the ID of the default node is None here
                         ins_addr=default_addr,
                     )

--- a/angr/analyses/decompiler/optimization_passes/switch_reused_entry_rewriter.py
+++ b/angr/analyses/decompiler/optimization_passes/switch_reused_entry_rewriter.py
@@ -81,7 +81,6 @@ class SwitchReusedEntryRewriter(OptimizationPass):
                     self.manager.next_atom(),
                     Const(
                         self.manager.next_atom(),
-                        None,
                         entry_node.addr,
                         self.project.arch.bits,
                         ins_addr=entry_node.addr,

--- a/angr/analyses/decompiler/optimization_passes/x86_gcc_getpc_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/x86_gcc_getpc_simplifier.py
@@ -54,7 +54,7 @@ class X86GccGetPcSimplifier(OptimizationPass):
             block.statements[stmt_idx] = ailment.Stmt.Assignment(
                 old_stmt.idx,
                 ailment.Expr.Register(self.manager.next_atom(), None, pcreg_offset, 32, reg_name=getpc_reg),
-                ailment.Expr.Const(self.manager.next_atom(), None, getpc_reg_value, 32),
+                ailment.Expr.Const(self.manager.next_atom(), getpc_reg_value, 32),
                 **old_stmt.tags,
             )
             # remove the statement that pushes return address onto the stack

--- a/angr/analyses/decompiler/optimization_passes/x86_gcc_getpc_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/x86_gcc_getpc_simplifier.py
@@ -53,7 +53,7 @@ class X86GccGetPcSimplifier(OptimizationPass):
             old_stmt = block.statements[stmt_idx]
             block.statements[stmt_idx] = ailment.Stmt.Assignment(
                 old_stmt.idx,
-                ailment.Expr.Register(self.manager.next_atom(), None, pcreg_offset, 32, reg_name=getpc_reg),
+                ailment.Expr.Register(self.manager.next_atom(), pcreg_offset, 32, reg_name=getpc_reg),
                 ailment.Expr.Const(self.manager.next_atom(), getpc_reg_value, 32),
                 **old_stmt.tags,
             )

--- a/angr/analyses/decompiler/peephole_optimizations/a_div_const_add_a_mul_n_div_const.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_div_const_add_a_mul_n_div_const.py
@@ -38,7 +38,6 @@ class ADivConstAddAMulNDivConst(PeepholeOptimizationExprBase):
                                 a0,
                                 Const(
                                     self.manager.next_atom(),
-                                    None,
                                     N1 + 1,
                                     expr.bits,
                                     **expr.operands[0].operands[1].tags,

--- a/angr/analyses/decompiler/peephole_optimizations/a_mul_const_div_shr_const.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_mul_const_div_shr_const.py
@@ -34,7 +34,6 @@ class AMulConstDivShrConst(PeepholeOptimizationExprBase):
                         a,
                         Const(
                             self.manager.next_atom(),
-                            None,
                             N0 // (2**N2),
                             expr.bits,
                             **expr.operands[0].operands[1].tags,

--- a/angr/analyses/decompiler/peephole_optimizations/a_mul_const_sub_a.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_mul_const_sub_a.py
@@ -27,7 +27,7 @@ class AMulConstSubA(PeepholeOptimizationExprBase):
                 return BinaryOp(
                     expr.idx,
                     "Mul",
-                    [a, Const(self.manager.next_atom(), None, N - 1, expr.bits, **expr.operands[0].operands[1].tags)],
+                    [a, Const(self.manager.next_atom(), N - 1, expr.bits, **expr.operands[0].operands[1].tags)],
                     expr.signed,
                     **expr.tags,
                 )

--- a/angr/analyses/decompiler/peephole_optimizations/a_shl_const_sub_a.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_shl_const_sub_a.py
@@ -29,7 +29,7 @@ class AShlConstSubA(PeepholeOptimizationExprBase):
                     "Mul",
                     [
                         a,
-                        Const(self.manager.next_atom(), None, 2**N - 1, expr.bits, **expr.operands[0].operands[1].tags),
+                        Const(self.manager.next_atom(), 2**N - 1, expr.bits, **expr.operands[0].operands[1].tags),
                     ],
                     expr.signed,
                     **expr.tags,

--- a/angr/analyses/decompiler/peephole_optimizations/a_sub_a_div.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_sub_a_div.py
@@ -21,14 +21,14 @@ class ASubADiv(PeepholeOptimizationExprBase):
                     mul = BinaryOp(
                         expr.idx,
                         "Mul",
-                        [a, Const(self.manager.next_atom(), None, N - 1, expr.bits)],
+                        [a, Const(self.manager.next_atom(), N - 1, expr.bits)],
                         False,
                         **expr.tags,
                     )
                     return BinaryOp(
                         expr1.idx,
                         "Div",
-                        [mul, Const(self.manager.next_atom(), None, N, expr.bits, **expr1.tags)],
+                        [mul, Const(self.manager.next_atom(), N, expr.bits, **expr1.tags)],
                         False,
                         **expr1.tags,
                     )

--- a/angr/analyses/decompiler/peephole_optimizations/a_sub_a_shr_const_shr_const.py
+++ b/angr/analyses/decompiler/peephole_optimizations/a_sub_a_shr_const_shr_const.py
@@ -35,6 +35,6 @@ class ASubAShrConstShrConst(PeepholeOptimizationExprBase):
             ):
                 dividend = 2 ** expr.operands[1].value
                 return BinaryOp(
-                    a0.idx, "Div", [a0, Const(self.manager.next_atom(), None, dividend, expr.bits)], True, **expr.tags
+                    a0.idx, "Div", [a0, Const(self.manager.next_atom(), dividend, expr.bits)], True, **expr.tags
                 )
         return None

--- a/angr/analyses/decompiler/peephole_optimizations/bitwise_inserts.py
+++ b/angr/analyses/decompiler/peephole_optimizations/bitwise_inserts.py
@@ -58,11 +58,9 @@ class SimplifyBitwiseInserts(PeepholeOptimizationExprBase):
             assert pb2.bits > pb2x.bits
             assert isinstance(pb2x, Const)
             assert isinstance(pb2x.value, int)
-            pb2x = Const(self.manager.next_atom(), None, pb2x.value << pb1o, pb2.bits)
+            pb2x = Const(self.manager.next_atom(), pb2x.value << pb1o, pb2.bits)
         elif pb1o != 0:
-            pb2x = BinaryOp(
-                self.manager.next_atom(), "Shl", [pb2x, Const(self.manager.next_atom(), None, pb1o, pb2x.bits)]
-            )
+            pb2x = BinaryOp(self.manager.next_atom(), "Shl", [pb2x, Const(self.manager.next_atom(), pb1o, pb2x.bits)])
 
         result = BinaryOp(self.manager.next_atom(), expr.value.op, [pb1, pb2x])
         if result.bits != expr.bits:

--- a/angr/analyses/decompiler/peephole_optimizations/coalesce_adjacent_shrs.py
+++ b/angr/analyses/decompiler/peephole_optimizations/coalesce_adjacent_shrs.py
@@ -31,7 +31,7 @@ class CoalesceAdjacentShiftRights(PeepholeOptimizationExprBase):
                 r = BinaryOp(
                     expr.idx,
                     expr.op,
-                    [inner.operands[0], Const(self.manager.next_atom(), None, new_shift, 8)],
+                    [inner.operands[0], Const(self.manager.next_atom(), new_shift, 8)],
                     expr.signed,
                     **expr.tags,
                 )

--- a/angr/analyses/decompiler/peephole_optimizations/constant_derefs.py
+++ b/angr/analyses/decompiler/peephole_optimizations/constant_derefs.py
@@ -30,9 +30,7 @@ class ConstantDereferences(PeepholeOptimizationExprBase):
                 if "got" in sec.name and val == 0:
                     return None
 
-                return Const(
-                    self.manager.next_atom(), None, val, expr.bits, **expr.tags, deref_src_addr=expr.addr.value
-                )
+                return Const(self.manager.next_atom(), val, expr.bits, **expr.tags, deref_src_addr=expr.addr.value)
 
             # is it loading from a blob?
             obj = self.project.loader.find_object_containing(expr.addr.value)
@@ -43,8 +41,6 @@ class ConstantDereferences(PeepholeOptimizationExprBase):
                 except KeyError:
                     return None
 
-                return Const(
-                    self.manager.next_atom(), None, val, expr.bits, **expr.tags, deref_src_addr=expr.addr.value
-                )
+                return Const(self.manager.next_atom(), val, expr.bits, **expr.tags, deref_src_addr=expr.addr.value)
 
         return None

--- a/angr/analyses/decompiler/peephole_optimizations/conv_a_sub0_shr_and.py
+++ b/angr/analyses/decompiler/peephole_optimizations/conv_a_sub0_shr_and.py
@@ -61,7 +61,7 @@ class ConvASub0ShrAnd(PeepholeOptimizationExprBase):
                     "CmpLT",
                     (
                         cvt,
-                        Const(self.manager.next_atom(), None, 0, to_bits),
+                        Const(self.manager.next_atom(), 0, to_bits),
                     ),
                     True,
                     **expr.tags,

--- a/angr/analyses/decompiler/peephole_optimizations/conv_shl_shr.py
+++ b/angr/analyses/decompiler/peephole_optimizations/conv_shl_shr.py
@@ -35,8 +35,6 @@ class ConvShlShr(PeepholeOptimizationExprBase):
                                 Const(self.manager.next_atom(), bitmask, n),
                             ),
                             False,
-                            variable=None,
-                            variable_offset=None,
                             **expr.tags,
                         )
                         return BinaryOp(

--- a/angr/analyses/decompiler/peephole_optimizations/conv_shl_shr.py
+++ b/angr/analyses/decompiler/peephole_optimizations/conv_shl_shr.py
@@ -32,7 +32,7 @@ class ConvShlShr(PeepholeOptimizationExprBase):
                             "And",
                             (
                                 Convert(expr_a.idx, m, n, False, expr_a.operand, **expr_a.tags),
-                                Const(self.manager.next_atom(), None, bitmask, n),
+                                Const(self.manager.next_atom(), bitmask, n),
                             ),
                             False,
                             variable=None,
@@ -44,7 +44,7 @@ class ConvShlShr(PeepholeOptimizationExprBase):
                             "Shr",
                             (
                                 and_expr,
-                                Const(self.manager.next_atom(), None, q - p, and_expr.bits),
+                                Const(self.manager.next_atom(), q - p, and_expr.bits),
                             ),
                             False,
                             **expr.tags,

--- a/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
+++ b/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
@@ -39,12 +39,11 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             ):
                 # const + const ==> const
                 mask = (1 << expr.bits) - 1
-                return Const(expr.idx, None, (op0.value + op1.value) & mask, expr.bits, **expr.tags)
+                return Const(expr.idx, (op0.value + op1.value) & mask, expr.bits, **expr.tags)
             if isinstance(op1, Const) and op1.value < 0:
                 # x + (-A)  ==>  x - A
                 new_op1 = Const(
                     op1.idx,
-                    None,
                     -op1.value,
                     op1.bits,
                     **op1.tags,
@@ -67,7 +66,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                     return BinaryOp(
                         left.idx,
                         "Add",
-                        [inner_expr, Const(const_0.idx, None, const_0.value + const_1.value, const_0.bits)],
+                        [inner_expr, Const(const_0.idx, const_0.value + const_1.value, const_0.bits)],
                         expr.signed,
                         **expr.tags,
                     )
@@ -75,13 +74,13 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                     return BinaryOp(
                         left.idx,
                         "Add",
-                        [inner_expr, Const(const_0.idx, None, const_1.value - const_0.value, const_0.bits)],
+                        [inner_expr, Const(const_0.idx, const_1.value - const_0.value, const_0.bits)],
                         expr.signed,
                         **expr.tags,
                     )
             if op0.likes(op1):
                 # x + x => 2 * x
-                count = Const(expr.idx, None, 2, op0.bits, **expr.tags)
+                count = Const(expr.idx, 2, op0.bits, **expr.tags)
                 return BinaryOp(expr.idx, "Mul", [op0, count], expr.signed, **expr.tags)
 
             op0_is_mulconst = (
@@ -110,17 +109,17 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             if op0_is_mulconst ^ op1_is_mulconst:
                 if x0 is not None and const0 is not None and x0.likes(op1):
                     # x * A + x => (A + 1) * x
-                    new_const = Const(const0.idx, None, const0.value + 1, const0.bits, **const0.tags)
+                    new_const = Const(const0.idx, const0.value + 1, const0.bits, **const0.tags)
                     return BinaryOp(expr.idx, "Mul", [x0, new_const], expr.signed, **expr.tags)
                 if x1 is not None and const1 is not None and x1.likes(op0):
                     # x + x * A => (A + 1) * x
-                    new_const = Const(const1.idx, None, const1.value + 1, const1.bits, **const1.tags)
+                    new_const = Const(const1.idx, const1.value + 1, const1.bits, **const1.tags)
                     return BinaryOp(expr.idx, "Mul", [x1, new_const], expr.signed, **expr.tags)
             elif op0_is_mulconst and op1_is_mulconst:
                 assert x0 is not None and x1 is not None and const0 is not None and const1 is not None
                 if x0.likes(x1):
                     # x * A + x * B => (A + B) * x
-                    new_const = Const(const0.idx, None, const0.value + const1.value, const0.bits, **const0.tags)
+                    new_const = Const(const0.idx, const0.value + const1.value, const0.bits, **const0.tags)
                     return BinaryOp(expr.idx, "Mul", [x0, new_const], expr.signed, **expr.tags)
 
             if isinstance(op0, StackBaseOffset) and isinstance(op1, Const) and op1.is_int:
@@ -136,14 +135,13 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 and isinstance(op1.value, int)
             ):
                 mask = (1 << expr.bits) - 1
-                return Const(expr.idx, None, (op0.value - op1.value) & mask, expr.bits, **expr.tags)
+                return Const(expr.idx, (op0.value - op1.value) & mask, expr.bits, **expr.tags)
             if isinstance(op1, Const) and op1.is_int and op1.sign_bit == 1:
                 # x - (-A)  ==>  x + A
                 assert isinstance(op1.value, int)
                 mask = (1 << op1.bits) - 1
                 complement = Const(
                     op1.idx,
-                    None,
                     ((~op1.value) + 1) & mask,
                     op1.bits,
                     **op1.tags,
@@ -165,7 +163,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                     return BinaryOp(
                         left.idx,
                         "Sub",
-                        [inner_expr, Const(const_0.idx, None, const_1.value - const_0.value, const_0.bits)],
+                        [inner_expr, Const(const_0.idx, const_1.value - const_0.value, const_0.bits)],
                         expr.signed,
                         **expr.tags,
                     )
@@ -173,7 +171,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                     return BinaryOp(
                         left.idx,
                         "Sub",
-                        [inner_expr, Const(const_0.idx, None, const_0.value + const_1.value, const_0.bits)],
+                        [inner_expr, Const(const_0.idx, const_0.value + const_1.value, const_0.bits)],
                         expr.signed,
                         **expr.tags,
                     )
@@ -186,7 +184,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
 
             if isinstance(op0, StackBaseOffset) and isinstance(op1, StackBaseOffset):
                 assert isinstance(op0.offset, int) and isinstance(op1.offset, int)
-                return Const(expr.idx, None, op0.offset - op1.offset, expr.bits, **expr.tags)
+                return Const(expr.idx, op0.offset - op1.offset, expr.bits, **expr.tags)
 
             if isinstance(op0, StackBaseOffset) and isinstance(op1, Const) and op1.is_int:
                 return StackBaseOffset(expr.idx, op0.bits, op0.offset - op1.value_int, **expr.tags)
@@ -201,9 +199,9 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 and isinstance(op1, Const)
                 and isinstance(op1.value, int)
             ):
-                return Const(expr.idx, None, (op0.value & op1.value), expr.bits, **expr.tags)
+                return Const(expr.idx, (op0.value & op1.value), expr.bits, **expr.tags)
             if isinstance(op1, Const) and op1.value == 0:
-                return Const(expr.idx, None, 0, expr.bits, **expr.tags)
+                return Const(expr.idx, 0, expr.bits, **expr.tags)
 
         elif expr.op == "Mul":
             if isinstance(op1, Const) and op1.value == 1:
@@ -213,7 +211,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 assert isinstance(op0.value, int) and isinstance(op1.value, int)
                 # constant multiplication
                 mask = (1 << expr.bits) - 1
-                return Const(expr.idx, None, (op0.value * op1.value) & mask, expr.bits, **expr.tags)
+                return Const(expr.idx, (op0.value * op1.value) & mask, expr.bits, **expr.tags)
             if {type(op0), type(op1)} == {BinaryOp, Const}:
                 op0, op1 = expr.operands
                 const_, x0 = (op0, op1) if isinstance(op0, Const) else (op1, op0)
@@ -223,7 +221,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                         const_x0, x = x0.operands[0], x0.operands[1]
                     else:
                         const_x0, x = x0.operands[1], x0.operands[0]
-                    new_const = Const(const_.idx, None, const_.value * const_x0.value, const_.bits, **const_x0.tags)
+                    new_const = Const(const_.idx, const_.value * const_x0.value, const_.bits, **const_x0.tags)
                     return BinaryOp(expr.idx, "Mul", [x, new_const], expr.signed, bits=expr.bits, **expr.tags)
 
         elif (
@@ -238,8 +236,8 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             if const_0.value != 0 and const_1.value != 0:
                 gcd_ = gcd(const_0.value, const_1.value)
                 if gcd_ != 1:
-                    new_const_1 = Const(const_1.idx, None, const_1.value // gcd_, const_1.bits, **const_1.tags)
-                    new_const_0 = Const(const_0.idx, None, const_0.value // gcd_, const_0.bits, **const_0.tags)
+                    new_const_1 = Const(const_1.idx, const_1.value // gcd_, const_1.bits, **const_1.tags)
+                    new_const_0 = Const(const_0.idx, const_0.value // gcd_, const_0.bits, **const_0.tags)
                     mul = BinaryOp(
                         expr0.idx,
                         "Mul",
@@ -259,7 +257,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 and isinstance(op1.value, int)
                 and op1.value != 0
             ):
-                return Const(expr.idx, None, op0.value % op1.value, expr.bits, **expr.tags)
+                return Const(expr.idx, op0.value % op1.value, expr.bits, **expr.tags)
 
         elif expr.op in {"Shr", "Sar"} and isinstance(op1, Const):
             expr0, expr1 = expr.operands
@@ -267,30 +265,30 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 # (a >> M) >> N  ==>  a >> (M + N)
                 const_a = expr0.operands[1]
                 const_b = expr1
-                const = Const(const_b.idx, None, const_a.value + const_b.value, const_b.bits, **const_b.tags)
+                const = Const(const_b.idx, const_a.value + const_b.value, const_b.bits, **const_b.tags)
                 return BinaryOp(expr.idx, expr.op, (expr0.operands[0], const), False, bits=expr.bits, **expr.tags)
 
             if isinstance(expr0, BinaryOp) and expr0.op == "Div" and isinstance(expr0.operands[1], Const):
                 # (a / M0) >> M1  ==>  a / (M0 * 2 ** M1)
                 const_m0 = expr0.operands[1]
                 const_m1 = expr1
-                const = Const(const_m0.idx, None, const_m0.value * 2**const_m1.value, const_m0.bits, **const_m0.tags)
+                const = Const(const_m0.idx, const_m0.value * 2**const_m1.value, const_m0.bits, **const_m0.tags)
                 return BinaryOp(expr.idx, "Div", (expr0.operands[0], const), expr.signed, bits=expr.bits, **expr.tags)
 
             if isinstance(expr0, Const):
                 const_a = expr0.value
                 mask = (2**expr0.bits) - 1
-                return Const(expr0.idx, None, (const_a >> expr1.value) & mask, expr0.bits, **expr0.tags)
+                return Const(expr0.idx, (const_a >> expr1.value) & mask, expr0.bits, **expr0.tags)
 
             if expr.op == "Shr" and op0.bits <= op1.value:
-                return Const(expr.idx, None, 0, op0.bits, **expr.tags)
+                return Const(expr.idx, 0, op0.bits, **expr.tags)
 
         elif expr.op == "Shl" and isinstance(op1, Const):
             expr0, expr1 = expr.operands
             if isinstance(expr0, Const):
                 const_a = expr0.value
                 mask = (2**expr0.bits) - 1
-                return Const(expr0.idx, None, (const_a << expr1.value) & mask, expr0.bits, **expr0.tags)
+                return Const(expr0.idx, (const_a << expr1.value) & mask, expr0.bits, **expr0.tags)
 
         elif expr.op == "Or":
             op0, op1 = expr.operands
@@ -300,7 +298,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 and isinstance(op1, Const)
                 and isinstance(op1.value, int)
             ):
-                return Const(expr.idx, None, op0.value | op1.value, expr.bits, **expr.tags)
+                return Const(expr.idx, op0.value | op1.value, expr.bits, **expr.tags)
             if isinstance(op0, Const) and op0.value == 0:
                 return op1
             if isinstance(op1, Const) and op1.value == 0:
@@ -320,31 +318,31 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 and isinstance(op1, Const)
                 and isinstance(op1.value, int)
             ):
-                return Const(expr.idx, None, op0.value ^ op1.value, expr.bits, **expr.tags)
+                return Const(expr.idx, op0.value ^ op1.value, expr.bits, **expr.tags)
 
         elif expr.op in {"CmpEQ", "CmpLE", "CmpGE"}:
             if op0.likes(op1):
                 # x == x => 1
-                return Const(expr.idx, None, 1, 1, **expr.tags)
+                return Const(expr.idx, 1, 1, **expr.tags)
             if isinstance(op0, Const) and isinstance(op1, Const):
                 if expr.op == "CmpEQ":
-                    return Const(expr.idx, None, 1 if op0.value == op1.value else 0, 1, **expr.tags)
+                    return Const(expr.idx, 1 if op0.value == op1.value else 0, 1, **expr.tags)
                 if expr.op == "CmpLE":
-                    return Const(expr.idx, None, 1 if op0.value <= op1.value else 0, 1, **expr.tags)
+                    return Const(expr.idx, 1 if op0.value <= op1.value else 0, 1, **expr.tags)
                 if expr.op == "CmpGE":
-                    return Const(expr.idx, None, 1 if op0.value >= op1.value else 0, 1, **expr.tags)
+                    return Const(expr.idx, 1 if op0.value >= op1.value else 0, 1, **expr.tags)
 
         elif expr.op in {"CmpNE", "CmpLT", "CmpGT"}:
             if op0.likes(op1):
                 # x != x => 0
-                return Const(expr.idx, None, 0, 1, **expr.tags)
+                return Const(expr.idx, 0, 1, **expr.tags)
             if isinstance(op0, Const) and isinstance(op1, Const):
                 if expr.op == "CmpNE":
-                    return Const(expr.idx, None, 1 if op0.value != op1.value else 0, 1, **expr.tags)
+                    return Const(expr.idx, 1 if op0.value != op1.value else 0, 1, **expr.tags)
                 if expr.op == "CmpLT":
-                    return Const(expr.idx, None, 1 if op0.value < op1.value else 0, 1, **expr.tags)
+                    return Const(expr.idx, 1 if op0.value < op1.value else 0, 1, **expr.tags)
                 if expr.op == "CmpGT":
-                    return Const(expr.idx, None, 1 if op0.value > op1.value else 0, 1, **expr.tags)
+                    return Const(expr.idx, 1 if op0.value > op1.value else 0, 1, **expr.tags)
 
         return None
 
@@ -375,7 +373,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             if n.likes(expr1):
                 # (n * C) - n  ==>  (C - 1) * n
                 coeff_0 = expr0.operands[1]
-                coeff = Const(coeff_0.idx, None, coeff_0.value - 1, expr.bits, **coeff_0.tags)
+                coeff = Const(coeff_0.idx, coeff_0.value - 1, expr.bits, **coeff_0.tags)
                 return BinaryOp(expr.idx, "Mul", [n, coeff], expr.signed, bits=expr.bits, **expr.tags)
             if isinstance(expr1, BinaryOp) and expr1.op == "Mul" and isinstance(expr.operands[1].operands[1], Const):
                 n1 = expr.operands[1].operands[0]
@@ -383,7 +381,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                     # (n * C) - (n1 * C1)  ==>  n * (C - C1)
                     coeff_0 = expr0.operands[1]
                     coeff_1 = expr1.operands[1]
-                    coeff = Const(coeff_0.idx, None, coeff_0.value - coeff_1.value, expr.bits, **coeff_0.tags)
+                    coeff = Const(coeff_0.idx, coeff_0.value - coeff_1.value, expr.bits, **coeff_0.tags)
                     return BinaryOp(
                         expr.idx,
                         "Mul",
@@ -399,7 +397,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
         if expr.op == "Neg" and isinstance(expr.operand, Const) and isinstance(expr.operand.value, int):
             const_a = expr.operand.value
             mask = (2**expr.bits) - 1
-            return Const(expr.idx, None, (~const_a) & mask, expr.bits, **expr.tags)
+            return Const(expr.idx, (~const_a) & mask, expr.bits, **expr.tags)
 
         return None
 
@@ -416,7 +414,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             # truncation
             mask = (1 << expr.to_bits) - 1
             v = expr.operand.value & mask
-            return Const(expr.idx, None, v, expr.to_bits, **expr.operand.tags)
+            return Const(expr.idx, v, expr.to_bits, **expr.operand.tags)
         if (
             isinstance(expr.operand, Const)
             and expr.operand.is_int
@@ -427,8 +425,8 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             assert isinstance(expr.operand.value, int)
             if expr.is_signed is False:
                 # unsigned extension
-                return Const(expr.idx, None, expr.operand.value, expr.to_bits, **expr.operand.tags)
+                return Const(expr.idx, expr.operand.value, expr.to_bits, **expr.operand.tags)
             # signed extension
             v = sign_extend(expr.operand.value, expr.to_bits)
-            return Const(expr.idx, None, v, expr.to_bits, **expr.operand.tags)
+            return Const(expr.idx, v, expr.to_bits, **expr.operand.tags)
         return None

--- a/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
+++ b/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
@@ -44,7 +44,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 # x + (-A)  ==>  x - A
                 new_op1 = Const(
                     op1.idx,
-                    op1.variable,
+                    None,
                     -op1.value,
                     op1.bits,
                     **op1.tags,
@@ -54,8 +54,6 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                     "Sub",
                     [op0, new_op1],
                     expr.signed,
-                    variable=expr.variable,
-                    variable_offset=expr.variable_offset,
                     bits=expr.bits,
                     **expr.tags,
                 )
@@ -145,7 +143,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 mask = (1 << op1.bits) - 1
                 complement = Const(
                     op1.idx,
-                    op1.variable,
+                    None,
                     ((~op1.value) + 1) & mask,
                     op1.bits,
                     **op1.tags,
@@ -155,8 +153,6 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                     "Add",
                     [op0, complement],
                     expr.signed,
-                    variable=expr.variable,
-                    variable_offset=expr.variable_offset,
                     bits=expr.bits,
                     **expr.tags,
                 )
@@ -242,19 +238,13 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             if const_0.value != 0 and const_1.value != 0:
                 gcd_ = gcd(const_0.value, const_1.value)
                 if gcd_ != 1:
-                    new_const_1 = Const(
-                        const_1.idx, const_1.variable, const_1.value // gcd_, const_1.bits, **const_1.tags
-                    )
-                    new_const_0 = Const(
-                        const_0.idx, const_0.variable, const_0.value // gcd_, const_0.bits, **const_0.tags
-                    )
+                    new_const_1 = Const(const_1.idx, None, const_1.value // gcd_, const_1.bits, **const_1.tags)
+                    new_const_0 = Const(const_0.idx, None, const_0.value // gcd_, const_0.bits, **const_0.tags)
                     mul = BinaryOp(
                         expr0.idx,
                         "Mul",
                         (expr0.operands[0], new_const_1),
                         expr0.signed,
-                        variable=expr0.variable,
-                        variable_offset=expr0.variable_offset,
                         bits=expr0.bits,
                         **expr0.tags,
                     )
@@ -386,9 +376,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                 # (n * C) - n  ==>  (C - 1) * n
                 coeff_0 = expr0.operands[1]
                 coeff = Const(coeff_0.idx, None, coeff_0.value - 1, expr.bits, **coeff_0.tags)
-                return BinaryOp(
-                    expr.idx, "Mul", [n, coeff], expr.signed, variable=expr.variable, bits=expr.bits, **expr.tags
-                )
+                return BinaryOp(expr.idx, "Mul", [n, coeff], expr.signed, bits=expr.bits, **expr.tags)
             if isinstance(expr1, BinaryOp) and expr1.op == "Mul" and isinstance(expr.operands[1].operands[1], Const):
                 n1 = expr.operands[1].operands[0]
                 if n.likes(n1):
@@ -401,7 +389,6 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
                         "Mul",
                         [n, coeff],
                         expr.signed,
-                        variable=expr.variable,
                         bits=expr.bits,
                         **expr.tags,
                     )
@@ -429,7 +416,7 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             # truncation
             mask = (1 << expr.to_bits) - 1
             v = expr.operand.value & mask
-            return Const(expr.idx, expr.operand.variable, v, expr.to_bits, **expr.operand.tags)
+            return Const(expr.idx, None, v, expr.to_bits, **expr.operand.tags)
         if (
             isinstance(expr.operand, Const)
             and expr.operand.is_int
@@ -440,8 +427,8 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
             assert isinstance(expr.operand.value, int)
             if expr.is_signed is False:
                 # unsigned extension
-                return Const(expr.idx, expr.operand.variable, expr.operand.value, expr.to_bits, **expr.operand.tags)
+                return Const(expr.idx, None, expr.operand.value, expr.to_bits, **expr.operand.tags)
             # signed extension
             v = sign_extend(expr.operand.value, expr.to_bits)
-            return Const(expr.idx, expr.operand.variable, v, expr.to_bits, **expr.operand.tags)
+            return Const(expr.idx, None, v, expr.to_bits, **expr.operand.tags)
         return None

--- a/angr/analyses/decompiler/peephole_optimizations/evaluate_const_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/evaluate_const_conversions.py
@@ -30,4 +30,4 @@ class EvaluateConstConversions(PeepholeOptimizationExprBase):
         if signed and value >= 1 << (expr.bits - 1):
             value -= 1 << expr.bits  # re-adds sign
 
-        return Const(inner.idx, None, value, expr.bits, **inner.tags)
+        return Const(inner.idx, value, expr.bits, **inner.tags)

--- a/angr/analyses/decompiler/peephole_optimizations/evaluate_const_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/evaluate_const_conversions.py
@@ -30,4 +30,4 @@ class EvaluateConstConversions(PeepholeOptimizationExprBase):
         if signed and value >= 1 << (expr.bits - 1):
             value -= 1 << expr.bits  # re-adds sign
 
-        return Const(inner.idx, inner.variable, value, expr.bits, **inner.tags)
+        return Const(inner.idx, None, value, expr.bits, **inner.tags)

--- a/angr/analyses/decompiler/peephole_optimizations/extended_byte_and_mask.py
+++ b/angr/analyses/decompiler/peephole_optimizations/extended_byte_and_mask.py
@@ -50,8 +50,6 @@ class ExtendedByteAndMask(PeepholeOptimizationExprBase):
                         binop_expr.op,
                         (atom, binop_expr.operands[1]),
                         binop_expr.signed,
-                        variable=binop_expr.variable,
-                        variable_offset=binop_expr.variable_offset,
                         **binop_expr.tags,
                     )
                     return Convert(

--- a/angr/analyses/decompiler/peephole_optimizations/invert_negated_logical_conjuction_disjunction.py
+++ b/angr/analyses/decompiler/peephole_optimizations/invert_negated_logical_conjuction_disjunction.py
@@ -27,8 +27,6 @@ class InvertNegatedLogicalConjunctionsAndDisjunctions(PeepholeOptimizationExprBa
                     "LogicalOr",
                     inner_operands,
                     expr.operand.signed,
-                    variable=expr.operand.variable,
-                    variable_offset=expr.operand.variable_offset,
                     bits=expr.operand.bits,
                     **expr.tags,
                 )
@@ -42,8 +40,6 @@ class InvertNegatedLogicalConjunctionsAndDisjunctions(PeepholeOptimizationExprBa
                     "LogicalAnd",
                     inner_operands,
                     expr.operand.signed,
-                    variable=expr.operand.variable,
-                    variable_offset=expr.operand.variable_offset,
                     bits=expr.operand.bits,
                     **expr.tags,
                 )

--- a/angr/analyses/decompiler/peephole_optimizations/optimized_div_simplifier.py
+++ b/angr/analyses/decompiler/peephole_optimizations/optimized_div_simplifier.py
@@ -106,7 +106,7 @@ class OptimizedDivisionSimplifier(PeepholeOptimizationExprBase):
                         ndigits = 5 if V == 32 else 6
                         divisor = self._check_divisor(pow(2, V), C, ndigits)
                         if divisor is not None:
-                            new_const = Const(self.manager.next_atom(), None, divisor, X.bits)
+                            new_const = Const(self.manager.next_atom(), divisor, X.bits)
                             r = BinaryOp(
                                 expr0_operand.idx,
                                 "Div",
@@ -189,7 +189,7 @@ class OptimizedDivisionSimplifier(PeepholeOptimizationExprBase):
                 ndigits = 5 if V == 32 else 6
                 divisor = self._check_divisor(pow(2, V), C, ndigits)
                 if divisor is not None:
-                    new_const = Const(self.manager.next_atom(), None, divisor, X.bits)
+                    new_const = Const(self.manager.next_atom(), divisor, X.bits)
                     # we cannot drop the convert in this case
                     return BinaryOp(
                         expr0.operands[0].idx,
@@ -296,7 +296,7 @@ class OptimizedDivisionSimplifier(PeepholeOptimizationExprBase):
         divisor = math.ceil((2 ** (32 + p)) / (m + 0x1_0000_0000))
         if divisor == 0:
             return None
-        divisor_expr = Const(self.manager.next_atom(), None, divisor, n.bits)
+        divisor_expr = Const(self.manager.next_atom(), divisor, n.bits)
         div = BinaryOp(expr.idx, "Div", [n, divisor_expr], signed=False, **expr.tags)
         if expr.bits != div.bits:
             div = Convert(expr.idx, div.bits, expr.bits, False, div, **expr.tags)
@@ -319,7 +319,7 @@ class OptimizedDivisionSimplifier(PeepholeOptimizationExprBase):
                 ndigits = 5 if V == 32 else 6
                 divisor = self._check_divisor(pow(2, V), C, ndigits)
                 if divisor is not None:
-                    new_const = Const(self.manager.next_atom(), None, divisor, X.bits)
+                    new_const = Const(self.manager.next_atom(), divisor, X.bits)
                     return BinaryOp(inner.idx, "Div", [X, new_const], inner.signed, **inner.tags)
         return None
 

--- a/angr/analyses/decompiler/peephole_optimizations/remove_cascading_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_cascading_conversions.py
@@ -32,7 +32,7 @@ class RemoveCascadingConversions(PeepholeOptimizationExprBase):
                 return BinaryOp(
                     expr.idx,
                     "And",
-                    [inner.operand, Const(self.manager.next_atom(), None, mask, inner.operand.bits)],
+                    [inner.operand, Const(self.manager.next_atom(), mask, inner.operand.bits)],
                     False,
                     **expr.tags,
                 )

--- a/angr/analyses/decompiler/peephole_optimizations/remove_const_insert.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_const_insert.py
@@ -32,13 +32,11 @@ class RemoveConstInsert(PeepholeOptimizationExprBase):
                 "Shl",
                 [
                     value,
-                    Const(self.manager.next_atom(), None, expr.offset.value * self.project.arch.byte_width, expr.bits),
+                    Const(self.manager.next_atom(), expr.offset.value * self.project.arch.byte_width, expr.bits),
                 ],
                 signed=False,
             )
             if expr.offset.value != 0
             else value
         )
-        return BinaryOp(
-            expr.idx, "Or", [shifted, Const(self.manager.next_atom(), None, base, shifted.bits)], signed=False
-        )
+        return BinaryOp(expr.idx, "Or", [shifted, Const(self.manager.next_atom(), base, shifted.bits)], signed=False)

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_bitmasks.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_bitmasks.py
@@ -50,7 +50,7 @@ class RemoveRedundantBitmasks(PeepholeOptimizationExprBase):
             # that the only bits we get from v0 will just be replaced with v1
             return Insert(
                 expr.idx,
-                Const(self.manager.next_atom(), None, 0, expr.bits),
+                Const(self.manager.next_atom(), 0, expr.bits),
                 expr.offset,
                 expr.value,
                 expr.endness,

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
@@ -70,7 +70,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                 elif expr.op in {"Add", "Sub"}:
                     # Add(Conv(32->64, expr), A) ==> Conv(32->64, Add(expr, A))
                     op0, op1 = expr.operands
-                    con = Const(op1.idx, op1.variable, op1.value, op0.from_bits)
+                    con = Const(op1.idx, None, op1.value, op0.from_bits)
                     return Convert(
                         op0.idx,
                         op0.from_bits,
@@ -117,7 +117,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                             r0 = BinaryOp(
                                 left.idx,
                                 left.op,
-                                [shift_lhs.operand, Const(a.idx, a.variable, a.value, from_bits)],
+                                [shift_lhs.operand, Const(a.idx, None, a.value, from_bits)],
                                 left.signed,
                                 bits=from_bits,
                                 **left.tags,
@@ -125,7 +125,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                             r1 = BinaryOp(
                                 op0.idx,
                                 op0.op,
-                                [r0, Const(b.idx, b.variable, b.value, from_bits)],
+                                [r0, Const(b.idx, None, b.value, from_bits)],
                                 op0.signed,
                                 bits=from_bits,
                                 **op0.tags,
@@ -133,7 +133,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                             return BinaryOp(
                                 expr.idx,
                                 expr.op,
-                                [r1, Const(c.idx, c.variable, c.value, from_bits)],
+                                [r1, Const(c.idx, None, c.value, from_bits)],
                                 expr.signed,
                                 bits=1,
                                 **expr.tags,

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
@@ -31,7 +31,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                         1 << to_bits
                     ) - (1 << (from_bits - 1)):
                         con = Const(
-                            self.manager.next_atom(), None, expr.operands[1].value, from_bits, **expr.operands[1].tags
+                            self.manager.next_atom(), expr.operands[1].value, from_bits, **expr.operands[1].tags
                         )
                         new_expr = BinaryOp(
                             expr.idx, "And", (expr.operands[0].operand, con), expr.signed, bits=from_bits, **expr.tags
@@ -61,7 +61,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                         expr.operands[0].is_signed and expr.operands[1].value >= (1 << to_bits) - (1 << (from_bits - 1))
                     ):
                         con = Const(
-                            self.manager.next_atom(), None, expr.operands[1].value, from_bits, **expr.operands[1].tags
+                            self.manager.next_atom(), expr.operands[1].value, from_bits, **expr.operands[1].tags
                         )
                         return BinaryOp(
                             expr.idx, expr.op, (expr.operands[0].operand, con), expr.signed, bits=1, **expr.tags
@@ -70,7 +70,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                 elif expr.op in {"Add", "Sub"}:
                     # Add(Conv(32->64, expr), A) ==> Conv(32->64, Add(expr, A))
                     op0, op1 = expr.operands
-                    con = Const(op1.idx, None, op1.value, op0.from_bits)
+                    con = Const(op1.idx, op1.value, op0.from_bits)
                     return Convert(
                         op0.idx,
                         op0.from_bits,
@@ -117,7 +117,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                             r0 = BinaryOp(
                                 left.idx,
                                 left.op,
-                                [shift_lhs.operand, Const(a.idx, None, a.value, from_bits)],
+                                [shift_lhs.operand, Const(a.idx, a.value, from_bits)],
                                 left.signed,
                                 bits=from_bits,
                                 **left.tags,
@@ -125,7 +125,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                             r1 = BinaryOp(
                                 op0.idx,
                                 op0.op,
-                                [r0, Const(b.idx, None, b.value, from_bits)],
+                                [r0, Const(b.idx, b.value, from_bits)],
                                 op0.signed,
                                 bits=from_bits,
                                 **op0.tags,
@@ -133,7 +133,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                             return BinaryOp(
                                 expr.idx,
                                 expr.op,
-                                [r1, Const(c.idx, None, c.value, from_bits)],
+                                [r1, Const(c.idx, c.value, from_bits)],
                                 expr.signed,
                                 bits=1,
                                 **expr.tags,

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
@@ -240,7 +240,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                     # ignore the high bits of each operand
                     op0, op1 = operand_expr.operands
                     new_op0 = Convert(
-                        expr.idx,
+                        self.manager.next_atom(),
                         expr.from_bits,
                         expr.to_bits,
                         False,
@@ -248,7 +248,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                         **expr.tags,
                     )
                     new_op1 = Convert(
-                        expr.idx,
+                        self.manager.next_atom(),
                         expr.from_bits,
                         expr.to_bits,
                         False,
@@ -257,7 +257,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                     )
 
                     return BinaryOp(
-                        expr.idx,
+                        self.manager.next_atom(),
                         operand_expr.op,
                         [new_op0, new_op1],
                         operand_expr.signed,
@@ -269,7 +269,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                     assert isinstance(op0, Convert)
                     if op0.to_bits > op0.from_bits and op0.to_bits == expr.from_bits:
                         new_operand = BinaryOp(
-                            expr.idx,
+                            self.manager.next_atom(),
                             operand_expr.op,
                             [op0.operand, op1],
                             operand_expr.signed,
@@ -277,7 +277,7 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
                             **operand_expr.tags,
                         )
                         return Convert(
-                            expr.idx,
+                            self.manager.next_atom(),
                             new_operand.bits,
                             expr.to_bits,
                             expr.is_signed,

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_reinterprets.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_reinterprets.py
@@ -40,6 +40,6 @@ class RemoveRedundantReinterprets(PeepholeOptimizationExprBase):
                 raise NotImplementedError
 
             value = struct.unpack(float_fmt, struct.pack(int_fmt, expr.operand.value))[0]
-            return Const(expr.idx, None, value, expr.bits, **expr.tags)
+            return Const(expr.idx, value, expr.bits, **expr.tags)
 
         return None

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_shifts_around_comparators.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_shifts_around_comparators.py
@@ -69,8 +69,8 @@ class RemoveRedundantShiftsAroundComparators(PeepholeOptimizationExprBase):
                     common_shift_amount = self._get_common_shift_amount(mul_0, mul_1)
                     if common_shift_amount > 0:
                         op_bits = op0_op.bits
-                        new_mul_0 = Const(self.manager.next_atom(), None, mul_0 >> common_shift_amount, op_bits)
-                        new_mul_1 = Const(self.manager.next_atom(), None, mul_1 >> common_shift_amount, op_bits)
+                        new_mul_0 = Const(self.manager.next_atom(), mul_0 >> common_shift_amount, op_bits)
+                        new_mul_1 = Const(self.manager.next_atom(), mul_1 >> common_shift_amount, op_bits)
                         new_cmp_0 = BinaryOp(op0.idx, "Mul", [op0_op, new_mul_0], op0.signed, bits=op0.bits, **op0.tags)
                         new_cmp_1 = (
                             BinaryOp(op1.idx, "Mul", [op1_op, new_mul_1], op1.signed, bits=op1.bits, **op1.tags)

--- a/angr/analyses/decompiler/peephole_optimizations/rewrite_bit_extractions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/rewrite_bit_extractions.py
@@ -30,8 +30,8 @@ class RewriteBitExtractions(PeepholeOptimizationExprBase):
                 return ITE(
                     expr.idx,
                     bitoffset2exprs[bit_offset],
-                    Const(self.manager.next_atom(), None, 0, expr.bits),
-                    Const(self.manager.next_atom(), None, 1, expr.bits),
+                    Const(self.manager.next_atom(), 0, expr.bits),
+                    Const(self.manager.next_atom(), 1, expr.bits),
                     **expr.tags,
                 )
 

--- a/angr/analyses/decompiler/peephole_optimizations/rewrite_mips_gp_loads.py
+++ b/angr/analyses/decompiler/peephole_optimizations/rewrite_mips_gp_loads.py
@@ -45,6 +45,6 @@ class RewriteMipsGpLoads(PeepholeOptimizationExprBase):
             else:
                 addr &= 0xFFFF_FFFF_FFFF_FFFF
             value = self.project.loader.memory.unpack_word(addr, size=expr.size)
-            return Const(self.manager.next_atom(), None, value, expr.size * self.project.arch.byte_width, **expr.tags)
+            return Const(self.manager.next_atom(), value, expr.size * self.project.arch.byte_width, **expr.tags)
 
         return None

--- a/angr/analyses/decompiler/peephole_optimizations/rol_ror.py
+++ b/angr/analyses/decompiler/peephole_optimizations/rol_ror.py
@@ -69,7 +69,7 @@ class RolRorRewriter(PeepholeOptimizationStmtBase):
                 and (shiftleft_amount := get_expr_shift_left_amount(stmt_1.src)) is not None
                 and shiftleft_amount + stmt2_op1.value == stmt.dst.bits
             ):
-                rol_amount = Const(self.manager.next_atom(), None, shiftleft_amount, 8, **stmt1_op1.tags)
+                rol_amount = Const(self.manager.next_atom(), shiftleft_amount, 8, **stmt1_op1.tags)
                 return Assignment(
                     stmt.idx,
                     stmt.dst,
@@ -121,7 +121,7 @@ class RolRorRewriter(PeepholeOptimizationStmtBase):
                 and (op0_shiftamount := get_expr_shift_left_amount(op0)) is not None
                 and op0_shiftamount + op1_v == stmt.dst.bits
             ):
-                shiftamount = Const(self.manager.next_atom(), None, op0_shiftamount, 8, **op0.operands[1].tags)
+                shiftamount = Const(self.manager.next_atom(), op0_shiftamount, 8, **op0.operands[1].tags)
                 return Assignment(
                     stmt.idx,
                     stmt.dst,

--- a/angr/analyses/decompiler/peephole_optimizations/sar_to_signed_div.py
+++ b/angr/analyses/decompiler/peephole_optimizations/sar_to_signed_div.py
@@ -67,7 +67,7 @@ class SarToSignedDiv(PeepholeOptimizationExprBase):
                             "Div",
                             [
                                 converted_innerexpr,
-                                Const(self.manager.next_atom(), None, 2**const_value, converted_innerexpr.bits),
+                                Const(self.manager.next_atom(), 2**const_value, converted_innerexpr.bits),
                             ],
                             True,
                             **inner_expr.tags,

--- a/angr/analyses/decompiler/peephole_optimizations/shl_to_mul.py
+++ b/angr/analyses/decompiler/peephole_optimizations/shl_to_mul.py
@@ -14,7 +14,7 @@ class ShlToMul(PeepholeOptimizationExprBase):
 
     def optimize(self, expr: BinaryOp, **kwargs):
         if expr.op == "Shl" and isinstance(expr.operands[1], Const):
-            mul_amount = Const(self.manager.next_atom(), None, 2 ** expr.operands[1].value_int, expr.operands[0].bits)
+            mul_amount = Const(self.manager.next_atom(), 2 ** expr.operands[1].value_int, expr.operands[0].bits)
             return BinaryOp(
                 expr.idx,
                 "Mul",

--- a/angr/analyses/decompiler/peephole_optimizations/simplify_pc_relative_loads.py
+++ b/angr/analyses/decompiler/peephole_optimizations/simplify_pc_relative_loads.py
@@ -47,6 +47,6 @@ class SimplifyPcRelativeLoads(PeepholeOptimizationExprBase):
                     except KeyError:
                         return expr
                     value = offset + op1.value
-                    return Const(self.manager.next_atom(), None, value, self.project.arch.bits, **expr.tags)
+                    return Const(self.manager.next_atom(), value, self.project.arch.bits, **expr.tags)
 
         return expr

--- a/angr/analyses/decompiler/redundant_label_remover.py
+++ b/angr/analyses/decompiler/redundant_label_remover.py
@@ -110,7 +110,7 @@ class RedundantLabelRemover:
                     if tpl in self._new_jump_target:
                         first_stmt.true_target = ailment.Expr.Const(
                             first_stmt.true_target.idx,
-                            first_stmt.true_target.variable,
+                            None,
                             self._new_jump_target[tpl][0],
                             first_stmt.true_target.bits,
                             **first_stmt.true_target.tags,
@@ -120,7 +120,7 @@ class RedundantLabelRemover:
                     if tpl in self._new_jump_target:
                         first_stmt.false_target = ailment.Expr.Const(
                             first_stmt.false_target.idx,
-                            first_stmt.false_target.variable,
+                            None,
                             self._new_jump_target[tpl][0],
                             first_stmt.false_target.bits,
                             **first_stmt.false_target.tags,
@@ -133,7 +133,7 @@ class RedundantLabelRemover:
                     if tpl in self._new_jump_target:
                         last_stmt.target = ailment.Expr.Const(
                             last_stmt.target.idx,
-                            last_stmt.target.variable,
+                            None,
                             self._new_jump_target[tpl][0],
                             last_stmt.target.bits,
                             **last_stmt.target.tags,

--- a/angr/analyses/decompiler/redundant_label_remover.py
+++ b/angr/analyses/decompiler/redundant_label_remover.py
@@ -110,7 +110,6 @@ class RedundantLabelRemover:
                     if tpl in self._new_jump_target:
                         first_stmt.true_target = ailment.Expr.Const(
                             first_stmt.true_target.idx,
-                            None,
                             self._new_jump_target[tpl][0],
                             first_stmt.true_target.bits,
                             **first_stmt.true_target.tags,
@@ -120,7 +119,6 @@ class RedundantLabelRemover:
                     if tpl in self._new_jump_target:
                         first_stmt.false_target = ailment.Expr.Const(
                             first_stmt.false_target.idx,
-                            None,
                             self._new_jump_target[tpl][0],
                             first_stmt.false_target.bits,
                             **first_stmt.false_target.tags,
@@ -133,7 +131,6 @@ class RedundantLabelRemover:
                     if tpl in self._new_jump_target:
                         last_stmt.target = ailment.Expr.Const(
                             last_stmt.target.idx,
-                            None,
                             self._new_jump_target[tpl][0],
                             last_stmt.target.bits,
                             **last_stmt.target.tags,

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -654,9 +654,7 @@ class RegionIdentifier(Analysis):
                             new_last_stmt = ConditionalJump(
                                 last_stmt.idx,
                                 last_stmt.condition,
-                                ailment.Expr.Const(
-                                    self.ail_manager.next_atom(), None, condnode_addr, self.project.arch.bits
-                                ),
+                                ailment.Expr.Const(self.ail_manager.next_atom(), condnode_addr, self.project.arch.bits),
                                 last_stmt.false_target,
                                 ins_addr=last_stmt.tags["ins_addr"],
                             )
@@ -668,9 +666,7 @@ class RegionIdentifier(Analysis):
                                 last_stmt.idx,
                                 last_stmt.condition,
                                 last_stmt.true_target,
-                                ailment.Expr.Const(
-                                    self.ail_manager.next_atom(), None, condnode_addr, self.project.arch.bits
-                                ),
+                                ailment.Expr.Const(self.ail_manager.next_atom(), condnode_addr, self.project.arch.bits),
                                 ins_addr=last_stmt.tags["ins_addr"],
                             )
                         else:
@@ -680,9 +676,7 @@ class RegionIdentifier(Analysis):
                         if isinstance(last_stmt.target, ailment.Expr.Const):
                             new_last_stmt = Jump(
                                 last_stmt.idx,
-                                ailment.Expr.Const(
-                                    self.ail_manager.next_atom(), None, condnode_addr, self.project.arch.bits
-                                ),
+                                ailment.Expr.Const(self.ail_manager.next_atom(), condnode_addr, self.project.arch.bits),
                                 ins_addr=last_stmt.tags["ins_addr"],
                             )
                         else:
@@ -1199,9 +1193,7 @@ class RegionIdentifier(Analysis):
                 node.statements.append(
                     Jump(
                         self.ail_manager.next_atom(),
-                        Const(
-                            self.ail_manager.next_atom(), None, node.addr + node.original_size, self.project.arch.bits
-                        ),
+                        Const(self.ail_manager.next_atom(), node.addr + node.original_size, self.project.arch.bits),
                         ins_addr=node.addr,
                     )
                 )
@@ -1219,7 +1211,6 @@ class RegionIdentifier(Analysis):
                             self.ail_manager.next_atom(),
                             Const(
                                 self.ail_manager.next_atom(),
-                                None,
                                 node.addr + node.original_size,
                                 self.project.arch.bits,
                             ),

--- a/angr/analyses/decompiler/region_simplifiers/expr_folding.py
+++ b/angr/analyses/decompiler/region_simplifiers/expr_folding.py
@@ -426,7 +426,7 @@ class InterferenceChecker(SequenceWalker):
     - Condition and CascadingCondition nodes
     """
 
-    def __init__(self, assignments: dict[int, Any], uses: dict[int, Any], node):
+    def __init__(self, assignments: dict[int, Any], uses: dict[int, Any], node, variable_map):
         handlers = {
             ailment.Block: self._handle_Block,
             ConditionNode: self._handle_Condition,
@@ -437,6 +437,7 @@ class InterferenceChecker(SequenceWalker):
         super().__init__(handlers, update_seqnode_in_place=False, force_forward_scan=True)
         self._assignments = assignments
         self._uses = uses
+        self._variable_map = variable_map
         self._assignment_interferences: dict[int, list] = {}
         self.interfered_assignments: set[int] = set()
         self.walk(node)
@@ -507,7 +508,7 @@ class InterferenceChecker(SequenceWalker):
                 isinstance(stmt, ailment.Stmt.SideEffectStatement)
                 and isinstance(stmt.ret_expr, ailment.Expr.VirtualVariable)
                 and stmt.ret_expr.was_reg
-                and stmt.ret_expr.variable is not None
+                and self._variable_map.variable(stmt.ret_expr) is not None
                 and stmt.ret_expr.varid in self._assignments
             ):
                 # we found this def
@@ -569,10 +570,11 @@ class InterferenceChecker(SequenceWalker):
 
 
 class ExpressionReplacer(AILBlockRewriter):
-    def __init__(self, assignments: dict[int, Any], uses: dict[int, Any]):
+    def __init__(self, assignments: dict[int, Any], uses: dict[int, Any], variable_map):
         super().__init__()
         self._assignments = assignments
         self._uses = uses
+        self._variable_map = variable_map
 
     def _handle_MultiStatementExpression(  # type: ignore
         self, expr_idx, expr: MultiStatementExpression, stmt_idx: int, stmt: Statement, block: Block | None
@@ -584,8 +586,8 @@ class ExpressionReplacer(AILBlockRewriter):
                 isinstance(stmt_, Assignment)
                 and isinstance(stmt_.dst, ailment.Expr.VirtualVariable)
                 and stmt_.dst.was_reg
-                and stmt_.dst.variable is not None
-            ) and stmt_.dst.variable in self._assignments:
+                and self._variable_map.variable(stmt_.dst) is not None
+            ) and self._variable_map.variable(stmt_.dst) in self._assignments:
                 # remove this statement
                 changed = True
                 continue
@@ -654,7 +656,7 @@ class ExpressionReplacer(AILBlockRewriter):
 
 
 class ExpressionFolder(SequenceWalker):
-    def __init__(self, assignments: dict[int, Any], uses: dict[int, Any], node):
+    def __init__(self, assignments: dict[int, Any], uses: dict[int, Any], node, variable_map):
         handlers = {
             ailment.Block: self._handle_Block,
             ConditionNode: self._handle_Condition,
@@ -666,6 +668,7 @@ class ExpressionFolder(SequenceWalker):
         super().__init__(handlers)
         self._assignments = assignments
         self._uses = uses
+        self._variable_map = variable_map
         self.walk(node)
 
     def _handle_Block(self, node: ailment.Block, **kwargs):
@@ -684,7 +687,7 @@ class ExpressionFolder(SequenceWalker):
                 isinstance(stmt, ailment.Stmt.SideEffectStatement)
                 and isinstance(stmt.ret_expr, ailment.Expr.VirtualVariable)
                 and stmt.ret_expr.was_reg
-                and stmt.ret_expr.variable is not None
+                and self._variable_map.variable(stmt.ret_expr) is not None
                 and stmt.ret_expr.varid in self._assignments
             ):
                 # remove this statement
@@ -693,25 +696,25 @@ class ExpressionFolder(SequenceWalker):
         node.statements = new_stmts
 
         # Walk the block to replace the use of each variable
-        replacer = ExpressionReplacer(self._assignments, self._uses)
+        replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
         replacer.walk(node)
 
     def _handle_ConditionalBreak(self, node: ConditionalBreakNode, **kwargs):
-        replacer = ExpressionReplacer(self._assignments, self._uses)
+        replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
         r = replacer.walk_expression(node.condition)
         if r is not None and r is not node.condition:
             node.condition = r
         return super()._handle_ConditionalBreak(node, **kwargs)
 
     def _handle_Condition(self, node: ConditionNode, **kwargs):
-        replacer = ExpressionReplacer(self._assignments, self._uses)
+        replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
         r = replacer.walk_expression(node.condition)
         if r is not None and r is not node.condition:
             node.condition = r
         return super()._handle_Condition(node, **kwargs)
 
     def _handle_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
-        replacer = ExpressionReplacer(self._assignments, self._uses)
+        replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
         for idx in range(len(node.condition_and_nodes)):  # pylint:disable=consider-using-enumerate
             cond, _ = node.condition_and_nodes[idx]
             r = replacer.walk_expression(cond)
@@ -720,7 +723,7 @@ class ExpressionFolder(SequenceWalker):
         return super()._handle_CascadingCondition(node, **kwargs)
 
     def _handle_Loop(self, node: LoopNode, **kwargs):
-        replacer = ExpressionReplacer(self._assignments, self._uses)
+        replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
 
         # iterator
         if node.iterator is not None:
@@ -744,7 +747,7 @@ class ExpressionFolder(SequenceWalker):
         return None
 
     def _handle_SwitchCase(self, node: SwitchCaseNode, **kwargs):
-        replacer = ExpressionReplacer(self._assignments, self._uses)
+        replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
 
         r = replacer.walk_expression(node.switch_expr)
         if r is not None and r is not node.switch_expr:

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -189,7 +189,7 @@ class RegionSimplifier(Analysis):
                 definition = definition.copy()
                 if definition.ret_expr is not None:
                     definition.ret_expr = definition.ret_expr.copy()
-                    definition.ret_expr.variable = None  # type: ignore
+                    self.ail_manager.variable_map.set_variable(definition.ret_expr, None)
             variable_assignments[var] = definition, loc
             variable_uses[var] = next(iter(expr_counter.outerscope_uses[var]))
             variable_assignment_dependencies[var] = deps
@@ -202,13 +202,13 @@ class RegionSimplifier(Analysis):
                 del variable_uses[var]
 
         # ensure there is no interference between the call site and the use site
-        checker = InterferenceChecker(variable_assignments, variable_uses, region)
+        checker = InterferenceChecker(variable_assignments, variable_uses, region, self.ail_manager.variable_map)
         for varid in checker.interfered_assignments:
             if varid in variable_assignments:
                 del variable_assignments[varid]
                 del variable_uses[varid]
         # fold these expressions if possible
-        ExpressionFolder(variable_assignments, variable_uses, region)
+        ExpressionFolder(variable_assignments, variable_uses, region, self.ail_manager.variable_map)
         return region
 
     def _simplify_switch_expressions(self, region):
@@ -216,7 +216,7 @@ class RegionSimplifier(Analysis):
         return region
 
     def _simplify_switch_clusters(self, region):
-        finder = SwitchClusterFinder(region)
+        finder = SwitchClusterFinder(region, self.ail_manager.variable_map)
         simplify_switch_clusters(region, finder.var2condnodes, finder.var2switches)
         simplify_lowered_switches(
             region,
@@ -263,7 +263,9 @@ class RegionSimplifier(Analysis):
 
     def _apply_region_loop_counter_naming(self, region) -> None:
         assert self._variable_manager is not None
-        namer = RegionLoopCounterNaming(region, self._variable_manager, self.kb.functions)
+        namer = RegionLoopCounterNaming(
+            region, self._variable_manager, self.kb.functions, self.ail_manager.variable_map
+        )
         namer.analyze()
         namer.apply_names()
 

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -185,10 +185,12 @@ class RegionSimplifier(Analysis):
                 continue
 
             if isinstance(definition, ailment.Stmt.SideEffectStatement):
-                # clear the existing variable since we no longer write to this variable after expression folding
+                # clear the existing variable since we no longer write to this variable after expression folding.
+                # deep_copy the ret_expr so it gets a fresh .idx; otherwise clearing its VariableMap entry (which is
+                # idx-keyed) would also clear the variable of the original ret_expr, which shares the same .idx.
                 definition = definition.copy()
                 if definition.ret_expr is not None:
-                    definition.ret_expr = definition.ret_expr.copy()
+                    definition.ret_expr = definition.ret_expr.deep_copy(self.ail_manager)
                     self.ail_manager.variable_map.set_variable(definition.ret_expr, None)
             variable_assignments[var] = definition, loc
             variable_uses[var] = next(iter(expr_counter.outerscope_uses[var]))

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -28,6 +28,7 @@ from .ifelse import IfElseFlattener
 from .loop import LoopSimplifier
 from .switch_cluster_simplifier import SwitchClusterFinder, simplify_lowered_switches, simplify_switch_clusters
 from .switch_expr_simplifier import SwitchExpressionSimplifier
+from ..variable_map import variable_map_of
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.variables.variable_manager import VariableManagerInternal
@@ -191,7 +192,7 @@ class RegionSimplifier(Analysis):
                 definition = definition.copy()
                 if definition.ret_expr is not None:
                     definition.ret_expr = definition.ret_expr.deep_copy(self.ail_manager)
-                    self.ail_manager.variable_map.set_variable(definition.ret_expr, None)
+                    variable_map_of(self.ail_manager).set_variable(definition.ret_expr, None)
             variable_assignments[var] = definition, loc
             variable_uses[var] = next(iter(expr_counter.outerscope_uses[var]))
             variable_assignment_dependencies[var] = deps
@@ -204,13 +205,13 @@ class RegionSimplifier(Analysis):
                 del variable_uses[var]
 
         # ensure there is no interference between the call site and the use site
-        checker = InterferenceChecker(variable_assignments, variable_uses, region, self.ail_manager.variable_map)
+        checker = InterferenceChecker(variable_assignments, variable_uses, region, variable_map_of(self.ail_manager))
         for varid in checker.interfered_assignments:
             if varid in variable_assignments:
                 del variable_assignments[varid]
                 del variable_uses[varid]
         # fold these expressions if possible
-        ExpressionFolder(variable_assignments, variable_uses, region, self.ail_manager.variable_map)
+        ExpressionFolder(variable_assignments, variable_uses, region, variable_map_of(self.ail_manager))
         return region
 
     def _simplify_switch_expressions(self, region):
@@ -218,7 +219,7 @@ class RegionSimplifier(Analysis):
         return region
 
     def _simplify_switch_clusters(self, region):
-        finder = SwitchClusterFinder(region, self.ail_manager.variable_map)
+        finder = SwitchClusterFinder(region, variable_map_of(self.ail_manager))
         simplify_switch_clusters(region, finder.var2condnodes, finder.var2switches)
         simplify_lowered_switches(
             region,
@@ -266,7 +267,7 @@ class RegionSimplifier(Analysis):
     def _apply_region_loop_counter_naming(self, region) -> None:
         assert self._variable_manager is not None
         namer = RegionLoopCounterNaming(
-            region, self._variable_manager, self.kb.functions, self.ail_manager.variable_map
+            region, self._variable_manager, self.kb.functions, variable_map_of(self.ail_manager)
         )
         namer.analyze()
         namer.apply_names()

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -12,6 +12,7 @@ from angr.analyses.decompiler.redundant_label_remover import RedundantLabelRemov
 from angr.analyses.decompiler.semantic_naming.region_loop_counter_naming import RegionLoopCounterNaming
 from angr.analyses.decompiler.structurer_nodes import LoopNode
 
+from ..variable_map import variable_map_of
 from .cascading_cond_transformer import CascadingConditionTransformer
 from .cascading_ifs import CascadingIfsRemover
 from .expr_folding import (
@@ -28,7 +29,6 @@ from .ifelse import IfElseFlattener
 from .loop import LoopSimplifier
 from .switch_cluster_simplifier import SwitchClusterFinder, simplify_lowered_switches, simplify_switch_clusters
 from .switch_expr_simplifier import SwitchExpressionSimplifier
-from ..variable_map import variable_map_of
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.variables.variable_manager import VariableManagerInternal

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -11,8 +11,8 @@ from angr.analyses.decompiler.jump_target_collector import JumpTargetCollector
 from angr.analyses.decompiler.redundant_label_remover import RedundantLabelRemover
 from angr.analyses.decompiler.semantic_naming.region_loop_counter_naming import RegionLoopCounterNaming
 from angr.analyses.decompiler.structurer_nodes import LoopNode
+from angr.analyses.decompiler.variable_map import variable_map_of
 
-from ..variable_map import variable_map_of
 from .cascading_cond_transformer import CascadingConditionTransformer
 from .cascading_ifs import CascadingIfsRemover
 from .expr_folding import (

--- a/angr/analyses/decompiler/region_simplifiers/switch_cluster_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/switch_cluster_simplifier.py
@@ -85,7 +85,7 @@ class SwitchClusterFinder(SequenceWalker):
     Find comparisons and switches in order to identify switch clusters.
     """
 
-    def __init__(self, node):
+    def __init__(self, node, variable_map):
         handlers = {
             SwitchCaseNode: self._handle_SwitchCase,
             ConditionNode: self._handle_Condition,
@@ -93,6 +93,7 @@ class SwitchClusterFinder(SequenceWalker):
         }
         super().__init__(handlers)
 
+        self._variable_map = variable_map
         self.var2condnodes: defaultdict[Any, list[ConditionalRegion]] = defaultdict(list)
         self.var2switches: defaultdict[Any, list[SwitchCaseRegion]] = defaultdict(list)
 
@@ -110,10 +111,9 @@ class SwitchClusterFinder(SequenceWalker):
 
     def _handle_SwitchCase(self, node: SwitchCaseNode, parent=None, **kwargs):
         cond = node.switch_expr
-        if hasattr(cond, "variable"):
-            variable = cond.variable
-            scr = SwitchCaseRegion(variable, node, parent)
-            self.var2switches[variable].append(scr)
+        variable = self._variable_map.variable(cond)
+        scr = SwitchCaseRegion(variable, node, parent)
+        self.var2switches[variable].append(scr)
         return super()._handle_SwitchCase(node, parent=parent, **kwargs)
 
     def _process_condition(self, cond: ailment.Expr.Expression, node: ConditionNode | ailment.Block, parent):
@@ -133,9 +133,9 @@ class SwitchClusterFinder(SequenceWalker):
             variable = None
             if isinstance(cond.operands[1], ailment.Expr.Const):
                 v = cond.operands[1].value
-            if isinstance(cond.operands[0], ailment.Expr.VirtualVariable) and hasattr(cond.operands[0], "variable"):
+            if isinstance(cond.operands[0], ailment.Expr.VirtualVariable):
                 # there we go
-                variable = cond.operands[0].variable
+                variable = self._variable_map.variable(cond.operands[0])
 
             if v is not None and variable is not None:
                 real_op = ailment.Expr.BinaryOp.COMPARISON_NEGATION[cond.op] if negated else cond.op

--- a/angr/analyses/decompiler/return_maker.py
+++ b/angr/analyses/decompiler/return_maker.py
@@ -48,7 +48,6 @@ class ReturnMaker(AILGraphWalker):
                 new_stmt.ret_exprs.append(
                     ailment.Expr.Register(
                         self._next_atom(),
-                        None,
                         reg[0],
                         ret_val.size * self.arch.byte_width,
                         reg_name=self.arch.translate_register_name(reg[0], ret_val.size),
@@ -75,7 +74,6 @@ class ReturnMaker(AILGraphWalker):
                         new_stmt.ret_exprs.append(
                             ailment.Expr.Register(
                                 self._next_atom(),
-                                None,
                                 reg[0],
                                 ret_val_loc.size * self.arch.byte_width,
                                 reg_name=self.arch.translate_register_name(reg[0], ret_val_loc.size),

--- a/angr/analyses/decompiler/semantic_naming/naming_base.py
+++ b/angr/analyses/decompiler/semantic_naming/naming_base.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from angr.ailment import Block
     from angr.analyses.decompiler.structurer_nodes import BaseNode
+    from angr.analyses.decompiler.variable_map import VariableMap
     from angr.knowledge_plugins.functions.function_manager import FunctionManager
     from angr.knowledge_plugins.variables.variable_manager import VariableManagerInternal
 
@@ -43,7 +44,7 @@ class SemanticNamingBase(ABC):
         self,
         variable_manager: VariableManagerInternal,
         functions: FunctionManager,
-        variable_map,
+        variable_map: VariableMap,
     ):
         self._variable_manager = variable_manager
         self._functions = functions
@@ -147,7 +148,7 @@ class ClinicNamingBase(SemanticNamingBase):
         variable_manager: VariableManagerInternal,
         functions: FunctionManager,
         entry_node: Block,
-        variable_map,
+        variable_map: VariableMap,
     ):
         super().__init__(variable_manager, functions, variable_map)
         self._graph = ail_graph

--- a/angr/analyses/decompiler/semantic_naming/naming_base.py
+++ b/angr/analyses/decompiler/semantic_naming/naming_base.py
@@ -43,9 +43,11 @@ class SemanticNamingBase(ABC):
         self,
         variable_manager: VariableManagerInternal,
         functions: FunctionManager,
+        variable_map,
     ):
         self._variable_manager = variable_manager
         self._functions = functions
+        self._variable_map = variable_map
         self._var_to_new_name: dict[SimVariable, str] = {}
 
     @abstractmethod
@@ -106,8 +108,9 @@ class SemanticNamingBase(ABC):
         """
         Get the SimVariable linked to an expression, if any.
         """
-        if hasattr(expr, "variable") and expr.variable is not None:
-            return self._variable_manager.unified_variable(expr.variable)
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            return self._variable_manager.unified_variable(expr_var)
         return None
 
     def _get_function_name(self, call: Call) -> str | None:
@@ -144,8 +147,9 @@ class ClinicNamingBase(SemanticNamingBase):
         variable_manager: VariableManagerInternal,
         functions: FunctionManager,
         entry_node: Block,
+        variable_map,
     ):
-        super().__init__(variable_manager, functions)
+        super().__init__(variable_manager, functions, variable_map)
         self._graph = ail_graph
         self._entry_node = entry_node
 
@@ -164,6 +168,7 @@ class RegionNamingBase(SemanticNamingBase):
         region: BaseNode,
         variable_manager: VariableManagerInternal,
         functions: FunctionManager,
+        variable_map,
     ):
-        super().__init__(variable_manager, functions)
+        super().__init__(variable_manager, functions, variable_map)
         self._region = region

--- a/angr/analyses/decompiler/semantic_naming/orchestrator.py
+++ b/angr/analyses/decompiler/semantic_naming/orchestrator.py
@@ -58,12 +58,14 @@ class SemanticNamingOrchestrator:
         variable_manager: VariableManagerInternal,
         functions: FunctionManager,
         entry_node: ailment.Block,
+        variable_map,
         patterns: list[type[ClinicNamingBase]] | None = None,
     ):
         self._graph = ail_graph
         self._variable_manager = variable_manager
         self._functions = functions
         self._entry_node = entry_node
+        self._variable_map = variable_map
         self._patterns = patterns or NAMING_PATTERNS
 
         # Track all renamed variables
@@ -87,6 +89,7 @@ class SemanticNamingOrchestrator:
                 self._variable_manager,
                 self._functions,
                 self._entry_node,
+                self._variable_map,
             )
 
             # Analyze to get suggested renames

--- a/angr/analyses/decompiler/semantic_naming/orchestrator.py
+++ b/angr/analyses/decompiler/semantic_naming/orchestrator.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import networkx
 
 from angr import ailment
+from angr.analyses.decompiler.variable_map import VariableMap
 from angr.sim_variable import SimVariable
 
 from .array_index_naming import ArrayIndexNaming
@@ -61,8 +62,6 @@ class SemanticNamingOrchestrator:
         variable_map=None,
         patterns: list[type[ClinicNamingBase]] | None = None,
     ):
-        from angr.analyses.decompiler.variable_map import VariableMap
-
         self._graph = ail_graph
         self._variable_manager = variable_manager
         self._functions = functions

--- a/angr/analyses/decompiler/semantic_naming/orchestrator.py
+++ b/angr/analyses/decompiler/semantic_naming/orchestrator.py
@@ -58,14 +58,16 @@ class SemanticNamingOrchestrator:
         variable_manager: VariableManagerInternal,
         functions: FunctionManager,
         entry_node: ailment.Block,
-        variable_map,
+        variable_map=None,
         patterns: list[type[ClinicNamingBase]] | None = None,
     ):
+        from angr.analyses.decompiler.variable_map import VariableMap
+
         self._graph = ail_graph
         self._variable_manager = variable_manager
         self._functions = functions
         self._entry_node = entry_node
-        self._variable_map = variable_map
+        self._variable_map = variable_map if variable_map is not None else VariableMap()
         self._patterns = patterns or NAMING_PATTERNS
 
         # Track all renamed variables

--- a/angr/analyses/decompiler/semantic_naming/region_loop_counter_naming.py
+++ b/angr/analyses/decompiler/semantic_naming/region_loop_counter_naming.py
@@ -53,8 +53,9 @@ class RegionLoopCounterNaming(RegionNamingBase):
         region: BaseNode,
         variable_manager: VariableManagerInternal,
         functions: FunctionManager,
+        variable_map,
     ):
-        super().__init__(region, variable_manager, functions)
+        super().__init__(region, variable_manager, functions, variable_map)
 
         # Track loops and their nesting
         self._loop_nodes: list[LoopNode] = []

--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -566,7 +566,7 @@ class SimEngineSSARewriting(
         return BinaryOp(
             expr.idx,
             "Add",
-            [refers, Const(self.ail_manager.next_atom(), None, vvar.stack_offset - expr.offset, refers.bits)],
+            [refers, Const(self.ail_manager.next_atom(), vvar.stack_offset - expr.offset, refers.bits)],
         )
 
     def _handle_expr_Extract(self, expr: Extract):
@@ -736,7 +736,7 @@ class SimEngineSSARewriting(
         if size > vvar.size:
             if self._fail_fast:
                 assert False, "Invariant failure: we generated a vvar which is smaller than one of its uses"
-            remainder = Const(self.ail_manager.next_atom(), None, 0, size * 8 - vvar.bits, uninitalized=True)
+            remainder = Const(self.ail_manager.next_atom(), 0, size * 8 - vvar.bits, uninitalized=True)
             order = [vvar, remainder] if endness == archinfo.Endness.LE else [remainder, vvar]
             return BinaryOp(
                 self.ail_manager.next_atom(),
@@ -748,7 +748,7 @@ class SimEngineSSARewriting(
             self.ail_manager.next_atom(),
             size * 8,
             vvar,
-            Const(self.ail_manager.next_atom(), None, offset, 64),
+            Const(self.ail_manager.next_atom(), offset, 64),
             endness,
             **orig_tags.tags,
         )
@@ -767,7 +767,7 @@ class SimEngineSSARewriting(
             else:
                 raise TypeError(vvar.category)
             if base is None:
-                base = Const(self.ail_manager.next_atom(), None, 0, vvar.bits, uninitialized=True)
+                base = Const(self.ail_manager.next_atom(), 0, vvar.bits, uninitialized=True)
             endness = (
                 self.project.arch.memory_endness
                 if vvar.was_stack or (vvar.was_parameter and vvar.parameter_category == VirtualVariableCategory.STACK)
@@ -777,7 +777,7 @@ class SimEngineSSARewriting(
                 base = BinaryOp(
                     self.ail_manager.next_atom(),
                     "Concat",
-                    [base, Const(self.ail_manager.next_atom(), None, 0, vvar.bits - base.bits, uninitialized=True)],
+                    [base, Const(self.ail_manager.next_atom(), 0, vvar.bits - base.bits, uninitialized=True)],
                     bits=vvar.bits,
                 )
             elif base.bits > vvar.bits:
@@ -785,13 +785,13 @@ class SimEngineSSARewriting(
                     self.ail_manager.next_atom(),
                     vvar.bits,
                     base,
-                    Const(self.ail_manager.next_atom(), None, offset, 64),
+                    Const(self.ail_manager.next_atom(), offset, 64),
                     endness,
                 )
             combined = Insert(
                 self.ail_manager.next_atom(),
                 base,
-                Const(self.ail_manager.next_atom(), None, offset, 64),
+                Const(self.ail_manager.next_atom(), offset, 64),
                 value,
                 endness,
             )

--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -309,7 +309,7 @@ class SimEngineSSARewriting(
             assert isinstance(stmt.fp_ret_expr, Atom)
             new_stmt = self._replace_def_expr(stmt.fp_ret_expr, replaced_call, stmt)
         if new_stmt is None:
-            new_stmt = SideEffectStatement(stmt.idx, replaced_call, **stmt.tags)
+            new_stmt = SideEffectStatement(self.ail_manager.next_atom(), replaced_call, **stmt.tags)
 
         return new_stmt
 

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -70,6 +70,7 @@ from angr.utils.loader import is_in_readonly_section, is_in_readonly_segment
 from angr.utils.strings import decode_utf16_string
 from angr.utils.types import dereference_simtype_by_lib, unpack_pointer_and_array, unpack_typeref
 
+from ..variable_map import VariableMap
 from .base import (
     BaseStructuredCodeGenerator,
     CConstantType,
@@ -2642,6 +2643,7 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         max_str_len: int | None = None,
         prettify_thiscall: bool = False,
         cstyle_void_param: bool = True,
+        variable_map: VariableMap | None = None,
     ):
         super().__init__(
             flavor=flavor,
@@ -2699,6 +2701,7 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         self._cfg = cfg
         self._sequence = sequence
         self._variable_kb = variable_kb if variable_kb is not None else self.kb
+        self._variable_map: VariableMap = variable_map if variable_map is not None else VariableMap()
         self.binop_depth_cutoff = binop_depth_cutoff
 
         self._variables_in_use: dict | None = None
@@ -3502,9 +3505,10 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                 return proposed_ty
             return old_ty
 
-        if stmt.variable is not None and cdata.type is not None:
-            cvar = self._variable(stmt.variable, stmt.size)
-            offset = stmt.offset or 0
+        stmt_var = self._variable_map.variable(stmt)
+        if stmt_var is not None and cdata.type is not None:
+            cvar = self._variable(stmt_var, stmt.size)
+            offset = self._variable_map.variable_offset(stmt) or 0
             assert type(offset) is int  # I refuse to deal with the alternative
 
             cdst = self._access_constant_offset(self._get_variable_reference(cvar), offset, cdata.type, True, negotiate)
@@ -3516,15 +3520,17 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
 
     def variables_unify(self, v1: Expr.VirtualVariable, v2: Expr.VirtualVariable) -> bool:
         vmi = self._variable_kb.variables[self._func.addr]
-        v1v = vmi.unified_variable(v1.variable) if v1.variable is not None else None
-        v2v = vmi.unified_variable(v2.variable) if v2.variable is not None else None
+        v1_var = self._variable_map.variable(v1)
+        v2_var = self._variable_map.variable(v2)
+        v1v = vmi.unified_variable(v1_var) if v1_var is not None else None
+        v2v = vmi.unified_variable(v2_var) if v2_var is not None else None
         return v1v == v2v
 
     def _handle_Stmt_Assignment(self, stmt, **kwargs):
         if (
             isinstance(stmt.dst, Expr.VirtualVariable)
             and stmt.dst.was_stack
-            and stmt.dst.variable is not None
+            and self._variable_map.variable(stmt.dst) is not None
             and isinstance(stmt.src, Expr.Insert)
             and isinstance(stmt.src.offset, Expr.Const)
             and isinstance(stmt.src.offset.value, int)
@@ -3534,7 +3540,7 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
             )
         ):
             offset = stmt.src.offset.value
-            var = stmt.dst.variable
+            var = self._variable_map.variable(stmt.dst)
             cvar = self._variable(var, stmt.dst.size, vvar_id=stmt.dst.varid)
             csrc = self._handle(stmt.src.value)
             src_type = csrc.type
@@ -3760,11 +3766,13 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                 return proposed_ty
             return old_ty
 
-        if expr.variable:
-            cvar = self._variable(expr.variable, None)
-            if expr.variable.size == expr.size:
+        expr_var = self._variable_map.variable(expr)
+        if expr_var:
+            cvar = self._variable(expr_var, None)
+            if expr_var.size == expr.size:
                 return cvar
-            offset = 0 if expr.variable_offset is None else expr.variable_offset
+            expr_var_offset = self._variable_map.variable_offset(expr)
+            offset = 0 if expr_var_offset is None else expr_var_offset
             # FIXME: The type should be associated to the register expression itself
             type_ = self.default_simtype_from_bits(expr.bits, signed=False)
             return self._access_constant_offset(self._get_variable_reference(cvar), offset, type_, lvalue, negotiate)
@@ -3794,9 +3802,10 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                 return proposed_ty
             return old_ty
 
-        if expr.variable is not None:
-            cvar = self._variable(expr.variable, expr_size)
-            offset = expr.variable_offset or 0
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            cvar = self._variable(expr_var, expr_size)
+            offset = self._variable_map.variable_offset(expr) or 0
 
             assert type(offset) is int  # I refuse to deal with the alternative
             return self._access_constant_offset(CUnaryOp("Reference", cvar, codegen=self), offset, ty, False, negotiate)
@@ -3823,11 +3832,13 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         if type_ is None and "type" in expr.tags:
             type_ = expr.tags["type"]
 
-        if type_ is None and expr.variable is not None:
-            type_ = self._get_variable_type(expr.variable)
+        expr_var = self._variable_map.variable(expr)
+        if type_ is None and expr_var is not None:
+            type_ = self._get_variable_type(expr_var)
 
-        if reference_values is None and "reference_values" in expr.tags:
-            reference_values = expr.tags["reference_values"].copy()
+        expr_reference_values = self._variable_map.reference_values(expr)
+        if reference_values is None and expr_reference_values is not None:
+            reference_values = expr_reference_values.copy()
         if type_ is None and reference_values is not None and len(reference_values) == 1:  # type: ignore
             type_ = next(iter(reference_values))  # type: ignore
 
@@ -3905,17 +3916,18 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
             # default to int or unsigned int, determined by likely_signed
             type_ = self.default_simtype_from_bits(expr.bits, signed=likely_signed)
 
-        if variable is None and "reference_variable" in expr.tags and expr.tags["reference_variable"] is not None:
-            variable = expr.tags["reference_variable"]
+        expr_reference_variable = self._variable_map.reference_variable(expr)
+        if variable is None and expr_reference_variable is not None:
+            variable = expr_reference_variable
             if inline_string:
-                self._inlined_strings.add(expr.tags["reference_variable"])
+                self._inlined_strings.add(expr_reference_variable)
             elif function_pointer:
-                self._function_pointers.add(expr.tags["reference_variable"])
+                self._function_pointers.add(expr_reference_variable)
 
         var_access = None
         if variable is not None and not reference_values:
             cvar = self._variable(variable, None)
-            offset = expr.tags.get("reference_variable_offset", 0)
+            offset = self._variable_map.reference_variable_offset(expr)
             var_access = self._access_constant_offset_reference(self._get_variable_reference(cvar), offset, None)
 
         if var_access is not None:
@@ -3945,10 +3957,11 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         )
 
     def _handle_Expr_BinaryOp(self, expr: BinaryOp, **kwargs):
-        if expr.variable is not None:
-            cvar = self._variable(expr.variable, None)
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            cvar = self._variable(expr_var, None)
             return self._access_constant_offset_reference(
-                self._get_variable_reference(cvar), expr.variable_offset or 0, None
+                self._get_variable_reference(cvar), self._variable_map.variable_offset(expr) or 0, None
             )
 
         lhs = self._handle(expr.operands[0])
@@ -4105,14 +4118,15 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         ref: bool = False,
         **kwargs,
     ):
-        if expr.variable is not None:
-            cvar = self._variable(expr.variable, None, vvar_id=expr.varid)
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            cvar = self._variable(expr_var, None, vvar_id=expr.varid)
 
-            if not lvalue and expr.variable.size != expr.size:
+            if not lvalue and expr_var.size != expr.size:
                 l.warning(
                     "VirtualVariable size (%d) and variable size (%d) do not match. Force a type cast.",
                     expr.size,
-                    expr.variable.size,
+                    expr_var.size,
                 )
                 src_type = cvar.type
                 dst_type = {
@@ -4128,8 +4142,9 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         return CDirtyExpression(expr, codegen=self)
 
     def _handle_Expr_StackBaseOffset(self, expr: StackBaseOffset, **kwargs):
-        if expr.variable is not None:
-            var_thing = self._variable(expr.variable, expr.size)
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            var_thing = self._variable(expr_var, expr.size)
             var_thing.tags = dict(expr.tags)
             if "def_at" in var_thing.tags and "ins_addr" not in var_thing.tags:
                 var_thing.tags["ins_addr"] = var_thing.tags["def_at"].tags["ins_addr"]

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -27,6 +27,7 @@ from angr.analyses.decompiler.structurer_nodes import (
     SwitchCaseNode,
 )
 from angr.analyses.decompiler.utils import structured_node_is_simple_return
+from angr.analyses.decompiler.variable_map import VariableMap
 from angr.errors import UnsupportedNodeTypeError
 from angr.knowledge_plugins.cfg.memory_data import MemoryData, MemoryDataSort
 from angr.knowledge_plugins.functions import Function
@@ -70,7 +71,6 @@ from angr.utils.loader import is_in_readonly_section, is_in_readonly_segment
 from angr.utils.strings import decode_utf16_string
 from angr.utils.types import dereference_simtype_by_lib, unpack_pointer_and_array, unpack_typeref
 
-from ..variable_map import VariableMap
 from .base import (
     BaseStructuredCodeGenerator,
     CConstantType,

--- a/angr/analyses/decompiler/structured_codegen/rust.py
+++ b/angr/analyses/decompiler/structured_codegen/rust.py
@@ -73,6 +73,7 @@ from angr.sim_variable import SimMemoryVariable, SimStackVariable, SimTemporaryV
 from angr.utils.constants import is_alignment_mask
 from angr.utils.loader import is_in_readonly_section, is_in_readonly_segment
 
+from ..variable_map import VariableMap
 from .base import BaseStructuredCodeGenerator, InstructionMapping, PositionMapping, PositionMappingElement
 
 if TYPE_CHECKING:
@@ -1769,7 +1770,7 @@ class RustLet(RustExpression):
         var = None
         if isinstance(def_, ailment.Stmt.Store):
             expr = def_.addr
-            var = def_.variable
+            var = self.codegen._variable_map.variable(def_)
         if expr and var is not None:
             var_thing = self.codegen._variable(var, expr.size)
             var_thing.tags = dict(expr.tags)
@@ -2745,6 +2746,7 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         min_data_addr: int = 0x400_000,
         notes=None,
         display_notes: bool = True,
+        variable_map: VariableMap | None = None,
     ):
         super().__init__(flavor=flavor, notes=notes)
 
@@ -2800,6 +2802,7 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         self._cfg = cfg
         self._sequence = sequence
         self._variable_kb = variable_kb if variable_kb is not None else self.kb
+        self._variable_map: VariableMap = variable_map if variable_map is not None else VariableMap()
         self.binop_depth_cutoff = binop_depth_cutoff
 
         self._variables_in_use: dict | None = None
@@ -3569,10 +3572,10 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         var = None
         if isinstance(move, ailment.Stmt.Store):
             expr = move.addr
-            var = move.variable
+            var = self._variable_map.variable(move)
         elif isinstance(move, ailment.Stmt.Assignment):
             expr = move.dst
-            var = move.dst.variable
+            var = self._variable_map.variable(move.dst)
         if expr and var is not None:
             var_thing = self._variable(var, expr.size)
             var_thing.tags = dict(expr.tags)
@@ -3647,9 +3650,10 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                 return proposed_ty
             return old_ty
 
-        if stmt.variable is not None:
-            cvar = self._variable(stmt.variable, stmt.size)
-            offset = stmt.offset or 0
+        stmt_var = self._variable_map.variable(stmt)
+        if stmt_var is not None:
+            cvar = self._variable(stmt_var, stmt.size)
+            offset = self._variable_map.variable_offset(stmt) or 0
             assert type(offset) is int  # I refuse to deal with the alternative
             cdst = self._access_constant_offset(self._get_variable_reference(cvar), offset, cdata.type, True, negotiate)
         else:
@@ -3784,11 +3788,13 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                     return proposed_ty
             return old_ty
 
-        if expr.variable:
-            cvar = self._variable(expr.variable, None)
-            if expr.variable.size == expr.size:
+        expr_var = self._variable_map.variable(expr)
+        if expr_var:
+            cvar = self._variable(expr_var, None)
+            if expr_var.size == expr.size:
                 return cvar
-            offset = 0 if expr.variable_offset is None else expr.variable_offset
+            expr_var_offset = self._variable_map.variable_offset(expr)
+            offset = 0 if expr_var_offset is None else expr_var_offset
             # FIXME: The type should be associated to the register expression itself
             type_ = self.default_simtype_from_size(expr.size, signed=False)
             return self._access_constant_offset(self._get_variable_reference(cvar), offset, type_, lvalue, negotiate)
@@ -3804,9 +3810,10 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                     return proposed_ty
             return old_ty
 
-        if expr.variable is not None:
-            cvar = self._variable(expr.variable, expr.size)
-            offset = expr.variable_offset or 0
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            cvar = self._variable(expr_var, expr.size)
+            offset = self._variable_map.variable_offset(expr) or 0
             assert type(offset) is int  # I refuse to deal with the alternative
             return self._access_constant_offset(
                 RustUnaryOp("Reference", cvar, codegen=self), offset, ty, False, negotiate
@@ -3910,16 +3917,17 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
             # default to int
             type_ = self.default_simtype_from_size(expr.size)
 
-        if variable is None and hasattr(expr, "reference_variable") and expr.reference_variable is not None:
-            variable = expr.reference_variable
+        expr_reference_variable = self._variable_map.reference_variable(expr)
+        if variable is None and expr_reference_variable is not None:
+            variable = expr_reference_variable
             if inline_string:
-                self._inlined_strings.add(expr.reference_variable)
+                self._inlined_strings.add(expr_reference_variable)
             elif function_pointer:
-                self._function_pointers.add(expr.reference_variable)
+                self._function_pointers.add(expr_reference_variable)
 
         if variable is not None and not reference_values:
             cvar = self._variable(variable, None)
-            offset = getattr(expr, "reference_variable_offset", 0)
+            offset = self._variable_map.reference_variable_offset(expr)
             return self._access_constant_offset_reference(self._get_variable_reference(cvar), offset, None)
 
         return RustConstant(expr.value, type_, reference_values=reference_values, tags=expr.tags, codegen=self)
@@ -4091,10 +4099,11 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         )
 
     def _handle_Expr_BinaryOp(self, expr: BinaryOp, **kwargs):
-        if expr.variable is not None:
-            cvar = self._variable(expr.variable, None)
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            cvar = self._variable(expr_var, None)
             return self._access_constant_offset_reference(
-                self._get_variable_reference(cvar), expr.variable_offset or 0, None
+                self._get_variable_reference(cvar), self._variable_map.variable_offset(expr) or 0, None
             )
 
         lhs = self._handle(expr.operands[0])
@@ -4187,13 +4196,14 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         return RustMultiStatementExpression(cstmts, cexpr, tags=expr.tags, codegen=self)
 
     def _handle_VirtualVariable(self, expr: Expr.VirtualVariable, **kwargs):
-        if expr.variable:
-            cvar = self._variable(expr.variable, None)
-            if expr.variable.size != expr.size:
+        expr_var = self._variable_map.variable(expr)
+        if expr_var:
+            cvar = self._variable(expr_var, None)
+            if expr_var.size != expr.size:
                 l.warning(
                     "VirtualVariable size (%d) and variable size (%d) do not match. Force a type cast.",
                     expr.size,
-                    expr.variable.size,
+                    expr_var.size,
                 )
                 src_type = cvar.type
                 dst_type = RustSimTypeInt(expr.bits, signed=False)
@@ -4204,8 +4214,9 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         return RustDirtyExpression(expr, codegen=self)
 
     def _handle_Expr_StackBaseOffset(self, expr: StackBaseOffset, **kwargs):
-        if expr.variable is not None:
-            var_thing = self._variable(expr.variable, expr.size)
+        expr_var = self._variable_map.variable(expr)
+        if expr_var is not None:
+            var_thing = self._variable(expr_var, expr.size)
             var_thing.tags = dict(expr.tags)
             if "def_at" in var_thing.tags and "ins_addr" not in var_thing.tags:
                 def_at = var_thing.tags["def_at"]

--- a/angr/analyses/decompiler/structured_codegen/rust.py
+++ b/angr/analyses/decompiler/structured_codegen/rust.py
@@ -36,6 +36,7 @@ from angr.analyses.decompiler.structurer_nodes import (
     SwitchCaseNode,
 )
 from angr.analyses.decompiler.utils import structured_node_is_simple_return
+from angr.analyses.decompiler.variable_map import VariableMap
 from angr.errors import UnsupportedNodeTypeError
 from angr.knowledge_plugins.cfg.memory_data import MemoryData, MemoryDataSort
 from angr.knowledge_plugins.functions import Function
@@ -73,7 +74,6 @@ from angr.sim_variable import SimMemoryVariable, SimStackVariable, SimTemporaryV
 from angr.utils.constants import is_alignment_mask
 from angr.utils.loader import is_in_readonly_section, is_in_readonly_segment
 
-from ..variable_map import VariableMap
 from .base import BaseStructuredCodeGenerator, InstructionMapping, PositionMapping, PositionMappingElement
 
 if TYPE_CHECKING:

--- a/angr/analyses/decompiler/structuring/dream.py
+++ b/angr/analyses/decompiler/structuring/dream.py
@@ -952,7 +952,7 @@ class DreamStructurer(StructurerBase):
                     statements=[
                         ailment.Stmt.Jump(
                             self.ail_manager.next_atom(),
-                            ailment.Expr.Const(self.ail_manager.next_atom(), None, entry_addr, self.project.arch.bits),
+                            ailment.Expr.Const(self.ail_manager.next_atom(), entry_addr, self.project.arch.bits),
                             ins_addr=0,
                             stmt_idx=0,
                         )
@@ -976,7 +976,7 @@ class DreamStructurer(StructurerBase):
                     statements=[
                         ailment.Stmt.Jump(
                             self.ail_manager.next_atom(),
-                            ailment.Expr.Const(self.ail_manager.next_atom(), None, entry_addr, self.project.arch.bits),
+                            ailment.Expr.Const(self.ail_manager.next_atom(), entry_addr, self.project.arch.bits),
                             ins_addr=0,
                             stmt_idx=0,
                         )

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -433,7 +433,7 @@ class PhoenixStructurer(StructurerBase):
                         assert last_stmt is not None
                         cond_jump = Jump(
                             self.ail_manager.next_atom(),
-                            Const(self.ail_manager.next_atom(), None, right.addr, self.project.arch.bits),
+                            Const(self.ail_manager.next_atom(), right.addr, self.project.arch.bits),
                             None,
                             ins_addr=last_stmt.tags["ins_addr"],
                         )
@@ -920,7 +920,7 @@ class PhoenixStructurer(StructurerBase):
                         if claripy.is_true(break_cond):
                             break_stmt = Jump(
                                 self.ail_manager.next_atom(),
-                                Const(self.ail_manager.next_atom(), None, successor.addr, self.project.arch.bits),
+                                Const(self.ail_manager.next_atom(), successor.addr, self.project.arch.bits),
                                 target_idx=successor.idx if isinstance(successor, Block) else None,
                                 ins_addr=last_src_stmt.tags["ins_addr"],
                             )
@@ -933,7 +933,7 @@ class PhoenixStructurer(StructurerBase):
                                 # we create a conditional jump that will be converted to a conditional break later
                                 break_stmt = Jump(
                                     self.ail_manager.next_atom(),
-                                    Const(self.ail_manager.next_atom(), None, successor.addr, self.project.arch.bits),
+                                    Const(self.ail_manager.next_atom(), successor.addr, self.project.arch.bits),
                                     target_idx=successor.idx if isinstance(successor, Block) else None,
                                     ins_addr=last_src_stmt.tags["ins_addr"],
                                 )
@@ -942,7 +942,6 @@ class PhoenixStructurer(StructurerBase):
                                     self.ail_manager.next_atom(),
                                     Const(
                                         self.ail_manager.next_atom(),
-                                        None,
                                         fallthrough_node.addr,
                                         self.project.arch.bits,
                                     ),
@@ -966,7 +965,7 @@ class PhoenixStructurer(StructurerBase):
                                 assert other_target is not None
                                 break_stmt = Jump(
                                     self.ail_manager.next_atom(),
-                                    Const(self.ail_manager.next_atom(), None, successor.addr, self.project.arch.bits),
+                                    Const(self.ail_manager.next_atom(), successor.addr, self.project.arch.bits),
                                     target_idx=successor.idx if isinstance(successor, Block) else None,
                                     ins_addr=last_src_stmt.tags["ins_addr"],
                                 )
@@ -1421,7 +1420,7 @@ class PhoenixStructurer(StructurerBase):
             # (e.g., inside another switch-case). we need to create a default node that jumps to the other node
             jmp_to_default_node = Jump(
                 self.ail_manager.next_atom(),
-                Const(self.ail_manager.next_atom(), None, node_default_addr, self.project.arch.bits),
+                Const(self.ail_manager.next_atom(), node_default_addr, self.project.arch.bits),
                 None,
                 ins_addr=SWITCH_MISSING_DEFAULT_NODE_ADDR,
             )
@@ -2098,7 +2097,7 @@ class PhoenixStructurer(StructurerBase):
                     statements=[
                         Jump(
                             self.ail_manager.next_atom(),
-                            Const(self.ail_manager.next_atom(), None, entry_addr, self.project.arch.bits),
+                            Const(self.ail_manager.next_atom(), entry_addr, self.project.arch.bits),
                             target_idx=entry_idx,
                             ins_addr=0,
                             stmt_idx=0,
@@ -2237,7 +2236,7 @@ class PhoenixStructurer(StructurerBase):
                 if not isinstance(case_node_last_stmt, Jump):
                     jump_stmt = Jump(
                         self.ail_manager.next_atom(),
-                        Const(self.ail_manager.next_atom(), None, head.addr, self.project.arch.bits),
+                        Const(self.ail_manager.next_atom(), head.addr, self.project.arch.bits),
                         None,
                         ins_addr=out_src.addr,
                     )
@@ -2597,7 +2596,7 @@ class PhoenixStructurer(StructurerBase):
                             statements=[
                                 Jump(
                                     self.ail_manager.next_atom(),
-                                    Const(self.ail_manager.next_atom(), None, right.addr, self.project.arch.bits),
+                                    Const(self.ail_manager.next_atom(), right.addr, self.project.arch.bits),
                                     ins_addr=new_cond_node.addr,
                                 )
                             ],
@@ -2742,8 +2741,8 @@ class PhoenixStructurer(StructurerBase):
             cond_jump = ConditionalJump(
                 self.ail_manager.next_atom(),
                 cond,
-                Const(self.ail_manager.next_atom(), None, right.addr, self.project.arch.bits),
-                Const(self.ail_manager.next_atom(), None, succ.addr, self.project.arch.bits),
+                Const(self.ail_manager.next_atom(), right.addr, self.project.arch.bits),
+                Const(self.ail_manager.next_atom(), succ.addr, self.project.arch.bits),
                 true_target_idx=right.idx if isinstance(right, (Block, MultiNode)) else None,
                 false_target_idx=succ.idx if isinstance(succ, (Block, MultiNode)) else None,
                 ins_addr=start_node.addr,
@@ -2783,10 +2782,8 @@ class PhoenixStructurer(StructurerBase):
             cond_jump = ConditionalJump(
                 self.ail_manager.next_atom(),
                 cond,
-                Const(self.ail_manager.next_atom(), None, left.addr, self.project.arch.bits, ins_addr=start_node.addr),
-                Const(
-                    self.ail_manager.next_atom(), None, else_node.addr, self.project.arch.bits, ins_addr=start_node.addr
-                ),
+                Const(self.ail_manager.next_atom(), left.addr, self.project.arch.bits, ins_addr=start_node.addr),
+                Const(self.ail_manager.next_atom(), else_node.addr, self.project.arch.bits, ins_addr=start_node.addr),
                 true_target_idx=left.idx if isinstance(left, (Block, MultiNode)) else None,
                 false_target_idx=else_node.idx if isinstance(else_node, (Block, MultiNode)) else None,
                 ins_addr=start_node.addr,
@@ -2829,8 +2826,8 @@ class PhoenixStructurer(StructurerBase):
             cond_jump = ConditionalJump(
                 self.ail_manager.next_atom(),
                 cond,
-                Const(self.ail_manager.next_atom(), None, right.addr, self.project.arch.bits),
-                Const(self.ail_manager.next_atom(), None, succ.addr, self.project.arch.bits),
+                Const(self.ail_manager.next_atom(), right.addr, self.project.arch.bits),
+                Const(self.ail_manager.next_atom(), succ.addr, self.project.arch.bits),
                 true_target_idx=right.idx if isinstance(right, (Block, MultiNode)) else None,
                 false_target_idx=succ.idx if isinstance(succ, (Block, MultiNode)) else None,
                 ins_addr=start_node.addr,
@@ -2869,8 +2866,8 @@ class PhoenixStructurer(StructurerBase):
             cond_jump = ConditionalJump(
                 self.ail_manager.next_atom(),
                 cond,
-                Const(self.ail_manager.next_atom(), None, right.addr, self.project.arch.bits),
-                Const(self.ail_manager.next_atom(), None, else_node.addr, self.project.arch.bits),
+                Const(self.ail_manager.next_atom(), right.addr, self.project.arch.bits),
+                Const(self.ail_manager.next_atom(), else_node.addr, self.project.arch.bits),
                 true_target_idx=right.idx if isinstance(right, (Block, MultiNode)) else None,
                 false_target_idx=else_node.idx if isinstance(else_node, (Block, MultiNode)) else None,
                 ins_addr=start_node.addr,
@@ -3213,7 +3210,7 @@ class PhoenixStructurer(StructurerBase):
                 statements=[
                     Jump(
                         self.ail_manager.next_atom(),
-                        Const(self.ail_manager.next_atom(), None, dst.addr, self.project.arch.bits),
+                        Const(self.ail_manager.next_atom(), dst.addr, self.project.arch.bits),
                         ins_addr=stmt_addr,
                         stmt_idx=0,
                     )

--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -202,7 +202,7 @@ class StructurerBase(Analysis):
                     # does not fall through to the next branch
                     goto_stmt = ailment.Stmt.Jump(
                         self.ail_manager.next_atom(),
-                        ailment.Expr.Const(self.ail_manager.next_atom(), None, switch_end_addr, self.project.arch.bits),
+                        ailment.Expr.Const(self.ail_manager.next_atom(), switch_end_addr, self.project.arch.bits),
                         target_idx=None,
                         ins_addr=cond_node.addr,
                     )

--- a/angr/analyses/decompiler/variable_map.py
+++ b/angr/analyses/decompiler/variable_map.py
@@ -10,6 +10,20 @@ if TYPE_CHECKING:
     from angr.sim_variable import SimVariable
 
 
+def variable_map_of(manager) -> VariableMap:
+    """
+    Return the :class:`VariableMap` attached to an ailment ``Manager``, lazily creating and attaching an empty one if
+    the manager does not have a map yet (e.g. Managers constructed outside of Clinic in tests). This keeps consumers
+    that reach the map through ``manager.variable_map`` from having to special-case ``None``.
+    """
+
+    vm = getattr(manager, "variable_map", None)
+    if vm is None:
+        vm = VariableMap()
+        manager.variable_map = vm
+    return vm
+
+
 class VariableMap:
     """
     A side container that maps the ``.idx`` of AIL :class:`Statement` and :class:`Expression` objects to

--- a/angr/analyses/decompiler/variable_map.py
+++ b/angr/analyses/decompiler/variable_map.py
@@ -1,23 +1,28 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from angr.sim_type import SimType
 
 if TYPE_CHECKING:
+    from angr.ailment.manager import Manager
     from angr.ailment.tagged_object import TaggedObject
     from angr.sim_variable import SimVariable
 
 
-def variable_map_of(manager) -> VariableMap:
+_l = logging.getLogger(name=__name__)
+
+
+def variable_map_of(manager: Manager) -> VariableMap:
     """
     Return the :class:`VariableMap` attached to an ailment ``Manager``, lazily creating and attaching an empty one if
     the manager does not have a map yet (e.g. Managers constructed outside of Clinic in tests). This keeps consumers
     that reach the map through ``manager.variable_map`` from having to special-case ``None``.
     """
 
-    vm = getattr(manager, "variable_map", None)
+    vm = manager.variable_map
     if vm is None:
         vm = VariableMap()
         manager.variable_map = vm
@@ -27,7 +32,7 @@ def variable_map_of(manager) -> VariableMap:
 class VariableMap:
     """
     A side container that maps the ``.idx`` of AIL :class:`Statement` and :class:`Expression` objects to
-    variable-related information that used to be stored directly on the AIL objects themselves.
+    variable-related information.
 
     The following pieces of information are tracked:
 
@@ -41,8 +46,8 @@ class VariableMap:
       ``variable_offset`` that are specifically used for constants that reference global/extern variables.
 
     Keys are the integer ``.idx`` values of AIL Statement/Expression objects. Because :class:`Clinic` builds one
-    :class:`ailment.Manager` per function, ``.idx`` values are unique within a single function, so a VariableMap is
-    scoped to one function and is stored on its :class:`DecompilationCache`.
+    :class:`ailment.Manager` per invocation, ``.idx`` values are unique within a single Clinic. So a VariableMap is
+    scoped to one Clinic instance and is stored in the corresponding :class:`DecompilationCache`.
     """
 
     __slots__ = (
@@ -68,7 +73,7 @@ class VariableMap:
 
     @staticmethod
     def _key(obj: TaggedObject | int) -> int:
-        return obj if type(obj) is int else obj.idx
+        return obj if isinstance(obj, int) else obj.idx
 
     #
     # Accessors
@@ -100,9 +105,16 @@ class VariableMap:
     #
 
     def set_variable(self, obj: TaggedObject | int, variable: SimVariable | None, offset: int = 0) -> None:
+        """Set the variable information for an AIL atom. If ``variable`` is ``None``, the variable information for
+        this atom is cleared."""
+
         key = self._key(obj)
-        self._variables[key] = variable
-        self._variable_offsets[key] = offset
+        if variable is None:
+            self._variables.pop(key, None)
+            self._variable_offsets.pop(key, None)
+        else:
+            self._variables[key] = variable
+            self._variable_offsets[key] = offset
 
     def set_variable_offset(self, obj: TaggedObject | int, offset: int) -> None:
         self._variable_offsets[self._key(obj)] = offset
@@ -114,9 +126,15 @@ class VariableMap:
         self._reference_values[self._key(obj)] = reference_values
 
     def set_reference_variable(self, obj: TaggedObject | int, variable: SimVariable | None, offset: int = 0) -> None:
+        """Set the reference variable information for an AIL atom. If ``variable`` is ``None``, the reference variable information for
+        this atom is cleared."""
         key = self._key(obj)
-        self._reference_variables[key] = variable
-        self._reference_variable_offsets[key] = offset
+        if variable is None:
+            self._reference_variables.pop(key, None)
+            self._reference_variable_offsets.pop(key, None)
+        else:
+            self._reference_variables[key] = variable
+            self._reference_variable_offsets[key] = offset
 
     def transfer(self, src: TaggedObject | int, dst: TaggedObject | int) -> None:
         """
@@ -137,7 +155,7 @@ class VariableMap:
             self._reference_variable_offsets,
         ):
             if src_key in d:
-                d[dst_key] = d[src_key]
+                d[dst_key] = d[src_key]  # type:ignore
 
     #
     # Serialization
@@ -156,9 +174,9 @@ class VariableMap:
         d: dict[SimType, Any] = {}
         for item in items:
             ty_json = item.get("type")
-            ty = SimType.from_json(ty_json) if ty_json is not None else None
-            if ty is None:
+            if ty_json is None:
                 continue
+            ty = SimType.from_json(ty_json)
             d[ty] = item.get("value")
         return d
 
@@ -193,11 +211,15 @@ class VariableMap:
 
         vm = cls()
 
-        def _resolve(ident):
+        def _resolve(ident) -> SimVariable | None:
             return resolve_variable(ident) if ident is not None else None
 
         for idx, ident in data.get("variables", {}).items():
-            vm._variables[int(idx)] = _resolve(ident)
+            v = _resolve(ident)
+            if v is not None:
+                vm._variables[int(idx)] = v
+            else:
+                _l.warning("Variable with ident %s could not be resolved during VariableMap deserialization", ident)
         for idx, offset in data.get("variable_offsets", {}).items():
             vm._variable_offsets[int(idx)] = offset
         for idx, value in data.get("custom_strings", {}).items():
@@ -205,7 +227,13 @@ class VariableMap:
         for idx, items in data.get("reference_values", {}).items():
             vm._reference_values[int(idx)] = cls._reference_values_from_json(items)
         for idx, ident in data.get("reference_variables", {}).items():
-            vm._reference_variables[int(idx)] = _resolve(ident)
+            v = _resolve(ident)
+            if v is not None:
+                vm._reference_variables[int(idx)] = v
+            else:
+                _l.warning(
+                    "Reference variable with ident %s could not be resolved during VariableMap deserialization", ident
+                )
         for idx, offset in data.get("reference_variable_offsets", {}).items():
             vm._reference_variable_offsets[int(idx)] = offset
 

--- a/angr/analyses/decompiler/variable_map.py
+++ b/angr/analyses/decompiler/variable_map.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+
+from angr.sim_type import SimType
+
+if TYPE_CHECKING:
+    from angr.ailment.tagged_object import TaggedObject
+    from angr.sim_variable import SimVariable
+
+
+class VariableMap:
+    """
+    A side container that maps the ``.idx`` of AIL :class:`Statement` and :class:`Expression` objects to
+    variable-related information that used to be stored directly on the AIL objects themselves.
+
+    The following pieces of information are tracked:
+
+    - ``variable`` (a :class:`SimVariable`) and ``variable_offset`` (an ``int``): the variable that an AIL atom
+      resolves to, and the offset into that variable.
+    - ``custom_string`` (a ``bool``): whether a ``Const`` expression refers to a custom string.
+    - ``reference_values`` (a ``dict`` mapping :class:`SimType` to a value): reference values associated with a
+      ``Const`` expression (e.g., custom strings).
+    - ``reference_variable`` (a :class:`SimVariable`) and ``reference_variable_offset`` (an ``int``): the variable
+      that a constant expression references, and the offset into it. These are siblings of ``variable`` /
+      ``variable_offset`` that are specifically used for constants that reference global/extern variables.
+
+    Keys are the integer ``.idx`` values of AIL Statement/Expression objects. Because :class:`Clinic` builds one
+    :class:`ailment.Manager` per function, ``.idx`` values are unique within a single function, so a VariableMap is
+    scoped to one function and is stored on its :class:`DecompilationCache`.
+    """
+
+    __slots__ = (
+        "_custom_strings",
+        "_reference_values",
+        "_reference_variable_offsets",
+        "_reference_variables",
+        "_variable_offsets",
+        "_variables",
+    )
+
+    def __init__(self):
+        self._variables: dict[int, SimVariable] = {}
+        self._variable_offsets: dict[int, int] = {}
+        self._custom_strings: dict[int, bool] = {}
+        self._reference_values: dict[int, dict[SimType, Any]] = {}
+        self._reference_variables: dict[int, SimVariable] = {}
+        self._reference_variable_offsets: dict[int, int] = {}
+
+    #
+    # Key helper
+    #
+
+    @staticmethod
+    def _key(obj: TaggedObject | int) -> int:
+        return obj if type(obj) is int else obj.idx
+
+    #
+    # Accessors
+    #
+
+    def variable(self, obj: TaggedObject | int) -> SimVariable | None:
+        return self._variables.get(self._key(obj))
+
+    def variable_offset(self, obj: TaggedObject | int) -> int:
+        return self._variable_offsets.get(self._key(obj), 0)
+
+    def custom_string(self, obj: TaggedObject | int) -> bool:
+        return self._custom_strings.get(self._key(obj), False)
+
+    def reference_values(self, obj: TaggedObject | int) -> dict[SimType, Any] | None:
+        return self._reference_values.get(self._key(obj))
+
+    def reference_variable(self, obj: TaggedObject | int) -> SimVariable | None:
+        return self._reference_variables.get(self._key(obj))
+
+    def reference_variable_offset(self, obj: TaggedObject | int) -> int:
+        return self._reference_variable_offsets.get(self._key(obj), 0)
+
+    def has_variable(self, obj: TaggedObject | int) -> bool:
+        return self._key(obj) in self._variables
+
+    #
+    # Setters
+    #
+
+    def set_variable(self, obj: TaggedObject | int, variable: SimVariable | None, offset: int = 0) -> None:
+        key = self._key(obj)
+        self._variables[key] = variable
+        self._variable_offsets[key] = offset
+
+    def set_variable_offset(self, obj: TaggedObject | int, offset: int) -> None:
+        self._variable_offsets[self._key(obj)] = offset
+
+    def set_custom_string(self, obj: TaggedObject | int, value: bool = True) -> None:
+        self._custom_strings[self._key(obj)] = value
+
+    def set_reference_values(self, obj: TaggedObject | int, reference_values: dict[SimType, Any]) -> None:
+        self._reference_values[self._key(obj)] = reference_values
+
+    def set_reference_variable(self, obj: TaggedObject | int, variable: SimVariable | None, offset: int = 0) -> None:
+        key = self._key(obj)
+        self._reference_variables[key] = variable
+        self._reference_variable_offsets[key] = offset
+
+    #
+    # Serialization
+    #
+
+    @staticmethod
+    def _reference_values_to_json(d: dict[SimType, Any]) -> list[dict[str, Any]]:
+        items = []
+        for ty, value in d.items():
+            ty_json = ty.to_json() if isinstance(ty, SimType) else None
+            items.append({"type": ty_json, "value": value if isinstance(value, (str, int, float, bool)) else None})
+        return items
+
+    @staticmethod
+    def _reference_values_from_json(items: list[dict[str, Any]]) -> dict[SimType, Any]:
+        d: dict[SimType, Any] = {}
+        for item in items:
+            ty_json = item.get("type")
+            ty = SimType.from_json(ty_json) if ty_json is not None else None
+            if ty is None:
+                continue
+            d[ty] = item.get("value")
+        return d
+
+    def to_json(self) -> dict[str, Any]:
+        """
+        Serialize this VariableMap to a JSON-compatible object.
+
+        Variables are referenced by their ``.ident`` (reference-by-ident); they must be resolved back to
+        :class:`SimVariable` objects via a resolver in :meth:`from_json`.
+        """
+
+        return {
+            "variables": {idx: (v.ident if v is not None else None) for idx, v in self._variables.items()},
+            "variable_offsets": dict(self._variable_offsets),
+            "custom_strings": dict(self._custom_strings),
+            "reference_values": {
+                idx: self._reference_values_to_json(d) for idx, d in self._reference_values.items()
+            },
+            "reference_variables": {
+                idx: (v.ident if v is not None else None) for idx, v in self._reference_variables.items()
+            },
+            "reference_variable_offsets": dict(self._reference_variable_offsets),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any], resolve_variable: Callable[[str], SimVariable | None]) -> VariableMap:
+        """
+        Deserialize a VariableMap from a JSON-compatible object produced by :meth:`to_json`.
+
+        :param data:             The JSON object.
+        :param resolve_variable: A callable that maps a variable ident (``str``) to a :class:`SimVariable` (or
+                                 ``None`` if it cannot be resolved).
+        """
+
+        vm = cls()
+
+        def _resolve(ident):
+            return resolve_variable(ident) if ident is not None else None
+
+        for idx, ident in data.get("variables", {}).items():
+            vm._variables[int(idx)] = _resolve(ident)
+        for idx, offset in data.get("variable_offsets", {}).items():
+            vm._variable_offsets[int(idx)] = offset
+        for idx, value in data.get("custom_strings", {}).items():
+            vm._custom_strings[int(idx)] = value
+        for idx, items in data.get("reference_values", {}).items():
+            vm._reference_values[int(idx)] = cls._reference_values_from_json(items)
+        for idx, ident in data.get("reference_variables", {}).items():
+            vm._reference_variables[int(idx)] = _resolve(ident)
+        for idx, offset in data.get("reference_variable_offsets", {}).items():
+            vm._reference_variable_offsets[int(idx)] = offset
+
+        return vm

--- a/angr/analyses/decompiler/variable_map.py
+++ b/angr/analyses/decompiler/variable_map.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from angr.sim_type import SimType
 
@@ -103,6 +104,27 @@ class VariableMap:
         self._reference_variables[key] = variable
         self._reference_variable_offsets[key] = offset
 
+    def transfer(self, src: TaggedObject | int, dst: TaggedObject | int) -> None:
+        """
+        Copy all variable information associated with ``src`` to ``dst``. Used when an AIL atom is deep-copied to a new
+        ``.idx`` (e.g. during structuring/duplication) so that the new atom keeps the same variable association.
+        """
+
+        src_key = self._key(src)
+        dst_key = self._key(dst)
+        if src_key == dst_key:
+            return
+        for d in (
+            self._variables,
+            self._variable_offsets,
+            self._custom_strings,
+            self._reference_values,
+            self._reference_variables,
+            self._reference_variable_offsets,
+        ):
+            if src_key in d:
+                d[dst_key] = d[src_key]
+
     #
     # Serialization
     #
@@ -138,9 +160,7 @@ class VariableMap:
             "variables": {idx: (v.ident if v is not None else None) for idx, v in self._variables.items()},
             "variable_offsets": dict(self._variable_offsets),
             "custom_strings": dict(self._custom_strings),
-            "reference_values": {
-                idx: self._reference_values_to_json(d) for idx, d in self._reference_values.items()
-            },
+            "reference_values": {idx: self._reference_values_to_json(d) for idx, d in self._reference_values.items()},
             "reference_variables": {
                 idx: (v.ident if v is not None else None) for idx, v in self._reference_variables.items()
             },

--- a/angr/analyses/decompiler/variable_map.py
+++ b/angr/analyses/decompiler/variable_map.py
@@ -51,10 +51,15 @@ class VariableMap:
     #
     # Key helper
     #
+    # AIL .idx values are NOT unique per object: ailment deliberately reuses an atom's .idx when rewriting
+    # expressions (e.g. a Const operand can share the .idx of the BinaryOp it lives in). Keying purely by .idx would
+    # therefore conflate distinct co-existing atoms. We key by (idx, class-name) instead, which matches AIL's own
+    # notion of identity (``__eq__`` requires equal type and idx) while still being preserved by ``copy()`` and
+    # transferable across ``deep_copy()``.
 
     @staticmethod
-    def _key(obj: TaggedObject | int) -> int:
-        return obj if type(obj) is int else obj.idx
+    def _key(obj: TaggedObject | tuple) -> tuple:
+        return obj if type(obj) is tuple else (obj.idx, type(obj).__name__)
 
     #
     # Accessors
@@ -148,23 +153,34 @@ class VariableMap:
             d[ty] = item.get("value")
         return d
 
+    @staticmethod
+    def _encode_key(key: tuple) -> str:
+        # key is (idx, class-name); encode as "<idx>:<class-name>" so it can be a JSON object key.
+        return f"{key[0]}:{key[1]}"
+
+    @staticmethod
+    def _decode_key(s: str) -> tuple:
+        idx, _, cls = s.partition(":")
+        return (int(idx), cls)
+
     def to_json(self) -> dict[str, Any]:
         """
         Serialize this VariableMap to a JSON-compatible object.
 
         Variables are referenced by their ``.ident`` (reference-by-ident); they must be resolved back to
-        :class:`SimVariable` objects via a resolver in :meth:`from_json`.
+        :class:`SimVariable` objects via a resolver in :meth:`from_json`. Keys are encoded as ``"<idx>:<class-name>"``.
         """
 
+        ek = self._encode_key
         return {
-            "variables": {idx: (v.ident if v is not None else None) for idx, v in self._variables.items()},
-            "variable_offsets": dict(self._variable_offsets),
-            "custom_strings": dict(self._custom_strings),
-            "reference_values": {idx: self._reference_values_to_json(d) for idx, d in self._reference_values.items()},
+            "variables": {ek(k): (v.ident if v is not None else None) for k, v in self._variables.items()},
+            "variable_offsets": {ek(k): v for k, v in self._variable_offsets.items()},
+            "custom_strings": {ek(k): v for k, v in self._custom_strings.items()},
+            "reference_values": {ek(k): self._reference_values_to_json(d) for k, d in self._reference_values.items()},
             "reference_variables": {
-                idx: (v.ident if v is not None else None) for idx, v in self._reference_variables.items()
+                ek(k): (v.ident if v is not None else None) for k, v in self._reference_variables.items()
             },
-            "reference_variable_offsets": dict(self._reference_variable_offsets),
+            "reference_variable_offsets": {ek(k): v for k, v in self._reference_variable_offsets.items()},
         }
 
     @classmethod
@@ -178,21 +194,22 @@ class VariableMap:
         """
 
         vm = cls()
+        dk = cls._decode_key
 
         def _resolve(ident):
             return resolve_variable(ident) if ident is not None else None
 
-        for idx, ident in data.get("variables", {}).items():
-            vm._variables[int(idx)] = _resolve(ident)
-        for idx, offset in data.get("variable_offsets", {}).items():
-            vm._variable_offsets[int(idx)] = offset
-        for idx, value in data.get("custom_strings", {}).items():
-            vm._custom_strings[int(idx)] = value
-        for idx, items in data.get("reference_values", {}).items():
-            vm._reference_values[int(idx)] = cls._reference_values_from_json(items)
-        for idx, ident in data.get("reference_variables", {}).items():
-            vm._reference_variables[int(idx)] = _resolve(ident)
-        for idx, offset in data.get("reference_variable_offsets", {}).items():
-            vm._reference_variable_offsets[int(idx)] = offset
+        for k, ident in data.get("variables", {}).items():
+            vm._variables[dk(k)] = _resolve(ident)
+        for k, offset in data.get("variable_offsets", {}).items():
+            vm._variable_offsets[dk(k)] = offset
+        for k, value in data.get("custom_strings", {}).items():
+            vm._custom_strings[dk(k)] = value
+        for k, items in data.get("reference_values", {}).items():
+            vm._reference_values[dk(k)] = cls._reference_values_from_json(items)
+        for k, ident in data.get("reference_variables", {}).items():
+            vm._reference_variables[dk(k)] = _resolve(ident)
+        for k, offset in data.get("reference_variable_offsets", {}).items():
+            vm._reference_variable_offsets[dk(k)] = offset
 
         return vm

--- a/angr/analyses/decompiler/variable_map.py
+++ b/angr/analyses/decompiler/variable_map.py
@@ -51,15 +51,10 @@ class VariableMap:
     #
     # Key helper
     #
-    # AIL .idx values are NOT unique per object: ailment deliberately reuses an atom's .idx when rewriting
-    # expressions (e.g. a Const operand can share the .idx of the BinaryOp it lives in). Keying purely by .idx would
-    # therefore conflate distinct co-existing atoms. We key by (idx, class-name) instead, which matches AIL's own
-    # notion of identity (``__eq__`` requires equal type and idx) while still being preserved by ``copy()`` and
-    # transferable across ``deep_copy()``.
 
     @staticmethod
-    def _key(obj: TaggedObject | tuple) -> tuple:
-        return obj if type(obj) is tuple else (obj.idx, type(obj).__name__)
+    def _key(obj: TaggedObject | int) -> int:
+        return obj if type(obj) is int else obj.idx
 
     #
     # Accessors
@@ -153,34 +148,23 @@ class VariableMap:
             d[ty] = item.get("value")
         return d
 
-    @staticmethod
-    def _encode_key(key: tuple) -> str:
-        # key is (idx, class-name); encode as "<idx>:<class-name>" so it can be a JSON object key.
-        return f"{key[0]}:{key[1]}"
-
-    @staticmethod
-    def _decode_key(s: str) -> tuple:
-        idx, _, cls = s.partition(":")
-        return (int(idx), cls)
-
     def to_json(self) -> dict[str, Any]:
         """
         Serialize this VariableMap to a JSON-compatible object.
 
         Variables are referenced by their ``.ident`` (reference-by-ident); they must be resolved back to
-        :class:`SimVariable` objects via a resolver in :meth:`from_json`. Keys are encoded as ``"<idx>:<class-name>"``.
+        :class:`SimVariable` objects via a resolver in :meth:`from_json`.
         """
 
-        ek = self._encode_key
         return {
-            "variables": {ek(k): (v.ident if v is not None else None) for k, v in self._variables.items()},
-            "variable_offsets": {ek(k): v for k, v in self._variable_offsets.items()},
-            "custom_strings": {ek(k): v for k, v in self._custom_strings.items()},
-            "reference_values": {ek(k): self._reference_values_to_json(d) for k, d in self._reference_values.items()},
+            "variables": {idx: (v.ident if v is not None else None) for idx, v in self._variables.items()},
+            "variable_offsets": dict(self._variable_offsets),
+            "custom_strings": dict(self._custom_strings),
+            "reference_values": {idx: self._reference_values_to_json(d) for idx, d in self._reference_values.items()},
             "reference_variables": {
-                ek(k): (v.ident if v is not None else None) for k, v in self._reference_variables.items()
+                idx: (v.ident if v is not None else None) for idx, v in self._reference_variables.items()
             },
-            "reference_variable_offsets": {ek(k): v for k, v in self._reference_variable_offsets.items()},
+            "reference_variable_offsets": dict(self._reference_variable_offsets),
         }
 
     @classmethod
@@ -194,22 +178,21 @@ class VariableMap:
         """
 
         vm = cls()
-        dk = cls._decode_key
 
         def _resolve(ident):
             return resolve_variable(ident) if ident is not None else None
 
-        for k, ident in data.get("variables", {}).items():
-            vm._variables[dk(k)] = _resolve(ident)
-        for k, offset in data.get("variable_offsets", {}).items():
-            vm._variable_offsets[dk(k)] = offset
-        for k, value in data.get("custom_strings", {}).items():
-            vm._custom_strings[dk(k)] = value
-        for k, items in data.get("reference_values", {}).items():
-            vm._reference_values[dk(k)] = cls._reference_values_from_json(items)
-        for k, ident in data.get("reference_variables", {}).items():
-            vm._reference_variables[dk(k)] = _resolve(ident)
-        for k, offset in data.get("reference_variable_offsets", {}).items():
-            vm._reference_variable_offsets[dk(k)] = offset
+        for idx, ident in data.get("variables", {}).items():
+            vm._variables[int(idx)] = _resolve(ident)
+        for idx, offset in data.get("variable_offsets", {}).items():
+            vm._variable_offsets[int(idx)] = offset
+        for idx, value in data.get("custom_strings", {}).items():
+            vm._custom_strings[int(idx)] = value
+        for idx, items in data.get("reference_values", {}).items():
+            vm._reference_values[int(idx)] = cls._reference_values_from_json(items)
+        for idx, ident in data.get("reference_variables", {}).items():
+            vm._reference_variables[int(idx)] = _resolve(ident)
+        for idx, offset in data.get("reference_variable_offsets", {}).items():
+            vm._reference_variable_offsets[int(idx)] = offset
 
         return vm

--- a/angr/analyses/deobfuscator/api_obf_peephole_optimizer.py
+++ b/angr/analyses/deobfuscator/api_obf_peephole_optimizer.py
@@ -44,7 +44,7 @@ class APIObfType1PeepholeOptimizer(PeepholeOptimizationExprBase):
                 func.find_declaration(ignore_binary_name=True)
             else:
                 func = self.kb.functions[funcname]
-            return Const(expr.idx, None, func.addr, self.project.arch.bits, **expr.tags)
+            return Const(expr.idx, func.addr, self.project.arch.bits, **expr.tags)
         return None
 
 
@@ -67,12 +67,12 @@ class APIObfType3PeepholeOptimizer(PeepholeOptimizationExprBase):
             # it's likely the main binary
             callees = list(self.project.kb.functions.get_by_name(api, check_previous_names=True))
             if len(callees) == 1:
-                return Const(expr.idx, None, callees[0].addr, expr.bits, **(expr.tags | {"always_propagate": True}))
+                return Const(expr.idx, callees[0].addr, expr.bits, **(expr.tags | {"always_propagate": True}))
             return None
         if dll not in self.project.loader.shared_objects:
             return None
         sym = self.project.loader.shared_objects[dll].get_symbol(api)
-        return Const(expr.idx, None, sym.rebased_addr, expr.bits, **(expr.tags | {"always_propagate": True}))
+        return Const(expr.idx, sym.rebased_addr, expr.bits, **(expr.tags | {"always_propagate": True}))
 
 
 EXPR_OPTS.append(APIObfType1PeepholeOptimizer)

--- a/angr/analyses/deobfuscator/data_transformation_embedder.py
+++ b/angr/analyses/deobfuscator/data_transformation_embedder.py
@@ -123,7 +123,7 @@ class DataTransformationEmbedder(Analysis):
             arg_sort = []
             for arg in args:
                 if isinstance(arg, Const):
-                    if arg.tags.get("custom_string", False):
+                    if self.clinic.variable_map.custom_string(arg):
                         has_constant_string_arg = True
                     if arg.value_int in cfg.memory_data:
                         md = cfg.memory_data[arg.value_int]
@@ -233,7 +233,7 @@ class DataTransformationEmbedder(Analysis):
             arg = trans_desc["args"][arg_idx]
             if arg_sort == "const":
                 if isinstance(arg, Const):
-                    if arg.tags.get("custom_string", False):
+                    if self.clinic.variable_map.custom_string(arg):
                         s = self.project.kb.custom_strings[arg.value_int]
                         # FIXME: we force the first argument to be a uint8_t* here
                         callee_func.prototype.args = (
@@ -286,8 +286,13 @@ class DataTransformationEmbedder(Analysis):
 
                 str_id = self.project.kb.custom_strings.allocate(data)
                 src_expr = Const(
-                    None, None, str_id, self.project.arch.bits, ins_addr=callsite_insaddr, custom_string=True
+                    self.clinic._ail_manager.next_atom(),
+                    None,
+                    str_id,
+                    self.project.arch.bits,
+                    ins_addr=callsite_insaddr,
                 )
+                self.clinic.variable_map.set_custom_string(src_expr)
                 assign_stmt = SideEffectStatement(
                     None,
                     Call(
@@ -595,7 +600,8 @@ class DataTransformationEmbedder(Analysis):
                 stmts.append(assign_stmt)
                 buffer_addr = v.concrete_value
                 str_id = self.project.kb.custom_strings.allocate(known_buffers[buffer_addr])
-                src_expr = Const(None, None, str_id, v.size(), ins_addr=addr, custom_string=True)
+                src_expr = Const(self.clinic._ail_manager.next_atom(), None, str_id, v.size(), ins_addr=addr)
+                self.clinic.variable_map.set_custom_string(src_expr)
                 size_expr = Const(None, None, len(known_buffers[buffer_addr]), v.size(), ins_addr=addr)
                 memcpy_stmt = SideEffectStatement(
                     None, Call(None, "memcpy", args=[old_vvar, src_expr, size_expr], ins_addr=addr), ins_addr=addr

--- a/angr/analyses/deobfuscator/data_transformation_embedder.py
+++ b/angr/analyses/deobfuscator/data_transformation_embedder.py
@@ -279,7 +279,7 @@ class DataTransformationEmbedder(Analysis):
                 alloc_expr = Call(
                     None,
                     "malloc",
-                    args=[Const(None, None, buf_size, self.project.arch.bits)],
+                    args=[Const(None, buf_size, self.project.arch.bits)],
                     bits=self.project.arch.bits,
                     ins_addr=callsite_insaddr,
                 )
@@ -288,7 +288,6 @@ class DataTransformationEmbedder(Analysis):
                 str_id = self.project.kb.custom_strings.allocate(data)
                 src_expr = Const(
                     self.clinic._ail_manager.next_atom(),
-                    None,
                     str_id,
                     self.project.arch.bits,
                     ins_addr=callsite_insaddr,
@@ -299,7 +298,7 @@ class DataTransformationEmbedder(Analysis):
                     Call(
                         None,
                         "memcpy",
-                        args=[dst, src_expr, Const(None, None, len(data), self.project.arch.bits)],
+                        args=[dst, src_expr, Const(None, len(data), self.project.arch.bits)],
                         ins_addr=callsite_insaddr,
                     ),
                     ins_addr=callsite_insaddr,
@@ -317,7 +316,7 @@ class DataTransformationEmbedder(Analysis):
                     )
                     if value.symbolic:
                         return False
-                    value_expr = Const(None, None, value.concrete_value, arg.operand.bits)
+                    value_expr = Const(None, value.concrete_value, arg.operand.bits)
                     alloc_stmt = Assignment(
                         None,
                         arg.operand,
@@ -601,15 +600,15 @@ class DataTransformationEmbedder(Analysis):
                 stmts.append(assign_stmt)
                 buffer_addr = v.concrete_value
                 str_id = self.project.kb.custom_strings.allocate(known_buffers[buffer_addr])
-                src_expr = Const(self.clinic._ail_manager.next_atom(), None, str_id, v.size(), ins_addr=addr)
+                src_expr = Const(self.clinic._ail_manager.next_atom(), str_id, v.size(), ins_addr=addr)
                 self.clinic.variable_map.set_custom_string(src_expr)
-                size_expr = Const(None, None, len(known_buffers[buffer_addr]), v.size(), ins_addr=addr)
+                size_expr = Const(None, len(known_buffers[buffer_addr]), v.size(), ins_addr=addr)
                 memcpy_stmt = SideEffectStatement(
                     None, Call(None, "memcpy", args=[old_vvar, src_expr, size_expr], ins_addr=addr), ins_addr=addr
                 )
                 stmts.append(memcpy_stmt)
             else:
-                const_expr = Const(None, None, v.concrete_value, v.size(), ins_addr=addr)
+                const_expr = Const(None, v.concrete_value, v.size(), ins_addr=addr)
                 assign_stmt = Assignment(None, old_vvar, const_expr, ins_addr=addr)
                 stmts.append(assign_stmt)
 

--- a/angr/analyses/deobfuscator/data_transformation_embedder.py
+++ b/angr/analyses/deobfuscator/data_transformation_embedder.py
@@ -1,3 +1,4 @@
+# pylint:disable=protected-access
 from __future__ import annotations
 
 import logging

--- a/angr/analyses/deobfuscator/string_obf_opt_passes.py
+++ b/angr/analyses/deobfuscator/string_obf_opt_passes.py
@@ -77,7 +77,7 @@ class StringObfType3Rewriter(OptimizationPass):
             old_call_expr: Call = old_stmt.src
         else:
             old_call_expr: Call = old_stmt.expr
-        str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
+        str_const = Const(self.manager.next_atom(), str_id, self.project.arch.bits)
         self.manager.variable_map.set_custom_string(str_const)
         new_call = Call(
             old_call_expr.idx,
@@ -85,7 +85,7 @@ class StringObfType3Rewriter(OptimizationPass):
             args=[
                 old_call_expr.args[0],
                 str_const,
-                Const(None, None, len(deobf_content), self.project.arch.bits),
+                Const(None, len(deobf_content), self.project.arch.bits),
             ],
             bits=old_call_expr.bits,
             **old_call_expr.tags,

--- a/angr/analyses/deobfuscator/string_obf_opt_passes.py
+++ b/angr/analyses/deobfuscator/string_obf_opt_passes.py
@@ -77,12 +77,14 @@ class StringObfType3Rewriter(OptimizationPass):
             old_call_expr: Call = old_stmt.src
         else:
             old_call_expr: Call = old_stmt.expr
+        str_const = Const(self.manager.next_atom(), None, str_id, self.project.arch.bits)
+        self.manager.variable_map.set_custom_string(str_const)
         new_call = Call(
             old_call_expr.idx,
             "init_str",
             args=[
                 old_call_expr.args[0],
-                Const(None, None, str_id, self.project.arch.bits, custom_string=True),
+                str_const,
                 Const(None, None, len(deobf_content), self.project.arch.bits),
             ],
             bits=old_call_expr.bits,

--- a/angr/analyses/deobfuscator/string_obf_peephole_optimizer.py
+++ b/angr/analyses/deobfuscator/string_obf_peephole_optimizer.py
@@ -38,7 +38,7 @@ class StringObfType1PeepholeOptimizer(PeepholeOptimizationExprBase):
 
                 if out.concrete:
                     return Const(
-                        None, None, out.concrete_value, self.project.arch.bits, **expr.tags
+                        None, out.concrete_value, self.project.arch.bits, **expr.tags
                     )  # FIXME: use out.bits when the function prototype recovery is more reliable
 
         return None

--- a/angr/analyses/loop_unroller/loop_unroller.py
+++ b/angr/analyses/loop_unroller/loop_unroller.py
@@ -173,12 +173,12 @@ class LoopUnroller(Analysis):
                         stmt.idx,
                         stmt.condition,
                         (
-                            Const(None, None, new_true_target[0], true_target.bits, **true_target.tags)
+                            Const(None, new_true_target[0], true_target.bits, **true_target.tags)
                             if new_true_target is not None
                             else true_target
                         ),
                         (
-                            Const(None, None, new_false_target[0], stmt.false_target.bits, **false_target.tags)
+                            Const(None, new_false_target[0], stmt.false_target.bits, **false_target.tags)
                             if new_false_target is not None
                             else false_target
                         ),
@@ -197,7 +197,7 @@ class LoopUnroller(Analysis):
                 if new_target is not None:
                     new_stmt = Jump(
                         stmt.idx,
-                        Const(None, None, new_target[0], target.bits, **target.tags),
+                        Const(None, new_target[0], target.bits, **target.tags),
                         target_idx=new_target[1],
                         **stmt.tags,
                     )

--- a/angr/analyses/outliner/outliner.py
+++ b/angr/analyses/outliner/outliner.py
@@ -203,7 +203,7 @@ class Outliner(Analysis):
 
         for ret_node, frontier_node in out_edges:
             if retval_to_target:
-                new_ret_exprs = [*ret_exprs[:-1], Const(None, None, frontier_node.addr, self.project.arch.bits)]
+                new_ret_exprs = [*ret_exprs[:-1], Const(None, frontier_node.addr, self.project.arch.bits)]
             else:
                 new_ret_exprs = ret_exprs
             ret_stmt = Return(None, new_ret_exprs, ins_addr=max(stmt.tags["ins_addr"] for stmt in ret_node.statements))
@@ -221,11 +221,11 @@ class Outliner(Analysis):
                     cond_jump = ret_node.statements[-1]
                     if isinstance(cond_jump.true_target, Const) and cond_jump.true_target.value == frontier_node.addr:
                         _, cond_jump = cond_jump.replace(
-                            cond_jump.true_target, Const(None, None, new_ret_node.addr, self.project.arch.bits)
+                            cond_jump.true_target, Const(None, new_ret_node.addr, self.project.arch.bits)
                         )
                     if isinstance(cond_jump.false_target, Const) and cond_jump.false_target.value == frontier_node.addr:
                         _, cond_jump = cond_jump.replace(
-                            cond_jump.false_target, Const(None, None, new_ret_node.addr, self.project.arch.bits)
+                            cond_jump.false_target, Const(None, new_ret_node.addr, self.project.arch.bits)
                         )
                     ret_node.statements[-1] = cond_jump
                     subgraph.add_edge(ret_node, new_ret_node)
@@ -241,13 +241,13 @@ class Outliner(Analysis):
                     dispatcher_node_addr = next_dispatcher_node_addr
                     next_dispatcher_node_addr = self._next_block_addr(), None
 
-                    retval_const = Const(None, None, retval, self.project.arch.bits)
+                    retval_const = Const(None, retval, self.project.arch.bits)
                     cmp = BinaryOp(None, "CmpEQ", [switch_vvar, retval_const])
                     stmt = ConditionalJump(
                         None,
                         cmp,
-                        Const(None, None, jump_target[0], self.project.arch.bits),
-                        Const(None, None, next_dispatcher_node_addr[0], self.project.arch.bits),
+                        Const(None, jump_target[0], self.project.arch.bits),
+                        Const(None, next_dispatcher_node_addr[0], self.project.arch.bits),
                         true_target_idx=jump_target[1],
                         false_target_idx=next_dispatcher_node_addr[1],
                         ins_addr=dispatcher_node_addr[0],

--- a/angr/analyses/proximity_graph.py
+++ b/angr/analyses/proximity_graph.py
@@ -325,18 +325,21 @@ class ProximityGraphAnalysis(Analysis):
                 # not a string. present it as a constant integer
                 args.append(IntegerProxiNode(arg.value_int, None))
         elif isinstance(arg, ailment.expression.Load):
-            if arg.variable is not None:
-                args.append(VariableProxiNode(arg.variable.addr, arg.variable.name))
-            elif arg.addr.variable is not None:
-                if isinstance(arg.addr.variable, SimMemoryVariable):
-                    args.append(VariableProxiNode(arg.addr.variable.addr, arg.addr.variable.name))
+            arg_var = self._variable_map.variable(arg)
+            arg_addr_var = self._variable_map.variable(arg.addr)
+            if arg_var is not None:
+                args.append(VariableProxiNode(arg_var.addr, arg_var.name))
+            elif arg_addr_var is not None:
+                if isinstance(arg_addr_var, SimMemoryVariable):
+                    args.append(VariableProxiNode(arg_addr_var.addr, arg_addr_var.name))
                 else:
-                    args.append(VariableProxiNode(None, arg.addr.variable.name))
+                    args.append(VariableProxiNode(None, arg_addr_var.name))
             else:
                 args.append(UnknownProxiNode("l_"))
         elif isinstance(arg, ailment.expression.StackBaseOffset):
-            if arg.variable is not None:
-                args.append(VariableProxiNode(arg.variable, arg.variable.name))
+            arg_var = self._variable_map.variable(arg)
+            if arg_var is not None:
+                args.append(VariableProxiNode(arg_var, arg_var.name))
             else:
                 args.append(UnknownProxiNode("s_"))
         else:
@@ -354,6 +357,7 @@ class ProximityGraphAnalysis(Analysis):
         ail_graph = decompilation.clinic.cc_graph
         if ail_graph is None:
             return []
+        self._variable_map = decompilation.clinic.variable_map
 
         def _handle_Call(
             expr_idx: int,

--- a/angr/analyses/proximity_graph.py
+++ b/angr/analyses/proximity_graph.py
@@ -175,6 +175,7 @@ class ProximityGraphAnalysis(Analysis):
         self._cfg_model = cfg_model
         self._xrefs = xrefs
         self._decompilation = decompilation
+        self._variable_map = self._decompilation._variable_map if self._decompilation is not None else None
         self._expand_funcs = expand_funcs.copy() if expand_funcs else None
 
         self.graph: networkx.DiGraph | None = None
@@ -197,7 +198,8 @@ class ProximityGraphAnalysis(Analysis):
         if blank_nodes:
             self._merge_nodes(graph, blank_nodes)
 
-    def _merge_nodes(self, graph: networkx.DiGraph, nodes: list[BaseProxiNode]) -> None:
+    @staticmethod
+    def _merge_nodes(graph: networkx.DiGraph, nodes: list[BaseProxiNode]) -> None:
         for node in nodes:
             predecessors = set(graph.predecessors(node))
             successors = set(graph.successors(node))
@@ -352,6 +354,9 @@ class ProximityGraphAnalysis(Analysis):
 
         # dedup
         string_refs: set[int] = set()
+
+        if decompilation.clinic is None:
+            return []
 
         # Walk the clinic structure to dump string references and function calls
         ail_graph = decompilation.clinic.cc_graph

--- a/angr/knowledge_plugins/propagations/prop_value.py
+++ b/angr/knowledge_plugins/propagations/prop_value.py
@@ -179,13 +179,11 @@ class PropValue:
 
         if isinstance(expr, ailment.Expr.Const):
             mask = (1 << bits) - 1
-            return ailment.Expr.Const(expr.idx, None, (expr.value >> start) & mask, bits, **expr.tags)
+            return ailment.Expr.Const(expr.idx, (expr.value >> start) & mask, bits, **expr.tags)
 
         if start == 0:
             return ailment.Expr.Convert(None, expr.bits, bits, False, expr, **expr.tags)
-        a = ailment.Expr.BinaryOp(
-            None, "Shr", (expr, ailment.Expr.Const(None, None, bits, expr.bits)), False, **expr.tags
-        )
+        a = ailment.Expr.BinaryOp(None, "Shr", (expr, ailment.Expr.Const(None, bits, expr.bits)), False, **expr.tags)
         return ailment.Expr.Convert(None, a.bits, bits, False, a, **expr.tags)
 
     @staticmethod
@@ -193,7 +191,7 @@ class PropValue:
         if expr is None:
             return None
         if isinstance(expr, ailment.Expr.Const):
-            return ailment.Expr.Const(expr.idx, None, expr.value, bits + expr.bits, **expr.tags)
+            return ailment.Expr.Const(expr.idx, expr.value, bits + expr.bits, **expr.tags)
         if isinstance(expr, ailment.Expr.Convert):
             return ailment.Expr.Convert(None, expr.from_bits, bits + expr.to_bits, False, expr.operand, **expr.tags)
         return ailment.Expr.Convert(None, expr.bits, bits + expr.bits, False, expr, **expr.tags)

--- a/angr/knowledge_plugins/propagations/prop_value.py
+++ b/angr/knowledge_plugins/propagations/prop_value.py
@@ -179,7 +179,7 @@ class PropValue:
 
         if isinstance(expr, ailment.Expr.Const):
             mask = (1 << bits) - 1
-            return ailment.Expr.Const(expr.idx, expr.variable, (expr.value >> start) & mask, bits, **expr.tags)
+            return ailment.Expr.Const(expr.idx, None, (expr.value >> start) & mask, bits, **expr.tags)
 
         if start == 0:
             return ailment.Expr.Convert(None, expr.bits, bits, False, expr, **expr.tags)
@@ -193,7 +193,7 @@ class PropValue:
         if expr is None:
             return None
         if isinstance(expr, ailment.Expr.Const):
-            return ailment.Expr.Const(expr.idx, expr.variable, expr.value, bits + expr.bits, **expr.tags)
+            return ailment.Expr.Const(expr.idx, None, expr.value, bits + expr.bits, **expr.tags)
         if isinstance(expr, ailment.Expr.Convert):
             return ailment.Expr.Convert(None, expr.from_bits, bits + expr.to_bits, False, expr.operand, **expr.tags)
         return ailment.Expr.Convert(None, expr.bits, bits + expr.bits, False, expr, **expr.tags)

--- a/angr/rust/analyses/rust_calling_convention/fact_collector.py
+++ b/angr/rust/analyses/rust_calling_convention/fact_collector.py
@@ -90,7 +90,7 @@ class CalleeWriteCollector:
             return
         func = self._fc.project.kb.functions[call.target.value]
         if func.name == "memcpy" and args is not None and len(args) == 3 and isinstance(args[2], Const):
-            tmp = Tmp(self._fc.ail_manager.next_atom(), None, 0, args[2].value * self._fc.project.arch.byte_width)
+            tmp = Tmp(self._fc.ail_manager.next_atom(), 0, args[2].value * self._fc.project.arch.byte_width)
             self._fc.has_write_to_arg0 = True
             # Use a single-block path as the key, consistent with memory_writes keying.
             path = (block,)

--- a/angr/rust/analyses/struct_builder.py
+++ b/angr/rust/analyses/struct_builder.py
@@ -51,7 +51,7 @@ class StructBuilder(Analysis):
             if isinstance(data, Load) and isinstance(data.addr, UnaryOp) and data.addr.op == "Reference":
                 size = bits // self.project.arch.byte_width
                 leftover_size = (data.bits - bits) // self.project.arch.byte_width
-                size_expr = Const(self.context.manager.next_atom(), None, size, data.addr.bits)
+                size_expr = Const(self.context.manager.next_atom(), size, data.addr.bits)
                 leftover_addr = BinaryOp(
                     self.context.manager.next_atom(),
                     "Add",

--- a/angr/rust/mixins/cfg_transformation_mixin.py
+++ b/angr/rust/mixins/cfg_transformation_mixin.py
@@ -132,7 +132,7 @@ class CFGTransformationMixin:
                 and last_stmt.target_idx == old_target_idx
             ):
                 new_stmt = last_stmt.copy()
-                new_stmt.target = Const(0, None, new_target, last_stmt.target.bits)
+                new_stmt.target = Const(0, new_target, last_stmt.target.bits)
                 new_stmt.target_idx = new_target_idx
                 block.statements[-1] = new_stmt
         elif isinstance(last_stmt, ConditionalJump):
@@ -147,7 +147,7 @@ class CFGTransformationMixin:
                 )
             ):
                 if isinstance(true_tgt, Const) and isinstance(false_tgt, Const):
-                    target = Const(0, None, new_target, true_tgt.bits)
+                    target = Const(0, new_target, true_tgt.bits)
                     if true_tgt.value_int == old_target and false_tgt.value_int == new_target:
                         new_target_idx = last_stmt.false_target_idx
                     else:

--- a/angr/rust/optimization_passes/outliners/unwrap_outliner.py
+++ b/angr/rust/optimization_passes/outliners/unwrap_outliner.py
@@ -169,7 +169,9 @@ class UnwrapOutliner(OptimizationPass, CFAMixin, SRDAMixin, DFAMixin, CFGTransfo
                     **last_stmt.tags,
                 )
                 if second_block is not None:
-                    second_block.statements[-1] = SideEffectStatement(last_stmt.idx, replacement, **last_stmt.tags)
+                    second_block.statements[-1] = SideEffectStatement(
+                        self.manager.next_atom(), replacement, **last_stmt.tags
+                    )
 
     def _analyze(self, cache=None):
         for block in list(self._graph.nodes):

--- a/angr/rust/optimization_passes/pattern_match_simplifier.py
+++ b/angr/rust/optimization_passes/pattern_match_simplifier.py
@@ -11,6 +11,7 @@ from angr.analyses.decompiler.optimization_passes.optimization_pass import (
 )
 from angr.analyses.decompiler.sequence_walker import SequenceWalker
 from angr.analyses.decompiler.structurer_nodes import ConditionNode
+from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.rust.mixins import DFAMixin
 from angr.rust.optimization_passes.pre_pattern_match_simplifier import PrePatternMatchSimplifier
 from angr.rust.sim_type import EnumVariant, RustSimTypeOption, RustSimTypeResult
@@ -21,10 +22,11 @@ from angr.rust.utils.ail import unwrap_stack_vvar_reference
 class PatternMatchWalker(SequenceWalker, DFAMixin):
     """Walker that converts condition nodes into pattern match or if-let nodes."""
 
-    def __init__(self, var_manager, graph):
+    def __init__(self, var_manager, graph, variable_map):
         super().__init__()
         self.var_manager = var_manager
         self.graph = graph
+        self._variable_map = variable_map
 
     @staticmethod
     def _find_first_block(node):
@@ -167,7 +169,7 @@ class PatternMatchWalker(SequenceWalker, DFAMixin):
         """Get the enum type from scrutinee's tags or variable manager."""
         enum_ty = scrutinee.tags.get("type", None)
         if enum_ty is None:
-            enum_ty = self.var_manager.get_variable_type(scrutinee.variable)
+            enum_ty = self.var_manager.get_variable_type(self._variable_map.variable(scrutinee))
         if isinstance(enum_ty, (RustSimTypeOption, RustSimTypeResult)):
             return enum_ty
         return None
@@ -257,6 +259,10 @@ class PatternMatchSimplifier(SequenceOptimizationPass):
     def _analyze(self, cache=None):
         if self._variable_kb is None:
             return
-        walker = PatternMatchWalker(self._variable_kb.variables.get_function_manager(self._func.addr), self._graph)
+        walker = PatternMatchWalker(
+            self._variable_kb.variables.get_function_manager(self._func.addr),
+            self._graph,
+            variable_map_of(self.manager),
+        )
         walker.walk(self.seq)
         self.out_seq = self.seq

--- a/angr/rust/optimization_passes/ret_expr_rewriter.py
+++ b/angr/rust/optimization_passes/ret_expr_rewriter.py
@@ -60,7 +60,7 @@ class RetExprRewriter(OptimizationPass):
                                 reg_name=reg_name,
                             )
                             regs.append(reg)
-                        ret_expr = ComboRegister(self.manager.next_atom(), None, regs)
+                        ret_expr = ComboRegister(self.manager.next_atom(), regs)
                         new_call = call_stmt.copy()
                         new_call.ret_expr = ret_expr
                         return new_call

--- a/angr/rust/optimization_passes/ret_expr_rewriter.py
+++ b/angr/rust/optimization_passes/ret_expr_rewriter.py
@@ -55,7 +55,6 @@ class RetExprRewriter(OptimizationPass):
                             reg_offset, reg_size = self.project.arch.registers[reg_name]
                             reg = Register(
                                 self.manager.next_atom(),
-                                None,
                                 reg_offset,
                                 reg_size * 8,
                                 reg_name=reg_name,

--- a/angr/rust/optimization_passes/str_argument_simplifier.py
+++ b/angr/rust/optimization_passes/str_argument_simplifier.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from angr.ailment import Block, Const
 from angr.ailment.expression import Call, Load, StringLiteral, VirtualVariable
 from angr.analyses.decompiler.optimization_passes.optimization_pass import OptimizationPass, OptimizationPassStage
+from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.rust.mixins import SRDAMixin
 from angr.rust.optimization_passes.utils import CallRewriter, extract_str
 from angr.rust.sim_type import RustSimStruct
@@ -79,7 +80,7 @@ class StrArgumentSimplifier(OptimizationPass, SRDAMixin):
             ):
                 if self._var_manager is None:
                     return None
-                ty = self._var_manager.get_variable_type(vvar0.variable)
+                ty = self._var_manager.get_variable_type(variable_map_of(self.manager).variable(vvar0))
                 if isinstance(ty, TypeRef):
                     ty = ty.type
                 if isinstance(ty, RustSimStruct) and ty.name == "&str":

--- a/angr/rust/optimization_passes/struct_instantiation_simplifier.py
+++ b/angr/rust/optimization_passes/struct_instantiation_simplifier.py
@@ -61,7 +61,7 @@ class StructBuilder:
             if isinstance(data, Load) and isinstance(data.addr, UnaryOp) and data.addr.op == "Reference":
                 size = bits // self.context.project.arch.byte_width
                 leftover_size = (data.bits - bits) // self.context.project.arch.byte_width
-                size_expr = Const(self.context.manager.next_atom(), None, size, data.addr.bits)
+                size_expr = Const(self.context.manager.next_atom(), size, data.addr.bits)
                 leftover_addr = BinaryOp(
                     self.context.manager.next_atom(),
                     "Add",

--- a/angr/utils/ail.py
+++ b/angr/utils/ail.py
@@ -85,7 +85,7 @@ def extract_partial_expr(base_expr: Expression, off: int, size: int, ail_manager
         raise ValueError("Insufficient expression bits")
 
     base_mask = ((1 << bits) - 1) << (off * byte_width)
-    base_mask = Const(ail_manager.next_atom(), None, base_mask, base_expr.bits)
+    base_mask = Const(ail_manager.next_atom(), base_mask, base_expr.bits)
     masked_base_expr = BinaryOp(
         ail_manager.next_atom(),
         "And",
@@ -95,7 +95,7 @@ def extract_partial_expr(base_expr: Expression, off: int, size: int, ail_manager
         **base_expr.tags,
     )
     if off > 0:
-        shift_amount = Const(ail_manager.next_atom(), None, off * byte_width, byte_width)
+        shift_amount = Const(ail_manager.next_atom(), off * byte_width, byte_width)
         shifted_vvar = BinaryOp(
             ail_manager.next_atom(),
             "Shr",

--- a/angr/utils/endness.py
+++ b/angr/utils/endness.py
@@ -15,5 +15,5 @@ def ail_const_to_be(expr: Const, endness: str) -> Const:
         for elem in lst:
             v <<= 8
             v += elem
-        return Const(expr.idx, None, v, expr.bits, **expr.tags)
+        return Const(expr.idx, v, expr.bits, **expr.tags)
     return expr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ disable = [
     "unidiomatic-typecheck",
     "arguments-differ",
     "signature-differs",
+    "too-many-nested-blocks",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -43,7 +43,7 @@ class ConstIncrementingRewriter(AILBlockRewriter):
 
     def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
         if expr.value == 1:
-            return Const(expr.idx, expr.variable, 2, expr.bits, **expr.tags)
+            return Const(expr.idx, None, 2, expr.bits, **expr.tags)
         return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
 
 

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -43,7 +43,7 @@ class ConstIncrementingRewriter(AILBlockRewriter):
 
     def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
         if expr.value == 1:
-            return Const(expr.idx, None, 2, expr.bits, **expr.tags)
+            return Const(expr.idx, 2, expr.bits, **expr.tags)
         return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
 
 
@@ -69,7 +69,7 @@ def test_block_walker_visits_rust_ail_expression_children():
 
 
 def test_block_rewriter_rebuilds_rust_ail_expression_containers():
-    old_const = Const(0, None, 1, 32)
+    old_const = Const(0, 1, 32)
     struct = Struct(1, "One", OrderedDict([(0, old_const)]), OrderedDict([("value", 0)]), 32)
     enum = RustEnum(2, "Some", [struct], 32)
     array = Array(3, [enum], 32)

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -48,8 +48,8 @@ class ConstIncrementingRewriter(AILBlockRewriter):
 
 
 def test_block_walker_visits_rust_ail_expression_children():
-    reg0 = Register(0, None, 16, 64)
-    reg1 = Register(1, None, 24, 64)
+    reg0 = Register(0, 16, 64)
+    reg1 = Register(1, 24, 64)
     combo = ComboRegister(2, None, [reg0, reg1])
     struct = Struct(3, "Pair", OrderedDict([(0, combo)]), OrderedDict([("value", 0)]), 128)
     enum = RustEnum(4, "Ok", [struct], 128)

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -50,7 +50,7 @@ class ConstIncrementingRewriter(AILBlockRewriter):
 def test_block_walker_visits_rust_ail_expression_children():
     reg0 = Register(0, 16, 64)
     reg1 = Register(1, 24, 64)
-    combo = ComboRegister(2, None, [reg0, reg1])
+    combo = ComboRegister(2, [reg0, reg1])
     struct = Struct(3, "Pair", OrderedDict([(0, combo)]), OrderedDict([("value", 0)]), 128)
     enum = RustEnum(4, "Ok", [struct], 128)
     array = Array(5, [enum], 128)

--- a/tests/ailment/test_expression.py
+++ b/tests/ailment/test_expression.py
@@ -71,11 +71,11 @@ class TestExpression(unittest.TestCase):
     def test_combo_register_and_virtual_variable_accessors(self):
         reg0 = Register(0, 16, 64, reg_name="rax")
         reg1 = Register(1, 24, 64, reg_name="rdx")
-        combo = ComboRegister(2, None, [reg0, reg1])
+        combo = ComboRegister(2, [reg0, reg1])
 
         assert combo.size == 16
         assert "ComboRegister" in str(combo)
-        assert combo.likes(ComboRegister(3, None, [reg0.copy(), reg1.copy()]))
+        assert combo.likes(ComboRegister(3, [reg0.copy(), reg1.copy()]))
         assert combo.matches(combo.copy())
         assert hash(combo) == hash(combo)
 

--- a/tests/ailment/test_expression.py
+++ b/tests/ailment/test_expression.py
@@ -69,8 +69,8 @@ class TestExpression(unittest.TestCase):
         assert copied_struct.tags == struct_expr.tags
 
     def test_combo_register_and_virtual_variable_accessors(self):
-        reg0 = Register(0, None, 16, 64, reg_name="rax")
-        reg1 = Register(1, None, 24, 64, reg_name="rdx")
+        reg0 = Register(0, 16, 64, reg_name="rax")
+        reg1 = Register(1, 24, 64, reg_name="rdx")
         combo = ComboRegister(2, None, [reg0, reg1])
 
         assert combo.size == 16

--- a/tests/ailment/test_expression.py
+++ b/tests/ailment/test_expression.py
@@ -121,8 +121,8 @@ class TestExpression(unittest.TestCase):
 
     def test_rust_ail_value_expressions(self):
         manager = ailment.Manager()
-        old = Const(0, None, 1, 32)
-        new = Const(1, None, 2, 32)
+        old = Const(0, 1, 32)
+        new = Const(1, 2, 32)
 
         literal = StringLiteral(2, b"hello\n", 48, tag="literal")
         assert literal.size == 6
@@ -146,7 +146,7 @@ class TestExpression(unittest.TestCase):
         replaced, new_outer = outer.replace(old, new)
         assert replaced
         assert new_outer.get_field("inner.value") is new
-        assert not outer.replace(Const(8, None, 99, 32), new)[0]
+        assert not outer.replace(Const(8, 99, 32), new)[0]
 
         enum_expr = RustEnum(9, "Ok", [old], 32)
         assert enum_expr.size == 4

--- a/tests/analyses/decompiler/test_ccall_rewriter_arm.py
+++ b/tests/analyses/decompiler/test_ccall_rewriter_arm.py
@@ -34,13 +34,13 @@ from angr.engines.vex.claripy.ccall import (
 
 def _make_ccall(callee, cond_n_op_val, dep1=None, dep2=None, dep3=None, bits=32):
     """Helper to build a VEXCCallExpression for armg_calculate_condition."""
-    cond_n_op = Expr.Const(0, None, cond_n_op_val, 32)
+    cond_n_op = Expr.Const(0, cond_n_op_val, 32)
     if dep1 is None:
         dep1 = Expr.Register(1, None, 0, 32)  # r0
     if dep2 is None:
         dep2 = Expr.Register(2, None, 4, 32)  # r1
     if dep3 is None:
-        dep3 = Expr.Const(3, None, 0, 32)
+        dep3 = Expr.Const(3, 0, 32)
     return Expr.VEXCCallExpression(
         idx=0,
         callee=callee,
@@ -51,13 +51,13 @@ def _make_ccall(callee, cond_n_op_val, dep1=None, dep2=None, dep3=None, bits=32)
 
 def _make_flag_ccall(callee, cc_op_val, dep1=None, dep2=None, dep3=None, bits=32):
     """Helper to build a VEXCCallExpression for armg_calculate_flag_*."""
-    cc_op = Expr.Const(0, None, cc_op_val, 32)
+    cc_op = Expr.Const(0, cc_op_val, 32)
     if dep1 is None:
         dep1 = Expr.Register(1, None, 0, 32)
     if dep2 is None:
         dep2 = Expr.Register(2, None, 4, 32)
     if dep3 is None:
-        dep3 = Expr.Const(3, None, 0, 32)
+        dep3 = Expr.Const(3, 0, 32)
     return Expr.VEXCCallExpression(
         idx=0,
         callee=callee,
@@ -246,19 +246,19 @@ class TestARMCCallRewriterCondition(unittest.TestCase):
     # ---- SBB conditions ----
 
     def test_sbb_hs_no_borrow(self):
-        dep3 = Expr.Const(0, None, 0, 32)
+        dep3 = Expr.Const(0, 0, 32)
         ccall = _make_ccall("armg_calculate_condition", _cond_n_op(ARMCondHS, ARMG_CC_OP_SBB), dep3=dep3)
         result = _unwrap_convert(_rewrite(ccall))
         assert isinstance(result, Expr.BinaryOp) and result.op == "CmpGE"
 
     def test_sbb_hs_with_borrow(self):
-        dep3 = Expr.Const(0, None, 1, 32)
+        dep3 = Expr.Const(0, 1, 32)
         ccall = _make_ccall("armg_calculate_condition", _cond_n_op(ARMCondHS, ARMG_CC_OP_SBB), dep3=dep3)
         result = _unwrap_convert(_rewrite(ccall))
         assert isinstance(result, Expr.BinaryOp) and result.op == "CmpGT"
 
     def test_sbb_lo_no_borrow(self):
-        dep3 = Expr.Const(0, None, 0, 32)
+        dep3 = Expr.Const(0, 0, 32)
         ccall = _make_ccall("armg_calculate_condition", _cond_n_op(ARMCondLO, ARMG_CC_OP_SBB), dep3=dep3)
         result = _unwrap_convert(_rewrite(ccall))
         assert isinstance(result, Expr.BinaryOp) and result.op == "CmpLT"
@@ -275,7 +275,7 @@ class TestARMCCallRewriterCondition(unittest.TestCase):
         cond_n_op = Expr.Register(0, None, 0, 32)  # symbolic
         dep1 = Expr.Register(1, None, 0, 32)
         dep2 = Expr.Register(2, None, 4, 32)
-        dep3 = Expr.Const(3, None, 0, 32)
+        dep3 = Expr.Const(3, 0, 32)
         ccall = Expr.VEXCCallExpression(
             idx=0,
             callee="armg_calculate_condition",
@@ -313,13 +313,13 @@ class TestARMCCallRewriterFlagHelpers(unittest.TestCase):
         assert isinstance(result.operands[0], Expr.BinaryOp) and result.operands[0].op == "Add"
 
     def test_flag_c_sbb_no_borrow(self):
-        dep3 = Expr.Const(0, None, 0, 32)
+        dep3 = Expr.Const(0, 0, 32)
         ccall = _make_flag_ccall("armg_calculate_flag_c", ARMG_CC_OP_SBB, dep3=dep3)
         result = _unwrap_convert(_rewrite(ccall))
         assert isinstance(result, Expr.BinaryOp) and result.op == "CmpGE"
 
     def test_flag_c_sbb_with_borrow(self):
-        dep3 = Expr.Const(0, None, 1, 32)
+        dep3 = Expr.Const(0, 1, 32)
         ccall = _make_flag_ccall("armg_calculate_flag_c", ARMG_CC_OP_SBB, dep3=dep3)
         result = _unwrap_convert(_rewrite(ccall))
         assert isinstance(result, Expr.BinaryOp) and result.op == "CmpGT"
@@ -340,7 +340,7 @@ class TestARMCCallRewriterFlagHelpers(unittest.TestCase):
         cc_op = Expr.Register(0, None, 0, 32)
         dep1 = Expr.Register(1, None, 0, 32)
         dep2 = Expr.Register(2, None, 4, 32)
-        dep3 = Expr.Const(3, None, 0, 32)
+        dep3 = Expr.Const(3, 0, 32)
         ccall = Expr.VEXCCallExpression(
             idx=0, callee="armg_calculate_flag_c", operands=(cc_op, dep1, dep2, dep3), bits=32
         )
@@ -417,7 +417,7 @@ class TestARMCCallRewriterRenamedCCall(unittest.TestCase):
 
     def test_renamed_ccall_wrong_operand_count_not_rewritten(self):
         # A _ccall with != 4 operands should not be rewritten
-        cond_n_op = Expr.Const(0, None, _cond_n_op(ARMCondEQ, ARMG_CC_OP_SUB), 32)
+        cond_n_op = Expr.Const(0, _cond_n_op(ARMCondEQ, ARMG_CC_OP_SUB), 32)
         dep1 = Expr.Register(1, None, 0, 32)
         ccall = Expr.VEXCCallExpression(idx=0, callee="_ccall", operands=(cond_n_op, dep1), bits=32)
         result = _rewrite(ccall)

--- a/tests/analyses/decompiler/test_ccall_rewriter_arm.py
+++ b/tests/analyses/decompiler/test_ccall_rewriter_arm.py
@@ -36,9 +36,9 @@ def _make_ccall(callee, cond_n_op_val, dep1=None, dep2=None, dep3=None, bits=32)
     """Helper to build a VEXCCallExpression for armg_calculate_condition."""
     cond_n_op = Expr.Const(0, cond_n_op_val, 32)
     if dep1 is None:
-        dep1 = Expr.Register(1, None, 0, 32)  # r0
+        dep1 = Expr.Register(1, 0, 32)  # r0
     if dep2 is None:
-        dep2 = Expr.Register(2, None, 4, 32)  # r1
+        dep2 = Expr.Register(2, 4, 32)  # r1
     if dep3 is None:
         dep3 = Expr.Const(3, 0, 32)
     return Expr.VEXCCallExpression(
@@ -53,9 +53,9 @@ def _make_flag_ccall(callee, cc_op_val, dep1=None, dep2=None, dep3=None, bits=32
     """Helper to build a VEXCCallExpression for armg_calculate_flag_*."""
     cc_op = Expr.Const(0, cc_op_val, 32)
     if dep1 is None:
-        dep1 = Expr.Register(1, None, 0, 32)
+        dep1 = Expr.Register(1, 0, 32)
     if dep2 is None:
-        dep2 = Expr.Register(2, None, 4, 32)
+        dep2 = Expr.Register(2, 4, 32)
     if dep3 is None:
         dep3 = Expr.Const(3, 0, 32)
     return Expr.VEXCCallExpression(
@@ -272,9 +272,9 @@ class TestARMCCallRewriterCondition(unittest.TestCase):
     # ---- Non-const cond_n_op returns None ----
 
     def test_symbolic_cond_n_op_returns_none(self):
-        cond_n_op = Expr.Register(0, None, 0, 32)  # symbolic
-        dep1 = Expr.Register(1, None, 0, 32)
-        dep2 = Expr.Register(2, None, 4, 32)
+        cond_n_op = Expr.Register(0, 0, 32)  # symbolic
+        dep1 = Expr.Register(1, 0, 32)
+        dep2 = Expr.Register(2, 4, 32)
         dep3 = Expr.Const(3, 0, 32)
         ccall = Expr.VEXCCallExpression(
             idx=0,
@@ -325,7 +325,7 @@ class TestARMCCallRewriterFlagHelpers(unittest.TestCase):
         assert isinstance(result, Expr.BinaryOp) and result.op == "CmpGT"
 
     def test_flag_c_logic_returns_dep2(self):
-        dep2 = Expr.Register(0, None, 4, 32)
+        dep2 = Expr.Register(0, 4, 32)
         ccall = _make_flag_ccall("armg_calculate_flag_c", ARMG_CC_OP_LOGIC, dep2=dep2)
         result = _rewrite(ccall)
         # Should return dep2 directly (shifter carry out)
@@ -337,9 +337,9 @@ class TestARMCCallRewriterFlagHelpers(unittest.TestCase):
         assert result is None
 
     def test_flag_c_symbolic_op_returns_none(self):
-        cc_op = Expr.Register(0, None, 0, 32)
-        dep1 = Expr.Register(1, None, 0, 32)
-        dep2 = Expr.Register(2, None, 4, 32)
+        cc_op = Expr.Register(0, 0, 32)
+        dep1 = Expr.Register(1, 0, 32)
+        dep2 = Expr.Register(2, 4, 32)
         dep3 = Expr.Const(3, 0, 32)
         ccall = Expr.VEXCCallExpression(
             idx=0, callee="armg_calculate_flag_c", operands=(cc_op, dep1, dep2, dep3), bits=32
@@ -418,7 +418,7 @@ class TestARMCCallRewriterRenamedCCall(unittest.TestCase):
     def test_renamed_ccall_wrong_operand_count_not_rewritten(self):
         # A _ccall with != 4 operands should not be rewritten
         cond_n_op = Expr.Const(0, _cond_n_op(ARMCondEQ, ARMG_CC_OP_SUB), 32)
-        dep1 = Expr.Register(1, None, 0, 32)
+        dep1 = Expr.Register(1, 0, 32)
         ccall = Expr.VEXCCallExpression(idx=0, callee="_ccall", operands=(cond_n_op, dep1), bits=32)
         result = _rewrite(ccall)
         assert result is None

--- a/tests/analyses/decompiler/test_optimization_passes.py
+++ b/tests/analyses/decompiler/test_optimization_passes.py
@@ -28,7 +28,7 @@ def c(v):
 
 def r(o):
     """Simple AIL Register shorthand"""
-    return Register(0, None, o, 32)
+    return Register(0, o, 32)
 
 
 class TestFlipBooleanCmp(unittest.TestCase):

--- a/tests/analyses/decompiler/test_optimization_passes.py
+++ b/tests/analyses/decompiler/test_optimization_passes.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 def c(v):
     """Simple AIL Const shorthand"""
-    return Const(0, None, v, 32)
+    return Const(0, v, 32)
 
 
 def r(o):

--- a/tests/analyses/decompiler/test_peephole_concat.py
+++ b/tests/analyses/decompiler/test_peephole_concat.py
@@ -24,7 +24,7 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
 
     def test_zero_extend_concat(self):
         # 0 CONCAT a  =>  Convert(a, unsigned, 2*bits)
-        low = Register(None, None, 0, 32)
+        low = Register(None, 0, 32)
         high = Const(None, 0, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
 
@@ -37,7 +37,7 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
 
     def test_sign_extend_concat(self):
         # (a >> 31) CONCAT a  =>  Convert(a, signed, 64)
-        low = Register(None, None, 0, 32)
+        low = Register(None, 0, 32)
         high = BinaryOp(None, "Sar", [low, Const(None, 31, 8)], False, bits=32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
 
@@ -50,8 +50,8 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
 
     def test_high_part_extraction(self):
         # (a CONCAT b) >> 32  =>  a
-        high = Register(None, None, 0, 32)
-        low = Register(None, None, 8, 32)
+        high = Register(None, 0, 32)
+        low = Register(None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
         shr = BinaryOp(None, "Shr", [concat, Const(None, 32, 8)], False, bits=64)
 
@@ -60,8 +60,8 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
 
     def test_low_part_extraction_and(self):
         # (a CONCAT b) & 0xFFFFFFFF  =>  b
-        high = Register(None, None, 0, 32)
-        low = Register(None, None, 8, 32)
+        high = Register(None, 0, 32)
+        low = Register(None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
         and_expr = BinaryOp(None, "And", [concat, Const(None, 0xFFFFFFFF, 64)], False, bits=64)
 
@@ -75,8 +75,8 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
 
     def test_truncate_concat(self):
         # Convert(a CONCAT b, 64->32)  =>  b
-        high = Register(None, None, 0, 32)
-        low = Register(None, None, 8, 32)
+        high = Register(None, 0, 32)
+        low = Register(None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
         conv = Convert(None, 64, 32, False, concat)
 
@@ -85,8 +85,8 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
 
     def test_no_optimization_non_matching_shift(self):
         # (a CONCAT b) >> 16  should NOT be optimized (not extracting high part exactly)
-        high = Register(None, None, 0, 32)
-        low = Register(None, None, 8, 32)
+        high = Register(None, 0, 32)
+        low = Register(None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
         shr = BinaryOp(None, "Shr", [concat, Const(None, 16, 8)], False, bits=64)
 
@@ -95,8 +95,8 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
 
     def test_no_optimization_non_matching_mask(self):
         # (a CONCAT b) & 0xFF  should NOT be optimized (not full low part mask)
-        high = Register(None, None, 0, 32)
-        low = Register(None, None, 8, 32)
+        high = Register(None, 0, 32)
+        low = Register(None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
         and_expr = BinaryOp(None, "And", [concat, Const(None, 0xFF, 64)], False, bits=64)
 

--- a/tests/analyses/decompiler/test_peephole_concat.py
+++ b/tests/analyses/decompiler/test_peephole_concat.py
@@ -25,7 +25,7 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
     def test_zero_extend_concat(self):
         # 0 CONCAT a  =>  Convert(a, unsigned, 2*bits)
         low = Register(None, None, 0, 32)
-        high = Const(None, None, 0, 32)
+        high = Const(None, 0, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
 
         result = self.opt.optimize(concat)
@@ -38,7 +38,7 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
     def test_sign_extend_concat(self):
         # (a >> 31) CONCAT a  =>  Convert(a, signed, 64)
         low = Register(None, None, 0, 32)
-        high = BinaryOp(None, "Sar", [low, Const(None, None, 31, 8)], False, bits=32)
+        high = BinaryOp(None, "Sar", [low, Const(None, 31, 8)], False, bits=32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
 
         result = self.opt.optimize(concat)
@@ -53,7 +53,7 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
         high = Register(None, None, 0, 32)
         low = Register(None, None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
-        shr = BinaryOp(None, "Shr", [concat, Const(None, None, 32, 8)], False, bits=64)
+        shr = BinaryOp(None, "Shr", [concat, Const(None, 32, 8)], False, bits=64)
 
         result = self.opt.optimize(shr)
         assert result == Convert(None, 32, 64, False, high)
@@ -63,7 +63,7 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
         high = Register(None, None, 0, 32)
         low = Register(None, None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
-        and_expr = BinaryOp(None, "And", [concat, Const(None, None, 0xFFFFFFFF, 64)], False, bits=64)
+        and_expr = BinaryOp(None, "And", [concat, Const(None, 0xFFFFFFFF, 64)], False, bits=64)
 
         result = self.opt.optimize(and_expr)
         # Result should be low, possibly with zero-extension
@@ -88,7 +88,7 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
         high = Register(None, None, 0, 32)
         low = Register(None, None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
-        shr = BinaryOp(None, "Shr", [concat, Const(None, None, 16, 8)], False, bits=64)
+        shr = BinaryOp(None, "Shr", [concat, Const(None, 16, 8)], False, bits=64)
 
         result = self.opt.optimize(shr)
         assert result is None
@@ -98,7 +98,7 @@ class TestPeepholeConcatSimplifier(unittest.TestCase):
         high = Register(None, None, 0, 32)
         low = Register(None, None, 8, 32)
         concat = BinaryOp(None, "Concat", [high, low], False, bits=64)
-        and_expr = BinaryOp(None, "And", [concat, Const(None, None, 0xFF, 64)], False, bits=64)
+        and_expr = BinaryOp(None, "And", [concat, Const(None, 0xFF, 64)], False, bits=64)
 
         result = self.opt.optimize(and_expr)
         assert result is None

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -28,7 +28,7 @@ class TestPeepholeOptimizations(unittest.TestCase):
 
         expr = ailment.Expr.Load(
             None,
-            ailment.Expr.Const(None, None, 0xA000, proj.arch.bits),
+            ailment.Expr.Const(None, 0xA000, proj.arch.bits),
             proj.arch.bytes,
             archinfo.Endness.LE,
             ins_addr=0x400100,
@@ -42,7 +42,7 @@ class TestPeepholeOptimizations(unittest.TestCase):
 
         # multiple cases that no optimization should happen
         # a. Loading a pointer from a writable location
-        expr = ailment.Expr.Load(None, ailment.Expr.Const(None, None, 0x21DF4, proj.arch.bits), 1, archinfo.Endness.LE)
+        expr = ailment.Expr.Load(None, ailment.Expr.Const(None, 0x21DF4, proj.arch.bits), 1, archinfo.Endness.LE)
         opt = ConstantDereferences(proj, proj.kb, manager, 0)
         optimized = opt.optimize(expr)
         assert optimized is None
@@ -54,13 +54,13 @@ class TestPeepholeOptimizations(unittest.TestCase):
         opt = EagerEvaluation(proj, proj.kb, manager)
 
         # Optimize 12 % 5 --> 2
-        expr = BinaryOp(None, "Mod", [Const(None, None, 12, 32), Const(None, None, 5, 32)])
+        expr = BinaryOp(None, "Mod", [Const(None, 12, 32), Const(None, 5, 32)])
         expr_opt = opt.optimize(expr)
         assert isinstance(expr_opt, Const)
         assert expr_opt.value == 2
 
         # Don't optimize x % 0
-        expr = BinaryOp(None, "Mod", [Const(None, None, 12, 32), Const(None, None, 0, 32)])
+        expr = BinaryOp(None, "Mod", [Const(None, 12, 32), Const(None, 0, 32)])
         expr_opt = opt.optimize(expr)
         assert expr_opt is None
 

--- a/tests/analyses/decompiler/test_rust_error_propagation_simplifier.py
+++ b/tests/analyses/decompiler/test_rust_error_propagation_simplifier.py
@@ -24,11 +24,11 @@ def _label(name: str = "lbl") -> Label:
 
 
 def _jump(target: int = 0x1000) -> Jump:
-    return Jump(0, Const(0, None, target, 64))
+    return Jump(0, Const(0, target, 64))
 
 
 def _const(value: int = 0, bits: int = 64) -> Const:
-    return Const(0, None, value, bits)
+    return Const(0, value, bits)
 
 
 def test_is_safe_block_accepts_label_and_register_assignment():

--- a/tests/analyses/decompiler/test_rust_misc_passes.py
+++ b/tests/analyses/decompiler/test_rust_misc_passes.py
@@ -33,7 +33,7 @@ from angr.rust.optimization_passes.struct_return_simplifier import StructReturnS
 
 
 def _const(value: int = 0, bits: int = 64) -> Const:
-    return Const(0, None, value, bits)
+    return Const(0, value, bits)
 
 
 def _stack_vvar(varid: int = 0, bits: int = 64, offset: int = 0x10) -> VirtualVariable:

--- a/tests/analyses/decompiler/test_rust_outliners.py
+++ b/tests/analyses/decompiler/test_rust_outliners.py
@@ -55,7 +55,7 @@ def _string_cmp_outliner() -> StringCmpOutliner:
 
 
 def _const(value: int, bits: int = 64) -> Const:
-    return Const(0, None, value, bits)
+    return Const(0, value, bits)
 
 
 def _load(addr_expr, bits: int = 64) -> Load:
@@ -200,8 +200,8 @@ def test_unwrap_state_decides_eq_discriminant_when_true_target_matches_failed_bl
     jump = ConditionalJump(
         0,
         cond,
-        Const(0, None, 0x4000, 64),
-        Const(0, None, 0x5000, 64),
+        Const(0, 0x4000, 64),
+        Const(0, 0x5000, 64),
         true_target_idx=0,
         false_target_idx=0,
     )
@@ -224,8 +224,8 @@ def test_unwrap_state_decides_ne_discriminant_when_false_target_matches_failed_b
     jump = ConditionalJump(
         0,
         cond,
-        Const(0, None, 0x5000, 64),
-        Const(0, None, 0x4000, 64),
+        Const(0, 0x5000, 64),
+        Const(0, 0x4000, 64),
         true_target_idx=0,
         false_target_idx=0,
     )
@@ -244,9 +244,7 @@ def test_unwrap_state_decides_ne_discriminant_when_false_target_matches_failed_b
 def test_unwrap_state_returns_none_for_non_binary_condition():
     vvar = _stack_vvar()
     failed_block = Block(0x4000, 0, statements=[], idx=0)
-    jump = ConditionalJump(
-        0, vvar, Const(0, None, 0x4000, 64), Const(0, None, 0x5000, 64), true_target_idx=0, false_target_idx=0
-    )
+    jump = ConditionalJump(0, vvar, Const(0, 0x4000, 64), Const(0, 0x5000, 64), true_target_idx=0, false_target_idx=0)
     cond_block = Block(0x3000, 0, statements=[jump], idx=0)
     state = UnwrapSimplifierState(
         conditional_jump_block=cond_block,

--- a/tests/analyses/decompiler/test_rust_pattern_match_simplifier.py
+++ b/tests/analyses/decompiler/test_rust_pattern_match_simplifier.py
@@ -14,7 +14,7 @@ class TestRustPatternMatchSimplifier(unittest.TestCase):
     def test_extracts_sign_bit_niche_discriminant(self):
         vvar = VirtualVariable(None, 0, 64, VirtualVariableCategory.STACK, -0x20)
         cast = Convert(None, 64, 64, True, vvar)
-        zero = Const(None, None, 0, 64)
+        zero = Const(None, 0, 64)
         condition = Convert(
             None,
             64,
@@ -33,7 +33,7 @@ class TestRustPatternMatchSimplifier(unittest.TestCase):
                         ],
                         bits=64,
                     ),
-                    Const(None, None, 63, 8),
+                    Const(None, 63, 8),
                 ],
                 bits=64,
             ),

--- a/tests/analyses/decompiler/test_rust_small_passes.py
+++ b/tests/analyses/decompiler/test_rust_small_passes.py
@@ -37,7 +37,7 @@ def _label_stmt(name: str = "lbl") -> Label:
 
 
 def _jump_stmt(target_addr: int = 0x1000) -> Jump:
-    return Jump(0, Const(0, None, target_addr, 64))
+    return Jump(0, Const(0, target_addr, 64))
 
 
 def test_cleanup_functions_list_covers_known_dealloc_and_drop_names():

--- a/tests/analyses/decompiler/test_rust_struct_instantiation_simplifier.py
+++ b/tests/analyses/decompiler/test_rust_struct_instantiation_simplifier.py
@@ -14,7 +14,7 @@ from angr.rust.optimization_passes.struct_instantiation_simplifier import Struct
 
 
 def _const(value: int = 0, bits: int = 64) -> Const:
-    return Const(0, None, value, bits)
+    return Const(0, value, bits)
 
 
 def test_rebase_field_exprs_subtracts_field_offset_from_each_key():

--- a/tests/analyses/decompiler/test_variable_map.py
+++ b/tests/analyses/decompiler/test_variable_map.py
@@ -11,111 +11,88 @@ from angr.sim_type import SimTypeChar, SimTypePointer
 from angr.sim_variable import SimRegisterVariable, SimStackVariable
 
 
-class _FakeConst:
-    """A stand-in for an AIL Const expression that only exposes ``.idx``."""
-
-    def __init__(self, idx):
-        self.idx = idx
-
-
-class _FakeBinOp:
-    """A stand-in for a different AIL expression class that shares an ``.idx`` with a _FakeConst."""
+class _FakeAtom:
+    """A stand-in for an AIL Statement/Expression that only exposes ``.idx``."""
 
     def __init__(self, idx):
         self.idx = idx
 
 
 class TestVariableMap(unittest.TestCase):
-    def test_set_and_get(self):
+    def test_set_and_get_by_object_and_idx(self):
         vm = VariableMap()
-        atom = _FakeConst(7)
+        atom = _FakeAtom(7)
         var = SimRegisterVariable(8, 8, ident="reg_1")
 
         vm.set_variable(atom, var, 4)
 
+        # access by object
         assert vm.variable(atom) is var
         assert vm.variable_offset(atom) == 4
-        assert vm.has_variable(atom)
-        # a freshly-constructed equal object resolves to the same entry (keyed by idx + class)
-        assert vm.variable(_FakeConst(7)) is var
-
-    def test_idx_collision_between_classes(self):
-        # AIL reuses .idx across distinct objects; objects of different classes that share an idx must NOT be
-        # conflated.
-        vm = VariableMap()
-        const = _FakeConst(11666)
-        binop = _FakeBinOp(11666)
-        var = SimRegisterVariable(8, 8, ident="reg_const")
-
-        vm.set_variable(const, var, 0)
-
-        assert vm.variable(const) is var
-        assert vm.variable(binop) is None
-        assert not vm.has_variable(binop)
+        # access by idx directly
+        assert vm.variable(7) is var
+        assert vm.variable_offset(7) == 4
+        assert vm.has_variable(7)
 
     def test_defaults_for_missing_keys(self):
         vm = VariableMap()
-        missing = _FakeConst(123)
-        assert vm.variable(missing) is None
-        assert vm.variable_offset(missing) == 0
-        assert vm.custom_string(missing) is False
-        assert vm.reference_values(missing) is None
-        assert vm.reference_variable(missing) is None
-        assert vm.reference_variable_offset(missing) == 0
-        assert not vm.has_variable(missing)
+        assert vm.variable(123) is None
+        assert vm.variable_offset(123) == 0
+        assert vm.custom_string(123) is False
+        assert vm.reference_values(123) is None
+        assert vm.reference_variable(123) is None
+        assert vm.reference_variable_offset(123) == 0
+        assert not vm.has_variable(123)
 
     def test_custom_string_and_reference_variable(self):
         vm = VariableMap()
-        a, b = _FakeConst(1), _FakeConst(2)
-        vm.set_custom_string(a)
+        vm.set_custom_string(1)
         ref_var = SimStackVariable(-0x10, 8, ident="stack_2")
-        vm.set_reference_variable(b, ref_var, 3)
+        vm.set_reference_variable(2, ref_var, 3)
 
-        assert vm.custom_string(a) is True
-        assert vm.reference_variable(b) is ref_var
-        assert vm.reference_variable_offset(b) == 3
+        assert vm.custom_string(1) is True
+        assert vm.reference_variable(2) is ref_var
+        assert vm.reference_variable_offset(2) == 3
 
     def test_transfer(self):
         vm = VariableMap()
-        src = _FakeConst(1)
-        dst = _FakeConst(2)
         var = SimRegisterVariable(8, 8, ident="reg_1")
-        vm.set_variable(src, var, 4)
-        vm.set_custom_string(src)
+        vm.set_variable(1, var, 4)
+        vm.set_custom_string(1)
 
-        vm.transfer(src, dst)
+        vm.transfer(1, 2)
 
-        assert vm.variable(dst) is var
-        assert vm.variable_offset(dst) == 4
-        assert vm.custom_string(dst) is True
+        assert vm.variable(2) is var
+        assert vm.variable_offset(2) == 4
+        assert vm.custom_string(2) is True
 
     def test_json_round_trip(self):
         vm = VariableMap()
         v1 = SimRegisterVariable(8, 8, ident="reg_1")
         v2 = SimStackVariable(-0x10, 8, ident="stack_2")
-        a, b, c, d, e = _FakeConst(1), _FakeConst(2), _FakeConst(3), _FakeConst(4), _FakeConst(5)
-        vm.set_variable(a, v1, 0)
-        vm.set_variable(b, v2, 8)
-        vm.set_custom_string(c)
-        vm.set_reference_variable(d, v2, 2)
+        vm.set_variable(1, v1, 0)
+        vm.set_variable(2, v2, 8)
+        vm.set_custom_string(3)
+        vm.set_reference_variable(4, v2, 2)
         char_ptr = SimTypePointer(SimTypeChar())
-        vm.set_reference_values(e, {char_ptr: "hello"})
+        vm.set_reference_values(5, {char_ptr: "hello"})
 
+        # ensure the result is JSON-serializable
         blob = json.dumps(vm.to_json())
         data = json.loads(blob)
 
         idents = {"reg_1": v1, "stack_2": v2}
         restored = VariableMap.from_json(data, idents.get)
 
-        assert restored.variable(a) is v1
-        assert restored.variable_offset(a) == 0
-        assert restored.variable(b) is v2
-        assert restored.variable_offset(b) == 8
-        assert restored.custom_string(c) is True
-        assert restored.reference_variable(d) is v2
-        assert restored.reference_variable_offset(d) == 2
+        assert restored.variable(1) is v1
+        assert restored.variable_offset(1) == 0
+        assert restored.variable(2) is v2
+        assert restored.variable_offset(2) == 8
+        assert restored.custom_string(3) is True
+        assert restored.reference_variable(4) is v2
+        assert restored.reference_variable_offset(4) == 2
 
-        ref_vals = restored.reference_values(e)
+        ref_vals = restored.reference_values(5)
         assert ref_vals is not None
         assert len(ref_vals) == 1
         (ty, val) = next(iter(ref_vals.items()))

--- a/tests/analyses/decompiler/test_variable_map.py
+++ b/tests/analyses/decompiler/test_variable_map.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use
 from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin

--- a/tests/analyses/decompiler/test_variable_map.py
+++ b/tests/analyses/decompiler/test_variable_map.py
@@ -11,76 +11,111 @@ from angr.sim_type import SimTypeChar, SimTypePointer
 from angr.sim_variable import SimRegisterVariable, SimStackVariable
 
 
-class _FakeAtom:
-    """A stand-in for an AIL Statement/Expression that only exposes ``.idx``."""
+class _FakeConst:
+    """A stand-in for an AIL Const expression that only exposes ``.idx``."""
+
+    def __init__(self, idx):
+        self.idx = idx
+
+
+class _FakeBinOp:
+    """A stand-in for a different AIL expression class that shares an ``.idx`` with a _FakeConst."""
 
     def __init__(self, idx):
         self.idx = idx
 
 
 class TestVariableMap(unittest.TestCase):
-    def test_set_and_get_by_object_and_idx(self):
+    def test_set_and_get(self):
         vm = VariableMap()
-        atom = _FakeAtom(7)
+        atom = _FakeConst(7)
         var = SimRegisterVariable(8, 8, ident="reg_1")
 
         vm.set_variable(atom, var, 4)
 
-        # access by object
         assert vm.variable(atom) is var
         assert vm.variable_offset(atom) == 4
-        # access by idx directly
-        assert vm.variable(7) is var
-        assert vm.variable_offset(7) == 4
-        assert vm.has_variable(7)
+        assert vm.has_variable(atom)
+        # a freshly-constructed equal object resolves to the same entry (keyed by idx + class)
+        assert vm.variable(_FakeConst(7)) is var
+
+    def test_idx_collision_between_classes(self):
+        # AIL reuses .idx across distinct objects; objects of different classes that share an idx must NOT be
+        # conflated.
+        vm = VariableMap()
+        const = _FakeConst(11666)
+        binop = _FakeBinOp(11666)
+        var = SimRegisterVariable(8, 8, ident="reg_const")
+
+        vm.set_variable(const, var, 0)
+
+        assert vm.variable(const) is var
+        assert vm.variable(binop) is None
+        assert not vm.has_variable(binop)
 
     def test_defaults_for_missing_keys(self):
         vm = VariableMap()
-        assert vm.variable(123) is None
-        assert vm.variable_offset(123) == 0
-        assert vm.custom_string(123) is False
-        assert vm.reference_values(123) is None
-        assert vm.reference_variable(123) is None
-        assert vm.reference_variable_offset(123) == 0
-        assert not vm.has_variable(123)
+        missing = _FakeConst(123)
+        assert vm.variable(missing) is None
+        assert vm.variable_offset(missing) == 0
+        assert vm.custom_string(missing) is False
+        assert vm.reference_values(missing) is None
+        assert vm.reference_variable(missing) is None
+        assert vm.reference_variable_offset(missing) == 0
+        assert not vm.has_variable(missing)
 
     def test_custom_string_and_reference_variable(self):
         vm = VariableMap()
-        vm.set_custom_string(1)
+        a, b = _FakeConst(1), _FakeConst(2)
+        vm.set_custom_string(a)
         ref_var = SimStackVariable(-0x10, 8, ident="stack_2")
-        vm.set_reference_variable(2, ref_var, 3)
+        vm.set_reference_variable(b, ref_var, 3)
 
-        assert vm.custom_string(1) is True
-        assert vm.reference_variable(2) is ref_var
-        assert vm.reference_variable_offset(2) == 3
+        assert vm.custom_string(a) is True
+        assert vm.reference_variable(b) is ref_var
+        assert vm.reference_variable_offset(b) == 3
+
+    def test_transfer(self):
+        vm = VariableMap()
+        src = _FakeConst(1)
+        dst = _FakeConst(2)
+        var = SimRegisterVariable(8, 8, ident="reg_1")
+        vm.set_variable(src, var, 4)
+        vm.set_custom_string(src)
+
+        vm.transfer(src, dst)
+
+        assert vm.variable(dst) is var
+        assert vm.variable_offset(dst) == 4
+        assert vm.custom_string(dst) is True
 
     def test_json_round_trip(self):
         vm = VariableMap()
         v1 = SimRegisterVariable(8, 8, ident="reg_1")
         v2 = SimStackVariable(-0x10, 8, ident="stack_2")
-        vm.set_variable(1, v1, 0)
-        vm.set_variable(2, v2, 8)
-        vm.set_custom_string(3)
-        vm.set_reference_variable(4, v2, 2)
+        a, b, c, d, e = _FakeConst(1), _FakeConst(2), _FakeConst(3), _FakeConst(4), _FakeConst(5)
+        vm.set_variable(a, v1, 0)
+        vm.set_variable(b, v2, 8)
+        vm.set_custom_string(c)
+        vm.set_reference_variable(d, v2, 2)
         char_ptr = SimTypePointer(SimTypeChar())
-        vm.set_reference_values(5, {char_ptr: "hello"})
+        vm.set_reference_values(e, {char_ptr: "hello"})
 
-        # ensure the result is JSON-serializable
         blob = json.dumps(vm.to_json())
         data = json.loads(blob)
 
         idents = {"reg_1": v1, "stack_2": v2}
         restored = VariableMap.from_json(data, idents.get)
 
-        assert restored.variable(1) is v1
-        assert restored.variable_offset(1) == 0
-        assert restored.variable(2) is v2
-        assert restored.variable_offset(2) == 8
-        assert restored.custom_string(3) is True
-        assert restored.reference_variable(4) is v2
-        assert restored.reference_variable_offset(4) == 2
+        assert restored.variable(a) is v1
+        assert restored.variable_offset(a) == 0
+        assert restored.variable(b) is v2
+        assert restored.variable_offset(b) == 8
+        assert restored.custom_string(c) is True
+        assert restored.reference_variable(d) is v2
+        assert restored.reference_variable_offset(d) == 2
 
-        ref_vals = restored.reference_values(5)
+        ref_vals = restored.reference_values(e)
         assert ref_vals is not None
         assert len(ref_vals) == 1
         (ty, val) = next(iter(ref_vals.items()))

--- a/tests/analyses/decompiler/test_variable_map.py
+++ b/tests/analyses/decompiler/test_variable_map.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import json
+import unittest
+
+from angr.analyses.decompiler.variable_map import VariableMap
+from angr.sim_type import SimTypeChar, SimTypePointer
+from angr.sim_variable import SimRegisterVariable, SimStackVariable
+
+
+class _FakeAtom:
+    """A stand-in for an AIL Statement/Expression that only exposes ``.idx``."""
+
+    def __init__(self, idx):
+        self.idx = idx
+
+
+class TestVariableMap(unittest.TestCase):
+    def test_set_and_get_by_object_and_idx(self):
+        vm = VariableMap()
+        atom = _FakeAtom(7)
+        var = SimRegisterVariable(8, 8, ident="reg_1")
+
+        vm.set_variable(atom, var, 4)
+
+        # access by object
+        assert vm.variable(atom) is var
+        assert vm.variable_offset(atom) == 4
+        # access by idx directly
+        assert vm.variable(7) is var
+        assert vm.variable_offset(7) == 4
+        assert vm.has_variable(7)
+
+    def test_defaults_for_missing_keys(self):
+        vm = VariableMap()
+        assert vm.variable(123) is None
+        assert vm.variable_offset(123) == 0
+        assert vm.custom_string(123) is False
+        assert vm.reference_values(123) is None
+        assert vm.reference_variable(123) is None
+        assert vm.reference_variable_offset(123) == 0
+        assert not vm.has_variable(123)
+
+    def test_custom_string_and_reference_variable(self):
+        vm = VariableMap()
+        vm.set_custom_string(1)
+        ref_var = SimStackVariable(-0x10, 8, ident="stack_2")
+        vm.set_reference_variable(2, ref_var, 3)
+
+        assert vm.custom_string(1) is True
+        assert vm.reference_variable(2) is ref_var
+        assert vm.reference_variable_offset(2) == 3
+
+    def test_json_round_trip(self):
+        vm = VariableMap()
+        v1 = SimRegisterVariable(8, 8, ident="reg_1")
+        v2 = SimStackVariable(-0x10, 8, ident="stack_2")
+        vm.set_variable(1, v1, 0)
+        vm.set_variable(2, v2, 8)
+        vm.set_custom_string(3)
+        vm.set_reference_variable(4, v2, 2)
+        char_ptr = SimTypePointer(SimTypeChar())
+        vm.set_reference_values(5, {char_ptr: "hello"})
+
+        # ensure the result is JSON-serializable
+        blob = json.dumps(vm.to_json())
+        data = json.loads(blob)
+
+        idents = {"reg_1": v1, "stack_2": v2}
+        restored = VariableMap.from_json(data, idents.get)
+
+        assert restored.variable(1) is v1
+        assert restored.variable_offset(1) == 0
+        assert restored.variable(2) is v2
+        assert restored.variable_offset(2) == 8
+        assert restored.custom_string(3) is True
+        assert restored.reference_variable(4) is v2
+        assert restored.reference_variable_offset(4) == 2
+
+        ref_vals = restored.reference_values(5)
+        assert ref_vals is not None
+        assert len(ref_vals) == 1
+        (ty, val) = next(iter(ref_vals.items()))
+        assert isinstance(ty, SimTypePointer)
+        assert val == "hello"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/test_rust_utils.py
+++ b/tests/analyses/test_rust_utils.py
@@ -47,7 +47,7 @@ def _ref(operand) -> UnaryOp:
 
 
 def _const(value: int, bits: int = 64) -> Const:
-    return Const(0, None, value, bits)
+    return Const(0, value, bits)
 
 
 def test_unwrap_stack_vvar_reference_returns_underlying_vvar():
@@ -195,27 +195,27 @@ def _project_with_synthetic_function(addr: int, name: str):
 
 def test_extract_callee_returns_function_for_call_with_const_target():
     project = _project_with_synthetic_function(0x0, "callee")
-    call = Call(0, Const(0, None, 0x0, 64), args=[])
+    call = Call(0, Const(0, 0x0, 64), args=[])
     result = extract_callee(call, project.kb)
     assert result is project.kb.functions[0x0]
 
 
 def test_extract_callee_walks_block_to_terminal_call():
     project = _project_with_synthetic_function(0x0, "callee")
-    call = Call(0, Const(0, None, 0x0, 64), args=[])
+    call = Call(0, Const(0, 0x0, 64), args=[])
     block = Block(0x100, 0, statements=[call])  # pyright: ignore[reportArgumentType]
     assert extract_callee(block, project.kb) is project.kb.functions[0x0]
 
 
 def test_extract_callee_returns_none_for_unknown_target():
     project = _project_with_synthetic_function(0x0, "callee")
-    unknown = Call(0, Const(0, None, 0xDEADBEEF, 64), args=[])
+    unknown = Call(0, Const(0, 0xDEADBEEF, 64), args=[])
     assert extract_callee(unknown, project.kb) is None
 
 
 def test_extract_callee_returns_none_for_non_block_non_call():
     project = _project_with_synthetic_function(0x0, "callee")
-    assert extract_callee(Const(0, None, 0, 64), project.kb) is None
+    assert extract_callee(Const(0, 0, 64), project.kb) is None
 
 
 def test_extract_str_short_circuits_for_zero_length():

--- a/tests/sim/test_ail_exec.py
+++ b/tests/sim/test_ail_exec.py
@@ -76,10 +76,10 @@ class TestAILExec(unittest.TestCase):
 
         # armg_calculate_condition(state, cond_n_op, cc_dep1, cc_dep2, cc_dep3) -> I32
         # Use ARMCondAL so the result should be 1.
-        cond_n_op = ailment.expression.Const(None, None, 0xE0, 32)  # (AL<<4) | 0
-        cc_dep1 = ailment.expression.Const(None, None, 0, 32)
-        cc_dep2 = ailment.expression.Const(None, None, 0, 32)
-        cc_dep3 = ailment.expression.Const(None, None, 0, 32)
+        cond_n_op = ailment.expression.Const(None, 0xE0, 32)  # (AL<<4) | 0
+        cc_dep1 = ailment.expression.Const(None, 0, 32)
+        cc_dep2 = ailment.expression.Const(None, 0, 32)
+        cc_dep3 = ailment.expression.Const(None, 0, 32)
         ccall_expr = ailment.expression.VEXCCallExpression(
             idx=0,
             callee="armg_calculate_condition",
@@ -93,7 +93,7 @@ class TestAILExec(unittest.TestCase):
             src=ccall_expr,
         )
         assign_stmt.tags["ins_addr"] = 0x400000
-        jump_stmt = ailment.statement.Jump(idx=1, target=ailment.expression.Const(None, None, 0x400004, 32))
+        jump_stmt = ailment.statement.Jump(idx=1, target=ailment.expression.Const(None, 0x400004, 32))
         jump_stmt.tags["ins_addr"] = 0x400000
         block = ailment.Block(0x400000, 0, statements=[assign_stmt, jump_stmt])
 
@@ -123,9 +123,9 @@ class TestAILExec(unittest.TestCase):
         state.register_plugin("callstack", bottom_frame)
         state.callstack.push(top_frame)
 
-        cond_bv1 = ailment.expression.Const(None, None, 1, 1)  # BV1(1)
-        true_tgt = ailment.expression.Const(None, None, 0x400004, 64)
-        false_tgt = ailment.expression.Const(None, None, 0x400008, 64)
+        cond_bv1 = ailment.expression.Const(None, 1, 1)  # BV1(1)
+        true_tgt = ailment.expression.Const(None, 0x400004, 64)
+        false_tgt = ailment.expression.Const(None, 0x400008, 64)
         cjmp = ailment.statement.ConditionalJump(0, cond_bv1, true_tgt, false_tgt)
         cjmp.tags["ins_addr"] = 0x400000
         block = ailment.Block(0x400000, 0, statements=[cjmp])
@@ -168,7 +168,7 @@ class TestAILExec(unittest.TestCase):
         state.callstack.push(top_frame)
 
         # predecessor block: jump to successor
-        pred_jump = ailment.statement.Jump(idx=0, target=ailment.expression.Const(None, None, 0x400004, 64))
+        pred_jump = ailment.statement.Jump(idx=0, target=ailment.expression.Const(None, 0x400004, 64))
         pred_jump.tags["ins_addr"] = 0x400000
         pred_block = ailment.Block(0x400000, 0, statements=[pred_jump])
 
@@ -197,7 +197,7 @@ class TestAILExec(unittest.TestCase):
             src=phi,
         )
         assign.tags["ins_addr"] = 0x400004
-        succ_jump = ailment.statement.Jump(idx=1, target=ailment.expression.Const(None, None, 0x400008, 64))
+        succ_jump = ailment.statement.Jump(idx=1, target=ailment.expression.Const(None, 0x400008, 64))
         succ_jump.tags["ins_addr"] = 0x400004
         succ_block = ailment.Block(0x400004, 0, statements=[assign, succ_jump])
 
@@ -242,12 +242,12 @@ class TestAILExec(unittest.TestCase):
         )
         ref = ailment.expression.UnaryOp(idx=0, op="Reference", operand=vvar, bits=p.arch.bits)
 
-        call_tgt = ailment.expression.Const(None, None, 0xDEADBEEF, p.arch.bits)
+        call_tgt = ailment.expression.Const(None, 0xDEADBEEF, p.arch.bits)
         call_expr = ailment.expression.Call(idx=0, target=call_tgt, args=[ref], bits=p.arch.bits)
         call = ailment.statement.SideEffectStatement(idx=0, expr=call_expr)
         call.tags["ins_addr"] = 0x400000
 
-        jmp = ailment.statement.Jump(idx=1, target=ailment.expression.Const(None, None, 0x400004, p.arch.bits))
+        jmp = ailment.statement.Jump(idx=1, target=ailment.expression.Const(None, 0x400004, p.arch.bits))
         jmp.tags["ins_addr"] = 0x400000
 
         block = ailment.Block(0x400000, 0, statements=[call, jmp])
@@ -284,7 +284,7 @@ class TestAILExec(unittest.TestCase):
         # A Call expression wrapped in SideEffectStatement with no return assignment (unused return value).
         call_expr = ailment.expression.Call(
             idx=0,
-            target=ailment.expression.Const(None, None, 0x5000, 32),
+            target=ailment.expression.Const(None, 0x5000, 32),
             args=[],
             bits=32,
         )
@@ -297,7 +297,7 @@ class TestAILExec(unittest.TestCase):
         # The light AIL engine expects statements to carry an instruction address tag.
         call_stmt.tags["ins_addr"] = 0x400000
         # Add a diverging statement afterwards to avoid requiring a real lifter/graph in _process_block_end().
-        jump_stmt = ailment.statement.Jump(idx=1, target=ailment.expression.Const(None, None, 0x400004, 32))
+        jump_stmt = ailment.statement.Jump(idx=1, target=ailment.expression.Const(None, 0x400004, 32))
         jump_stmt.tags["ins_addr"] = 0x400000
         block = ailment.Block(0x400000, 0, statements=[call_stmt, jump_stmt])
 
@@ -380,7 +380,7 @@ class TestAILExec(unittest.TestCase):
 
         state.globals["ail_lifter"] = lambda _addr: _FakeClinic()  # type: ignore
 
-        jump = ailment.statement.Jump(0, ailment.expression.Const(None, None, 0x400004, 64))
+        jump = ailment.statement.Jump(0, ailment.expression.Const(None, 0x400004, 64))
         jump.tags["ins_addr"] = 0x400000
         block = ailment.Block(0x400000, 0, statements=[jump])
 

--- a/tests/sim/test_ail_exec.py
+++ b/tests/sim/test_ail_exec.py
@@ -89,7 +89,7 @@ class TestAILExec(unittest.TestCase):
         r0_offset = p.arch.registers["r0"][0]
         assign_stmt = ailment.statement.Assignment(
             idx=0,
-            dst=ailment.expression.Register(None, None, r0_offset, 32),
+            dst=ailment.expression.Register(None, r0_offset, 32),
             src=ccall_expr,
         )
         assign_stmt.tags["ins_addr"] = 0x400000
@@ -193,7 +193,7 @@ class TestAILExec(unittest.TestCase):
         rax_offset = p.arch.registers["rax"][0]
         assign = ailment.statement.Assignment(
             idx=0,
-            dst=ailment.expression.Register(None, None, rax_offset, 64),
+            dst=ailment.expression.Register(None, rax_offset, 64),
             src=phi,
         )
         assign.tags["ins_addr"] = 0x400004


### PR DESCRIPTION
This refactor eliminates `Expression.variable` and `Expression.variable_offset`, along with a few relevant fields on `Expression` and `Statement`.