### PR TITLE
RemoveRedundantShifts: Retain sign extensions.

### DIFF
--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_shifts.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_shifts.py
@@ -19,12 +19,19 @@ class RemoveRedundantShifts(PeepholeOptimizationExprBase):
 
     def optimize(self, expr: BinaryOp, **kwargs):
         # (expr << N) >> N  ==> Convert((M-N)->M, Convert(M->(M-N), expr))
+        #
+        # For a *logical* right shift (Shr) the outer conversion zero-extends, which the C backend renders as a
+        # bitmask (e.g. `& 0xfff`) that is correct for any width. For an *arithmetic* right shift (Sar) the outer
+        # conversion must sign-extend the low (M-N) bits; that is only rendered faithfully by the C backend when
+        # (M-N) is a standard integer width (8/16/32/64). For non-standard widths we leave the Sar/Shl pair intact
+        # (which renders as a signed `(expr << N) >> N`) rather than emit a bogus zero-extend mask that silently
+        # drops the sign bit.
         if expr.op in ("Shr", "Sar") and isinstance(expr.operands[1], Const):
             expr_a = expr.operands[0]
             n0 = expr.operands[1].value
             if isinstance(expr_a, BinaryOp) and expr_a.op in {"Shl", "Mul"} and isinstance(expr_a.operands[1], Const):
                 n1 = get_expr_shift_left_amount(expr_a)
-                if n0 == n1:
+                if n0 == n1 and (expr.op == "Shr" or (expr_a.bits - n0) in (8, 16, 32, 64)):
                     inner_expr = expr_a.operands[0]
                     conv_inner_expr = Convert(
                         self.manager.next_atom(),
@@ -38,7 +45,7 @@ class RemoveRedundantShifts(PeepholeOptimizationExprBase):
                         self.manager.next_atom(),
                         expr_a.bits - n0,
                         expr.bits,
-                        False,
+                        expr.op == "Sar",  # sign-extend for arithmetic shift, zero-extend for logical shift
                         conv_inner_expr,
                         **expr.tags,
                     )

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -2271,6 +2271,34 @@ class CBinaryOp(CExpression):
         yield from self._c_repr_chunks(" << ")
 
     def _c_repr_chunks_sar(self):
+        # Sar is an arithmetic (signed) right shift, but it renders as the C `>>` operator, which only performs an
+        # arithmetic shift when its left operand is signed. If the left operand renders as an unsigned integer, emit
+        # an explicit signed cast; otherwise `>>` would be a logical shift and silently drop the sign bit. The cast is
+        # emitted here at render time because the earlier typecast-collapsing passes treat same-size signed/unsigned
+        # integer casts as redundant and would strip a cast added during code generation.
+        lhs_ty = self.lhs.type
+        if (
+            isinstance(lhs_ty, (SimTypeInt, SimTypeChar, SimTypeNum))
+            and getattr(lhs_ty, "signed", None) is False
+            and lhs_ty.size is not None
+        ):
+            signed_ty = self.codegen.default_simtype_from_bits(lhs_ty.size, signed=True)
+            paren = CClosingObject("(")
+            yield "(", paren
+            yield f"{signed_ty.c_repr(name=None)}", signed_ty
+            yield ")", paren
+            yield "(", paren
+            yield from self._try_c_repr_chunks(self.lhs)
+            yield ")", paren
+            yield " >> ", self
+            if isinstance(self.rhs, CBinaryOp) and self.op_precedence > self.rhs.op_precedence:
+                paren2 = CClosingObject("(")
+                yield "(", paren2
+                yield from self._try_c_repr_chunks(self.rhs)
+                yield ")", paren2
+            else:
+                yield from self._try_c_repr_chunks(self.rhs)
+            return
         yield from self._c_repr_chunks(" >> ")
 
     def _c_repr_chunks_logicaland(self):

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -21,6 +21,7 @@ from angr.analyses.decompiler.peephole_optimizations import (
     ConstantDereferences,
     EagerEvaluation,
     OptimizedDivisionSimplifier,
+    RemoveRedundantShifts,
     SimplifyBitwiseInserts,
 )
 from angr.analyses.decompiler.utils import peephole_optimize_expr
@@ -233,6 +234,39 @@ class TestPeepholeOptimizations(unittest.TestCase):
                 assert isinstance(r.operand, BinaryOp) and r.operand.op == "Div"
                 divisor_operand = r.operand.operands[1]
                 assert isinstance(divisor_operand, Const) and divisor_operand.value == divisor
+
+    def test_remove_redundant_shifts_preserves_sign_extension(self):
+        # (x << N) Sar N is a sign-extension of the low (bits - N) bits and must NOT be turned into a
+        # zero-extending bitmask. Regression test for the simplifier dropping the sign bit, decompiling
+        # `(int)(x << 20) >> 20` (sign-extend the low 12 bits) into the wrong `x & 0xfff` (zero-extend).
+        mgr = Manager(arch=archinfo.arch_from_id("AMD64"))
+
+        # Arithmetic shift, standard resulting width (32 - 16 = 16): sign-extend via a *signed* outer Convert.
+        x = Register(mgr.next_atom(), 16, 32)
+        shl = BinaryOp(mgr.next_atom(), "Shl", [x, Const(mgr.next_atom(), 16, 8)], False, bits=32)
+        sar = BinaryOp(mgr.next_atom(), "Sar", [shl, Const(mgr.next_atom(), 16, 8)], True, bits=32)
+        r = RemoveRedundantShifts(None, None, mgr).optimize(sar)
+        assert isinstance(r, Convert)
+        assert r.from_bits == 16 and r.to_bits == 32
+        assert r.is_signed is True  # the outer conversion MUST sign-extend (not zero-extend)
+        assert isinstance(r.operand, Convert) and r.operand.from_bits == 32 and r.operand.to_bits == 16
+
+        # Arithmetic shift, non-standard resulting width (32 - 20 = 12): leave the Sar/Shl pair intact rather
+        # than emit a zero-extend mask that would silently drop the sign bit (12 bits has no clean C type).
+        x = Register(mgr.next_atom(), 16, 32)
+        shl = BinaryOp(mgr.next_atom(), "Shl", [x, Const(mgr.next_atom(), 20, 8)], False, bits=32)
+        sar = BinaryOp(mgr.next_atom(), "Sar", [shl, Const(mgr.next_atom(), 20, 8)], True, bits=32)
+        r = RemoveRedundantShifts(None, None, mgr).optimize(sar)
+        assert r is None
+
+        # Logical shift (Shr): the low-bit *zero*-extension is correct for any width -> unsigned outer Convert.
+        x = Register(mgr.next_atom(), 16, 32)
+        shl = BinaryOp(mgr.next_atom(), "Shl", [x, Const(mgr.next_atom(), 20, 8)], False, bits=32)
+        shr = BinaryOp(mgr.next_atom(), "Shr", [shl, Const(mgr.next_atom(), 20, 8)], False, bits=32)
+        r = RemoveRedundantShifts(None, None, mgr).optimize(shr)
+        assert isinstance(r, Convert)
+        assert r.from_bits == 12 and r.to_bits == 32
+        assert r.is_signed is False  # zero-extend
 
     def test_bswap32_intrinsic_name(self):
         proj = angr.load_shellcode(b"\x90", "AMD64")


### PR DESCRIPTION
`(x << N) >> N` was rewritten into a Convert-of-Convert pair whose outer Convert zero-extended for both logical (Shr) and arithmetic (Sar) right shifts. For Sar this is unsound: the idiom sign-extends the low (M-N) bits, but the zero-extending Convert rendered as a bitmask, so e.g. `(int)(x << 20) >> 20` decompiled to `x & 0xfff` (and the 64-bit twin to `x & 0xffffffffff`), which drops the sign bit.