### PR TITLE
angr/rust: recover if-let from truthiness-style enum discriminant checks

### DIFF
--- a/angr/rust/optimization_passes/pre_pattern_match_simplifier.py
+++ b/angr/rust/optimization_passes/pre_pattern_match_simplifier.py
@@ -218,6 +218,21 @@ class PrePatternMatchSimplifier(OptimizationPass, ReturnDuplicatorBase, DFAMixin
             discriminant = PrePatternMatchSimplifier._const_value(op1)
         if scrutinee is not None and discriminant is not None and cmp_op:
             return scrutinee, discriminant, cmp_op, leftover
+
+        # Truthiness-style discriminant check. A boolean-truncating conversion
+        # `Conv(N->1, x)` means "x != 0"; wrapped in `Not(...)` it means "x == 0".
+        # Compilers emit these for enum discriminant tests rendered as
+        # `if result as i8 { ... }` / `if !(result as i8) { ... }`.
+        truth_cond = condition
+        truth_cmp = "CmpNE"
+        if isinstance(truth_cond, UnaryOp) and truth_cond.op == "Not":
+            truth_cond = truth_cond.operand
+            truth_cmp = "CmpEQ"
+        if isinstance(truth_cond, Convert) and truth_cond.to_bits == 1:
+            truth_scrutinee = PrePatternMatchSimplifier._match_scrutinee(truth_cond)
+            if truth_scrutinee is not None:
+                return truth_scrutinee, 0, truth_cmp, leftover
+
         return None, None, None, None
 
     @staticmethod

--- a/tests/analyses/decompiler/test_rust_pattern_match_simplifier.py
+++ b/tests/analyses/decompiler/test_rust_pattern_match_simplifier.py
@@ -48,6 +48,57 @@ class TestRustPatternMatchSimplifier(unittest.TestCase):
         self.assertEqual(cmp_op, "CmpEQ")
         self.assertIsNone(leftover)
 
+    def test_extracts_truthiness_discriminant(self):
+        # `Conv(N -> 1, disc)`, rendered `if result as i8`, means `disc != 0`.
+        vvar = VirtualVariable(None, 0, 64, VirtualVariableCategory.STACK, -0x20)
+        condition = Convert(None, 64, 1, False, vvar)
+
+        scrutinee, discriminant, cmp_op, leftover = PrePatternMatchSimplifier.extract_scrutinee_and_discriminant(
+            condition
+        )
+
+        self.assertIs(scrutinee, vvar)
+        self.assertEqual(discriminant, 0)
+        self.assertEqual(cmp_op, "CmpNE")
+        self.assertIsNone(leftover)
+
+    def test_extracts_negated_truthiness_discriminant(self):
+        # `Not(Conv(N -> 1, disc))`, rendered `if !(result as i8)`, means `disc == 0`.
+        vvar = VirtualVariable(None, 0, 64, VirtualVariableCategory.STACK, -0x20)
+        condition = UnaryOp(None, "Not", Convert(None, 64, 1, False, vvar))
+
+        scrutinee, discriminant, cmp_op, leftover = PrePatternMatchSimplifier.extract_scrutinee_and_discriminant(
+            condition
+        )
+
+        self.assertIs(scrutinee, vvar)
+        self.assertEqual(discriminant, 0)
+        self.assertEqual(cmp_op, "CmpEQ")
+        self.assertIsNone(leftover)
+
+    def test_truthiness_discriminant_preserves_logical_and_leftover(self):
+        vvar = VirtualVariable(None, 0, 64, VirtualVariableCategory.STACK, -0x20)
+        rest = Const(None, 1, 8)
+        condition = BinaryOp(None, "LogicalAnd", [Convert(None, 64, 1, False, vvar), rest], bits=8)
+
+        scrutinee, discriminant, cmp_op, leftover = PrePatternMatchSimplifier.extract_scrutinee_and_discriminant(
+            condition
+        )
+
+        self.assertIs(scrutinee, vvar)
+        self.assertEqual(discriminant, 0)
+        self.assertEqual(cmp_op, "CmpNE")
+        self.assertIs(leftover, rest)
+
+    def test_non_boolean_conversion_is_not_a_discriminant(self):
+        # A wider truncation (`to_bits != 1`) is an ordinary cast, not a truthiness test.
+        vvar = VirtualVariable(None, 0, 64, VirtualVariableCategory.STACK, -0x20)
+        condition = Convert(None, 64, 8, False, vvar)
+
+        result = PrePatternMatchSimplifier.extract_scrutinee_and_discriminant(condition)
+
+        self.assertEqual(result, (None, None, None, None))
+
     def test_enum_variant_lookup_matches_signed_and_unsigned_discriminants(self):
         enum_ty = RustSimTypeResult(
             RustSimTypeInt(64, signed=False),


### PR DESCRIPTION
`extract_scrutinee_and_discriminant` recognized enum discriminant tests only in `CmpEQ`/`CmpNE` and sign-bit forms. Compilers also emit a discriminant test as a boolean-truncating conversion:

- `Conv(N -> 1, disc)` — rendered `if result as i8` — meaning `disc != 0`
- `Not(Conv(N -> 1, disc))` — meaning `disc == 0`

In that form the outer `Result`'s `Ok`/`Err` test rendered as `if !(v as i8)` instead of being recovered as `if let Ok(...)`. This adds truthiness handling for both polarities. Both call sites already gate on an `Option`/`Result`-typed scrutinee, so the new form is only matched where a discriminant test is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
