### PR TITLE
docs: Fix a python snippet and reST formatting

### DIFF
--- a/docs/core-concepts/simulation.rst
+++ b/docs/core-concepts/simulation.rst
@@ -104,7 +104,7 @@ cool! A point is set as follows:
    # on the other hand, we can have a breakpoint trigger right *after* a memory write happens.
    # we can also have a callback function run instead of opening ipdb.
    >>> def debug_func(state):
-   ...     print("State %s is about to do a memory write!")
+   ...     print(f"State {state} is about to do a memory write!")
 
    >>> s.inspect.b('mem_write', when=angr.BP_AFTER, action=debug_func)
 

--- a/docs/core-concepts/states.rst
+++ b/docs/core-concepts/states.rst
@@ -180,8 +180,8 @@ You can customize the state through several arguments to these constructors:
 
 * To specify the calling convention used for a function with ``call_state``, you
   can pass a :py:class:`~angr.calling_conventions.SimCC` instance as the ``cc``
-  argument.:raw-html-m2r:`<br>` We try to pick a sane default, but for special
-  cases you will need to help angr out.
+  argument. We try to pick a sane default, but for special cases you will need
+  to help angr out.
 
 There are several more options that can be used in any of these constructors!
 See the docs on the ``project.factory`` object (an


### PR DESCRIPTION
Some more nits I noticed when reading the docs.

The snippet from `simulation.rst` now prints stuff like `State <SimState @ 0x8584011> is about to do a memory write!`. Not ideal, but no idea what the original author wanted to print there.

For `:raw-html-m2r:`, I'll check in a second whether my fix works (by looking at your docs pipeline).

There are two more issues I found, but I don't know how to fix them, as the referenced docs doesn't seem to exist yet or anymore:

[core-concepts/pathgroups.html](https://docs.angr.io/en/latest/core-concepts/pathgroups.html):
- leftover TODO: "but you should check out the API documentation. TODO: link"
- there's no such crackme now? also, it points to .md, not .rst: "Let’s look at a simple crackme example <./examples.md#reverseme-modern-binary-exploitation—csci-4968>:"