### PR TITLE
Clinic: Skip diamond rewriting if there are too many cases.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -209,6 +209,7 @@ class Clinic(Analysis):
         variable_kb: KnowledgeBase | None = None,
         reset_variable_names=False,
         rewrite_ites_to_diamonds=True,
+        rewrite_ites_to_diamond_max_cases: int = 15,
         cache: DecompilationCache | None = None,
         mode: ClinicMode = ClinicMode.DECOMPILE,
         sp_shift: int = 0,
@@ -281,6 +282,7 @@ class Clinic(Analysis):
         self._must_struct = must_struct
         self._reset_variable_names = reset_variable_names
         self._rewrite_ites_to_diamonds = rewrite_ites_to_diamonds
+        self._rewrite_ites_to_diamond_max_cases = rewrite_ites_to_diamond_max_cases
         self.reaching_definitions: SRDAModel | None = None
         self._cache = cache
         self._mode = mode
@@ -2834,7 +2836,8 @@ class Clinic(Analysis):
 
     def _rewrite_ite_expressions(self, ail_graph):
         cfg = self._cfg
-        for block in list(ail_graph):
+        block_and_ite_ins_addrs = []
+        for block in ail_graph:
             if cfg is not None and block.addr in cfg.jump_tables:
                 continue
 
@@ -2852,6 +2855,19 @@ class Clinic(Analysis):
                 ):
                     ite_ins_addrs.append(stmt.tags["ins_addr"])
 
+            if ite_ins_addrs:
+                block_and_ite_ins_addrs.append((block, ite_ins_addrs))
+
+        if len(block_and_ite_ins_addrs) > self._rewrite_ites_to_diamond_max_cases:
+            l.debug(
+                "Too many ITE expressions (%d) to convert to diamond shapes in this function. The maximum "
+                "allowed is %d. Skipping.",
+                len(block_and_ite_ins_addrs),
+                self._rewrite_ites_to_diamond_max_cases,
+            )
+            return
+
+        for block, ite_ins_addrs in block_and_ite_ins_addrs:
             if ite_ins_addrs:
                 block_addr = block.addr
                 for ite_ins_addr in ite_ins_addrs:


### PR DESCRIPTION
This is critical so that we do not rewrite thousands of cmovnz instructions into diamond shapes in potentially adversarial functions.