### PR TITLE
SRDAView: Speed up observe().

### DIFF
--- a/angr/analyses/s_reaching_definitions/s_rda_view.py
+++ b/angr/analyses/s_reaching_definitions/s_rda_view.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Callable
 
 from angr.ailment import Block
-from angr.ailment.expression import Expression, VirtualVariable, VirtualVariableCategory
+from angr.ailment.expression import Call, Expression, VirtualVariable, VirtualVariableCategory
 from angr.ailment.statement import Assignment, Label, SideEffectStatement, Statement
 from angr.calling_conventions import SimRegArg, default_cc
 from angr.knowledge_plugins.key_definitions.constants import ObservationPoint, ObservationPointType
@@ -43,6 +43,8 @@ class RegVVarPredicate:
 
     def _get_call_clobbered_regs(self, stmt: SideEffectStatement) -> set[int]:
         call = stmt.expr
+        if not isinstance(call, Call):
+            return set()
         if isinstance(call.target, str):
             # pseudo calls do not clobber any registers
             return set()

--- a/angr/analyses/s_reaching_definitions/s_rda_view.py
+++ b/angr/analyses/s_reaching_definitions/s_rda_view.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import logging
 from collections import defaultdict
 from collections.abc import Callable
@@ -17,6 +16,17 @@ from angr.utils.ssa import get_reg_offset_base
 from .s_rda_model import SRDAModel
 
 log = logging.getLogger(__name__)
+
+
+def _copy_reg2vvarid(reg2vvarid: dict[int, dict[int, int]]) -> dict[int, dict[int, int]]:
+    """Fast deep copy of a reg2vvarid map.
+
+    ``reg2vvarid`` is always a ``dict[int, dict[int, int]]`` (register base offset -> {size -> vvar id}); all keys and
+    values are immutable ints. ``copy.deepcopy`` works but its generic machinery (memo dict, ``_keep_alive``,
+    per-object dispatch) dominates SReachingDefinitions runtime because ``observe`` copies this map at every graph edge
+    and observation point. A two-level dict comprehension is semantically identical and far cheaper.
+    """
+    return {offset: sizes.copy() for offset, sizes in reg2vvarid.items()}
 
 
 class RegVVarPredicate:
@@ -108,6 +118,7 @@ class SRDAView:
 
     def __init__(self, model: SRDAModel):
         self.model = model
+        self._traversal_order: list[Block] | None = None
 
     def _get_vvar_by_stmt(
         self,
@@ -285,7 +296,12 @@ class SRDAView:
         }
         # TODO: Other types
 
-        traversal_order = GraphUtils.quasi_topological_sort_nodes(self.model.func_graph)
+        # The traversal order depends only on func_graph, which is immutable for the lifetime of this view. observe()
+        # is frequently called more than once per analysis (e.g. call-site uses and callee-saved-register uses), and
+        # the quasi-topological sort dominates observe(), so cache it across calls.
+        if self._traversal_order is None:
+            self._traversal_order = GraphUtils.quasi_topological_sort_nodes(self.model.func_graph)
+        traversal_order = self._traversal_order
         all_reg2vvarid: defaultdict[tuple[int, int | None], dict[int, dict[int, int]]] = defaultdict(dict)
 
         observations = {}
@@ -295,7 +311,7 @@ class SRDAView:
             if (block.addr, block.idx) in node_ops and node_ops[
                 (block.addr, block.idx)
             ] == ObservationPointType.OP_BEFORE:
-                observations[("node", (block.addr, block.idx), ObservationPointType.OP_BEFORE)] = copy.deepcopy(
+                observations[("node", (block.addr, block.idx), ObservationPointType.OP_BEFORE)] = _copy_reg2vvarid(
                     reg2vvarid
                 )
 
@@ -304,21 +320,21 @@ class SRDAView:
                 if last_insn_addr != stmt.tags["ins_addr"]:
                     # observe
                     if last_insn_addr in insn_ops and insn_ops[last_insn_addr] == ObservationPointType.OP_AFTER:
-                        observations[("insn", last_insn_addr, ObservationPointType.OP_AFTER)] = copy.deepcopy(
+                        observations[("insn", last_insn_addr, ObservationPointType.OP_AFTER)] = _copy_reg2vvarid(
                             reg2vvarid
                         )
                     if (
                         stmt.tags["ins_addr"] in insn_ops
                         and insn_ops[stmt.tags["ins_addr"]] == ObservationPointType.OP_BEFORE
                     ):
-                        observations[("insn", last_insn_addr, ObservationPointType.OP_BEFORE)] = copy.deepcopy(
+                        observations[("insn", last_insn_addr, ObservationPointType.OP_BEFORE)] = _copy_reg2vvarid(
                             reg2vvarid
                         )
                     last_insn_addr = stmt.tags["ins_addr"]
 
                 stmt_key = (block.addr, block.idx), stmt_idx
                 if stmt_key in stmt_ops and stmt_ops[stmt_key] == ObservationPointType.OP_BEFORE:
-                    observations[("stmt", stmt_key, ObservationPointType.OP_BEFORE)] = copy.deepcopy(reg2vvarid)
+                    observations[("stmt", stmt_key, ObservationPointType.OP_BEFORE)] = _copy_reg2vvarid(reg2vvarid)
 
                 if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable) and stmt.dst.was_reg:
                     base_offset = get_reg_offset_base(stmt.dst.reg_offset, self.model.arch)
@@ -336,18 +352,18 @@ class SRDAView:
                     reg2vvarid[base_offset][stmt.ret_expr.size] = stmt.ret_expr.varid
 
                 if stmt_key in stmt_ops and stmt_ops[stmt_key] == ObservationPointType.OP_AFTER:
-                    observations[("stmt", stmt_key, ObservationPointType.OP_AFTER)] = copy.deepcopy(reg2vvarid)
+                    observations[("stmt", stmt_key, ObservationPointType.OP_AFTER)] = _copy_reg2vvarid(reg2vvarid)
 
             if (block.addr, block.idx) in node_ops and node_ops[
                 (block.addr, block.idx)
             ] == ObservationPointType.OP_AFTER:
-                observations[("node", (block.addr, block.idx), ObservationPointType.OP_AFTER)] = copy.deepcopy(
+                observations[("node", (block.addr, block.idx), ObservationPointType.OP_AFTER)] = _copy_reg2vvarid(
                     reg2vvarid
                 )
 
             for succ in self.model.func_graph.successors(block):
                 if succ is block:
                     continue
-                all_reg2vvarid[succ.addr, succ.idx] = copy.deepcopy(reg2vvarid)
+                all_reg2vvarid[succ.addr, succ.idx] = _copy_reg2vvarid(reg2vvarid)
 
         return observations


### PR DESCRIPTION
- Cache the quasi-topological traversal order for function graphs.

- Avoid deep copies that are unnecessary.