### PR TITLE
RegionOverlay: detach_edge removes view-only absorbed-successor edges.

### DIFF
--- a/angr/analyses/decompiler/region_overlay.py
+++ b/angr/analyses/decompiler/region_overlay.py
@@ -820,6 +820,15 @@ class RegionOverlay:
         """
         for u, v in self.underlying_edge_pairs(src, dst):
             self._mgr.graph_remove_edge(u, v)
+        # the edge may (also) exist as a view-only extra edge introduced by absorb_successor_into(); such edges
+        # have no shared-graph counterpart, so drop them here or the edge would survive its own virtualization
+        # (last-resort refinement would then pick it again forever)
+        extra = [(u, v) for u, v in self._extra_full_edges if u is src and v is dst]
+        if extra:
+            self._extra_full_edges.difference_update(extra)
+            self._mgr._record(lambda: self._extra_full_edges.update(extra))
+            self._mgr._touch(src)
+            self._mgr._touch(dst)
         self._invalidate()
 
     def mark_edge(self, src, dst, **attrs) -> None:

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -2972,7 +2972,8 @@ class PhoenixStructurer(StructurerBase):
             while self._edge_virtualization_hints:
                 src, dst = self._edge_virtualization_hints.pop(0)
                 if graph_raw.filtered().has_edge(src, dst):
-                    self._virtualize_edge(src, dst)
+                    if not self._virtualize_edge(src, dst):
+                        return self._on_virtualize_edge_failure(src, dst)
                     l.debug("last_resort: Removed edge %r -> %r (type 3)", src, dst)
                     return True
 
@@ -3042,7 +3043,8 @@ class PhoenixStructurer(StructurerBase):
             all_edges_wo_dominance = self._order_virtualizable_edges(full_graph, all_edges_wo_dominance, node_seq)
             # virtualize the first edge
             src, dst = all_edges_wo_dominance[0]
-            self._virtualize_edge(src, dst)
+            if not self._virtualize_edge(src, dst):
+                return self._on_virtualize_edge_failure(src, dst)
             l.debug("last_resort: Removed edge %r -> %r (type 1)", src, dst)
             return True
 
@@ -3050,7 +3052,8 @@ class PhoenixStructurer(StructurerBase):
             secondary_edges = self._order_virtualizable_edges(full_graph, secondary_edges, node_seq)
             # virtualize the first edge
             src, dst = secondary_edges[0]
-            self._virtualize_edge(src, dst)
+            if not self._virtualize_edge(src, dst):
+                return self._on_virtualize_edge_failure(src, dst)
             l.debug("last_resort: Removed edge %r -> %r (type 2)", src, dst)
             return True
 
@@ -3080,14 +3083,36 @@ class PhoenixStructurer(StructurerBase):
             if cycle_edges:
                 cycle_edges = sorted(cycle_edges, key=lambda edge: (edge[0].addr, edge[1].addr))
                 src, dst = cycle_edges[0]
-                self._virtualize_edge(src, dst)
+                if not self._virtualize_edge(src, dst):
+                    return self._on_virtualize_edge_failure(src, dst)
                 l.debug("last_resort: Removed cycle edge %r -> %r in an acyclic region (type 4)", src, dst)
                 return True
 
         l.debug("last_resort: No edge to remove")
         return False
 
-    def _virtualize_edge(self, src, dst):
+    @staticmethod
+    def _on_virtualize_edge_failure(src, dst) -> bool:
+        """
+        Terminate last-resort refinement when virtualizing an edge failed to remove it from the graph. Reporting
+        no progress dissolves the region into its parent (extra gotos in the output) instead of picking the same
+        edge again on every future round, which would loop until the analysis is killed.
+        """
+        l.error(
+            "last_resort: Virtualizing edge %r -> %r did not remove it from the graph (a graph bookkeeping bug); "
+            "giving up on this region to avoid an infinite refinement loop.",
+            src,
+            dst,
+        )
+        return False
+
+    def _virtualize_edge(self, src, dst) -> bool:
+        """
+        Virtualize the edge src -> dst: rewrite the jump into a goto and remove the edge from the region.
+        Returns True when the edge is actually gone from the with-successors view afterwards; a False return
+        means removal failed (a bug in graph bookkeeping) and the caller must not treat it as progress, or
+        refinement would pick the same edge again forever.
+        """
         # if the last statement of src is a conditional jump, we rewrite it into a Condition(Jump) and a direct jump
         try:
             last_stmt = self.cond_proc.get_last_statement(src)
@@ -3159,6 +3184,8 @@ class PhoenixStructurer(StructurerBase):
             self.replace_nodes_both(src, new_src)
         if remove_src_last_stmt:
             remove_last_statements(src)
+        final_src = new_src if new_src is not None else src
+        return not self._region.view_with_successors().has_edge(final_src, dst)
 
     def _should_use_multistmtexprs(self, node: Block | BaseNode) -> bool:
         """

--- a/tests/analyses/decompiler/test_region_overlay.py
+++ b/tests/analyses/decompiler/test_region_overlay.py
@@ -334,6 +334,44 @@ class TestRegionOverlayViewEdgeCases(unittest.TestCase):
         assert sub2.successor_nodes() == {nodes[3], nodes[4]}
         assert (nodes[3], nodes[4]) not in edge_set(sub2.view_with_successors())
 
+    def test_detach_edge_removes_absorbed_successor_edge(self):
+        # loop {2, 3} with successors {4, 5} and a successor-successor edge 4 -> 5
+        nodes = {i: Node(i) for i in range(1, 6)}
+        g = networkx.DiGraph()
+        g.add_edges_from(
+            [
+                (nodes[1], nodes[2]),
+                (nodes[2], nodes[3]),
+                (nodes[3], nodes[2]),
+                (nodes[3], nodes[4]),
+                (nodes[3], nodes[5]),
+                (nodes[4], nodes[5]),
+            ]
+        )
+        mgr = OverlayManager(g)
+        mgr.root.head = nodes[1]
+        loop = mgr.root.create_subregion(nodes[2], [nodes[2], nodes[3]], cyclic=True)
+
+        # absorbing successor 4 into member 3 re-attaches the 4 -> 5 edge to node 3 as a view-only extra edge
+        loop.absorb_successor_into(nodes[4], nodes[3])
+        assert (nodes[3], nodes[5]) in loop._extra_full_edges
+        assert loop.view_with_successors().has_edge(nodes[3], nodes[5])
+
+        checkpoint = mgr.checkpoint()
+
+        # detaching the edge must remove both the shared-graph edge and the view-only extra edge; if the extra
+        # edge survived, virtualizing this edge would pick it again forever in last-resort refinement
+        loop.detach_edge(nodes[3], nodes[5])
+        assert not g.has_edge(nodes[3], nodes[5])
+        assert (nodes[3], nodes[5]) not in loop._extra_full_edges
+        assert not loop.view_with_successors().has_edge(nodes[3], nodes[5])
+
+        # the removal is undoable
+        mgr.rollback(checkpoint)
+        assert g.has_edge(nodes[3], nodes[5])
+        assert (nodes[3], nodes[5]) in loop._extra_full_edges
+        assert loop.view_with_successors().has_edge(nodes[3], nodes[5])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Edges re-attached by absorb_successor_into() live only in _extra_full_edges and have no shared-graph counterpart, so detach_edge() silently ignored them. This causes last-resort refinement in Phoenix to not be able to virtualized such an edge and believe the edge was virtualized, causing forever loops.