### PR TITLE
CFGFast: rebuild function graphs for fresh models

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -761,6 +761,8 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             if is_dotnet and once("dotnet_native"):
                 l.warning("You're trying to analyze a .NET binary as native code. Are you sure?")
 
+        self._model_was_provided = model is not None
+
         CFGBase.__init__(
             self,
             "fast",
@@ -1529,6 +1531,16 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
         # Call _initialize_cfg() before self.functions is used.
         self._initialize_cfg()
+
+        # A fresh CFG model must not be recovered into function graphs left over from a different model. In
+        # particular, a normalized graph may contain artificial splits of overlapping instruction streams that a
+        # lifter cannot reproduce. Retain function metadata and known starts, but rebuild all structural data from
+        # this model.
+        if not self._model_was_provided:
+            self.functions.callgraph.clear_edges()
+            for function in self.functions.values():
+                function._clear_transition_graph()
+                self.functions.set_func_block_count(function.addr, 0)
 
         # Scan for __x86_return_thunk and friends
         self._known_thunks = self._find_thunks()

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -770,6 +770,8 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             if is_dotnet and once("dotnet_native"):
                 l.warning("You're trying to analyze a .NET binary as native code. Are you sure?")
 
+        self._model_was_provided = model is not None
+
         CFGBase.__init__(
             self,
             "fast",
@@ -1691,6 +1693,16 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
         # Call _initialize_cfg() before self.functions is used.
         self._initialize_cfg()
+
+        # A fresh CFG model must not be recovered into function graphs left over from a different model. In
+        # particular, a normalized graph may contain artificial splits of overlapping instruction streams that a
+        # lifter cannot reproduce. Retain function metadata and known starts, but rebuild all structural data from
+        # this model.
+        if not self._model_was_provided:
+            self.functions.callgraph.clear_edges()
+            for function in self.functions.values():
+                function._clear_transition_graph()  # pylint: disable=protected-access
+                self.functions.set_func_block_count(function.addr, 0)
 
         # Scan for __x86_return_thunk and friends
         self._known_thunks = self._find_thunks()

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1068,6 +1068,7 @@ class Function(Serializable):
 
     @dirty_func
     def _clear_transition_graph(self):
+        self.normalized = False
         self._block_sizes = {}
         self._addr_to_block_node = {}
         self._local_blocks = {}

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -1066,6 +1066,8 @@ class Function(Serializable):
 
     @dirty_func
     def _clear_transition_graph(self):
+        self.normalized = False
+        self._cyclomatic_complexity = None
         self._block_sizes = {}
         self._addr_to_block_node = {}
         self._local_blocks = {}

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -9,12 +9,14 @@ import logging
 import os
 import random
 import unittest
+from unittest import mock
 
 import archinfo
 
 import angr
+from angr.analyses.cfg.cfg_fast import CFGFast
 from angr.analyses.cfg.indirect_jump_resolvers import mips_elf_fast
-from angr.codenode import FuncNode
+from angr.codenode import BlockNode, FuncNode
 from angr.knowledge_plugins.cfg import CFGModel, CFGNode
 from tests.common import bin_location, broken
 
@@ -1140,6 +1142,64 @@ class TestCfgfast(unittest.TestCase):
         assert block_size(4096, repeating_byte_run_threshold=0) == 99
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
+
+    def test_fresh_model_rebuilds_function_graphs(self):
+        project = angr.Project(os.path.join(test_location, "armel", "libsoap.so"), auto_load_libs=False)
+        original_post_analysis = CFGFast._post_analysis  # pylint: disable=protected-access
+        observed_block_sizes = []
+
+        def observe_before_normalization(cfg):
+            function = cfg.functions[0x4066C8]
+            observed_block_sizes.append(
+                sorted(node.size for node in function.graph if isinstance(node, BlockNode) and node.addr == 0x4066EC)
+            )
+            return original_post_analysis(cfg)
+
+        with mock.patch.object(CFGFast, "_post_analysis", observe_before_normalization):
+            for _ in range(2):
+                cfg = project.analyses.CFGFast(
+                    normalize=True,
+                    regions=[(0x4066C8, 0x40676C)],
+                    function_starts=[0x4066C8],
+                )
+                self.assertTrue(cfg.functions[0x4066C8].normalized)
+
+        self.assertEqual(observed_block_sizes, [[28], [28]])
+
+    def test_fresh_model_invalidates_function_graph_caches(self):
+        project = angr.Project(os.path.join(test_location, "armel", "libsoap.so"), auto_load_libs=False)
+        function_addr = 0x4066C8
+        first = project.analyses.CFGFast(
+            normalize=False,
+            regions=[(function_addr, 0x406710)],
+            function_starts=[function_addr],
+        )
+        function = first.functions[function_addr]
+        first_complexity = function.cyclomatic_complexity
+        original_post_analysis = CFGFast._post_analysis  # pylint: disable=protected-access
+        observed = {}
+
+        def observe_rebuilt_graph(cfg):
+            rebuilt_function = cfg.functions[function_addr]
+            observed["same_function"] = rebuilt_function is function
+            observed["formula"] = (
+                rebuilt_function.transition_graph.number_of_edges()
+                - rebuilt_function.transition_graph.number_of_nodes()
+                + 2
+            )
+            observed["complexity"] = rebuilt_function.cyclomatic_complexity
+            return original_post_analysis(cfg)
+
+        with mock.patch.object(CFGFast, "_post_analysis", observe_rebuilt_graph):
+            project.analyses.CFGFast(
+                normalize=False,
+                regions=[(function_addr, 0x40676C)],
+                function_starts=[function_addr],
+            )
+
+        self.assertTrue(observed["same_function"])
+        self.assertNotEqual(first_complexity, observed["formula"])
+        self.assertEqual(observed["complexity"], observed["formula"])
 
 
 if __name__ == "__main__":

--- a/tests/analyses/cfg/test_cfgfast_pcode.py
+++ b/tests/analyses/cfg/test_cfgfast_pcode.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from itertools import combinations
+
+import archinfo
+
+import angr
+from angr.analyses.decompiler.clinic import Clinic, ClinicMode
+from angr.codenode import BlockNode
+
+
+def _block_ranges(function):
+    return sorted((node.addr, node.size) for node in function.graph if isinstance(node, BlockNode))
+
+
+def _overlapping_pairs(blocks):
+    return [
+        (left, right)
+        for left, right in combinations(blocks, 2)
+        if left[0] < right[0] + right[1] and right[0] < left[0] + left[1]
+    ]
+
+
+def test_cfgfast_rebuilds_function_graphs_for_fresh_pcode_model(monkeypatch):
+    # The branch at 0x8000 targets the end of the raw block that begins at 0x8002. The first CFGFast run therefore
+    # presents Clinic with a valid provisional overlap: [0x8002, 0x8007) and [0x8005, 0x8007). Normalization splits
+    # the former at 0x8005. A later CFGFast run on the same knowledge base creates a fresh CFG model and must rebuild
+    # the function graph as well. Otherwise it registers a new [0x8002, 0x8007) block alongside the normalized
+    # [0x8002, 0x8005) block left by the first model.
+    code = bytes.fromhex("d003 eaeaea d000 d000 d000 d000 d000 d000 d000 4c1380")
+    project = angr.load_shellcode(
+        code,
+        arch=archinfo.ArchPcode("6502:LE:16:default"),
+        load_address=0x8000,
+        engine=angr.engines.UberEnginePcode,
+    )
+
+    original_clinic_init = Clinic.__init__
+    clinic_block_ranges = []
+    clinic_normalized = []
+
+    def clinic_init(self, function, *args, **kwargs):
+        if kwargs.get("mode", ClinicMode.DECOMPILE) == ClinicMode.COLLECT_DATA_REFS:
+            assert function is project.kb.functions[function.addr]
+            blocks = _block_ranges(function)
+            clinic_block_ranges.append(blocks)
+            clinic_normalized.append(function.normalized)
+            assert not any(left[0] == right[0] for left, right in combinations(blocks, 2))
+        original_clinic_init(self, function, *args, **kwargs)
+
+    monkeypatch.setattr(Clinic, "__init__", clinic_init)
+
+    cfgs = []
+    for _ in range(2):
+        cfg = project.analyses.CFGFast(
+            function_starts=[0x8000],
+            force_smart_scan=False,
+            normalize=True,
+            data_references=True,
+        )
+        cfgs.append(cfg)
+        assert cfg.functions[0x8000].normalized
+        assert not _overlapping_pairs(_block_ranges(cfg.functions[0x8000]))
+
+    assert len(clinic_block_ranges) == 2
+    assert clinic_normalized == [False, False]
+    assert ((0x8002, 5), (0x8005, 2)) in _overlapping_pairs(clinic_block_ranges[0])
+    assert ((0x8002, 5), (0x8005, 2)) in _overlapping_pairs(clinic_block_ranges[1])
+    assert (0x8002, 3) in {(node.addr, node.size) for node in cfgs[1].model.nodes()}
+    assert (0x8002, 5) not in {(node.addr, node.size) for node in cfgs[1].model.nodes()}


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Running `CFGFast` twice on one `Project` with a fresh model each time leaves stale structural blocks in the shared `FunctionManager`. On `armel/libsoap.so`, function `0x4066c8`, the second run observes two blocks at `0x4066ec`:

```text
run 2 pre-normalization sizes at 0x4066ec: [16, 28]
```

### Root cause

The first run recovers the 28-byte block and normalization leaves a 16-byte split in the persistent function graph. The second fresh CFG model recovers the 28-byte block again but reuses that old structural graph, mixing boundaries that the fresh lift did not produce.

### Fix

Fresh models now clear function transition graphs, callgraph edges, block counts, normalization state, and graph-derived complexity before recovery. Function objects, metadata, and known starts remain available, and an explicitly supplied model is not cleared. The second run now contains only the freshly recovered block:

```text
run 2 pre-normalization sizes at 0x4066ec: [28]
```

### Testing

The regression runs ordinary `CFGFast` twice on the existing `armel/libsoap.so` fixture and checks both the observed block sizes and graph-derived complexity invalidation. Validation: https://github.com/angr/angr/pull/6655#issuecomment-5430934743

session: sharpen
