### PR TITLE
Decompiler: disambiguate Extract condition placeholders

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -995,7 +995,11 @@ class ConditionProcessor:
                 if not isinstance(condition.offset, ailment.expression.Const)
                 else condition.offset.value
             )
-            var = claripy.BVS(f"ailexpr_Extract({offset_expr}, {hash(var_)})", condition.bits, explicit_name=True)
+            var = claripy.BVS(
+                f"ailexpr_Extract({condition.bits}, {condition.endness}, {offset_expr}, {hash(var_)})",
+                condition.bits,
+                explicit_name=True,
+            )
             self._condition_mapping[var.args[0]] = condition
             return var
         if isinstance(condition, ailment.expression.Insert):

--- a/tests/analyses/decompiler/test_condition_processor.py
+++ b/tests/analyses/decompiler/test_condition_processor.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import archinfo
+
+from angr import ailment
+from angr.ailment.expression import Const, Extract, VirtualVariable, VirtualVariableCategory
+from angr.analyses.decompiler.condition_processor import ConditionProcessor
+
+
+def test_extract_placeholders_include_semantic_properties():
+    arch = archinfo.ArchAMD64()
+    manager = ailment.Manager(arch=arch)
+    condition_processor = ConditionProcessor(arch, manager)
+
+    base = VirtualVariable(0, 1, 64, VirtualVariableCategory.REGISTER, oident=arch.registers["rax"][0])
+    offset = Const(1, 0, 64)
+    extract_byte = Extract(2, 8, base, offset, arch.memory_endness)
+    extract_word = Extract(3, 16, base, offset, arch.memory_endness)
+    extract_byte_be = Extract(4, 8, base, offset, archinfo.Endness.BE)
+
+    byte_ast = condition_processor.claripy_ast_from_ail_condition(extract_byte)
+    word_ast = condition_processor.claripy_ast_from_ail_condition(extract_word)
+    byte_be_ast = condition_processor.claripy_ast_from_ail_condition(extract_byte_be)
+
+    assert byte_ast.args[0] != word_ast.args[0]
+    assert byte_ast.args[0] != byte_be_ast.args[0]
+    assert condition_processor.convert_claripy_bool_ast(byte_ast) is extract_byte
+    assert condition_processor.convert_claripy_bool_ast(word_ast) is extract_word
+    assert condition_processor.convert_claripy_bool_ast(byte_be_ast) is extract_byte_be


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

`ConditionProcessor` turns AIL expressions into Claripy placeholders and keeps a reverse mapping from each placeholder name to its AIL expression. `Extract` placeholders previously encoded only the offset and base hash.

This change:

- includes the result width and endianness in every `Extract` placeholder name; and
- adds a focused regression test for width and endianness collisions and exact AIL round-tripping.

## Root cause

Two extracts from the same base and byte offset received the same symbolic name even when one produced 8 bits and the other produced 16 bits. Inserting the second expression into `_condition_mapping` silently replaced the first. During structuring, angr could then restore a 16-bit AIL expression for an 8-bit Claripy leaf and eventually raise:

```text
claripy.errors.ClaripyOperationError: args' length must all be equal
```

Endianness was another omitted semantic property with the same overwrite risk. Adding both properties makes the reverse-map key match the semantics that determine an extract's result.

## DecBench results

The baseline below is the published angr 9.2.223 DecBench result set. Both stored failures were also reproduced on current unpatched `master`; after this change:

| DecBench function | Before | After |
| --- | --- | --- |
| `O2/e2fsprogs/e2fsck:e2fsck_pass1` | exception, no codegen | codegen in 16.70 s |
| `O2-noinline/e2fsprogs/e2fsck:check_inode_extra_space` | exception in 0.45 s, no codegen | codegen in 0.50 s |

Treating those two direct reruns as isolated deltas, rather than claiming a full current-master rescore:

| Slice | Before | After |
| --- | ---: | ---: |
| Full | 88,761 / 94,716 (93.712783%) | 88,763 / 94,716 (93.714895%) |
| Inlined (`O2`) | 23,578 / 25,609 (92.069194%) | 23,579 / 25,609 (92.073099%) |
| Optimized (`O2-noinline`) | 31,114 / 34,647 (89.802869%) | 31,115 / 34,647 (89.805755%) |

The stored-success `e2fsck_pass1` controls at `O0` and `O2-noinline` still decompile successfully after the change (8.43 s and 8.76 s respectively).

A separate capped run of all 250 public DecBench sample-set functions produced 247 successful decompilations, zero timeouts, a maximum function time of 11.17 s, and a maximum CFG time of 37.92 s. The three remaining failures occur earlier in Typehoon or SPropagator, before this `ConditionProcessor` path. The published sample-set result was 220/250; the broader 247/250 result includes unrelated changes since angr 9.2.223 and is not attributed solely to this patch.

## Why this should not regress other functions

The change only alters internal, ephemeral Claripy leaf names. It does not modify the AIL expression, condition semantics, public APIs, or serialized state. Extracts with identical width, endianness, offset, and base retain the same mapping behavior; semantically different extracts no longer overwrite one another.

The regression test verifies both distinct names and exact reverse conversion for:

- equal-base/equal-offset extracts with different widths; and
- equal-base/equal-offset/equal-width extracts with different endianness.

## Validation

- Focused condition/structurer tests: 18 passed.
- Complete angr-agentic workspace gate:
  - angr Python: 2,220 passed, 46 skipped, 2 expected xfails;
  - angr Rust: 30 passed;
  - angr-management: 500 passed;
  - archinfo, pypcode, pyvex, cle, claripy, and workspace checks passed.
- Public DecBench sample set: 250/250 processed under 180 s CFG and 300 s/function hard caps; 247 codegen successes, 3 pre-structuring exceptions, 0 timeouts.
