### PR TITLE
Copy stateful address concretization strategies on state fork

### DIFF
--- a/angr/storage/memory_mixins/address_concretization_mixin.py
+++ b/angr/storage/memory_mixins/address_concretization_mixin.py
@@ -66,8 +66,26 @@ class AddressConcretizationMixin(MemoryMixin):
     @MemoryMixin.memo
     def copy(self, memo):
         o = super().copy(memo)
-        o.read_strategies = list(self.read_strategies)
-        o.write_strategies = list(self.write_strategies)
+
+        # Concretization strategies are usually stateless and their ``copy()`` method
+        # returns ``self``. Some strategies do carry per-state data, however (for
+        # example, the no-repeat strategies), and explicitly implement ``copy()`` so
+        # that forks do not mutate one another. Merely copying the two lists leaves the
+        # strategy instances shared and makes that API ineffective.
+        #
+        # A strategy may intentionally be installed for both reads and writes. Preserve
+        # that alias within the new memory while still separating it from the source
+        # memory by copying each distinct source strategy exactly once.
+        copied_strategies = {}
+
+        def copy_strategy(strategy):
+            key = id(strategy)
+            if key not in copied_strategies:
+                copied_strategies[key] = strategy.copy()
+            return copied_strategies[key]
+
+        o.read_strategies = [copy_strategy(s) for s in self.read_strategies]
+        o.write_strategies = [copy_strategy(s) for s in self.write_strategies]
         return o
 
     def merge(self, others, merge_conditions, common_ancestor=None) -> bool:

--- a/tests/storage/test_address_concretization.py
+++ b/tests/storage/test_address_concretization.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import angr
+
+
+class _StatefulStrategy(angr.concretization_strategies.SimConcretizationStrategy):
+    def __init__(self, values=None):
+        super().__init__()
+        self.values = [] if values is None else values
+
+    def _concretize(self, memory, addr, **kwargs):
+        return None
+
+    def copy(self):
+        return _StatefulStrategy(list(self.values))
+
+
+def test_stateful_concretization_strategies_are_copied_with_memory():
+    state = angr.SimState(arch="AMD64")
+    strategy = _StatefulStrategy([1])
+    state.memory.read_strategies = [strategy, strategy]
+    state.memory.write_strategies = [strategy]
+
+    fork = state.copy()
+    fork_strategy = fork.memory.read_strategies[0]
+
+    assert fork_strategy is not strategy
+    assert fork.memory.read_strategies[1] is fork_strategy
+    assert fork.memory.write_strategies[0] is fork_strategy
+
+    fork_strategy.values.append(2)
+    assert strategy.values == [1]
+    assert fork_strategy.values == [1, 2]

--- a/tests/storage/test_address_concretization.py
+++ b/tests/storage/test_address_concretization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import archinfo
+
 import angr
 
 
@@ -16,12 +18,14 @@ class _StatefulStrategy(angr.concretization_strategies.SimConcretizationStrategy
 
 
 def test_stateful_concretization_strategies_are_copied_with_memory():
-    state = angr.SimState(arch="AMD64")
+    state = angr.SimState(arch=archinfo.ArchAMD64())
     strategy = _StatefulStrategy([1])
     state.memory.read_strategies = [strategy, strategy]
     state.memory.write_strategies = [strategy]
 
     fork = state.copy()
+    assert fork.memory.read_strategies is not None
+    assert fork.memory.write_strategies is not None
     fork_strategy = fork.memory.read_strategies[0]
 
     assert fork_strategy is not strategy


### PR DESCRIPTION
## Summary

- Invoke each address-concretization strategy's documented `copy()` hook when memory is copied.
- Copy each distinct source strategy once so a strategy intentionally shared by the read and write lists remains shared inside the child state.
- Add a regression covering both fork isolation and read/write alias preservation.

## Motivation

`AddressConcretizationMixin.copy()` copied only the strategy lists. Stateful strategies, including the no-repeat strategies, therefore remained shared across forked states even when they implemented `copy()`, allowing one fork's concretization history to affect another.

## Testing

- `python -m pytest -q tests/storage/test_address_concretization.py tests/storage/test_memory.py tests/storage/test_memory_merge.py` (27 passed)
- `ruff check angr/storage/memory_mixins/address_concretization_mixin.py tests/storage/test_address_concretization.py`
- `ruff format --check angr/storage/memory_mixins/address_concretization_mixin.py tests/storage/test_address_concretization.py`
