### PR TITLE
Fix exceeding key size by hashing on lmdb Transaction (txn) library

### DIFF
--- a/angr/knowledge_plugins/cfg/spilling_digraph.py
+++ b/angr/knowledge_plugins/cfg/spilling_digraph.py
@@ -15,6 +15,7 @@ import struct
 import threading
 from collections import OrderedDict, UserDict
 from collections.abc import Iterator, MutableMapping
+from hashlib import sha256  # for hashing Transaction keys
 from typing import TYPE_CHECKING, Any
 
 import lmdb
@@ -24,8 +25,6 @@ from archinfo.arch_soot import SootAddressDescriptor, SootMethodDescriptor
 from angr.protos import cfg_pb2
 from angr.utils.enums_conv import cfg_jumpkind_from_pb, cfg_jumpkind_to_pb
 from angr.utils.json_utils import json_decode, json_encode
-
-from hashlib import sha256 # for hashing Transaction keys
 
 from .block_id import BlockID
 from .types import CFG_ADDR_TYPES, K

--- a/angr/knowledge_plugins/cfg/spilling_digraph.py
+++ b/angr/knowledge_plugins/cfg/spilling_digraph.py
@@ -25,6 +25,8 @@ from angr.protos import cfg_pb2
 from angr.utils.enums_conv import cfg_jumpkind_from_pb, cfg_jumpkind_to_pb
 from angr.utils.json_utils import json_decode, json_encode
 
+from hashlib import sha256 # for hashing Transaction keys
+
 from .block_id import BlockID
 from .types import CFG_ADDR_TYPES, K
 
@@ -365,7 +367,7 @@ class SpillingAdjDict(MutableMapping):
             try:
                 with self.rtdb.begin_txn(self._edgesdb, write=True) as txn:
                     for src_key, inner_dict in entries:
-                        key = repr(src_key).encode("utf-8")
+                        key = sha256(repr(src_key).encode()).hexdigest().encode("utf-8")
                         value = self._serialize_inner_dict(inner_dict)
                         txn.put(key, value)
                 break
@@ -388,7 +390,7 @@ class SpillingAdjDict(MutableMapping):
         self._loading_from_lmdb = True
 
         try:
-            lmdb_key = repr(key).encode("utf-8")
+            lmdb_key = sha256(repr(key).encode()).hexdigest().encode("utf-8")
 
             with self.rtdb.begin_txn(self._edgesdb) as txn:
                 value = txn.get(lmdb_key)
@@ -485,7 +487,7 @@ class SpillingAdjDict(MutableMapping):
                 self.rtdb.begin_txn(new_dict._edgesdb, write=True) as dst_txn,
             ):
                 for key in self._spilled_keys:
-                    lmdb_key = repr(key).encode("utf-8")
+                    lmdb_key = sha256(repr(key).encode()).hexdigest().encode("utf-8")
                     value = src_txn.get(lmdb_key)
                     if value is not None:
                         dst_txn.put(lmdb_key, value)


### PR DESCRIPTION
Another bugfix on lmdb storage, the problem here is that the edge case of `len(key) > 511` is missed. It's a little bit hard to increase the `max_key_size` (511 by default) since it's set inside C modules and it's static also must be re-defined and re-compiled etc. since we have a better solution we don't need to deal with that actually.

Solution is hashing the keys by sha256 digest, therefore all the keys with any size will be allowed. Also I think it's a better approach for database optimization.