### PR TITLE
Phoenix: Speed up last-resort refinement.

### DIFF
--- a/angr/analyses/decompiler/region_overlay.py
+++ b/angr/analyses/decompiler/region_overlay.py
@@ -1285,7 +1285,7 @@ class _OverlayAdjInner(Mapping):
 class _OverlayAdjAtlas(Mapping):
     """Outer adjacency mapping of a RegionOverlayGraph: view node -> _OverlayAdjInner."""
 
-    __slots__ = ("_cache", "_epoch", "_pred", "_rog")
+    __slots__ = ("_cache", "_epoch", "_pred", "_rog", "_succ_cache", "_succ_version")
 
     def __init__(self, rog: RegionOverlayGraph, pred: bool):
         self._rog = rog
@@ -1296,6 +1296,13 @@ class _OverlayAdjAtlas(Mapping):
         # (bumped by lifecycle ops / rollback) and forces a full clear when it changes.
         self._cache: dict[Any, tuple[int, _OverlayAdjInner]] = {}
         self._epoch: int | None = None
+        # successor-node adjacency cache: a successor's view adjacency depends on the whole region's successor
+        # set and view state, not just on that node, so it cannot be keyed by the node's own version. Key the
+        # whole cache by the manager's global version instead (bumped by every mutation and view-state change,
+        # the same invariant _node_set relies on): reads between two mutations -- dominator fixpoints, SAILR's
+        # per-edge in_degree queries -- hit the cache, and any mutation drops it wholesale.
+        self._succ_cache: dict[Any, _OverlayAdjInner] = {}
+        self._succ_version: int | None = None
 
     def __len__(self):
         return len(self._rog._node_set())
@@ -1313,12 +1320,27 @@ class _OverlayAdjAtlas(Mapping):
         if n not in self._rog._node_set():
             raise KeyError(n)
         overlay = self._rog.overlay
-        # Only member nodes are cached: their view-adjacency is a function of graph.adj[n] (plus this overlay's
-        # own visibility state), all of which bump n's node version when they change, so the cached order and
-        # keyset stay correct. A successor node's adjacency instead depends on the whole region's successor set
-        # (which can change without touching that node), so it is always rebuilt fresh. Members are the hot path.
+        # Member nodes are cached per node version: their view-adjacency is a function of graph.adj[n] (plus
+        # this overlay's own visibility state), all of which bump n's node version when they change, so the
+        # cached order and keyset stay correct. Non-member (successor) nodes are cached in _succ_cache, keyed
+        # by the manager's global version (see __init__).
         if n not in overlay.members:
-            return _OverlayAdjInner(self._rog, n, self._pred)
+            mgr = overlay.manager
+            if self._succ_version != mgr.version:
+                self._succ_cache.clear()
+                self._succ_version = mgr.version
+            succ_inner = self._succ_cache.get(n)
+            if succ_inner is None:
+                succ_inner = _OverlayAdjInner(self._rog, n, self._pred)
+                self._succ_cache[n] = succ_inner
+            elif _PARANOID_ADJ_CHECK:
+                fresh = _OverlayAdjInner(self._rog, n, self._pred)
+                # order-sensitive: Phoenix structuring depends on neighbor iteration order, not just the set
+                assert list(fresh._d.items()) == list(succ_inner._d.items()), (
+                    f"stale adjacency for successor node {n!r} (pred={self._pred}) in overlay {overlay!r}: "
+                    f"a mutation changed its neighbors (or their order) without bumping the manager version"
+                )
+            return succ_inner
         mgr = overlay.manager
         if self._epoch != mgr._adj_epoch:
             self._cache.clear()

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -46,7 +46,13 @@ from angr.analyses.decompiler.utils import (
 from angr.knowledge_plugins.cfg import IndirectJump, IndirectJumpType
 from angr.utils.ail import is_head_controlled_loop_block, is_phi_assignment
 from angr.utils.constants import SWITCH_MISSING_DEFAULT_NODE_ADDR
-from angr.utils.graph import DirectedGraphHelper, GraphUtils, dfs_back_edges, dominates
+from angr.utils.graph import (
+    DirectedGraphHelper,
+    GraphUtils,
+    compute_dominance_intervals,
+    dfs_back_edges,
+    dominates_by_intervals,
+)
 
 from .structurer_base import StructurerBase
 
@@ -3032,12 +3038,13 @@ class PhoenixStructurer(StructurerBase):
         graph = graph_raw.filtered()
 
         idoms = networkx.immediate_dominators(full_graph, head)
+        # answering dominance queries through Euler-tour intervals avoids dominates()'s O(tree depth) chain walk
+        # for each of the 2*|E| queries below
+        dominance_intervals = compute_dominance_intervals(idoms, head)
+        graph_is_dag = networkx.is_directed_acyclic_graph(full_graph)
         # acyclic_graph is read-only here (edges, in_degree, has_edge, iteration), so use a zero-copy overlay view
         # instead of materializing the whole region graph on every last-resort attempt.
-        if networkx.is_directed_acyclic_graph(full_graph):
-            acyclic_graph = full_graph
-        else:
-            acyclic_graph = self._graph_helper.to_acyclic_by_order(full_graph)
+        acyclic_graph = full_graph if graph_is_dag else self._graph_helper.to_acyclic_by_order(full_graph)
         for src, dst in acyclic_graph.edges:
             if src is dst:
                 continue
@@ -3051,10 +3058,11 @@ class PhoenixStructurer(StructurerBase):
                 # this is a head of an incomplete switch-case construct (that we will definitely be structuring later),
                 # so we do not want to remove any edges going out of this block
                 continue
-            if not dominates(idoms, src, dst) and not dominates(idoms, dst, src):
+            src_dominates_dst = dominates_by_intervals(dominance_intervals, src, dst)
+            if not src_dominates_dst and not dominates_by_intervals(dominance_intervals, dst, src):
                 if (src.addr, dst.addr) not in self.whitelist_edges:
                     all_edges_wo_dominance.append((src, dst))
-            elif not dominates(idoms, src, dst):
+            elif not src_dominates_dst:
                 if (src.addr, dst.addr) not in self.whitelist_edges:
                     secondary_edges.append((src, dst))
             else:
@@ -3062,8 +3070,8 @@ class PhoenixStructurer(StructurerBase):
                     other_edges.append((src, dst))
 
         # acyclic_graph may contain more than one entry node. Cover every entry in the post-order without mutating the
-        # graph (it is a zero-copy overlay view) via a deterministic multi-source DFS seeded with all entries -- this
-        # reproduces the old synthetic-head traversal (entries visited in _sort_node order) with no temporary node.
+        # graph via a deterministic multi-source DFS seeded with all entries -- this reproduces the old
+        # synthetic-head traversal (entries visited in _sort_node order) with no temporary node.
         graph_entries = [nn for nn in acyclic_graph if acyclic_graph.in_degree[nn] == 0]
         if len(graph_entries) > 1:
             ordered_nodes = list(
@@ -3102,14 +3110,10 @@ class PhoenixStructurer(StructurerBase):
             l.debug("last_resort: Removed edge %r -> %r (type 2)", src, dst)
             return True
 
-        if (
-            self._region.parent is None
-            and not self._region.cyclic
-            and not networkx.is_directed_acyclic_graph(full_graph)
-        ):
+        if self._region.parent is None and not self._region.cyclic and not graph_is_dag:
             # an acyclic region must not contain cycles; one can appear as debris when an inner cyclic region
             # fails to structure and dissolves its partially-refined body into this region. the cycle-closing
-            # edges are excluded from the candidate lists above (to_acyclic_by_order dropped them from
+            # edges are excluded from the candidate lists above (they are back edges, dropped from
             # acyclic_graph), so without this fallback the region can never become structurable. only the root
             # region recovers this way (a goto): anywhere else, failing and dissolving into an enclosing region
             # gives a cyclic ancestor the chance to structure the loop properly first.

--- a/angr/utils/graph.py
+++ b/angr/utils/graph.py
@@ -210,6 +210,50 @@ def dominates[T](idom: dict[T, T], dominator_node: T, node: T) -> bool:
     return False
 
 
+def compute_dominance_intervals[T](idom: dict[T, T], head: T) -> dict[T, tuple[int, int]]:
+    """
+    Compute entry/exit (Euler tour) intervals over the dominator tree described by ``idom``, so that dominance
+    queries answer in O(1) via dominates_by_intervals() instead of dominates()'s O(tree depth) chain walk.
+    Only nodes present in ``idom`` (i.e., reachable from the head) get an interval.
+    """
+    children: dict[T, list[T]] = {}
+    for n, d in idom.items():
+        if n != d:
+            children.setdefault(d, []).append(n)
+    intervals: dict[T, tuple[int, int]] = {}
+    entry: dict[T, int] = {}
+    time = 0
+    stack: list[tuple[T, bool]] = [(head, False)]
+    while stack:
+        node, exiting = stack.pop()
+        if exiting:
+            intervals[node] = (entry[node], time)
+            time += 1
+            continue
+        if node in entry:
+            continue
+        entry[node] = time
+        time += 1
+        stack.append((node, True))
+        for child in children.get(node, ()):
+            stack.append((child, False))
+    return intervals
+
+
+def dominates_by_intervals[T](intervals: dict[T, tuple[int, int]], dominator_node: T, node: T) -> bool:
+    """
+    O(1) equivalent of dominates() over intervals from compute_dominance_intervals(). Node objects must be
+    truthy (all AIL and structurer nodes are), which is the only case where dominates() behaves differently.
+    """
+    if dominator_node == node:
+        return True
+    a = intervals.get(dominator_node)
+    b = intervals.get(node)
+    if a is None or b is None:
+        return False
+    return a[0] <= b[0] and b[1] <= a[1]
+
+
 #
 # Dominance frontier
 #
@@ -1257,12 +1301,15 @@ class DirectedGraphHelper[T]:
                 order = self._node_order[node]
                 self._node_order[successor] = order + 1
 
-    def to_acyclic_by_order(self, graph: RegionOverlayGraph[T]) -> networkx.DiGraph[T]:
+    def get_node_order(self) -> dict[T, int]:
         if self._node_order is None:
             self._generate_node_order()
 
         assert self._node_order is not None
-        return graph.to_acyclic_by_order(self._node_order)
+        return self._node_order
+
+    def to_acyclic_by_order(self, graph: RegionOverlayGraph[T]) -> networkx.DiGraph[T]:
+        return graph.to_acyclic_by_order(self.get_node_order())
 
     def sort_nodes_by_order(self, nodes: list[T]) -> list[T]:
         if self._node_order is None:


### PR DESCRIPTION
- Answer dominance queries in O(1) through Euler-tour intervals, which are computed once per run from the dominator tree, and compute the DAG check once.

- RegionOverlay: Cache successor-node adjacency in _OverlayAdjAtlas.