### PR TITLE
SPropogator: Reduce the number of AILBlockWalker instances.

### DIFF
--- a/angr/ailment/block_walker.py
+++ b/angr/ailment/block_walker.py
@@ -99,6 +99,12 @@ class AILBlockWalker[ExprType, StmtType, BlockType]:
             expr_handlers or _default_expr_handlers
         )
 
+    def reset(self) -> None:
+        """
+        Reset per-walk state variables so that this walker can be reused for another walk. Subclasses that updates
+        state across a walk must override this to clear that state.
+        """
+
     def walk(self, block: Block) -> BlockType:
         i = 0
         results = []

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -12,6 +12,7 @@ from cle import SymbolType
 from angr import ailment
 from angr.analyses.analysis import AnalysesHub, Analysis
 from angr.analyses.cfg import CFGFast
+from angr.analyses.s_propagator import sprop_cache_scope
 from angr.analyses.typehoon.typehoon import Typehoon
 from angr.analyses.typehoon.typevars import TypeVariableManager
 from angr.errors import AngrAIError
@@ -196,6 +197,11 @@ class Decompiler(Analysis):
         self.use_cache = use_cache
         self.update_cache = update_cache
 
+        # cache of reusable AILBlockWalker instances that are shared by all SPropagator instances created during
+        # decompilation. Owned here so all walkers are released when this Decompiler instance is garbage-collected.
+        # SPropagator picks up this cache (see walker_cache_scope).
+        self._sprop_walker_cache: dict = {}
+
         self._codegen_cls = CStructuredCodeGenerator
         self._typehoon_cls = Typehoon
         if self._flavor == "rust":
@@ -204,7 +210,7 @@ class Decompiler(Analysis):
 
         if decompile:
             with self._resilience():
-                self._decompile()
+                self._decompile_with_cache()
             if self.errors:
                 if self.update_cache:
                     if (self.func.addr, self._flavor) not in self.kb.decompilations:
@@ -217,7 +223,7 @@ class Decompiler(Analysis):
                         self._optimization_passes = DECOMPILATION_PRESETS["basic"].get_optimization_passes(
                             self.project.arch, self.project.simos.name
                         )
-                        self._decompile()
+                        self._decompile_with_cache()
                         if self.update_cache:
                             for error in self.errors:
                                 self.kb.decompilations[(self.func.addr, self._flavor)].errors.append(error.format())
@@ -242,6 +248,10 @@ class Decompiler(Analysis):
                 o = PARAM_TO_OPTION[o]
             converted_options.append((o, v))
         return converted_options
+
+    def _decompile_with_cache(self):
+        with sprop_cache_scope(self._sprop_walker_cache):
+            self._decompile()
 
     @timethis
     def _decompile(self):

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -1,4 +1,4 @@
-# pylint:disable=unused-import
+# pylint:disable=unused-import,protected-access
 from __future__ import annotations
 
 import logging
@@ -196,6 +196,13 @@ class Decompiler(Analysis):
         self.region_identifier = None
         self.use_cache = use_cache
         self.update_cache = update_cache
+
+        self._variable_map = None
+        # structuring-specific parameters - will be reset in _decompile()
+        self._force_loop_single_exit = True
+        self._refine_loops_with_single_successor = False
+        self._complete_successors = False
+        self._recursive_structurer_params = {}
 
         # cache of reusable AILBlockWalker instances that are shared by all SPropagator instances created during
         # decompilation. Owned here so all walkers are released when this Decompiler instance is garbage-collected.

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -868,6 +868,9 @@ class _PeepholeExprsWalker(ailment.AILBlockRewriter):
 
         super().__init__(*args, **kwargs)
 
+    def reset(self) -> None:
+        self.any_update = False
+
     def _handle_expr(
         self, expr_idx: int, expr: ailment.Expr.Expression, stmt_idx: int, stmt: ailment.Stmt.Statement | None, block
     ) -> ailment.Expression:

--- a/angr/analyses/s_liveness.py
+++ b/angr/analyses/s_liveness.py
@@ -56,6 +56,9 @@ class SLivenessAnalysis(Analysis):
         graph = self.func_graph
         entry = self.entry
 
+        # a single collector is reused for every statement (reset before each walk)
+        vvar_use_collector = VVarUsesCollector()
+
         # initialize the live_in and live_out sets
         live_ins = {}
         live_outs = {}
@@ -143,7 +146,7 @@ class SLivenessAnalysis(Analysis):
                         if src != (block.addr, block.idx) and vvar is not None:
                             live |= {vvar.varid}
                 else:
-                    vvar_use_collector = VVarUsesCollector()
+                    vvar_use_collector.reset()
                     vvar_use_collector.walk_statement(stmt)
                     live |= vvar_use_collector.vvars
 
@@ -177,6 +180,9 @@ class SLivenessAnalysis(Analysis):
 
         graph = networkx.Graph()
 
+        # a single collector is reused for every statement (reset before each walk)
+        vvar_use_collector = VVarUsesCollector()
+
         for block in self.func_graph.nodes():
             live = self.model.live_outs[(block.addr, block.idx)].copy()
 
@@ -198,7 +204,7 @@ class SLivenessAnalysis(Analysis):
                     def_vvars.append(stmt.ret_expr.varid)
 
                 # handle the statement: add used vvars to the live set
-                vvar_use_collector = VVarUsesCollector()
+                vvar_use_collector.reset()
                 vvar_use_collector.walk_statement(stmt)
 
                 for def_vvar in def_vvars:
@@ -222,6 +228,9 @@ class SLivenessAnalysis(Analysis):
         :return: A dictionary mapping statements to sets of live variable IDs.
         """
         live_vars = defaultdict(dict)
+
+        # a single collector is reused for every statement (reset before each walk)
+        vvar_use_collector = VVarUsesCollector()
 
         for block in self.func_graph.nodes():
             live = self.model.live_outs[(block.addr, block.idx)].copy()
@@ -247,7 +256,7 @@ class SLivenessAnalysis(Analysis):
                     def_vvars.append(stmt.ret_expr.varid)
 
                 # handle the statement: add used vvars to the live set
-                vvar_use_collector = VVarUsesCollector()
+                vvar_use_collector.reset()
                 vvar_use_collector.walk_statement(stmt)
 
                 live_vars[block_key][stmt_idx] = live.copy()

--- a/angr/analyses/s_propagator.py
+++ b/angr/analyses/s_propagator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import threading
 from collections import defaultdict
 from collections.abc import Mapping
 
@@ -25,6 +26,11 @@ from angr.analyses.analysis import Analysis, register_analysis
 from angr.code_location import AILCodeLocation
 from angr.knowledge_plugins.functions import Function
 from angr.utils.ssa import (
+    CONST_VVAR_LOAD_DIRTY_WHITELIST,
+    CONST_VVAR_LOAD_WHITELIST,
+    CONST_VVAR_TMP_WHITELIST,
+    CONST_VVAR_WHITELIST,
+    AILWhitelistExprTypeWalker,
     get_tmp_deflocs,
     get_tmp_uselocs,
     get_vvar_deflocs,
@@ -41,6 +47,38 @@ from angr.utils.ssa import (
     is_phi_assignment,
     is_vvar_propagatable,
 )
+
+# The cache of reusable AILBlockWalker instances, which are used by is_const_*(). The cache dict itself is
+# owned by the corresponding Decompiler instance (so it is released when the Decompiler is gone). This thread-local
+# points at the active Decompiler's walker cache for the duration of its run, which allows all SPropagator instances
+# created during the same decompilation run share walkers.
+# Make sure all walkers added to this cache are properly reset before using.
+_tls = threading.local()
+
+
+@contextlib.contextmanager
+def sprop_cache_scope(cache: dict[tuple[type, ...], AILWhitelistExprTypeWalker]):
+    """
+    Install ``cache`` as the active AILBlockWalker cache for the current thread.
+    """
+    prev = getattr(_tls, "walker_cache", None)
+    _tls.walker_cache = cache
+    try:
+        yield
+    finally:
+        _tls.walker_cache = prev
+
+
+def _whitelist_walker(whitelist: tuple[type, ...]) -> AILWhitelistExprTypeWalker:
+    cache = getattr(_tls, "walker_cache", None)
+    if cache is None:
+        # no active Decompiler scope (e.g. standalone SPropagator use); fall back to a throwaway walker
+        return AILWhitelistExprTypeWalker(whitelist)
+    walker = cache.get(whitelist)
+    if walker is None:
+        walker = AILWhitelistExprTypeWalker(whitelist)
+        cache[whitelist] = walker
+    return walker
 
 
 class SPropagatorModel:
@@ -304,7 +342,9 @@ class SPropagatorAnalysis(Analysis):
                     if len(vvar_uselocs_set) == 1:
                         vvar_used, vvar_useloc = next(iter(vvar_uselocs_set))
                         if (
-                            is_const_vvar_load_assignment(stmt)
+                            is_const_vvar_load_assignment(
+                                stmt, walker_cached=_whitelist_walker(CONST_VVAR_LOAD_WHITELIST)
+                            )
                             and not has_store_stmt_in_between_stmts(self.func_graph, blocks, defloc, vvar_useloc)
                             and not has_tmp_expr(stmt.src)
                         ):
@@ -312,7 +352,9 @@ class SPropagatorAnalysis(Analysis):
                             self.replace(replacements, vvar_useloc, vvar_used, stmt.src)
                             continue
 
-                        if is_const_and_vvar_assignment(stmt) and not has_tmp_expr(stmt.src):
+                        if is_const_and_vvar_assignment(
+                            stmt, walker_cached=_whitelist_walker(CONST_VVAR_WHITELIST)
+                        ) and not has_tmp_expr(stmt.src):
                             # if the useloc is a phi assignment statement, ensure that stmt.src is the same as the phi
                             # variable
                             assert vvar_useloc.block_addr is not None
@@ -332,7 +374,7 @@ class SPropagatorAnalysis(Analysis):
                             continue
 
                     else:
-                        if is_const_and_vvar_assignment(stmt):
+                        if is_const_and_vvar_assignment(stmt, walker_cached=_whitelist_walker(CONST_VVAR_WHITELIST)):
                             non_exitsite_uselocs = []
                             exitsite_uselocs_to_count = defaultdict(int)
                             for _, loc in vvar_uselocs[vvar_id]:
@@ -452,7 +494,7 @@ class SPropagatorAnalysis(Analysis):
                             self.replace(replacements, loc, tmp_used, stmt.src)
                         continue
 
-                    r = is_const_vvar_tmp_assignment(stmt)
+                    r = is_const_vvar_tmp_assignment(stmt, walker_cached=_whitelist_walker(CONST_VVAR_TMP_WHITELIST))
                     if r:
                         # we can propagate it!
                         if isinstance(stmt.src, VirtualVariable):
@@ -465,7 +507,9 @@ class SPropagatorAnalysis(Analysis):
                             self.replace(replacements, loc, tmp_used, v)
                         continue
 
-                    if len(tmp_uses) <= 2 and is_const_vvar_load_dirty_assignment(stmt):
+                    if len(tmp_uses) <= 2 and is_const_vvar_load_dirty_assignment(
+                        stmt, walker_cached=_whitelist_walker(CONST_VVAR_LOAD_DIRTY_WHITELIST)
+                    ):
                         for tmp_used, tmp_use_stmtidx in tmp_uses:
                             same_inst = (
                                 block.statements[tmp_def_stmtidx].tags["ins_addr"]

--- a/angr/utils/ssa/__init__.py
+++ b/angr/utils/ssa/__init__.py
@@ -11,20 +11,20 @@ from angr.ailment import Address, Block, Expression
 from angr.ailment.block_walker import AILBlockViewer
 from angr.ailment.expression import (
     ITE,
+    BinaryOp,
     Call,
     Const,
     Convert,
     DirtyExpression,
     Extract,
-    FunctionLikeMacro,
     Insert,
     Load,
+    MultiStatementExpression,
     Phi,
-    Register,
+    Reinterpret,
     StackBaseOffset,
     Tmp,
     UnaryOp,
-    VEXCCallExpression,
     VirtualVariable,
 )
 from angr.ailment.statement import CAS, Assignment, SideEffectStatement, Statement, Store
@@ -136,16 +136,10 @@ def get_vvar_deflocs(
 
 
 def get_vvar_uselocs(blocks) -> dict[int, list[tuple[VirtualVariable, AILCodeLocation]]]:
-    vvar_to_loc: dict[int, list[tuple[VirtualVariable, AILCodeLocation]]] = defaultdict(list)
+    collector = VVarUsesCollector()
     for block in blocks:
-        collector = VVarUsesCollector()
         collector.walk(block)
-        for vvar_idx, vvar_and_uselocs in collector.vvar_and_uselocs.items():
-            if vvar_idx not in vvar_to_loc:
-                vvar_to_loc[vvar_idx] = list(vvar_and_uselocs)
-            else:
-                vvar_to_loc[vvar_idx] += vvar_and_uselocs
-    return vvar_to_loc
+    return collector.vvar_and_uselocs
 
 
 def get_tmp_deflocs(blocks: Iterable[Block]) -> dict[Address, dict[atoms.Tmp, int]]:
@@ -167,9 +161,9 @@ def get_tmp_deflocs(blocks: Iterable[Block]) -> dict[Address, dict[atoms.Tmp, in
 
 def get_tmp_uselocs(blocks: Iterable[Block]) -> dict[Address, dict[atoms.Tmp, set[tuple[Tmp, int]]]]:
     tmp_to_loc: dict[Address, dict[atoms.Tmp, set[tuple[Tmp, int]]]] = defaultdict(dict)
-
+    collector = TmpUsesCollector()
     for block in blocks:
-        collector = TmpUsesCollector()
+        collector.reset()
         collector.walk(block)
         block_loc = (block.addr, block.idx)
         for (tmp_idx, tmp_bits), tmp_and_stmtids in collector.tmp_and_uselocs.items():
@@ -230,42 +224,81 @@ class AILBlacklistExprTypeWalker(AILBlockViewer):
         return super()._handle_VirtualVariable(expr_idx, expr, stmt_idx, stmt, block)
 
 
-def is_const_and_vvar_assignment(stmt: Statement) -> bool:
+class AILWhitelistExprTypeWalker(AILBlockViewer):
+    """
+    Walks an AIL expression or statement and determines if it is built *only* out of a whitelisted set of expression
+    types. ``has_nonwhitelisted_exprs`` is set to True as soon as any expression whose type is not in the whitelist is
+    encountered.
+
+    Note that the whitelist must include the operator/container types that the walker recurses through (e.g. BinaryOp,
+    UnaryOp), otherwise those nodes would be flagged as non-whitelisted.
+    """
+
+    def __init__(self, whitelist_expr_types: tuple[type, ...]):
+        super().__init__()
+        self.whitelist_expr_types = whitelist_expr_types
+        self.has_nonwhitelisted_exprs = False
+
+    def reset(self) -> None:
+        self.has_nonwhitelisted_exprs = False
+
+    def _handle_expr(
+        self, expr_idx: int, expr: Expression, stmt_idx: int, stmt: Statement | None, block: Block | None
+    ) -> Any:
+        if not isinstance(expr, self.whitelist_expr_types):
+            self.has_nonwhitelisted_exprs = True
+            # the result is already determined; no need to recurse into this subtree
+            return None
+        return super()._handle_expr(expr_idx, expr, stmt_idx, stmt, block)
+
+
+_CONST_VVAR_OPERATORS: tuple[type, ...] = (
+    BinaryOp,
+    UnaryOp,
+    ITE,
+    Extract,
+    Insert,
+    MultiStatementExpression,
+    StackBaseOffset,
+    Convert,
+    Reinterpret,
+)
+CONST_VVAR_WHITELIST = (Const, VirtualVariable, *_CONST_VVAR_OPERATORS)
+CONST_VVAR_TMP_WHITELIST = (*CONST_VVAR_WHITELIST, Tmp)
+CONST_VVAR_LOAD_WHITELIST = (*CONST_VVAR_WHITELIST, Load)
+CONST_VVAR_LOAD_DIRTY_WHITELIST = (*CONST_VVAR_WHITELIST, Load, DirtyExpression)
+
+
+def _check_whitelisted_assignment_src(
+    stmt: Statement, whitelist: tuple[type, ...], walker_cached: AILWhitelistExprTypeWalker | None
+) -> bool:
     if isinstance(stmt, Assignment):
-        walker = AILBlacklistExprTypeWalker(
-            (Tmp, Load, Register, Phi, Call, DirtyExpression, VEXCCallExpression, FunctionLikeMacro)
-        )
+        if walker_cached is None:
+            walker = AILWhitelistExprTypeWalker(whitelist)
+        else:
+            walker = walker_cached
+            walker.reset()
         walker.walk_expression(stmt.src)
-        return not walker.has_blacklisted_exprs
+        return not walker.has_nonwhitelisted_exprs
     return False
 
 
-def is_const_vvar_tmp_assignment(stmt: Statement) -> bool:
-    if isinstance(stmt, Assignment):
-        walker = AILBlacklistExprTypeWalker(
-            (Load, Register, Phi, Call, DirtyExpression, VEXCCallExpression, FunctionLikeMacro)
-        )
-        walker.walk_expression(stmt.src)
-        return not walker.has_blacklisted_exprs
-    return False
+def is_const_and_vvar_assignment(stmt: Statement, walker_cached: AILWhitelistExprTypeWalker | None = None) -> bool:
+    return _check_whitelisted_assignment_src(stmt, CONST_VVAR_WHITELIST, walker_cached)
 
 
-def is_const_vvar_load_assignment(stmt: Statement) -> bool:
-    if isinstance(stmt, Assignment):
-        walker = AILBlacklistExprTypeWalker(
-            (Tmp, Register, Phi, Call, DirtyExpression, VEXCCallExpression, FunctionLikeMacro)
-        )
-        walker.walk_expression(stmt.src)
-        return not walker.has_blacklisted_exprs
-    return False
+def is_const_vvar_tmp_assignment(stmt: Statement, walker_cached: AILWhitelistExprTypeWalker | None = None) -> bool:
+    return _check_whitelisted_assignment_src(stmt, CONST_VVAR_TMP_WHITELIST, walker_cached)
 
 
-def is_const_vvar_load_dirty_assignment(stmt: Statement) -> bool:
-    if isinstance(stmt, Assignment):
-        walker = AILBlacklistExprTypeWalker((Tmp, Register, Phi, Call, VEXCCallExpression, FunctionLikeMacro))
-        walker.walk_expression(stmt.src)
-        return not walker.has_blacklisted_exprs
-    return False
+def is_const_vvar_load_assignment(stmt: Statement, walker_cached: AILWhitelistExprTypeWalker | None = None) -> bool:
+    return _check_whitelisted_assignment_src(stmt, CONST_VVAR_LOAD_WHITELIST, walker_cached)
+
+
+def is_const_vvar_load_dirty_assignment(
+    stmt: Statement, walker_cached: AILWhitelistExprTypeWalker | None = None
+) -> bool:
+    return _check_whitelisted_assignment_src(stmt, CONST_VVAR_LOAD_DIRTY_WHITELIST, walker_cached)
 
 
 def is_phi_assignment(stmt: Statement) -> bool:
@@ -496,6 +529,11 @@ def is_vvar_eliminatable(vvar: VirtualVariable, def_stmt: Statement | None) -> b
 
 
 __all__ = (
+    "CONST_VVAR_LOAD_DIRTY_WHITELIST",
+    "CONST_VVAR_LOAD_WHITELIST",
+    "CONST_VVAR_TMP_WHITELIST",
+    "CONST_VVAR_WHITELIST",
+    "AILWhitelistExprTypeWalker",
     "VVarUsesCollector",
     "check_in_between_stmts",
     "get_tmp_deflocs",

--- a/angr/utils/ssa/tmp_uses_collector.py
+++ b/angr/utils/ssa/tmp_uses_collector.py
@@ -18,6 +18,9 @@ class TmpUsesCollector(AILBlockViewer):
 
         self.tmp_and_uselocs: dict[tuple[int, int], set[tuple[Tmp, int]]] = defaultdict(set)
 
+    def reset(self) -> None:
+        self.tmp_and_uselocs = defaultdict(set)
+
     def _handle_Tmp(self, expr_idx: int, expr: Tmp, stmt_idx: int, stmt: Statement, block: Block | None):
         if isinstance(stmt, Assignment) and expr is stmt.dst:
             return

--- a/angr/utils/ssa/vvar_uses_collector.py
+++ b/angr/utils/ssa/vvar_uses_collector.py
@@ -21,6 +21,10 @@ class VVarUsesCollector(AILBlockViewer):
         self.vvar_and_uselocs: dict[int, list[tuple[VirtualVariable, AILCodeLocation]]] = defaultdict(list)
         self.vvars: set[int] = set()
 
+    def reset(self) -> None:
+        self.vvar_and_uselocs = defaultdict(list)
+        self.vvars = set()
+
     def _handle_expr(self, expr_idx: int, expr, stmt_idx: int, stmt, block: Block | None):
         if expr.tags.get("extra_def", False):
             return None


### PR DESCRIPTION
Also introduced AILWhitelistExprTypeWalker and a Decompiler-specific TLS cache for walker instances that are used repeatedly during decompilation.