### PR TITLE
AILSimplifier: Don't fold calls with write side effects.

### DIFF
--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -1630,6 +1630,16 @@ class AILSimplifier(Analysis):
                 assert the_def.codeloc.block_addr is not None
                 assert the_def.codeloc.stmt_idx is not None
 
+                # Do not fold a call whose defining statement carries extra_defs (side-effect writes through pointer
+                # arguments, e.g. a call that fills a stack buffer). Folding moves the call to its single return-value
+                # use site, which would move the side-effect write as well and leave other uses of the written-through
+                # vvars reading an undefined value.
+                def_block = addr_and_idx_to_block.get((the_def.codeloc.block_addr, the_def.codeloc.block_idx))
+                if def_block is not None:
+                    def_block = self.blocks.get(def_block, def_block)
+                    if def_block.statements[the_def.codeloc.stmt_idx].tags.get("extra_defs"):
+                        continue
+
                 all_uses = rd.get_vvar_uses_with_expr(the_def.atom)
                 if eq.is_weakassignment:
                     # eliminate the "use" at the weak assignment site

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3853,6 +3853,32 @@ class TestDecompiler(unittest.TestCase):
         for case_no in [63, 65, 70, 73, 86, 97, 98, 100, 102, 104, 105, 115, 121]:
             assert f"case {case_no}:" in d.codegen.text
 
+    def test_call_with_pointer_write_side_effect_not_folded(self, decompiler_options=None):
+        # Regression test: a call that fills a stack buffer through a pointer argument (a side-effect write captured
+        # as an "extra_def") whose return value is unused must not be folded into its return-value use site. Folding
+        # it would move the call (and its buffer write) away, leaving the buffer reads referencing a stack variable
+        # that is never written -- a used-but-undefined value.
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "hostname")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        proj.analyses.CompleteCallingConventions(cfg=cfg)
+        f = proj.kb.functions["main"]
+        d = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
+        assert d.codegen is not None and d.clinic is not None
+
+        rd = proj.analyses.SReachingDefinitions(subject=f, func_graph=d.clinic.graph, func_args=set()).model
+        used_but_undefined_stack_vars = [
+            str(rd.varid_to_vvar[vid])
+            for vid, loc in rd.all_vvar_definitions.items()
+            if loc.is_extern
+            and getattr(rd.varid_to_vvar.get(vid), "was_stack", False)
+            and any(expr is not None for expr, _ in rd.all_vvar_uses.get(vid, []))
+        ]
+        assert not used_but_undefined_stack_vars, (
+            "Stack variables are read without ever being written (a side-effecting call was likely folded away): "
+            f"{used_but_undefined_stack_vars}"
+        )
+
     @structuring_algo("sailr")
     def test_incorrect_function_argument_unification(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "liblzma.so.5.6.1")


### PR DESCRIPTION
_fold_call_exprs folds a call whose return value is used exactly once into that use site and removes the original call statement. This is incorrect when the call may write via a pointer argument: when they have "extra_defs" operands, e.g. a call that fills a stack buffer. Folding moves the call and its side-effect write to the return-value use site, leaving every other read of the written-through vvar referencing a value that is now never written.