### PR TITLE
Support native AIL Abs expressions in light engines

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/engine_base.py
+++ b/angr/analyses/decompiler/optimization_passes/engine_base.py
@@ -377,6 +377,7 @@ class SimplifierAILEngine(
             return ailment.expression.UnaryOp(expr.idx, expr.op, operand, **expr.tags)
         return expr
 
+    _handle_unop_Abs = _handle_unop_Default
     _handle_unop_Not = _handle_unop_Default
     _handle_unop_Neg = _handle_unop_Default
     _handle_unop_BitwiseNeg = _handle_unop_Default

--- a/angr/analyses/decompiler/optimization_passes/inlined_string_transformation_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/inlined_string_transformation_simplifier.py
@@ -347,6 +347,9 @@ class InlinedStringTransformationAILEngine(
             return ~v
         return None
 
+    def _handle_unop_Abs(self, expr: UnaryOp):
+        self._expr(expr.operand)
+
     def _handle_unop_Default(self, expr: UnaryOp):
         return None
 

--- a/angr/analyses/purity/engine.py
+++ b/angr/analyses/purity/engine.py
@@ -420,6 +420,7 @@ class PurityEngineAIL(SimEngineLightAIL[StateType, DataType_co, StmtDataType, Re
     def _handle_unop_default(self, expr: ailment.Expression) -> DataType_co:
         return self._expr_noconst(expr.operand)
 
+    _handle_unop_Abs = _handle_unop_default
     _handle_unop_Clz = _handle_unop_default
     _handle_unop_Ctz = _handle_unop_default
     _handle_unop_GetMSBs = _handle_unop_default

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -603,6 +603,10 @@ class SimEngineRDAIL(
     def _handle_unop_Default(self, expr):
         return self._top(expr.bits)
 
+    def _handle_unop_Abs(self, expr):
+        self._expr(expr.operand)
+        return self._top(expr.bits)
+
     _handle_unop_Reference = _handle_unop_Default
     _handle_unop_Ctz = _handle_unop_Default
     _handle_unop_Dereference = _handle_unop_Default

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -1294,6 +1294,13 @@ class SimEngineVRAIL(
         r = self.state.top(result_size)
         return RichR(r, typevar=expr.typevar)
 
+    def _handle_unop_Abs(self, expr):
+        operand = self._expr(expr.operand)
+        return cast(
+            RichR[claripy.ast.BV | claripy.ast.FP],
+            RichR(self.state.top(expr.bits), typevar=operand.typevar),
+        )
+
     def _handle_unop_Default(self, expr: ailment.expression.UnaryOp) -> RichR[claripy.ast.BV | claripy.ast.FP]:
         self._expr(expr.operands[0])
         return cast(RichR[claripy.ast.BV | claripy.ast.FP], RichR(self.state.top(expr.bits)))

--- a/angr/engines/ail/engine_light.py
+++ b/angr/engines/ail/engine_light.py
@@ -642,6 +642,12 @@ class SimEngineAILSimState(SimEngineLightAIL[StateType, DataType, bool, None]):
         v = self._expr_bv(expr.operand)
         return ~v
 
+    def _handle_unop_Abs(self, expr: ailment.UnaryOp) -> DataType:
+        value = self._expr(expr.operand)
+        if isinstance(value, claripy.ast.FP):
+            return claripy.fpAbs(value)
+        return self._top(expr.bits)
+
     def _handle_unop_Reference(self, expr: ailment.expression.UnaryOp) -> DataType:
         match expr.operand:
             case ailment.expression.VirtualVariable():

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -571,6 +571,7 @@ class SimEngineLightAIL[StateType, DataType_co, StmtDataType, ResultType](
             "ComboRegister": self._handle_expr_ComboRegister,
         }
         self._unop_handlers: dict[str, Callable[[ailment.UnaryOp], DataType_co]] = {
+            "Abs": self._handle_unop_Abs,
             "Not": self._handle_unop_Not,
             "Neg": self._handle_unop_Neg,
             "BitwiseNeg": self._handle_unop_BitwiseNeg,
@@ -851,6 +852,10 @@ class SimEngineLightAIL[StateType, DataType_co, StmtDataType, ResultType](
     #
     # UnOps
     #
+
+    def _handle_unop_Abs(self, expr: ailment.expression.UnaryOp) -> DataType_co:
+        self._expr(expr.operand)
+        return self._top(expr.bits)
 
     @abstractmethod
     def _handle_unop_Not(self, expr: ailment.expression.UnaryOp) -> DataType_co: ...

--- a/tests/engines/light/test_light_engine.py
+++ b/tests/engines/light/test_light_engine.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-class-docstring,no-self-use
+# pylint: disable=missing-class-docstring,no-self-use,protected-access
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -48,14 +48,13 @@ class TestLightEngine(TestCase):
     def test_inlined_string_abs_visits_operand(self):
         engine: Any = object.__new__(InlinedStringTransformationAILEngine)
         seen = []
-        engine._expr = lambda expr: seen.append(expr)
+        engine._expr = seen.append
         operand = ailment.Expr.Const(0, 1.0, 32)  # pyright: ignore[reportArgumentType]
         abs_expr = ailment.Expr.UnaryOp(1, "Abs", operand)
 
-        result = engine._handle_unop_Abs(abs_expr)
+        engine._handle_unop_Abs(abs_expr)
 
         assert seen == [operand]
-        assert result is None
 
     def test_rda_abs_visits_operand(self):
         engine: Any = object.__new__(SimEngineRDAIL)

--- a/tests/engines/light/test_light_engine.py
+++ b/tests/engines/light/test_light_engine.py
@@ -2,9 +2,25 @@
 # pylint: disable=missing-class-docstring,no-self-use
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
 from unittest import TestCase, main
 
+import archinfo
+import claripy
+
+from angr import ailment
+from angr.analyses.decompiler.optimization_passes.engine_base import SimplifierAILEngine
+from angr.analyses.decompiler.optimization_passes.inlined_string_transformation_simplifier import (
+    InlinedStringTransformationAILEngine,
+)
+from angr.analyses.purity.engine import DataSource, PurityEngineAIL
+from angr.analyses.reaching_definitions.engine_ail import SimEngineRDAIL
+from angr.analyses.typehoon.typevars import TypeVariable
+from angr.analyses.variable_recovery.engine_ail import SimEngineVRAIL
+from angr.analyses.variable_recovery.engine_base import RichR
 from angr.engines.light.engine import longest_prefix_lookup
+from angr.storage.memory_mixins.paged_memory.pages.multi_values import MultiValues
 
 
 class TestLightEngine(TestCase):
@@ -20,6 +36,70 @@ class TestLightEngine(TestCase):
         assert longest_prefix_lookup("32to1", mapping) is handle_unop_32to1
         assert longest_prefix_lookup("32to1_foo", mapping) is handle_unop_32to1
         assert longest_prefix_lookup("32to", mapping) is None
+
+    def test_ail_abs_unop_dispatch(self):
+        arch = archinfo.ArchAMD64()
+        engine = SimplifierAILEngine(SimpleNamespace(arch=arch))  # pyright: ignore[reportArgumentType]
+        operand = ailment.Expr.Const(0, 1.0, 32)  # pyright: ignore[reportArgumentType]
+
+        abs_expr = ailment.Expr.UnaryOp(1, "Abs", operand)
+        assert engine._handle_expr_UnaryOp(abs_expr) is abs_expr
+
+    def test_inlined_string_abs_visits_operand(self):
+        engine: Any = object.__new__(InlinedStringTransformationAILEngine)
+        seen = []
+        engine._expr = lambda expr: seen.append(expr)
+        operand = ailment.Expr.Const(0, 1.0, 32)  # pyright: ignore[reportArgumentType]
+        abs_expr = ailment.Expr.UnaryOp(1, "Abs", operand)
+
+        result = engine._handle_unop_Abs(abs_expr)
+
+        assert seen == [operand]
+        assert result is None
+
+    def test_rda_abs_visits_operand(self):
+        engine: Any = object.__new__(SimEngineRDAIL)
+        seen = []
+        engine._expr = lambda expr: (seen.append(expr), MultiValues(claripy.BVV(0, expr.bits)))[1]
+        engine.state = SimpleNamespace(top=lambda bits: claripy.BVS("rda_abs_top", bits))
+        operand = ailment.Expr.Const(0, 0, 32)
+        abs_expr = ailment.Expr.UnaryOp(1, "Abs", operand)
+
+        result = engine._handle_unop_Abs(abs_expr)
+
+        assert seen == [operand]
+        assert isinstance(result, MultiValues)
+
+    def test_variable_recovery_abs_preserves_typevar(self):
+        operand_typevar = TypeVariable(name="abs_operand")
+        engine: Any = object.__new__(SimEngineVRAIL)
+        seen = []
+        engine._expr = lambda expr: (
+            seen.append(expr),
+            RichR(claripy.BVV(0, expr.bits), typevar=operand_typevar),
+        )[1]
+        engine.state = SimpleNamespace(top=lambda bits: claripy.BVS("vr_abs_top", bits))
+        operand = ailment.Expr.Const(0, 0, 32)
+        abs_expr = ailment.Expr.UnaryOp(1, "Abs", operand)
+
+        result = engine._handle_unop_Abs(abs_expr)
+
+        assert seen == [operand]
+        assert result.typevar is operand_typevar
+        assert len(result.data) == 32
+
+    def test_purity_abs_preserves_provenance(self):
+        provenance = frozenset((DataSource(function_arg=0),))
+        engine: Any = object.__new__(PurityEngineAIL)
+        seen = []
+        engine._expr_noconst = lambda expr: (seen.append(expr), provenance)[1]
+        operand = ailment.Expr.Const(0, 0, 32)
+        abs_expr = ailment.Expr.UnaryOp(1, "Abs", operand)
+
+        result = engine._handle_unop_Abs(abs_expr)
+
+        assert seen == [operand]
+        assert result is provenance
 
 
 if __name__ == "__main__":

--- a/tests/sim/test_ail_exec.py
+++ b/tests/sim/test_ail_exec.py
@@ -23,6 +23,32 @@ test_location = os.path.join(bin_location, "tests")
 
 
 class TestAILExec(unittest.TestCase):
+    def test_abs_expression_preserves_fp_sort(self):
+        class _Engine(SimEngineAILSimState):
+            value: claripy.ast.Bits
+
+            def _expr(self, expr):  # pylint: disable=unused-argument
+                return self.value
+
+        engine = object.__new__(_Engine)
+        expr = SimpleNamespace(operand=object(), bits=32)
+
+        engine.value = claripy.FPV(-1.5, claripy.FSORT_FLOAT)
+        fp_result = engine._handle_unop_Abs(expr)  # pyright: ignore[reportArgumentType]  # pylint: disable=protected-access
+        assert isinstance(fp_result, claripy.ast.FP)
+        assert fp_result.sort == claripy.FSORT_FLOAT
+        assert fp_result.concrete and fp_result.args[0] == 1.5
+
+        engine.value = claripy.BVV(0x80000000, 32)
+        bv_result = engine._handle_unop_Abs(expr)  # pyright: ignore[reportArgumentType]  # pylint: disable=protected-access
+        assert isinstance(bv_result, claripy.ast.BV)
+        assert len(bv_result) == 32
+        assert (
+            bv_result.op == "BVS"
+            and isinstance(bv_result.args[0], str)
+            and bv_result.args[0].startswith("ail_engine_top")
+        )
+
     def test_haddv_expression(self):
         p = angr.load_shellcode(b"\x00", arch="ARMEL", load_address=0x400000)
         state = p.factory.blank_state()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

Support native AIL `Abs` expressions across the light engine, executor, variable recovery, reaching definitions, purity analysis, and simplifiers.

## Root cause

Native AIL can emit `Abs`, but `SimEngineLightAIL` omitted it from unary-operation dispatch. Valid expressions therefore raised `KeyError: Abs` when consumed by light-engine analyses.

## Fix

Register `Abs` and handle it conservatively: visit operands, preserve provenance and type information where available, compute floating-point absolute values in the executor, and otherwise return an appropriately sized unknown value. Simplifiers traverse or preserve the expression.

This deliberately does not fabricate a C or Rust lowering for `Abs`; it only makes existing AIL consumers handle the native node safely.

## Public DecBench results

A/B environment: angr source base `2dd6cb3`, DecBench dataset revision `4b42a0d`, identical inputs and harness on both sides.

- Before: 0/14 affected cases completed; all 14 raised `KeyError: Abs`.
- After: 14/14 completed, with a maximum runtime of 1.026 seconds.
- AMD64, X86, and ARM controls: 3/3 retained exact code, structure, and type hashes.
- The seven duplicate source/binary aliases were byte-identical, leaving seven unique affected binaries.

## Validation

- Focused regression suite: 7/7 passed.
- Complete workspace gate passed:
  - archinfo: 17 passed
  - pypcode: 46 passed, 187 subtests passed
  - pyvex: 63 passed
  - CLE: 202 passed, 9 skipped
  - claripy: 331 passed, 1 skipped
  - angr: 2,231 passed, 200 subtests passed, 46 skipped, 2 expected failures
  - angr Rust: 30 passed
  - angr-management GUI: 500 passed

The unchanged multiarchitecture controls and complete workspace gate provide the non-regression check; the implementation is operation-generic and contains no binary-, function-, or address-specific logic.