### PR TITLE
Decompiler: reject float constants in string simplifiers

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/inlined_strcpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_strcpy_simplifier.py
@@ -96,9 +96,11 @@ class InlinedStrcpySimplifier(OptimizationPass):
             elif (
                 isinstance(stmt.src, Insert)
                 and isinstance(stmt.src.base, (Const, VirtualVariable))
+                and (not isinstance(stmt.src.base, Const) or stmt.src.base.is_int)
                 and isinstance(stmt.src.value, Const)
                 and stmt.src.value.is_int
                 and isinstance(stmt.src.offset, Const)
+                and stmt.src.offset.is_int
             ):
                 inlined_strcpy_candidate = True
                 src = stmt.src.value
@@ -253,7 +255,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
             delta = self._get_delta(addr_last, addr_curr)
             if delta is not None and delta == len(s_last):
                 new_str = s_last + s_curr
-        elif isinstance(stmt, Store) and isinstance(stmt.data, Const):
+        elif isinstance(stmt, Store) and isinstance(stmt.data, Const) and stmt.data.is_int:
             addr_curr = stmt.addr
             delta = self._get_delta(addr_last, addr_curr)
             if delta is not None and delta == len(s_last):
@@ -322,7 +324,7 @@ class InlinedStrcpySimplifier(OptimizationPass):
                 and stmt.dst.was_stack
                 and isinstance(stmt.dst.stack_offset, int)
             ):
-                if isinstance(stmt.src, Const):
+                if isinstance(stmt.src, Const) and stmt.src.is_int:
                     r[stmt.dst.stack_offset] = idx, ail_const_to_be(stmt.src, self.project.arch.memory_endness)
                 if (
                     isinstance(stmt.src, Insert)
@@ -334,17 +336,20 @@ class InlinedStrcpySimplifier(OptimizationPass):
                             and stmt.src.base.stack_offset == stmt.dst.stack_offset
                         )
                     )
+                    and (not isinstance(stmt.src.base, Const) or stmt.src.base.is_int)
                     and isinstance(stmt.src.offset, Const)
+                    and stmt.src.offset.is_int
                     and isinstance(stmt.src.value, Const)
+                    and stmt.src.value.is_int
                 ):
-                    r[stmt.dst.stack_offset + stmt.src.offset.value] = (
+                    r[stmt.dst.stack_offset + stmt.src.offset.value_int] = (
                         idx,
                         ail_const_to_be(stmt.src.value, self.project.arch.memory_endness),
                     )
                 else:
                     r[stmt.dst.stack_offset] = idx, None
             elif isinstance(stmt, Store) and isinstance(stmt.addr, StackBaseOffset):
-                if isinstance(stmt.data, Const):
+                if isinstance(stmt.data, Const) and stmt.data.is_int:
                     r[stmt.addr.offset] = idx, ail_const_to_be(stmt.data, self.project.arch.memory_endness)
                 else:
                     r[stmt.addr.offset] = idx, None
@@ -420,12 +425,12 @@ class InlinedStrcpySimplifier(OptimizationPass):
         ):
             return StackBaseOffset(-1, addr.bits, 0), addr.operand.stack_offset
         if isinstance(addr, BinaryOp):
-            if addr.op == "Add" and isinstance(addr.operands[1], Const):
+            if addr.op == "Add" and isinstance(addr.operands[1], Const) and addr.operands[1].is_int:
                 base_0, offset_0 = InlinedStrcpySimplifier._parse_addr(addr.operands[0])
-                return base_0, offset_0 + addr.operands[1].value
-            if addr.op == "Sub" and isinstance(addr.operands[1], Const):
+                return base_0, offset_0 + addr.operands[1].value_int
+            if addr.op == "Sub" and isinstance(addr.operands[1], Const) and addr.operands[1].is_int:
                 base_0, offset_0 = InlinedStrcpySimplifier._parse_addr(addr.operands[0])
-                return base_0, offset_0 - addr.operands[1].value
+                return base_0, offset_0 - addr.operands[1].value_int
         return addr, 0
 
     @staticmethod

--- a/angr/analyses/decompiler/optimization_passes/inlined_wcscpy_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_wcscpy_simplifier.py
@@ -176,8 +176,11 @@ class InlinedWcscpySimplifier(OptimizationPass):
             if isinstance(stmt, SideEffectStatement) and self.is_inlined_wcsncpy(stmt):
                 assert stmt.expr.args is not None and len(stmt.expr.args) >= 3
                 base, off = self._parse_addr(stmt.expr.args[0])
-                store_size = stmt.expr.args[2].value * 2 if isinstance(stmt.expr.args[2], Const) else None
-                if off is not None and store_size is not None:
+                count = stmt.expr.args[2]
+                if not isinstance(count, Const) or not count.is_int:
+                    return None
+                store_size = count.value_int * 2
+                if off is not None:
                     candidates.append((i, base, off, store_size, stmt))
             elif isinstance(stmt, Store) and isinstance(stmt.data, Const):
                 base, off = self._parse_addr(stmt.addr)
@@ -262,8 +265,10 @@ class InlinedWcscpySimplifier(OptimizationPass):
                         merged_stmt = merged[0]
                         new_base, new_off = self._parse_addr(merged_stmt.expr.args[0])
                         new_sz = (
-                            merged_stmt.expr.args[2].value * 2
-                            if len(merged_stmt.expr.args) >= 3 and isinstance(merged_stmt.expr.args[2], Const)
+                            merged_stmt.expr.args[2].value_int * 2
+                            if len(merged_stmt.expr.args) >= 3
+                            and isinstance(merged_stmt.expr.args[2], Const)
+                            and merged_stmt.expr.args[2].is_int
                             else sz0 + sz1
                         )
                         new_item = idx0, new_base, new_off, new_sz, merged_stmt
@@ -442,6 +447,7 @@ class InlinedWcscpySimplifier(OptimizationPass):
                 and starting_stmt.addr.op == "Add"
                 and isinstance(starting_stmt.addr.operands[0], VirtualVariable)
                 and isinstance(starting_stmt.addr.operands[1], Const)
+                and starting_stmt.addr.operands[1].is_int
             ):
                 expected_store_varid = starting_stmt.addr.operands[0].varid
             else:
@@ -464,7 +470,9 @@ class InlinedWcscpySimplifier(OptimizationPass):
             ):
                 offset = stmt.dst.stack_offset
                 value = (
-                    ail_const_to_be(stmt.src, self.project.arch.memory_endness) if isinstance(stmt.src, Const) else None
+                    ail_const_to_be(stmt.src, self.project.arch.memory_endness)
+                    if isinstance(stmt.src, Const) and stmt.src.is_int
+                    else None
                 )
             elif expected_type == "store" and isinstance(stmt, Store):
                 if isinstance(stmt.addr, VirtualVariable) and stmt.addr.varid == expected_store_varid:
@@ -474,14 +482,15 @@ class InlinedWcscpySimplifier(OptimizationPass):
                     and stmt.addr.op == "Add"
                     and isinstance(stmt.addr.operands[0], VirtualVariable)
                     and isinstance(stmt.addr.operands[1], Const)
+                    and stmt.addr.operands[1].is_int
                     and stmt.addr.operands[0].varid == expected_store_varid
                 ):
-                    offset = stmt.addr.operands[1].value
+                    offset = stmt.addr.operands[1].value_int
                 else:
                     offset = None
                 value = (
                     ail_const_to_be(stmt.data, self.project.arch.memory_endness)
-                    if isinstance(stmt.data, Const)
+                    if isinstance(stmt.data, Const) and stmt.data.is_int
                     else None
                 )
             else:
@@ -508,16 +517,19 @@ class InlinedWcscpySimplifier(OptimizationPass):
     def even_offsets_are_zero(lst):
         if len(lst) >= 2 and lst[-1] == 0 and lst[-2] == 0:
             lst = lst[:-2]
-        return all((ch == 0 if i % 2 == 0 else ch != 0) for i, ch in enumerate(lst))
+        return all(isinstance(ch, int) and (ch == 0 if i % 2 == 0 else ch != 0) for i, ch in enumerate(lst))
 
     @staticmethod
     def odd_offsets_are_zero(lst):
         if len(lst) >= 2 and lst[-1] == 0 and lst[-2] == 0:
             lst = lst[:-2]
-        return all((ch == 0 if i % 2 == 1 else ch != 0) for i, ch in enumerate(lst))
+        return all(isinstance(ch, int) and (ch == 0 if i % 2 == 1 else ch != 0) for i, ch in enumerate(lst))
 
     @staticmethod
     def is_integer_likely_a_wide_string(v, size, endness, min_length=4):
+        if not isinstance(v, int) or not isinstance(size, int):
+            return False, None
+
         chars = []
         if endness == Endness.LE:
             while v != 0:
@@ -579,12 +591,12 @@ class InlinedWcscpySimplifier(OptimizationPass):
         ):
             return StackBaseOffset(-1, 64, 0), addr.operand.stack_offset
         if isinstance(addr, BinaryOp):
-            if addr.op == "Add" and isinstance(addr.operands[1], Const) and isinstance(addr.operands[1].value, int):
+            if addr.op == "Add" and isinstance(addr.operands[1], Const) and addr.operands[1].is_int:
                 base_0, offset_0 = InlinedWcscpySimplifier._parse_addr(addr.operands[0])
-                return base_0, offset_0 + addr.operands[1].value
-            if addr.op == "Sub" and isinstance(addr.operands[1], Const) and isinstance(addr.operands[1].value, int):
+                return base_0, offset_0 + addr.operands[1].value_int
+            if addr.op == "Sub" and isinstance(addr.operands[1], Const) and addr.operands[1].is_int:
                 base_0, offset_0 = InlinedWcscpySimplifier._parse_addr(addr.operands[0])
-                return base_0, offset_0 - addr.operands[1].value
+                return base_0, offset_0 - addr.operands[1].value_int
         return addr, 0
 
     @staticmethod

--- a/tests/analyses/decompiler/test_inlined_string_simplifiers.py
+++ b/tests/analyses/decompiler/test_inlined_string_simplifiers.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import angr
+from angr.ailment.expression import (
+    BinaryOp,
+    Call,
+    Const,
+    Insert,
+    StackBaseOffset,
+    VirtualVariable,
+    VirtualVariableCategory,
+)
+from angr.ailment.manager import Manager
+from angr.ailment.statement import Assignment, SideEffectStatement, Store
+from angr.analyses.decompiler.optimization_passes.inlined_strcpy_simplifier import InlinedStrcpySimplifier
+from angr.analyses.decompiler.optimization_passes.inlined_wcscpy_simplifier import InlinedWcscpySimplifier
+from angr.analyses.decompiler.variable_map import variable_map_of
+
+
+def _simplifier(cls):
+    project = angr.load_shellcode(b"\x90", arch="AMD64")
+    func = project.kb.functions.function(addr=0, name="dummy", create=True)
+    simplifier = object.__new__(cls)
+    simplifier._func = func  # pyright: ignore[reportAttributeAccessIssue]
+    simplifier.manager = Manager()
+    return simplifier
+
+
+def _stack_vvar(varid: int, offset: int, bits: int = 32):
+    return VirtualVariable(varid, varid, bits, VirtualVariableCategory.STACK, oident=offset)
+
+
+def _register_vvar(varid: int, bits: int = 64):
+    return VirtualVariable(varid, varid, bits, VirtualVariableCategory.REGISTER, oident=0)
+
+
+def _float_const(idx: int, value: float = 1.0, bits: int = 32):
+    return Const(idx, value, bits)  # pyright: ignore[reportArgumentType]
+
+
+def _integer_stack_assignment(idx: int, offset: int):
+    return Assignment(idx, _stack_vvar(idx, offset), Const(idx, 0x41414141, 32))
+
+
+def _inlined_wcsncpy(simplifier, idx: int, offset: int, data: bytes, count=None):
+    string_id = simplifier.kb.custom_strings.allocate(data)
+    string_const = Const(idx, string_id, 64)
+    variable_map_of(simplifier.manager).set_custom_string(string_const)
+    if count is None:
+        count = Const(idx + 1, len(data) // 2, 64)
+    call = Call(
+        idx + 2,
+        "wcsncpy",
+        args=[StackBaseOffset(idx + 3, 64, offset), string_const, count],
+    )
+    return SideEffectStatement(idx + 4, call)
+
+
+def test_strcpy_collector_rejects_float_stack_assignment():
+    simplifier = _simplifier(InlinedStrcpySimplifier)
+    statements = [
+        _integer_stack_assignment(0, -8),
+        Assignment(1, _stack_vvar(1, -4), _float_const(1)),
+    ]
+
+    collected = simplifier._collect_constant_stores(statements, 0)
+
+    assert collected[-4][1] is None
+
+
+def test_strcpy_collector_rejects_float_insert_value_and_offset():
+    simplifier = _simplifier(InlinedStrcpySimplifier)
+    dst = _stack_vvar(1, -4)
+    statements = [
+        _integer_stack_assignment(0, -8),
+        Assignment(1, dst, Insert(1, dst, Const(2, 0, 32), _float_const(3), "Iend_LE")),
+    ]
+    collected = simplifier._collect_constant_stores(statements, 0)
+    assert collected[-4][1] is None
+
+    statements[1] = Assignment(
+        1,
+        dst,
+        Insert(1, dst, _float_const(2, 0.0), Const(3, 0x41, 8), "Iend_LE"),
+    )
+    collected = simplifier._collect_constant_stores(statements, 0)
+    assert collected[-4][1] is None
+
+
+def test_strcpy_collector_rejects_float_insert_base():
+    simplifier = _simplifier(InlinedStrcpySimplifier)
+    dst = _stack_vvar(1, -8)
+    statements = [
+        Assignment(
+            1,
+            dst,
+            Insert(1, _float_const(2), Const(3, 4, 32), Const(4, 0x44434241, 32), "Iend_LE"),
+        )
+    ]
+
+    collected = simplifier._collect_constant_stores(statements, 0)
+
+    assert -4 not in collected
+    assert collected[-8][1] is None
+
+
+def test_strcpy_single_statement_rejects_float_insert_offset():
+    simplifier = _simplifier(InlinedStrcpySimplifier)
+    dst = _stack_vvar(0, -4)
+    stmt = Assignment(
+        0,
+        dst,
+        Insert(0, dst, _float_const(1, 0.0), Const(2, 0x44434241, 32), "Iend_LE"),
+    )
+
+    assert simplifier._optimize_single_stmt(stmt, 0, [stmt]) is None
+
+
+def test_strcpy_single_statement_rejects_float_insert_base():
+    simplifier = _simplifier(InlinedStrcpySimplifier)
+    dst = _stack_vvar(0, -4)
+    stmt = Assignment(
+        0,
+        dst,
+        Insert(0, _float_const(1), Const(2, 0, 32), Const(3, 0x44434241, 32), "Iend_LE"),
+    )
+
+    assert simplifier._optimize_single_stmt(stmt, 0, [stmt]) is None
+
+
+def test_strcpy_collector_rejects_float_stack_store():
+    simplifier = _simplifier(InlinedStrcpySimplifier)
+    statements = [
+        _integer_stack_assignment(0, -8),
+        Store(1, StackBaseOffset(1, 64, -4), _float_const(1), 4, "Iend_LE"),
+    ]
+
+    collected = simplifier._collect_constant_stores(statements, 0)
+
+    assert collected[-4][1] is None
+
+
+def test_strcpy_collector_keeps_integer_insert_and_stack_store():
+    simplifier = _simplifier(InlinedStrcpySimplifier)
+    dst = _stack_vvar(0, -8)
+    statements = [
+        Assignment(0, dst, Insert(0, dst, Const(1, 0, 32), Const(2, 0x44434241, 32), "Iend_LE")),
+        Store(1, StackBaseOffset(1, 64, -4), Const(3, 0x48474645, 32), 4, "Iend_LE"),
+    ]
+
+    collected = simplifier._collect_constant_stores(statements, 0)
+
+    assert collected[-8][1].is_int
+    assert collected[-4][1].is_int
+
+
+def test_strcpy_consolidation_rejects_float_store():
+    simplifier = _simplifier(InlinedStrcpySimplifier)
+    dst = StackBaseOffset(0, 64, -8)
+    string_id = simplifier.kb.custom_strings.allocate(b"abcd")
+    string_const = Const(1, string_id, 64)
+    variable_map_of(simplifier.manager).set_custom_string(string_const)
+    call = Call(2, "strncpy", args=[dst, string_const, Const(3, 4, 64)])
+    inlined_strcpy = SideEffectStatement(4, call)
+    float_store = Store(5, StackBaseOffset(5, 64, -4), _float_const(6), 4, "Iend_LE")
+
+    assert simplifier._consolidate_pair(inlined_strcpy, float_store) is None
+
+
+def test_strcpy_address_parser_rejects_float_offset():
+    base = _register_vvar(0)
+    addr = BinaryOp(1, "Add", [base, _float_const(2, 4.0, 64)])
+
+    assert InlinedStrcpySimplifier._get_delta(base, addr) is None
+
+
+def test_wcscpy_collector_rejects_float_stack_assignment():
+    simplifier = _simplifier(InlinedWcscpySimplifier)
+    statements = [
+        _integer_stack_assignment(0, -8),
+        Assignment(1, _stack_vvar(1, -4), _float_const(1)),
+    ]
+
+    collected = simplifier._collect_constant_stores(statements, 0)
+
+    assert collected[-4][1] is None
+
+
+def test_wcscpy_collector_rejects_float_store_and_offset():
+    simplifier = _simplifier(InlinedWcscpySimplifier)
+    base = _register_vvar(0)
+    statements = [
+        Store(0, base, Const(0, 0x41004200, 32), 4, "Iend_LE"),
+        Store(
+            1,
+            BinaryOp(1, "Add", [base, Const(1, 4, 64)]),
+            _float_const(1),
+            4,
+            "Iend_LE",
+        ),
+    ]
+    collected = simplifier._collect_constant_stores(statements, 0)
+    assert collected[4][1] is None
+
+    statements[1] = Store(
+        1,
+        BinaryOp(1, "Add", [base, _float_const(1, 4.0, 64)]),
+        Const(1, 0x43004400, 32),
+        4,
+        "Iend_LE",
+    )
+    collected = simplifier._collect_constant_stores(statements, 0)
+    assert 4 not in collected
+
+
+def test_wcscpy_collector_keeps_integer_store_and_offset():
+    simplifier = _simplifier(InlinedWcscpySimplifier)
+    base = _register_vvar(0)
+    statements = [
+        Store(0, base, Const(0, 0x41004200, 32), 4, "Iend_LE"),
+        Store(
+            1,
+            BinaryOp(1, "Add", [base, Const(1, 4, 64)]),
+            Const(2, 0x43004400, 32),
+            4,
+            "Iend_LE",
+        ),
+    ]
+
+    collected = simplifier._collect_constant_stores(statements, 0)
+
+    assert collected[0][1].is_int
+    assert collected[4][1].is_int
+
+
+def test_wcscpy_consolidation_preserves_float_store_as_overlap_barrier():
+    simplifier = _simplifier(InlinedWcscpySimplifier)
+    call = _inlined_wcsncpy(simplifier, 0, 0, b"A\x00B\x00")
+    float_store = Store(5, StackBaseOffset(6, 64, 4), _float_const(7, bits=16), 2, "Iend_LE")
+    final_store = Store(8, StackBaseOffset(9, 64, 4), Const(10, 0, 16), 2, "Iend_LE")
+
+    assert simplifier._consolidate_wcscpy_calls([call, final_store]) is not None
+    assert simplifier._consolidate_wcscpy_calls([call, float_store, final_store]) is None
+
+
+def test_wcscpy_consolidation_preserves_float_assignment_as_overlap_barrier():
+    simplifier = _simplifier(InlinedWcscpySimplifier)
+    call = _inlined_wcsncpy(simplifier, 0, 0, b"A\x00B\x00")
+    float_assignment = Assignment(5, _stack_vvar(6, 4, bits=16), _float_const(7, bits=16))
+    final_assignment = Assignment(8, _stack_vvar(9, 4, bits=16), Const(10, 0x43, 16))
+
+    assert simplifier._consolidate_wcscpy_calls([call, final_assignment]) is not None
+    assert simplifier._consolidate_wcscpy_calls([call, float_assignment, final_assignment]) is None
+
+
+def test_wcscpy_consolidation_aborts_on_noninteger_wcsncpy_count():
+    simplifier = _simplifier(InlinedWcscpySimplifier)
+    invalid_call = _inlined_wcsncpy(simplifier, 0, 8, b"C\x00", count=_float_const(1, 1.0, 64))
+    valid_call = _inlined_wcsncpy(simplifier, 10, 0, b"A\x00B\x00")
+    final_store = Store(20, StackBaseOffset(21, 64, 4), Const(22, 0, 16), 2, "Iend_LE")
+
+    assert simplifier._consolidate_wcscpy_calls([valid_call, final_store]) is not None
+    assert simplifier._consolidate_wcscpy_calls([invalid_call, valid_call, final_store]) is None
+
+
+def test_wcscpy_wide_string_predicates_reject_floats():
+    assert not InlinedWcscpySimplifier.even_offsets_are_zero([0.0, 65.0])
+    assert not InlinedWcscpySimplifier.odd_offsets_are_zero([65.0, 0.0])
+    assert InlinedWcscpySimplifier.is_integer_likely_a_wide_string(1.0, 4, "Iend_LE") == (False, None)

--- a/tests/analyses/decompiler/test_inlined_string_simplifiers.py
+++ b/tests/analyses/decompiler/test_inlined_string_simplifiers.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 from __future__ import annotations
 
 import angr


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

- Require integer AIL constants before decoding inlined narrow or wide strings.
- Treat noninteger stores and insert expressions as opaque ordering/overlap barriers instead of trying to fold them.
- Abort an inlined `wcsncpy` consolidation when its count is not an integer.

## Root cause

AIL `Const` nodes may contain floating-point values. The inlined string simplifiers assumed every numeric-looking constant was an integer and eventually passed a float to bitwise byte extraction, raising `TypeError`. Adjacent paths also risked consolidating across a noninteger write or accepting a noninteger insert base.

The fix guards every such path with the AIL integer contract and conservatively leaves unsupported patterns unchanged. It contains no binary, address, function, or dataset-specific special cases.

## Public DecBench A/B

Using the complete public manifest at revision `4b42a0dc`, all eight affected Crazyflie entries failed on the parent commit with `TypeError`; all eight decompiled successfully after this patch, with zero errors and zero timeouts. These entries represent four unique binary-content/function pairs because the `cf2` and `firmware` aliases are byte-identical. Maximum patched runtime was 7.824 seconds under a 60-second cap.

As a regression control, 11 functions spanning ten public projects and AMD64, X86, ARMEL, and ARMCortexM succeeded both before and after. Every control produced exactly the same canonical decompilation hash and line count. Timing deltas are intentionally not claimed.

## Validation

- 16 focused string-simplifier regression tests passed.
- Full workspace gate passed: archinfo 17; pypcode 46 plus 187 subtests; pyvex 63; CLE 202 with 9 skipped; claripy 331 with 1 skipped; angr 2,241 plus 200 subtests with 46 skipped and 2 expected xfails; angr Rust 30; angr-management 500.
- Ruff, formatting, Pyright, diff checks, and final worktree-integrity audit passed.