### PR TITLE
Avoid integer eager evaluation of floating-point expressions

### DIFF
--- a/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
+++ b/angr/analyses/decompiler/peephole_optimizations/eager_eval.py
@@ -29,6 +29,10 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
 
     @staticmethod
     def _optimize_binaryop(expr: BinaryOp):
+        # The identities below assume integer arithmetic and are not generally valid under IEEE 754.
+        if expr.floating_point:
+            return None
+
         op0, op1 = expr.operands
         if expr.op == "Add":
             if (
@@ -227,17 +231,20 @@ class EagerEvaluation(PeepholeOptimizationExprBase):
         elif (
             expr.op == "Div"
             and isinstance(op1, Const)
+            and op1.is_int
             and isinstance(op0, BinaryOp)
             and op0.op == "Mul"
+            and not op0.floating_point
             and isinstance(op0.operands[1], Const)
+            and op0.operands[1].is_int
         ):
             expr0, const_0 = expr.operands
             const_1 = expr0.operands[1]
-            if const_0.value != 0 and const_1.value != 0:
-                gcd_ = gcd(const_0.value, const_1.value)
+            if const_0.value_int != 0 and const_1.value_int != 0:
+                gcd_ = gcd(const_0.value_int, const_1.value_int)
                 if gcd_ != 1:
-                    new_const_1 = Const(const_1.idx, const_1.value // gcd_, const_1.bits, **const_1.tags)
-                    new_const_0 = Const(const_0.idx, const_0.value // gcd_, const_0.bits, **const_0.tags)
+                    new_const_1 = Const(const_1.idx, const_1.value_int // gcd_, const_1.bits, **const_1.tags)
+                    new_const_0 = Const(const_0.idx, const_0.value_int // gcd_, const_0.bits, **const_0.tags)
                     mul = BinaryOp(
                         expr0.idx,
                         "Mul",

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -84,6 +84,83 @@ class TestPeepholeOptimizations(unittest.TestCase):
         expr_opt = opt.optimize(expr)
         assert expr_opt is None
 
+    def test_eager_eval_mul_div_cancellation_requires_integers(self):
+        proj = angr.load_shellcode(b"\x90", "AMD64")
+        manager = Manager()
+        opt = EagerEvaluation(proj, proj.kb, manager)
+        x = Register(manager.next_atom(), 0, 32)
+
+        def mul_div(multiplier, divisor, *, mul_floating_point=False, div_floating_point=False):
+            mul = BinaryOp(
+                manager.next_atom(),
+                "Mul",
+                [x, Const(manager.next_atom(), multiplier, 32)],
+                False,
+                bits=32,
+                floating_point=mul_floating_point,
+            )
+            return BinaryOp(
+                manager.next_atom(),
+                "Div",
+                [mul, Const(manager.next_atom(), divisor, 32)],
+                False,
+                bits=32,
+                floating_point=div_floating_point,
+            )
+
+        # (x * 6) / 8 -> (x * 3) / 4
+        out = opt.optimize(mul_div(6, 8))
+        assert isinstance(out, BinaryOp) and out.op == "Div"
+        assert isinstance(out.operands[0], BinaryOp) and out.operands[0].op == "Mul"
+        assert out.operands[0].operands[1].value == 3
+        assert out.operands[1].value == 4
+
+        # AIL constants may contain floats. Integer cancellation does not apply to them.
+        for multiplier, divisor in ((6.0, 8), (6, 8.0), (6.0, 8.0)):
+            with self.subTest(multiplier=multiplier, divisor=divisor):
+                assert opt.optimize(mul_div(multiplier, divisor)) is None
+
+        # Integer-valued constants do not make floating-point Mul or Div cancellable by an integer GCD.
+        for mul_floating_point, div_floating_point in ((True, False), (False, True), (True, True)):
+            with self.subTest(
+                mul_floating_point=mul_floating_point,
+                div_floating_point=div_floating_point,
+            ):
+                assert (
+                    opt.optimize(
+                        mul_div(
+                            6,
+                            8,
+                            mul_floating_point=mul_floating_point,
+                            div_floating_point=div_floating_point,
+                        )
+                    )
+                    is None
+                )
+
+    def test_eager_eval_skips_floating_point_binary_operations(self):
+        proj = angr.load_shellcode(b"\x90", "AMD64")
+        manager = Manager()
+        opt = EagerEvaluation(proj, proj.kb, manager)
+        x = Register(manager.next_atom(), 0, 32)
+
+        for op, operands, bits in (
+            ("Mul", (x, Const(manager.next_atom(), 1, 32)), 32),
+            ("Add", (x, Const(manager.next_atom(), 0, 32)), 32),
+            ("Add", (x, Const(manager.next_atom(), -1, 32)), 32),
+            ("CmpEQ", (x, x), 1),
+        ):
+            with self.subTest(op=op, operands=operands):
+                expr = BinaryOp(
+                    manager.next_atom(),
+                    op,
+                    operands,
+                    False,
+                    bits=bits,
+                    floating_point=True,
+                )
+                assert opt.optimize(expr) is None
+
     def test_cmp_masked_shift(self):
         proj = angr.load_shellcode(b"\x90", "AMD64")
         manager = Manager()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

- Keep integer algebraic peepholes from rewriting explicit floating-point binary operations.
- Restrict `(x * C1) / C0` GCD cancellation to integer operations and integer AIL constants.

## Root cause

`EagerEvaluation` assumed that every binary expression and `Const` it saw represented integer arithmetic. AIL constants can also contain Python floats, and ARM hard-float lifting marks the corresponding `Mul`/`Div` operations as floating point. For example, public DecBench firmware reaches a floating-point division with a `31.0` denominator; the pass forwarded that float to `math.gcd()` and aborted decompilation.

Guarding only the exception would leave other integer identities active on IEEE-754 expressions. Reassociation, `x + 0`, `x * 1`, and `x == x` folding can change rounding, signed zero, NaN, or exception behavior. The pass now preserves explicit floating-point operations and uses `Const.is_int`/`value_int` at the integer cancellation boundary.

## Regression

The focused regression keeps the valid integer reduction `(x * 6) / 8 -> (x * 3) / 4`, while covering float-valued constants, floating-point flags on either operation, and representative floating-point add/multiply/compare identities.

Public DecBench results with a 60-second per-function cap:

- Direct current-master crash cohort: **0/24 -> 24/24** decompiled, with no timeout; patched maximum was 32.290 s.
- Exhaustive A/B of all 252 functions whose behavior reaches a floating-point EagerEvaluation rewrite or exception: **220 success / 32 failure / 0 timeout -> 244 success / 8 failure / 0 timeout**. Every prior success remained successful; all 24 target failures recovered.
- Raw discovered-function score: **102,351/102,631 -> 102,375/102,631** (+24).
- Official scored result: **88,759/94,716 -> 88,780/94,716** (+21): O0 +9, O2 +7, O2-noinline +5. Three recovered raw symbols are duplicate same-name copies and are not separately scored.
- The published older baseline was 88,761/94,716; current master had since regressed two Crazyflie O2 `gravityLight` entries. This patch restores those two plus 19 additional published misses, for a net +19 versus that snapshot.
- The other 624 explicit-floating-point candidates across the remaining affected public projects produced no EagerEvaluation rewrite/exception event, so this guard is inert for them at this pass.

The eight remaining A/B failures have a separate pre-existing cause outside this pass.

## Validation

- `pytest -q repos/angr/tests/analyses/decompiler/test_peephole_optimizations.py` — 12 passed, 13 subtests passed.
- `./.agents/skills/angr-validate-workspace/scripts/run-all-tests.sh --jobs 2` — all workspace suites passed; angr 2,221 passed / 46 skipped / 2 expected xfails / 188 subtests, Rust 30 passed, and angr-management 500 passed.
- `ruff format --check ... && ruff check ... && git diff --check` — passed.
