### PR TITLE
Phoenix: Reduce node sorting and graph traversal.

### DIFF
--- a/angr/analyses/decompiler/region_overlay.py
+++ b/angr/analyses/decompiler/region_overlay.py
@@ -1330,7 +1330,7 @@ class _OverlayAdjAtlas(Mapping):
         return entry[1]
 
 
-class RegionOverlayGraph(networkx.DiGraph):
+class RegionOverlayGraph[T](networkx.DiGraph[T]):
     """
     A read-only, networkx-compatible view of a RegionOverlay that stores no copy of the region's subgraph: all
     queries traverse the original shared graph through the overlay's membership. Compatible with every networkx

--- a/angr/analyses/decompiler/region_overlay.py
+++ b/angr/analyses/decompiler/region_overlay.py
@@ -1330,7 +1330,7 @@ class _OverlayAdjAtlas(Mapping):
         return entry[1]
 
 
-class RegionOverlayGraph[T](networkx.DiGraph[T]):
+class RegionOverlayGraph[T](networkx.DiGraph):
     """
     A read-only, networkx-compatible view of a RegionOverlay that stores no copy of the region's subgraph: all
     queries traverse the original shared graph through the overlay's membership. Compatible with every networkx

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -2927,7 +2927,7 @@ class PhoenixStructurer(StructurerBase):
         if networkx.is_directed_acyclic_graph(full_graph):
             acyclic_graph = full_graph
         else:
-            acyclic_graph = full_graph.to_acyclic_by_order(self._node_order)
+            acyclic_graph = self._graph_helper.to_acyclic_by_order(full_graph)
         for src, dst in acyclic_graph.edges:
             if src is dst:
                 continue

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -168,6 +168,9 @@ class PhoenixStructurer(StructurerBase):
 
         has_cycle = self._has_cycle()
 
+        # initialize the directed graph helper
+        self._graph_helper = DirectedGraphHelper(self._region.graph_with_successors, has_cycle, self._region.head)
+
         # special handling for single-node loops
         if len(self._region.graph.nodes) == 1 and has_cycle:
             self._analyze_cyclic()
@@ -175,9 +178,6 @@ class PhoenixStructurer(StructurerBase):
         # checkpoint the region prior to conducting a cyclic refinement because we may not be able to structure a
         # cycle out of the refined graph. in that case, we roll the region back and return.
         pre_refinement_checkpoint: int | None = None
-
-        # initialize the directed graph helper
-        self._graph_helper = DirectedGraphHelper(self._region.graph_with_successors, has_cycle, self._region.head)
 
         while len(self._region.graph.nodes) > 1:
             progressed = self._analyze_acyclic()

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -115,8 +115,6 @@ class PhoenixStructurer(StructurerBase):
         # also whitelist certain nodes that are definitely header for switch-case constructs. they should not be merged
         # into another node before we successfully structure the entire switch-case.
         self.switch_case_known_heads: set[Block | BaseNode] = set()
-        # a cache of unstructured switch-case heads and dispatch nodes
-        self._unstructured_switch_case_heads_and_dispatch_nodes: set[Block | BaseNode] | None = None
 
         # whitelist certain nodes that should be treated as a tail node for do-whiles. these nodes should not be
         # absorbed into other SequenceNodes

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -1304,7 +1304,7 @@ class PhoenixStructurer(StructurerBase):
             node_default = Block(SWITCH_MISSING_DEFAULT_NODE_ADDR, 0, statements=[jmp_to_default_node])
             self._region.add_edge(node, node_default)
             fake_node_default = True
-            self._graph_helper.replace_node(node, node_default)
+            self._graph_helper.add_node_successor(node, node_default)
 
         r = self._make_switch_cases_core(
             node,
@@ -1644,6 +1644,9 @@ class PhoenixStructurer(StructurerBase):
                 return False
             # update node
             node = next(iter(nn for nn in graph.nodes if nn.addr == jump_table.addr))
+            # _unpack_incompleteswitchcasenode_overlay() unpacks a bunch of nodes.
+            # Reset the cache so it's rebuilt from the current graph.
+            self._graph_helper.reset()
 
         case_and_entry_addrs = self._find_case_and_entry_addrs(node, graph, cmp_lb, jump_table)
 

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -46,7 +46,7 @@ from angr.analyses.decompiler.utils import (
 from angr.knowledge_plugins.cfg import IndirectJump, IndirectJumpType
 from angr.utils.ail import is_head_controlled_loop_block, is_phi_assignment
 from angr.utils.constants import SWITCH_MISSING_DEFAULT_NODE_ADDR
-from angr.utils.graph import GraphUtils, dfs_back_edges, dominates
+from angr.utils.graph import DirectedGraphHelper, GraphUtils, dfs_back_edges, dominates
 
 from .structurer_base import StructurerBase
 
@@ -115,6 +115,8 @@ class PhoenixStructurer(StructurerBase):
         # also whitelist certain nodes that are definitely header for switch-case constructs. they should not be merged
         # into another node before we successfully structure the entire switch-case.
         self.switch_case_known_heads: set[Block | BaseNode] = set()
+        # a cache of unstructured switch-case heads and dispatch nodes
+        self._unstructured_switch_case_heads_and_dispatch_nodes: set[Block | BaseNode] | None = None
 
         # whitelist certain nodes that should be treated as a tail node for do-whiles. these nodes should not be
         # absorbed into other SequenceNodes
@@ -136,11 +138,7 @@ class PhoenixStructurer(StructurerBase):
         # TestDecompiler.test_decompiling_abnormal_switch_case_within_a_loop_with_redundant_jump captures this case.
         self._matched_incomplete_switch_case_addrs: set[int] = set()
 
-        # node_order keeps a dictionary of nodes and their order in a quasi-topological sort of the region full graph
-        # (graph_with_successors). _generate_node_order() initializes this dictionary. we then update this dictionary
-        # when new nodes are created. we do not populate this dictionary when working on acyclic graphs because it's
-        # not used for acyclic graphs.
-        self._node_order: dict[Any, int] | None = None
+        self._graph_helper: DirectedGraphHelper[Block | BaseNode] = None  # type: ignore[assignment]
 
         self._use_multistmtexprs = use_multistmtexprs
         self._multistmtexpr_stmt_threshold = multistmtexpr_stmt_threshold
@@ -177,6 +175,9 @@ class PhoenixStructurer(StructurerBase):
         # checkpoint the region prior to conducting a cyclic refinement because we may not be able to structure a
         # cycle out of the refined graph. in that case, we roll the region back and return.
         pre_refinement_checkpoint: int | None = None
+
+        # initialize the directed graph helper
+        self._graph_helper = DirectedGraphHelper(self._region.graph_with_successors, has_cycle, self._region.head)
 
         while len(self._region.graph.nodes) > 1:
             progressed = self._analyze_acyclic()
@@ -239,11 +240,9 @@ class PhoenixStructurer(StructurerBase):
 
     def _analyze_cyclic(self) -> bool:
         any_matches = False
+        loop_heads = list(self._graph_helper.loop_heads())
 
-        if self._node_order is None:
-            self._generate_node_order()
-        acyclic_graph = self._region.graph.to_acyclic_by_order(self._node_order)
-        for node in list(GraphUtils.dfs_postorder_nodes_deterministic(acyclic_graph, self._region.head)):
+        for node in reversed(self._graph_helper.sort_nodes_by_order(loop_heads)):
             if node not in self._region.graph:
                 continue
             matched = self._match_cyclic_schemas(
@@ -514,9 +513,8 @@ class PhoenixStructurer(StructurerBase):
         self.replace_nodes_both(node, loop_node, self_loop=False, drop_refinement_marks=True)
         self._region.add_edge(loop_node, successor_node)
 
-        if self._node_order is not None:
-            self._node_order[loop_node] = self._node_order[node]
-            self._node_order[successor_node] = self._node_order[loop_node]
+        self._graph_helper.replace_node(node, loop_node)
+        self._graph_helper.replace_node(loop_node, successor_node)
 
         return True, loop_node, successor_node
 
@@ -673,7 +671,7 @@ class PhoenixStructurer(StructurerBase):
     def _refine_cyclic(self) -> bool:
         graph = self._region.graph
         loop_heads = {t for _, t in dfs_back_edges(graph, self._region.head, visit_all_nodes=True)}
-        sorted_loop_heads = GraphUtils.quasi_topological_sort_nodes(graph, nodes=list(loop_heads))
+        sorted_loop_heads = self._graph_helper.sort_nodes_by_order(list(loop_heads))
 
         for head in sorted_loop_heads:
             l.debug("... refining cyclic at %r", head)
@@ -907,9 +905,7 @@ class PhoenixStructurer(StructurerBase):
         if len(continue_edges) > 1:
             # convert all but one (the one that is the farthest from the head, topological-wise) head-going edges into
             # continues
-            sorted_nodes = GraphUtils.quasi_topological_sort_nodes(
-                fullgraph, nodes=[src for src, _ in continue_edges], loop_heads=[loop_head]
-            )
+            sorted_nodes = self._graph_helper.sort_nodes_by_order([src for src, _ in continue_edges])
             src_to_ignore = sorted_nodes[-1]
             replacements = {}
 
@@ -1179,13 +1175,7 @@ class PhoenixStructurer(StructurerBase):
 
         self._assert_graph_ok(self._region.graph, "Got a wrong graph to work on")
 
-        if graph.in_degree[head] == 0 or any(graph.in_degree[n] == 0 for n in graph):
-            acyclic_graph = graph
-        else:
-            acyclic_graph = graph.to_acyclic(list(graph.in_edges(head)))
-            self._assert_graph_ok(acyclic_graph, "Removed wrong edges")
-
-        for node in list(GraphUtils.dfs_postorder_nodes_deterministic(acyclic_graph, head)):
+        for node in self._graph_helper.dfs_postorder_nodes_deterministic(head):
             if node not in graph:
                 continue
             if graph.has_edge(node, head):
@@ -1308,8 +1298,8 @@ class PhoenixStructurer(StructurerBase):
             node_default = Block(SWITCH_MISSING_DEFAULT_NODE_ADDR, 0, statements=[jmp_to_default_node])
             self._region.add_edge(node, node_default)
             fake_node_default = True
-            if self._node_order is not None:
-                self._node_order[node_default] = self._node_order[node]
+            self._graph_helper.replace_node(node, node_default)
+
         r = self._make_switch_cases_core(
             node,
             self.cond_proc.claripy_ast_from_ail_condition(last_stmt.switch_variable),
@@ -1327,8 +1317,7 @@ class PhoenixStructurer(StructurerBase):
                 # a failed match must leave the graph unchanged: drop the fake default node we just inserted, or it
                 # accumulates as a phantom successor and blocks cyclic matchers on later rounds
                 self._region.remove_node(node_default)
-                if self._node_order is not None:
-                    self._node_order.pop(node_default, None)
+                self._graph_helper.remove_node(node_default)
             return False
 
         # special handling of duplicated default nodes
@@ -1485,8 +1474,9 @@ class PhoenixStructurer(StructurerBase):
         # un-structure IncompleteSwitchCaseNode
         if isinstance(node_a, SequenceNode) and node_a.nodes and isinstance(node_a.nodes[0], IncompleteSwitchCaseNode):
             _, new_seq_node = self._unpack_sequencenode_head_overlay(node_a)
-            if new_seq_node is not None and self._node_order is not None:
-                self._node_order[new_seq_node] = self._node_order[node_a]
+            if new_seq_node is not None:
+                self._graph_helper.replace_node(node_a, new_seq_node)
+
             # update node_a
             node_a = next(iter(nn for nn in graph.nodes if nn.addr == target))
         if isinstance(node_a, IncompleteSwitchCaseNode):
@@ -1507,8 +1497,8 @@ class PhoenixStructurer(StructurerBase):
                 return False
             # update node_a
             node_a = next(iter(nn for nn in graph.nodes if nn.addr == target))
-            if self._node_order is not None:
-                self._generate_node_order()
+            # graph is changed; update the graph helper cache
+            self._graph_helper.reset()
 
         better_node_a = node_a
         if isinstance(node_a, SequenceNode) and is_empty_or_label_only_node(node_a.nodes[0]) and len(node_a.nodes) == 2:
@@ -1547,8 +1537,7 @@ class PhoenixStructurer(StructurerBase):
             for succ in all_succs:
                 region.add_edge(newsc, succ)
 
-            if self._node_order is not None:
-                self._node_order[newsc] = self._node_order[better_node_a]
+            self._graph_helper.replace_node(better_node_a, newsc)
 
             return True
 
@@ -1888,8 +1877,7 @@ class PhoenixStructurer(StructurerBase):
                         self._region.remove_node(succ_node, absorbed_into=new_node)
                     if out_nodes:
                         self._region.add_edge(new_node, out_nodes[0])
-                    if self._node_order:
-                        self._node_order[new_node] = self._node_order[node]
+                    self._graph_helper.replace_node(node, new_node)
                     return True
         return False
 
@@ -2076,23 +2064,6 @@ class PhoenixStructurer(StructurerBase):
             # there will definitely be dangling nodes after structuring. it's not ready to be structured yet.
             return False
 
-        if node_default is not None:
-            # the head no longer goes to the default case
-            self._region.detach_edge(head, node_default)
-        elif node_default_addr is not None:
-            # the default node is not in the current graph, but it might be in the full graph
-            node_default_in_full_graph = next(iter(nn for nn in full_graph if nn.addr == node_default_addr), None)
-            if node_default_in_full_graph is not None and full_graph.has_edge(head, node_default_in_full_graph):
-                # the head no longer jumps to the default node - the switch jumps to it
-                self._region.hide_edge(head, node_default_in_full_graph)
-
-        self._region.add_edge(head, scnode)
-        for nn in to_remove:
-            self._region.remove_node(nn, absorbed_into=scnode)
-
-        if self._node_order is not None:
-            self._node_order[scnode] = self._node_order[head]
-
         if out_edges:
             # sort out_edges
             out_edges_to_head = [edge for edge in out_edges if edge[1] is head]
@@ -2146,13 +2117,16 @@ class PhoenixStructurer(StructurerBase):
                     sorted(out_dst_succs_fullgraph, key=lambda o: o.addr)[0] if out_dst_succs_fullgraph else None
                 )
                 if len(out_dst_succs) > 1:
-                    assert out_dst_succ is not None
-                    l.warning(
-                        "Multiple in-region successors detected for switch-case node at %#x. Picking %#x as the "
-                        "successor and dropping others.",
-                        scnode.addr,
-                        out_dst_succ.addr,
-                    )
+                    if self.dowhile_known_tail_nodes:
+                        assert out_dst_succ is not None
+                        l.warning(
+                            "Multiple in-region successors detected for switch-case node at %#x. Picking %#x as the "
+                            "successor and dropping others.",
+                            scnode.addr,
+                            out_dst_succ.addr,
+                        )
+                    else:
+                        return False
                 if len(out_dst_succs_fullgraph) > 1:
                     assert out_dst_succ_fullgraph is not None
                     l.warning(
@@ -2180,6 +2154,22 @@ class PhoenixStructurer(StructurerBase):
                     and full_graph.in_degree[out_dst] == 0
                 ):
                     self._region.remove_node(out_dst)
+
+        if node_default is not None:
+            # the head no longer goes to the default case
+            self._region.detach_edge(head, node_default)
+        elif node_default_addr is not None:
+            # the default node is not in the current graph, but it might be in the full graph
+            node_default_in_full_graph = next(iter(nn for nn in full_graph if nn.addr == node_default_addr), None)
+            if node_default_in_full_graph is not None and full_graph.has_edge(head, node_default_in_full_graph):
+                # the head no longer jumps to the default node - the switch jumps to it
+                self._region.hide_edge(head, node_default_in_full_graph)
+
+        self._region.add_edge(head, scnode)
+        for nn in to_remove:
+            self._region.remove_node(nn, absorbed_into=scnode)
+
+        self._graph_helper.add_node_successor(head, scnode)
 
         # the head's own out-of-region case targets (e.g., the region successor when a case continues to the
         # enclosing loop head) are represented as goto-cases inside scnode, but the head's direct edges to them
@@ -3440,15 +3430,6 @@ class PhoenixStructurer(StructurerBase):
 
         return sorted(edges, key=_sort_edge, reverse=True)
 
-    def _generate_node_order(self):
-        the_graph = self._region.graph_with_successors
-        the_head = self._region.head
-        ordered_nodes = GraphUtils.quasi_topological_sort_nodes(
-            the_graph,
-            loop_heads=[the_head],
-        )
-        self._node_order = {n: i for i, n in enumerate(ordered_nodes)}
-
     def replace_nodes_both(
         self,
         old_node_0,
@@ -3470,11 +3451,11 @@ class PhoenixStructurer(StructurerBase):
             region.absorb_successor_into(old_node_1, new_node)
         if drop_refinement_marks:
             region.drop_edge_marks_from(new_node, "cyclic_refinement_outgoing")
-        if self._node_order is not None:
-            if old_node_1 is not None and old_node_1 in self._node_order:
-                self._node_order[new_node] = min(self._node_order[old_node_0], self._node_order[old_node_1])
-            else:
-                self._node_order[new_node] = self._node_order[old_node_0]
+
+        if old_node_1 is not None:
+            self._graph_helper.replace_nodes(old_node_0, old_node_1, new_node)
+        else:
+            self._graph_helper.replace_node(old_node_0, new_node)
 
     def _remove_edges_except_overlay(self, src, dst) -> None:
         """

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -673,7 +673,7 @@ class PhoenixStructurer(StructurerBase):
 
         for head in sorted_loop_heads:
             l.debug("... refining cyclic at %r", head)
-            refined = self._refine_cyclic_core(head)
+            refined = self._refine_cyclic_core(head, loop_heads)
             l.debug("... refined: %s", refined)
             if refined:
                 self._assert_graph_ok(self._region.graph, "Refinement went wrong")
@@ -681,7 +681,7 @@ class PhoenixStructurer(StructurerBase):
                 return True
         return False
 
-    def _refine_cyclic_core(self, loop_head) -> bool:
+    def _refine_cyclic_core(self, loop_head, loop_heads) -> bool:
         graph_raw = self._region.raw_graph
         fullgraph_raw = self._region.raw_graph_with_successors
 
@@ -696,7 +696,7 @@ class PhoenixStructurer(StructurerBase):
         continue_node = loop_head
 
         is_while, result_while = self._refine_cyclic_is_while_loop(graph, fullgraph, loop_head, head_succs)
-        is_dowhile, result_dowhile = self._refine_cyclic_is_dowhile_loop(graph, fullgraph, loop_head)
+        is_dowhile, result_dowhile = self._refine_cyclic_is_dowhile_loop(graph, fullgraph, loop_head, loop_heads)
 
         continue_edges: list[tuple[BaseNode, BaseNode]] = []
         outgoing_edges: list = []
@@ -737,7 +737,7 @@ class PhoenixStructurer(StructurerBase):
 
         if loop_type is None:
             # natural loop. select *any* exit edge to determine the successor
-            is_natural, result_natural = self._refine_cyclic_make_natural_loop(graph, fullgraph, loop_head)
+            is_natural, result_natural = self._refine_cyclic_make_natural_loop(graph, fullgraph, loop_head, loop_heads)
             if not is_natural:
                 # cannot refine this loop
                 return False
@@ -980,7 +980,7 @@ class PhoenixStructurer(StructurerBase):
         return bool(outgoing_edges or len(continue_edges) > 1)
 
     @staticmethod
-    def _refine_cyclic_determine_loop_body(graph, fullgraph, loop_head, successor=None) -> set[BaseNode]:
+    def _refine_cyclic_determine_loop_body(graph, fullgraph, loop_head, loop_heads, successor=None) -> set[BaseNode]:
         # determine the loop body: all nodes that have paths going to loop_head
         # networkx.has_path(graph, node, loop_head) is too expensive though.
         loop_body = {loop_head}
@@ -989,6 +989,10 @@ class PhoenixStructurer(StructurerBase):
         for node in networkx.descendants(fullgraph, loop_head):
             if node in graph and node in inverted_loophead_descendants:
                 loop_body.add(node)
+
+        if any(other_loop_head in loop_body for other_loop_head in loop_heads if other_loop_head is not loop_head):
+            # the loop body cannot contain other loop heads
+            return set()
 
         # extend the loop body if possible
         while True:
@@ -1053,7 +1057,7 @@ class PhoenixStructurer(StructurerBase):
         return False, None
 
     def _refine_cyclic_is_dowhile_loop(
-        self, graph, fullgraph, loop_head
+        self, graph, fullgraph, loop_head, loop_heads
     ) -> tuple[bool, tuple[list, list, BaseNode, BaseNode] | None]:
         # check if there is an out-going edge from the loop tail
         head_preds = list(fullgraph.predecessors(loop_head))
@@ -1072,7 +1076,7 @@ class PhoenixStructurer(StructurerBase):
                     # virtualize all other edges
                     continue_node = head_pred
                     loop_body = PhoenixStructurer._refine_cyclic_determine_loop_body(
-                        graph, fullgraph, loop_head, successor=successor
+                        graph, fullgraph, loop_head, loop_heads, successor=successor
                     )
                     for node in loop_body:
                         if node is head_pred:
@@ -1094,11 +1098,15 @@ class PhoenixStructurer(StructurerBase):
         return False, None
 
     @staticmethod
-    def _refine_cyclic_make_natural_loop(graph, fullgraph, loop_head) -> tuple[bool, tuple[list, list, Any] | None]:
+    def _refine_cyclic_make_natural_loop(
+        graph, fullgraph, loop_head, loop_heads
+    ) -> tuple[bool, tuple[list, list, Any] | None]:
         continue_edges = []
         outgoing_edges = []
 
-        loop_body = PhoenixStructurer._refine_cyclic_determine_loop_body(graph, fullgraph, loop_head)
+        loop_body = PhoenixStructurer._refine_cyclic_determine_loop_body(graph, fullgraph, loop_head, loop_heads)
+        if not loop_body:
+            return False, None
 
         # determine successor candidates using the loop body
         successor_candidates = set()

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -11,6 +11,8 @@ import networkx.algorithms
 if TYPE_CHECKING:
     from angr.analyses.decompiler.region_overlay import RegionOverlayGraph
 
+l = logging.getLogger(__name__)
+
 
 def shallow_reverse[T](g: networkx.DiGraph[T]) -> networkx.DiGraph[T]:
     """
@@ -1111,7 +1113,9 @@ class DirectedGraphHelper[T]:
             llnode.v = new_node
 
         if self._node_order is not None:
-            order = self._node_order.pop(old_node)
+            if old_node not in self._node_order:
+                l.debug("Old node %r is not in node order cache. This should not happen.", old_node)
+            order = self._node_order.pop(old_node, 0)
             self._node_order[new_node] = order
 
         if old_node == self._head:

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -1145,8 +1145,8 @@ class DirectedGraphHelper[T]:
                 llnode_1 = self._postorder_node_to_llnode.pop(old_node_1)
                 if llnode_0.prev == llnode_1:
                     llnode_0.prev = llnode_1.prev
-                if llnode_1.prev is not None:
-                    llnode_1.prev.next = llnode_0
+                    if llnode_1.prev is not None:
+                        llnode_1.prev.next = llnode_0
             elif not old_nodes_succs:
                 raise ValueError("Cannot replace nodes with no parent in postorder cache")
             else:

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -1001,3 +1001,221 @@ class GraphUtils:
             graph_copy.remove_edge(*loop_backedge)
 
         return loop_head_to_loop_nodes
+
+
+class LinkedListNode[T]:
+    """
+    A node in a linked list.
+    """
+
+    __slots__ = ("next", "prev", "v")
+
+    def __init__(self, v: T):
+        self.v: T = v
+        self.next: LinkedListNode[T] | None = None
+        self.prev: LinkedListNode[T] | None = None
+
+    def __repr__(self):
+        return f"LLNode({self.v!r})"
+
+
+class DirectedGraphHelper[T]:
+    """
+    A helper class for accelerating some graph algorithms on directed graphs.
+
+    _node_order keeps a dictionary of nodes and their order in a quasi-topological sort of the region full graph
+    (graph_with_successors). _generate_node_order() initializes this dictionary. we then update this dictionary when
+    new nodes are created.
+
+    We do not populate _node_order when working on acyclic graphs because it's not used for acyclic graphs.
+    """
+
+    def __init__(self, graph: networkx.DiGraph[T], cyclic_graph: bool, head: T):
+        self._graph: networkx.DiGraph[T] = graph
+        self._cyclic_graph = cyclic_graph
+        self._head: T | None = head
+        self._node_order: dict[T, int] | None = None
+        self._postorder_node_to_llnode: dict[T, LinkedListNode[T]] | None = None
+        self._postorder_node_ll: LinkedListNode[T] | None = None
+        self._postorder_node_head: LinkedListNode[T] | None = None
+
+    def _generate_postorder_cache(self):
+        self._postorder_node_to_llnode = {}
+
+        if self._node_order is None and self._cyclic_graph:
+            self._generate_node_order()
+            acyclic_graph = self._graph.to_acyclic_by_order(self._node_order)
+        else:
+            acyclic_graph = self._graph
+
+        assert self._head is not None
+        sorted_nodes = list(GraphUtils.dfs_postorder_nodes_deterministic(acyclic_graph, self._head))
+        for i, node in enumerate(sorted_nodes):
+            llnode = LinkedListNode(node)
+            self._postorder_node_to_llnode[node] = llnode
+            if i == 0:
+                self._postorder_node_head = llnode
+            else:
+                prev_node = sorted_nodes[i - 1]
+                assert self._postorder_node_to_llnode is not None
+                prev_llnode = self._postorder_node_to_llnode[prev_node]
+                prev_llnode.next = llnode
+                llnode.prev = prev_llnode
+
+    def _generate_node_order(self):
+        ordered_nodes = GraphUtils.quasi_topological_sort_nodes(
+            self._graph,
+            loop_heads=[self._head],
+        )
+        self._node_order = {n: i for i, n in enumerate(ordered_nodes)}
+
+    def reset(self):
+        self._node_order = None
+        self._postorder_node_to_llnode = None
+        self._postorder_node_ll = None
+        self._postorder_node_head = None
+
+    def dfs_postorder_nodes_deterministic(self, source: T) -> Iterator[T]:
+        """
+        Post-order DFS traversal of the directed graph using cache. Avoids acyclic-graph conversion or full-graph
+        traversal when cache is available.
+        """
+
+        if self._postorder_node_to_llnode is None:
+            self._generate_postorder_cache()
+
+        assert self._postorder_node_to_llnode is not None
+        llnode = self._postorder_node_head
+        while llnode is not None:
+            yield llnode.v
+            if llnode.v == source:
+                break
+            llnode = llnode.next
+
+    def replace_node(self, old_node: T, new_node: T):
+        """
+        Update cache when a node is replaced in the graph.
+        """
+
+        if self._postorder_node_to_llnode is not None and old_node in self._postorder_node_to_llnode:
+            llnode = self._postorder_node_to_llnode.pop(old_node)
+            self._postorder_node_to_llnode[new_node] = llnode
+            llnode.v = new_node
+
+        if self._node_order is not None:
+            order = self._node_order.pop(old_node)
+            self._node_order[new_node] = order
+
+        if old_node == self._head:
+            self._head = new_node
+
+    def replace_nodes(self, old_node_0: T, old_node_1: T, new_node: T) -> None:
+        """
+        Update cache when multiple nodes are replaced by a single node in the graph.
+        """
+
+        if self._postorder_node_to_llnode is not None:
+            old_nodes_succs: set[T | None] = set()
+            for old_node in [old_node_0, old_node_1]:
+                llnode = self._postorder_node_to_llnode[old_node]
+                if llnode.next is None:
+                    old_nodes_succs.add(None)
+                if llnode.next is not None and llnode.next.v not in [old_node_0, old_node_1]:
+                    old_nodes_succs.add(llnode.next.v)
+
+            if len(old_nodes_succs) == 1:
+                # old nodes have the same parent or they are consecutive
+                succ = old_nodes_succs.pop()
+                llnode_0 = self._postorder_node_to_llnode[old_node_0]
+                llnode_0.v = new_node
+                llnode_0.next = self._postorder_node_to_llnode[succ] if succ is not None else None
+                if llnode_0.next is not None:
+                    llnode_0.next.prev = llnode_0
+                self._postorder_node_to_llnode[new_node] = llnode_0
+                # clean up the old nodes
+                self._postorder_node_to_llnode.pop(old_node_0)
+                llnode_1 = self._postorder_node_to_llnode.pop(old_node_1)
+                if llnode_0.prev == llnode_1:
+                    llnode_0.prev = llnode_1.prev
+                if llnode_1.prev is not None:
+                    llnode_1.prev.next = llnode_0
+            elif not old_nodes_succs:
+                raise ValueError("Cannot replace nodes with no parent in postorder cache")
+            else:
+                # two parents; nothing we can do here, we have to invalidate the postorder cache
+                self._postorder_node_to_llnode = None
+
+        if self._node_order is not None:
+            order_0 = self._node_order.pop(old_node_0)
+            order_1 = self._node_order.pop(old_node_1)
+            self._node_order[new_node] = min(order_0, order_1)
+
+        if old_node_0 == self._head or old_node_1 == self._head:
+            self._head = new_node
+
+    def remove_node(self, node: T):
+        """
+        Update cache when a node is removed from the graph.
+        """
+
+        if self._postorder_node_to_llnode is not None and node in self._postorder_node_to_llnode:
+            llnode = self._postorder_node_to_llnode.pop(node)
+            if llnode.prev is not None:
+                llnode.prev.next = llnode.next
+            if llnode.next is not None:
+                llnode.next.prev = llnode.prev
+
+        if self._node_order is not None:
+            self._node_order.pop(node, None)
+
+        if node == self._head:
+            self._head = None  # type: ignore
+
+    def add_node_successor(self, node: T, successor: T) -> None:
+        if self._postorder_node_to_llnode is not None and successor not in self._postorder_node_to_llnode:
+            assert node in self._postorder_node_to_llnode
+            llnode = self._postorder_node_to_llnode[node]
+            succ_node = LinkedListNode(successor)
+            succ_node.next = llnode.next
+            succ_node.prev = llnode
+            if llnode.next is not None:
+                llnode.next.prev = succ_node
+            llnode.next = succ_node
+            self._postorder_node_to_llnode[successor] = succ_node
+
+        if self._node_order is not None and successor not in self._node_order:
+            assert node in self._node_order
+            for nn, o in list(self._node_order.items()):
+                if o > self._node_order[node]:
+                    self._node_order[nn] = o + 1
+            order = self._node_order[node]
+            self._node_order[successor] = order + 1
+
+    def to_acyclic_by_order(self, graph: networkx.DiGraph[T]) -> networkx.DiGraph[T]:
+        if self._node_order is None:
+            self._generate_node_order()
+
+        assert self._node_order is not None
+        return graph.to_acyclic_by_order(self._node_order)
+
+    def sort_nodes_by_order(self, nodes: list[T]) -> list[T]:
+        if self._node_order is None:
+            self._generate_node_order()
+
+        assert self._node_order is not None
+        return sorted(nodes, key=lambda n: self._node_order[n])
+
+    def loop_heads(self) -> set[T]:
+        loop_heads = set()
+
+        if not self._cyclic_graph:
+            return loop_heads
+
+        if self._node_order is None:
+            self._generate_node_order()
+        assert self._node_order is not None
+
+        for src, dst in self._graph.edges():
+            if self._node_order[src] >= self._node_order[dst]:
+                loop_heads.add(dst)
+        return loop_heads

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -1048,8 +1048,8 @@ class DirectedGraphHelper[T]:
         if self._node_order is None and self._cyclic_graph:
             self._generate_node_order()
 
-            from angr.analyses.decompiler.region_overlay import (
-                RegionOverlayGraph,  # pylint:disable=import-outside-toplevel
+            from angr.analyses.decompiler.region_overlay import (  # pylint:disable=import-outside-toplevel
+                RegionOverlayGraph,
             )
 
             acyclic_graph = cast(RegionOverlayGraph[T], self._graph).to_acyclic_by_order(self._node_order)
@@ -1158,7 +1158,7 @@ class DirectedGraphHelper[T]:
             order_1 = self._node_order.pop(old_node_1)
             self._node_order[new_node] = min(order_0, order_1)
 
-        if old_node_0 == self._head or old_node_1 == self._head:
+        if self._head in [old_node_0, old_node_1]:
             self._head = new_node
 
     def remove_node(self, node: T):

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import logging
 from collections import OrderedDict, defaultdict
 from collections.abc import Iterable, Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import networkx
 import networkx.algorithms
+
+if TYPE_CHECKING:
+    from angr.analyses.decompiler.region_overlay import RegionOverlayGraph
 
 
 def shallow_reverse[T](g: networkx.DiGraph[T]) -> networkx.DiGraph[T]:
@@ -1044,7 +1047,7 @@ class DirectedGraphHelper[T]:
 
         if self._node_order is None and self._cyclic_graph:
             self._generate_node_order()
-            acyclic_graph = self._graph.to_acyclic_by_order(self._node_order)
+            acyclic_graph = cast(RegionOverlayGraph[T], self._graph).to_acyclic_by_order(self._node_order)
         else:
             acyclic_graph = self._graph
 
@@ -1191,7 +1194,7 @@ class DirectedGraphHelper[T]:
             order = self._node_order[node]
             self._node_order[successor] = order + 1
 
-    def to_acyclic_by_order(self, graph: networkx.DiGraph[T]) -> networkx.DiGraph[T]:
+    def to_acyclic_by_order(self, graph: RegionOverlayGraph[T]) -> networkx.DiGraph[T]:
         if self._node_order is None:
             self._generate_node_order()
 
@@ -1203,7 +1206,7 @@ class DirectedGraphHelper[T]:
             self._generate_node_order()
 
         assert self._node_order is not None
-        return sorted(nodes, key=lambda n: self._node_order[n])
+        return sorted(nodes, key=lambda n: self._node_order[n])  # type: ignore
 
     def loop_heads(self) -> set[T]:
         loop_heads = set()

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -1047,6 +1047,11 @@ class DirectedGraphHelper[T]:
 
         if self._node_order is None and self._cyclic_graph:
             self._generate_node_order()
+
+            from angr.analyses.decompiler.region_overlay import (
+                RegionOverlayGraph,  # pylint:disable=import-outside-toplevel
+            )
+
             acyclic_graph = cast(RegionOverlayGraph[T], self._graph).to_acyclic_by_order(self._node_order)
         else:
             acyclic_graph = self._graph


### PR DESCRIPTION
- Introduce a DirectedGraphHelper to keep track of node order and post-order graph traversal sequence when graphs change. This way we significantly reduce the number of calls to
RegionOverlayGraph.successors().

- Fix an issue that leads to pre-maturely structuring a switch-case.