### PR TITLE
angr: wrap strided-interval annotation bounds to unsigned at construction

### DIFF
--- a/angr/state_plugins/solver.py
+++ b/angr/state_plugins/solver.py
@@ -424,7 +424,12 @@ class SimSolver(SimStatePlugin):
                 **kwargs,
             )
             if any(x is not None for x in (min, max, stride)):
-                r = r.annotate(claripy.annotation.StridedIntervalAnnotation(stride, min, max))
+                # Strided-interval bounds are stored unsigned; wrap any signed
+                # bound to its two's-complement representation at this width.
+                mask = (1 << size) - 1
+                si_min = None if min is None else min & mask
+                si_max = None if max is None else max & mask
+                r = r.annotate(claripy.annotation.StridedIntervalAnnotation(stride, si_min, si_max))
             if uninitialized:
                 r = r.annotate(claripy.annotation.UninitializedAnnotation())
             if key is not None:

--- a/angr/utils/balancer.py
+++ b/angr/utils/balancer.py
@@ -68,8 +68,8 @@ class Balancer:
             ast = self._ast_hash_map[k]
             max_int = (1 << len(ast)) - 1
             min_int = 0
-            mn = self._lower_bounds.get(k, min_int)
-            mx = self._upper_bounds.get(k, max_int)
+            mn = self._lower_bounds.get(k, min_int) & max_int
+            mx = self._upper_bounds.get(k, max_int) & max_int
             bound_si = claripy.BVS("bound", len(ast)).annotate(StridedIntervalAnnotation(1, mn, mx))
             log.debug("Yielding bound %s for %s.", bound_si, ast)
             if ast.op == "Reverse":
@@ -104,8 +104,9 @@ class Balancer:
     @staticmethod
     def _same_bound_bv(a: BV) -> BV:
         si = claripy.backends.vsa.simplify(a)
-        mx = Balancer._max(a)
-        mn = Balancer._min(a)
+        mask = (1 << len(a)) - 1
+        mx = Balancer._max(a) & mask
+        mn = Balancer._min(a) & mask
         si_anno = si.get_annotation(StridedIntervalAnnotation)
         stride = si_anno.stride if si_anno is not None else 0
         return claripy.BVS("bounds", len(a)).annotate(StridedIntervalAnnotation(stride, mn, mx))


### PR DESCRIPTION
`StridedIntervalAnnotation` stores unsigned bounds, but the balancer can derive *signed* bounds (e.g. from a constraint like `x > -5`). This wraps each bound to its two's-complement representation at the value's bit width **before** constructing the annotation, in the two balancer sites (`_replacements_iter`, `_same_bound_bv`) and in `SimSolver` (with `None`-guards for unset bounds).

This is behavior-preserving: the strided interval materialized from the annotation is unchanged (the bounds were wrapped at materialization regardless); this just normalizes the stored bounds to match it, so a signed bound isn't stashed verbatim in an annotation documented as unsigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)