### PR TITLE
AILVexLifter: Fix libVEX overread by padding in convert_from_lift.

### DIFF
--- a/native/angr/src/ailment/convert_vex.rs
+++ b/native/angr/src/ailment/convert_vex.rs
@@ -2119,7 +2119,29 @@ impl VEXIRSBConverter {
         if (bytes_offset as usize) >= data_len {
             return Err(PyValueError::new_err("bytes_offset past end of data"));
         }
-        let insn_start = unsafe { data_ptr.add(bytes_offset as usize) };
+
+        // libVEX decoders may read the full length of an instruction that
+        // *starts* inside the [bytes_offset, bytes_offset + mb) window -- i.e.
+        // a few bytes past `mb`, and past the end of the caller's buffer when
+        // the window ends at (or near) it. pyvex guards its Python path by
+        // lifting from a copy padded with 8 NUL bytes; mirror that here, but
+        // only when the window actually ends within 8 bytes of the buffer end
+        // so the common case stays zero-copy.
+        let window_end = bytes_offset as usize + mb as usize;
+        // Held until the end of this function so `insn_start` stays valid.
+        let _padded: Option<Vec<u8>>;
+        let lift_base: *const u8 = if window_end + 8 <= data_len {
+            _padded = None;
+            data_ptr
+        } else {
+            let mut v = Vec::with_capacity(data_len + 8);
+            v.extend_from_slice(unsafe { std::slice::from_raw_parts(data_ptr, data_len) });
+            v.extend_from_slice(&[0u8; 8]);
+            let p = v.as_ptr();
+            _padded = Some(v);
+            p
+        };
+        let insn_start = unsafe { lift_base.add(bytes_offset as usize) };
 
         // SAFETY: GIL is held for the whole call; we read the result before any
         // other lift can run. libVEX's `_lift_r`/arena stay valid until then.

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -207,6 +207,39 @@ class TestVexConverterAcrossArches(unittest.TestCase):
                 self._check_binary(os.path.normpath(os.path.join(base, rel)))
 
 
+class TestLiftWindowOverread(unittest.TestCase):
+    """libVEX decoders may read the full length of an instruction that starts
+    inside the lift window, i.e. a few bytes past ``max_bytes`` -- and past the
+    end of the buffer when the window ends at it. The fast path must pad such
+    windows with NULs (mirroring pyvex) instead of lifting adjacent heap
+    garbage, which made the block content (jumpkind, temp numbering)
+    nondeterministic."""
+
+    # 38 bytes at 0x400b5a in s390x/fauxware: nopr padding + function prologue,
+    # ending with the first 4 bytes of a 6-byte `lg` at 0x400b7c. The last two
+    # bytes of the `lg` fall outside the window; whether it decodes depends
+    # entirely on out-of-window bytes.
+    window = bytes.fromhex("070707070707eb6ff0300024b904001fa7fbff60e310f0000024c0c000000a060707e340f110")
+    addr = 0x400B5A
+
+    def test_lift_does_not_read_past_window(self):
+        arch = archinfo.arch_from_id("s390x")
+        from_py = VEXIRSBConverter.convert(
+            pyvex.IRSB(self.window, self.addr, arch, opt_level=1), ailment.Manager(arch=arch)
+        )
+        # 0x04 completes the truncated `lg`: an unguarded overread decodes it
+        # and ends the block Ijk_Boring instead of Ijk_NoDecode.
+        backing = bytearray(self.window + b"\x04" * 8)
+        from_lift_mv = VEXIRSBConverter.convert_from_lift(
+            arch, self.addr, memoryview(backing)[: len(self.window)], ailment.Manager(arch=arch), opt_level=1
+        )
+        from_lift_bytes = VEXIRSBConverter.convert_from_lift(
+            arch, self.addr, self.window, ailment.Manager(arch=arch), opt_level=1
+        )
+        assert from_py == from_lift_mv
+        assert from_py == from_lift_bytes
+
+
 class TestVexOpParity(unittest.TestCase):
     """The Rust vexop classifier must match Python ``vexop_to_simop`` for every
     VEX op (guards against drift in the hand-ported claripy/irop name-sets)."""


### PR DESCRIPTION
This PR fixes the flaky s390x AIL lifting test.