### PR TITLE
Typehoon: preserve standard SimTypeNum types

### DIFF
--- a/angr/analyses/typehoon/translator.py
+++ b/angr/analyses/typehoon/translator.py
@@ -285,6 +285,14 @@ class TypeTranslator:
     # SimType handlers
     #
 
+    def _translate_SimTypeNum(self, st: sim_type.SimTypeNum) -> typeconsts.TypeConstant:
+        if st.size not in {8, 16, 32, 64}:
+            return typeconsts.BottomType()
+
+        tc = typeconsts.signed_int_type(st.size) if st.signed else typeconsts.unsigned_int_type(st.size)
+        tc.name = st.label
+        return tc
+
     def _translate_SimTypeInt128(self, st: sim_type.SimTypeChar) -> typeconsts.Int128:
         return typeconsts.Int128(name=st.label)
 
@@ -441,6 +449,7 @@ TypeConstHandlers = {
 
 SimTypeHandlers = {
     sim_type.SimTypePointer: TypeTranslator._translate_SimTypePointer,
+    sim_type.SimTypeNum: TypeTranslator._translate_SimTypeNum,
     sim_type.SimTypeChar: TypeTranslator._translate_SimTypeChar,
     sim_type.SimTypeWideChar: TypeTranslator._translate_SimTypeWideChar,
     sim_type.SimTypeInt: TypeTranslator._translate_SimTypeInt,

--- a/tests/analyses/test_typehoon.py
+++ b/tests/analyses/test_typehoon.py
@@ -15,7 +15,20 @@ import angr
 from angr.analyses.decompiler.clinic import Clinic
 from angr.analyses.typehoon.simple_solver import SimpleSolver
 from angr.analyses.typehoon.translator import TypeTranslator
-from angr.analyses.typehoon.typeconsts import Float32, Float64, Int32, Pointer64, Struct
+from angr.analyses.typehoon.typeconsts import (
+    Array,
+    BottomType,
+    Float32,
+    Float64,
+    Int1,
+    Int8,
+    Int32,
+    IntVar,
+    Pointer64,
+    SInt32,
+    SInt64,
+    Struct,
+)
 from angr.analyses.typehoon.typehoon import Typehoon
 from angr.analyses.typehoon.typevars import (
     DerivedTypeVariable,
@@ -36,6 +49,7 @@ from angr.sim_type import (
     SimTypeFloat,
     SimTypeFunction,
     SimTypeInt,
+    SimTypeNum,
     SimTypePointer,
 )
 from tests.common import bin_location, print_decompilation_result
@@ -441,6 +455,79 @@ class TestTypeTranslator(unittest.TestCase):
         st = SimTypeFloat()
         tc = tx.simtype2tc(st)
         assert isinstance(tc, Float32)
+
+    def test_simtypenum_struct_round_trip(self):
+        arch = archinfo.arch_from_id("amd64")
+        st = SimTypePointer(
+            SimStruct(
+                OrderedDict(
+                    {
+                        "ut_addr_v6": SimTypeArray(SimTypeNum(32, signed=True, label="int32_t"), 4),
+                        "tv_usec": SimTypeNum(64, signed=True, label="int64_t"),
+                    }
+                ),
+                name="utmp",
+            )
+        ).with_arch(arch)
+        tx = TypeTranslator(arch)
+
+        tc = tx.simtype2tc(st)
+        assert isinstance(tc, Pointer64)
+        assert isinstance(tc.basetype, Struct)
+        assert isinstance(tc.basetype.fields[0], Array)
+        assert isinstance(tc.basetype.fields[0].element, SInt32)
+        assert tc.basetype.fields[0].element.name == "int32_t"
+        assert isinstance(tc.basetype.fields[16], SInt64)
+        assert tc.basetype.fields[16].name == "int64_t"
+
+        restored, has_nonexistent_ref = tx.tc2simtype(tc)
+        assert not has_nonexistent_ref
+        assert isinstance(restored, SimTypePointer)
+        assert isinstance(restored.pts_to, SimStruct)
+        assert restored.pts_to.offsets == {"ut_addr_v6": 0, "tv_usec": 16}
+        assert restored.pts_to.size == 192
+        restored_array = restored.pts_to.fields["ut_addr_v6"]
+        assert isinstance(restored_array, SimTypeArray)
+        assert restored_array.size == 128
+        assert restored_array.elem_type.size == 32
+        assert restored_array.elem_type.signed is True
+
+    def test_unsupported_width_simtypenum(self):
+        arch = archinfo.arch_from_id("amd64")
+        tx = TypeTranslator(arch)
+
+        for bits in (1, 9, 24, 128):
+            for signed in (False, True):
+                with self.subTest(bits=bits, signed=signed):
+                    tc = tx.simtype2tc(SimTypeNum(bits, signed=signed, label=f"int{bits}_t").with_arch(arch))
+                    assert isinstance(tc, BottomType)
+
+        # Int1 and IntVar cannot be converted to equally-sized SimTypes: their sizes use incompatible units. They must
+        # remain unsupported rather than creating zero-alignment or incorrectly laid-out fields in a SimStruct.
+        struct = Struct(fields={0: Int1(), 1: IntVar(9), 2: Int8()})
+        restored, has_nonexistent_ref = tx.tc2simtype(struct)
+        assert not has_nonexistent_ref
+        assert isinstance(restored, SimStruct)
+        assert restored.offsets == {"field_0": 0, "field_1": 1, "field_2": 2}
+
+    def test_standard_width_simtypenum_round_trip(self):
+        arch = archinfo.arch_from_id("amd64")
+        tx = TypeTranslator(arch)
+
+        for bits in (8, 16, 32, 64):
+            for signed in (False, True):
+                with self.subTest(bits=bits, signed=signed):
+                    label = f"{'u' if not signed else ''}int{bits}_t"
+                    tc = tx.simtype2tc(SimTypeNum(bits, signed=signed, label=label).with_arch(arch))
+                    assert not isinstance(tc, IntVar)
+                    assert tc.size * arch.byte_width == bits
+                    assert tc.name == label
+
+                    restored, has_nonexistent_ref = tx.tc2simtype(tc)
+                    assert not has_nonexistent_ref
+                    assert restored.size == bits
+                    assert restored.signed is signed
+                    assert restored.label == label
 
     def test_lift_recursive_struct(self):
         arch = archinfo.arch_from_id("amd64")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

Teach the Typehoon translator to preserve 8-, 16-, 32-, and 64-bit `SimTypeNum` values, including signedness and labels, instead of reducing them to `BottomType`.

This restores decompilation when a library prototype introduces fixed-width numeric fields inside a struct. Widths that TypeConstants cannot represent losslessly remain on the existing `BottomType` fallback.

## Root cause

The `getutent()` prototype returns `struct utmp *`. That struct contains `ut_addr_v6`, an array of signed 32-bit `SimTypeNum` elements, and a signed 64-bit timeval field.

`TypeTranslator` had no `SimTypeNum` handler. Those fields therefore became `BottomType`; the nested array remained unsized, and translating the inferred struct back to a SimType attempted `None // arch.byte_width`, raising `TypeError`.

The new exact-class handler maps only the standard widths whose TypeConstant families preserve both width and signedness. Tests also lock in the safe fallback for 1-, 9-, 24-, and 128-bit values, avoiding zero-alignment and size-unit errors from lossy `Int1` or `IntVar` conversions.

## Public DecBench before/after

Baseline: `origin/master` at `1808e7fadd0448d20a51bf4ddc04fe0835c98327`. Each run used a fresh project, `CFGFast(normalize=True)`, `Decompiler(..., fail_fast=True)`, and no auto-loaded libraries.

| O2-noinline function | Current master | This PR |
| --- | --- | --- |
| `sysvinit/shutdown:wall` | `TypeError` after 0.836 s; no codegen | codegen in 0.781 s; 0 recorded errors |
| `sysvinit/wall:wall` | `TypeError` after 0.824 s; no codegen | codegen in 0.869 s; 0 recorded errors |

Affected-function success is **0/2 -> 2/2**, with zero timeouts. Both patched runs completed CFG plus decompilation in under 1.3 seconds, emitted 7,503 characters, and recovered `int ut_addr_v6[4];`.

These functions succeeded in the published angr 9.2.223 DecBench results, so this repairs a current-master regression; it is not presented as a gain over that older published aggregate. This is a targeted before/after, not a full DecBench rescore.

A pre-existing structured-codegen size-mismatch diagnostic remains later in both functions. This PR claims elimination of the Typehoon crash and recovery of the sized field, not complete semantic correctness of their entire output.

## Regression safety

- The handler is limited to the four widths with lossless signed/unsigned TypeConstant mappings.
- Unsupported widths retain their previous `BottomType` behavior.
- Round-trip tests cover every supported width and both signednesses, labels, the production-shaped nested `utmp` layout, and unsafe-width struct fallbacks.
- Independent adversarial review found and eliminated an earlier unsafe `Int1`/`IntVar` reverse mapping before publication.

Validation on the exact committed source:

- Typehoon module: 34 passed, 16 subtests passed.
- Full workspace: archinfo 17; pypcode 46 plus 187 subtests; pyvex 63; cle 199 passed/9 skipped; claripy 331 passed/1 skipped; angr 2,222 passed/46 skipped/2 xfailed plus 194 subtests; Rust 30; angr-management 500.
- Workspace integrity checks, Ruff formatting/lint, and `git diff --check` passed.