### PR TITLE
Fix cache misses in DirectedGraphHelper.

### DIFF
--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -510,11 +510,12 @@ class PhoenixStructurer(StructurerBase):
         for node_ in seq_node.nodes:
             if node_ is not node_copy and node_ is not node:
                 self._region.remove_node(node_, absorbed_into=node, absorb_out_edges=True)
+                self._graph_helper.remove_node(node_)
+        # replace_nodes_both() updates the graph helper cache for node -> loop_node
         self.replace_nodes_both(node, loop_node, self_loop=False, drop_refinement_marks=True)
         self._region.add_edge(loop_node, successor_node)
-
-        self._graph_helper.replace_node(node, loop_node)
-        self._graph_helper.replace_node(loop_node, successor_node)
+        # successor_node was not a graph node before; it is now the successor of loop_node
+        self._graph_helper.add_node_successor(loop_node, successor_node)
 
         return True, loop_node, successor_node
 
@@ -1483,9 +1484,13 @@ class PhoenixStructurer(StructurerBase):
 
         # un-structure IncompleteSwitchCaseNode
         if isinstance(node_a, SequenceNode) and node_a.nodes and isinstance(node_a.nodes[0], IncompleteSwitchCaseNode):
+            unpacked_head = node_a.nodes[0]
             _, new_seq_node = self._unpack_sequencenode_head_overlay(node_a)
             if new_seq_node is not None:
-                self._graph_helper.replace_node(node_a, new_seq_node)
+                # node_a was split into two graph nodes: its head (which takes node_a's place) followed by the
+                # new sequence node that holds the remaining nodes
+                self._graph_helper.replace_node(node_a, unpacked_head)
+                self._graph_helper.add_node_successor(unpacked_head, new_seq_node)
 
             # update node_a
             node_a = next(iter(nn for nn in graph.nodes if nn.addr == target))
@@ -1540,6 +1545,7 @@ class PhoenixStructurer(StructurerBase):
             region.add_node(newsc)
             if node_default is not None:
                 region.remove_node(node_default, absorbed_into=newsc)
+                self._graph_helper.remove_node(node_default)
             region.remove_node(node, absorbed_into=newsc)
             region.remove_node(node_a, absorbed_into=newsc)
             for pred in all_preds:
@@ -1547,9 +1553,21 @@ class PhoenixStructurer(StructurerBase):
             for succ in all_succs:
                 region.add_edge(newsc, succ)
 
-            self._graph_helper.replace_node(better_node_a, newsc)
+            # newsc takes the place of node (the switch head) in the graph; node_a and node_default are absorbed
+            # into newsc and no longer exist. note that better_node_a may not be a graph node at all (it may be a
+            # node inside the node_a sequence node), so it must not be used to update the graph helper cache.
+            self._graph_helper.replace_node(node, newsc)
+            self._graph_helper.remove_node(node_a)
 
             return True
+
+        if isinstance(better_node_a, SwitchCaseNode) or (
+            isinstance(node_a, SequenceNode) and node_a.nodes and isinstance(node_a.nodes[-1], SwitchCaseNode)
+        ):
+            # the jump table dispatch in node_a has already been structured into a switch-case node that we cannot
+            # recreate here. rebuilding the switch from the current graph would discard the existing switch-case
+            # node together with all of its case nodes. bail.
+            return False
 
         if node_default is None:
             switch_end_addr = node_b_addr
@@ -1885,12 +1903,13 @@ class PhoenixStructurer(StructurerBase):
                 ) and node.addr not in self._matched_incomplete_switch_case_addrs:
                     self._matched_incomplete_switch_case_addrs.add(node.addr)
                     new_node = IncompleteSwitchCaseNode(node.addr, node, successors)
+                    # replace_nodes_both() updates the graph helper cache for node -> new_node
                     self.replace_nodes_both(node, new_node)
                     for succ_node in successors:
                         self._region.remove_node(succ_node, absorbed_into=new_node)
+                        self._graph_helper.remove_node(succ_node)
                     if out_nodes:
                         self._region.add_edge(new_node, out_nodes[0])
-                    self._graph_helper.replace_node(node, new_node)
                     return True
         return False
 

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -1060,6 +1060,16 @@ class DirectedGraphHelper[T]:
 
         assert self._head is not None
         sorted_nodes = list(GraphUtils.dfs_postorder_nodes_deterministic(acyclic_graph, self._head))
+        if len(sorted_nodes) < len(acyclic_graph):
+            # some nodes are unreachable from the head (e.g., when edge marks hide the head's out-edges from this
+            # view). they must still be present in the cache because node-replacement updates may reference them;
+            # append them after the head so iteration from the head is unaffected.
+            seen = set(sorted_nodes)
+            rest = sorted((n for n in acyclic_graph if n not in seen), key=GraphUtils._sort_node)
+            for node in GraphUtils.dfs_postorder_nodes_deterministic_multi(acyclic_graph, rest):
+                if node not in seen:
+                    seen.add(node)
+                    sorted_nodes.append(node)
         for i, node in enumerate(sorted_nodes):
             llnode = LinkedListNode(node)
             self._postorder_node_to_llnode[node] = llnode
@@ -1081,6 +1091,11 @@ class DirectedGraphHelper[T]:
 
     def reset(self):
         self._node_order = None
+        self._postorder_node_to_llnode = None
+        self._postorder_node_ll = None
+        self._postorder_node_head = None
+
+    def _invalidate_postorder_cache(self) -> None:
         self._postorder_node_to_llnode = None
         self._postorder_node_ll = None
         self._postorder_node_head = None
@@ -1107,16 +1122,25 @@ class DirectedGraphHelper[T]:
         Update cache when a node is replaced in the graph.
         """
 
-        if self._postorder_node_to_llnode is not None and old_node in self._postorder_node_to_llnode:
-            llnode = self._postorder_node_to_llnode.pop(old_node)
-            self._postorder_node_to_llnode[new_node] = llnode
-            llnode.v = new_node
+        if self._postorder_node_to_llnode is not None:
+            if old_node not in self._postorder_node_to_llnode:
+                # last resort: the cache is stale; invalidate it so that it gets regenerated on demand. this should
+                # not happen - fix the offending graph updater if it does.
+                l.warning("replace_node: Node %r is not in the postorder cache.", old_node)
+                self._invalidate_postorder_cache()
+            else:
+                llnode = self._postorder_node_to_llnode.pop(old_node)
+                self._postorder_node_to_llnode[new_node] = llnode
+                llnode.v = new_node
 
         if self._node_order is not None:
             if old_node not in self._node_order:
-                l.debug("Old node %r is not in node order cache. This should not happen.", old_node)
-            order = self._node_order.pop(old_node, 0)
-            self._node_order[new_node] = order
+                # last resort: the cache is stale; invalidate it so that it gets regenerated on demand. this should
+                # not happen - fix the offending graph updater if it does.
+                l.warning("replace_node: Node %r is not in the node order cache.", old_node)
+                self._node_order = None
+            else:
+                self._node_order[new_node] = self._node_order.pop(old_node)
 
         if old_node == self._head:
             self._head = new_node
@@ -1125,6 +1149,14 @@ class DirectedGraphHelper[T]:
         """
         Update cache when multiple nodes are replaced by a single node in the graph.
         """
+
+        if self._postorder_node_to_llnode is not None and (
+            old_node_0 not in self._postorder_node_to_llnode or old_node_1 not in self._postorder_node_to_llnode
+        ):
+            # last resort: a node was added to the graph without updating the cache; invalidate the cache so that
+            # it gets regenerated on demand. this should not happen - fix the offending graph updater if it does.
+            l.warning("replace_nodes: Node %r or %r is not in the postorder cache.", old_node_0, old_node_1)
+            self._invalidate_postorder_cache()
 
         if self._postorder_node_to_llnode is not None:
             old_nodes_succs: set[T | None] = set()
@@ -1138,29 +1170,39 @@ class DirectedGraphHelper[T]:
             if len(old_nodes_succs) == 1:
                 # old nodes have the same parent or they are consecutive
                 succ = old_nodes_succs.pop()
-                llnode_0 = self._postorder_node_to_llnode[old_node_0]
+                # pop the old nodes before inserting the new node: new_node may be the same object as old_node_0 or
+                # old_node_1 (e.g., when a node is absorbed into its successor in place), in which case popping the
+                # old nodes last would remove the newly inserted entry.
+                llnode_0 = self._postorder_node_to_llnode.pop(old_node_0)
+                llnode_1 = self._postorder_node_to_llnode.pop(old_node_1)
                 llnode_0.v = new_node
                 llnode_0.next = self._postorder_node_to_llnode[succ] if succ is not None else None
                 if llnode_0.next is not None:
                     llnode_0.next.prev = llnode_0
                 self._postorder_node_to_llnode[new_node] = llnode_0
-                # clean up the old nodes
-                self._postorder_node_to_llnode.pop(old_node_0)
-                llnode_1 = self._postorder_node_to_llnode.pop(old_node_1)
+                # unlink llnode_1
                 if llnode_0.prev == llnode_1:
                     llnode_0.prev = llnode_1.prev
                     if llnode_1.prev is not None:
                         llnode_1.prev.next = llnode_0
+                if self._postorder_node_head is llnode_1:
+                    self._postorder_node_head = llnode_0
             elif not old_nodes_succs:
                 raise ValueError("Cannot replace nodes with no parent in postorder cache")
             else:
                 # two parents; nothing we can do here, we have to invalidate the postorder cache
-                self._postorder_node_to_llnode = None
+                self._invalidate_postorder_cache()
 
         if self._node_order is not None:
-            order_0 = self._node_order.pop(old_node_0)
-            order_1 = self._node_order.pop(old_node_1)
-            self._node_order[new_node] = min(order_0, order_1)
+            if old_node_0 not in self._node_order or old_node_1 not in self._node_order:
+                # last resort: the cache is stale; invalidate it so that it gets regenerated on demand. this should
+                # not happen - fix the offending graph updater if it does.
+                l.warning("replace_nodes: Node %r or %r is not in the node order cache.", old_node_0, old_node_1)
+                self._node_order = None
+            else:
+                order_0 = self._node_order.pop(old_node_0)
+                order_1 = self._node_order.pop(old_node_1)
+                self._node_order[new_node] = min(order_0, order_1)
 
         if self._head in [old_node_0, old_node_1]:
             self._head = new_node
@@ -1176,6 +1218,8 @@ class DirectedGraphHelper[T]:
                 llnode.prev.next = llnode.next
             if llnode.next is not None:
                 llnode.next.prev = llnode.prev
+            if self._postorder_node_head is llnode:
+                self._postorder_node_head = llnode.next
 
         if self._node_order is not None:
             self._node_order.pop(node, None)
@@ -1185,23 +1229,33 @@ class DirectedGraphHelper[T]:
 
     def add_node_successor(self, node: T, successor: T) -> None:
         if self._postorder_node_to_llnode is not None and successor not in self._postorder_node_to_llnode:
-            assert node in self._postorder_node_to_llnode
-            llnode = self._postorder_node_to_llnode[node]
-            succ_node = LinkedListNode(successor)
-            succ_node.next = llnode.next
-            succ_node.prev = llnode
-            if llnode.next is not None:
-                llnode.next.prev = succ_node
-            llnode.next = succ_node
-            self._postorder_node_to_llnode[successor] = succ_node
+            if node not in self._postorder_node_to_llnode:
+                # last resort: the cache is stale; invalidate it so that it gets regenerated on demand. this should
+                # not happen - fix the offending graph updater if it does.
+                l.warning("add_node_successor: Node %r is not in the postorder cache.", node)
+                self._invalidate_postorder_cache()
+            else:
+                llnode = self._postorder_node_to_llnode[node]
+                succ_node = LinkedListNode(successor)
+                succ_node.next = llnode.next
+                succ_node.prev = llnode
+                if llnode.next is not None:
+                    llnode.next.prev = succ_node
+                llnode.next = succ_node
+                self._postorder_node_to_llnode[successor] = succ_node
 
         if self._node_order is not None and successor not in self._node_order:
-            assert node in self._node_order
-            for nn, o in list(self._node_order.items()):
-                if o > self._node_order[node]:
-                    self._node_order[nn] = o + 1
-            order = self._node_order[node]
-            self._node_order[successor] = order + 1
+            if node not in self._node_order:
+                # last resort: the cache is stale; invalidate it so that it gets regenerated on demand. this should
+                # not happen - fix the offending graph updater if it does.
+                l.warning("add_node_successor: Node %r is not in the node order cache.", node)
+                self._node_order = None
+            else:
+                for nn, o in list(self._node_order.items()):
+                    if o > self._node_order[node]:
+                        self._node_order[nn] = o + 1
+                order = self._node_order[node]
+                self._node_order[successor] = order + 1
 
     def to_acyclic_by_order(self, graph: RegionOverlayGraph[T]) -> networkx.DiGraph[T]:
         if self._node_order is None:
@@ -1212,6 +1266,11 @@ class DirectedGraphHelper[T]:
 
     def sort_nodes_by_order(self, nodes: list[T]) -> list[T]:
         if self._node_order is None:
+            self._generate_node_order()
+        elif any(n not in self._node_order for n in nodes):
+            # last resort: the cache is stale; regenerate it. this should not happen - fix the offending graph
+            # updater if it does.
+            l.warning("sort_nodes_by_order: Some nodes are not in the node order cache.")
             self._generate_node_order()
 
         assert self._node_order is not None
@@ -1224,6 +1283,11 @@ class DirectedGraphHelper[T]:
             return loop_heads
 
         if self._node_order is None:
+            self._generate_node_order()
+        elif any(src not in self._node_order or dst not in self._node_order for src, dst in self._graph.edges()):
+            # last resort: the cache is stale; regenerate it. this should not happen - fix the offending graph
+            # updater if it does.
+            l.warning("loop_heads: Some nodes are not in the node order cache.")
             self._generate_node_order()
         assert self._node_order is not None
 

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -110,7 +110,7 @@ def dfs_back_edges[T](
 
     visited = set() if visited is None else visited  # Tracks visited nodes
     finished = set()  # Tracks nodes whose descendants are fully explored
-    stack = [(start_node, iter(sorted(graph[start_node], key=GraphUtils._sort_node)))]
+    stack = [(start_node, iter(sorted(graph[start_node], key=GraphUtils.sort_node)))]
 
     while stack:
         node, children = stack[-1]
@@ -122,7 +122,7 @@ def dfs_back_edges[T](
                 if child not in finished:
                     yield node, child  # Found a back edge
             elif child not in finished:  # Check if the child has not been finished
-                stack.append((child, iter(sorted(graph[child], key=GraphUtils._sort_node))))
+                stack.append((child, iter(sorted(graph[child], key=GraphUtils.sort_node))))
         except StopIteration:
             stack.pop()  # Done with this node's children
             finished.add(node)  # Mark this node as finished
@@ -130,7 +130,7 @@ def dfs_back_edges[T](
     if visit_all_nodes:
         while len(visited) < len(graph):
             # If we need to visit all nodes, we can start from unvisited nodes
-            node = sorted(set(graph) - visited, key=GraphUtils._sort_node)[0]
+            node = sorted(set(graph) - visited, key=GraphUtils.sort_node)[0]
             yield from dfs_back_edges(graph, node, visited=visited)
 
 
@@ -709,7 +709,7 @@ class GraphUtils:
             if pre_visit and node not in visited:
                 visited.add(node)
                 stack.append((node, False))
-                for succ in sorted(graph.successors(node), key=GraphUtils._sort_node):
+                for succ in sorted(graph.successors(node), key=GraphUtils.sort_node):
                     if succ not in visited:
                         stack.append((succ, True))
             elif not pre_visit:
@@ -726,13 +726,13 @@ class GraphUtils:
         visited: set = set()
         # seeding the stack with the sources in ascending _sort_node order makes the LIFO stack pop them largest-first,
         # exactly as a synthetic super-source's sorted successors would have been expanded.
-        stack: list[tuple[Any, bool]] = [(s, True) for s in sorted(sources, key=GraphUtils._sort_node)]
+        stack: list[tuple[Any, bool]] = [(s, True) for s in sorted(sources, key=GraphUtils.sort_node)]
         while stack:
             node, pre_visit = stack.pop()
             if pre_visit and node not in visited:
                 visited.add(node)
                 stack.append((node, False))
-                for succ in sorted(graph.successors(node), key=GraphUtils._sort_node):
+                for succ in sorted(graph.successors(node), key=GraphUtils.sort_node):
                     if succ not in visited:
                         stack.append((succ, True))
             elif not pre_visit:
@@ -758,7 +758,7 @@ class GraphUtils:
         return sorted(nodes, key=lambda n: addrs_to_index[n.addr], reverse=True)
 
     @staticmethod
-    def _sort_node(node):
+    def sort_node(node):
         """
         A sorter to make a deterministic order of nodes.
         """
@@ -767,7 +767,7 @@ class GraphUtils:
         return node
 
     @staticmethod
-    def _sort_edge(edge):
+    def sort_edge(edge):
         """
         A sorter to make a deterministic order of edges.
         """
@@ -833,7 +833,7 @@ class GraphUtils:
                     comp_indices[node] = (i, scc_addr)
 
         # collapse all strongly connected components
-        for src, dst in sorted(graph.edges(), key=GraphUtils._sort_edge):
+        for src, dst in sorted(graph.edges(), key=GraphUtils.sort_edge):
             scc_index, scc_addr = comp_indices.get(src, (None, None))
             if scc_index is not None:
                 src = SCCPlaceholder(scc_index, scc_addr)
@@ -934,7 +934,7 @@ class GraphUtils:
                 if len(scc_succs) > 1:
                     # calculate the distance between each pair of nodes within scc_succs, pick the one with the
                     # shortest total distance
-                    sorted_scc_succs = sorted(scc_succs, key=GraphUtils._sort_node)
+                    sorted_scc_succs = sorted(scc_succs, key=GraphUtils.sort_node)
                     scc_node_distance = defaultdict(int)
                     for scc_succ in sorted_scc_succs:
                         for other_node in sorted_scc_succs:
@@ -950,7 +950,7 @@ class GraphUtils:
 
         if loop_head is None:
             # pick the first one
-            loop_head = sorted(scc, key=GraphUtils._sort_node)[0]
+            loop_head = sorted(scc, key=GraphUtils.sort_node)[0]
 
         subgraph: networkx.DiGraph = graph.subgraph(scc).copy()  # type: ignore
         for src, _ in list(subgraph.in_edges(loop_head)):
@@ -961,7 +961,7 @@ class GraphUtils:
         # panic mode that will aggressively remove edges
 
         if len(subgraph) > panic_mode_threshold and len(subgraph.edges) > len(subgraph) * 1.4:
-            for n0, n1 in sorted(dfs_back_edges(subgraph, loop_head), key=GraphUtils._sort_edge):
+            for n0, n1 in sorted(dfs_back_edges(subgraph, loop_head), key=GraphUtils.sort_edge):
                 subgraph.remove_edge(n0, n1)
                 if len(subgraph.edges) <= len(subgraph) * 1.4:
                     break
@@ -1065,7 +1065,7 @@ class DirectedGraphHelper[T]:
             # view). they must still be present in the cache because node-replacement updates may reference them;
             # append them after the head so iteration from the head is unaffected.
             seen = set(sorted_nodes)
-            rest = sorted((n for n in acyclic_graph if n not in seen), key=GraphUtils._sort_node)
+            rest = sorted((n for n in acyclic_graph if n not in seen), key=GraphUtils.sort_node)
             for node in GraphUtils.dfs_postorder_nodes_deterministic_multi(acyclic_graph, rest):
                 if node not in seen:
                     seen.add(node)

--- a/tests/analyses/decompiler/test_phoenix_node_order_cache.py
+++ b/tests/analyses/decompiler/test_phoenix_node_order_cache.py
@@ -5,6 +5,7 @@ Regression tests for DirectedGraphHelper, the node-order / postorder cache that 
 with the region graph. Each test corresponds to a bug that made the cache go stale and crashed the decompiler
 with a KeyError in `replace_nodes`.
 """
+
 from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin

--- a/tests/analyses/decompiler/test_phoenix_node_order_cache.py
+++ b/tests/analyses/decompiler/test_phoenix_node_order_cache.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use
+"""
+Regression tests for DirectedGraphHelper, the node-order / postorder cache that PhoenixStructurer keeps in sync
+with the region graph. Each test corresponds to a bug that made the cache go stale and crashed the decompiler
+with a KeyError in `replace_nodes`.
+"""
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import unittest
+
+import networkx
+
+from angr.analyses.decompiler.region_overlay import OverlayManager
+from angr.utils.graph import DirectedGraphHelper
+
+
+class _Node:
+    """A minimal graph node with an address, mimicking AIL blocks / structurer nodes."""
+
+    __slots__ = ("addr",)
+
+    def __init__(self, addr: int):
+        self.addr = addr
+
+    def __repr__(self):
+        return f"N({self.addr:#x})"
+
+
+def _make_helper(edges, head, cyclic=False):
+    g = networkx.DiGraph(edges)
+    return g, DirectedGraphHelper(g, cyclic, head)
+
+
+def _linked_list_values(helper):
+    values = []
+    llnode = helper._postorder_node_to_llnode and helper._postorder_node_head
+    while llnode is not None:
+        values.append(llnode.v)
+        llnode = llnode.next
+    return values
+
+
+class TestPostorderCacheGeneration(unittest.TestCase):
+    """The postorder cache must cover every node of the graph, not only nodes reachable from the head."""
+
+    def test_unreachable_nodes_are_cached(self):
+        # nodes 4 and 5 are not reachable from the head; they used to be missing from the cache, so a later
+        # replace_nodes() on them raised KeyError
+        _, helper = _make_helper([(1, 2), (2, 3), (4, 5)], head=1)
+
+        order = list(helper.dfs_postorder_nodes_deterministic(1))
+        # iteration-until-head semantics are unchanged: unreachable nodes are appended after the head and thus
+        # never yielded when iterating up to the head
+        assert order == [3, 2, 1]
+        assert set(helper._postorder_node_to_llnode) == {1, 2, 3, 4, 5}
+
+        helper.replace_nodes(4, 5, 45)  # must not raise
+        assert 45 in helper._postorder_node_to_llnode
+        # and the merge must not have invalidated the cache
+        assert helper._postorder_node_to_llnode is not None
+        assert list(helper.dfs_postorder_nodes_deterministic(1)) == [3, 2, 1]
+
+    def test_marked_edges_hide_head_out_edges(self):
+        # the real-world trigger (tar sub_529cb0): after cyclic refinement marks the head's only out-edge with
+        # cyclic_refinement_outgoing, the head becomes a sink in the filtered region view that the graph helper
+        # traverses, so the cache used to cover only the head itself; matching a cyclic while against the loop
+        # body then crashed with KeyError in replace_nodes
+        h, a, b, c, d = (_Node(x) for x in (0x10, 0x20, 0x30, 0x40, 0x50))
+        shared = networkx.DiGraph([(h, a), (a, b), (a, c), (b, a), (b, d), (d, h)])
+        mgr = OverlayManager(shared)
+        region = mgr.root.create_subregion(h, {h, a, b, c, d}, cyclic=True)
+        region.mark_edge(h, a, cyclic_refinement_outgoing=True)
+
+        # this is exactly how PhoenixStructurer._analyze() initializes the helper
+        helper = DirectedGraphHelper(region.graph_with_successors, True, h)
+
+        # the head is a sink in the filtered view: iterating up to the head yields the head only
+        assert list(helper.dfs_postorder_nodes_deterministic(h)) == [h]
+        # but the cache must still cover the whole graph
+        assert set(helper._postorder_node_to_llnode) == {h, a, b, c, d}
+
+        # what _match_cyclic_while does when merging the loop body: this used to raise KeyError
+        loop_node = _Node(0x20)
+        helper.replace_nodes(a, b, loop_node)
+        cached = set(helper._postorder_node_to_llnode)
+        assert loop_node in cached
+        assert a not in cached
+        assert b not in cached
+
+
+class TestReplaceNodesAliasing(unittest.TestCase):
+    """replace_nodes() must survive new_node being the same object as one of the old nodes (in-place absorption,
+    as done by _match_acyclic_sequence with an IncompleteSwitchCaseNode successor)."""
+
+    def test_new_node_is_old_node_1(self):
+        _, helper = _make_helper([(1, 2), (2, 3), (3, 4)], head=1)
+        list(helper.dfs_postorder_nodes_deterministic(1))
+
+        helper.replace_nodes(2, 3, 3)
+        # node 3 used to be evicted from the cache here (popped after insertion), making the very next
+        # replace involving it crash
+        assert 3 in helper._postorder_node_to_llnode
+        assert 2 not in helper._postorder_node_to_llnode
+        assert list(helper.dfs_postorder_nodes_deterministic(1)) == [4, 3, 1]
+
+    def test_new_node_is_old_node_0(self):
+        _, helper = _make_helper([(1, 2), (2, 3), (3, 4)], head=1)
+        list(helper.dfs_postorder_nodes_deterministic(1))
+
+        helper.replace_nodes(2, 3, 2)
+        assert 2 in helper._postorder_node_to_llnode
+        assert 3 not in helper._postorder_node_to_llnode
+        assert list(helper.dfs_postorder_nodes_deterministic(1)) == [4, 2, 1]
+
+    def test_unlinking_the_list_head(self):
+        # postorder of 1 -> 2 is [2, 1]: node 2 is the first linked-list node. merging (1, 2) must move the
+        # list head to the merged node instead of leaving it on the unlinked node
+        _, helper = _make_helper([(1, 2)], head=1)
+        list(helper.dfs_postorder_nodes_deterministic(1))
+
+        helper.replace_nodes(1, 2, 99)
+        assert _linked_list_values(helper) == [99]
+
+    def test_remove_node_updates_list_head(self):
+        _, helper = _make_helper([(1, 2), (1, 3)], head=1)
+        postorder = list(helper.dfs_postorder_nodes_deterministic(1))
+
+        helper.remove_node(postorder[0])
+        assert _linked_list_values(helper) == postorder[1:]
+
+
+class TestStaleCacheLastResort(unittest.TestCase):
+    """A cache update that references an unknown node signals a bug in the caller, but it must degrade to
+    invalidate-and-regenerate instead of KeyError / AssertionError / silent corruption."""
+
+    def test_replace_node_with_stale_node_invalidates(self):
+        _, helper = _make_helper([(1, 2), (2, 3)], head=1)
+        list(helper.dfs_postorder_nodes_deterministic(1))
+
+        helper.replace_node(99, 100)  # 99 was never in the graph
+        assert helper._postorder_node_to_llnode is None
+        # the cache regenerates transparently on the next query
+        assert list(helper.dfs_postorder_nodes_deterministic(1)) == [3, 2, 1]
+
+    def test_replace_nodes_with_stale_node_invalidates(self):
+        _, helper = _make_helper([(1, 2), (2, 3)], head=1)
+        list(helper.dfs_postorder_nodes_deterministic(1))
+
+        helper.replace_nodes(99, 100, 101)  # must not raise KeyError
+        assert helper._postorder_node_to_llnode is None
+        assert list(helper.dfs_postorder_nodes_deterministic(1)) == [3, 2, 1]
+
+    def test_add_node_successor_with_stale_node_invalidates(self):
+        _, helper = _make_helper([(1, 2), (2, 3)], head=1)
+        list(helper.dfs_postorder_nodes_deterministic(1))
+
+        helper.add_node_successor(99, 100)  # used to fail an assertion
+        assert helper._postorder_node_to_llnode is None
+        assert list(helper.dfs_postorder_nodes_deterministic(1)) == [3, 2, 1]
+
+    def test_replace_node_does_not_corrupt_node_order(self):
+        # the node order cache used to silently assign order 0 to the new node when the old node was unknown
+        # (dict.pop(old, 0)), breaking sort_nodes_by_order for every later query
+        g = networkx.DiGraph([(1, 2), (2, 3), (3, 1)])
+        helper = DirectedGraphHelper(g, True, 1)
+        assert helper.loop_heads() == {1}  # generates the node order
+
+        helper.replace_node(99, 100)
+        assert helper._node_order is None
+        assert helper.sort_nodes_by_order([3, 1, 2]) == [1, 2, 3]
+
+    def test_add_node_successor_with_stale_node_invalidates_node_order(self):
+        g = networkx.DiGraph([(1, 2), (2, 3), (3, 1)])
+        helper = DirectedGraphHelper(g, True, 1)
+        helper.loop_heads()
+
+        helper.add_node_successor(99, 100)  # used to fail an assertion
+        assert helper._node_order is None
+        assert helper.sort_nodes_by_order([2, 1]) == [1, 2]
+
+    def test_sort_nodes_by_order_regenerates_for_unknown_nodes(self):
+        g = networkx.DiGraph([(1, 2), (2, 3), (3, 1)])
+        helper = DirectedGraphHelper(g, True, 1)
+        helper.loop_heads()
+
+        # a node added to the graph behind the helper's back used to raise KeyError when sorted
+        g.add_edge(3, 4)
+        assert helper.sort_nodes_by_order([4, 2, 1]) == [1, 2, 4]
+
+    def test_loop_heads_regenerates_for_unknown_nodes(self):
+        g = networkx.DiGraph([(1, 2), (2, 3), (3, 1)])
+        helper = DirectedGraphHelper(g, True, 1)
+        assert helper.loop_heads() == {1}
+
+        g.add_edge(3, 4)
+        assert helper.loop_heads() == {1}  # used to raise KeyError on the (3, 4) edge
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_phoenix_node_order_cache.py
+++ b/tests/analyses/decompiler/test_phoenix_node_order_cache.py
@@ -30,7 +30,7 @@ class _Node:
         return f"N({self.addr:#x})"
 
 
-def _make_helper(edges, head, cyclic=False):
+def _make_helper(edges, head, cyclic=False) -> tuple[networkx.DiGraph, DirectedGraphHelper[int]]:
     g = networkx.DiGraph(edges)
     return g, DirectedGraphHelper(g, cyclic, head)
 
@@ -56,6 +56,7 @@ class TestPostorderCacheGeneration(unittest.TestCase):
         # iteration-until-head semantics are unchanged: unreachable nodes are appended after the head and thus
         # never yielded when iterating up to the head
         assert order == [3, 2, 1]
+        assert helper._postorder_node_to_llnode is not None
         assert set(helper._postorder_node_to_llnode) == {1, 2, 3, 4, 5}
 
         helper.replace_nodes(4, 5, 45)  # must not raise
@@ -81,6 +82,7 @@ class TestPostorderCacheGeneration(unittest.TestCase):
         # the head is a sink in the filtered view: iterating up to the head yields the head only
         assert list(helper.dfs_postorder_nodes_deterministic(h)) == [h]
         # but the cache must still cover the whole graph
+        assert helper._postorder_node_to_llnode is not None
         assert set(helper._postorder_node_to_llnode) == {h, a, b, c, d}
 
         # what _match_cyclic_while does when merging the loop body: this used to raise KeyError
@@ -103,6 +105,7 @@ class TestReplaceNodesAliasing(unittest.TestCase):
         helper.replace_nodes(2, 3, 3)
         # node 3 used to be evicted from the cache here (popped after insertion), making the very next
         # replace involving it crash
+        assert helper._postorder_node_to_llnode is not None
         assert 3 in helper._postorder_node_to_llnode
         assert 2 not in helper._postorder_node_to_llnode
         assert list(helper.dfs_postorder_nodes_deterministic(1)) == [4, 3, 1]
@@ -112,6 +115,7 @@ class TestReplaceNodesAliasing(unittest.TestCase):
         list(helper.dfs_postorder_nodes_deterministic(1))
 
         helper.replace_nodes(2, 3, 2)
+        assert helper._postorder_node_to_llnode is not None
         assert 2 in helper._postorder_node_to_llnode
         assert 3 not in helper._postorder_node_to_llnode
         assert list(helper.dfs_postorder_nodes_deterministic(1)) == [4, 2, 1]
@@ -166,7 +170,7 @@ class TestStaleCacheLastResort(unittest.TestCase):
         # the node order cache used to silently assign order 0 to the new node when the old node was unknown
         # (dict.pop(old, 0)), breaking sort_nodes_by_order for every later query
         g = networkx.DiGraph([(1, 2), (2, 3), (3, 1)])
-        helper = DirectedGraphHelper(g, True, 1)
+        helper: DirectedGraphHelper[int] = DirectedGraphHelper(g, True, 1)  # type:ignore[reportAssignmentType]
         assert helper.loop_heads() == {1}  # generates the node order
 
         helper.replace_node(99, 100)
@@ -175,7 +179,7 @@ class TestStaleCacheLastResort(unittest.TestCase):
 
     def test_add_node_successor_with_stale_node_invalidates_node_order(self):
         g = networkx.DiGraph([(1, 2), (2, 3), (3, 1)])
-        helper = DirectedGraphHelper(g, True, 1)
+        helper: DirectedGraphHelper[int] = DirectedGraphHelper(g, True, 1)  # type:ignore[reportAssignmentType]
         helper.loop_heads()
 
         helper.add_node_successor(99, 100)  # used to fail an assertion
@@ -184,19 +188,19 @@ class TestStaleCacheLastResort(unittest.TestCase):
 
     def test_sort_nodes_by_order_regenerates_for_unknown_nodes(self):
         g = networkx.DiGraph([(1, 2), (2, 3), (3, 1)])
-        helper = DirectedGraphHelper(g, True, 1)
+        helper: DirectedGraphHelper[int] = DirectedGraphHelper(g, True, 1)  # type:ignore[reportAssignmentType]
         helper.loop_heads()
 
         # a node added to the graph behind the helper's back used to raise KeyError when sorted
-        g.add_edge(3, 4)
+        g.add_edge(3, 4)  # type: ignore
         assert helper.sort_nodes_by_order([4, 2, 1]) == [1, 2, 4]
 
     def test_loop_heads_regenerates_for_unknown_nodes(self):
         g = networkx.DiGraph([(1, 2), (2, 3), (3, 1)])
-        helper = DirectedGraphHelper(g, True, 1)
+        helper: DirectedGraphHelper[int] = DirectedGraphHelper(g, True, 1)  # type:ignore[reportAssignmentType]
         assert helper.loop_heads() == {1}
 
-        g.add_edge(3, 4)
+        g.add_edge(3, 4)  # type: ignore
         assert helper.loop_heads() == {1}  # used to raise KeyError on the (3, 4) edge
 
 

--- a/tests/analyses/decompiler/test_phoenix_node_order_cache.py
+++ b/tests/analyses/decompiler/test_phoenix_node_order_cache.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint:disable=missing-class-docstring,no-self-use
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
 """
 Regression tests for DirectedGraphHelper, the node-order / postorder cache that PhoenixStructurer keeps in sync
 with the region graph. Each test corresponds to a bug that made the cache go stale and crashed the decompiler


### PR DESCRIPTION
- Fix incomplete cache generation after cyclic refinement.

- Fix cache update errors in Phoenix.

- Warn and re-generate the cache if a miss is detected.