### PR TITLE
angr/decompiler: rewrite shifted-equality back to a masked compare

### DIFF
--- a/angr/analyses/decompiler/peephole_optimizations/__init__.py
+++ b/angr/analyses/decompiler/peephole_optimizations/__init__.py
@@ -18,6 +18,7 @@ from .bitwise_or_to_logical_or import BitwiseOrToLogicalOr
 from .bool_expr_xor_1 import BoolExprXor1
 from .bswap import Bswap
 from .cas_intrinsics import CASIntrinsics
+from .cmp_masked_shift import CmpMaskedShift
 from .cmpord_rewriter import CmpORDRewriter
 from .coalesce_adjacent_shrs import CoalesceAdjacentShiftRights
 from .coalesce_same_cascading_ifs import CoalesceSameCascadingIfs
@@ -108,6 +109,7 @@ ALL_PEEPHOLE_OPTS: list[Any] = [
     InvertNegatedLogicalConjunctionsAndDisjunctions,
     RolRorRewriter,
     CmpORDRewriter,
+    CmpMaskedShift,
     CoalesceAdjacentShiftRights,
     ShlToMul,
     RewriteCxxOperatorCalls,

--- a/angr/analyses/decompiler/peephole_optimizations/cmp_masked_shift.py
+++ b/angr/analyses/decompiler/peephole_optimizations/cmp_masked_shift.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from angr.ailment.expression import BinaryOp, Const, Convert
+
+from .base import PeepholeOptimizationExprBase
+
+
+class CmpMaskedShift(PeepholeOptimizationExprBase):
+    """
+    Rewrite an equality comparison against a right-shifted value back into a
+    masked comparison, which reads better for flag/discriminant checks.
+
+        (x >> n) == c                   ==>  (x & mask) == (c << n)
+        Convert(N->M, x >> n) == c      ==>  (x & mask) == (c << n)
+
+    where ``mask`` selects the compared bits ``[n, n+width-1]`` of ``x`` and
+    ``width`` is the truncated width ``M`` (or ``N - n`` when there is no
+    Convert). This is the inverse of a simplification that can turn
+    ``(x & high_mask) == c`` (a mask that clears the low bits) into the
+    shift/extract form: the masked compare is the clearer form in decompiled
+    output, so restore it.
+
+    Only logical right shifts and unsigned truncations are handled, and only
+    ``n > 0`` (a low-mask compare, ``n == 0``, already reads as a cast).
+    """
+
+    __slots__ = ()
+
+    NAME = "(x >> n) == c => (x & mask) == (c << n)"
+    expr_classes = (BinaryOp,)
+
+    def optimize(self, expr: BinaryOp, **kwargs):
+        if expr.op not in ("CmpEQ", "CmpNE"):
+            return None
+
+        op0, op1 = expr.operands
+        # Normalize so the constant is op1.
+        if isinstance(op0, Const) and not isinstance(op1, Const):
+            op0, op1 = op1, op0
+        if not isinstance(op1, Const) or not op1.is_int:
+            return None
+
+        # Peel an optional unsigned truncating Convert.
+        shifted = op0
+        width = None
+        if isinstance(shifted, Convert):
+            if shifted.is_signed or shifted.to_bits >= shifted.from_bits:
+                return None
+            width = shifted.to_bits
+            shifted = shifted.operand
+
+        # The inner expression must be a logical right shift by a constant.
+        if not (isinstance(shifted, BinaryOp) and shifted.op == "Shr"):
+            return None
+        x, shift = shifted.operands
+        if not (isinstance(shift, Const) and shift.is_int):
+            return None
+        n = shift.value_int
+        if n <= 0:
+            return None
+
+        bits = x.bits
+        if width is None:
+            width = bits - n
+        if width <= 0 or n + width > bits:
+            return None
+
+        c = op1.value_int
+        if c >> width != 0:
+            # The constant does not fit in the compared width; not this pattern.
+            return None
+
+        mask = ((1 << width) - 1) << n
+        new_const = c << n
+
+        and_expr = BinaryOp(
+            self.manager.next_atom(),
+            "And",
+            (
+                x,
+                Const(self.manager.next_atom(), mask, bits),
+            ),
+            False,
+            **expr.tags,
+        )
+        return BinaryOp(
+            expr.idx,
+            expr.op,
+            (
+                and_expr,
+                Const(self.manager.next_atom(), new_const, bits),
+            ),
+            expr.signed,
+            bits=expr.bits,
+            floating_point=expr.floating_point,
+            rounding_mode=expr.rounding_mode,
+            **expr.tags,
+        )

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -107,9 +107,7 @@ class TestPeepholeOptimizations(unittest.TestCase):
         assert opt.optimize(expr) is None
 
         # constant too wide for the compared width: not this pattern
-        conv = ailment.Expr.Convert(
-            None, 32, 28, False, BinaryOp(None, "Shr", [x, Const(None, 4, 32)], False, bits=32)
-        )
+        conv = ailment.Expr.Convert(None, 32, 28, False, BinaryOp(None, "Shr", [x, Const(None, 4, 32)], False, bits=32))
         expr = BinaryOp(None, "CmpEQ", [conv, Const(None, 1 << 28, 32)], False, bits=1)
         assert opt.optimize(expr) is None
 

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -13,7 +13,7 @@ import angr
 from angr import ailment
 from angr.ailment.expression import BinaryOp, Const
 from angr.ailment.manager import Manager
-from angr.analyses.decompiler.peephole_optimizations import ConstantDereferences, EagerEvaluation
+from angr.analyses.decompiler.peephole_optimizations import CmpMaskedShift, ConstantDereferences, EagerEvaluation
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
@@ -63,6 +63,55 @@ class TestPeepholeOptimizations(unittest.TestCase):
         expr = BinaryOp(None, "Mod", [Const(None, 12, 32), Const(None, 0, 32)])
         expr_opt = opt.optimize(expr)
         assert expr_opt is None
+
+    def test_cmp_masked_shift(self):
+        proj = angr.load_shellcode(b"\x90", "AMD64")
+        manager = Manager()
+        opt = CmpMaskedShift(proj, proj.kb, manager)
+
+        x = ailment.Expr.Register(None, 0, 32)
+
+        # Convert(32->28, x >> 4) == 0x184d2a5  ==>  (x & 0xfffffff0) == 0x184d2a50
+        shr = BinaryOp(None, "Shr", [x, Const(None, 4, 32)], False, bits=32)
+        conv = ailment.Expr.Convert(None, 32, 28, False, shr)
+        expr = BinaryOp(None, "CmpEQ", [conv, Const(None, 0x184D2A5, 28)], False, bits=1)
+        out = opt.optimize(expr)
+        assert isinstance(out, BinaryOp) and out.op == "CmpEQ"
+        and_expr, rhs = out.operands
+        assert isinstance(and_expr, BinaryOp) and and_expr.op == "And"
+        assert isinstance(and_expr.operands[1], Const) and and_expr.operands[1].value == 0xFFFFFFF0
+        assert isinstance(rhs, Const) and rhs.value == 0x184D2A50
+
+        # bare (x >> 8) != 0x12  ==>  (x & 0xffffff00) != 0x1200
+        shr = BinaryOp(None, "Shr", [x, Const(None, 8, 32)], False, bits=32)
+        expr = BinaryOp(None, "CmpNE", [shr, Const(None, 0x12, 32)], False, bits=1)
+        out = opt.optimize(expr)
+        assert isinstance(out, BinaryOp) and out.op == "CmpNE"
+        and_expr, rhs = out.operands
+        assert and_expr.operands[1].value == 0xFFFFFF00
+        assert rhs.value == 0x1200
+
+        # n == 0 (low-mask / cast case) is left alone
+        expr = BinaryOp(
+            None,
+            "CmpEQ",
+            [BinaryOp(None, "Shr", [x, Const(None, 0, 32)], False, bits=32), Const(None, 5, 32)],
+            False,
+            bits=1,
+        )
+        assert opt.optimize(expr) is None
+
+        # arithmetic shift (Sar) is left alone
+        sar = BinaryOp(None, "Sar", [x, Const(None, 4, 32)], True, bits=32)
+        expr = BinaryOp(None, "CmpEQ", [sar, Const(None, 5, 28)], False, bits=1)
+        assert opt.optimize(expr) is None
+
+        # constant too wide for the compared width: not this pattern
+        conv = ailment.Expr.Convert(
+            None, 32, 28, False, BinaryOp(None, "Shr", [x, Const(None, 4, 32)], False, bits=32)
+        )
+        expr = BinaryOp(None, "CmpEQ", [conv, Const(None, 1 << 28, 32)], False, bits=1)
+        assert opt.optimize(expr) is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a `CmpMaskedShift` peephole optimization that rewrites an equality comparison against a right-shifted value back into a masked comparison:

```
(x >> n) == c                ==>  (x & mask) == (c << n)
Convert(N->M, x >> n) == c   ==>  (x & mask) == (c << n)
```

where `mask` selects the compared bits `[n, n+width-1]` of `x`.

This is the inverse of a simplification that can turn a masked compare that clears the low bits into the shift/extract form. The masked compare is the clearer form in decompiled output — e.g. an aligned-pointer or bit-field check reads as `(*p & 0xfffffff0) == 0x184d2a50` rather than `(*p >> 4) == 0x184d2a5` — so this restores it.

## Details

The rewrite is value-equivalent. Guards:

- only logical right shifts (`Shr`) and unsigned truncating `Convert`s are handled;
- only `n > 0` (an `n == 0` low-mask already reads as a cast);
- only when the compared constant fits the compared width.

## Testing

Adds `test_cmp_masked_shift` to `tests/analyses/decompiler/test_peephole_optimizations.py`, covering the plain-shift and `Convert(...>>n)` forms and the guard cases. The full `test_peephole_optimizations.py` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)