### PR TITLE
Block: _using_pcode_engine returns false when project is none

### DIFF
--- a/angr/block.py
+++ b/angr/block.py
@@ -427,6 +427,8 @@ class Block(Serializable):
 
     @property
     def _using_pcode_engine(self) -> bool:
+        if self._project is None:
+            return False
         return (pcode is not None) and isinstance(self._vex_engine, pcode.HeavyPcodeMixin)
 
     @property


### PR DESCRIPTION
Trying to access `block.disassembly` without setting project raises ValueError in `Block._vex_engine`. 
This change fixes that and makes `block.disassembly` fall through to `block.capstone`.