### PR TITLE
storage: store/load whole values verbatim in slotted memory

### DIFF
--- a/angr/storage/memory_mixins/slotted_memory.py
+++ b/angr/storage/memory_mixins/slotted_memory.py
@@ -112,10 +112,7 @@ class SlottedMemoryMixin(MemoryMixin):
         accesses = self._resolve_access(addr, size)
 
         pieces = [self._single_load(addr, offset, size) for addr, offset, size in accesses]
-        # A single access is the whole value; wrapping it in a one-element
-        # Concat would rebuild a fresh node and drop any non-relocatable
-        # annotations (e.g. StackLocationAnnotation) the backend doesn't carry
-        # onto derived ASTs.
+        # Concat pieces of there are multiple
         value = pieces[0] if len(pieces) == 1 else claripy.Concat(*pieces)
         if endness != self.endness:
             value = value.reversed
@@ -127,9 +124,9 @@ class SlottedMemoryMixin(MemoryMixin):
             data = data.reversed
 
         accesses = self._resolve_access(addr, size)
-        # When a single slot covers the whole value, store it verbatim rather
-        # than slicing with get_bytes, which would rebuild a fresh node and drop
-        # any non-relocatable annotations.
+        
+        # If we only have one access, we can skip the splitting and concatenation logic
+        # which has the side affect of creating extra claripy ASTs
         if len(accesses) == 1:
             addr, offset, size = accesses[0]
             self._single_store(addr, offset, size, data)

--- a/angr/storage/memory_mixins/slotted_memory.py
+++ b/angr/storage/memory_mixins/slotted_memory.py
@@ -111,7 +111,12 @@ class SlottedMemoryMixin(MemoryMixin):
     def load(self, addr, size=None, *, endness=None, **kwargs):
         accesses = self._resolve_access(addr, size)
 
-        value = claripy.Concat(*(self._single_load(addr, offset, size) for addr, offset, size in accesses))
+        pieces = [self._single_load(addr, offset, size) for addr, offset, size in accesses]
+        # A single access is the whole value; wrapping it in a one-element
+        # Concat would rebuild a fresh node and drop any non-relocatable
+        # annotations (e.g. StackLocationAnnotation) the backend doesn't carry
+        # onto derived ASTs.
+        value = pieces[0] if len(pieces) == 1 else claripy.Concat(*pieces)
         if endness != self.endness:
             value = value.reversed
 
@@ -122,6 +127,14 @@ class SlottedMemoryMixin(MemoryMixin):
             data = data.reversed
 
         accesses = self._resolve_access(addr, size)
+        # When a single slot covers the whole value, store it verbatim rather
+        # than slicing with get_bytes, which would rebuild a fresh node and drop
+        # any non-relocatable annotations.
+        if len(accesses) == 1:
+            addr, offset, size = accesses[0]
+            self._single_store(addr, offset, size, data)
+            return
+
         cur_offset = 0
         for addr, offset, size in accesses:
             piece = data.get_bytes(cur_offset, size)

--- a/angr/storage/memory_mixins/slotted_memory.py
+++ b/angr/storage/memory_mixins/slotted_memory.py
@@ -112,8 +112,9 @@ class SlottedMemoryMixin(MemoryMixin):
         accesses = self._resolve_access(addr, size)
 
         pieces = [self._single_load(addr, offset, size) for addr, offset, size in accesses]
-        # Concat pieces of there are multiple
+        # Concat pieces if there are multiple
         value = pieces[0] if len(pieces) == 1 else claripy.Concat(*pieces)
+
         if endness != self.endness:
             value = value.reversed
 
@@ -124,7 +125,7 @@ class SlottedMemoryMixin(MemoryMixin):
             data = data.reversed
 
         accesses = self._resolve_access(addr, size)
-        
+
         # If we only have one access, we can skip the splitting and concatenation logic
         # which has the side affect of creating extra claripy ASTs
         if len(accesses) == 1:


### PR DESCRIPTION
## Summary

`SlottedMemoryMixin` slices every store with `get_bytes` and reassembles every load with `Concat`, even when a single slot already covers the whole value. For a single access those operations are no-ops on the value, but they still build a fresh AST node.

This change skips the slice/concat when there is a single access: the store writes the value verbatim, and the load returns the single loaded piece directly.

## Why

Two benefits:

1. **Avoids unnecessary work** — no `get_bytes`/`Concat` round-trip for the common single-slot (e.g. register) case.
2. **Preserves non-relocatable annotations** — rebuilding the value through a single-element `Concat`/`Extract` produces a new node, onto which a backend need not carry a non-relocatable annotation. Returning the value unchanged keeps such annotations attached across a slotted-memory round-trip.

A concrete case: `VariableRecovery` annotates the initial stack pointer with a (non-relocatable) `StackLocationAnnotation`, and the analysis runs with `mode="fastpath"`, whose `FAST_REGISTERS` register file is backed by `SlottedMemoryMixin`. The store/load round-trip rebuilt the SP and dropped the annotation, so `_addr_to_stack_offset` could no longer recognize stack-relative addresses. Storing/loading the value verbatim fixes that.

## Compatibility

Behaviorally equivalent on backends that already fold a single-element `Concat`/full-width `Extract` to the operand — the returned value is identical, the work is just skipped. The single-access store and load paths are exercised by the existing memory, CFG, and variable-recovery suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)