### PR TITLE
DecompilerObserver: Improve visibility into the decompilation pipeline.

### DIFF
--- a/angr/analyses/decompiler/__init__.py
+++ b/angr/analyses/decompiler/__init__.py
@@ -8,6 +8,7 @@ from .clinic import Clinic, ClinicMode
 from .decompilation_cache import DecompilationCache
 from .decompilation_options import options, options_by_category
 from .decompiler import Decompiler
+from .decompiler_observer import DecompilerObserver, ObserverFormat
 from .dephication import GraphDephication, SeqNodeDephication
 from .presets import DECOMPILATION_PRESETS
 from .region_identifier import RegionIdentifier
@@ -31,8 +32,10 @@ __all__ = (
     "ClinicMode",
     "DecompilationCache",
     "Decompiler",
+    "DecompilerObserver",
     "GraphDephication",
     "ImportSourceCode",
+    "ObserverFormat",
     "RegionIdentifier",
     "RegionOverlay",
     "RegionSimplifier",

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -92,6 +92,7 @@ if TYPE_CHECKING:
     from angr.knowledge_plugins.cfg import CFGModel
 
     from .decompilation_cache import DecompilationCache
+    from .decompiler_observer import DecompilerObserver
     from .notes import DecompilationNote
     from .peephole_optimizations import PeepholeOptimizationExprBase, PeepholeOptimizationStmtBase
 
@@ -246,6 +247,7 @@ class Clinic(Analysis):
         semvar_naming: bool = True,
         flavor: str = "pseudocode",
         variable_map: VariableMap | None = None,
+        observer: DecompilerObserver | None = None,
     ):
         if not func.normalized and mode == ClinicMode.DECOMPILE:
             raise ValueError("Decompilation must work on normalized function graphs.")
@@ -305,6 +307,7 @@ class Clinic(Analysis):
         self.secondary_stackvars: set[int] = set()
         self._typehoon_cls = typehoon_cls
 
+        self._observer = observer
         self.notes = notes if notes is not None else {}
         self.static_vvars = static_vvars if static_vvars is not None else {}
         self.static_buffers = static_buffers if static_buffers is not None else {}
@@ -410,6 +413,14 @@ class Clinic(Analysis):
     # Private methods
     #
 
+    def _notify_observer(self, stage_name: str, graph: networkx.DiGraph | None) -> None:
+        if self._observer is None or graph is None:
+            return
+        try:
+            self._observer.on_clinic_stage(self.function.addr, stage_name, graph)
+        except Exception:  # pylint:disable=broad-exception-caught
+            l.warning("DecompilerObserver failed at clinic stage %s", stage_name, exc_info=True)
+
     def _analyze_for_decompiling(self):
         # initialize the AIL conversion manager
         self._ail_manager = ailment.Manager(arch=self.project.arch)
@@ -419,8 +430,10 @@ class Clinic(Analysis):
         ail_graph = self._init_ail_graph if self._init_ail_graph is not None else self._decompilation_graph_recovery()
         if not ail_graph:
             return
+        self._notify_observer(ClinicStage.AIL_GRAPH_CONVERSION.name, ail_graph)
         if self._start_stage <= ClinicStage.INITIALIZATION:
             ail_graph = self._decompilation_fixups(ail_graph)
+            self._notify_observer(ClinicStage.INITIALIZATION.name, ail_graph)
 
         if self._inline_functions:
             self._max_stack_depth += self.calculate_stack_depth()
@@ -744,9 +757,11 @@ class Clinic(Analysis):
             if stage < self._start_stage or stage > self._end_stage or stage in self._skip_stages:
                 continue
             stages[stage]()
+            self._notify_observer(stage.name, self._ail_graph)
 
         # remove empty nodes from the graph
         self._ail_graph = self.remove_empty_nodes(self._ail_graph)
+        self._notify_observer("REMOVE_EMPTY_NODES", self._ail_graph)
         # note that there are still edges to remove before we can structure this graph!
 
         self.cc_graph = self.copy_graph(self._ail_graph)

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from angr.analyses.typehoon.typevars import TypeConstraint, TypeVariable
     from angr.knowledge_plugins.cfg.cfg_model import CFGModel
 
+    from .decompiler_observer import DecompilerObserver
     from .peephole_optimizations import PeepholeOptimizationExprBase, PeepholeOptimizationStmtBase
     from .structured_codegen.base import BaseStructuredCodeGenerator
 
@@ -98,6 +99,7 @@ class Decompiler(Analysis):
         static_vvars: dict | None = None,
         static_buffers: dict | None = None,
         codegen_cls=CStructuredCodeGenerator,
+        observer: DecompilerObserver | None = None,
     ):
         if not isinstance(func, Function):
             func = self.kb.functions[func]
@@ -151,6 +153,8 @@ class Decompiler(Analysis):
         self._desired_variables = frozenset(desired_variables) if desired_variables else set()
         self._static_vvars = static_vvars if static_vvars is not None else {}
         self._static_buffers = static_buffers if static_buffers is not None else {}
+        # the observer is pure observability; it is deliberately excluded from _cache_parameters
+        self._observer = observer
         self._cache_parameters = (
             {
                 "cfg": self._cfg,
@@ -259,6 +263,14 @@ class Decompiler(Analysis):
     def _decompile_with_cache(self):
         with sprop_cache_scope(self._sprop_walker_cache):
             self._decompile()
+
+    def _notify_observer(self, stage_name: str) -> None:
+        if self._observer is None or self.clinic is None or self.clinic.graph is None:
+            return
+        try:
+            self._observer.on_decompiler_stage(self.func.addr, stage_name, self.clinic.graph)
+        except Exception:  # pylint:disable=broad-exception-caught
+            l.warning("DecompilerObserver failed at decompiler stage %s", stage_name, exc_info=True)
 
     @timethis
     def _decompile(self):
@@ -373,6 +385,7 @@ class Decompiler(Analysis):
                 static_buffers=self._static_buffers,
                 flavor=self._flavor,
                 variable_map=variable_map,
+                observer=self._observer,
                 **self.options_to_params(self.options_by_class["clinic"]),
             )
         else:
@@ -396,6 +409,8 @@ class Decompiler(Analysis):
             # the function is empty
             return
 
+        self._notify_observer("CLINIC")
+
         # expose a copy of the graph before any optimizations that may change the graph occur;
         # use this graph if you need a reference of exact mapping of instructions to AIL statements
         self.unoptimized_ail_graph = (
@@ -408,12 +423,14 @@ class Decompiler(Analysis):
             clinic.reaching_definitions,
             ite_exprs=ite_exprs,
         )
+        self._notify_observer("GRAPH_SIMPLIFICATION")
 
         # recover regions, delay updating when we have optimizations that may update regions themselves
         delay_graph_updates = any(
             pass_.STAGE == OptimizationPassStage.DURING_REGION_IDENTIFICATION for pass_ in self._optimization_passes
         )
         self.region_identifier = self._recover_regions(clinic.graph, cond_proc, update_graph=not delay_graph_updates)
+        self._notify_observer("REGION_IDENTIFICATION")
 
         self._update_progress(73.0, text="Running region-simplification passes")
 
@@ -426,6 +443,7 @@ class Decompiler(Analysis):
             arg_vvars=set(clinic.arg_vvars) if clinic.arg_vvars is not None else set(),
             edges_to_remove=clinic.edges_to_remove,
         )
+        self._notify_observer("REGION_SIMPLIFICATION")
 
         if not self._want_full_graph:
             # finally (no more graph-based simplifications will run in the future),
@@ -434,6 +452,7 @@ class Decompiler(Analysis):
 
         # save the graph before structuring happens (for AIL view)
         clinic.cc_graph = clinic.copy_graph()
+        self._notify_observer("EDGE_REMOVAL")
 
         codegen = None
         seq_node = None
@@ -453,6 +472,7 @@ class Decompiler(Analysis):
                 ail_manager=clinic._ail_manager,
                 **self._recursive_structurer_params,
             )
+            self._notify_observer("STRUCTURING")
             self._update_progress(80.0, text="Simplifying regions")
 
             # simplify it
@@ -477,6 +497,7 @@ class Decompiler(Analysis):
                 **region_simplifier_params,
             )
             seq_node = s.result
+            self._notify_observer("REGION_SIMPLIFIER")
             seq_node = self._run_post_structuring_simplification_passes(
                 seq_node,
                 binop_operators=cache.binop_operators,
@@ -484,9 +505,11 @@ class Decompiler(Analysis):
                 graph=clinic.graph,
                 variable_kb=self._variable_kb,
             )
+            self._notify_observer("POST_STRUCTURING")
 
             # rewrite the sequence node to remove phi expressions
             seq_node = self.transform_seqnode_from_ssa(seq_node)
+            self._notify_observer("SSA_TO_NONSSA")
 
             # update memory data
             if self._cfg is not None and self._update_memory_data:
@@ -511,6 +534,7 @@ class Decompiler(Analysis):
                     notes=self.notes,
                     **self.options_to_params(self.options_by_class["codegen"]),
                 )
+                self._notify_observer("CODEGEN")
 
         self.seq_node = seq_node
         self.codegen = codegen

--- a/angr/analyses/decompiler/decompiler_observer.py
+++ b/angr/analyses/decompiler/decompiler_observer.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import itertools
+import json
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import networkx
+
+    from angr.ailment import Block
+
+
+class ObserverFormat:
+    """
+    Output formats supported by DecompilerObserver.
+    """
+
+    JSON = "json"
+    DOT = "dot"
+    TEXT = "text"
+
+    ALL = (JSON, DOT, TEXT)
+
+
+class DecompilerObserver:
+    """
+    Dumps intermediate decompilation state to disk for observability purposes.
+
+    When passed to the Decompiler analysis (observer=...), it is invoked after each Clinic stage and after each stage
+    in Decompiler itself, and dumps two types of data for the current AIL graph:
+
+    - The graph itself (only block addresses and block IDs).
+    - All AIL blocks in the graph, pretty-printed.
+
+    Each dump is written to output_dir with a monotonically increasing sequence number so that files sort
+    chronologically. Notes:
+
+    - Clinic-stage dumps only appear when Clinic actually runs; when the Decompiler reuses a cached Clinic
+      (regen_clinic=False with a cache hit), only Decompiler-stage dumps are produced.
+    - The observer is not forwarded to child Clinic instances created for inlined callees.
+    - Observer failures are logged and swallowed by the callers; they never alter decompilation results.
+
+    :ivar output_dir:   The directory where dump files are written. Created if it does not exist.
+    :ivar formats:      The output formats to dump in; one or more of ObserverFormat.ALL.
+    """
+
+    def __init__(self, output_dir: str, formats: str | tuple[str, ...] = (ObserverFormat.JSON,)):
+        if isinstance(formats, str):
+            formats = (formats,)
+        for fmt in formats:
+            if fmt not in ObserverFormat.ALL:
+                raise ValueError(f"Unsupported dump format {fmt!r}; expected one of {ObserverFormat.ALL}")
+        if not formats:
+            raise ValueError("At least one dump format must be specified")
+        self.output_dir = output_dir
+        self.formats: tuple[str, ...] = tuple(formats)
+        self._seq = itertools.count()
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    #
+    # Callbacks
+    #
+
+    def on_clinic_stage(self, func_addr: int, stage_name: str, ail_graph: networkx.DiGraph) -> None:
+        self._dump(func_addr, "clinic", stage_name, ail_graph)
+
+    def on_decompiler_stage(self, func_addr: int, stage_name: str, ail_graph: networkx.DiGraph) -> None:
+        self._dump(func_addr, "decompiler", stage_name, ail_graph)
+
+    #
+    # Private methods
+    #
+
+    @staticmethod
+    def _sort_key(block: Block) -> tuple[int, int]:
+        return block.addr, -1 if block.idx is None else block.idx
+
+    @staticmethod
+    def _node_str(block: Block) -> str:
+        return f"{block.addr:#x}:{block.idx}"
+
+    def _dump(self, func_addr: int, phase: str, stage_name: str, ail_graph: networkx.DiGraph) -> None:
+        seq = next(self._seq)
+        basename = f"{seq:03d}_{func_addr:#x}_{phase}_{stage_name}"
+
+        nodes = sorted(ail_graph.nodes(), key=self._sort_key)
+        edges = sorted(ail_graph.edges(), key=lambda e: (self._sort_key(e[0]), self._sort_key(e[1])))
+
+        for fmt in self.formats:
+            if fmt == ObserverFormat.JSON:
+                self._dump_json(basename, func_addr, seq, phase, stage_name, nodes, edges)
+            elif fmt == ObserverFormat.DOT:
+                self._dump_dot(basename, func_addr, stage_name, nodes, edges)
+            elif fmt == ObserverFormat.TEXT:
+                self._dump_text(basename, func_addr, seq, phase, stage_name, nodes, edges)
+
+    def _dump_json(
+        self,
+        basename: str,
+        func_addr: int,
+        seq: int,
+        phase: str,
+        stage_name: str,
+        nodes: list[Block],
+        edges: list[tuple[Block, Block]],
+    ) -> None:
+        data = {
+            "function": hex(func_addr),
+            "sequence": seq,
+            "phase": phase,
+            "stage": stage_name,
+            "graph": {
+                "nodes": [{"addr": node.addr, "idx": node.idx} for node in nodes],
+                "edges": [
+                    [{"addr": src.addr, "idx": src.idx}, {"addr": dst.addr, "idx": dst.idx}] for src, dst in edges
+                ],
+            },
+            "blocks": [{"addr": node.addr, "idx": node.idx, "dbg_repr": node.dbg_repr()} for node in nodes],
+        }
+        with open(os.path.join(self.output_dir, basename + ".json"), "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    def _dump_dot(
+        self,
+        basename: str,
+        func_addr: int,
+        stage_name: str,
+        nodes: list[Block],
+        edges: list[tuple[Block, Block]],
+    ) -> None:
+        def node_id(block: Block) -> str:
+            return f"n_{block.addr:#x}_{block.idx}"
+
+        lines = [f'digraph "{func_addr:#x} {stage_name}" {{']
+        lines.extend(f'  {node_id(node)} [label="{node.addr:#x} (idx={node.idx})"];' for node in nodes)
+        lines.extend(f"  {node_id(src)} -> {node_id(dst)};" for src, dst in edges)
+        lines.append("}")
+        with open(os.path.join(self.output_dir, basename + ".dot"), "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+
+        # DOT files cannot sanely hold multi-line block bodies; dump pretty-printed blocks alongside
+        with open(os.path.join(self.output_dir, basename + "_blocks.txt"), "w", encoding="utf-8") as f:
+            f.write(self._blocks_text(nodes))
+
+    def _dump_text(
+        self,
+        basename: str,
+        func_addr: int,
+        seq: int,
+        phase: str,
+        stage_name: str,
+        nodes: list[Block],
+        edges: list[tuple[Block, Block]],
+    ) -> None:
+        lines = [
+            f"# function: {func_addr:#x}",
+            f"# sequence: {seq}",
+            f"# phase: {phase}",
+            f"# stage: {stage_name}",
+            "",
+            "== Graph ==",
+        ]
+        lines.extend(f"{self._node_str(src)} -> {self._node_str(dst)}" for src, dst in edges)
+        nodes_with_edges = {node for edge in edges for node in edge}
+        isolated = [node for node in nodes if node not in nodes_with_edges]
+        lines.extend(f"{self._node_str(node)} (isolated)" for node in isolated)
+        lines += ["", "== Blocks ==", self._blocks_text(nodes)]
+        with open(os.path.join(self.output_dir, basename + ".txt"), "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+    def _blocks_text(self, nodes: list[Block]) -> str:
+        return "\n\n".join(f"## Block {self._node_str(node)}\n{node.dbg_repr()}" for node in nodes) + "\n"

--- a/tests/analyses/decompiler/test_decompiler_observer.py
+++ b/tests/analyses/decompiler/test_decompiler_observer.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+import networkx
+
+import angr
+from angr.ailment import Block
+from angr.analyses.decompiler import Decompiler, DecompilerObserver, ObserverFormat
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+def _make_test_graph() -> networkx.DiGraph:
+    b0 = Block(0x1000, 4, statements=[], idx=None)
+    b1 = Block(0x1010, 4, statements=[], idx=1)
+    g = networkx.DiGraph()
+    g.add_edge(b0, b1)
+    return g
+
+
+class RaisingObserver(DecompilerObserver):
+    def on_clinic_stage(self, func_addr, stage_name, ail_graph):
+        raise RuntimeError("observer failure")
+
+    def on_decompiler_stage(self, func_addr, stage_name, ail_graph):
+        raise RuntimeError("observer failure")
+
+
+class TestDecompilerObserver(unittest.TestCase):
+    def test_observer_dump_formats(self):
+        g = _make_test_graph()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            obs = DecompilerObserver(tmpdir, formats=(ObserverFormat.JSON, ObserverFormat.DOT, ObserverFormat.TEXT))
+            obs.on_clinic_stage(0x1000, "TEST_STAGE", g)
+
+            basename = "000_0x1000_clinic_TEST_STAGE"
+            files = os.listdir(tmpdir)
+            assert sorted(files) == [
+                basename + ".dot",
+                basename + ".json",
+                basename + ".txt",
+                basename + "_blocks.txt",
+            ]
+
+            # JSON
+            with open(os.path.join(tmpdir, basename + ".json"), encoding="utf-8") as f:
+                data = json.load(f)
+            assert data["function"] == "0x1000"
+            assert data["sequence"] == 0
+            assert data["phase"] == "clinic"
+            assert data["stage"] == "TEST_STAGE"
+            assert data["graph"]["nodes"] == [{"addr": 0x1000, "idx": None}, {"addr": 0x1010, "idx": 1}]
+            assert data["graph"]["edges"] == [[{"addr": 0x1000, "idx": None}, {"addr": 0x1010, "idx": 1}]]
+            assert len(data["blocks"]) == 2
+            assert all(isinstance(blk["dbg_repr"], str) for blk in data["blocks"])
+
+            # DOT
+            with open(os.path.join(tmpdir, basename + ".dot"), encoding="utf-8") as f:
+                dot = f.read()
+            assert dot.startswith("digraph")
+            assert "n_0x1000_None" in dot
+            assert "n_0x1010_1" in dot
+            assert "n_0x1000_None -> n_0x1010_1;" in dot
+
+            # TEXT
+            with open(os.path.join(tmpdir, basename + ".txt"), encoding="utf-8") as f:
+                text = f.read()
+            assert "== Graph ==" in text
+            assert "== Blocks ==" in text
+            assert "0x1000:None -> 0x1010:1" in text
+
+    def test_observer_isolated_nodes_in_text_dump(self):
+        g = networkx.DiGraph()
+        g.add_node(Block(0x2000, 4, statements=[], idx=None))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            obs = DecompilerObserver(tmpdir, formats=ObserverFormat.TEXT)
+            obs.on_decompiler_stage(0x2000, "TEST_STAGE", g)
+            with open(os.path.join(tmpdir, "000_0x2000_decompiler_TEST_STAGE.txt"), encoding="utf-8") as f:
+                text = f.read()
+            assert "0x2000:None (isolated)" in text
+
+    def test_observer_unknown_format(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError):
+                DecompilerObserver(tmpdir, formats=("yaml",))
+            with self.assertRaises(ValueError):
+                DecompilerObserver(tmpdir, formats=())
+
+    def test_observer_full_decompilation(self):
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        f = proj.kb.functions["main"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            obs = DecompilerObserver(tmpdir, formats=(ObserverFormat.JSON,))
+            dec = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, observer=obs)
+
+            # the observer must not break decompilation
+            assert dec.codegen is not None and dec.codegen.text
+
+            files = sorted(os.listdir(tmpdir))
+            clinic_files = [fn for fn in files if "_clinic_" in fn]
+            decompiler_files = [fn for fn in files if "_decompiler_" in fn]
+            # stage sets shift over time; use loose lower bounds
+            assert len(clinic_files) >= 12
+            assert len(decompiler_files) >= 8
+
+            for stage in ("SSA_LEVEL0_TRANSFORMATION", "RECOVER_VARIABLES", "REMOVE_EMPTY_NODES"):
+                assert any(stage in fn for fn in clinic_files), f"missing clinic stage dump {stage}"
+            for stage in ("CLINIC", "REGION_IDENTIFICATION", "STRUCTURING", "CODEGEN"):
+                assert any(stage in fn for fn in decompiler_files), f"missing decompiler stage dump {stage}"
+
+            # all dumps must be valid JSON following the schema
+            for fn in files:
+                with open(os.path.join(tmpdir, fn), encoding="utf-8") as fp:
+                    data = json.load(fp)
+                assert set(data) == {"function", "sequence", "phase", "stage", "graph", "blocks"}
+                assert data["function"] == hex(f.addr)
+                assert len(data["blocks"]) == len(data["graph"]["nodes"]) >= 1
+                assert all(blk["dbg_repr"] for blk in data["blocks"])
+                node_keys = {(n["addr"], n["idx"]) for n in data["graph"]["nodes"]}
+                for src, dst in data["graph"]["edges"]:
+                    assert (src["addr"], src["idx"]) in node_keys
+                    assert (dst["addr"], dst["idx"]) in node_keys
+
+            # sequence numbers are strictly increasing in listing order, and clinic dumps come first
+            seqs = [int(fn.split("_", 1)[0]) for fn in files]
+            assert seqs == sorted(set(seqs))
+            max_clinic_seq = max(int(fn.split("_", 1)[0]) for fn in clinic_files)
+            min_decompiler_seq = min(int(fn.split("_", 1)[0]) for fn in decompiler_files)
+            assert max_clinic_seq < min_decompiler_seq
+
+    def test_observer_failure_does_not_break_decompilation(self):
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        f = proj.kb.functions["main"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            obs = RaisingObserver(tmpdir, formats=(ObserverFormat.JSON,))
+            dec = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, observer=obs)
+            assert dec.codegen is not None and dec.codegen.text
+            assert not os.listdir(tmpdir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
DecompilerObserver, when passed to the Decompiler analysis, dumps the current AIL state after each Clinic stage and after each Decompiler stage in JSON, DOT, and/or plain text. Each dump contains the ail_graph (block addresses and IDs only) and all AIL blocks pretty-printed. Observer failures are logged and never alter decompilation results; the observer is excluded from decompilation cache parameters.