### PR TITLE
Keep entry jumps inside sized function symbols

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3596,7 +3596,10 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                     target_func_addr = node.function_address
             # case 2: if the source instruction is the first instruction of the current function, has only one branch
             # to the target address, and is a jump (Ijk_Boring, not a call), then the target address is likely the
-            # start of another function
+            # start of another function. A compiler may also begin a function with an
+            # unconditional jump to an internal loop guard (loop rotation). When the loader
+            # supplies a non-empty function symbol, its extent is stronger evidence than this
+            # tail-jump heuristic: keep a target inside that extent in the current function.
             if (
                 target_func_addr is None
                 and len(src_node.instruction_addrs) == 1
@@ -3605,7 +3608,17 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 and all_successors is not None
                 and len(all_successors) == 1
             ):
-                target_func_addr = target_addr
+                current_symbol = self.project.loader.find_symbol(current_function_addr)
+                current_symbol_size = getattr(current_symbol, "size", 0) or 0
+                target_is_inside_current_symbol = (
+                    current_symbol is not None
+                    and current_symbol.is_function
+                    and current_symbol.rebased_addr == current_function_addr
+                    and current_symbol_size > 0
+                    and current_function_addr <= target_addr < current_function_addr + current_symbol_size
+                )
+                if not target_is_inside_current_symbol:
+                    target_func_addr = target_addr
             # last resort: the block probably belongs to the current function
             if target_func_addr is None:
                 target_func_addr = current_function_addr

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -6,9 +6,6 @@ __package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-bu
 
 import logging
 import os
-import shutil
-import subprocess
-import tempfile
 import unittest
 
 import archinfo
@@ -739,44 +736,20 @@ class TestCfgfast(unittest.TestCase):
 
         assert len(cfg.model.graph) == 2
 
-    @unittest.skipUnless(shutil.which("gcc"), "gcc is required")
     def test_entry_jump_within_function_symbol_is_not_tail_jump(self):
         """Loop rotation may put an unconditional jump at a function's entry."""
-        source = r"""
-.text
-.globl rotated_loop
-.type rotated_loop, @function
-rotated_loop:
-    jmp .Lguard
-.Lbody:
-    addl $1, (%rdi)
-.Lguard:
-    cmpl $4, (%rdi)
-    jne .Lbody
-    ret
-.size rotated_loop, .-rotated_loop
-"""
-        with tempfile.TemporaryDirectory() as tmp:
-            source_path = os.path.join(tmp, "rotated_loop.s")
-            binary_path = os.path.join(tmp, "rotated_loop.so")
-            with open(source_path, "w", encoding="utf-8") as fp:
-                fp.write(source)
-            subprocess.run(
-                ["gcc", "-shared", "-fPIC", "-nostdlib", "-o", binary_path, source_path],
-                check=True,
-            )
+        binary_path = os.path.join(test_location, "x86_64", "cfg_entry_jump_within_function")
+        proj = angr.Project(binary_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        function_symbol = proj.loader.find_symbol("rotated_loop")
+        assert function_symbol is not None
+        function_addr = function_symbol.rebased_addr
+        entry = cfg.model.get_any_node(function_addr)
 
-            proj = angr.Project(binary_path, auto_load_libs=False)
-            cfg = proj.analyses.CFGFast(normalize=True)
-            function_symbol = proj.loader.find_symbol("rotated_loop")
-            assert function_symbol is not None
-            function_addr = function_symbol.rebased_addr
-            entry = cfg.model.get_any_node(function_addr)
-
-            assert entry is not None
-            assert len(entry.successors) == 1
-            assert entry.successors[0].function_address == function_addr
-            assert entry.successors[0].addr in {node.addr for node in cfg.functions[function_addr].graph}
+        assert entry is not None
+        assert len(entry.successors) == 1
+        assert entry.successors[0].function_address == function_addr
+        assert entry.successors[0].addr in {node.addr for node in cfg.functions[function_addr].graph}
 
     def test_starting_point_ordering(self):
         # project entry should always be first

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -6,6 +6,9 @@ __package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-bu
 
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
 import unittest
 
 import archinfo
@@ -735,6 +738,43 @@ class TestCfgfast(unittest.TestCase):
         cfg = proj.analyses.CFGFast()
 
         assert len(cfg.model.graph) == 2
+
+    @unittest.skipUnless(shutil.which("gcc"), "gcc is required")
+    def test_entry_jump_within_function_symbol_is_not_tail_jump(self):
+        """Loop rotation may put an unconditional jump at a function's entry."""
+        source = r"""
+.text
+.globl rotated_loop
+.type rotated_loop, @function
+rotated_loop:
+    jmp .Lguard
+.Lbody:
+    addl $1, (%rdi)
+.Lguard:
+    cmpl $4, (%rdi)
+    jne .Lbody
+    ret
+.size rotated_loop, .-rotated_loop
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            source_path = os.path.join(tmp, "rotated_loop.s")
+            binary_path = os.path.join(tmp, "rotated_loop.so")
+            with open(source_path, "w", encoding="utf-8") as fp:
+                fp.write(source)
+            subprocess.run(
+                ["gcc", "-shared", "-fPIC", "-nostdlib", "-o", binary_path, source_path],
+                check=True,
+            )
+
+            proj = angr.Project(binary_path, auto_load_libs=False)
+            cfg = proj.analyses.CFGFast(normalize=True)
+            function_addr = proj.loader.find_symbol("rotated_loop").rebased_addr
+            entry = cfg.model.get_any_node(function_addr)
+
+            assert entry is not None
+            assert len(entry.successors) == 1
+            assert entry.successors[0].function_address == function_addr
+            assert entry.successors[0].addr in {node.addr for node in cfg.functions[function_addr].graph}
 
     def test_starting_point_ordering(self):
         # project entry should always be first

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -768,7 +768,9 @@ rotated_loop:
 
             proj = angr.Project(binary_path, auto_load_libs=False)
             cfg = proj.analyses.CFGFast(normalize=True)
-            function_addr = proj.loader.find_symbol("rotated_loop").rebased_addr
+            function_symbol = proj.loader.find_symbol("rotated_loop")
+            assert function_symbol is not None
+            function_addr = function_symbol.rebased_addr
             entry = cfg.model.get_any_node(function_addr)
 
             assert entry is not None


### PR DESCRIPTION
## Summary

- Treat a non-empty loader function symbol's extent as stronger evidence than CFGFast's single-entry-jump tail-call heuristic.
- Keep an entry jump target in the current function when it lies inside that symbol extent.
- Add a regression for a loop-rotated function that begins by jumping to its internal guard.

## Motivation

Compilers can rotate loops so a function starts with an unconditional jump to an internal guard. CFGFast's entry-jump heuristic classified that target as a new function, splitting a symbol-backed function in the middle despite the loader providing an exact non-empty function extent.

## Testing

- Focused regression plus neighboring tail-jump/function-boundary cases (4 passed)
- `tests/analyses/cfg/test_cfgfast.py` excluding two tests whose Mach-O universal-binary fixture is absent locally (43 passed, 2 skipped, 2 deselected, 2 subtests passed)
- Ruff lint and format checks on both changed files

sync: angr/binaries#172