### PR TITLE
angr/decompiler: key AILExprIdAnnotation on the AIL expression id

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -74,15 +74,7 @@ class AILExprIdAnnotation(claripy.Annotation):
     """
     An annotation that we use to annotate BVVs so that they are differentiable between other BVVs with the same value
     and size.
-
-    Identity is keyed on the originating AIL expression's ``idx``: two annotations compare equal iff they carry the
-    same id, giving the annotated constant a stable, deterministic hash (unlike Python's default object-identity hash).
-    Constants from the same AIL expression therefore annotate identically (so structurally-equal conditions compare
-    equal regardless of process), while constants from different AIL expressions stay distinguishable.
     """
-
-    def __init__(self, expr_id):
-        self.expr_id = expr_id
 
     @property
     def eliminatable(self):
@@ -93,10 +85,10 @@ class AILExprIdAnnotation(claripy.Annotation):
         return False
 
     def __hash__(self):
-        return hash((AILExprIdAnnotation, self.expr_id))
+        return 1
 
     def __eq__(self, other):
-        return isinstance(other, AILExprIdAnnotation) and self.expr_id == other.expr_id
+        return isinstance(other, AILExprIdAnnotation)
 
 
 #
@@ -1039,7 +1031,7 @@ class ConditionProcessor:
                 var = claripy.BVV(condition.value, condition.bits)
                 if condition.idx is not None:
                     # we do not want to lose track of this constant when it has idx
-                    var = var.annotate(AILExprIdAnnotation(condition.idx))
+                    var = var.annotate(AILExprIdAnnotation())
                     self._condition_mapping[var] = condition
             if isinstance(var, claripy.ast.Bits) and var.size() == 1:
                 var = claripy.true() if var.concrete_value == 1 else claripy.false()

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -74,7 +74,15 @@ class AILExprIdAnnotation(claripy.Annotation):
     """
     An annotation that we use to annotate BVVs so that they are differentiable between other BVVs with the same value
     and size.
+
+    Identity is keyed on the originating AIL expression's ``idx``: two annotations compare equal iff they carry the
+    same id, giving the annotated constant a stable, deterministic hash (unlike Python's default object-identity hash).
+    Constants from the same AIL expression therefore annotate identically (so structurally-equal conditions compare
+    equal regardless of process), while constants from different AIL expressions stay distinguishable.
     """
+
+    def __init__(self, expr_id):
+        self.expr_id = expr_id
 
     @property
     def eliminatable(self):
@@ -83,6 +91,12 @@ class AILExprIdAnnotation(claripy.Annotation):
     @property
     def relocatable(self):
         return False
+
+    def __hash__(self):
+        return hash((AILExprIdAnnotation, self.expr_id))
+
+    def __eq__(self, other):
+        return isinstance(other, AILExprIdAnnotation) and self.expr_id == other.expr_id
 
 
 #
@@ -1025,7 +1039,7 @@ class ConditionProcessor:
                 var = claripy.BVV(condition.value, condition.bits)
                 if condition.idx is not None:
                     # we do not want to lose track of this constant when it has idx
-                    var = var.annotate(AILExprIdAnnotation())
+                    var = var.annotate(AILExprIdAnnotation(condition.idx))
                     self._condition_mapping[var] = condition
             if isinstance(var, claripy.ast.Bits) and var.size() == 1:
                 var = claripy.true() if var.concrete_value == 1 else claripy.false()


### PR DESCRIPTION
`AILExprIdAnnotation` annotates constants during AIL↔claripy condition conversion so that equal-valued constants stay distinguishable. It used Python's default object-identity `__hash__`, so an annotated constant's hash varied from run to run — two conversions of the *same* constant produced different hashes.

This defines `__hash__`/`__eq__` keyed on the originating AIL expression's `idx`:
- constants from the **same** AIL expression annotate identically → stable, deterministic hash;
- constants from **different** AIL expressions stay distinguishable (the annotation's purpose).

Behavior-preserving and deterministic. This also makes structuring's condition comparisons (which compare simplified ASTs) reproducible across processes, which matters when running the decompiler under `pytest -n auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)