### PR TITLE
Handle case-insensitive P-code memory space names in AIL conversion

### DIFF
--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -329,7 +329,7 @@ class PCodeIRSBConverter(Converter):
                 return Convert(self._manager.next_atom(), t.bits, size, False, t, ins_addr=self._manager.ins_addr)
 
             return Tmp(self._manager.next_atom(), offset, size)
-        if space_name in ["ram", "mem"]:
+        if space_name.lower() in ["ram", "mem"]:
             assert not is_write
             addr = Const(self._manager.next_atom(), varnode.offset, self._manager.arch.bits)
             # Note: Load takes bytes, not bits, for size
@@ -359,7 +359,7 @@ class PCodeIRSBConverter(Converter):
             return Assignment(
                 self._statement_idx, self._convert_varnode(varnode, True), value, ins_addr=self._manager.ins_addr
             )
-        if space_name in ["ram", "mem"]:
+        if space_name.lower() in ["ram", "mem"]:
             addr = Const(self._manager.next_atom(), varnode.offset, self._manager.arch.bits)
             return Store(
                 self._statement_idx,

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -6,6 +6,7 @@ import pickle
 import unittest
 
 import archinfo
+import pypcode
 import pyvex
 from pyvex.enums import irop_enums_to_ints
 
@@ -40,6 +41,28 @@ class TestIrsb(unittest.TestCase):
         irsb = p.factory.block(self.block_addr).vex
         ablock = ailment.IRSBConverter.convert(irsb, manager)
         assert ablock  # TODO: test if this conversion is valid
+
+    def test_convert_pcode_uppercase_memory_space(self):
+        arch = archinfo.ArchPcode("6502:LE:16:default")
+        manager = ailment.Manager(arch=arch)
+        translation = pypcode.Context(arch.name).translate(bytes.fromhex("ad34128d7856"), base_address=0)
+        load_varnode = translation.ops[1].inputs[0]
+        store_varnode = translation.ops[5].output
+        assert load_varnode.space.name == store_varnode.space.name == "RAM"
+
+        converter = object.__new__(ailment.PCodeIRSBConverter)
+        converter._manager = manager
+        converter._statement_idx = 0
+
+        load = converter._get_value(load_varnode)
+        store = converter._set_value(store_varnode, ailment.Expr.Const(None, 0xAA, 8))
+
+        assert isinstance(load, ailment.Expr.Load)
+        assert load.addr.value == 0x1234
+        assert load.size == 1
+        assert isinstance(store, ailment.Stmt.Store)
+        assert store.addr.value == 0x5678
+        assert store.size == 1
 
     def test_lift_path_matches_python_path(self):
         """The direct libVEX-lift fast path must produce the same AIL block as

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -44,10 +44,12 @@ class TestIrsb(unittest.TestCase):
 
     def test_convert_pcode_uppercase_memory_space(self):
         arch = archinfo.ArchPcode("6502:LE:16:default")
-        manager = ailment.Manager(arch=arch)
+        manager = ailment.Manager(arch=arch)  # pyright: ignore[reportArgumentType]
         translation = pypcode.Context(arch.name).translate(bytes.fromhex("ad34128d7856"), base_address=0)
         load_varnode = translation.ops[1].inputs[0]
         store_varnode = translation.ops[5].output
+        assert load_varnode is not None
+        assert store_varnode is not None
         assert load_varnode.space.name == store_varnode.space.name == "RAM"
 
         converter = object.__new__(ailment.PCodeIRSBConverter)
@@ -58,9 +60,11 @@ class TestIrsb(unittest.TestCase):
         store = converter._set_value(store_varnode, ailment.Expr.Const(None, 0xAA, 8))
 
         assert isinstance(load, ailment.Expr.Load)
+        assert isinstance(load.addr, ailment.Expr.Const)
         assert load.addr.value == 0x1234
         assert load.size == 1
         assert isinstance(store, ailment.Stmt.Store)
+        assert isinstance(store.addr, ailment.Expr.Const)
         assert store.addr.value == 0x5678
         assert store.size == 1
 


### PR DESCRIPTION
## Summary

- Normalize P-code address-space names when recognizing RAM/memory varnodes.
- Apply the normalization to both AIL load and store conversion paths.
- Add a 6502 SLEIGH regression using real translated instructions whose direct-memory varnodes use the uppercase `RAM` space.

## Motivation

`PCodeIRSBConverter` recognized only lowercase `ram` and `mem`, but valid SLEIGH languages such as 6502 expose the default memory space as uppercase `RAM`. Direct memory varnodes therefore raised `NotImplementedError`, aborting AIL conversion and decompilation.

## Testing

- `python -m pytest -q tests/engines/pcode tests/ailment/test_irsb.py` (30 passed, 28 subtests)
- End-to-end P-code lift and AIL conversion check for the 6502 load/store sequence
- Ruff lint and format checks on both changed files
