### PR TITLE
Decompiler: Fix re-rendering of decompilation caches reloaded from angrDb.

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1446,12 +1446,12 @@ class CAssignment(CStatement):
             and self.rhs.op in compound_assignment_ops
             and self.lhs.unified_variable is not None
         ):
-            if isinstance(self.rhs.lhs, CVariable) and self.lhs.unified_variable is self.rhs.lhs.unified_variable:
+            if isinstance(self.rhs.lhs, CVariable) and self.lhs.unified_variable == self.rhs.lhs.unified_variable:
                 compound_expr_rhs = self.rhs.rhs
             elif (
                 self.rhs.op in commutative_ops
                 and isinstance(self.rhs.rhs, CVariable)
-                and self.lhs.unified_variable is self.rhs.rhs.unified_variable
+                and self.lhs.unified_variable == self.rhs.rhs.unified_variable
             ):
                 compound_expr_rhs = self.rhs.lhs
 
@@ -2995,6 +2995,9 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
         """
         if self.cfunc is None:
             return
+        # recompute the unified local variables and their types from the (possibly updated or freshly deserialized)
+        # variable manager, so re-rendering reflects the current variable types
+        self.cfunc.refresh()
         self.cleanup()
         (
             self.text,

--- a/angr/analyses/decompiler/structured_codegen/c_serialize.py
+++ b/angr/analyses/decompiler/structured_codegen/c_serialize.py
@@ -10,6 +10,7 @@ reference into the AST without duplicating subtrees.
 
 from __future__ import annotations
 
+import inspect
 import json
 import zlib
 from collections import defaultdict
@@ -352,6 +353,9 @@ class ParseContext:
     def set_codegen(self, codegen) -> None:
         for node in self._parsed.values():
             node.codegen = codegen
+            # CBinaryOp caches this display flag per-instance at __init__ (bypassed by parse); rebuild it here
+            if isinstance(node, CBinaryOp):
+                node._cstyle_null_cmp = codegen.cstyle_null_cmp
 
 
 #
@@ -506,6 +510,16 @@ _DISPLAY_OPTION_FIELD_FIRST = codegen_pb2.Codegen.DESCRIPTOR.fields_by_name["ind
 _DISPLAY_OPTION_ATTRS = tuple(
     f.name for f in codegen_pb2.Codegen.DESCRIPTOR.fields if f.number >= _DISPLAY_OPTION_FIELD_FIRST
 )
+# Constructor defaults for the display options, so a deserialized codegen has the same values a fresh one would for
+# options that were not serialized (an option whose value is None, e.g. max_str_len, is skipped on serialize).
+_CODEGEN_CTOR_DEFAULTS = {
+    name: param.default
+    for name, param in inspect.signature(CStructuredCodeGenerator.__init__).parameters.items()
+    if param.default is not inspect.Parameter.empty
+}
+_DISPLAY_OPTION_DEFAULTS = {
+    attr: _CODEGEN_CTOR_DEFAULTS[attr] for attr in _DISPLAY_OPTION_ATTRS if attr in _CODEGEN_CTOR_DEFAULTS
+}
 
 
 def serialize_codegen(codegen) -> codegen_pb2.Codegen:
@@ -626,12 +640,17 @@ def parse_codegen(msg, *, project=None, kb=None, func=None):
 
     cg.cexterns = {ctx.resolve(i) for i in msg.cexterns_ids} if msg.cexterns_ids else None
 
-    # Display options: only set those present in the cmessage.
+    # Display options: those present in the cmessage override the constructor defaults; options that were not
+    # serialized (a None value, e.g. max_str_len) fall back to the constructor default so the attribute exists.
     for attr in _DISPLAY_OPTION_ATTRS:
+        cg_attr = "_indent" if attr == "indent" else attr
         if msg.HasField(attr):
-            setattr(cg, "_indent" if attr == "indent" else attr, getattr(msg, attr))
+            setattr(cg, cg_attr, getattr(msg, attr))
+        elif attr in _DISPLAY_OPTION_DEFAULTS:
+            setattr(cg, cg_attr, _DISPLAY_OPTION_DEFAULTS[attr])
 
     # Runtime / back-reference state — caller-provided.
+    cg.project = project
     cg._func = func
     cg._func_args = None
     cg._cfg = None
@@ -1151,7 +1170,12 @@ def _parse_cconst(pb, ctx):
             elif w == "str_value":
                 refs[key] = entry.str_value
             elif w == "memory_data":
-                refs[key] = MemoryData.parse(entry.memory_data)
+                md = MemoryData.parse(entry.memory_data)
+                # MemoryData.content (e.g. the string bytes) is not serialized; re-read it from the loader so string
+                # references render as strings rather than raw addresses
+                if md.content is None and ctx.project is not None:
+                    md.fill_content(ctx.project.loader)
+                refs[key] = md
         obj.reference_values = refs
     else:
         obj.reference_values = None

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from collections import defaultdict
 from collections.abc import Iterator
@@ -287,7 +288,27 @@ class VariableManagerInternal(Serializable):
                 phi_relations.append(relation)
         cmsg.phi2var.extend(phi_relations)
 
-        # TODO: Types
+        # Types: variable_to_types (SimVariable ident -> SimType), with the manual-type flag. SimType JSON strings
+        # are interned into a shared type pool since many variables share the same type.
+        type_pool: list[str] = []
+        type_ref_by_json: dict[str, int] = {}
+        type_entries = []
+        for var, var_type in self.variable_to_types.items():
+            if var.ident is None:
+                continue
+            type_json = json.dumps(var_type.to_json())
+            ref = type_ref_by_json.get(type_json)
+            if ref is None:
+                type_pool.append(type_json)
+                ref = len(type_pool)  # index+1
+                type_ref_by_json[type_json] = ref
+            entry = variables_pb2.VariableType()  # type: ignore[reportAttributeAccessIssue]
+            entry.ident = var.ident
+            entry.type_ref = ref
+            entry.manual = var in self.variables_with_manual_types
+            type_entries.append(entry)
+        cmsg.types.extend(type_entries)
+        cmsg.type_pool.extend(type_pool)
 
         # TODO: vvarid_to_varialbes & variable_to_vvarids
 
@@ -404,7 +425,21 @@ class VariableManagerInternal(Serializable):
             model._phi_variables[phi].add(var)
             model._variables_to_phivars[var].add(phi)
 
-        # TODO: Types
+        # Types: variable_to_types (keyed by both regular and unified variables) + variables_with_manual_types.
+        # Each pooled type JSON is parsed once and shared across the variables that reference it.
+        arch = model.manager._kb._project.arch if model.manager is not None else None
+        type_by_ref: dict[int, SimType] = {}
+        for ref, type_json in enumerate(cmsg.type_pool, start=1):
+            var_type = SimType.from_json(json.loads(type_json))
+            type_by_ref[ref] = var_type.with_arch(arch) if arch is not None else var_type
+        for type_pb2 in cmsg.types:
+            var = variable_by_ident.get(type_pb2.ident) or unified_variable_by_ident.get(type_pb2.ident)
+            var_type = type_by_ref.get(type_pb2.type_ref)
+            if var is None or var_type is None:
+                continue
+            model.variable_to_types[var] = var_type
+            if type_pb2.manual:
+                model.variables_with_manual_types.add(var)
 
         for var in model._variables:
             if isinstance(var, SimStackVariable):

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -1,3 +1,4 @@
+# pylint:disable=protected-access
 from __future__ import annotations
 
 import json

--- a/angr/protos/variables.proto
+++ b/angr/protos/variables.proto
@@ -70,7 +70,8 @@ message VariableAccess {
 
 message VariableType {
     string          ident = 1;
-    string          var_type = 2;  // FIXME: Use a better solution than a string!
+    uint32          type_ref = 2;  // index+1 into VariableManagerInternal.type_pool
+    bool            manual = 3;    // whether the type was set manually (variables_with_manual_types)
 }
 
 message Var2Unified {
@@ -101,6 +102,8 @@ message VariableManagerInternal {
     repeated Var2Unified var2unified = 10;
     // Types
     repeated VariableType types = 11;
+    // Interned SimType JSON strings (json.dumps(SimType.to_json())); VariableType.type_ref is index+1 into this pool
+    repeated string type_pool = 14;
     // Phi variables
     repeated Phi2Var phi2var = 12;
 }

--- a/tests/serialization/test_db.py
+++ b/tests/serialization/test_db.py
@@ -817,6 +817,47 @@ class TestDb(unittest.TestCase):
 
             _proj = AngrDB(nullpool=True).load(out_db)
 
+    def test_angrdb_reloaded_decompilation_rerenders_identically(self):
+        # Full workflow: load a binary, decompile a function (populating kb.dec_variables), spill the decompilation
+        # and dec_variables into angrdb, reload, then re-render the cached codegen. The re-rendered output must be
+        # byte-identical to the original — variable declarations (types) and string constants included.
+        bin_path = os.path.join(test_location, "x86_64", "1after909")
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = os.path.join(td, "1after909.adb")
+
+            proj = angr.Project(bin_path, auto_load_libs=False)
+            cfg = proj.analyses.CFGFast(normalize=True)
+            proj.analyses.CompleteCallingConventions(recover_variables=False)
+            func = proj.kb.functions.function(name="doit")
+            dec = proj.analyses.Decompiler(func, cfg=cfg.model)
+            assert dec.codegen is not None and dec.codegen.text is not None
+            original_text = dec.codegen.text
+            # sanity: the original has variable declarations and rendered strings
+            assert "int node;" in original_text
+            assert 'puts("1 AFTER 909:' in original_text or "1 AFTER 909" in original_text
+
+            AngrDB(proj, nullpool=True).dump(db_file)
+            reloaded = AngrDB(nullpool=True).load(db_file)
+            func2 = reloaded.kb.functions.function(name="doit")
+
+            # dec_variables (with types) round-tripped
+            assert func2.addr in reloaded.kb.dec_variables
+            assert reloaded.kb.dec_variables[func2.addr].variable_to_types
+
+            # the cached codegen re-renders identically (what angr-management does on display/edit)
+            cached = reloaded.kb.decompilations[(func2.addr, "pseudocode")]
+            assert cached.codegen is not None
+            assert cached.codegen.text == original_text  # stored text
+            cached.codegen.regenerate_text()
+            assert cached.codegen.text == original_text  # re-rendered text
+
+            # and going through the Decompiler again yields the same, re-renderable, result
+            dec2 = reloaded.analyses.Decompiler(func2, cfg=reloaded.kb.cfgs.get_most_accurate())
+            assert dec2.codegen is not None
+            dec2.codegen.regenerate_text()
+            assert dec2.codegen.text == original_text
+
     def test_angrdb_blob_loader_options_roundtrip(self):
         with tempfile.TemporaryDirectory() as td:
             blob_path = os.path.join(td, "sample.bin")


### PR DESCRIPTION
Re-rendering a deserialized CodeGen (as angr-management does on display/edit) dropped variable declarations and string constants and rendered slightly different C, because several pieces of state were not restored:

- VariableManagerInternal never serialized variable_to_types / variables_with_ manual_types, so get_variable_type() returned None and all locals rendered as int.
- parse_codegen did not attach the project, and left display options that serialize as None (e.g. max_str_len) unset. Attach project and initialize display options from the codegen constructor defaults.
- CConstant string references lost MemoryData.content (not serialized); re-read it from the loader at parse time so strings render as strings, not raw addresses.
- regenerate_text() now refreshes CFunction.unified_local_vars from the (restored or updated) variable manager so declarations reflect current types.
- CBinaryOp._cstyle_null_cmp is rebuilt from the codegen flag in set_codegen, restoring !x vs x == 0.
- Compound-assignment folding (x += 1) compared unified variables by identity; use == so it works across deserialized variables that are equal but not the same object.

Adds an end-to-end test (1after909::doit) asserting a reloaded cache re-renders byte-identically.