### PR TITLE
VariableManager: skip phi sub-variables that aren't unification candidates

### DIFF
--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -1174,7 +1174,8 @@ class VariableManagerInternal(Serializable):
                 if not isinstance(v, (SimRegisterVariable, SimStackVariable)):
                     continue
                 for subv in subvs:
-                    unify(subv, v)
+                    if subv in congruence_classes:
+                        unify(subv, v)
 
             # unify stack variables at the same offsets only if their corresponding vvars do not interfere
             stack_vars_by_offset: dict[int, set[SimStackVariable]] = defaultdict(set)

--- a/tests/knowledge_plugins/test_variable_manager.py
+++ b/tests/knowledge_plugins/test_variable_manager.py
@@ -8,13 +8,47 @@ import os
 import pickle
 import unittest
 
+import networkx
+
 import angr
+from angr.sim_variable import SimMemoryVariable, SimStackVariable
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
 
 
 class TestVariableManager(unittest.TestCase):
+    def test_unify_variables_tolerates_non_candidate_phi_subvariable(self):
+        # A phi sub-variable may be a global SimMemoryVariable that is not itself a
+        # recovered variable (e.g. a local assigned from a global on one path). Such
+        # a sub-variable is absent from the congruence classes, and unify_variables()
+        # must not choke on it. Regression test for a KeyError in unify().
+        p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        vmi = p.kb.variables.get_function_manager(0x400000)
+
+        # Two recovered stack locals at the same slot -> they appear in get_variables().
+        sv_a = SimStackVariable(-0x20, 4, base="bp", ident=vmi.next_variable_ident("stack"))
+        sv_b = SimStackVariable(-0x20, 4, base="bp", ident=vmi.next_variable_ident("stack"))
+        vmi.set_variable("stack", -0x20, sv_a)
+        vmi.set_variable("stack", -0x20, sv_b)
+
+        # A global load that is *not* a recovered variable (absent from get_variables()).
+        gv = SimMemoryVariable(0x601000, 4, ident=vmi.next_variable_ident("global"))
+
+        # A stack phi over the two locals, with the global merged in as a third source.
+        phi = vmi.make_phi_node(0x400100, sv_a, sv_b)
+        vmi.make_phi_node(0x400100, phi, gv)
+        assert isinstance(phi, SimStackVariable)
+        assert gv in vmi.get_phi_subvariables(phi)
+        assert gv not in vmi.get_variables()
+
+        # Must not raise (previously: KeyError on the global sub-variable).
+        vmi.unify_variables(interference=networkx.Graph())
+
+        # The stack locals are unified; the non-candidate global is left alone.
+        assert vmi.unified_variable(sv_a) is not None
+        assert vmi.unified_variable(gv) is None
+
     def test_variable_manager_internal_pickle(self):
         p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
         vm = p.kb.variables


### PR DESCRIPTION
## Summary

`VariableManagerInternal.unify_variables()` builds `congruence_classes` from `get_variables() + _phi_variables`, **excluding `SimConstantVariable`**, and then unifies each phi sub-variable with its phi result via `unify(subv, v)`.

The `SimConstantVariable` exclusion already establishes that not every phi sub-variable is a unification candidate — but the `unify()` call isn't guarded against it. Any sub-variable absent from `congruence_classes` raises `KeyError` on the `congruence_classes[subv]` lookup.

Besides constants, a **global `SimMemoryVariable`** can appear as a phi sub-variable — e.g. a local that is assigned from a global on one path and from a register/stack slot on another. It is likewise absent from `congruence_classes`, so `unify()` raises `KeyError: <... Mem 0x... N>`.

## Fix

Guard the `unify()` call on membership. Sub-variables that aren't unification candidates (constants, globals) are simply not unified with the phi result, which is the intended behavior since they denote different storage:

```python
for subv in subvs:
    if subv in congruence_classes:
        unify(subv, v)
```

## Testing

Adds `test_unify_variables_tolerates_non_candidate_phi_subvariable`, which builds a stack phi whose sources include a global `SimMemoryVariable` that is not a recovered variable, and asserts `unify_variables()` does not raise and leaves the global un-unified (while the stack locals are unified). The test fails with `KeyError` without the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)