### PR TITLE
knowledge_plugins, code_location: recompute hashes after unpickling

### DIFF
--- a/angr/code_location.py
+++ b/angr/code_location.py
@@ -57,6 +57,27 @@ class CodeLocation[BlockAddr: int | None, StmtIdx: int | None, Context]:
         if kwargs:
             self._store_kwargs(**kwargs)
 
+    def __getstate__(self):
+        # Exclude the cached hash from the pickle: it can fold in per-process-salted
+        # hashes (e.g. of a SimProcedure class), so a persisted value is stale when
+        # unpickled in another process. It is recomputed lazily instead.
+        slotstate = {
+            slot: getattr(self, slot)
+            for klass in type(self).__mro__
+            for slot in getattr(klass, "__slots__", ())
+            if slot != "_hash" and hasattr(self, slot)
+        }
+        return getattr(self, "__dict__", None), slotstate
+
+    def __setstate__(self, state):
+        dictstate, slotstate = state if isinstance(state, tuple) else (None, state)
+        if dictstate:
+            self.__dict__.update(dictstate)
+        for slot, value in (slotstate or {}).items():
+            if slot != "_hash":
+                setattr(self, slot, value)
+        self._hash = None
+
     def __repr__(self):
         if self.block_addr is None:
             return f"<{self.sim_procedure}>"

--- a/angr/knowledge_plugins/key_definitions/atoms.py
+++ b/angr/knowledge_plugins/key_definitions/atoms.py
@@ -40,6 +40,27 @@ class Atom:
         self.size = size
         self._hash = None
 
+    def __getstate__(self):
+        # Exclude the cached hash from the pickle: it folds in per-process-salted
+        # string hashes (e.g. register names), so a persisted value is stale when
+        # unpickled in another process. It is recomputed lazily instead.
+        slotstate = {
+            slot: getattr(self, slot)
+            for klass in type(self).__mro__
+            for slot in getattr(klass, "__slots__", ())
+            if slot != "_hash" and hasattr(self, slot)
+        }
+        return getattr(self, "__dict__", None), slotstate
+
+    def __setstate__(self, state):
+        dictstate, slotstate = state if isinstance(state, tuple) else (None, state)
+        if dictstate:
+            self.__dict__.update(dictstate)
+        for slot, value in (slotstate or {}).items():
+            if slot != "_hash":
+                setattr(self, slot, value)
+        self._hash = None
+
     def __repr__(self):
         raise NotImplementedError
 

--- a/angr/knowledge_plugins/key_definitions/definition.py
+++ b/angr/knowledge_plugins/key_definitions/definition.py
@@ -169,6 +169,27 @@ class Definition[A: Atom, CodeLoc: CodeLocation | AILCodeLocation]:
         self.tags = tags or set()
         self._hash = None
 
+    def __getstate__(self):
+        # Exclude the cached hash from the pickle: it derives from the atom's hash,
+        # which folds in per-process-salted string hashes, so a persisted value is
+        # stale when unpickled in another process. It is recomputed lazily instead.
+        slotstate = {
+            slot: getattr(self, slot)
+            for klass in type(self).__mro__
+            for slot in getattr(klass, "__slots__", ())
+            if slot != "_hash" and hasattr(self, slot)
+        }
+        return getattr(self, "__dict__", None), slotstate
+
+    def __setstate__(self, state):
+        dictstate, slotstate = state if isinstance(state, tuple) else (None, state)
+        if dictstate:
+            self.__dict__.update(dictstate)
+        for slot, value in (slotstate or {}).items():
+            if slot != "_hash":
+                setattr(self, slot, value)
+        self._hash = None
+
     def __eq__(self, other):
         return self.atom == other.atom and self.codeloc == other.codeloc
 

--- a/tests/knowledge_plugins/key_definitions/test_atoms.py
+++ b/tests/knowledge_plugins/key_definitions/test_atoms.py
@@ -35,9 +35,9 @@ class TestAtoms(TestCase):
 
         for obj in (register, codeloc, definition):
             hash(obj)  # populate the cache
-            self.assertIsNotNone(obj._hash)
+            self.assertIsNotNone(obj._hash)  # pylint: disable=protected-access
             clone = pickle.loads(pickle.dumps(obj))
-            self.assertIsNone(clone._hash)
+            self.assertIsNone(clone._hash)  # pylint: disable=protected-access
             self.assertEqual(hash(clone), hash(obj))
 
 

--- a/tests/knowledge_plugins/key_definitions/test_atoms.py
+++ b/tests/knowledge_plugins/key_definitions/test_atoms.py
@@ -2,12 +2,15 @@
 # pylint: disable=missing-class-docstring
 from __future__ import annotations
 
+import pickle
 from unittest import TestCase, main
 
 from archinfo import ArchMIPS32
 
 from angr.calling_conventions import SimRegArg
+from angr.code_location import CodeLocation
 from angr.knowledge_plugins.key_definitions.atoms import Atom, Register
+from angr.knowledge_plugins.key_definitions.definition import Definition
 
 
 class TestAtoms(TestCase):
@@ -20,6 +23,22 @@ class TestAtoms(TestCase):
         self.assertTrue(isinstance(result, Register))
         self.assertEqual(result.reg_offset, arch.registers["r0"][0])
         self.assertEqual(result.size, 4)
+
+    def test_cached_hash_not_carried_across_pickling(self):
+        # The cached hash folds in per-process-salted hashes (e.g. of register
+        # name strings), so persisting it makes it stale when unpickled in
+        # another process. It must be dropped on pickling and recomputed lazily.
+        arch = ArchMIPS32()
+        register = Atom.from_argument(SimRegArg("r0", 4), arch)
+        codeloc = CodeLocation(0x400000, 0)
+        definition = Definition(register, codeloc)
+
+        for obj in (register, codeloc, definition):
+            hash(obj)  # populate the cache
+            self.assertIsNotNone(obj._hash)
+            clone = pickle.loads(pickle.dumps(obj))
+            self.assertIsNone(clone._hash)
+            self.assertEqual(hash(clone), hash(obj))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`Atom`, `Definition`, and `CodeLocation` cache their hash in a `_hash` slot, which the default pickling persists. The hash folds in per-process-salted hashes (e.g. of register-name strings, via `SpOffset`/`Register`), so a `_hash` pickled in one process is **stale** when unpickled in another: equal objects then hash differently, breaking any `set`/`dict` — or `assertCountEqual` — rebuilt from a pickle.

This adds `__getstate__`/`__setstate__` to those three classes that exclude `_hash` from the pickle and reset it to `None` on load, so it is recomputed lazily in-process. `__dict__` and all MRO slots are otherwise preserved (e.g. function-handler atoms that keep state in `__dict__`), and the existing default-format pickles still load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
