### PR TITLE
Decompiler: fix operand width in the CondZ/CondNZ DEC ccall

### DIFF
--- a/angr/analyses/decompiler/ccall_rewriters/amd64_ccalls.py
+++ b/angr/analyses/decompiler/ccall_rewriters/amd64_ccalls.py
@@ -259,9 +259,9 @@ class AMD64CCallRewriter(CCallRewriterBase):
                         dep_1 = self._fix_size(
                             dep_1,
                             op_v,
-                            AMD64_OpTypes["G_CC_OP_SHRB"],
-                            AMD64_OpTypes["G_CC_OP_SHRW"],
-                            AMD64_OpTypes["G_CC_OP_SHRL"],
+                            AMD64_OpTypes["G_CC_OP_DECB"],
+                            AMD64_OpTypes["G_CC_OP_DECW"],
+                            AMD64_OpTypes["G_CC_OP_DECL"],
                             ccall.tags,
                         )
                         expr_op = "CmpEQ" if cond_v == AMD64_CondTypes["CondZ"] else "CmpNE"

--- a/tests/analyses/decompiler/test_ccall_rewriting.py
+++ b/tests/analyses/decompiler/test_ccall_rewriting.py
@@ -32,5 +32,53 @@ class TestCCallRewriting(unittest.TestCase):
         assert "v0 = NtGetCurrentPeb();" in dec.codegen.text
 
 
+class TestAMD64CCallRewriterDecWidth(unittest.TestCase):
+    """CondZ/CondNZ over DEC must compare only the low nbits of the result.
+
+    ZF for dec on a sub-register is computed from that sub-register alone: for
+    dec al with rax == 0x101 the hardware sets ZF (al becomes 0), but a
+    full-width compare tests 0x100 == 0 and takes the wrong branch.
+    """
+
+    def _rewrite(self, cond, op, dep1_value):
+        from angr.ailment import Expr, Manager
+        from angr.analyses.decompiler.ccall_rewriters.amd64_ccalls import AMD64CCallRewriter
+        from angr.engines.vex.claripy.ccall import data
+
+        cond_v = data["AMD64"]["CondTypes"][cond]
+        op_v = data["AMD64"]["OpTypes"][op]
+        ccall = Expr.VEXCCallExpression(
+            idx=0,
+            callee="amd64g_calculate_condition",
+            operands=(
+                Expr.Const(0, cond_v, 64),
+                Expr.Const(0, op_v, 64),
+                Expr.Const(1, dep1_value, 64),
+                Expr.Const(2, 0, 64),
+                Expr.Const(3, 0, 64),
+            ),
+            bits=64,
+        )
+        proj = angr.load_shellcode(b"\x90", arch="AMD64")
+        return AMD64CCallRewriter(ccall, proj, Manager(arch=proj.arch)).result
+
+    def test_condz_dec_narrows_to_op_width(self):
+        for op, bits in (("G_CC_OP_DECB", 8), ("G_CC_OP_DECW", 16), ("G_CC_OP_DECL", 32), ("G_CC_OP_DECQ", 64)):
+            for cond in ("CondZ", "CondNZ"):
+                result = self._rewrite(cond, op, 1 << bits if bits < 64 else 1)
+                cmp = result.operand  # strip the Convert back to ccall.bits
+                lhs = cmp.operands[0]
+                assert lhs.bits == bits, f"{cond} x {op}: operand is {lhs.bits}-bit, expected {bits}"
+
+    def test_condz_decb_ignores_upper_bits(self):
+        # result low byte is 0 (ZF set) while bits above it are non-zero
+        result = self._rewrite("CondZ", "G_CC_OP_DECB", 0x100)
+        cmp = result.operand
+        assert cmp.op == "CmpEQ"
+        lhs, rhs = cmp.operands
+        assert lhs.value_int == 0 and lhs.bits == 8  # 0x100 truncated to its low byte
+        assert rhs.value_int == 0
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/analyses/decompiler/test_ccall_rewriting.py
+++ b/tests/analyses/decompiler/test_ccall_rewriting.py
@@ -8,6 +8,9 @@ import os
 import unittest
 
 import angr
+from angr.ailment import Expr, Manager
+from angr.analyses.decompiler.ccall_rewriters.amd64_ccalls import AMD64CCallRewriter
+from angr.engines.vex.claripy.ccall import data
 from tests.common import bin_location, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -41,12 +44,9 @@ class TestAMD64CCallRewriterDecWidth(unittest.TestCase):
     """
 
     def _rewrite(self, cond, op, dep1_value):
-        from angr.ailment import Expr, Manager
-        from angr.analyses.decompiler.ccall_rewriters.amd64_ccalls import AMD64CCallRewriter
-        from angr.engines.vex.claripy.ccall import data
-
         cond_v = data["AMD64"]["CondTypes"][cond]
         op_v = data["AMD64"]["OpTypes"][op]
+        assert cond_v is not None and op_v is not None
         ccall = Expr.VEXCCallExpression(
             idx=0,
             callee="amd64g_calculate_condition",
@@ -66,6 +66,7 @@ class TestAMD64CCallRewriterDecWidth(unittest.TestCase):
         for op, bits in (("G_CC_OP_DECB", 8), ("G_CC_OP_DECW", 16), ("G_CC_OP_DECL", 32), ("G_CC_OP_DECQ", 64)):
             for cond in ("CondZ", "CondNZ"):
                 result = self._rewrite(cond, op, 1 << bits if bits < 64 else 1)
+                assert isinstance(result, Expr.Convert)
                 cmp = result.operand  # strip the Convert back to ccall.bits
                 lhs = cmp.operands[0]
                 assert lhs.bits == bits, f"{cond} x {op}: operand is {lhs.bits}-bit, expected {bits}"
@@ -73,6 +74,7 @@ class TestAMD64CCallRewriterDecWidth(unittest.TestCase):
     def test_condz_decb_ignores_upper_bits(self):
         # result low byte is 0 (ZF set) while bits above it are non-zero
         result = self._rewrite("CondZ", "G_CC_OP_DECB", 0x100)
+        assert isinstance(result, Expr.Convert)
         cmp = result.operand
         assert cmp.op == "CmpEQ"
         lhs, rhs = cmp.operands


### PR DESCRIPTION
The DEC arm passed the SHR op constants to _fix_size, which never match a DEC op, so the operand was never narrowed below 64 bits. dec on a sub-register followed by je/jne then decompiled to a full-width compare: for dec al with rax == 0x101 the hardware sets ZF (al becomes 0) but the emitted C tests 0x100 == 0, inverting the branch. Pass the DEC constants.