### PR TITLE
SSA: guard missing loop stack outstates

### DIFF
--- a/angr/analyses/decompiler/ssailification/rewriting.py
+++ b/angr/analyses/decompiler/ssailification/rewriting.py
@@ -217,7 +217,7 @@ class RewritingAnalysis:
     def _stack_predicate(self, node_: Block, *, stack_offset: int) -> tuple[bool, Any]:
         out_state: RewritingState = (
             self.head_controlled_loop_outstates[(node_.addr, node_.idx)]
-            if is_head_controlled_loop_block(node_)
+            if is_head_controlled_loop_block(node_) and (node_.addr, node_.idx) in self.head_controlled_loop_outstates
             else self.out_states[(node_.addr, node_.idx)]
         )
         if stack_offset in out_state.stackvars:

--- a/tests/analyses/decompiler/test_ssa_rewriting.py
+++ b/tests/analyses/decompiler/test_ssa_rewriting.py
@@ -1,0 +1,37 @@
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from angr.ailment import Block
+from angr.ailment.expression import Const, VirtualVariable, VirtualVariableCategory
+from angr.ailment.manager import Manager
+from angr.ailment.statement import ConditionalJump, Return
+from angr.analyses.decompiler.ssailification.rewriting import RewritingAnalysis
+from angr.analyses.decompiler.ssailification.rewriting_engine import SimEngineSSARewriting
+from angr.utils.ail import is_head_controlled_loop_block
+
+
+def test_stack_predicate_without_head_controlled_loop_outstate():
+    jump = ConditionalJump(0, Const(1, 1, 1), Const(2, 0x4002, 64), None)
+    block = Block(
+        0x4000,
+        4,
+        statements=[
+            jump,
+            Return(3, []),
+        ],
+    )
+    assert is_head_controlled_loop_block(block)
+    assert not SimEngineSSARewriting._is_head_controlled_loop_jump(block, jump)
+
+    stack_vvar = VirtualVariable(4, 1, 32, VirtualVariableCategory.STACK, oident=-8)
+    rewriting = object.__new__(RewritingAnalysis)
+    rewriting._ail_manager = Manager()
+    rewriting.head_controlled_loop_outstates = {}
+    rewriting.out_states = {(block.addr, block.idx): SimpleNamespace(stackvars={-8: stack_vvar})}
+
+    stop, result = rewriting._stack_predicate(block, stack_offset=-8)
+
+    assert stop
+    assert result is not None and result is not stack_vvar and result.likes(stack_vvar)

--- a/tests/analyses/decompiler/test_ssa_rewriting.py
+++ b/tests/analyses/decompiler/test_ssa_rewriting.py
@@ -1,0 +1,45 @@
+# pylint: disable=missing-class-docstring,protected-access
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from angr.ailment import Block
+from angr.ailment.expression import Const, VirtualVariable, VirtualVariableCategory
+from angr.ailment.manager import Manager
+from angr.ailment.statement import ConditionalJump, Return
+from angr.analyses.decompiler.ssailification.rewriting import RewritingAnalysis
+from angr.analyses.decompiler.ssailification.rewriting_engine import SimEngineSSARewriting
+from angr.utils.ail import is_head_controlled_loop_block
+
+
+class TestSSARewriting(unittest.TestCase):
+    def test_stack_predicate_without_head_controlled_loop_outstate(self):
+        jump = ConditionalJump(0, Const(1, 1, 1), Const(2, 0x4002, 64), None)
+        block = Block(
+            0x4000,
+            4,
+            statements=[
+                jump,
+                Return(3, []),
+            ],
+        )
+        self.assertTrue(is_head_controlled_loop_block(block))
+        self.assertFalse(SimEngineSSARewriting._is_head_controlled_loop_jump(block, jump))
+
+        stack_vvar = VirtualVariable(4, 1, 32, VirtualVariableCategory.STACK, oident=-8)
+        rewriting = object.__new__(RewritingAnalysis)
+        rewriting._ail_manager = Manager()
+        rewriting.head_controlled_loop_outstates = {}
+        rewriting.out_states = {(block.addr, block.idx): SimpleNamespace(stackvars={-8: stack_vvar})}
+
+        stop, result = rewriting._stack_predicate(block, stack_offset=-8)
+
+        self.assertTrue(stop)
+        self.assertIsNotNone(result)
+        self.assertIsNot(result, stack_vvar)
+        self.assertTrue(result.likes(stack_vvar))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling a function aborts during SSA rewriting, and the whole function is
lost from the result:

```text
KeyError: (134243221, None)
```

Reproducer, public and needing no new fixture: `inav_3.0.1_KAKUTEF4.hex`, the
iNav 3.0.1 firmware release asset (GPL-3.0), from
https://github.com/iNavFlight/inav/releases/download/3.0.1/inav_3.0.1_KAKUTEF4.hex

```python
p = angr.Project(path, auto_load_libs=False, main_opts={"backend": "hex", "arch": "ARMEL"})
cfg = p.analyses.CFGFast(normalize=True, data_references=True)
p.analyses.Decompiler.prep(fail_fast=True)(p.kb.functions[0x8006271], cfg=cfg.model)
```

raises the above at `ssailification/rewriting.py:219`. On the normal path, with
`fail_fast=False`, it produces no code at all.

### Root cause

The stack-variable predicate used `is_head_controlled_loop_block()` to select a
special out-state. That classification also matches conditional jumps for which
the engine never creates the keyed `head_controlled_loop_outstates` entry.

The same defect was fixed at the sibling `_reg_predicate` by `9ce06e393` — "Rewriting: Fix KeyErrors when accessing
head_controlled_loop_outstates" (#5732). `_stack_predicate` was already in the
file carrying the same unguarded subscript and did not get the guard, and #6009
later rewrote `_stack_predicate` and carried that shape forward. So this finishes
#5732 at the one site it missed, rather than adding a new defensive check.

### Fix

The lookup selects the special state only when its key exists, and otherwise uses
the normal block out-state — the same rule the register predicate has had since
#5732. The function above then decompiles to 6,452 characters instead of raising.

### Testing

The regression constructs the classification mismatch and verifies that rewriting
uses the normal state; it fails at the merge base and passes at this head.
[Validation record](https://github.com/angr/angr/pull/6685#issuecomment-5162004429).

session: sharpen
