### PR TITLE
AILSimplifier: incrementally update SRDA in dead-assignment removal

### DIFF
--- a/angr/ailment/__init__.py
+++ b/angr/ailment/__init__.py
@@ -8,7 +8,7 @@ from .block_walker import AILBlockRewriter, AILBlockViewer, AILBlockWalker
 from .converter_common import Converter
 from .expression import BinaryOp, Const, Expression, Register, Tmp, UnaryOp
 from .manager import Manager
-from .statement import Assignment, Statement
+from .statement import Assignment, NoOp, Statement
 
 log = logging.getLogger(__name__)
 
@@ -71,6 +71,7 @@ __all__ = [
     "Expression",
     "IRSBConverter",
     "Manager",
+    "NoOp",
     "PCodeIRSBConverter",
     "Register",
     "Statement",

--- a/angr/ailment/statement.py
+++ b/angr/ailment/statement.py
@@ -983,3 +983,40 @@ class Label(Statement):
 
     def deep_copy(self, manager) -> Label:
         return Label(manager.next_atom(), self.name, **self.tags)
+
+
+class NoOp(Statement):
+    """
+    A statement that does nothing. It defines and uses no atoms. It is primarily used as an in-place placeholder for a
+    removed statement so that the indices of the surrounding statements (and code locations referencing them) remain
+    stable until the block is compacted.
+    """
+
+    __slots__ = ()
+
+    def likes(self, other):
+        return isinstance(other, NoOp)
+
+    def replace(self, old_expr, new_expr):
+        return False, self
+
+    @property
+    def depth(self) -> int:
+        return 0
+
+    matches = likes
+
+    def _hash_core(self):
+        return stable_hash((NoOp,))
+
+    def __repr__(self):
+        return "NoOp"
+
+    def __str__(self):
+        return "NoOp"
+
+    def copy(self) -> NoOp:
+        return NoOp(self.idx, **self.tags)
+
+    def deep_copy(self, manager) -> NoOp:
+        return NoOp(manager.next_atom(), **self.tags)

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections import defaultdict
 from collections.abc import Container, Iterable
 from enum import Enum
@@ -32,6 +33,7 @@ from angr.ailment.statement import (
     Assignment,
     ConditionalJump,
     DirtyStatement,
+    NoOp,
     Return,
     SideEffectStatement,
     Statement,
@@ -70,6 +72,10 @@ if TYPE_CHECKING:
 
 
 _l = logging.getLogger(__name__)
+
+# When enabled (env var VERIFY_INCREMENTAL_RD), every incremental reaching-definitions update is checked against a
+# full rebuild. Used to validate the incremental update; off by default because the full rebuild defeats its purpose.
+_VERIFY_INCREMENTAL_RD = os.environ.get("VERIFY_INCREMENTAL_RD", "").lower() not in {"", "0", "no", "false"}
 
 
 class HasCallNotification(Exception):
@@ -313,6 +319,12 @@ class AILSimplifier(Analysis):
         if r:
             _l.debug("... dead assignments removed")
             self.simplified = True
+
+        # Dead-assignment removal leaves NoOp placeholders in the graph (so reaching definitions could be updated
+        # incrementally instead of rebuilt between iterations). All simplification steps are done now, so compact them
+        # away. The reaching-definitions result is not needed past this point, so just invalidate it.
+        if self._compact_noop_statements():
+            self._clear_cache()
 
     def _rebuild_func_graph(self):
         def _handler(node):
@@ -1813,14 +1825,61 @@ class AILSimplifier(Analysis):
     def _iteratively_remove_dead_assignments(self) -> bool:
         anything_removed = False
         while True:
-            r = self._remove_dead_assignments()
+            r, changed_block_keys = self._remove_dead_assignments()
             if not r:
-                return anything_removed
+                break
+            anything_removed = True
             self._rebuild_func_graph()
-            self._clear_cache()
+            # Instead of discarding the reaching-definitions cache and recomputing it from scratch on every iteration,
+            # incrementally update it: removed statements were replaced in place by NoOp placeholders, so statement
+            # indices are stable and we only need to drop the removed vvar definitions and their now-eliminated uses.
+            if self._reaching_definitions is not None and changed_block_keys:
+                edited_blocks = [
+                    block for block in self.func_graph.nodes() if (block.addr, block.idx) in changed_block_keys
+                ]
+                self._reaching_definitions.update_after_block_edits(edited_blocks)
+                if _VERIFY_INCREMENTAL_RD:
+                    self._verify_incremental_reaching_definitions()
+            # propagation results are no longer reliable after removing statements
+            self._propagator = None
+
+        # NoOp placeholders are left in the graph and the reaching-definitions cache is kept valid: subsequent
+        # simplification steps reuse it instead of rebuilding from scratch. The placeholders are compacted away once,
+        # at the end of _simplify().
+        return anything_removed
+
+    def _compact_noop_statements(self) -> bool:
+        found = False
+        for block in list(self.func_graph.nodes()):
+            if any(isinstance(stmt, NoOp) for stmt in block.statements):
+                new_block = block.copy()
+                new_block.statements = [stmt for stmt in block.statements if not isinstance(stmt, NoOp)]
+                self.blocks[block] = new_block
+                found = True
+        if found:
+            self._rebuild_func_graph()
+        return found
+
+    def _verify_incremental_reaching_definitions(self) -> None:
+        # Debug-only (env var VERIFY_INCREMENTAL_RD): assert the incrementally-updated model is identical to a full
+        # rebuild on the current (NoOp-containing) graph.
+        assert self._reaching_definitions is not None
+        func_args = {vvar for vvar, _ in self._arg_vvars.values()} if self._arg_vvars else set()
+        reference = (
+            self.project.analyses[SReachingDefinitionsAnalysis]
+            .prep()(
+                subject=self.func,
+                func_graph=self.func_graph,
+                func_args=func_args,
+                use_callee_saved_regs_at_return=self._use_callee_saved_regs_at_return,
+            )
+            .model
+        )
+        if self._reaching_definitions.canonical_form() != reference.canonical_form():
+            raise AssertionError("Incremental SRDA update diverged from a full rebuild")
 
     @timethis
-    def _remove_dead_assignments(self) -> bool:
+    def _remove_dead_assignments(self) -> tuple[bool, set[tuple[int, int | None]]]:
         # keeping tracking of statements to remove and statements (as well as dead vvars) to keep allows us to handle
         # cases where a statement defines more than one atom, e.g., a call statement that defines both the return
         # value and the floating-point return value.
@@ -1948,6 +2007,7 @@ class AILSimplifier(Analysis):
             stmts_to_remove_per_block[codeloc.block_addr, codeloc.block_idx].add(codeloc.stmt_idx)
 
         simplified = False
+        changed_block_keys: set[tuple[int, int | None]] = set()
 
         # Remove the statements
         for old_block in self.func_graph.nodes():
@@ -1997,12 +2057,18 @@ class AILSimplifier(Analysis):
                         codeloc = AILCodeLocation(block.addr, block.idx, idx, stmt.tags.get("ins_addr"))
                         if codeloc in self._assignments_to_remove:
                             # it should be removed
+                            new_statements.append(
+                                NoOp(stmt.idx, **{k: v for k, v in stmt.tags.items() if k != "extra_defs"})
+                            )
                             simplified = True
                             continue
 
                         if self._statement_has_call_exprs(stmt):
                             if codeloc in self._calls_to_remove:
                                 # it has a call and must be removed
+                                new_statements.append(
+                                    NoOp(stmt.idx, **{k: v for k, v in stmt.tags.items() if k != "extra_defs"})
+                                )
                                 simplified = True
                                 continue
                             if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable):
@@ -2021,12 +2087,18 @@ class AILSimplifier(Analysis):
                                     pass
                         else:
                             # no calls. remove it
+                            new_statements.append(
+                                NoOp(stmt.idx, **{k: v for k, v in stmt.tags.items() if k != "extra_defs"})
+                            )
                             simplified = True
                             continue
                     elif isinstance(stmt, SideEffectStatement):
                         codeloc = AILCodeLocation(block.addr, block.idx, idx, stmt.tags.get("ins_addr"))
                         if codeloc in self._calls_to_remove:
                             # this call can be removed
+                            new_statements.append(
+                                NoOp(stmt.idx, **{k: v for k, v in stmt.tags.items() if k != "extra_defs"})
+                            )
                             simplified = True
                             continue
 
@@ -2047,13 +2119,14 @@ class AILSimplifier(Analysis):
             new_block = block.copy()
             new_block.statements = new_statements
             self.blocks[old_block] = new_block
+            changed_block_keys.add((new_block.addr, new_block.idx))
 
         # we can only use calls_to_remove and assignments_to_remove once; if any statements in blocks are removed, then
         # the statement IDs in calls_to_remove and assignments_to_remove no longer match!
         self._calls_to_remove.clear()
         self._assignments_to_remove.clear()
 
-        return simplified
+        return simplified, changed_block_keys
 
     @staticmethod
     def _get_vvar_used_by(

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -2020,7 +2020,7 @@ class AILSimplifier(Analysis):
             if (block.addr, block.idx) not in stmts_to_remove_per_block:
                 continue
 
-            new_statements = []
+            new_statements: list[Statement] = []
             stmts_to_remove = stmts_to_remove_per_block[(block.addr, block.idx)]
             stmts_to_keep = stmts_to_keep_per_block[(block.addr, block.idx)]
 
@@ -2057,18 +2057,14 @@ class AILSimplifier(Analysis):
                         codeloc = AILCodeLocation(block.addr, block.idx, idx, stmt.tags.get("ins_addr"))
                         if codeloc in self._assignments_to_remove:
                             # it should be removed
-                            new_statements.append(
-                                NoOp(stmt.idx, **{k: v for k, v in stmt.tags.items() if k != "extra_defs"})
-                            )
+                            new_statements.append(NoOp(stmt.idx, ins_addr=stmt.tags.get("ins_addr", -1)))
                             simplified = True
                             continue
 
                         if self._statement_has_call_exprs(stmt):
                             if codeloc in self._calls_to_remove:
                                 # it has a call and must be removed
-                                new_statements.append(
-                                    NoOp(stmt.idx, **{k: v for k, v in stmt.tags.items() if k != "extra_defs"})
-                                )
+                                new_statements.append(NoOp(stmt.idx, ins_addr=stmt.tags.get("ins_addr", -1)))
                                 simplified = True
                                 continue
                             if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable):
@@ -2087,18 +2083,14 @@ class AILSimplifier(Analysis):
                                     pass
                         else:
                             # no calls. remove it
-                            new_statements.append(
-                                NoOp(stmt.idx, **{k: v for k, v in stmt.tags.items() if k != "extra_defs"})
-                            )
+                            new_statements.append(NoOp(stmt.idx, ins_addr=stmt.tags.get("ins_addr", -1)))
                             simplified = True
                             continue
                     elif isinstance(stmt, SideEffectStatement):
                         codeloc = AILCodeLocation(block.addr, block.idx, idx, stmt.tags.get("ins_addr"))
                         if codeloc in self._calls_to_remove:
                             # this call can be removed
-                            new_statements.append(
-                                NoOp(stmt.idx, **{k: v for k, v in stmt.tags.items() if k != "extra_defs"})
-                            )
+                            new_statements.append(NoOp(stmt.idx, ins_addr=stmt.tags.get("ins_addr", -1)))
                             simplified = True
                             continue
 

--- a/angr/analyses/s_reaching_definitions/s_rda_model.py
+++ b/angr/analyses/s_reaching_definitions/s_rda_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Iterator
 from typing import Any, Literal, overload
 
@@ -35,6 +35,125 @@ class SRDAModel:
         if loc not in self.vvar_uses_by_loc:
             self.vvar_uses_by_loc[loc] = []
         self.vvar_uses_by_loc[loc].append(vvar_id)
+
+    def update_after_block_edits(self, edited_blocks) -> None:
+        """
+        Incrementally update the model after the statements of ``edited_blocks`` were edited *in place* (statement
+        indices preserved, e.g. by replacing removed statements with ``NoOp`` placeholders). vvar definitions and
+        explicit vvar uses inside the edited blocks are recomputed from the edited blocks; implicit uses (``expr is
+        None``, e.g. call-site argument registers) and all unedited blocks are left untouched.
+
+        This is designed to be equivalent to a full SRDA rebuild on the edited graph for the kind of edits performed
+        by dead-assignment removal: statements are only removed (turned into NoOp) or rewritten in place, never
+        inserted or reordered, and removed vvars are dead (so they are never used elsewhere, including by phi nodes or
+        implicit call-site uses). Tmp tracking is not updated (AILSimplifier does not track tmps).
+        """
+        from angr.utils.ssa import get_vvar_deflocs, get_vvar_uselocs  # local import to avoid an import cycle
+
+        edited_blocks = list(edited_blocks)
+        block_keys = {(b.addr, b.idx) for b in edited_blocks}
+
+        def in_edited(loc: AILCodeLocation) -> bool:
+            return (loc.block_addr, loc.block_idx) in block_keys
+
+        # --- definitions ---
+        new_phi: dict[int, set[int | None]] = {}
+        # check_extra_defs is disabled because we scan only a subset of the graph's blocks here
+        new_deflocs = get_vvar_deflocs(edited_blocks, phi_vvars=new_phi, check_extra_defs=False)
+
+        old_def_vids = {vid for vid, loc in self.all_vvar_definitions.items() if in_edited(loc)}
+        for vid in old_def_vids - set(new_deflocs):
+            # this definition no longer exists; keep its uses for now (if the vvar is still used elsewhere it becomes
+            # a used-but-undefined extern vvar, reconciled below)
+            self.varid_to_vvar.pop(vid, None)
+            self.all_vvar_definitions.pop(vid, None)
+            self.phi_vvar_ids.discard(vid)
+            self.phivarid_to_varids.pop(vid, None)
+            self.phivarid_to_varids_with_unknown.pop(vid, None)
+
+        # surviving defs keep their (index-stable) location; refresh vvar and phi info from the rescan
+        for vid, (vvar, defloc) in new_deflocs.items():
+            self.varid_to_vvar[vid] = vvar
+            self.all_vvar_definitions[vid] = defloc
+            if vid in new_phi:
+                src = new_phi[vid]
+                self.phi_vvar_ids.add(vid)
+                self.phivarid_to_varids_with_unknown[vid] = src
+                self.phivarid_to_varids[vid] = {x for x in src if x is not None} if None in src else set(src)
+            else:
+                self.phi_vvar_ids.discard(vid)
+                self.phivarid_to_varids.pop(vid, None)
+                self.phivarid_to_varids_with_unknown.pop(vid, None)
+
+        # --- explicit uses ---
+        # drop explicit uses (expr is not None) located in edited blocks; keep implicit uses (expr is None)
+        for vid in list(self.all_vvar_uses):
+            entries = self.all_vvar_uses[vid]
+            kept = [(e, loc) for e, loc in entries if e is None or not in_edited(loc)]
+            if len(kept) != len(entries):
+                if kept:
+                    self.all_vvar_uses[vid] = kept
+                else:
+                    del self.all_vvar_uses[vid]
+        # re-add the recomputed explicit uses for the edited blocks
+        for vid, uses in get_vvar_uselocs(edited_blocks).items():
+            for expr, loc in uses:
+                self.all_vvar_uses[vid].append((expr, loc))
+
+        # --- rebuild vvar_uses_by_loc for affected locations from the updated all_vvar_uses ---
+        for loc in [loc for loc in self.vvar_uses_by_loc if in_edited(loc)]:
+            del self.vvar_uses_by_loc[loc]
+        for vid, entries in self.all_vvar_uses.items():
+            for _expr, loc in entries:
+                if in_edited(loc):
+                    if loc not in self.vvar_uses_by_loc:
+                        self.vvar_uses_by_loc[loc] = []
+                    self.vvar_uses_by_loc[loc].append(vid)
+
+        # --- reconcile extern (used-but-undefined) definitions to match a full rebuild ---
+        # A vvar that is explicitly used but has no real definition (e.g. its defining statement was just removed) gets
+        # a synthetic extern definition; an extern, non-argument vvar that is no longer explicitly used is dropped.
+        func_arg_ids = {vvar.varid for vvar in self.func_args} if self.func_args else set()
+        explicit_use_repr: dict[int, VirtualVariable] = {}
+        for vid, entries in self.all_vvar_uses.items():
+            for expr, _loc in entries:
+                if expr is not None:
+                    explicit_use_repr[vid] = expr
+                    break
+        for vid, expr in explicit_use_repr.items():
+            if vid not in self.all_vvar_definitions:
+                self.varid_to_vvar[vid] = expr
+                self.all_vvar_definitions[vid] = AILCodeLocation.make_extern(vid)
+        for vid in [
+            vid
+            for vid, loc in self.all_vvar_definitions.items()
+            if loc.is_extern and vid not in func_arg_ids and vid not in explicit_use_repr
+        ]:
+            self.varid_to_vvar.pop(vid, None)
+            self.all_vvar_definitions.pop(vid, None)
+            self.all_vvar_uses.pop(vid, None)
+            self.phi_vvar_ids.discard(vid)
+            self.phivarid_to_varids.pop(vid, None)
+            self.phivarid_to_varids_with_unknown.pop(vid, None)
+
+    def canonical_form(self):
+        """
+        An order-insensitive snapshot of the model's vvar-keyed data, for asserting equivalence between an
+        incrementally-updated model and a freshly-rebuilt one (used by the incremental-update verification harness).
+        """
+        return (
+            set(self.varid_to_vvar),
+            dict(self.all_vvar_definitions),
+            {
+                vid: Counter((e.varid if e is not None else None, loc) for e, loc in lst)
+                for vid, lst in self.all_vvar_uses.items()
+                if lst
+            },
+            set(self.phi_vvar_ids),
+            {k: frozenset(v) for k, v in self.phivarid_to_varids.items()},
+            {k: frozenset(v) for k, v in self.phivarid_to_varids_with_unknown.items()},
+            {loc: Counter(vids) for loc, vids in self.vvar_uses_by_loc.items() if vids},
+        )
 
     @property
     def all_definitions(self) -> Iterator[Definition[atoms.VirtualVariable, AILCodeLocation]]:

--- a/angr/analyses/s_reaching_definitions/s_rda_model.py
+++ b/angr/analyses/s_reaching_definitions/s_rda_model.py
@@ -48,7 +48,8 @@ class SRDAModel:
         inserted or reordered, and removed vvars are dead (so they are never used elsewhere, including by phi nodes or
         implicit call-site uses). Tmp tracking is not updated (AILSimplifier does not track tmps).
         """
-        from angr.utils.ssa import get_vvar_deflocs, get_vvar_uselocs  # local import to avoid an import cycle
+
+        from angr.utils.ssa import get_vvar_deflocs, get_vvar_uselocs  # pylint:disable=import-outside-toplevel
 
         edited_blocks = list(edited_blocks)
         block_keys = {(b.addr, b.idx) for b in edited_blocks}
@@ -79,7 +80,7 @@ class SRDAModel:
                 src = new_phi[vid]
                 self.phi_vvar_ids.add(vid)
                 self.phivarid_to_varids_with_unknown[vid] = src
-                self.phivarid_to_varids[vid] = {x for x in src if x is not None} if None in src else set(src)
+                self.phivarid_to_varids[vid] = {x for x in src if x is not None} if None in src else set(src)  # type: ignore
             else:
                 self.phi_vvar_ids.discard(vid)
                 self.phivarid_to_varids.pop(vid, None)

--- a/angr/utils/ssa/__init__.py
+++ b/angr/utils/ssa/__init__.py
@@ -100,7 +100,7 @@ def get_reg_offset_base(reg_offset, arch, size=None, resilient=True):
 
 
 def get_vvar_deflocs(
-    blocks, phi_vvars: dict[int, set[int | None]] | None = None
+    blocks, phi_vvars: dict[int, set[int | None]] | None = None, check_extra_defs: bool = True
 ) -> dict[int, tuple[VirtualVariable, AILCodeLocation]]:
     vvar_to_loc: dict[int, tuple[VirtualVariable, AILCodeLocation]] = {}
     walker = FindExtraDefs()
@@ -130,7 +130,11 @@ def get_vvar_deflocs(
 
             if extra_defs := stmt.tags.get("extra_defs", None):
                 walker.walk_statement(stmt, block, stmt_idx)
-                assert all(varid in vvar_to_loc for varid in extra_defs), "extra_def tag was dropped"
+                # When scanning only a subset of blocks (e.g. incremental updates), an extra-def varid may be defined
+                # in a block that is not part of the subset, so this consistency check is skipped there.
+                assert not check_extra_defs or all(varid in vvar_to_loc for varid in extra_defs), (
+                    "extra_def tag was dropped"
+                )
 
     return vvar_to_loc
 


### PR DESCRIPTION
_iteratively_remove_dead_assignments fully rebuilt the SReachingDefinitions model after every iteration, which is expensive. This PR add a way to incrementally update SRDA models after dead assignments are removed.