### PR TITLE
Handle rust_demangler Unabletodemangle errors

### DIFF
--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 import claripy
 import networkx
 import pydemumble
-import rust_demangler
 from archinfo.arch_arm import get_real_address_if_arm
 from cle.backends.symbol import Symbol
 
@@ -28,6 +27,7 @@ from angr.knowledge_plugins.xrefs.xref import XRef
 from angr.procedures import SIM_LIBRARIES
 from angr.procedures.definitions import SimLibrary, SimSyscallLibrary
 from angr.protos import function_pb2
+from angr.rust.utils.demangler import demangle
 from angr.serializable import Serializable
 from angr.sim_type import SimTypeFunction, parse_defns
 from angr.utils.library import get_cpp_function_name_and_metadata
@@ -1977,14 +1977,7 @@ class Function(Serializable):
     @property
     def demangled_name(self):
         if self.is_rust_function():
-            parts = rust_demangler.demangle(self.name).split("::")
-            # Drop the trailing 17-char `h<16 hex>` disambiguation hash if present (e.g.,
-            # "std::rt::lang_start::h9b2e0b6aeda0bae0" -> "std::rt::lang_start").
-            if len(parts) >= 2:
-                last = parts[-1]
-                if len(last) == 17 and last.startswith("h") and all(c in "0123456789abcdef" for c in last[1:]):
-                    parts = parts[:-1]
-            return "::".join(parts)
+            return demangle(self.name)
         ast = pydemumble.demangle(self.name).strip()
         return ast or self.name
 

--- a/angr/rust/utils/demangler.py
+++ b/angr/rust/utils/demangler.py
@@ -4,6 +4,8 @@ import re
 
 import rust_demangler
 from rust_demangler.rust import TypeNotFoundError
+from rust_demangler.rust_legacy import UnableToLegacyDemangle
+from rust_demangler.rust_v0 import UnableTov0Demangle
 
 
 def _is_rust_hash(s):
@@ -18,7 +20,7 @@ IMPL_XXX_AS_YYY_PATTERN = re.compile(r"<impl\s([^<]+?)\sas\s([^<]+?)>")
 def demangle(s):
     try:
         demangled = rust_demangler.demangle(s).split("::")
-    except TypeNotFoundError:
+    except (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDemangle):
         return s
     if len(demangled) >= 2 and _is_rust_hash(demangled[-1]):
         demangled = "::".join(demangled[:-1])


### PR DESCRIPTION
If the demangler fails, default to the mangled string.
