### PR TITLE
Fix misspelled relocatable property on Annotation subclasses

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -81,7 +81,7 @@ class AILExprIdAnnotation(claripy.Annotation):
         return True
 
     @property
-    def relocateable(self):
+    def relocatable(self):
         return False
 
 

--- a/angr/storage/memory_mixins/address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/address_concretization_mixin.py
@@ -17,7 +17,7 @@ class MultiwriteAnnotation(claripy.Annotation):
         return False
 
     @property
-    def relocateable(self):
+    def relocatable(self):
         return True
 
 


### PR DESCRIPTION
## Problem
claripy's `Annotation` property is `relocatable`. Two angr `Annotation` subclasses override a misspelled `relocateable` instead, making the override dead code — the base-class default (`relocatable=False`) silently applies:

- `MultiwriteAnnotation` (`angr/storage/memory_mixins/address_concretization_mixin.py`) — intended `relocatable=True`
- `AILExprIdAnnotation` (`angr/analyses/decompiler/condition_processor.py`) — intended `relocatable=False`

## Impact
For `MultiwriteAnnotation` the typo has a real consequence: a non-relocatable annotation is **dropped** when the annotated AST is simplified. Demonstrated on claripy 9.2.221 with `eliminatable=False` and an annotated zero folded out of `x + 0`:

```
relocateable (typo, effective False):  result annotations = []        <- tag lost
relocatable=True (fixed):              result annotations = [Fixed]   <- tag survives
```

`fgets`/`gets`/`memchr`/`strchr` annotate end addresses with `MultiwriteAnnotation`, and `_multiwrite_filter` selects the multiwrite concretization strategy by checking `has_annotation_type` — so any simplification of the address expression silently disables multiwrite concretization today.

For `AILExprIdAnnotation` the intended value (`False`) equals the base default, so there is no behavior change; the override just becomes effective instead of accidental.

## Change
Rename both properties `relocateable` → `relocatable` (2 lines). No other occurrences of the misspelling exist in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)