### PR TITLE
native/angr: add package metadata required by workspace cargo lints

### DIFF
--- a/native/angr/Cargo.toml
+++ b/native/angr/Cargo.toml
@@ -2,6 +2,12 @@
 name = "angr"
 version = "0.1.0"
 edition = "2024"
+description = "Native extension for angr, a multi-architecture binary analysis toolkit"
+license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+repository.workspace = true
 
 [lib]
 name = "rustylib"


### PR DESCRIPTION
## Summary

The root workspace enables `clippy::cargo = "warn"` in `[workspace.lints.clippy]` and CI runs clippy with `-D warnings`, but the `angr` crate does not declare the description/license/readme/keywords/categories/repository metadata that `cargo_common_metadata` checks. Today no crate in the workspace opts into the workspace lints, so the lint never fires — but any crate that sets `[lints] workspace = true` (e.g. the vendored crates in the clarirs migration, #6550) turns this into a hard failure in the Rust Check CI job.

Inherit the shared fields from `[workspace.package]` and add a description.

## Testing

`cargo clippy -p angr --all-targets` — no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)