### PR TITLE
Refine C++ symbol prototypes with machine ABI facts

### DIFF
--- a/angr/analyses/calling_convention/calling_convention.py
+++ b/angr/analyses/calling_convention/calling_convention.py
@@ -184,7 +184,7 @@ class CallingConventionAnalysis(Analysis):
 
         assert self._function is not None
 
-        cpp_symbol_result = None
+        cpp_symbol_result: tuple[SimCC, SimTypeCppFunction, str | None] | None = None
         demangled_name = self._function.demangled_name
         if demangled_name != self._function.name:
             r_demangled = self._analyze_demangled_name(demangled_name)
@@ -193,10 +193,11 @@ class CallingConventionAnalysis(Analysis):
                 # not distinguish a namespace/static function from a non-static member.
                 # parse_cpp_file() consequently carries a possible-this placeholder.
                 # Do not let that incomplete declaration bypass callee/callsite analysis;
-                # refine it with machine facts below.  Non-C++ symbol declarations remain
-                # authoritative as before.
-                if isinstance(r_demangled[1], SimTypeCppFunction):
-                    cpp_symbol_result = r_demangled
+                # refine it with machine facts below. Declarations that encode an explicit
+                # calling convention (such as Microsoft C++ symbols) remain authoritative.
+                demangled_cc, demangled_proto, demangled_libname = r_demangled
+                if isinstance(demangled_proto, SimTypeCppFunction) and demangled_proto.convention is None:
+                    cpp_symbol_result = demangled_cc, demangled_proto, demangled_libname
                 else:
                     self.cc, self.prototype, self.prototype_libname = r_demangled
                     self.proto_from_symbol = True

--- a/angr/analyses/calling_convention/calling_convention.py
+++ b/angr/analyses/calling_convention/calling_convention.py
@@ -45,6 +45,7 @@ from angr.sim_type import (
     SimTypeInt128,
     SimTypeLongLong,
     SimTypePointer,
+    SimTypeReg,
     SimTypeShort,
     parse_cpp_file,
 )
@@ -183,13 +184,23 @@ class CallingConventionAnalysis(Analysis):
 
         assert self._function is not None
 
+        cpp_symbol_result = None
         demangled_name = self._function.demangled_name
         if demangled_name != self._function.name:
             r_demangled = self._analyze_demangled_name(demangled_name)
             if r_demangled is not None:
-                self.cc, self.prototype, self.prototype_libname = r_demangled
-                self.proto_from_symbol = True
-                return
+                # Itanium names usually omit the return type, and a qualified name does
+                # not distinguish a namespace/static function from a non-static member.
+                # parse_cpp_file() consequently carries a possible-this placeholder.
+                # Do not let that incomplete declaration bypass callee/callsite analysis;
+                # refine it with machine facts below.  Non-C++ symbol declarations remain
+                # authoritative as before.
+                if isinstance(r_demangled[1], SimTypeCppFunction):
+                    cpp_symbol_result = r_demangled
+                else:
+                    self.cc, self.prototype, self.prototype_libname = r_demangled
+                    self.proto_from_symbol = True
+                    return
 
         if self._function.is_simprocedure:
             hooker = self.project.hooked_by(self._function.addr)
@@ -282,6 +293,9 @@ class CallingConventionAnalysis(Analysis):
         r = self._analyze_function()
         if r is None:
             l.warning("Cannot determine calling convention for %r.", self._function)
+            if cpp_symbol_result is not None:
+                self.cc, self.prototype, self.prototype_libname = cpp_symbol_result
+                self.proto_from_symbol = True
         else:
             # adjust prototype if needed
             cc, prototype = r
@@ -296,8 +310,47 @@ class CallingConventionAnalysis(Analysis):
                     else None
                 )
 
+            if cpp_symbol_result is not None and prototype is not None:
+                prototype = self._refine_cpp_symbol_prototype(prototype, cpp_symbol_result[1])
             self.cc = cc
             self.prototype = prototype
+
+    @staticmethod
+    def _refine_cpp_symbol_prototype(
+        machine_proto: SimTypeFunction, symbol_proto: SimTypeCppFunction
+    ) -> SimTypeFunction:
+        """Merge encoded C++ types only where machine ABI arity disambiguates them.
+
+        The parser's first pointer is a *possible* ``this``.  If machine facts recover
+        one fewer arguments, the qualified name was a namespace/static function and the
+        placeholder is removed.  If arity agrees it is retained.  Any other disagreement
+        keeps the machine-derived arguments.  A non-Bottom encoded template return may
+        refine the return type; ordinary Itanium names keep the machine-derived return.
+        """
+        machine_args = tuple(machine_proto.args or ())
+        symbol_args = tuple(symbol_proto.args or ())
+        if len(symbol_args) == len(machine_args):
+            selected = symbol_args
+        elif len(symbol_args) == len(machine_args) + 1 and symbol_args and isinstance(symbol_args[0], SimTypePointer):
+            selected = symbol_args[1:]
+        else:
+            selected = machine_args
+        # Opaque C++ classes cannot be laid out by a calling convention.  Preserve the
+        # machine-derived slot for those arguments; only scalar/reference or pointer
+        # types from the linkage name are safe refinements.
+        args = tuple(
+            sym if isinstance(sym, (SimTypeReg, SimTypePointer)) else machine
+            for machine, sym in zip(machine_args, selected)
+        )
+        symbol_ret = symbol_proto.returnty
+        ret = (
+            symbol_ret
+            if symbol_ret is not None
+            and not isinstance(symbol_ret, SimTypeBottom)
+            and isinstance(symbol_ret, (SimTypeReg, SimTypePointer))
+            else machine_proto.returnty
+        )
+        return SimTypeFunction(args, ret, variadic=machine_proto.variadic)
 
     def _analyze_callsite_only(self):
         assert self.caller_func_addr is not None

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -5,6 +5,9 @@ __package__ = __package__ or "tests.analyses"  # pylint:disable=redefined-builti
 
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
 import unittest
 from functools import wraps
 
@@ -40,6 +43,35 @@ def cca_mode(modes: str):
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
 class TestCallingConventionAnalysis(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("g++"), "g++ is required")
+    def test_itanium_qualified_free_function_does_not_gain_this(self):
+        """Machine facts must disambiguate namespace functions from members."""
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "qualified.cc")
+            binary = os.path.join(tmp, "qualified.so")
+            with open(source, "w", encoding="utf-8") as fh:
+                fh.write("""
+namespace demo {
+__attribute__((noinline, used)) bool free_value() { return true; }
+struct Box { __attribute__((noinline, used)) int add(int x) { return x + 1; } };
+__attribute__((used)) int call(Box *b, int x) { return b->add(x); }
+}
+""")
+            subprocess.run(
+                ["g++", "-O0", "-fno-inline", "-shared", "-fPIC", "-o", binary, source],
+                check=True,
+            )
+            project = angr.Project(binary, auto_load_libs=False)
+            cfg = project.analyses.CFGFast(normalize=True)
+            project.analyses.CompleteCallingConventions(recover_variables=True, cfg=cfg.model, analyze_callsites=True)
+            free = project.kb.functions["_ZN4demo10free_valueEv"]
+            assert free.prototype is not None
+            assert len(free.prototype.args) == 0
+            assert isinstance(free.prototype.returnty, SimTypeInt)
+            member = project.kb.functions["_ZN4demo3Box3addEi"]
+            assert member.prototype is not None
+            assert len(member.prototype.args) == 2
+
     def _run_fauxware(self, arch, function_and_cc_list):
         binary_path = os.path.join(test_location, arch, "fauxware")
         fauxware = angr.Project(binary_path, auto_load_libs=False)

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -5,9 +5,6 @@ __package__ = __package__ or "tests.analyses"  # pylint:disable=redefined-builti
 
 import logging
 import os
-import shutil
-import subprocess
-import tempfile
 import unittest
 from functools import wraps
 
@@ -43,34 +40,19 @@ def cca_mode(modes: str):
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
 class TestCallingConventionAnalysis(unittest.TestCase):
-    @unittest.skipUnless(shutil.which("g++"), "g++ is required")
     def test_itanium_qualified_free_function_does_not_gain_this(self):
         """Machine facts must disambiguate namespace functions from members."""
-        with tempfile.TemporaryDirectory() as tmp:
-            source = os.path.join(tmp, "qualified.cc")
-            binary = os.path.join(tmp, "qualified.so")
-            with open(source, "w", encoding="utf-8") as fh:
-                fh.write("""
-namespace demo {
-__attribute__((noinline, used)) bool free_value() { return true; }
-struct Box { __attribute__((noinline, used)) int add(int x) { return x + 1; } };
-__attribute__((used)) int call(Box *b, int x) { return b->add(x); }
-}
-""")
-            subprocess.run(
-                ["g++", "-O0", "-fno-inline", "-shared", "-fPIC", "-o", binary, source],
-                check=True,
-            )
-            project = angr.Project(binary, auto_load_libs=False)
-            cfg = project.analyses.CFGFast(normalize=True)
-            project.analyses.CompleteCallingConventions(recover_variables=True, cfg=cfg.model, analyze_callsites=True)
-            free = project.kb.functions["_ZN4demo10free_valueEv"]
-            assert free.prototype is not None
-            assert len(free.prototype.args) == 0
-            assert isinstance(free.prototype.returnty, SimTypeInt)
-            member = project.kb.functions["_ZN4demo3Box3addEi"]
-            assert member.prototype is not None
-            assert len(member.prototype.args) == 2
+        binary = os.path.join(test_location, "x86_64", "cpp_qualified_symbols.so")
+        project = angr.Project(binary, auto_load_libs=False)
+        cfg = project.analyses.CFGFast(normalize=True)
+        project.analyses.CompleteCallingConventions(recover_variables=True, cfg=cfg.model, analyze_callsites=True)
+        free = project.kb.functions["_ZN4demo10free_valueEv"]
+        assert free.prototype is not None
+        assert len(free.prototype.args) == 0
+        assert isinstance(free.prototype.returnty, SimTypeInt)
+        member = project.kb.functions["_ZN4demo3Box3addEi"]
+        assert member.prototype is not None
+        assert len(member.prototype.args) == 2
 
     def _run_fauxware(self, arch, function_and_cc_list):
         binary_path = os.path.join(test_location, arch, "fauxware")


### PR DESCRIPTION
## Summary

- Keep analyzing callee and call-site machine facts after parsing a demangled C++ symbol.
- Use recovered machine arity to distinguish a possible `this` placeholder from a real member-function argument.
- Preserve machine-derived ABI slots for opaque C++ types and machine-derived return types when the linkage name does not encode one.
- Add an end-to-end namespace-function/member-function regression backed by a prebuilt fixture in angr/binaries#172.

## Motivation

Itanium linkage names generally omit return types and do not distinguish namespace/static functions from non-static members. `parse_cpp_file()` therefore treats the first pointer as a possible `this`, but calling-convention analysis previously returned immediately with that incomplete prototype. Namespace functions such as `std::__is_constant_evaluated()` could consequently gain a bogus argument and bypass the available ABI evidence.

## Testing

- Fixture-backed namespace/member regression (1 passed)
- Full calling-convention analysis module against the fixture branch (passed)
- `python -m pytest -q tests/types/test_types.py` (25 passed)
- Ruff lint and format checks on both changed files

sync: angr/binaries#172