### PR TITLE
Decompiler: preserve dual call return candidates

### DIFF
--- a/angr/ailment/block_walker.py
+++ b/angr/ailment/block_walker.py
@@ -851,6 +851,13 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
             if new_ret_expr is not None and new_ret_expr != ret_expr_in:
                 changed = True
 
+        new_fp_ret_expr = None
+        fp_ret_expr_in = stmt.fp_ret_expr
+        if fp_ret_expr_in is not None:
+            new_fp_ret_expr = self._handle_expr(-2, fp_ret_expr_in, stmt_idx, stmt, block)
+            if new_fp_ret_expr is not None and new_fp_ret_expr != fp_ret_expr_in:
+                changed = True
+
         if changed:
             # ``FunctionLikeMacro`` is included because it is a Call-shaped expression that may legitimately replace a
             # Call inside a SideEffectStatement (e.g. format_macro_simplifier rewrites ``stmt.expr`` from a Call to
@@ -861,7 +868,7 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
                 stmt.idx,
                 side_effect_expr,
                 ret_expr=new_ret_expr,
-                fp_ret_expr=stmt.fp_ret_expr,
+                fp_ret_expr=new_fp_ret_expr,
                 **stmt.tags,
             )
         return stmt

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -53,9 +53,11 @@ from angr.knowledge_plugins.propagations.states import Equivalence
 from angr.sim_variable import SimMemoryVariable, SimStackVariable, SimVariable
 from angr.utils.ail import HasExprWalker, is_expr_used_as_reg_base_value, is_phi_assignment
 from angr.utils.ssa import (
+    find_semantic_terminal_call,
     has_call_in_between_stmts,
     has_load_expr_in_between_stmts,
     has_store_stmt_in_between_stmts,
+    is_call_result_fixup,
     is_vvar_eliminatable,
 )
 from angr.utils.timing import timethis
@@ -395,12 +397,12 @@ class AILSimplifier(Analysis):
                     codeloc = AILCodeLocation(block.addr, block.idx, stmt_idx, stmt.tags.get("ins_addr"))
                     equivalence.add(Equivalence(codeloc, stmt.dst, stmt.src, is_weakassignment=True))
                 elif isinstance(stmt, SideEffectStatement):
-                    if isinstance(stmt.ret_expr, (VirtualVariable, Load)):
+                    return_exprs = tuple(
+                        expr for expr in (stmt.ret_expr, stmt.fp_ret_expr) if isinstance(expr, (VirtualVariable, Load))
+                    )
+                    if len(return_exprs) == 1 and (stmt.ret_expr is None or stmt.fp_ret_expr is None):
                         codeloc = AILCodeLocation(block.addr, block.idx, stmt_idx, stmt.tags.get("ins_addr"))
-                        equivalence.add(Equivalence(codeloc, stmt.ret_expr, stmt))
-                    elif isinstance(stmt.fp_ret_expr, (VirtualVariable, Load)):
-                        codeloc = AILCodeLocation(block.addr, block.idx, stmt_idx, stmt.tags.get("ins_addr"))
-                        equivalence.add(Equivalence(codeloc, stmt.fp_ret_expr, stmt))
+                        equivalence.add(Equivalence(codeloc, return_exprs[0], stmt))
                 elif (
                     isinstance(stmt, Store)
                     and isinstance(stmt.size, int)
@@ -1609,12 +1611,19 @@ class AILSimplifier(Analysis):
         ):
             # register variable == Call
             if isinstance(eq.atom0, VirtualVariable) and (eq.atom0.was_reg or eq.atom0.was_tmp):
+                call_return_bits = None
                 if isinstance(eq.atom1, Call):
                     # register variable = Call
                     call: Expression = eq.atom1
                     # call_addr = call.target.value if isinstance(call.target, Const) else None
                 elif isinstance(eq.atom1, SideEffectStatement):
+                    if (eq.atom1.ret_expr is None) == (eq.atom1.fp_ret_expr is None):
+                        # A call with zero or multiple candidate ABI return locations is not a scalar expression.
+                        continue
                     call: Expression = eq.atom1.expr
+                    return_expr = eq.atom1.ret_expr if eq.atom1.ret_expr is not None else eq.atom1.fp_ret_expr
+                    assert return_expr is not None
+                    call_return_bits = return_expr.bits
                 elif isinstance(eq.atom1, Convert) and isinstance(eq.atom1.operand, Call):
                     # register variable = Convert(Call)
                     call = eq.atom1
@@ -1739,11 +1748,8 @@ class AILSimplifier(Analysis):
                     src = used_expr
                     dst: Expression = call.copy()
 
-                    if isinstance(dst, SideEffectStatement):
-                        dst_bits = dst.ret_expr.bits if dst.ret_expr is not None else dst.bits
-                        # extract the Call expression from the SideEffectStatement
-                        dst = dst.expr
-                        dst.bits = dst_bits
+                    if call_return_bits is not None:
+                        dst.bits = call_return_bits
 
                     if src.bits != dst.bits and not eq.is_weakassignment:
                         dst = Convert(
@@ -1809,8 +1815,10 @@ class AILSimplifier(Analysis):
 
         encountered_block_addrs: set[tuple[int, int | None]] = {(b.addr, b.idx)}
         while True:
-            if terminate_with_calls and b.statements and isinstance(b.statements[-1], SideEffectStatement):
-                return False
+            if terminate_with_calls and (terminal_call := find_semantic_terminal_call(b)) is not None:
+                _, call_stmt, _ = terminal_call
+                if isinstance(call_stmt, SideEffectStatement) or is_call_result_fixup(call_stmt):
+                    return False
 
             encountered_block_addrs.add((b.addr, b.idx))
             successors = list(self.func_graph.successors(b))
@@ -2051,14 +2059,25 @@ class AILSimplifier(Analysis):
                 if idx in stmts_to_remove and idx in stmts_to_keep and isinstance(stmt, SideEffectStatement):
                     # this statement declares more than one variable. we should handle it surgically
                     # case 1: stmt.ret_expr and stmt.fp_ret_expr are both set, but one of them is not used
-                    if isinstance(stmt.ret_expr, VirtualVariable) and stmt.ret_expr.varid in dead_vvar_ids:
-                        stmt = stmt.copy()
-                        stmt.ret_expr = None
+                    ret_expr = stmt.ret_expr
+                    fp_ret_expr = stmt.fp_ret_expr
+                    return_changed = False
+                    if isinstance(ret_expr, VirtualVariable) and ret_expr.varid in dead_vvar_ids:
+                        ret_expr = None
+                        return_changed = True
                         simplified = True
-                    if isinstance(stmt.fp_ret_expr, VirtualVariable) and stmt.fp_ret_expr.varid in dead_vvar_ids:
-                        stmt = stmt.copy()
-                        stmt.fp_ret_expr = None
+                    if isinstance(fp_ret_expr, VirtualVariable) and fp_ret_expr.varid in dead_vvar_ids:
+                        fp_ret_expr = None
+                        return_changed = True
                         simplified = True
+                    if return_changed:
+                        stmt = SideEffectStatement(
+                            stmt.idx,
+                            stmt.expr,
+                            ret_expr=ret_expr,
+                            fp_ret_expr=fp_ret_expr,
+                            **stmt.tags,
+                        )
 
                 if idx in stmts_to_remove and idx not in stmts_to_keep and not isinstance(stmt, DirtyStatement):
                     if isinstance(stmt, (Assignment, WeakAssignment, Store)):
@@ -2118,9 +2137,7 @@ class AILSimplifier(Analysis):
                             isinstance(stmt.ret_expr, VirtualVariable) and stmt.ret_expr.was_combo_reg
                         ):
                             # both the return expr and the fp_ret_expr are not used
-                            stmt = stmt.copy()
-                            stmt.ret_expr = None
-                            stmt.fp_ret_expr = None
+                            stmt = SideEffectStatement(stmt.idx, stmt.expr, **stmt.tags)
                             simplified = True
                     else:
                         # Should not happen!

--- a/angr/analyses/decompiler/block_io_finder.py
+++ b/angr/analyses/decompiler/block_io_finder.py
@@ -146,8 +146,15 @@ class BlockIOFinder(AILBlockViewer):
                 input_loc = self._handle_expr(i, arg, stmt_idx, stmt, block)
                 self._add_or_update_dict(self.inputs_by_stmt, stmt_idx, input_loc)
 
-        out_loc = self._handle_expr(0, stmt.ret_expr, stmt_idx, stmt, block)
-        self._add_or_update_dict(self.outputs_by_stmt, stmt_idx, out_loc)
+        has_return_expr = False
+        for expr_idx, ret_expr in enumerate((stmt.ret_expr, stmt.fp_ret_expr)):
+            if ret_expr is not None:
+                has_return_expr = True
+                out_loc = self._handle_expr(expr_idx, ret_expr, stmt_idx, stmt, block)
+                self._add_or_update_dict(self.outputs_by_stmt, stmt_idx, out_loc)
+        if not has_return_expr:
+            # Preserve the conservative unknown-output marker used for calls without a modeled return location.
+            self._add_or_update_dict(self.outputs_by_stmt, stmt_idx, None)
 
     def _handle_Store(self, stmt_idx: int, stmt: Store, block: Block | None):
         out_loc = self._handle_expr(0, stmt.addr, stmt_idx, stmt, block, is_memory=True)

--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -263,8 +263,12 @@ class BlockSimplifier(Analysis):
                         # never replace an l-value with an r-value
                         r = False
                         new_stmt = None
-                    elif isinstance(stmt, SideEffectStatement) and isinstance(new, Call) and old == stmt.ret_expr:
-                        # special case: do not replace the ret_expr of a call statement to another call statement
+                    elif (
+                        isinstance(stmt, SideEffectStatement)
+                        and isinstance(new, Call)
+                        and old in (stmt.ret_expr, stmt.fp_ret_expr)
+                    ):
+                        # special case: do not replace a return definition of a call statement with another call
                         r = False
                         new_stmt = None
                     elif isinstance(stmt, Assignment) and not replace_assignment_dsts:

--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -29,6 +29,7 @@ from angr.sim_type import (
     SimTypeFunction,
     SimTypePointer,
 )
+from angr.utils.ssa import VVarUsesCollector, find_semantic_terminal_call, is_call_result_fixup
 from angr.utils.types import dereference_simtype_by_lib
 
 from .stackarg_offset_manager import StackArgOffsetManager
@@ -68,33 +69,12 @@ class CallSiteMaker(Analysis):
         if not self.block.statements:
             return
 
-        last_stmt = self.block.statements[-1]
-
-        if isinstance(last_stmt, Stmt.SideEffectStatement):
-            call_expr = last_stmt.expr
-        elif isinstance(last_stmt, Stmt.Assignment) and isinstance(last_stmt.src, Expr.Call):
-            call_expr = last_stmt.src
-        elif (
-            isinstance(last_stmt, Stmt.Assignment)
-            and isinstance(last_stmt.src, Expr.Convert)
-            and isinstance(last_stmt.src.operand, Expr.Call)
-        ):
-            call_expr = last_stmt.src.operand
-        elif (
-            isinstance(last_stmt, Stmt.Assignment)
-            and isinstance(last_stmt.src, Expr.Insert)
-            and isinstance(last_stmt.src.value, Expr.Call)
-        ):
-            call_expr = last_stmt.src.value
-        elif (
-            isinstance(last_stmt, Stmt.Assignment)
-            and isinstance(last_stmt.src, Expr.Extract)
-            and isinstance(last_stmt.src.base, Expr.Call)
-        ):
-            call_expr = last_stmt.src.base
-        else:
+        terminal_call = find_semantic_terminal_call(self.block)
+        if terminal_call is None:
             self.result_block = self.block
             return
+        call_stmt_idx, last_stmt, call_expr = terminal_call
+        trailing_stmts = self.block.statements[call_stmt_idx + 1 :]
 
         if isinstance(call_expr.target, str):
             # custom function calls
@@ -158,7 +138,7 @@ class CallSiteMaker(Analysis):
                 if prototype.variadic:
                     # determine the number of variadic arguments
                     assert func is not None
-                    variadic_args = self._determine_variadic_arguments(func, cc, call_expr)
+                    variadic_args = self._determine_variadic_arguments(func, cc, call_expr, call_stmt_idx)
                     if variadic_args:
                         callsite_ty = copy.copy(prototype)
                         callsite_ty.args = tuple(callsite_ty.args) + tuple(variadic_args)
@@ -184,7 +164,7 @@ class CallSiteMaker(Analysis):
                 if isinstance(arg_loc, SimRegArg):
                     size = arg_loc.size
                     offset = arg_loc.check_offset(cc.arch)
-                    value_and_def = self._resolve_register_argument(arg_loc)
+                    value_and_def = self._resolve_register_argument(arg_loc, call_stmt_idx)
                     if value_and_def is not None:
                         vvar_def = value_and_def[1]
                         arg_vvars.append(vvar_def)
@@ -242,7 +222,7 @@ class CallSiteMaker(Analysis):
                         arg_expr = reg
                 elif isinstance(arg_loc, SimStackArg):
                     stack_arg_locs.append(arg_loc)
-                    _, the_arg = self._resolve_stack_argument(call_expr, arg_loc)
+                    _, the_arg = self._resolve_stack_argument(call_expr, arg_loc, call_stmt_idx)
                     arg_expr = the_arg if the_arg is not None else None
                 elif isinstance(arg_loc, SimStructArg):
                     arg_expr = None
@@ -259,7 +239,7 @@ class CallSiteMaker(Analysis):
                     args.append(arg_expr)
 
         # Remove the old call statement
-        new_stmts = self.block.statements[:-1]
+        new_stmts = self.block.statements[:call_stmt_idx]
 
         # remove the statement that stores the return address
         if self.project.arch.call_pushes_ret:
@@ -358,9 +338,17 @@ class CallSiteMaker(Analysis):
             # we need to determine the return type of this call (ret_expr vs fp_ret_expr)
             is_float = isinstance(prototype.returnty, SimTypeFloat)
             if is_float:
+                discarded_result = ret_expr
                 ret_expr = None
             else:
+                discarded_result = fp_ret_expr
                 fp_ret_expr = None
+            if isinstance(discarded_result, Expr.VirtualVariable):
+                trailing_stmts = [
+                    stmt
+                    for stmt in trailing_stmts
+                    if not self._call_result_fixup_consumes_vvar(stmt, discarded_result.varid)
+                ]
 
         if (
             ret_expr is not None
@@ -392,8 +380,17 @@ class CallSiteMaker(Analysis):
         vm.set_prototype(new_call, prototype)
         if isinstance(last_stmt, Stmt.Assignment):
             if not new_call.bits:
-                new_call.bits = last_stmt.src.bits
-            new_stmt = Stmt.Assignment(last_stmt.idx, last_stmt.dst, new_call, **last_stmt.tags)
+                new_call.bits = (
+                    call_expr.bits
+                    if is_call_result_fixup(last_stmt) and call_expr.bits is not None
+                    else last_stmt.src.bits
+                )
+            if is_call_result_fixup(last_stmt):
+                replaced, new_src = last_stmt.src.replace(call_expr, new_call)
+                assert replaced
+                new_stmt = Stmt.Assignment(last_stmt.idx, last_stmt.dst, new_src, **last_stmt.tags)
+            else:
+                new_stmt = Stmt.Assignment(last_stmt.idx, last_stmt.dst, new_call, **last_stmt.tags)
         else:
             if not new_call.bits:
                 if ret_expr is not None:
@@ -409,10 +406,20 @@ class CallSiteMaker(Analysis):
             )
 
         new_stmts.append(new_stmt)
+        new_stmts.extend(trailing_stmts)
 
         new_block = self.block.copy(statements=new_stmts)
 
         self.result_block = new_block
+
+    @staticmethod
+    def _call_result_fixup_consumes_vvar(stmt: Stmt.Statement, vvar_id: int) -> bool:
+        if not is_call_result_fixup(stmt):
+            return False
+        assert isinstance(stmt, Stmt.Assignment)
+        collector = VVarUsesCollector()
+        collector.walk_expression(stmt.src)
+        return vvar_id in collector.vvars
 
     def _find_variable_from_definition(self, def_: Definition):
         """
@@ -436,7 +443,9 @@ class CallSiteMaker(Analysis):
         )
         return None
 
-    def _resolve_register_argument(self, arg_loc) -> tuple[Expr.Expression | None, Expr.VirtualVariable] | None:
+    def _resolve_register_argument(
+        self, arg_loc, call_stmt_idx: int
+    ) -> tuple[Expr.Expression | None, Expr.VirtualVariable] | None:
         offset = arg_loc.check_offset(self.project.arch)
 
         if self._reaching_definitions is not None:
@@ -447,7 +456,7 @@ class CallSiteMaker(Analysis):
                 arg_loc.size,
                 self.block.addr,
                 self.block.idx,
-                len(self.block.statements) - 1,
+                call_stmt_idx,
                 OP_BEFORE,
             )
 
@@ -459,7 +468,9 @@ class CallSiteMaker(Analysis):
 
         return None
 
-    def _resolve_stack_argument(self, call_stmt: Expr.Call, arg_loc: SimStackArg) -> tuple[Any, Any]:
+    def _resolve_stack_argument(
+        self, call_stmt: Expr.Call, arg_loc: SimStackArg, call_stmt_idx: int
+    ) -> tuple[Any, Any]:
         assert self._stack_pointer_tracker is not None
 
         size = arg_loc.size
@@ -481,7 +492,7 @@ class CallSiteMaker(Analysis):
                 # find its definition
                 view = SRDAView(self._reaching_definitions)
                 vvar = view.get_stack_vvar_by_stmt(
-                    sp_offset, size, self.block.addr, self.block.idx, len(self.block.statements) - 1, OP_BEFORE
+                    sp_offset, size, self.block.addr, self.block.idx, call_stmt_idx, OP_BEFORE
                 )
                 if vvar is not None:
                     # FIXME: vvar may be larger than that we ask; we may need to chop the correct value of vvar
@@ -556,12 +567,16 @@ class CallSiteMaker(Analysis):
 
         return s
 
-    def _determine_variadic_arguments(self, func: Function, cc: SimCC, call_expr: Expr.Call) -> list[SimType]:
+    def _determine_variadic_arguments(
+        self, func: Function, cc: SimCC, call_expr: Expr.Call, call_stmt_idx: int
+    ) -> list[SimType]:
         if "printf" in func.name or "scanf" in func.name:
-            return self._determine_variadic_arguments_for_format_strings(func, cc, call_expr)
+            return self._determine_variadic_arguments_for_format_strings(func, cc, call_expr, call_stmt_idx)
         return []
 
-    def _determine_variadic_arguments_for_format_strings(self, func, cc: SimCC, call_expr: Expr.Call) -> list[SimType]:
+    def _determine_variadic_arguments_for_format_strings(
+        self, func, cc: SimCC, call_expr: Expr.Call, call_stmt_idx: int
+    ) -> list[SimType]:
         proto = func.prototype
         if proto is None:
             # TODO: Support cases where prototypes are not available
@@ -591,12 +606,12 @@ class CallSiteMaker(Analysis):
             arg_loc = arg_locs[fmt_arg_idx]
 
             if isinstance(arg_loc, SimRegArg):
-                value_and_def = self._resolve_register_argument(arg_loc)
+                value_and_def = self._resolve_register_argument(arg_loc, call_stmt_idx)
                 if value_and_def is not None:
                     value = value_and_def[0]
 
             elif isinstance(arg_loc, SimStackArg):
-                value, _ = self._resolve_stack_argument(call_expr, arg_loc)
+                value, _ = self._resolve_stack_argument(call_expr, arg_loc, call_stmt_idx)
             else:
                 # Unexpected type of argument
                 l.warning("Unexpected type of argument type %s.", arg_loc.__class__)

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -82,7 +82,7 @@ from angr.utils.ail_serialization import (
     simvar_to_bytes_polymorphic,
 )
 from angr.utils.graph import GraphUtils
-from angr.utils.ssa import is_phi_assignment
+from angr.utils.ssa import find_semantic_terminal_call, is_phi_assignment
 from angr.utils.types import dereference_simtype_by_lib
 
 from .ail_simplifier import AILSimplifier
@@ -1333,15 +1333,23 @@ class Clinic(Analysis, Serializable):
                             if (
                                 isinstance(last_stmt, ailment.Stmt.SideEffectStatement)
                                 and last_stmt.ret_expr is None
+                                and last_stmt.fp_ret_expr is None
                                 and isinstance(cc.cc.RETURN_VAL, SimRegArg)
                             ):
                                 reg_offset, reg_size = self.project.arch.registers[cc.cc.RETURN_VAL.reg_name]
-                                last_stmt.ret_expr = ailment.Expr.Register(
+                                ret_expr = ailment.Expr.Register(
                                     self._ail_manager.next_atom(),
                                     reg_offset,
                                     reg_size * 8,
                                     ins_addr=callsite_ins_addr,
                                     reg_name=cc.cc.RETURN_VAL.reg_name,
+                                )
+                                callsite_ail_block.statements[-1] = ailment.Stmt.SideEffectStatement(
+                                    last_stmt.idx,
+                                    last_stmt.expr,
+                                    ret_expr=ret_expr,
+                                    fp_ret_expr=last_stmt.fp_ret_expr,
+                                    **last_stmt.tags,
                                 )
 
         # finally, recover the calling convention of the current function
@@ -2643,10 +2651,11 @@ class Clinic(Analysis, Serializable):
 
             elif isinstance(stmt, ailment.Stmt.SideEffectStatement):
                 self._link_variables_on_expr(variable_manager, global_variables, block, stmt_idx, stmt, stmt.expr)
-                if stmt.ret_expr:
-                    self._link_variables_on_expr(
-                        variable_manager, global_variables, block, stmt_idx, stmt, stmt.ret_expr
-                    )
+                for return_expr in (stmt.ret_expr, stmt.fp_ret_expr):
+                    if return_expr is not None:
+                        self._link_variables_on_expr(
+                            variable_manager, global_variables, block, stmt_idx, stmt, return_expr
+                        )
 
             elif isinstance(stmt, ailment.Stmt.Return):
                 assert isinstance(stmt, ailment.Stmt.Return)
@@ -3902,18 +3911,20 @@ class Clinic(Analysis, Serializable):
         for node in ail_graph:
             if not node.statements or ail_graph.out_degree[node] != 1:
                 continue
-            last_stmt = node.statements[-1]
-            if isinstance(last_stmt, ailment.Stmt.SideEffectStatement) and isinstance(
-                last_stmt.expr.target, ailment.Expr.Const
-            ):
+            terminal_call = find_semantic_terminal_call(node)
+            if terminal_call is not None:
+                call_stmt_idx, _, call = terminal_call
+            else:
+                continue
+            if isinstance(call.target, ailment.Expr.Const):
                 func = (
-                    self.project.kb.functions.get_by_addr(last_stmt.expr.target.value)
-                    if self.project.kb.functions.contains_addr(last_stmt.expr.target.value)
+                    self.project.kb.functions.get_by_addr(call.target.value)
+                    if self.project.kb.functions.contains_addr(call.target.value)
                     else None
                 )
                 if func is not None and func.info.get("is_rust_probestack", False) is True:
-                    # get rid of this call
-                    node.statements = node.statements[:-1]
+                    # get rid of this call and its synthetic result fixups
+                    node.statements = node.statements[:call_stmt_idx]
                     if self.project.arch.call_pushes_ret and node.statements:
                         last_stmt = node.statements[-1]
                         succ = next(iter(ail_graph.successors(node)))
@@ -3943,18 +3954,20 @@ class Clinic(Analysis, Serializable):
         for node in ail_graph:
             if not node.statements or ail_graph.out_degree[node] != 1:
                 continue
-            last_stmt = node.statements[-1]
-            if isinstance(last_stmt, ailment.Stmt.SideEffectStatement) and isinstance(
-                last_stmt.expr.target, ailment.Expr.Const
-            ):
+            terminal_call = find_semantic_terminal_call(node)
+            if terminal_call is not None:
+                call_stmt_idx, _, call = terminal_call
+            else:
+                continue
+            if isinstance(call.target, ailment.Expr.Const):
                 func = (
-                    self.project.kb.functions.get_by_addr(last_stmt.expr.target.value)
-                    if self.project.kb.functions.contains_addr(last_stmt.expr.target.value)
+                    self.project.kb.functions.get_by_addr(call.target.value)
+                    if self.project.kb.functions.contains_addr(call.target.value)
                     else None
                 )
                 if func is not None and (func.name == "__chkstk" or func.info.get("is_alloca_probe", False) is True):
-                    # get rid of this call
-                    node.statements = node.statements[:-1]
+                    # get rid of this call and its synthetic result fixups
+                    node.statements = node.statements[:call_stmt_idx]
                     if self.project.arch.call_pushes_ret and node.statements:
                         last_stmt = node.statements[-1]
                         succ = next(iter(ail_graph.successors(node)))

--- a/angr/analyses/decompiler/expression_narrower.py
+++ b/angr/analyses/decompiler/expression_narrower.py
@@ -171,8 +171,9 @@ class EffectiveSizeExtractor(AILBlockWalker[None, None, None]):
         if stmt.expr.args is not None:
             self._handle_call_args(stmt.expr.args, stmt_idx, stmt, block)
 
-        if stmt.ret_expr is not None:
-            self._handle_expr(0, stmt.ret_expr, stmt_idx, stmt, block)
+        for expr_idx, return_expr in enumerate((stmt.ret_expr, stmt.fp_ret_expr)):
+            if return_expr is not None:
+                self._handle_expr(expr_idx, return_expr, stmt_idx, stmt, block)
 
     def _handle_BinaryOp(
         self, expr_idx: int, expr: BinaryOp, stmt_idx: int, stmt: Statement | None, block: Block | None
@@ -371,31 +372,43 @@ class ExpressionNarrower(AILBlockRewriter):
         new_stmt = super()._handle_SideEffectStatement(stmt_idx, stmt, block)
         assert isinstance(new_stmt, SideEffectStatement)
         changed = new_stmt is not stmt
+        return_exprs = [new_stmt.ret_expr, new_stmt.fp_ret_expr]
+        narrowed_return_expr = False
 
-        if (
-            stmt.ret_expr is not None
-            and isinstance(stmt.ret_expr, VirtualVariable)
-            and stmt.ret_expr.was_reg
-            and stmt.ret_expr.varid in self.new_vvar_sizes
-            and stmt.ret_expr.size != self.new_vvar_sizes[stmt.ret_expr.varid]
-        ):
-            changed = True
+        for idx, return_expr in enumerate((stmt.ret_expr, stmt.fp_ret_expr)):
+            if (
+                isinstance(return_expr, VirtualVariable)
+                and return_expr.was_reg
+                and return_expr.varid in self.new_vvar_sizes
+                and return_expr.size != self.new_vvar_sizes[return_expr.varid]
+            ):
+                changed = True
+                narrowed_return_expr = True
 
-            # update reg name
-            tags = dict(stmt.ret_expr.tags)
-            tags["reg_name"] = self.project.arch.translate_register_name(
-                stmt.ret_expr.reg_offset, size=self.new_vvar_sizes[stmt.ret_expr.varid]
+                # update reg name
+                tags = dict(return_expr.tags)
+                tags["reg_name"] = self.project.arch.translate_register_name(
+                    return_expr.reg_offset, size=self.new_vvar_sizes[return_expr.varid]
+                )
+                new_return_expr = VirtualVariable(
+                    return_expr.idx,
+                    return_expr.varid,
+                    self.new_vvar_sizes[return_expr.varid] * self.project.arch.byte_width,
+                    category=return_expr.category,
+                    oident=return_expr.oident,
+                    **tags,
+                )
+                self.replacement_core_vvars[new_return_expr.varid].append(new_return_expr)
+                return_exprs[idx] = new_return_expr
+
+        if narrowed_return_expr:
+            new_stmt = SideEffectStatement(
+                new_stmt.idx,
+                new_stmt.expr,
+                ret_expr=return_exprs[0],
+                fp_ret_expr=return_exprs[1],
+                **new_stmt.tags,
             )
-            new_ret_expr = VirtualVariable(
-                stmt.ret_expr.idx,
-                stmt.ret_expr.varid,
-                self.new_vvar_sizes[stmt.ret_expr.varid] * self.project.arch.byte_width,
-                category=stmt.ret_expr.category,
-                oident=stmt.ret_expr.oident,
-                **tags,
-            )
-            self.replacement_core_vvars[new_ret_expr.varid].append(new_ret_expr)
-            new_stmt.ret_expr = new_ret_expr
 
         if changed:
             self.narrowed_any = True

--- a/angr/analyses/decompiler/optimization_passes/call_stmt_rewriter.py
+++ b/angr/analyses/decompiler/optimization_passes/call_stmt_rewriter.py
@@ -34,11 +34,18 @@ class CallStatementRewriter(OptimizationPass):
         for block in self._graph.nodes:
             for idx in range(len(block.statements)):  # pylint:disable=consider-using-enumerate
                 stmt = block.statements[idx]
-                if isinstance(stmt, SideEffectStatement) and stmt.ret_expr is not None and stmt.fp_ret_expr is None:
-                    src = stmt.expr.copy()
-                    new_stmt = Assignment(stmt.idx, stmt.ret_expr, src, **stmt.tags)
-                    block.statements[idx] = new_stmt
-                    changed = True
+                if not isinstance(stmt, SideEffectStatement):
+                    continue
+                if stmt.ret_expr is not None and stmt.fp_ret_expr is None:
+                    dst = stmt.ret_expr
+                elif stmt.fp_ret_expr is not None and stmt.ret_expr is None:
+                    dst = stmt.fp_ret_expr
+                else:
+                    continue
+                src = stmt.expr.copy()
+                new_stmt = Assignment(stmt.idx, dst, src, **stmt.tags)
+                block.statements[idx] = new_stmt
+                changed = True
 
         if changed:
             self.out_graph = self._graph

--- a/angr/analyses/decompiler/optimization_passes/ite_region_converter.py
+++ b/angr/analyses/decompiler/optimization_passes/ite_region_converter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 
 from angr.ailment.block import Block
-from angr.ailment.expression import ITE, Call, Const, Phi, VirtualVariable
+from angr.ailment.expression import ITE, Const, Phi, VirtualVariable
 from angr.ailment.statement import Assignment, ConditionalJump, Jump, SideEffectStatement, Statement
 from angr.analyses.decompiler.utils import remove_labels, to_ail_supergraph
 from angr.utils.ail import is_phi_assignment
@@ -13,6 +13,12 @@ from angr.utils.graph import subgraph_between_nodes
 from .optimization_pass import OptimizationPass, OptimizationPassStage
 
 _l = logging.getLogger(__name__)
+
+
+def _single_side_effect_return_expr(stmt: SideEffectStatement):
+    if (stmt.ret_expr is None) == (stmt.fp_ret_expr is None):
+        return None
+    return stmt.ret_expr if stmt.ret_expr is not None else stmt.fp_ret_expr
 
 
 class ITERegionConverter(OptimizationPass):
@@ -158,10 +164,16 @@ class ITERegionConverter(OptimizationPass):
 
     @staticmethod
     def _has_qualified_phi_assignments(
-        block: Block, block0: Block, stmt0: Assignment | Call, block1: Block, stmt1: Assignment | Call
+        block: Block,
+        block0: Block,
+        stmt0: Assignment | SideEffectStatement,
+        block1: Block,
+        stmt1: Assignment | SideEffectStatement,
     ):
-        vvar0 = stmt0.dst if isinstance(stmt0, Assignment) else stmt0.ret_expr
-        vvar1 = stmt1.dst if isinstance(stmt1, Assignment) else stmt1.ret_expr
+        vvar0 = stmt0.dst if isinstance(stmt0, Assignment) else _single_side_effect_return_expr(stmt0)
+        vvar1 = stmt1.dst if isinstance(stmt1, Assignment) else _single_side_effect_return_expr(stmt1)
+        if not isinstance(vvar0, VirtualVariable) or not isinstance(vvar1, VirtualVariable):
+            return False
 
         addr0 = block0.addr, block0.idx
         addr1 = block1.addr, block1.idx
@@ -188,8 +200,8 @@ class ITERegionConverter(OptimizationPass):
         self,
         region_head,
         region_tail,
-        true_stmt: Assignment | Call,
-        false_stmt: Assignment | Call,
+        true_stmt: Assignment | SideEffectStatement,
+        false_stmt: Assignment | SideEffectStatement,
     ):
         if region_head not in self._graph or region_tail not in self._graph:
             return False
@@ -209,10 +221,16 @@ class ITERegionConverter(OptimizationPass):
         new_region_head = region_head.copy()
         conditional_jump: ConditionalJump = region_head.statements[-1]
 
-        true_stmt_src = true_stmt.src if isinstance(true_stmt, Assignment) else true_stmt
-        true_stmt_dst = true_stmt.dst if isinstance(true_stmt, Assignment) else true_stmt.ret_expr
-        false_stmt_src = false_stmt.src if isinstance(false_stmt, Assignment) else false_stmt
-        false_stmt_dst = false_stmt.dst if isinstance(false_stmt, Assignment) else false_stmt.ret_expr
+        true_stmt_src = true_stmt.src if isinstance(true_stmt, Assignment) else true_stmt.expr
+        true_stmt_dst = (
+            true_stmt.dst if isinstance(true_stmt, Assignment) else _single_side_effect_return_expr(true_stmt)
+        )
+        false_stmt_src = false_stmt.src if isinstance(false_stmt, Assignment) else false_stmt.expr
+        false_stmt_dst = (
+            false_stmt.dst if isinstance(false_stmt, Assignment) else _single_side_effect_return_expr(false_stmt)
+        )
+        assert isinstance(true_stmt_dst, VirtualVariable)
+        assert isinstance(false_stmt_dst, VirtualVariable)
 
         addr_obj = true_stmt_src if "ins_addr" in true_stmt_src.tags else true_stmt
         ternary_expr = ITE(
@@ -336,6 +354,8 @@ class ITERegionConverter(OptimizationPass):
 
     @staticmethod
     def _is_assigning_to_vvar(stmt: Statement) -> bool:
-        return (isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable)) or (
-            isinstance(stmt, SideEffectStatement) and isinstance(stmt.ret_expr, VirtualVariable)
-        )
+        if isinstance(stmt, Assignment):
+            return isinstance(stmt.dst, VirtualVariable)
+        if isinstance(stmt, SideEffectStatement):
+            return isinstance(_single_side_effect_return_expr(stmt), VirtualVariable)
+        return False

--- a/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
@@ -12,6 +12,7 @@ import angr.ailment as ailment
 from angr.analyses.decompiler.stack_item import StackItem, StackItemType
 from angr.calling_conventions import SimRegArg
 from angr.code_location import CodeLocation
+from angr.utils.ssa import find_semantic_terminal_call
 
 from .optimization_pass import OptimizationPass, OptimizationPassStage
 
@@ -151,10 +152,11 @@ class RegisterSaveAreaSimplifier(OptimizationPass):
                 preds = list(self._graph.predecessors(ret_blocks[0]))
                 if len(preds) == 1:
                     pred = preds[0]
-                    if pred.statements and isinstance(pred.statements[-1], ailment.Stmt.SideEffectStatement):
-                        last_stmt = pred.statements[-1]
-                        if isinstance(last_stmt.expr.target, ailment.Expr.Const):
-                            callee_addr = last_stmt.expr.target.value
+                    terminal_call = find_semantic_terminal_call(pred)
+                    if terminal_call is not None:
+                        call = terminal_call[2]
+                        if isinstance(call.target, ailment.Expr.Const):
+                            callee_addr = call.target.value
                             if self.project.kb.functions.contains_addr(callee_addr):
                                 callee_func = self.project.kb.functions.get_by_addr(callee_addr)
                                 if callee_func.name == "_security_check_cookie":

--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_base.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_base.py
@@ -30,26 +30,42 @@ class FreshVirtualVariableRewriter(AILBlockRewriter):
         self.vvar_mapping = vvar_mapping
         self.new_block = None
 
+    def _fresh_definition(self, vvar: VirtualVariable) -> VirtualVariable:
+        self.vvar_mapping[vvar.varid] = self.vvar_idx
+        self.vvar_idx += 1
+        return VirtualVariable(
+            vvar.idx,
+            self.vvar_mapping[vvar.varid],
+            vvar.bits,
+            vvar.category,
+            vvar.oident,
+            **vvar.tags,
+        )
+
     def _handle_Assignment(self, stmt_idx: int, stmt: Assignment, block: Block | None):
         new_stmt = super()._handle_Assignment(stmt_idx, stmt, block)
         dst = new_stmt.dst if new_stmt is not None else stmt.dst
         src = new_stmt.src if new_stmt is not None else stmt.src
         if isinstance(dst, VirtualVariable):
-            self.vvar_mapping[dst.varid] = self.vvar_idx
-            self.vvar_idx += 1
-
-            dst = VirtualVariable(
-                dst.idx,
-                self.vvar_mapping[dst.varid],
-                dst.bits,
-                dst.category,
-                dst.oident,
-                **dst.tags,
-            )
-
+            dst = self._fresh_definition(dst)
             return Assignment(stmt.idx, dst, src, **stmt.tags)
 
         return new_stmt
+
+    def _handle_SideEffectStatement(self, stmt_idx: int, stmt: SideEffectStatement, block: Block | None):
+        expr = self._handle_expr(0, stmt.expr, stmt_idx, stmt, block)
+        return_exprs = []
+        for return_expr in (stmt.ret_expr, stmt.fp_ret_expr):
+            if isinstance(return_expr, VirtualVariable):
+                return_expr = self._fresh_definition(return_expr)
+            return_exprs.append(return_expr)
+        return SideEffectStatement(
+            stmt.idx,
+            expr,
+            ret_expr=return_exprs[0],
+            fp_ret_expr=return_exprs[1],
+            **stmt.tags,
+        )
 
     def _handle_VirtualVariable(
         self, expr_idx: int, expr: VirtualVariable, stmt_idx: int, stmt, block: Block | None

--- a/angr/analyses/decompiler/optimization_passes/win_stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/win_stack_canary_simplifier.py
@@ -9,7 +9,7 @@ import cle
 from angr import ailment
 from angr.analyses.decompiler.stack_item import StackItem, StackItemType
 from angr.utils.funcid import is_function_security_check_cookie
-from angr.utils.ssa import stmt_is_simple_call
+from angr.utils.ssa import find_semantic_terminal_call, stmt_is_simple_call
 
 from .optimization_pass import OptimizationPass, OptimizationPassStage
 
@@ -164,11 +164,11 @@ class WinStackCanarySimplifier(OptimizationPass):
             return first_block, r
 
         # if the first block is calling alloca_probe, we may want to take the second block instead
+        terminal_call = find_semantic_terminal_call(first_block)
         if (
-            first_block.statements
+            terminal_call is not None
             and first_block.original_size > 0
-            and (call := stmt_is_simple_call(first_block.statements[-1])) is not None
-            and isinstance(call.target, ailment.expression.Const)
+            and isinstance((call := terminal_call[2]).target, ailment.expression.Const)
         ):
             # check if the target is alloca_probe
             callee_addr = call.target.value

--- a/angr/analyses/decompiler/peephole_optimizations/rewrite_cxx_operator_calls.py
+++ b/angr/analyses/decompiler/peephole_optimizations/rewrite_cxx_operator_calls.py
@@ -29,6 +29,9 @@ class RewriteCxxOperatorCalls(PeepholeOptimizationStmtBase):
         if not isinstance(stmt.expr, Call):
             return None
 
+        if stmt.ret_expr is not None and stmt.fp_ret_expr is not None:
+            return None
+
         # are we calling a function that we deem as an overridden operator function?
         if isinstance(stmt.expr.target, Const):
             func_addr = stmt.expr.target.value
@@ -74,6 +77,11 @@ class RewriteCxxOperatorCalls(PeepholeOptimizationStmtBase):
         return None
 
     def _optimize_operator_add(self, stmt: SideEffectStatement) -> WeakAssignment | None:
+        return_expr = None
+        if stmt.ret_expr is not None and stmt.fp_ret_expr is None:
+            return_expr = stmt.ret_expr
+        elif stmt.fp_ret_expr is not None and stmt.ret_expr is None:
+            return_expr = stmt.fp_ret_expr
         if (
             stmt.expr.args
             and len(stmt.expr.args) == 3
@@ -81,7 +89,7 @@ class RewriteCxxOperatorCalls(PeepholeOptimizationStmtBase):
             and stmt.expr.args[1].op == "Reference"
             and isinstance(stmt.expr.args[1].operand, VirtualVariable)
             and isinstance(stmt.expr.args[2], Const)
-            and isinstance(stmt.ret_expr, VirtualVariable)
+            and isinstance(return_expr, VirtualVariable)
         ):
             arg2 = Load(self.manager.next_atom(), stmt.expr.args[2], UNDETERMINED_SIZE, Endness.BE, **stmt.tags)
             addition = BinaryOp(self.manager.next_atom(), "Add", [stmt.expr.args[1].operand, arg2], **stmt.tags)
@@ -92,7 +100,7 @@ class RewriteCxxOperatorCalls(PeepholeOptimizationStmtBase):
                 if isinstance(dst_ty, SimTypeReference):
                     dst_ty = dst_ty.refs
                 type_ = {"dst": dst_ty, "src": prototype.args[1]}
-            return WeakAssignment(stmt.idx, stmt.ret_expr, addition, type=type_, **stmt.tags)
+            return WeakAssignment(stmt.idx, return_expr, addition, type=type_, **stmt.tags)
         return None
 
     @staticmethod

--- a/angr/analyses/decompiler/region_simplifiers/expr_folding.py
+++ b/angr/analyses/decompiler/region_simplifiers/expr_folding.py
@@ -25,6 +25,12 @@ if TYPE_CHECKING:
     from angr.ailment.expression import MultiStatementExpression
 
 
+def _single_side_effect_return_expr(stmt: ailment.Stmt.SideEffectStatement):
+    if (stmt.ret_expr is None) == (stmt.fp_ret_expr is None):
+        return None
+    return stmt.ret_expr if stmt.ret_expr is not None else stmt.fp_ret_expr
+
+
 class LocationBase:
     __slots__ = ()
 
@@ -300,15 +306,14 @@ class ExpressionCounter(SequenceWalker):
                         dependency_finder.has_load,
                     )
                 )
-        if (
-            isinstance(stmt, ailment.Stmt.SideEffectStatement)
-            and isinstance(stmt.ret_expr, ailment.Expr.VirtualVariable)
-            and stmt.ret_expr.was_reg
-        ):
+        return_expr = (
+            _single_side_effect_return_expr(stmt) if isinstance(stmt, ailment.Stmt.SideEffectStatement) else None
+        )
+        if isinstance(return_expr, ailment.Expr.VirtualVariable) and return_expr.was_reg:
             dependency_finder = ExpressionUseFinder()
             dependency_finder.walk_expression(stmt)
             dependencies = tuple(dependency_finder.uses)
-            self.assignments[stmt.ret_expr.varid].add(
+            self.assignments[return_expr.varid].add(
                 (
                     stmt,
                     dependencies,
@@ -504,15 +509,17 @@ class InterferenceChecker(SequenceWalker):
                 # we found this def
                 self._assignment_interferences[stmt.dst.varid] = []
 
+            return_expr = (
+                _single_side_effect_return_expr(stmt) if isinstance(stmt, ailment.Stmt.SideEffectStatement) else None
+            )
             if (
-                isinstance(stmt, ailment.Stmt.SideEffectStatement)
-                and isinstance(stmt.ret_expr, ailment.Expr.VirtualVariable)
-                and stmt.ret_expr.was_reg
-                and self._variable_map.variable(stmt.ret_expr) is not None
-                and stmt.ret_expr.varid in self._assignments
+                isinstance(return_expr, ailment.Expr.VirtualVariable)
+                and return_expr.was_reg
+                and self._variable_map.variable(return_expr) is not None
+                and return_expr.varid in self._assignments
             ):
                 # we found this def
-                self._assignment_interferences[stmt.ret_expr.varid] = []
+                self._assignment_interferences[return_expr.varid] = []
 
     def _handle_ConditionalBreak(self, node: ConditionalBreakNode, **kwargs):
         spotter = ExpressionSpotter()
@@ -683,12 +690,14 @@ class ExpressionFolder(SequenceWalker):
             ):
                 # remove this statement
                 continue
+            return_expr = (
+                _single_side_effect_return_expr(stmt) if isinstance(stmt, ailment.Stmt.SideEffectStatement) else None
+            )
             if (
-                isinstance(stmt, ailment.Stmt.SideEffectStatement)
-                and isinstance(stmt.ret_expr, ailment.Expr.VirtualVariable)
-                and stmt.ret_expr.was_reg
-                and self._variable_map.variable(stmt.ret_expr) is not None
-                and stmt.ret_expr.varid in self._assignments
+                isinstance(return_expr, ailment.Expr.VirtualVariable)
+                and return_expr.was_reg
+                and self._variable_map.variable(return_expr) is not None
+                and return_expr.varid in self._assignments
             ):
                 # remove this statement
                 continue

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -187,12 +187,21 @@ class RegionSimplifier(Analysis):
 
             if isinstance(definition, ailment.Stmt.SideEffectStatement):
                 # clear the existing variable since we no longer write to this variable after expression folding.
-                # deep_copy the ret_expr so it gets a fresh .idx; otherwise clearing its VariableMap entry (which is
-                # idx-keyed) would also clear the variable of the original ret_expr, which shares the same .idx.
-                definition = definition.copy()
-                if definition.ret_expr is not None:
-                    definition.ret_expr = definition.ret_expr.deep_copy(self.ail_manager)
-                    variable_map_of(self.ail_manager).set_variable(definition.ret_expr, None)
+                # Deep-copy each modeled return expression so it gets a fresh .idx; otherwise clearing its VariableMap
+                # entry (which is idx-keyed) would also clear the variable of the original expression.
+                return_exprs = []
+                for return_expr in (definition.ret_expr, definition.fp_ret_expr):
+                    if return_expr is not None:
+                        return_expr = return_expr.deep_copy(self.ail_manager)
+                        variable_map_of(self.ail_manager).set_variable(return_expr, None)
+                    return_exprs.append(return_expr)
+                definition = ailment.Stmt.SideEffectStatement(
+                    definition.idx,
+                    definition.expr,
+                    ret_expr=return_exprs[0],
+                    fp_ret_expr=return_exprs[1],
+                    **definition.tags,
+                )
             variable_assignments[var] = definition, loc
             variable_uses[var] = next(iter(expr_counter.outerscope_uses[var]))
             variable_assignment_dependencies[var] = deps

--- a/angr/analyses/decompiler/semantic_naming/call_result_naming.py
+++ b/angr/analyses/decompiler/semantic_naming/call_result_naming.py
@@ -153,11 +153,14 @@ class CallResultNaming(ClinicNamingBase):
         """
         Analyze a Call statement for its return value.
         """
-        if call.ret_expr is None:
+        return_exprs = tuple(
+            return_expr for return_expr in (call.ret_expr, call.fp_ret_expr) if return_expr is not None
+        )
+        if len(return_exprs) != 1:
             return
 
         # Get the variable storing the result
-        var = self._get_linked_variable(call.ret_expr)
+        var = self._get_linked_variable(return_exprs[0])
         if var is None:
             return
 

--- a/angr/analyses/decompiler/semantic_naming/pointer_naming.py
+++ b/angr/analyses/decompiler/semantic_naming/pointer_naming.py
@@ -226,8 +226,12 @@ class PointerNaming(ClinicNamingBase):
                 continue
 
             for stmt in node.statements:
-                if isinstance(stmt, SideEffectStatement):
-                    self._analyze_call_for_pointers(stmt.expr, ret_expr=stmt.ret_expr)
+                if isinstance(stmt, SideEffectStatement) and isinstance(stmt.expr, Call):
+                    return_exprs = tuple(
+                        return_expr for return_expr in (stmt.ret_expr, stmt.fp_ret_expr) if return_expr is not None
+                    )
+                    return_expr = return_exprs[0] if len(return_exprs) == 1 else None
+                    self._analyze_call_for_pointers(stmt.expr, ret_expr=return_expr)
                 elif isinstance(stmt, Assignment) and isinstance(stmt.src, Call):
                     self._analyze_call_for_pointers(stmt.src, ret_expr=stmt.dst)
 

--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -47,6 +47,7 @@ from angr.ailment.tagged_object import TaggedObject
 from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.calling_conventions import call_clobbered_regs
 from angr.engines.light.engine import SimEngineNostmtAIL
+from angr.utils.ssa import CALL_RESULT_FIXUP_TAG
 
 from .consts import MAX_STACK_VAR_SIZE
 from .rewriting_state import RewritingState
@@ -56,6 +57,8 @@ if TYPE_CHECKING:
 
 
 _l = logging.getLogger(__name__)
+
+type DefinitionOrigin = TaggedObject | Expression | Statement
 
 
 class SimEngineSSARewriting(
@@ -148,7 +151,7 @@ class SimEngineSSARewriting(
         self._extra_defs = []
         result = super()._stmt(stmt)
         for rstmt in result if isinstance(result, tuple) else [result] if isinstance(result, Statement) else []:
-            if self._extra_defs:
+            if self._extra_defs and (not isinstance(result, tuple) or isinstance(rstmt, SideEffectStatement)):
                 rstmt.tags["extra_defs"] = self._extra_defs
             else:
                 rstmt.tags.pop("extra_defs", None)
@@ -292,7 +295,7 @@ class SimEngineSSARewriting(
                 return None
         return None
 
-    def _handle_stmt_SideEffectStatement(self, stmt: SideEffectStatement) -> Statement | None:
+    def _handle_stmt_SideEffectStatement(self, stmt: SideEffectStatement) -> Statement | tuple[Statement, ...] | None:
         new_expr = self._expr(stmt.expr)
         vm = variable_map_of(self.ail_manager)
         cc = vm.calling_convention(stmt.expr)
@@ -314,19 +317,44 @@ class SimEngineSSARewriting(
                 for suboff in range(base_off, base_off + base_size):
                     self.state.registers.pop(suboff, None)
 
-        new_stmt = None
-        if stmt.ret_expr is not None:
+        call_expr = new_expr if new_expr is not None else stmt.expr
+        new_stmt: Statement | tuple[Statement, ...] | None = None
+        if stmt.ret_expr is not None and stmt.fp_ret_expr is not None:
             assert isinstance(stmt.ret_expr, Atom)
-            new_stmt = self._replace_def_expr(stmt.ret_expr, new_expr if new_expr is not None else stmt.expr, stmt)
+            assert isinstance(stmt.fp_ret_expr, Atom)
+            ret_stmt = self._replace_def_expr(stmt.ret_expr, call_expr, stmt)
+            fp_ret_stmt = self._replace_def_expr(stmt.fp_ret_expr, call_expr, stmt)
+            ret_expr, ret_fixup = self._split_call_result(stmt.ret_expr, ret_stmt, call_expr)
+            fp_ret_expr, fp_ret_fixup = self._split_call_result(stmt.fp_ret_expr, fp_ret_stmt, call_expr)
+            call_stmt = SideEffectStatement(
+                self.ail_manager.next_atom(),
+                call_expr,
+                ret_expr=ret_expr,
+                fp_ret_expr=fp_ret_expr,
+                **stmt.tags,
+            )
+            fixups = tuple(fixup for fixup in (ret_fixup, fp_ret_fixup) if fixup is not None)
+            new_stmt = (call_stmt, *fixups) if fixups else call_stmt
+        elif stmt.ret_expr is not None:
+            assert isinstance(stmt.ret_expr, Atom)
+            new_stmt = self._replace_def_expr(stmt.ret_expr, call_expr, stmt)
             # becomes an Assignment
         elif stmt.fp_ret_expr is not None:
             assert isinstance(stmt.fp_ret_expr, Atom)
-            new_stmt = self._replace_def_expr(stmt.fp_ret_expr, new_expr if new_expr is not None else stmt.expr, stmt)
+            new_stmt = self._replace_def_expr(stmt.fp_ret_expr, call_expr, stmt)
             # becomes an Assignment
 
         if new_stmt is None and new_expr is not None:
-            # only create a new SideEffectStatement if we get a new inner expr
-            new_stmt = SideEffectStatement(self.ail_manager.next_atom(), new_expr, **stmt.tags)
+            # only create a new SideEffectStatement if we get a new inner expr. A later SSA pass can encounter
+            # return definitions that are already in SSA form, in which case _replace_def_expr() does not return
+            # a replacement statement. Keep those definitions attached to the call.
+            new_stmt = SideEffectStatement(
+                self.ail_manager.next_atom(),
+                new_expr,
+                ret_expr=stmt.ret_expr,
+                fp_ret_expr=stmt.fp_ret_expr,
+                **stmt.tags,
+            )
 
         return new_stmt
 
@@ -606,7 +634,61 @@ class SimEngineSSARewriting(
     # Expression replacement
     #
 
-    def _replace_def_expr(self, thing: Atom, value: Expression, orig_tags: TaggedObject) -> Assignment | None:
+    def _split_call_result(
+        self,
+        return_expr: Atom,
+        return_stmt: Assignment | None,
+        call_expr: Expression,
+    ) -> tuple[Atom, Assignment | None]:
+        """
+        Keep a dual-return call as one side effect while preserving partial-width SSA updates.
+
+        ``_replace_def_expr`` may widen a return definition and produce an assignment such as
+        ``full = Insert(base, offset, call)``. A call cannot appear in both return assignments without being executed
+        twice, so the side effect defines a fresh narrow vvar and a following assignment composes it into the full
+        destination. Exact-width definitions remain direct side-effect outputs.
+        """
+        if return_stmt is None:
+            return return_expr, None
+        if return_stmt.src.likes(call_expr):
+            assert isinstance(return_stmt.dst, Atom)
+            return return_stmt.dst, None
+
+        assert isinstance(return_stmt.dst, VirtualVariable)
+        if isinstance(return_expr, Register):
+            category = VirtualVariableCategory.REGISTER
+            oident = return_expr.reg_offset
+        elif isinstance(return_expr, Tmp):
+            category = VirtualVariableCategory.TMP
+            oident = return_expr.tmp_idx
+        elif isinstance(return_expr, VirtualVariable):
+            category = return_expr.category
+            oident = return_expr.oident
+        else:
+            category = return_stmt.dst.category
+            oident = return_stmt.dst.oident
+
+        result_vvar = VirtualVariable(
+            self.ail_manager.next_atom(),
+            self._current_vvar_id,
+            call_expr.bits,
+            category,
+            oident=oident,
+            **{**return_expr.tags, "ins_addr": self.ins_addr},
+        )
+        self._current_vvar_id += 1
+
+        replaced, fixup_src = return_stmt.src.replace(call_expr, result_vvar)
+        assert replaced, "A non-trivial call-result assignment must contain the call expression"
+        fixup = Assignment(
+            return_stmt.idx,
+            return_stmt.dst,
+            fixup_src,
+            **{**return_stmt.tags, CALL_RESULT_FIXUP_TAG: True},
+        )
+        return result_vvar, fixup
+
+    def _replace_def_expr(self, thing: Atom, value: Expression, orig_tags: DefinitionOrigin) -> Assignment | None:
         """
         Return a new virtual variable for the given defined expression.
         """
@@ -627,7 +709,7 @@ class SimEngineSSARewriting(
                     self.state.stackvars[suboff] = thing
         return None
 
-    def _replace_def_combo_reg(self, expr: ComboRegister, value: Expression, orig_tags: TaggedObject) -> Assignment:
+    def _replace_def_combo_reg(self, expr: ComboRegister, value: Expression, orig_tags: DefinitionOrigin) -> Assignment:
         # Create individual register VirtualVariables for each sub-register
         reg_vvars = []
         for reg in expr.registers:
@@ -660,14 +742,14 @@ class SimEngineSSARewriting(
             self._varid_to_combo_reg[reg_vvar.varid] = result
         return Assignment(self.ail_manager.next_atom(), result, value, **orig_tags.tags)
 
-    def _replace_def_reg(self, expr: Register, value: Expression, orig_tags: TaggedObject) -> Assignment:
+    def _replace_def_reg(self, expr: Register, value: Expression, orig_tags: DefinitionOrigin) -> Assignment:
         """
         Return a new virtual variable for the given defined register.
         """
         vvar = self._expr_to_vvar(expr, False)
         return self._vvar_update(vvar, expr.reg_offset - vvar.reg_offset, value, orig_tags)
 
-    def _replace_def_tmp(self, expr: Tmp, value: Expression, orig_tags: TaggedObject) -> Assignment:
+    def _replace_def_tmp(self, expr: Tmp, value: Expression, orig_tags: DefinitionOrigin) -> Assignment:
         if not self.rewrite_tmps:
             return Assignment(orig_tags.idx, expr, value, **orig_tags.tags)
         vvar = self._handle_expr_Tmp(expr)
@@ -739,7 +821,7 @@ class SimEngineSSARewriting(
         return vvar
 
     def _vvar_extract(
-        self, vvar: VirtualVariable, size: int, offset: int, orig_tags: TaggedObject
+        self, vvar: VirtualVariable, size: int, offset: int, orig_tags: DefinitionOrigin
     ) -> Extract | VirtualVariable | BinaryOp:
         assert offset >= 0
         if size == vvar.size:
@@ -770,7 +852,7 @@ class SimEngineSSARewriting(
         )
 
     def _vvar_update(
-        self, vvar: VirtualVariable, offset: int, value: Expression, orig_tags: TaggedObject
+        self, vvar: VirtualVariable, offset: int, value: Expression, orig_tags: DefinitionOrigin
     ) -> Assignment:
         assert offset >= 0
         if value.bits == vvar.bits:

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -3827,8 +3827,13 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
                 args.append(new_arg)
 
         ret_expr = None
-        if not is_expr and stmt.ret_expr is not None:
-            ret_expr = self._handle(stmt.ret_expr)
+        if not is_expr:
+            return_exprs = tuple(
+                return_expr for return_expr in (stmt.ret_expr, stmt.fp_ret_expr) if return_expr is not None
+            )
+            if len(return_exprs) == 1:
+                ret_expr = self._handle(return_exprs[0])
+            # If both ABI return candidates remain unresolved, emit the call once as a standalone statement.
 
         call_expr = CFunctionCall(
             target,

--- a/angr/analyses/decompiler/structured_codegen/rust.py
+++ b/angr/analyses/decompiler/structured_codegen/rust.py
@@ -3703,10 +3703,15 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         return RustAssignment(cdst, csrc, tags=stmt.tags, codegen=self)
 
     def _handle_Stmt_SideEffectStatement(self, stmt: Stmt.SideEffectStatement, is_expr: bool = False, **kwargs):
+        return_exprs = tuple(
+            return_expr for return_expr in (stmt.ret_expr, stmt.fp_ret_expr) if return_expr is not None
+        )
+        # If both ABI return candidates remain unresolved, emit the call once as a standalone statement.
+        returned_expr = return_exprs[0] if len(return_exprs) == 1 else None
         if isinstance(stmt.expr, FunctionLikeMacro):
-            macro = self._handle_FunctionLikeMacro(stmt.expr, is_expr=is_expr or stmt.ret_expr is not None)
-            if not is_expr and stmt.ret_expr is not None:
-                ret_expr = self._handle(stmt.ret_expr)
+            macro = self._handle_FunctionLikeMacro(stmt.expr, is_expr=is_expr or returned_expr is not None)
+            if not is_expr and returned_expr is not None:
+                ret_expr = self._handle(returned_expr)
                 if isinstance(ret_expr, RustUnaryOp) and ret_expr.op == "Reference":
                     ret_expr = ret_expr.operand
                 return RustAssignment(ret_expr, macro, tags=stmt.tags, codegen=self)
@@ -3741,8 +3746,8 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                 args.append(new_arg)
 
         ret_expr = None
-        if not is_expr and stmt.ret_expr is not None:
-            ret_expr = self._handle(stmt.ret_expr)
+        if not is_expr and returned_expr is not None:
+            ret_expr = self._handle(returned_expr)
             if isinstance(ret_expr, RustUnaryOp) and ret_expr.op == "Reference":
                 ret_expr = ret_expr.operand
 

--- a/angr/analyses/deobfuscator/string_obf_opt_passes.py
+++ b/angr/analyses/deobfuscator/string_obf_opt_passes.py
@@ -9,6 +9,7 @@ from angr.ailment.statement import Assignment, SideEffectStatement, Statement
 from angr.analyses.decompiler.notes.deobfuscated_strings import DeobfuscatedStringsNote
 from angr.analyses.decompiler.optimization_passes import register_optimization_pass
 from angr.analyses.decompiler.optimization_passes.optimization_pass import OptimizationPass, OptimizationPassStage
+from angr.analyses.decompiler.variable_map import variable_map_of
 
 WIN64_REG_ARGS = {
     archinfo.ArchAMD64().registers["rcx"][0],
@@ -74,11 +75,14 @@ class StringObfType3Rewriter(OptimizationPass):
         old_stmt: Statement = block.statements[-1]
         str_id = self.kb.custom_strings.allocate(deobf_content)
         if isinstance(old_stmt, Assignment):
-            old_call_expr: Call = old_stmt.src
+            assert isinstance(old_stmt.src, Call)
+            old_call_expr = old_stmt.src
         else:
-            old_call_expr: Call = old_stmt.expr
+            assert isinstance(old_stmt, SideEffectStatement)
+            assert isinstance(old_stmt.expr, Call)
+            old_call_expr = old_stmt.expr
         str_const = Const(self.manager.next_atom(), str_id, self.project.arch.bits)
-        self.manager.variable_map.set_custom_string(str_const)
+        variable_map_of(self.manager).set_custom_string(str_const)
         new_call = Call(
             old_call_expr.idx,
             "init_str",
@@ -93,7 +97,13 @@ class StringObfType3Rewriter(OptimizationPass):
         if isinstance(old_stmt, Assignment):
             new_stmt = Assignment(old_stmt.idx, old_stmt.dst, new_call, **old_stmt.tags)
         else:
-            new_stmt = SideEffectStatement(old_stmt.idx, new_call, ret_expr=old_stmt.ret_expr, **old_stmt.tags)
+            new_stmt = SideEffectStatement(
+                old_stmt.idx,
+                new_call,
+                ret_expr=old_stmt.ret_expr,
+                fp_ret_expr=old_stmt.fp_ret_expr,
+                **old_stmt.tags,
+            )
 
         statements = [*block.statements[:-1], new_stmt]
 

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -205,37 +205,48 @@ class SimEngineRDAIL(
         self.state.kill_definitions(ip)
 
     def _handle_stmt_SideEffectStatement(self, stmt: ailment.Stmt.SideEffectStatement):
+        assert isinstance(stmt.expr, ailment.Expr.Call)
         data = self._handle_Call_base(stmt.expr, is_expr=False)
         src = data.ret_values
         if src is None:
             return
 
-        dst = stmt.ret_expr
-        if isinstance(dst, ailment.Tmp):
-            _, defs = self.state.kill_and_add_definition(Tmp(dst.tmp_idx, dst.size), src, uses=data.ret_values_deps)
-            self.tmps[dst.tmp_idx] = src
+        defs = set()
+        for dst in (stmt.ret_expr, stmt.fp_ret_expr):
+            if not isinstance(dst, (ailment.Tmp, ailment.Register)):
+                continue
 
-        elif isinstance(dst, ailment.Register):
-            full_reg_offset, full_reg_size = self.arch.registers[
-                self.arch.register_names[RegisterOffset(dst.reg_offset)]
-            ]
-            if dst.size != full_reg_size:
-                # we need to extend the value to overwrite the entire register
-                otv = {}
-                next_off = 0
-                if full_reg_offset < dst.reg_offset:
-                    otv[0] = {claripy.BVV(0, (dst.reg_offset - full_reg_offset) * 8)}
-                    next_off = dst.reg_offset - full_reg_offset
-                for off, items in src.items():
-                    otv[next_off + off] = set(items)
-                next_off += len(src) // 8
-                if next_off < full_reg_size:
-                    otv[next_off] = {claripy.BVV(0, (full_reg_size - next_off) * 8)}
-                src = MultiValues(offset_to_values=otv)
-            reg = Register(full_reg_offset, full_reg_size)
-            _, defs = self.state.kill_and_add_definition(reg, src, uses=data.ret_values_deps)
-        else:
-            defs = set()
+            # A dual-return call models multiple candidate ABI locations, whose declared widths may differ. The
+            # function handler produces one abstract return value, so only reuse it when its width matches this
+            # candidate. Otherwise, preserve the dependency relationship but use a correctly sized conservative TOP.
+            dst_src = src if len(src) == dst.bits else self._top(dst.bits)
+            if isinstance(dst, ailment.Tmp):
+                _, dst_defs = self.state.kill_and_add_definition(
+                    Tmp(dst.tmp_idx, dst.size), dst_src, uses=data.ret_values_deps
+                )
+                self.tmps[dst.tmp_idx] = dst_src
+                defs.update(dst_defs)
+
+            elif isinstance(dst, ailment.Register):
+                full_reg_offset, full_reg_size = self.arch.registers[
+                    self.arch.register_names[RegisterOffset(dst.reg_offset)]
+                ]
+                if dst.size != full_reg_size:
+                    # we need to extend the value to overwrite the entire register
+                    otv = {}
+                    next_off = 0
+                    if full_reg_offset < dst.reg_offset:
+                        otv[0] = {claripy.BVV(0, (dst.reg_offset - full_reg_offset) * 8)}
+                        next_off = dst.reg_offset - full_reg_offset
+                    for off, items in dst_src.items():
+                        otv[next_off + off] = set(items)
+                    next_off += len(dst_src) // 8
+                    if next_off < full_reg_size:
+                        otv[next_off] = {claripy.BVV(0, (full_reg_size - next_off) * 8)}
+                    dst_src = MultiValues(offset_to_values=otv)
+                reg = Register(full_reg_offset, full_reg_size)
+                _, dst_defs = self.state.kill_and_add_definition(reg, dst_src, uses=data.ret_values_deps)
+                defs.update(dst_defs)
 
         if self.state.analysis:
             self.state.analysis.function_calls[data.callsite_codeloc].ret_defns.update(defs)

--- a/angr/analyses/s_liveness.py
+++ b/angr/analyses/s_liveness.py
@@ -13,6 +13,14 @@ from angr.utils.ail import is_head_controlled_loop_block, is_phi_assignment
 from angr.utils.ssa import VVarUsesCollector, phi_assignment_get_src
 
 
+def _side_effect_vvar_defs(stmt: SideEffectStatement):
+    return tuple(
+        return_expr.varid
+        for return_expr in (stmt.ret_expr, stmt.fp_ret_expr)
+        if isinstance(return_expr, VirtualVariable)
+    )
+
+
 class SLivenessModel:
     """
     The SLiveness model that stores LiveIn and LiveOut sets for each block in a partial-SSA function.
@@ -117,8 +125,8 @@ class SLivenessAnalysis(Analysis):
                 # handle assignments: a defined vvar is not live before the assignment
                 if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable):
                     live.discard(stmt.dst.varid)
-                elif isinstance(stmt, SideEffectStatement) and isinstance(stmt.ret_expr, VirtualVariable):
-                    live.discard(stmt.ret_expr.varid)
+                elif isinstance(stmt, SideEffectStatement):
+                    live.difference_update(_side_effect_vvar_defs(stmt))
                 live.difference_update(stmt.tags.get("extra_defs", ()))
 
                 phi_expr = phi_assignment_get_src(stmt)
@@ -200,8 +208,8 @@ class SLivenessAnalysis(Analysis):
                 def_vvars = list(stmt.tags.get("extra_defs", []))
                 if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable):
                     def_vvars.append(stmt.dst.varid)
-                elif isinstance(stmt, SideEffectStatement) and isinstance(stmt.ret_expr, VirtualVariable):
-                    def_vvars.append(stmt.ret_expr.varid)
+                elif isinstance(stmt, SideEffectStatement):
+                    def_vvars.extend(_side_effect_vvar_defs(stmt))
 
                 # handle the statement: add used vvars to the live set
                 vvar_use_collector.reset()
@@ -252,8 +260,8 @@ class SLivenessAnalysis(Analysis):
                 def_vvars = list(stmt.tags.get("extra_defs", []))
                 if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable):
                     def_vvars.append(stmt.dst.varid)
-                elif isinstance(stmt, SideEffectStatement) and isinstance(stmt.ret_expr, VirtualVariable):
-                    def_vvars.append(stmt.ret_expr.varid)
+                elif isinstance(stmt, SideEffectStatement):
+                    def_vvars.extend(_side_effect_vvar_defs(stmt))
 
                 # handle the statement: add used vvars to the live set
                 vvar_use_collector.reset()

--- a/angr/analyses/s_reaching_definitions/s_rda_view.py
+++ b/angr/analyses/s_reaching_definitions/s_rda_view.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import networkx
 
@@ -11,10 +11,10 @@ from angr.ailment import Block
 from angr.ailment.expression import Call, Const, Expression, VirtualVariable, VirtualVariableCategory
 from angr.ailment.statement import Assignment, Label, SideEffectStatement, Statement
 from angr.calling_conventions import SimRegArg, call_clobbered_regs, default_cc
-from angr.knowledge_plugins.key_definitions.constants import ObservationPoint, ObservationPointType
+from angr.knowledge_plugins.key_definitions.constants import ObservationPointType
 from angr.utils.ail import is_phi_assignment
 from angr.utils.graph import GraphUtils
-from angr.utils.ssa import get_reg_offset_base
+from angr.utils.ssa import get_reg_offset_base, stmt_is_simple_call
 
 from .s_rda_model import SRDAModel
 
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
     from angr.knowledge_plugins.functions.function_manager import FunctionManager
 
 log = logging.getLogger(__name__)
+
+_RegDef = tuple[int, int, int]
+_StmtRegEffects = tuple[tuple[_RegDef, ...], frozenset[int]]
+type _SRDAObservationPoint = (
+    tuple[Literal["insn"], int, ObservationPointType]
+    | tuple[Literal["stmt"], tuple[tuple[int, int | None], int], ObservationPointType]
+    | tuple[Literal["node"], tuple[int, int | None], ObservationPointType]
+)
 
 
 def _copy_reg2vvarid(reg2vvarid: dict[int, dict[int, int]]) -> dict[int, dict[int, int]]:
@@ -98,22 +106,25 @@ class RegVVarPredicate:
                 self.vvars.append(stmt.dst)
             return True
         if isinstance(stmt, SideEffectStatement):
-            if (
-                isinstance(stmt.ret_expr, VirtualVariable)
-                and stmt.ret_expr.was_reg
-                and stmt.ret_expr.reg_offset == self.reg_offset
-                and stmt.ret_expr.size >= self.min_size
-            ):
-                if stmt.ret_expr not in self.vvars:
-                    self.vvars.append(stmt.ret_expr)
-                return True
-            if isinstance(stmt.expr, Call):
-                # is it clobbered maybe?
-                clobbered_regs = get_call_clobbered_regs(
-                    stmt.expr, self.variable_map, self.functions, self.arch, self.platform, self.language
-                )
-                if self.reg_offset in clobbered_regs:
+            for return_expr in (stmt.ret_expr, stmt.fp_ret_expr):
+                if (
+                    isinstance(return_expr, VirtualVariable)
+                    and return_expr.was_reg
+                    and return_expr.reg_offset == self.reg_offset
+                    and return_expr.size >= self.min_size
+                ):
+                    if return_expr not in self.vvars:
+                        self.vvars.append(return_expr)
                     return True
+        if (call := stmt_is_simple_call(stmt)) is not None:
+            # A matching explicit result definition above takes precedence because call clobbers happen before result
+            # definitions. Otherwise the call is a barrier for earlier definitions of caller-saved registers,
+            # including when simplification has folded it into an Assignment wrapper.
+            clobbered_regs = get_call_clobbered_regs(
+                call, self.variable_map, self.functions, self.arch, self.platform, self.language
+            )
+            if self.reg_offset in clobbered_regs:
+                return True
         return False
 
 
@@ -151,7 +162,7 @@ class SRDAView:
         self._traversal_order: list[Block] | None = None
         # caches for the dominance-based observe() fast path (func_graph is immutable for this view's lifetime)
         self._idoms: dict[Block, Block] | None = None
-        self._block_reg_defs: dict[tuple[int, int | None], dict[tuple[int, int], int]] | None = None
+        self._block_reg_effects: dict[tuple[int, int | None], tuple[_StmtRegEffects, ...]] = {}
         self._blocks_by_key: dict[tuple[int, int | None], Block] | None = None
 
     def _get_vvar_by_stmt(
@@ -360,7 +371,7 @@ class SRDAView:
                 break
         return None
 
-    def observe(self, observation_points: list[ObservationPoint], entry: Block | None = None):
+    def observe(self, observation_points: list[_SRDAObservationPoint], entry: Block | None = None):
         insn_ops: dict[int, ObservationPointType] = {op[1]: op[2] for op in observation_points if op[0] == "insn"}
         stmt_ops: dict[tuple[tuple[int, int | None], int], ObservationPointType] = {
             op[1]: op[2] for op in observation_points if op[0] == "stmt"
@@ -385,12 +396,12 @@ class SRDAView:
         ``observations`` at this block's node/insn/stmt observation points. Shared by both observe() paths so their
         per-block snapshot semantics are byte-for-byte identical; the paths differ only in how the entry map is seeded.
         """
-        arch = self.model.arch
         block_key = block.addr, block.idx
 
         if block_key in node_ops and node_ops[block_key] == ObservationPointType.OP_BEFORE:
             observations[("node", block_key, ObservationPointType.OP_BEFORE)] = _copy_reg2vvarid(reg2vvarid)
 
+        block_reg_effects = self._get_block_reg_effects(block)
         last_insn_addr = None
         for stmt_idx, stmt in enumerate(block.statements):
             if last_insn_addr != stmt.tags["ins_addr"]:
@@ -409,20 +420,13 @@ class SRDAView:
             if stmt_key in stmt_ops and stmt_ops[stmt_key] == ObservationPointType.OP_BEFORE:
                 observations[("stmt", stmt_key, ObservationPointType.OP_BEFORE)] = _copy_reg2vvarid(reg2vvarid)
 
-            if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable) and stmt.dst.was_reg:
-                base_offset = get_reg_offset_base(stmt.dst.reg_offset, arch)
+            reg_defs, clobbered_regs = block_reg_effects[stmt_idx]
+            for base_offset in clobbered_regs:
+                reg2vvarid.pop(base_offset, None)
+            for base_offset, size, varid in reg_defs:
                 if base_offset not in reg2vvarid:
                     reg2vvarid[base_offset] = {}
-                reg2vvarid[base_offset][stmt.dst.size] = stmt.dst.varid
-            elif (
-                isinstance(stmt, SideEffectStatement)
-                and isinstance(stmt.ret_expr, VirtualVariable)
-                and stmt.ret_expr.was_reg
-            ):
-                base_offset = get_reg_offset_base(stmt.ret_expr.reg_offset, arch)
-                if base_offset not in reg2vvarid:
-                    reg2vvarid[base_offset] = {}
-                reg2vvarid[base_offset][stmt.ret_expr.size] = stmt.ret_expr.varid
+                reg2vvarid[base_offset][size] = varid
 
             if stmt_key in stmt_ops and stmt_ops[stmt_key] == ObservationPointType.OP_AFTER:
                 observations[("stmt", stmt_key, ObservationPointType.OP_AFTER)] = _copy_reg2vvarid(reg2vvarid)
@@ -449,33 +453,64 @@ class SRDAView:
 
         return observations
 
-    def _build_block_reg_defs(self) -> dict[tuple[int, int | None], dict[tuple[int, int], int]]:
+    def _get_block_reg_effects(self, block: Block) -> tuple[_StmtRegEffects, ...]:
         """
-        Per-block index of register-vvar definitions: ``(block addr, idx) -> {(base reg offset, size): vvar id}``,
-        keeping the last (highest stmt_idx) definition per ``(base, size)`` in each block. Derived from the model's
-        definition locations -- no graph traversal. Extern (function-argument) definitions are skipped, matching the
-        forward path which starts the entry block with an empty register map.
+        Return cached register effects for each statement in ``block``.
+
+        Definitions are stored in forward execution order. A call's clobbered base-register offsets are stored
+        separately because forward observation applies the clobber before the statement's explicit return definition,
+        while reverse dominator seeding must consider those definitions before treating the call as a barrier.
         """
         arch = self.model.arch
-        tmp: dict[tuple[int, int | None], dict[tuple[int, int], tuple[int, int]]] = defaultdict(dict)
-        for vid, defloc in self.model.all_vvar_definitions.items():
-            if defloc.is_extern:
-                continue
-            vvar = self.model.varid_to_vvar.get(vid)
-            if vvar is None or not vvar.was_reg:
-                continue
-            key = (get_reg_offset_base(vvar.reg_offset, arch), vvar.size)
-            block_key = defloc.addr, defloc.block_idx
-            cur = tmp[block_key].get(key)
-            if cur is None or defloc.stmt_idx > cur[0]:
-                tmp[block_key][key] = (defloc.stmt_idx, vid)
-        return {bk: {k: v[1] for k, v in d.items()} for bk, d in tmp.items()}
+        block_key = block.addr, block.idx
+        effects = self._block_reg_effects.get(block_key)
+        if effects is not None:
+            return effects
 
-    def _seed_from_dominators(self, block, idoms, block_reg_defs) -> dict[int, dict[int, int]]:
+        stmt_effects = []
+        for stmt in block.statements:
+            reg_defs = []
+            if isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable) and stmt.dst.was_reg:
+                reg_defs.append((get_reg_offset_base(stmt.dst.reg_offset, arch), stmt.dst.size, stmt.dst.varid))
+            elif isinstance(stmt, SideEffectStatement):
+                for return_expr in (stmt.ret_expr, stmt.fp_ret_expr):
+                    if isinstance(return_expr, VirtualVariable) and return_expr.was_reg:
+                        reg_defs.append(
+                            (
+                                get_reg_offset_base(return_expr.reg_offset, arch),
+                                return_expr.size,
+                                return_expr.varid,
+                            )
+                        )
+
+            call = stmt_is_simple_call(stmt)
+            clobbered_regs = (
+                frozenset(
+                    get_reg_offset_base(reg_offset, arch)
+                    for reg_offset in get_call_clobbered_regs(
+                        call,
+                        self.model.variable_map,
+                        self.model.functions,
+                        arch,
+                        self.model.platform,
+                        self.model.language,
+                    )
+                )
+                if call is not None
+                else frozenset()
+            )
+            stmt_effects.append((tuple(reg_defs), clobbered_regs))
+
+        effects = tuple(stmt_effects)
+        self._block_reg_effects[block_key] = effects
+        return effects
+
+    def _seed_from_dominators(self, block, idoms) -> dict[int, dict[int, int]]:
         """
         The register map reaching ``block``'s entry: for each ``(base register, size)``, the definition in the closest
         strict dominator that defines it. In SSA this is exactly the reaching definition at the block entry (phis are
-        defs in the merge block and so are picked up by the in-block walk, not here).
+        defs in the merge block and so are picked up by the in-block walk, not here). Calls form barriers for all
+        earlier definitions of each clobbered base register; definitions at or after a call remain visible.
         """
         reg2vvarid: dict[int, dict[int, int]] = {}
         d = idoms.get(block)
@@ -483,59 +518,19 @@ class SRDAView:
             # entry block (its immediate dominator is itself) or unreachable node: no strict dominators
             return reg2vvarid
         found: set[tuple[int, int]] = set()
+        blocked_bases: set[int] = set()
         while True:
-            # registers will get clobbered by calls, so we check if the block starts or ends with a call statement
-            # note that we do not yet handle the case where a call is folded into the middle of a block
-            if d.statements:
-                first_stmt = d.statements[0]
-                call_expr = None
-                if isinstance(first_stmt, SideEffectStatement) and isinstance(first_stmt.expr, Call):
-                    call_expr = first_stmt.expr
-                elif isinstance(first_stmt, Assignment) and isinstance(first_stmt.src, Call):
-                    call_expr = first_stmt.src
-                if call_expr is not None:
-                    clobbered_regs = get_call_clobbered_regs(
-                        call_expr,
-                        self.model.variable_map,
-                        self.model.functions,
-                        self.model.arch,
-                        self.model.platform,
-                        self.model.language,
-                    )
-                    for reg_offset in clobbered_regs:
-                        if reg_offset in reg2vvarid:
-                            reg2vvarid.pop(reg_offset)
-
-            defs = block_reg_defs.get((d.addr, d.idx))
-            if defs:
-                for key, vid in defs.items():
-                    if key not in found:
+            for reg_defs, clobbered_regs in reversed(self._get_block_reg_effects(d)):
+                # These definitions occur after the call's clobber in forward execution, so inspect them first while
+                # scanning backward. Do not remove already-found post-call definitions when installing the barrier.
+                for base, size, vid in reversed(reg_defs):
+                    key = base, size
+                    if base not in blocked_bases and key not in found:
                         found.add(key)
-                        base, size = key
                         if base not in reg2vvarid:
                             reg2vvarid[base] = {}
                         reg2vvarid[base][size] = vid
-
-            # register clobbering by calls
-            if d.statements and len(d.statements) > 1:
-                last_stmt = d.statements[-1]
-                call_expr = None
-                if isinstance(last_stmt, SideEffectStatement) and isinstance(last_stmt.expr, Call):
-                    call_expr = last_stmt.expr
-                elif isinstance(last_stmt, Assignment) and isinstance(last_stmt.src, Call):
-                    call_expr = last_stmt.src
-                if call_expr is not None:
-                    clobbered_regs = get_call_clobbered_regs(
-                        call_expr,
-                        self.model.variable_map,
-                        self.model.functions,
-                        self.model.arch,
-                        self.model.platform,
-                        self.model.language,
-                    )
-                    for reg_offset in clobbered_regs:
-                        if reg_offset in reg2vvarid:
-                            reg2vvarid.pop(reg_offset)
+                blocked_bases.update(clobbered_regs)
 
             nd = idoms.get(d)
             if nd is None or nd is d:
@@ -547,9 +542,6 @@ class SRDAView:
         if self._idoms is None:
             self._idoms = networkx.immediate_dominators(self.model.func_graph, entry)
         idoms = self._idoms
-        if self._block_reg_defs is None:
-            self._block_reg_defs = self._build_block_reg_defs()
-        block_reg_defs = self._block_reg_defs
         if self._blocks_by_key is None:
             self._blocks_by_key = {(b.addr, b.idx): b for b in self.model.func_graph}
         blocks_by_key = self._blocks_by_key
@@ -564,6 +556,6 @@ class SRDAView:
             block = blocks_by_key.get(block_key)
             if block is None:
                 continue
-            reg2vvarid = self._seed_from_dominators(block, idoms, block_reg_defs)
+            reg2vvarid = self._seed_from_dominators(block, idoms)
             self._observe_block(block, reg2vvarid, no_insn_ops, stmt_ops, node_ops, observations)
         return observations

--- a/angr/analyses/s_reaching_definitions/s_reaching_definitions.py
+++ b/angr/analyses/s_reaching_definitions/s_reaching_definitions.py
@@ -11,6 +11,7 @@ from angr.calling_conventions import SimRegArg, default_cc
 from angr.code_location import AILCodeLocation
 from angr.knowledge_plugins.functions import Function
 from angr.knowledge_plugins.key_definitions.constants import ObservationPointType
+from angr.utils.ssa import stmt_is_simple_call
 
 from .s_rda_model import SRDAModel, populate_model
 from .s_rda_view import SRDAView
@@ -97,15 +98,13 @@ class SReachingDefinitionsAnalysis(Analysis):
             call_stmt_ids = []
             for block in blocks.values():
                 for stmt_idx, stmt in enumerate(block.statements):
-                    if (  # pylint:disable=too-many-boolean-expressions
-                        (
-                            isinstance(stmt, SideEffectStatement)
-                            and isinstance(stmt.expr, Call)
-                            and stmt.expr.args is None
-                        )
-                        or (isinstance(stmt, Assignment) and isinstance(stmt.src, Call) and stmt.src.args is None)
-                        or (isinstance(stmt, Return) and stmt.ret_exprs and isinstance(stmt.ret_exprs[0], Call))
-                    ):
+                    return_call = (
+                        stmt.ret_exprs[0]
+                        if isinstance(stmt, Return) and stmt.ret_exprs and isinstance(stmt.ret_exprs[0], Call)
+                        else None
+                    )
+                    call = return_call if return_call is not None else stmt_is_simple_call(stmt)
+                    if return_call is not None or (call is not None and call.args is None):
                         call_stmt_ids.append(((block.addr, block.idx), stmt_idx))
 
             observations = srda_view.observe(
@@ -120,11 +119,9 @@ class SReachingDefinitionsAnalysis(Analysis):
                 assert isinstance(stmt, (SideEffectStatement, Assignment, Return))
 
                 call = (
-                    stmt.expr
-                    if isinstance(stmt, SideEffectStatement)
-                    else stmt.src
-                    if isinstance(stmt, Assignment)
-                    else stmt.ret_exprs[0]
+                    stmt.ret_exprs[0]
+                    if isinstance(stmt, Return) and stmt.ret_exprs and isinstance(stmt.ret_exprs[0], Call)
+                    else stmt_is_simple_call(stmt)
                 )
                 assert isinstance(call, Call)
 

--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -153,11 +153,12 @@ class SimEngineVRAIL(
     def _handle_stmt_ConditionalJump(self, stmt):
         self._expr(stmt.condition)
 
-    def _handle_expr_Tmp(self, expr):
+    def _handle_expr_Tmp(self, expr) -> RichR[claripy.ast.BV | claripy.ast.FP]:
         try:
             return self.tmps[expr.tmp_idx]
         except KeyError:
-            return self._top(expr.bits)
+            result: RichR[claripy.ast.BV | claripy.ast.FP] = RichR(self.state.top(expr.bits))
+            return result
 
     def _handle_expr_MultiStatementExpression(self, expr):
         for stmt in expr.stmts:
@@ -279,17 +280,10 @@ class SimEngineVRAIL(
                 self._reference_spoffset = False
                 args.append(richr)
 
-        ret_expr_bits = self.state.arch.bits
-        create_variable = True
-
-        # this is a call statement. we need to update the return value register later
-        ret_expr = stmt.ret_expr
-        if ret_expr is not None:
-            if ret_expr.category == ailment.Expr.VirtualVariableCategory.REGISTER:
-                ret_expr_bits = ret_expr.bits
-        else:
-            # the return expression is not used, so we treat this call as not returning anything
-            create_variable = False
+        # These are alternative ABI return candidates until the call prototype or later simplification selects one.
+        return_exprs = tuple(
+            return_expr for return_expr in (stmt.ret_expr, stmt.fp_ret_expr) if return_expr is not None
+        )
 
         if isinstance(target, ailment.Expr.Expression) and not isinstance(
             target, (ailment.Expr.Const, ailment.Expr.DirtyExpression)
@@ -340,26 +334,24 @@ class SimEngineVRAIL(
         # TODO: Expose it as an option
         return_value_use_full_width_reg = True
 
-        # update the return value register
-        if isinstance(ret_expr, ailment.Expr.VirtualVariable):
-            expr_bits = ret_expr_bits
-            self._assign_to_vvar(
-                ret_expr,
-                RichR(self.state.top(expr_bits), typevar=ret_ty),
-                dst=ret_expr,
-                create_variable=create_variable,
-                vvar_id=self._mapped_vvarid(ret_expr.varid),
-            )
-        elif isinstance(ret_expr, ailment.Expr.Register):
-            l.warning("Left-over register found in call.ret_expr.")
-            expr_bits = self.state.arch.bits if return_value_use_full_width_reg else ret_expr_bits
-            self._assign_to_register(
-                ret_expr.reg_offset,
-                RichR(self.state.top(expr_bits), typevar=ret_ty),
-                expr_bits // self.arch.byte_width,
-                dst=ret_expr,
-                create_variable=create_variable,
-            )
+        # Conservatively define every candidate. Scalar call rewriting only happens after one candidate remains.
+        for return_expr in return_exprs:
+            if isinstance(return_expr, ailment.Expr.VirtualVariable):
+                self._assign_to_vvar(
+                    return_expr,
+                    RichR(self.state.top(return_expr.bits), typevar=ret_ty),
+                    dst=return_expr,
+                    vvar_id=self._mapped_vvarid(return_expr.varid),
+                )
+            elif isinstance(return_expr, ailment.Expr.Register):
+                l.warning("Left-over register found in a call return expression.")
+                expr_bits = self.state.arch.bits if return_value_use_full_width_reg else return_expr.bits
+                self._assign_to_register(
+                    return_expr.reg_offset,
+                    RichR(self.state.top(expr_bits), typevar=ret_ty),
+                    expr_bits // self.arch.byte_width,
+                    dst=return_expr,
+                )
 
     def _call_add_arg_based_type_constraints(
         self, prototype: SimTypeFunction, prototype_libname: str | None, args: list, arg_atoms: list

--- a/angr/engines/ail/engine_light.py
+++ b/angr/engines/ail/engine_light.py
@@ -261,6 +261,18 @@ class SimEngineAILSimState(SimEngineLightAIL[StateType, DataType, bool, None]):
         assert isinstance(result, claripy.ast.FP)
         return result
 
+    @staticmethod
+    def _symbolic_call_result(name: str, bits: int, *, floating_point: bool) -> claripy.ast.Bits:
+        if not floating_point:
+            return claripy.BVS(name, bits)
+        if bits == 32:
+            return claripy.FPS(name, claripy.FSORT_FLOAT)
+        if bits == 64:
+            return claripy.FPS(name, claripy.FSORT_DOUBLE)
+        # Claripy does not provide sorts for extended floating-point widths. Preserve those results as raw bits so
+        # call emulation remains width-correct and later AIL conversions can interpret them.
+        return claripy.BVS(name, bits)
+
     def _do_call(
         self,
         call: ailment.expression.Call,
@@ -274,15 +286,28 @@ class SimEngineAILSimState(SimEngineLightAIL[StateType, DataType, bool, None]):
                 # ????? if doing ret emulation and this is an expr (no lvalue expression)
                 # how do I tell if this is a float ret or not?
                 return (claripy.BVS(f"callless_stub_{call.target}", call.bits),)
-            if stmt is not None and stmt.ret_expr is not None:
-                return (claripy.BVS(f"callless_stub_{call.target}", stmt.ret_expr.bits),)
-            if stmt is not None and stmt.fp_ret_expr is not None:
-                return (
-                    claripy.FPS(
-                        f"callless_stub_{call.target}",
-                        claripy.FSORT_FLOAT if stmt.fp_ret_expr.bits == 32 else claripy.FSORT_DOUBLE,
-                    ),
-                )
+            if stmt is not None:
+                dual_return = stmt.ret_expr is not None and stmt.fp_ret_expr is not None
+                results = []
+                if stmt.ret_expr is not None:
+                    suffix = "_ret" if dual_return else ""
+                    results.append(
+                        self._symbolic_call_result(
+                            f"callless_stub_{call.target}{suffix}",
+                            stmt.ret_expr.bits,
+                            floating_point=False,
+                        )
+                    )
+                if stmt.fp_ret_expr is not None:
+                    suffix = "_fp" if dual_return else ""
+                    results.append(
+                        self._symbolic_call_result(
+                            f"callless_stub_{call.target}{suffix}",
+                            stmt.fp_ret_expr.bits,
+                            floating_point=True,
+                        )
+                    )
+                return tuple(results)
             return ()
         target_addr = self._expr_bv(call.target)
         assert target_addr.concrete
@@ -425,13 +450,78 @@ class SimEngineAILSimState(SimEngineLightAIL[StateType, DataType, bool, None]):
     def _handle_stmt_SideEffectStatement(self, stmt: ailment.statement.SideEffectStatement) -> bool:
         assert isinstance(stmt.expr, ailment.expression.Call)
         results = self._do_call(stmt.expr, stmt=stmt)
-        ret_expr = stmt.ret_expr or stmt.fp_ret_expr
-        ret_exprs = [] if ret_expr is None else [ret_expr]
-        if len(results) < len(ret_exprs):
+        ret_exprs = tuple(expr for expr in (stmt.ret_expr, stmt.fp_ret_expr) if expr is not None)
+        if ret_exprs and not results:
             raise errors.AngrRuntimeError(
-                f"Call statement expects {len(ret_exprs)} return value(s) but called function provided {len(results)}"
+                f"Call statement expects at least one return value but called function provided {len(results)}"
             )
-        for ret_expr, result in zip(ret_exprs, results):
+
+        if len(ret_exprs) == 2 and len(results) == 1:
+            result = results[0]
+            if isinstance(result, claripy.ast.FP):
+                assignments = (
+                    (
+                        ret_exprs[0],
+                        self._symbolic_call_result(
+                            f"unconstrained_call_result_{stmt.expr.target}_ret",
+                            ret_exprs[0].bits,
+                            floating_point=False,
+                        ),
+                    ),
+                    (ret_exprs[1], result),
+                )
+            elif isinstance(result, claripy.ast.BV):
+                # Extended floating-point values have no Claripy FP sort and therefore arrive as raw BVs. A width
+                # that uniquely matches the FP candidate disambiguates that case; equal-width ABI candidates retain
+                # the conventional BV-to-integer fallback.
+                raw_extended_fp = (
+                    ret_exprs[1].bits not in (32, 64)
+                    and len(result) == ret_exprs[1].bits
+                    and len(result) != ret_exprs[0].bits
+                )
+                if raw_extended_fp:
+                    assignments = (
+                        (
+                            ret_exprs[0],
+                            self._symbolic_call_result(
+                                f"unconstrained_call_result_{stmt.expr.target}_ret",
+                                ret_exprs[0].bits,
+                                floating_point=False,
+                            ),
+                        ),
+                        (ret_exprs[1], result),
+                    )
+                else:
+                    assignments = (
+                        (ret_exprs[0], result),
+                        (
+                            ret_exprs[1],
+                            self._symbolic_call_result(
+                                f"unconstrained_call_result_{stmt.expr.target}_fp",
+                                ret_exprs[1].bits,
+                                floating_point=True,
+                            ),
+                        ),
+                    )
+            else:
+                raise errors.AngrRuntimeError(f"Unsupported call result type {type(result)}")
+        elif len(ret_exprs) == 1 and len(results) > 1:
+            # A prototype-aware pass may have selected one of two provisional ABI return locations after the callee
+            # graph was built. Prefer a result with the expected sort, then use the corresponding ABI slot so raw
+            # extended-precision FP values (which Claripy represents as bitvectors) remain correctly routed.
+            expects_fp = stmt.fp_ret_expr is not None
+            result_type = claripy.ast.FP if expects_fp else claripy.ast.BV
+            result = next(
+                (candidate for candidate in results if isinstance(candidate, result_type)),
+                results[min(1 if expects_fp else 0, len(results) - 1)],
+            )
+            assignments = ((ret_exprs[0], result),)
+        else:
+            assignments = zip(ret_exprs, results)
+
+        for ret_expr, result in assignments:
+            if not isinstance(result, (claripy.ast.BV, claripy.ast.FP)):
+                raise errors.AngrRuntimeError(f"Unsupported call result type {type(result)}")
             # these may be provided by misbehaving simprocedures. truncate the result as needed.
             self._do_assign(ret_expr, result, auto_narrow=True)
         return True
@@ -583,7 +673,10 @@ class SimEngineAILSimState(SimEngineLightAIL[StateType, DataType, bool, None]):
         return child[expr.bits + offset_bits - 1 : offset_bits]
 
     def _handle_expr_Insert(self, expr: ailment.expression.Insert) -> DataType:
-        value = self._expr_bv(expr.value)
+        value = self._expr_bits(expr.value)
+        if isinstance(value, claripy.ast.FP):
+            value = value.raw_to_bv()
+        assert isinstance(value, claripy.ast.BV)
         offset = self._expr_bv(expr.offset)
         base = self._expr_bv(expr.base)
         assert offset.concrete

--- a/angr/rust/mixins/cfa_mixin.py
+++ b/angr/rust/mixins/cfa_mixin.py
@@ -5,6 +5,7 @@ from angr.ailment.expression import Call
 from angr.ailment.statement import ConditionalJump, Label, Statement
 from angr.rust.utils.ail import CallFinder
 from angr.rust.utils.demangler import normalize
+from angr.utils.ssa import find_semantic_terminal_call
 
 
 class CFAMixin:
@@ -49,6 +50,10 @@ class CFAMixin:
             block.statements.remove(stmt)
 
     def terminal_call(self, block) -> Call | None:
+        semantic_call = find_semantic_terminal_call(block)
+        if semantic_call is not None:
+            return semantic_call[2]
+
         stmt = self.last_stmt(block)
         if stmt is None:
             return None

--- a/angr/rust/mixins/dfa_mixin.py
+++ b/angr/rust/mixins/dfa_mixin.py
@@ -7,6 +7,7 @@ from angr.ailment import Assignment, Block, Expression, Statement, UnaryOp
 from angr.ailment.expression import BasePointerOffset, BinaryOp, Const, Load, StackBaseOffset, VirtualVariable
 from angr.ailment.statement import Store
 from angr.rust.utils.ail import CallFinder, unwrap_stack_vvar_reference
+from angr.utils.ssa import find_semantic_terminal_call
 
 
 @dataclass
@@ -65,7 +66,13 @@ class DFAMixin:
         found_call = False
         stmts = []
         cur_block = callsite_block
-        while not (found_call and cur_block.statements and self._has_call(cur_block.statements[-1])):
+        while not (
+            found_call
+            and (
+                find_semantic_terminal_call(cur_block) is not None
+                or (cur_block.statements and self._has_call(cur_block.statements[-1]))
+            )
+        ):
             for idx, stmt in enumerate(reversed(cur_block.statements)):
                 idx = len(cur_block.statements) - idx - 1
                 if not found_call:

--- a/angr/rust/optimization_passes/cleanup_code_remover.py
+++ b/angr/rust/optimization_passes/cleanup_code_remover.py
@@ -10,6 +10,7 @@ from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.rust.mixins import CFAMixin, CFGTransformationMixin, SRDAMixin
 from angr.rust.utils.ail import find_call, get_terminal_call
 from angr.rust.utils.demangler import demangle
+from angr.utils.ssa import find_semantic_terminal_call
 
 if TYPE_CHECKING:
     from angr.ailment import Manager
@@ -51,8 +52,11 @@ class CleanupCodeRemover(OptimizationPass, CFGTransformationMixin, CFAMixin, SRD
         return self.project.is_rust_binary, None
 
     @staticmethod
-    def _is_simple_block(block):
-        stmts = block.statements[:-1] if len(block.statements) > 0 else []
+    def _is_simple_block(block, call_stmt_idx=None):
+        if call_stmt_idx is None:
+            terminal_call = find_semantic_terminal_call(block)
+            call_stmt_idx = terminal_call[0] if terminal_call is not None else max(len(block.statements) - 1, 0)
+        stmts = block.statements[:call_stmt_idx]
         return all(isinstance(stmt, Label) for stmt in stmts)
 
     def _should_remove(self, call):
@@ -75,12 +79,16 @@ class CleanupCodeRemover(OptimizationPass, CFGTransformationMixin, CFAMixin, SRD
     def _remove_cleanup_calls(self):
         blocks_to_remove = set()
         for block in self._graph.nodes:
-            call = get_terminal_call(block)
+            terminal_call = find_semantic_terminal_call(block)
+            call = terminal_call[2] if terminal_call is not None else get_terminal_call(block)
             if self._should_remove(call):
                 self._collect_type_hint(call)
                 if isinstance(block.statements[-1], Return):
                     block.statements[-1].ret_exprs = []
-                elif not self._is_simple_block(block):
+                elif terminal_call is not None and not self._is_simple_block(block, terminal_call[0]):
+                    l.debug("Removed the terminal call and result fixups of\n%s", block)
+                    block.statements = block.statements[: terminal_call[0]]
+                elif terminal_call is None and not self._is_simple_block(block):
                     l.debug("Removed the last statement of\n%s", block)
                     block.statements = block.statements[:-1]
                 else:

--- a/angr/rust/utils/ail.py
+++ b/angr/rust/utils/ail.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from angr.ailment import AILBlockViewer, BinaryOp, Block, Const, Expression, UnaryOp
 from angr.ailment.expression import Call, FunctionLikeMacro, VirtualVariable
 from angr.ailment.statement import Statement
+from angr.utils.ssa import find_semantic_terminal_call
 
 
 class CallFinder(AILBlockViewer):
@@ -41,11 +42,14 @@ def has_call(obj: Block | Statement | Expression, include_macro=False):
 
 def get_terminal_call(block: Block):
     if block.statements:
+        semantic_call = find_semantic_terminal_call(block)
+        if semantic_call is not None:
+            return semantic_call[2]
         terminal = block.statements[-1]
         if isinstance(terminal, Call):
             return terminal
         finder = CallFinder()
-        finder.walk_statement(terminal)
+        finder.walk_statement(terminal, block)
         return finder.call
     return None
 

--- a/angr/utils/ssa/__init__.py
+++ b/angr/utils/ssa/__init__.py
@@ -50,6 +50,7 @@ _EK_TMP = _EK.Tmp
 _EK_PHI = _EK.Phi
 
 DEPHI_VVAR_REG_OFFSET = 4096
+CALL_RESULT_FIXUP_TAG = "call_result_fixup"
 
 
 @overload
@@ -493,6 +494,30 @@ def stmt_is_simple_call(stmt: Statement) -> Call | None:
             src = src.value
         else:
             return None
+
+
+def is_call_result_fixup(stmt: Statement) -> bool:
+    """
+    Return whether ``stmt`` is a synthetic assignment that composes a narrow call result into its full-width SSA
+    destination.
+    """
+    return isinstance(stmt, Assignment) and stmt.tags.get(CALL_RESULT_FIXUP_TAG, False) is True
+
+
+def find_semantic_terminal_call(block: Block) -> tuple[int, Statement, Call] | None:
+    """
+    Find a call that is semantically terminal even when SSA result-fixup assignments physically follow it.
+
+    Only a contiguous suffix of explicitly tagged fixups is skipped. Arbitrary statements after a call remain
+    significant and prevent the call from being considered terminal.
+    """
+    for stmt_idx in range(len(block.statements) - 1, -1, -1):
+        stmt = block.statements[stmt_idx]
+        if (call := stmt_is_simple_call(stmt)) is not None:
+            return stmt_idx, stmt, call
+        if not is_call_result_fixup(stmt):
+            break
+    return None
 
 
 def check_in_between_stmts(

--- a/tests/analyses/decompiler/test_rust_small_passes.py
+++ b/tests/analyses/decompiler/test_rust_small_passes.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=protected-access
 """Unit tests for the smaller Rust optimization passes.
 
 The passes targeted here are the ones whose logic is small or whose pure
@@ -15,9 +16,13 @@ from __future__ import annotations
 
 from collections import OrderedDict
 
+import networkx
+import pytest
+
+import angr
 from angr.ailment import Block
-from angr.ailment.expression import Const
-from angr.ailment.statement import Jump, Label
+from angr.ailment.expression import Call, Const, Insert, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import Assignment, Jump, Label, SideEffectStatement, Statement
 from angr.calling_conventions import SimRegArg, SimStructArg
 from angr.rust.optimization_passes.cleanup_code_remover import (
     CLEANUP_FUNCTIONS,
@@ -26,6 +31,7 @@ from angr.rust.optimization_passes.cleanup_code_remover import (
 from angr.rust.optimization_passes.ret_expr_rewriter import RetExprRewriter
 from angr.rust.optimization_passes.security_check_remover import SECURITY_CHECK_FUNCTIONS
 from angr.sim_type import SimStruct, SimTypeLongLong
+from angr.utils.ssa import CALL_RESULT_FIXUP_TAG
 
 
 def _two_field_struct(name: str = "Pair") -> SimStruct:
@@ -84,6 +90,60 @@ def test_cleanup_is_simple_block_treats_single_statement_as_terminator_only():
     # regardless of the statement type.
     block = Block(0x4000, 0, statements=[_jump_stmt()])
     assert CleanupCodeRemover._is_simple_block(block) is True
+
+
+def _reg_vvar(varid: int, reg_offset: int, bits: int = 64) -> VirtualVariable:
+    return VirtualVariable(0, varid, bits, VirtualVariableCategory.REGISTER, oident=reg_offset)
+
+
+@pytest.mark.parametrize("folded_call", (False, True))
+def test_cleanup_remover_drops_semantic_call_and_tagged_result_suffix(folded_call):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    target = 0x2000
+    callee = project.kb.functions.function(addr=target, create=True)
+    assert callee is not None
+    callee.name = "free"
+
+    setup = Assignment(0, _reg_vvar(1, project.arch.registers["rbx"][0]), Const(1, 1, 64))
+    call = Call(2, Const(3, target, 64), args=[], bits=64)
+    raw_result = _reg_vvar(2, project.arch.registers["rax"][0])
+    final_result = _reg_vvar(3, project.arch.registers["rax"][0], bits=128)
+    fixup = Assignment(
+        4,
+        final_result,
+        Insert(
+            5,
+            Const(6, 0, 128),
+            Const(7, 0, 64),
+            call if folded_call else raw_result,
+            project.arch.register_endness,
+        ),
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    trailing_fixup = Assignment(
+        8,
+        _reg_vvar(4, project.arch.registers["xmm0"][0], bits=128),
+        Const(9, 0, 128),
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    statements: list[Statement] = (
+        [setup, fixup, trailing_fixup]
+        if folded_call
+        else [setup, SideEffectStatement(10, call, ret_expr=raw_result), fixup]
+    )
+    block = Block(0x1000, 1, statements=statements)
+    remover = object.__new__(CleanupCodeRemover)
+    remover._project = project
+    func = project.kb.functions.function(addr=block.addr, create=True)
+    assert func is not None
+    remover._func = func
+    remover._graph = networkx.DiGraph()
+    remover._graph.add_node(block)
+
+    remover._remove_cleanup_calls()
+
+    assert len(block.statements) == 1
+    assert block.statements[0].likes(setup)
 
 
 def test_security_check_functions_list_covers_panic_branches():

--- a/tests/analyses/decompiler/test_ssa_dual_call_returns.py
+++ b/tests/analyses/decompiler/test_ssa_dual_call_returns.py
@@ -1,0 +1,1506 @@
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import networkx
+import pytest
+
+import angr
+from angr import ailment
+from angr.ailment.expression import Call, Expression
+from angr.ailment.statement import Return, SideEffectStatement
+from angr.analyses.decompiler.ail_simplifier import AILSimplifier
+from angr.analyses.decompiler.block_io_finder import BlockIOFinder
+from angr.analyses.decompiler.callsite_maker import CallSiteMaker
+from angr.analyses.decompiler.clinic import Clinic
+from angr.analyses.decompiler.expression_narrower import EffectiveSizeExtractor, ExpressionNarrower
+from angr.analyses.decompiler.optimization_passes.call_stmt_rewriter import CallStatementRewriter
+from angr.analyses.decompiler.optimization_passes.ite_region_converter import ITERegionConverter
+from angr.analyses.decompiler.optimization_passes.return_duplicator_base import FreshVirtualVariableRewriter
+from angr.analyses.decompiler.peephole_optimizations.rewrite_cxx_operator_calls import RewriteCxxOperatorCalls
+from angr.analyses.decompiler.region_simplifiers.expr_folding import ExpressionCounter
+from angr.analyses.decompiler.semantic_naming.call_result_naming import CallResultNaming
+from angr.analyses.decompiler.semantic_naming.pointer_naming import PointerNaming
+from angr.analyses.decompiler.ssailification.rewriting_engine import SimEngineSSARewriting
+from angr.analyses.decompiler.ssailification.rewriting_state import RewritingState
+from angr.analyses.decompiler.ssailification.ssailification import Def, UDef
+from angr.analyses.decompiler.structured_codegen.c import (
+    CAssignment,
+    CExpressionStatement,
+    CFunctionCall,
+    CStructuredCodeGenerator,
+)
+from angr.analyses.decompiler.structured_codegen.rust import RustFunctionCall, RustStructuredCodeGenerator
+from angr.analyses.decompiler.variable_map import variable_map_of
+from angr.analyses.deobfuscator.string_obf_opt_passes import StringObfType3Rewriter
+from angr.analyses.s_reaching_definitions import SRDAModel, SRDAView
+from angr.code_location import AILCodeLocation
+from angr.knowledge_plugins.key_definitions.atoms import Register as RegisterAtom
+from angr.knowledge_plugins.key_definitions.constants import ObservationPointType
+from angr.sim_type import SimTypeDouble, SimTypeFunction, SimTypeLongLong
+from angr.sim_variable import SimRegisterVariable
+from angr.utils.ssa import CALL_RESULT_FIXUP_TAG, find_semantic_terminal_call
+
+
+def _rebuild_call_expr(call: Call, *, args: list[Expression] | None = None, bits: int | None = None) -> Call:
+    return cast(
+        Call,
+        ailment.Expr.Call(
+            call.idx,
+            call.target,
+            args=call.args if args is None else args,
+            bits=call.bits if bits is None else bits,
+            arg_vvars=call.arg_vvars,
+            **call.tags,
+        ),
+    )
+
+
+def _rebuild_call_stmt(
+    stmt: SideEffectStatement,
+    *,
+    expr: Expression | None = None,
+    keep_ret_expr: bool = True,
+    keep_fp_ret_expr: bool = True,
+) -> SideEffectStatement:
+    return cast(
+        SideEffectStatement,
+        ailment.Stmt.SideEffectStatement(
+            stmt.idx,
+            stmt.expr if expr is None else expr,
+            ret_expr=stmt.ret_expr if keep_ret_expr else None,
+            fp_ret_expr=stmt.fp_ret_expr if keep_fp_ret_expr else None,
+            **stmt.tags,
+        ),
+    )
+
+
+def _make_dual_vvar_call(project, *, ret_varid=1, fp_varid=2):
+    ret_expr = ailment.Expr.VirtualVariable(
+        0,
+        ret_varid,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["rax"][0],
+        ins_addr=0x1000,
+    )
+    fp_ret_expr = ailment.Expr.VirtualVariable(
+        1,
+        fp_varid,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["xmm0"][0],
+        ins_addr=0x1000,
+    )
+    call = ailment.Expr.Call(2, "callee", args=[], bits=64, ins_addr=0x1000)
+    stmt = ailment.Stmt.SideEffectStatement(
+        3,
+        call,
+        ret_expr=ret_expr,
+        fp_ret_expr=fp_ret_expr,
+        ins_addr=0x1000,
+    )
+    return stmt, ret_expr, fp_ret_expr
+
+
+def _single_block_graph(block):
+    graph = networkx.DiGraph()
+    graph.add_node(block)
+    return graph
+
+
+def _count_calls(block):
+    class CallCounter(ailment.AILBlockViewer):
+        """Count call expressions while walking a test block."""
+
+        def __init__(self):
+            super().__init__()
+            self.count = 0
+
+        def _handle_Call(self, expr_idx, expr, stmt_idx, stmt, block):
+            self.count += 1
+            super()._handle_Call(expr_idx, expr, stmt_idx, stmt, block)
+
+    counter = CallCounter()
+    counter.walk(block)
+    return counter.count
+
+
+def _rewrite_ssa_block(project, block, def_to_udef, *, incomplete_defs=None, stackvars=False):
+    function = project.kb.functions.function(addr=block.addr, create=True)
+    state = RewritingState(
+        AILCodeLocation(block.addr, block.idx, 0, block.addr),
+        project.arch,
+        function,
+        block,
+    )
+    engine = SimEngineSSARewriting(
+        project,
+        ail_manager=ailment.Manager(arch=project.arch),
+        def_to_udef=def_to_udef,
+        incomplete_defs=set() if incomplete_defs is None else incomplete_defs,
+        stackvars=stackvars,
+        fail_fast=True,
+    )
+    engine.process(state, block=block)
+    assert engine.out_block is not None
+    return engine.out_block
+
+
+def _make_codegen_stubs(project, handle):
+    c_codegen = cast(Any, object.__new__(CStructuredCodeGenerator))
+    c_codegen.kb = project.kb
+    c_codegen.show_demangled_name = False
+    c_codegen.show_disambiguated_name = False
+    c_codegen.ident_counters = {}
+    c_codegen._next_node_idx = 1
+    c_codegen._handle = handle
+
+    rust_codegen = cast(Any, object.__new__(RustStructuredCodeGenerator))
+    rust_codegen.kb = project.kb
+    rust_codegen._variable_map = SimpleNamespace(prototype=lambda _: None)
+    rust_codegen.show_demangled_name = False
+    rust_codegen._handle = handle
+    return c_codegen, rust_codegen
+
+
+def _simplify_single_block(project, block, *, unify_variables, fold_expressions=False):
+    function = project.kb.functions.function(addr=block.addr, create=True)
+    simplifier = project.analyses[AILSimplifier].prep()(
+        function,
+        _single_block_graph(block),
+        ailment.Manager(arch=project.arch),
+        fold_expressions=fold_expressions,
+        narrow_expressions=False,
+        rewrite_ccalls=False,
+        rewrite_dirty=False,
+        unify_variables=unify_variables,
+        use_callee_saved_regs_at_return=False,
+    )
+    assert len(simplifier.func_graph) == 1
+    return next(iter(simplifier.func_graph))
+
+
+def test_generic_block_rewriter_visits_both_call_return_candidates():
+    class ReturnCandidateRewriter(ailment.AILBlockRewriter):
+        """Give each provisional call-return definition a distinct virtual-variable ID."""
+
+        def _handle_VirtualVariable(self, expr_idx, expr, stmt_idx, stmt, block):
+            new_varids = {1: 11, 2: 12}
+            if expr.varid not in new_varids:
+                return expr
+            return ailment.Expr.VirtualVariable(
+                expr.idx,
+                new_varids[expr.varid],
+                expr.bits,
+                expr.category,
+                expr.oident,
+                **expr.tags,
+            )
+
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, _, _ = _make_dual_vvar_call(project)
+
+    rewritten = ReturnCandidateRewriter().walk_statement(call_stmt)
+
+    assert isinstance(rewritten, SideEffectStatement)
+    assert isinstance(rewritten.ret_expr, ailment.Expr.VirtualVariable)
+    assert isinstance(rewritten.fp_ret_expr, ailment.Expr.VirtualVariable)
+    assert rewritten.ret_expr.varid == 11
+    assert rewritten.fp_ret_expr.varid == 12
+
+
+@pytest.mark.parametrize("selected_return", ("integer", "floating_point"))
+def test_ssa_rewriting_preserves_integer_and_floating_point_call_returns(selected_return):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    manager = ailment.Manager(arch=project.arch)
+    function = project.kb.functions.function(addr=0x1000, create=True)
+
+    ret_expr = ailment.Expr.Register(0, project.arch.registers["rax"][0], 64, ins_addr=0x1000)
+    fp_ret_expr = ailment.Expr.Register(1, project.arch.registers["xmm0"][0], 64, ins_addr=0x1000)
+    selected_expr = ret_expr if selected_return == "integer" else fp_ret_expr
+    selected_use = ailment.Expr.Register(2, selected_expr.reg_offset, 64, ins_addr=0x1005)
+    dst = ailment.Expr.Register(3, project.arch.registers["rbx"][0], 64, ins_addr=0x1005)
+    call = ailment.Expr.Call(4, "callee", args=[], bits=64, ins_addr=0x1000)
+    block = ailment.Block(
+        0x1000,
+        6,
+        statements=[
+            ailment.Stmt.SideEffectStatement(
+                5,
+                call,
+                ret_expr=ret_expr,
+                fp_ret_expr=fp_ret_expr,
+                ins_addr=0x1000,
+            ),
+            ailment.Stmt.Assignment(6, dst, selected_use, ins_addr=0x1005),
+        ],
+    )
+    def_to_udef: dict[Def, UDef] = {
+        ret_expr: ("reg", ret_expr.reg_offset, ret_expr.size),
+        fp_ret_expr: ("reg", fp_ret_expr.reg_offset, fp_ret_expr.size),
+        dst: ("reg", dst.reg_offset, dst.size),
+    }
+    state = RewritingState(
+        AILCodeLocation(block.addr, block.idx, 0, block.addr),
+        project.arch,
+        function,
+        block,
+    )
+    engine = SimEngineSSARewriting(
+        project,
+        ail_manager=manager,
+        def_to_udef=def_to_udef,
+        incomplete_defs=set(),
+        fail_fast=True,
+    )
+
+    call_outputs = BlockIOFinder(block, project).outputs_by_stmt[0]
+    assert {output.reg_offset for output in call_outputs if isinstance(output, RegisterAtom)} == {
+        ret_expr.reg_offset,
+        fp_ret_expr.reg_offset,
+    }
+
+    engine.process(state, block=block)
+
+    assert engine.out_block is not None
+    call_stmt, use_stmt = engine.out_block.statements
+    assert isinstance(call_stmt, ailment.Stmt.SideEffectStatement)
+    assert isinstance(call_stmt.ret_expr, ailment.Expr.VirtualVariable)
+    assert isinstance(call_stmt.fp_ret_expr, ailment.Expr.VirtualVariable)
+    assert call_stmt.ret_expr.varid != call_stmt.fp_ret_expr.varid
+    assert isinstance(use_stmt, ailment.Stmt.Assignment)
+    assert isinstance(use_stmt.src, ailment.Expr.VirtualVariable)
+    selected_vvar = call_stmt.ret_expr if selected_return == "integer" else call_stmt.fp_ret_expr
+    assert use_stmt.src.varid == selected_vvar.varid
+
+
+@pytest.mark.parametrize("selected_return", ("integer", "floating_point"))
+def test_ssa_rewriting_preserves_selected_vvar_call_return_on_later_pass(selected_return):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    ret_expr = ailment.Expr.VirtualVariable(
+        0,
+        1,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["rax"][0],
+        ins_addr=0x1000,
+    )
+    fp_ret_expr = ailment.Expr.VirtualVariable(
+        1,
+        2,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["xmm0"][0],
+        ins_addr=0x1000,
+    )
+    selected_expr = ret_expr if selected_return == "integer" else fp_ret_expr
+    call = ailment.Expr.Call(2, "callee", args=[], bits=64, ins_addr=0x1000)
+    call_stmt = ailment.Stmt.SideEffectStatement(
+        3,
+        call,
+        ret_expr=selected_expr if selected_return == "integer" else None,
+        fp_ret_expr=selected_expr if selected_return == "floating_point" else None,
+        ins_addr=0x1000,
+    )
+    use_stmt = ailment.Stmt.Return(4, [selected_expr], ins_addr=0x1001)
+    block = ailment.Block(0x1000, 2, statements=[call_stmt, use_stmt])
+
+    rewritten = _rewrite_ssa_block(project, block, {})
+
+    rewritten_call, rewritten_use = rewritten.statements
+    assert isinstance(rewritten_call, SideEffectStatement)
+    rewritten_result = rewritten_call.ret_expr if selected_return == "integer" else rewritten_call.fp_ret_expr
+    assert isinstance(rewritten_result, ailment.Expr.VirtualVariable)
+    assert rewritten_result.varid == selected_expr.varid
+    assert isinstance(rewritten_use, Return)
+    assert isinstance(rewritten_use.ret_exprs[0], ailment.Expr.VirtualVariable)
+    assert rewritten_use.ret_exprs[0].varid == rewritten_result.varid
+
+
+def test_ssa_dual_call_return_preserves_widened_xmm_definition():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    rax_offset = project.arch.registers["rax"][0]
+    xmm0_offset = project.arch.registers["xmm0"][0]
+    xmm1_offset = project.arch.registers["xmm1"][0]
+
+    prior_fp_def = ailment.Expr.Register(0, xmm0_offset, 128, ins_addr=0x1000)
+    ret_expr = ailment.Expr.Register(1, rax_offset, 64, ins_addr=0x1001)
+    fp_ret_expr = ailment.Expr.Register(2, xmm0_offset, 64, ins_addr=0x1001)
+    fp_use = ailment.Expr.Register(3, xmm0_offset, 128, ins_addr=0x1005)
+    use_dst = ailment.Expr.Register(4, xmm1_offset, 128, ins_addr=0x1005)
+    stack_ptr = ailment.Expr.StackBaseOffset(5, 64, -0x20, ins_addr=0x1001)
+    call = ailment.Expr.Call(6, "callee", args=[stack_ptr], bits=64, ins_addr=0x1001)
+    block = ailment.Block(
+        0x1000,
+        6,
+        statements=[
+            ailment.Stmt.Assignment(
+                7,
+                prior_fp_def,
+                ailment.Expr.Const(8, 0x112233445566778899AABBCCDDEEFF00, 128),
+                ins_addr=0x1000,
+            ),
+            ailment.Stmt.SideEffectStatement(
+                9,
+                call,
+                ret_expr=ret_expr,
+                fp_ret_expr=fp_ret_expr,
+                ins_addr=0x1001,
+            ),
+            ailment.Stmt.Assignment(10, use_dst, fp_use, ins_addr=0x1005),
+        ],
+    )
+    def_to_udef: dict[Def, UDef] = {
+        prior_fp_def: ("reg", xmm0_offset, 16),
+        ret_expr: ("reg", rax_offset, 8),
+        fp_ret_expr: ("reg", xmm0_offset, 16),
+        use_dst: ("reg", xmm1_offset, 16),
+        stack_ptr: ("stack", -0x20, 8),
+    }
+
+    rewritten = _rewrite_ssa_block(
+        project,
+        block,
+        def_to_udef,
+        incomplete_defs={fp_ret_expr},
+        stackvars=True,
+    )
+
+    assert len(rewritten.statements) == 4
+    prior_stmt, call_stmt, fp_fixup, use_stmt = rewritten.statements
+    assert isinstance(prior_stmt, ailment.Stmt.Assignment)
+    assert isinstance(prior_stmt.dst, ailment.Expr.VirtualVariable)
+    assert isinstance(call_stmt, SideEffectStatement)
+    assert isinstance(call_stmt.ret_expr, ailment.Expr.VirtualVariable)
+    assert isinstance(call_stmt.fp_ret_expr, ailment.Expr.VirtualVariable)
+    assert call_stmt.ret_expr.bits == 64
+    assert call_stmt.ret_expr.category == ailment.Expr.VirtualVariableCategory.REGISTER
+    assert call_stmt.ret_expr.oident == rax_offset
+    assert call_stmt.fp_ret_expr.bits == 64
+    assert call_stmt.fp_ret_expr.category == ailment.Expr.VirtualVariableCategory.REGISTER
+    assert call_stmt.fp_ret_expr.oident == xmm0_offset
+
+    assert isinstance(fp_fixup, ailment.Stmt.Assignment)
+    assert isinstance(fp_fixup.dst, ailment.Expr.VirtualVariable)
+    assert fp_fixup.dst.bits == 128
+    assert fp_fixup.dst.category == ailment.Expr.VirtualVariableCategory.REGISTER
+    assert fp_fixup.dst.oident == xmm0_offset
+    assert isinstance(fp_fixup.src, ailment.Expr.Insert)
+    assert isinstance(fp_fixup.src.base, ailment.Expr.VirtualVariable)
+    assert fp_fixup.src.base.varid == prior_stmt.dst.varid
+    assert isinstance(fp_fixup.src.value, ailment.Expr.VirtualVariable)
+    assert fp_fixup.src.value.varid == call_stmt.fp_ret_expr.varid
+    assert fp_fixup.tags.get(CALL_RESULT_FIXUP_TAG) is True
+
+    assert isinstance(use_stmt, ailment.Stmt.Assignment)
+    assert isinstance(use_stmt.src, ailment.Expr.VirtualVariable)
+    assert use_stmt.src.varid == fp_fixup.dst.varid
+    assert _count_calls(rewritten) == 1
+
+    assert call_stmt.tags.get("extra_defs")
+    assert isinstance(call_stmt.expr, ailment.Expr.Call)
+    rewritten_arg = call_stmt.expr.args[0]
+    assert isinstance(rewritten_arg, ailment.Expr.UnaryOp)
+    assert rewritten_arg.tags.get("extra_def") is True
+    assert isinstance(rewritten_arg.operand, ailment.Expr.VirtualVariable)
+    assert call_stmt.tags["extra_defs"] == [rewritten_arg.operand.varid]
+    assert "extra_defs" not in fp_fixup.tags
+
+
+def test_ssa_dual_call_return_splits_both_widened_definitions():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    rax_offset = project.arch.registers["rax"][0]
+    xmm0_offset = project.arch.registers["xmm0"][0]
+
+    prior_ret_def = ailment.Expr.Register(0, rax_offset, 64, ins_addr=0x1000)
+    prior_fp_def = ailment.Expr.Register(1, xmm0_offset, 128, ins_addr=0x1000)
+    ret_expr = ailment.Expr.Register(2, rax_offset, 32, ins_addr=0x1001)
+    fp_ret_expr = ailment.Expr.Register(3, xmm0_offset, 32, ins_addr=0x1001)
+    call = ailment.Expr.Call(4, "callee", args=[], bits=32, ins_addr=0x1001)
+    block = ailment.Block(
+        0x1000,
+        2,
+        statements=[
+            ailment.Stmt.Assignment(
+                5,
+                prior_ret_def,
+                ailment.Expr.Const(6, 0x1122334455667788, 64),
+                ins_addr=0x1000,
+            ),
+            ailment.Stmt.Assignment(
+                7,
+                prior_fp_def,
+                ailment.Expr.Const(8, 0x112233445566778899AABBCCDDEEFF00, 128),
+                ins_addr=0x1000,
+            ),
+            ailment.Stmt.SideEffectStatement(
+                9,
+                call,
+                ret_expr=ret_expr,
+                fp_ret_expr=fp_ret_expr,
+                ins_addr=0x1001,
+            ),
+        ],
+    )
+    def_to_udef: dict[Def, UDef] = {
+        prior_ret_def: ("reg", rax_offset, 8),
+        prior_fp_def: ("reg", xmm0_offset, 16),
+        ret_expr: ("reg", rax_offset, 8),
+        fp_ret_expr: ("reg", xmm0_offset, 16),
+    }
+
+    rewritten = _rewrite_ssa_block(
+        project,
+        block,
+        def_to_udef,
+        incomplete_defs={ret_expr, fp_ret_expr},
+    )
+
+    assert len(rewritten.statements) == 5
+    prior_ret_stmt, prior_fp_stmt, call_stmt, ret_fixup, fp_fixup = rewritten.statements
+    assert isinstance(prior_ret_stmt, ailment.Stmt.Assignment)
+    assert isinstance(prior_fp_stmt, ailment.Stmt.Assignment)
+    assert isinstance(call_stmt, SideEffectStatement)
+    assert isinstance(call_stmt.ret_expr, ailment.Expr.VirtualVariable)
+    assert isinstance(call_stmt.fp_ret_expr, ailment.Expr.VirtualVariable)
+    assert call_stmt.ret_expr.varid != call_stmt.fp_ret_expr.varid
+    for result_vvar, reg_offset in (
+        (call_stmt.ret_expr, rax_offset),
+        (call_stmt.fp_ret_expr, xmm0_offset),
+    ):
+        assert result_vvar.bits == 32
+        assert result_vvar.category == ailment.Expr.VirtualVariableCategory.REGISTER
+        assert result_vvar.oident == reg_offset
+
+    assert isinstance(ret_fixup, ailment.Stmt.Assignment)
+    assert isinstance(ret_fixup.dst, ailment.Expr.VirtualVariable)
+    assert ret_fixup.dst.bits == 64
+    assert ret_fixup.dst.oident == rax_offset
+    assert isinstance(ret_fixup.src, ailment.Expr.Insert)
+    assert isinstance(ret_fixup.src.base, ailment.Expr.Const)
+    assert ret_fixup.src.base.bits == 64
+    assert isinstance(ret_fixup.src.value, ailment.Expr.VirtualVariable)
+    assert ret_fixup.src.value.varid == call_stmt.ret_expr.varid
+    assert ret_fixup.tags.get(CALL_RESULT_FIXUP_TAG) is True
+
+    assert isinstance(fp_fixup, ailment.Stmt.Assignment)
+    assert isinstance(fp_fixup.dst, ailment.Expr.VirtualVariable)
+    assert fp_fixup.dst.bits == 128
+    assert fp_fixup.dst.oident == xmm0_offset
+    assert isinstance(fp_fixup.src, ailment.Expr.Insert)
+    assert isinstance(fp_fixup.src.base, ailment.Expr.VirtualVariable)
+    assert isinstance(prior_fp_stmt.dst, ailment.Expr.VirtualVariable)
+    assert fp_fixup.src.base.varid == prior_fp_stmt.dst.varid
+    assert isinstance(fp_fixup.src.value, ailment.Expr.VirtualVariable)
+    assert fp_fixup.src.value.varid == call_stmt.fp_ret_expr.varid
+    assert fp_fixup.tags.get(CALL_RESULT_FIXUP_TAG) is True
+
+    assert _count_calls(rewritten) == 1
+    assert "extra_defs" not in call_stmt.tags
+    assert "extra_defs" not in ret_fixup.tags
+    assert "extra_defs" not in fp_fixup.tags
+
+
+def test_semantic_terminal_call_skips_only_tagged_result_fixups():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, _, fp_ret_expr = _make_dual_vvar_call(project)
+    fp_final = ailment.Expr.VirtualVariable(
+        4,
+        3,
+        128,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["xmm0"][0],
+    )
+    fixup = ailment.Stmt.Assignment(
+        5,
+        fp_final,
+        ailment.Expr.Insert(
+            6,
+            ailment.Expr.Const(7, 0, 128),
+            ailment.Expr.Const(8, 0, 64),
+            fp_ret_expr,
+            project.arch.register_endness,
+        ),
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    block = ailment.Block(0x1000, 1, statements=[call_stmt, fixup])
+
+    terminal_call = find_semantic_terminal_call(block)
+
+    assert terminal_call is not None
+    assert terminal_call[0] == 0
+    assert terminal_call[1].likes(call_stmt)
+    assert terminal_call[2].likes(call_stmt.expr)
+
+    ordinary_tail = ailment.Stmt.Assignment(9, fp_final, ailment.Expr.Const(10, 0, 128))
+    assert find_semantic_terminal_call(block.copy(statements=[call_stmt, fixup, ordinary_tail])) is None
+
+
+def test_semantic_terminal_call_finds_call_folded_into_tagged_fixup():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call = ailment.Expr.Call(0, "callee", args=[], bits=64)
+    final = ailment.Expr.VirtualVariable(
+        1,
+        1,
+        128,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["xmm0"][0],
+    )
+    folded_fixup = ailment.Stmt.Assignment(
+        2,
+        final,
+        ailment.Expr.Insert(
+            3,
+            ailment.Expr.Const(4, 0, 128),
+            ailment.Expr.Const(5, 0, 64),
+            call,
+            project.arch.register_endness,
+        ),
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    trailing_fixup = ailment.Stmt.Assignment(
+        6,
+        final,
+        ailment.Expr.Const(7, 0, 128),
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    block = ailment.Block(0x1000, 1, statements=[folded_fixup, trailing_fixup])
+
+    terminal_call = find_semantic_terminal_call(block)
+
+    assert terminal_call is not None
+    assert terminal_call[0] == 0
+    assert terminal_call[1].likes(folded_fixup)
+    assert terminal_call[2].likes(call)
+
+
+def test_ail_simplifier_call_barrier_is_limited_to_side_effects_and_tagged_fixups():
+    call = ailment.Expr.Call(0, "callee", args=[], bits=64)
+    result = ailment.Expr.VirtualVariable(
+        1,
+        1,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=0,
+    )
+    target = ailment.Block(0x2000, 1, statements=[])
+    simplifier = object.__new__(AILSimplifier)
+
+    ordinary_call = ailment.Stmt.Assignment(2, result, call)
+    ordinary_start = ailment.Block(0x1000, 1, statements=[ordinary_call])
+    simplifier.func_graph = networkx.DiGraph([(ordinary_start, target)])
+    assert simplifier._loc_within_superblock(
+        ordinary_start,
+        target.addr,
+        target.idx,
+        terminate_with_calls=True,
+    )
+
+    folded_fixup = ailment.Stmt.Assignment(
+        3,
+        result,
+        call,
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    fixup_start = ailment.Block(0x1100, 1, statements=[folded_fixup])
+    simplifier.func_graph = networkx.DiGraph([(fixup_start, target)])
+    assert not simplifier._loc_within_superblock(
+        fixup_start,
+        target.addr,
+        target.idx,
+        terminate_with_calls=True,
+    )
+
+    side_effect = ailment.Stmt.SideEffectStatement(4, call, ret_expr=result)
+    side_effect_start = ailment.Block(0x1200, 1, statements=[side_effect])
+    simplifier.func_graph = networkx.DiGraph([(side_effect_start, target)])
+    assert not simplifier._loc_within_superblock(
+        side_effect_start,
+        target.addr,
+        target.idx,
+        terminate_with_calls=True,
+    )
+
+
+@pytest.mark.parametrize("folded_call", (False, True))
+@pytest.mark.parametrize("probe_kind", ("rust", "windows"))
+def test_clinic_removes_probe_call_and_tagged_result_suffix(folded_call, probe_kind):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    if probe_kind == "windows":
+        assert project.simos is not None
+        project.simos.name = "Win32"
+    target = 0x2000
+    callee = project.kb.functions.function(addr=target, create=True)
+    assert callee is not None
+    if probe_kind == "rust":
+        callee.info["is_rust_probestack"] = True
+    else:
+        callee.name = "__chkstk"
+
+    setup_dst = ailment.Expr.VirtualVariable(
+        0,
+        1,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["rcx"][0],
+    )
+    setup = ailment.Stmt.Assignment(1, setup_dst, ailment.Expr.Const(2, 1, 64))
+    call = ailment.Expr.Call(3, ailment.Expr.Const(4, target, 64), args=[], bits=64)
+    result = ailment.Expr.VirtualVariable(
+        5,
+        2,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["rax"][0],
+    )
+    final = ailment.Expr.VirtualVariable(
+        6,
+        3,
+        128,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["rax"][0],
+    )
+    fixup = ailment.Stmt.Assignment(
+        7,
+        final,
+        ailment.Expr.Insert(
+            8,
+            ailment.Expr.Const(9, 0, 128),
+            ailment.Expr.Const(10, 0, 64),
+            call if folded_call else result,
+            project.arch.register_endness,
+        ),
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    if folded_call:
+        call_and_suffix = [
+            fixup,
+            ailment.Stmt.Assignment(
+                11,
+                final,
+                ailment.Expr.Const(12, 0, 128),
+                **{CALL_RESULT_FIXUP_TAG: True},
+            ),
+        ]
+    else:
+        call_and_suffix = [ailment.Stmt.SideEffectStatement(11, call, ret_expr=result), fixup]
+    block = ailment.Block(0x1000, 1, statements=[setup, *call_and_suffix])
+    successor = ailment.Block(0x1010, 1, statements=[])
+    graph = networkx.DiGraph([(block, successor)])
+    clinic = cast(Clinic, SimpleNamespace(project=project))
+
+    if probe_kind == "rust":
+        Clinic._rewrite_rust_probestack_call(clinic, graph)
+    else:
+        Clinic._rewrite_windows_chkstk_call(clinic, graph)
+
+    assert len(block.statements) == 1
+    assert block.statements[0].likes(setup)
+
+
+def test_callsite_maker_preserves_insert_when_call_was_folded_into_tagged_fixup():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    manager = ailment.Manager(arch=project.arch)
+    target = 0x2000
+    callee = project.kb.functions.function(addr=target, create=True)
+    assert callee is not None
+    callee.calling_convention = project.factory.cc()
+    callee.prototype = SimTypeFunction([], SimTypeDouble()).with_arch(project.arch)
+
+    call = ailment.Expr.Call(
+        0,
+        ailment.Expr.Const(1, target, 64),
+        args=[],
+        bits=64,
+        ins_addr=0x1000,
+    )
+    final = ailment.Expr.VirtualVariable(
+        2,
+        1,
+        128,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["xmm0"][0],
+        ins_addr=0x1000,
+    )
+    folded_fixup = ailment.Stmt.Assignment(
+        3,
+        final,
+        ailment.Expr.Insert(
+            4,
+            ailment.Expr.Const(5, 0, 128),
+            ailment.Expr.Const(6, 0, 64),
+            call,
+            project.arch.register_endness,
+        ),
+        ins_addr=0x1000,
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    block = ailment.Block(0x1000, 4, idx=0, statements=[folded_fixup])
+
+    result = project.analyses[CallSiteMaker].prep()(block, ail_manager=manager).result_block
+
+    assert result is not None
+    assert len(result.statements) == 1
+    rewritten_fixup = result.statements[0]
+    assert isinstance(rewritten_fixup, ailment.Stmt.Assignment)
+    assert rewritten_fixup.tags.get(CALL_RESULT_FIXUP_TAG) is True
+    assert rewritten_fixup.dst.bits == 128
+    assert isinstance(rewritten_fixup.src, ailment.Expr.Insert)
+    assert rewritten_fixup.src.bits == 128
+    assert isinstance(rewritten_fixup.src.value, ailment.Expr.Call)
+    assert rewritten_fixup.src.value.bits == call.bits
+    assert rewritten_fixup.src.value.target.likes(call.target)
+
+
+@pytest.mark.parametrize(
+    ("return_type", "select_fp"),
+    [(SimTypeDouble(), True), (SimTypeLongLong(), False)],
+)
+def test_callsite_maker_selects_typed_result_and_observes_fp_arg_before_tagged_fixup(
+    monkeypatch, return_type, select_fp
+):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    manager = ailment.Manager(arch=project.arch)
+    target = 0x2000
+    callee = project.kb.functions.function(addr=target, create=True)
+    assert callee is not None
+    callee.calling_convention = project.factory.cc()
+    callee.prototype = SimTypeFunction([SimTypeDouble()], return_type).with_arch(project.arch)
+
+    rax_offset = project.arch.registers["rax"][0]
+    xmm0_offset = project.arch.registers["xmm0"][0]
+    fp_arg = ailment.Expr.VirtualVariable(
+        0,
+        10,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=xmm0_offset,
+        ins_addr=0x1000,
+    )
+    arg_def = ailment.Stmt.Assignment(1, fp_arg, ailment.Expr.Const(2, 0x3FF0000000000000, 64), ins_addr=0x1000)
+    ret_expr = ailment.Expr.VirtualVariable(
+        3,
+        11,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=rax_offset,
+        ins_addr=0x1001,
+    )
+    fp_ret_expr = ailment.Expr.VirtualVariable(
+        4,
+        12,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=xmm0_offset,
+        ins_addr=0x1001,
+    )
+    call = ailment.Expr.Call(
+        5,
+        ailment.Expr.Const(6, target, 64),
+        args=[],
+        bits=64,
+        ins_addr=0x1001,
+    )
+    call_stmt = ailment.Stmt.SideEffectStatement(
+        7,
+        call,
+        ret_expr=ret_expr,
+        fp_ret_expr=fp_ret_expr,
+        ins_addr=0x1001,
+    )
+    ret_final = ailment.Expr.VirtualVariable(
+        8,
+        13,
+        128,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=rax_offset,
+        ins_addr=0x1001,
+    )
+    ret_fixup = ailment.Stmt.Assignment(
+        9,
+        ret_final,
+        ailment.Expr.Insert(
+            10,
+            ailment.Expr.Const(11, 0, 128),
+            ailment.Expr.Const(12, 0, 64),
+            ret_expr,
+            project.arch.register_endness,
+        ),
+        ins_addr=0x1001,
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    fp_final = ailment.Expr.VirtualVariable(
+        13,
+        14,
+        128,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=xmm0_offset,
+        ins_addr=0x1001,
+    )
+    fp_fixup = ailment.Stmt.Assignment(
+        14,
+        fp_final,
+        ailment.Expr.Insert(
+            15,
+            ailment.Expr.Const(16, 0, 128),
+            ailment.Expr.Const(17, 0, 64),
+            fp_ret_expr,
+            project.arch.register_endness,
+        ),
+        ins_addr=0x1001,
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    block = ailment.Block(0x1000, 4, idx=0, statements=[arg_def, call_stmt, ret_fixup, fp_fixup])
+
+    observations = []
+
+    def get_reg_vvar_by_stmt(
+        _view,
+        reg_offset,
+        min_size,
+        block_addr,
+        block_idx,
+        stmt_idx,
+        op_type,
+    ):
+        observations.append((reg_offset, min_size, block_addr, block_idx, stmt_idx, op_type))
+        return fp_arg
+
+    monkeypatch.setattr(SRDAView, "get_reg_vvar_by_stmt", get_reg_vvar_by_stmt)
+    monkeypatch.setattr(SRDAView, "get_vvar_value", lambda _view, _vvar: None)
+
+    result = (
+        project.analyses[CallSiteMaker]
+        .prep()(
+            block,
+            ail_manager=manager,
+            reaching_definitions=cast(SRDAModel, SimpleNamespace()),
+        )
+        .result_block
+    )
+
+    assert result is not None
+    assert len(result.statements) == 3
+    rewritten_call = result.statements[1]
+    assert isinstance(rewritten_call, SideEffectStatement)
+    if select_fp:
+        assert rewritten_call.ret_expr is None
+        assert isinstance(rewritten_call.fp_ret_expr, ailment.Expr.VirtualVariable)
+        assert rewritten_call.fp_ret_expr.varid == fp_ret_expr.varid
+        kept_fixup, discarded_fixup = fp_fixup, ret_fixup
+    else:
+        assert isinstance(rewritten_call.ret_expr, ailment.Expr.VirtualVariable)
+        assert rewritten_call.ret_expr.varid == ret_expr.varid
+        assert rewritten_call.fp_ret_expr is None
+        kept_fixup, discarded_fixup = ret_fixup, fp_fixup
+    assert result.statements[2].likes(kept_fixup)
+    assert result.statements[2].tags.get(CALL_RESULT_FIXUP_TAG) is True
+    assert all(not stmt.likes(discarded_fixup) for stmt in result.statements)
+
+    assert isinstance(rewritten_call.expr, ailment.Expr.Call)
+    assert rewritten_call.expr.args is not None and len(rewritten_call.expr.args) == 1
+    rewritten_arg = rewritten_call.expr.args[0]
+    assert isinstance(rewritten_arg, ailment.Expr.VirtualVariable)
+    assert rewritten_arg.varid == fp_arg.varid
+    assert observations == [
+        (
+            xmm0_offset,
+            8,
+            block.addr,
+            block.idx,
+            1,
+            ObservationPointType.OP_BEFORE,
+        )
+    ]
+
+
+def test_srda_records_implicit_register_uses_for_call_folded_into_result_fixup():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    function = project.kb.functions.function(addr=0x1000, create=True)
+    assert function is not None
+    rdi_offset = project.arch.registers["rdi"][0]
+    arg = ailment.Expr.VirtualVariable(
+        0,
+        1,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=rdi_offset,
+        ins_addr=0x1000,
+    )
+    result = ailment.Expr.VirtualVariable(
+        1,
+        2,
+        128,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["xmm0"][0],
+        ins_addr=0x1001,
+    )
+    call = ailment.Expr.Call(2, "callee", args=None, bits=64, ins_addr=0x1001)
+    folded_fixup = ailment.Stmt.Assignment(
+        3,
+        result,
+        ailment.Expr.Insert(
+            4,
+            ailment.Expr.Const(5, 0, 128),
+            ailment.Expr.Const(6, 0, 64),
+            call,
+            project.arch.register_endness,
+        ),
+        ins_addr=0x1001,
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    block = ailment.Block(
+        0x1000,
+        2,
+        statements=[
+            ailment.Stmt.Assignment(7, arg, ailment.Expr.Const(8, 1, 64), ins_addr=0x1000),
+            folded_fixup,
+        ],
+    )
+
+    model = project.analyses.SReachingDefinitions(
+        subject=function,
+        func_graph=_single_block_graph(block),
+        func_args=set(),
+    ).model
+
+    assert any(
+        used_expr is None and use_loc.block_addr == block.addr and use_loc.stmt_idx == 1
+        for used_expr, use_loc in model.all_vvar_uses[arg.varid]
+    )
+
+
+def test_classic_reaching_definitions_records_both_call_return_candidates():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    ret_expr = ailment.Expr.Register(0, project.arch.registers["rax"][0], 32, ins_addr=0x1000)
+    fp_ret_expr = ailment.Expr.Register(1, project.arch.registers["xmm0"][0], 64, ins_addr=0x1000)
+    call_expr = ailment.Expr.Call(3, "callee", args=[], bits=64, ins_addr=0x1000)
+    block = ailment.Block(
+        0x1000,
+        1,
+        idx=0,
+        statements=[
+            ailment.Stmt.SideEffectStatement(
+                2,
+                call_expr,
+                ret_expr=ret_expr,
+                fp_ret_expr=fp_ret_expr,
+                ins_addr=0x1000,
+            )
+        ],
+    )
+    assert block.idx is not None
+    observation = ("stmt", (block.addr, block.idx, 0), ObservationPointType.OP_AFTER)
+    variable_map = variable_map_of(ailment.Manager(arch=project.arch))
+    variable_map.set_prototype(
+        call_expr,
+        SimTypeFunction((), SimTypeLongLong()).with_arch(project.arch),
+    )
+
+    rda = project.analyses.ReachingDefinitions(
+        subject=block,
+        observation_points=[observation],
+        variable_map=variable_map,
+    )
+
+    call_relationship = next(iter(rda.function_calls.values()))
+    return_register_offsets = {
+        definition.atom.reg_offset
+        for definition in call_relationship.ret_defns
+        if isinstance(definition.atom, RegisterAtom)
+    }
+    assert {ret_expr.reg_offset, fp_ret_expr.reg_offset} <= return_register_offsets
+
+    live_definitions = rda.one_result
+    for return_expr in (ret_expr, fp_ret_expr):
+        values = live_definitions.get_values(RegisterAtom(return_expr.reg_offset, return_expr.size))
+        assert values is not None
+        value = values.one_value()
+        assert value is not None
+        assert len(value) == return_expr.bits
+        assert live_definitions.is_top(value)
+
+    upper_rax = live_definitions.get_values(RegisterAtom(ret_expr.reg_offset + ret_expr.size, ret_expr.size))
+    assert upper_rax is not None
+    upper_rax_value = upper_rax.one_value()
+    assert upper_rax_value is not None
+    assert upper_rax_value.concrete_value == 0
+
+
+@pytest.mark.parametrize("selected_return", ("integer", "floating_point"))
+def test_dead_return_candidate_is_removed_without_removing_call(selected_return):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    selected_expr = ret_expr if selected_return == "integer" else fp_ret_expr
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            call_stmt,
+            ailment.Stmt.Return(4, [selected_expr], ins_addr=0x1001),
+        ],
+    )
+
+    result_block = _simplify_single_block(project, block, unify_variables=False)
+
+    calls = [stmt for stmt in result_block.statements if isinstance(stmt, ailment.Stmt.SideEffectStatement)]
+    assert len(calls) == 1
+    simplified_call = calls[0]
+    if selected_return == "integer":
+        assert simplified_call.ret_expr is not None
+        assert simplified_call.fp_ret_expr is None
+    else:
+        assert simplified_call.ret_expr is None
+        assert simplified_call.fp_ret_expr is not None
+
+
+def test_both_live_return_candidates_do_not_fold_or_remove_call():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            call_stmt,
+            ailment.Stmt.Return(4, [ret_expr, fp_ret_expr], ins_addr=0x1001),
+        ],
+    )
+
+    result_block = _simplify_single_block(project, block, unify_variables=True, fold_expressions=True)
+
+    calls = [stmt for stmt in result_block.statements if isinstance(stmt, ailment.Stmt.SideEffectStatement)]
+    assert len(calls) == 1
+    assert calls[0].ret_expr is not None
+    assert calls[0].fp_ret_expr is not None
+
+
+@pytest.mark.parametrize("selected_return", ("integer", "floating_point"))
+def test_ail_simplifier_folds_exactly_one_return_candidate(selected_return):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    selected_expr = ret_expr if selected_return == "integer" else fp_ret_expr
+    if selected_return == "integer":
+        call_stmt = _rebuild_call_stmt(call_stmt, keep_fp_ret_expr=False)
+    else:
+        call_stmt = _rebuild_call_stmt(call_stmt, keep_ret_expr=False)
+    # Ensure folding takes its result width from the selected candidate, not the provisional inner Call.
+    assert isinstance(call_stmt.expr, Call)
+    call_stmt = _rebuild_call_stmt(call_stmt, expr=_rebuild_call_expr(call_stmt.expr, bits=32))
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            call_stmt,
+            ailment.Stmt.Return(4, [selected_expr], ins_addr=0x1001),
+        ],
+    )
+
+    result_block = _simplify_single_block(project, block, unify_variables=True)
+
+    assert not any(isinstance(stmt, ailment.Stmt.SideEffectStatement) for stmt in result_block.statements)
+    return_stmt = next(stmt for stmt in result_block.statements if isinstance(stmt, ailment.Stmt.Return))
+    assert isinstance(return_stmt.ret_exprs[0], ailment.Expr.Call)
+    assert return_stmt.ret_exprs[0].bits == selected_expr.bits
+
+
+@pytest.mark.parametrize("selected_return", ("integer", "floating_point"))
+def test_call_statement_rewriter_handles_exactly_one_return_candidate(selected_return):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    expected_dst = ret_expr if selected_return == "integer" else fp_ret_expr
+    if selected_return == "integer":
+        call_stmt = _rebuild_call_stmt(call_stmt, keep_fp_ret_expr=False)
+    else:
+        call_stmt = _rebuild_call_stmt(call_stmt, keep_ret_expr=False)
+    block = ailment.Block(0x1000, 1, statements=[call_stmt])
+    graph = _single_block_graph(block)
+    rewriter = object.__new__(CallStatementRewriter)
+    rewriter._graph = graph
+    rewriter.out_graph = None
+
+    rewriter._analyze()
+
+    rewritten = block.statements[0]
+    assert isinstance(rewritten, ailment.Stmt.Assignment)
+    assert rewritten.dst.likes(expected_dst)
+    assert isinstance(rewritten.src, ailment.Expr.Call)
+    assert rewriter.out_graph is graph
+
+
+def test_call_statement_rewriter_preserves_unresolved_dual_return():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, _, _ = _make_dual_vvar_call(project)
+    block = ailment.Block(0x1000, 1, statements=[call_stmt])
+    graph = _single_block_graph(block)
+    rewriter = object.__new__(CallStatementRewriter)
+    rewriter._graph = graph
+    rewriter.out_graph = None
+
+    rewriter._analyze()
+
+    assert block.statements[0] is call_stmt
+    assert rewriter.out_graph is None
+
+
+def test_string_obfuscation_rewriter_preserves_both_return_candidates():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    manager = ailment.Manager(arch=project.arch)
+    _, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    call_stmt = ailment.Stmt.SideEffectStatement(
+        3,
+        ailment.Expr.Call(
+            2,
+            "decode",
+            args=[ailment.Expr.Const(4, 0x2000, 64)],
+            bits=64,
+            ins_addr=0x1000,
+        ),
+        ret_expr=ret_expr,
+        fp_ret_expr=fp_ret_expr,
+        ins_addr=0x1000,
+    )
+    block = ailment.Block(0x1000, 1, statements=[call_stmt])
+    rewriter = object.__new__(StringObfType3Rewriter)
+    function = project.kb.functions.function(addr=block.addr, create=True)
+    assert function is not None
+    rewriter._func = function
+    rewriter.manager = manager
+    variable_map_of(manager)
+
+    rewritten_block = rewriter._process_block(block, b"xy")
+    rewritten_call = rewritten_block.statements[-1]
+
+    assert isinstance(rewritten_call, ailment.Stmt.SideEffectStatement)
+    assert rewritten_call.ret_expr is not None
+    assert rewritten_call.fp_ret_expr is not None
+    assert rewritten_call.ret_expr.likes(ret_expr)
+    assert rewritten_call.fp_ret_expr.likes(fp_ret_expr)
+
+
+def test_cxx_operator_scalar_rewriter_skips_unresolved_dual_return():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    manager = ailment.Manager(arch=project.arch)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    referenced = ailment.Expr.VirtualVariable(
+        5,
+        3,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["rbx"][0],
+    )
+    assert isinstance(call_stmt.expr, Call)
+    call_stmt = _rebuild_call_stmt(
+        call_stmt,
+        expr=_rebuild_call_expr(
+            call_stmt.expr,
+            args=[
+                ailment.Expr.Const(6, 0, 64),
+                ailment.Expr.UnaryOp(7, "Reference", referenced, bits=64),
+                ailment.Expr.Const(8, 0x2000, 64),
+            ],
+        ),
+    )
+    rewriter = RewriteCxxOperatorCalls(project, project.kb, manager)
+
+    assert rewriter._optimize_operator_add(call_stmt) is None
+
+    resolved_call = _rebuild_call_stmt(call_stmt, keep_fp_ret_expr=False)
+    rewritten = rewriter._optimize_operator_add(resolved_call)
+    assert isinstance(rewritten, ailment.Stmt.WeakAssignment)
+    assert rewritten.dst.likes(ret_expr)
+
+    fp_resolved_call = _rebuild_call_stmt(call_stmt, keep_ret_expr=False)
+    fp_rewritten = rewriter._optimize_operator_add(fp_resolved_call)
+    assert isinstance(fp_rewritten, ailment.Stmt.WeakAssignment)
+    assert fp_rewritten.dst.likes(fp_ret_expr)
+
+
+def test_semantic_naming_selects_only_one_return_candidate():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    dual_call, _, fp_ret_expr = _make_dual_vvar_call(project)
+    linked_var = SimRegisterVariable(project.arch.registers["rax"][0], 8)
+    result_namer = object.__new__(CallResultNaming)
+    result_namer._result_vars = {}
+    result_namer._get_function_name = lambda call: "malloc"
+    result_namer._get_linked_variable = lambda expr: linked_var
+
+    result_namer._analyze_call(dual_call)
+    assert not result_namer._result_vars
+
+    fp_only_call = _rebuild_call_stmt(dual_call, keep_ret_expr=False)
+    result_namer._analyze_call(fp_only_call)
+    assert result_namer._result_vars == {linked_var: "ptr"}
+
+    pointer_namer = object.__new__(PointerNaming)
+    pointer_namer._graph = networkx.DiGraph()
+    pointer_namer._graph.add_nodes_from(
+        [
+            ailment.Block(0x1000, 1, statements=[dual_call]),
+            ailment.Block(0x1001, 1, statements=[fp_only_call]),
+        ]
+    )
+    selected_returns = []
+    pointer_namer._analyze_call_for_pointers = lambda call, ret_expr=None: selected_returns.append(ret_expr)
+    pointer_namer._find_function_pointer_params()
+    assert selected_returns == [None, fp_ret_expr]
+
+
+def test_block_io_preserves_void_call_unknown_output():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call = ailment.Stmt.SideEffectStatement(
+        0,
+        ailment.Expr.Call(1, "callee", args=[], bits=64, ins_addr=0x1000),
+        ins_addr=0x1000,
+    )
+    src = ailment.Expr.VirtualVariable(
+        2,
+        1,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["rax"][0],
+        ins_addr=0x1001,
+    )
+    dst = ailment.Expr.VirtualVariable(
+        3,
+        2,
+        64,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers["rbx"][0],
+        ins_addr=0x1001,
+    )
+    assignment = ailment.Stmt.Assignment(4, dst, src, ins_addr=0x1001)
+    statements = [call, assignment]
+
+    io_finder = BlockIOFinder(statements, project)
+
+    assert io_finder.outputs_by_stmt[0] == {None}
+    assert not io_finder.can_swap(call, statements, 1)
+
+
+@pytest.mark.parametrize("return_mode", ("dual", "integer", "floating_point"))
+def test_return_candidates_are_definitions_for_liveness_srda_and_variable_recovery(return_mode):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    function = project.kb.functions.function(addr=0x1000, create=True)
+    assert function is not None
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    if return_mode == "integer":
+        call_stmt = _rebuild_call_stmt(call_stmt, keep_fp_ret_expr=False)
+        return_exprs = (ret_expr,)
+    elif return_mode == "floating_point":
+        call_stmt = _rebuild_call_stmt(call_stmt, keep_ret_expr=False)
+        return_exprs = (fp_ret_expr,)
+    else:
+        return_exprs = (ret_expr, fp_ret_expr)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            call_stmt,
+            ailment.Stmt.Return(4, list(return_exprs), ins_addr=0x1001),
+        ],
+    )
+    graph = _single_block_graph(block)
+
+    liveness = project.analyses.SLiveness(function, graph)
+    for return_expr in return_exprs:
+        assert return_expr.varid not in liveness.model.live_ins[(block.addr, block.idx)]
+
+    srda_model = project.analyses.SReachingDefinitions(
+        subject=function,
+        func_graph=graph,
+        func_args=set(),
+    ).model
+    srda_view = SRDAView(srda_model)
+    for return_expr in return_exprs:
+        assert (
+            srda_view.get_reg_vvar_by_stmt(
+                return_expr.reg_offset,
+                return_expr.size,
+                block.addr,
+                block.idx,
+                1,
+                ObservationPointType.OP_BEFORE,
+            )
+            == return_expr
+        )
+
+    # SRDA's statement observation keys retain their historical nested block-key shape.
+    observation = cast(Any, ("stmt", ((block.addr, block.idx), 0), ObservationPointType.OP_AFTER))
+    reg_map = srda_view.observe([observation], entry=block)[observation]
+    for return_expr in return_exprs:
+        assert reg_map[return_expr.reg_offset][return_expr.size] == return_expr.varid
+
+    variable_recovery = project.analyses.VariableRecoveryFast(
+        function,
+        func_graph=graph,
+        unify_variables=False,
+    )
+    variable_manager = variable_recovery.variable_manager[function.addr]
+    for return_expr in return_exprs:
+        assert variable_manager.find_variables_by_atom(
+            block.addr,
+            0,
+            return_expr,
+            block_idx=block.idx,
+        )
+
+
+def test_clinic_links_both_return_candidates():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    block = ailment.Block(0x1000, 1, statements=[call_stmt])
+    clinic = cast(Any, object.__new__(Clinic))
+    clinic.function = SimpleNamespace(addr=block.addr)
+    linked_exprs = []
+    clinic._link_variables_on_expr = lambda *args: linked_exprs.append(args[-1])
+    kb = SimpleNamespace(variables={block.addr: object(), "global": object()})
+
+    clinic._link_variables_on_block(block, kb)
+
+    assert call_stmt.expr in linked_exprs
+    assert ret_expr in linked_exprs
+    assert fp_ret_expr in linked_exprs
+
+
+def test_expression_narrowing_visits_and_rewrites_both_return_candidates():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    manager = ailment.Manager(arch=project.arch)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    block = ailment.Block(0x1000, 1, statements=[call_stmt])
+
+    extractor = EffectiveSizeExtractor()
+    extractor.walk_statement(call_stmt)
+    assert ret_expr.varid in extractor.vvar_effective_bits
+    assert fp_ret_expr.varid in extractor.vvar_effective_bits
+
+    narrower = ExpressionNarrower(project, None, manager, [], {}, {})
+    narrower.new_vvar_sizes = {
+        ret_expr.varid: 4,
+        fp_ret_expr.varid: 4,
+    }
+    rewritten_block = narrower.walk(block)
+    rewritten_call = rewritten_block.statements[0]
+
+    assert isinstance(rewritten_call, SideEffectStatement)
+    assert rewritten_call.ret_expr is not None
+    assert rewritten_call.fp_ret_expr is not None
+    assert rewritten_call.ret_expr.size == 4
+    assert rewritten_call.fp_ret_expr.size == 4
+
+
+def test_expression_narrowing_copies_an_fp_only_return_definition():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    manager = ailment.Manager(arch=project.arch)
+    call_stmt, _, fp_ret_expr = _make_dual_vvar_call(project)
+    call_stmt = _rebuild_call_stmt(call_stmt, keep_ret_expr=False)
+    block = ailment.Block(0x1000, 1, statements=[call_stmt])
+    narrower = ExpressionNarrower(project, None, manager, [], {}, {})
+    narrower.new_vvar_sizes = {fp_ret_expr.varid: 4}
+
+    rewritten_block = narrower.walk(block)
+    rewritten_call = rewritten_block.statements[0]
+
+    assert rewritten_call is not call_stmt
+    assert isinstance(rewritten_call, SideEffectStatement)
+    assert rewritten_call.fp_ret_expr is not None
+    assert call_stmt.fp_ret_expr is not None
+    assert rewritten_call.fp_ret_expr.size == 4
+    assert call_stmt.fp_ret_expr.likes(fp_ret_expr)
+    assert fp_ret_expr.size == 8
+
+
+def test_region_folding_and_ite_conversion_reject_unresolved_dual_return():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            call_stmt,
+            ailment.Stmt.Return(4, [ret_expr, fp_ret_expr], ins_addr=0x1001),
+        ],
+    )
+
+    expression_counter = ExpressionCounter(block)
+
+    assert ret_expr.varid not in expression_counter.assignments
+    assert fp_ret_expr.varid not in expression_counter.assignments
+    assert not ITERegionConverter._is_assigning_to_vvar(call_stmt)
+
+    fp_only_call = _rebuild_call_stmt(call_stmt, keep_ret_expr=False)
+    fp_only_counter = ExpressionCounter(ailment.Block(0x1000, 1, statements=[fp_only_call]))
+    assert fp_ret_expr.varid in fp_only_counter.assignments
+    assert ITERegionConverter._is_assigning_to_vvar(fp_only_call)
+
+
+def test_return_duplicator_freshens_both_return_definitions_and_uses():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            call_stmt,
+            ailment.Stmt.Return(4, [ret_expr, fp_ret_expr], ins_addr=0x1001),
+        ],
+    )
+    rewriter = FreshVirtualVariableRewriter(10, {})
+
+    rewritten_block = rewriter.walk(block)
+    rewritten_call, rewritten_return = rewritten_block.statements
+
+    assert isinstance(rewritten_call, SideEffectStatement)
+    assert isinstance(rewritten_call.ret_expr, ailment.Expr.VirtualVariable)
+    assert isinstance(rewritten_call.fp_ret_expr, ailment.Expr.VirtualVariable)
+    assert isinstance(rewritten_return, Return)
+    assert rewritten_call.ret_expr.varid == 10
+    assert rewritten_call.fp_ret_expr.varid == 11
+    assert [expr.varid for expr in rewritten_return.ret_exprs] == [10, 11]
+
+
+@pytest.mark.parametrize("selected_return", ("integer", "floating_point"))
+def test_codegen_assigns_exactly_one_return_candidate(selected_return):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, ret_expr, fp_ret_expr = _make_dual_vvar_call(project)
+    if selected_return == "integer":
+        call_stmt = _rebuild_call_stmt(call_stmt, keep_fp_ret_expr=False)
+        selected_expr = ret_expr
+    else:
+        call_stmt = _rebuild_call_stmt(call_stmt, keep_ret_expr=False)
+        selected_expr = fp_ret_expr
+    handled_return = object()
+
+    def handle(expr, **_kwargs):
+        return (
+            handled_return
+            if isinstance(expr, ailment.Expr.VirtualVariable) and expr.varid == selected_expr.varid
+            else expr
+        )
+
+    c_codegen, rust_codegen = _make_codegen_stubs(project, handle)
+    c_result = c_codegen._handle_Stmt_SideEffectStatement(call_stmt)
+    rust_result = rust_codegen._handle_Stmt_SideEffectStatement(call_stmt)
+
+    assert isinstance(c_result, CAssignment)
+    assert c_result.lhs is handled_return
+    assert isinstance(rust_result, RustFunctionCall)
+    assert rust_result.ret_expr is handled_return
+
+
+def test_codegen_emits_unresolved_dual_return_as_one_standalone_call():
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    call_stmt, _, _ = _make_dual_vvar_call(project)
+
+    c_codegen, rust_codegen = _make_codegen_stubs(project, lambda expr, **kwargs: expr)
+    c_result = c_codegen._handle_Stmt_SideEffectStatement(call_stmt)
+    rust_result = rust_codegen._handle_Stmt_SideEffectStatement(call_stmt)
+
+    assert isinstance(c_result, CExpressionStatement)
+    assert isinstance(c_result.expr, CFunctionCall)
+    assert c_result.expr.callee_target == "callee"
+    assert isinstance(rust_result, RustFunctionCall)
+    assert rust_result.callee_target == "callee"
+    assert rust_result.ret_expr is None

--- a/tests/analyses/reaching_definitions/test_srda_view_call_clobbers.py
+++ b/tests/analyses/reaching_definitions/test_srda_view_call_clobbers.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import networkx
+import pytest
+
+import angr
+from angr import ailment
+from angr.ailment.statement import Statement
+from angr.analyses.s_reaching_definitions.s_rda_model import SRDAModel, populate_model
+from angr.analyses.s_reaching_definitions.s_rda_view import SRDAView
+from angr.knowledge_plugins.key_definitions.constants import ObservationPointType
+from angr.utils.ssa import CALL_RESULT_FIXUP_TAG
+
+
+def _reg_vvar(project, idx, varid, reg_name, bits, ins_addr):
+    return ailment.Expr.VirtualVariable(
+        idx,
+        varid,
+        bits,
+        ailment.Expr.VirtualVariableCategory.REGISTER,
+        oident=project.arch.registers[reg_name][0],
+        ins_addr=ins_addr,
+    )
+
+
+@pytest.mark.parametrize("fold_call_into_fixup", (False, True))
+def test_call_clobbers_are_ordered_before_explicit_register_definitions(fold_call_into_fixup):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    arch = project.arch
+    rax_offset = arch.registers["rax"][0]
+    rdi_offset = arch.registers["rdi"][0]
+    rbx_offset = arch.registers["rbx"][0]
+
+    old_ax = _reg_vvar(project, 0, 1, "rax", 16, 0x1000)
+    old_rax = _reg_vvar(project, 1, 2, "rax", 64, 0x1001)
+    old_rdi = _reg_vvar(project, 2, 3, "rdi", 64, 0x1002)
+    old_rbx = _reg_vvar(project, 3, 4, "rbx", 64, 0x1003)
+    final_rax = _reg_vvar(project, 4, 6, "rax", 64, 0x1005)
+
+    statements: list[Statement] = [
+        ailment.Stmt.Assignment(10, old_ax, ailment.Expr.Const(11, 0x1234, 16), ins_addr=0x1000),
+        ailment.Stmt.Assignment(12, old_rax, ailment.Expr.Const(13, 0x12345678, 64), ins_addr=0x1001),
+        ailment.Stmt.Assignment(14, old_rdi, ailment.Expr.Const(15, 1, 64), ins_addr=0x1002),
+        ailment.Stmt.Assignment(16, old_rbx, ailment.Expr.Const(17, 2, 64), ins_addr=0x1003),
+    ]
+    call = ailment.Expr.Call(
+        18,
+        ailment.Expr.Const(19, 0x4000, 64),
+        args=[],
+        bits=32,
+        ins_addr=0x1004,
+    )
+    offset = ailment.Expr.Const(20, 0, 64)
+
+    if fold_call_into_fixup:
+        fixup_src = ailment.Expr.Insert(21, old_rax, offset, call, arch.register_endness, ins_addr=0x1004)
+        statements.append(
+            ailment.Stmt.Assignment(
+                22,
+                final_rax,
+                fixup_src,
+                **{"ins_addr": 0x1004, CALL_RESULT_FIXUP_TAG: True},
+            )
+        )
+        expected_rax_defs = {8: final_rax.varid}
+    else:
+        raw_eax = _reg_vvar(project, 5, 5, "rax", 32, 0x1004)
+        statements.extend(
+            [
+                ailment.Stmt.SideEffectStatement(21, call, ret_expr=raw_eax, ins_addr=0x1004),
+                ailment.Stmt.Assignment(
+                    22,
+                    final_rax,
+                    ailment.Expr.Insert(
+                        23,
+                        old_rax,
+                        offset,
+                        raw_eax,
+                        arch.register_endness,
+                        ins_addr=0x1005,
+                    ),
+                    **{"ins_addr": 0x1005, CALL_RESULT_FIXUP_TAG: True},
+                ),
+            ]
+        )
+        expected_rax_defs = {4: raw_eax.varid, 8: final_rax.varid}
+
+    call_block = ailment.Block(0x1000, 0x10, statements=statements)
+    successor = ailment.Block(0x1010, 1, statements=[])
+    graph = networkx.DiGraph([(call_block, successor)])
+    model = SRDAModel(graph, set(), arch, platform="Linux")
+    populate_model(model, {(block.addr, block.idx): block for block in graph}, set())
+    view = SRDAView(model)
+
+    observation = ("node", (successor.addr, successor.idx), ObservationPointType.OP_BEFORE)
+    dominance_result = view.observe([observation], entry=call_block)[observation]
+    forward_result = view.observe([observation])[observation]
+
+    assert dominance_result == forward_result
+    assert dominance_result[rax_offset] == expected_rax_defs
+    assert rdi_offset not in dominance_result
+    assert dominance_result[rbx_offset] == {8: old_rbx.varid}
+
+
+@pytest.mark.parametrize("fold_call_into_fixup", (False, True))
+def test_backward_register_queries_stop_at_wrapped_calls(fold_call_into_fixup):
+    project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+    arch = project.arch
+    rax_offset = arch.registers["rax"][0]
+    rdi_offset = arch.registers["rdi"][0]
+    rbx_offset = arch.registers["rbx"][0]
+
+    old_rax = _reg_vvar(project, 0, 1, "rax", 64, 0x1000)
+    old_rdi = _reg_vvar(project, 1, 2, "rdi", 64, 0x1001)
+    old_rbx = _reg_vvar(project, 2, 3, "rbx", 64, 0x1002)
+    call = ailment.Expr.Call(
+        3,
+        ailment.Expr.Const(4, 0x4000, 64),
+        args=[],
+        bits=32,
+        ins_addr=0x1004,
+    )
+    statements: list[Statement] = [
+        ailment.Stmt.Assignment(5, old_rax, ailment.Expr.Const(6, 1, 64), ins_addr=0x1000),
+        ailment.Stmt.Assignment(7, old_rdi, ailment.Expr.Const(8, 2, 64), ins_addr=0x1001),
+        ailment.Stmt.Assignment(9, old_rbx, ailment.Expr.Const(10, 3, 64), ins_addr=0x1002),
+    ]
+
+    if fold_call_into_fixup:
+        call_result = _reg_vvar(project, 11, 4, "rax", 64, 0x1004)
+        statements.append(
+            ailment.Stmt.Assignment(
+                12,
+                call_result,
+                ailment.Expr.Insert(
+                    13,
+                    old_rax,
+                    ailment.Expr.Const(14, 0, 64),
+                    call,
+                    arch.register_endness,
+                    ins_addr=0x1004,
+                ),
+                **{"ins_addr": 0x1004, CALL_RESULT_FIXUP_TAG: True},
+            )
+        )
+        result_min_size = 8
+    else:
+        call_result = _reg_vvar(project, 11, 4, "rax", 32, 0x1004)
+        statements.append(ailment.Stmt.Assignment(12, call_result, call, ins_addr=0x1004))
+        result_min_size = 4
+
+    block = ailment.Block(0x1000, 0x10, idx=0, statements=statements)
+    graph = networkx.DiGraph()
+    graph.add_node(block)
+    model = SRDAModel(graph, set(), arch, platform="Linux")
+    populate_model(model, {(block.addr, block.idx): block}, set())
+    view = SRDAView(model)
+    call_stmt_idx = len(statements) - 1
+
+    query_results = (
+        (
+            view.get_reg_vvar_by_stmt(
+                rax_offset,
+                result_min_size,
+                block.addr,
+                block.idx,
+                call_stmt_idx,
+                ObservationPointType.OP_AFTER,
+            ),
+            view.get_reg_vvar_by_stmt(
+                rdi_offset,
+                8,
+                block.addr,
+                block.idx,
+                call_stmt_idx,
+                ObservationPointType.OP_AFTER,
+            ),
+            view.get_reg_vvar_by_stmt(
+                rbx_offset,
+                8,
+                block.addr,
+                block.idx,
+                call_stmt_idx,
+                ObservationPointType.OP_AFTER,
+            ),
+        ),
+        (
+            view.get_reg_vvar_by_insn(
+                rax_offset,
+                result_min_size,
+                0x1004,
+                ObservationPointType.OP_AFTER,
+                block_idx=block.idx,
+            ),
+            view.get_reg_vvar_by_insn(
+                rdi_offset,
+                8,
+                0x1004,
+                ObservationPointType.OP_AFTER,
+                block_idx=block.idx,
+            ),
+            view.get_reg_vvar_by_insn(
+                rbx_offset,
+                8,
+                0x1004,
+                ObservationPointType.OP_AFTER,
+                block_idx=block.idx,
+            ),
+        ),
+    )
+
+    for result_vvar, rdi_vvar, rbx_vvar in query_results:
+        assert result_vvar is not None and result_vvar.varid == call_result.varid
+        assert rdi_vvar is None
+        assert rbx_vvar is not None and rbx_vvar.varid == old_rbx.varid
+
+    if not fold_call_into_fixup:
+        # The 32-bit result does not satisfy a 64-bit query, but the call still blocks the old 64-bit RAX definition.
+        assert (
+            view.get_reg_vvar_by_stmt(
+                rax_offset,
+                8,
+                block.addr,
+                block.idx,
+                call_stmt_idx,
+                ObservationPointType.OP_AFTER,
+            )
+            is None
+        )
+
+
+if __name__ == "__main__":
+    pytest.main(args=[__file__, "-v"])

--- a/tests/analyses/test_rust_utils.py
+++ b/tests/analyses/test_rust_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import networkx
+
 import angr
 from angr.ailment import Block
 from angr.ailment.expression import (
@@ -10,7 +12,9 @@ from angr.ailment.expression import (
     VirtualVariable,
     VirtualVariableCategory,
 )
-from angr.ailment.statement import Assignment
+from angr.ailment.statement import Assignment, Return, SideEffectStatement
+from angr.rust.mixins.cfa_mixin import CFAMixin
+from angr.rust.mixins.dfa_mixin import DFAMixin
 from angr.rust.optimization_passes.utils import (
     extract_callee,
     extract_str,
@@ -28,6 +32,7 @@ from angr.rust.utils.ail import (
     unwrap_stack_vvar_reference_with_offset,
 )
 from angr.rust.utils.demangler import _is_rust_hash, demangle, normalize
+from angr.utils.ssa import CALL_RESULT_FIXUP_TAG
 
 
 def _stack_vvar(vvar_id: int = 0, offset: int = 16) -> VirtualVariable:
@@ -142,6 +147,73 @@ def test_get_terminal_call_descends_into_assignment_with_call_rhs():
         statements=[Assignment(0, _stack_vvar(0), inner_call)],
     )
     assert get_terminal_call(block) == inner_call
+
+
+def test_get_terminal_call_skips_tagged_ssa_result_fixup():
+    inner_call = Call(2, "inner_callee", args=[])
+    call_stmt = SideEffectStatement(0, inner_call)
+    fixup = Assignment(
+        1,
+        _reg_vvar(1),
+        _const(0),
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    block = Block(0x4030, 0, statements=[call_stmt, fixup])
+
+    assert get_terminal_call(block) == inner_call
+
+
+def test_get_terminal_call_preserves_nested_call_fallback():
+    inner_call = Call(2, "inner_callee", args=[])
+    block = Block(0x4030, 0, statements=[Return(0, [inner_call])])
+
+    assert get_terminal_call(block) == inner_call
+
+
+def test_rust_mixins_treat_call_before_tagged_fixup_as_terminal():
+    inner_call = Call(2, "inner_callee", args=[])
+    call_stmt = SideEffectStatement(0, inner_call)
+    setup = Assignment(1, _reg_vvar(1), _const(1))
+    fixup = Assignment(
+        2,
+        _reg_vvar(2),
+        _const(0),
+        **{CALL_RESULT_FIXUP_TAG: True},
+    )
+    call_block = Block(0x4030, 0, statements=[setup, call_stmt, fixup])
+    predecessor_setup = Assignment(3, _reg_vvar(3), _const(2))
+    predecessor = Block(0x4020, 0, statements=[predecessor_setup])
+    graph = networkx.DiGraph([(predecessor, call_block)])
+
+    assert CFAMixin(graph, None).terminal_call(call_block) == inner_call
+    assert DFAMixin(graph)._collect_callsite_stmts(call_block) == [  # pylint: disable=protected-access
+        (setup, 0, call_block),
+        (predecessor_setup, 0, predecessor),
+    ]
+
+
+def test_rust_dfa_stops_at_predecessor_call_before_tagged_fixup():
+    target_call = Call(2, "target_callee", args=[])
+    target_setup = Assignment(1, _reg_vvar(1), _const(1))
+    target_block = Block(0x4040, 0, statements=[target_setup, SideEffectStatement(0, target_call)])
+
+    barrier_call = Call(3, "barrier_callee", args=[])
+    barrier_block = Block(
+        0x4030,
+        0,
+        statements=[
+            Assignment(2, _reg_vvar(2), _const(2)),
+            SideEffectStatement(3, barrier_call),
+            Assignment(4, _reg_vvar(3), _const(0), **{CALL_RESULT_FIXUP_TAG: True}),
+        ],
+    )
+    older_setup = Assignment(5, _reg_vvar(4), _const(3))
+    older_block = Block(0x4020, 0, statements=[older_setup])
+    graph = networkx.DiGraph([(older_block, barrier_block), (barrier_block, target_block)])
+
+    assert DFAMixin(graph)._collect_callsite_stmts(target_block) == [  # pylint: disable=protected-access
+        (target_setup, 0, target_block)
+    ]
 
 
 def test_get_terminal_call_returns_none_for_empty_block():

--- a/tests/sim/test_ail_exec.py
+++ b/tests/sim/test_ail_exec.py
@@ -22,6 +22,100 @@ from tests.common import bin_location
 test_location = os.path.join(bin_location, "tests")
 
 
+def _execute_dual_return_call(
+    *,
+    callless,
+    result=None,
+    widen_fp=False,
+    selected_return=None,
+    ret_bits=64,
+    fp_bits=64,
+):
+    """Execute one AIL call with unresolved integer and floating-point return candidates."""
+    p = angr.load_shellcode(b"\x90", arch="AMD64", load_address=0x400000)
+    options = {angr.options.CALLLESS} if callless else set()
+    state = p.factory.blank_state(add_options=options)
+    state.addr = (0x400000, None)
+
+    bottom_frame = AILCallStack()
+    top_frame = AILCallStack(func_addr=0x400000)
+    top_frame.passed_args = None
+    if result is not None:
+        top_frame.passed_rets = (result if isinstance(result, tuple) else (result,),)
+    state.register_plugin("callstack", bottom_frame)
+    state.callstack.push(top_frame)
+
+    ret_expr = ailment.expression.VirtualVariable(
+        0,
+        100,
+        ret_bits,
+        ailment.expression.VirtualVariableCategory.REGISTER,
+        oident=p.arch.registers["rax"][0],
+    )
+    fp_ret_expr = ailment.expression.VirtualVariable(
+        1,
+        101,
+        fp_bits,
+        ailment.expression.VirtualVariableCategory.REGISTER,
+        oident=p.arch.registers["xmm0"][0],
+    )
+    call_stmt = ailment.statement.SideEffectStatement(
+        0,
+        ailment.expression.Call(
+            2,
+            ailment.expression.Const(None, 0x5000, 64),
+            args=[],
+            bits=64,
+        ),
+        ret_expr=ret_expr if selected_return in (None, "integer") else None,
+        fp_ret_expr=fp_ret_expr if selected_return in (None, "floating_point") else None,
+        ins_addr=0x400000,
+    )
+    statements: list[ailment.Statement] = [call_stmt]
+    fp_final_expr = None
+    if widen_fp:
+        fp_base_expr = ailment.expression.VirtualVariable(
+            3,
+            99,
+            128,
+            ailment.expression.VirtualVariableCategory.REGISTER,
+            oident=p.arch.registers["xmm0"][0],
+        )
+        fp_final_expr = ailment.expression.VirtualVariable(
+            4,
+            102,
+            128,
+            ailment.expression.VirtualVariableCategory.REGISTER,
+            oident=p.arch.registers["xmm0"][0],
+        )
+        state.callstack.vars[fp_base_expr.varid] = claripy.BVV(0x112233445566778899AABBCCDDEEFF00, 128)
+        statements.append(
+            ailment.statement.Assignment(
+                5,
+                fp_final_expr,
+                ailment.expression.Insert(
+                    6,
+                    fp_base_expr,
+                    ailment.expression.Const(None, 0, 64),
+                    fp_ret_expr,
+                    p.arch.register_endness,
+                ),
+                ins_addr=0x400000,
+            )
+        )
+    jump_stmt = ailment.statement.Jump(
+        7,
+        ailment.expression.Const(None, 0x400004, 64),
+        ins_addr=0x400000,
+    )
+    statements.append(jump_stmt)
+    block = ailment.Block(0x400000, 0, statements=statements)
+
+    successors = SimSuccessors(state.addr, state)
+    SimEngineAILSimState(p, successors).process(state, block=block)
+    return state, successors, ret_expr, fp_ret_expr, fp_final_expr
+
+
 class TestAILExec(unittest.TestCase):
     def test_abs_expression_preserves_fp_sort(self):
         class _Engine(SimEngineAILSimState):
@@ -309,6 +403,130 @@ class TestAILExec(unittest.TestCase):
         frame = state.callstack
         assert 217 in frame.vars
         assert 217 in frame.var_refs_rev
+
+    def test_callless_dual_return_defines_distinct_integer_and_fp_stubs(self):
+        state, successors, ret_expr, fp_ret_expr, _ = _execute_dual_return_call(callless=True)
+
+        ret_value = state.callstack.vars[ret_expr.varid]
+        fp_ret_value = state.callstack.vars[fp_ret_expr.varid]
+        assert isinstance(ret_value, claripy.ast.BV)
+        assert isinstance(fp_ret_value, claripy.ast.FP)
+        assert ret_value.variables
+        assert fp_ret_value.variables
+        assert ret_value.variables.isdisjoint(fp_ret_value.variables)
+        assert any("_ret" in name for name in ret_value.variables)
+        assert any("_fp" in name for name in fp_ret_value.variables)
+        assert len(successors.successors) == 1
+        assert successors.successors[0].addr == 0x400004
+
+    def test_resumed_dual_return_routes_bv_to_integer_candidate(self):
+        result = claripy.BVV(0x12345678, 64)
+        state, successors, ret_expr, fp_ret_expr, _ = _execute_dual_return_call(callless=False, result=result)
+
+        ret_value = state.callstack.vars[ret_expr.varid]
+        fp_ret_value = state.callstack.vars[fp_ret_expr.varid]
+        assert isinstance(ret_value, claripy.ast.BV)
+        assert ret_value.concrete and ret_value.concrete_value == 0x12345678
+        assert isinstance(fp_ret_value, claripy.ast.FP)
+        assert any("unconstrained_call_result" in name for name in fp_ret_value.variables)
+        assert len(successors.successors) == 1
+        assert successors.successors[0].addr == 0x400004
+
+    def test_resumed_dual_return_routes_fp_to_fp_candidate(self):
+        result = claripy.FPV(3.5, claripy.FSORT_DOUBLE)
+        state, successors, ret_expr, fp_ret_expr, _ = _execute_dual_return_call(callless=False, result=result)
+
+        ret_value = state.callstack.vars[ret_expr.varid]
+        fp_ret_value = state.callstack.vars[fp_ret_expr.varid]
+        assert isinstance(ret_value, claripy.ast.BV)
+        assert any("unconstrained_call_result" in name for name in ret_value.variables)
+        assert isinstance(fp_ret_value, claripy.ast.FP)
+        assert fp_ret_value.sort == claripy.FSORT_DOUBLE
+        assert fp_ret_value.concrete and fp_ret_value.args[0] == 3.5
+        assert len(successors.successors) == 1
+        assert successors.successors[0].addr == 0x400004
+
+    def test_resumed_selected_fp_return_uses_fp_abi_slot(self):
+        for fp_result in (claripy.FPV(3.5, claripy.FSORT_DOUBLE), claripy.BVV(0x400C000000000000, 64)):
+            with self.subTest(result_type=type(fp_result).__name__):
+                state, successors, ret_expr, fp_ret_expr, _ = _execute_dual_return_call(
+                    callless=False,
+                    result=(claripy.BVV(0x12345678, 64), fp_result),
+                    selected_return="floating_point",
+                )
+
+                assert ret_expr.varid not in state.callstack.vars
+                assert state.callstack.vars[fp_ret_expr.varid] is fp_result
+                assert len(successors.successors) == 1
+                assert successors.successors[0].addr == 0x400004
+
+    def test_callless_extended_fp_return_preserves_raw_width(self):
+        state, successors, _, fp_ret_expr, _ = _execute_dual_return_call(callless=True, fp_bits=80)
+
+        fp_ret_value = state.callstack.vars[fp_ret_expr.varid]
+        assert isinstance(fp_ret_value, claripy.ast.BV)
+        assert len(fp_ret_value) == 80
+        assert any("_fp" in name for name in fp_ret_value.variables)
+        assert len(successors.successors) == 1
+        assert successors.successors[0].addr == 0x400004
+
+    def test_resumed_dual_return_routes_uniquely_sized_raw_fp_to_fp_candidate(self):
+        result = claripy.BVV(0x4000C000000000000000, 80)
+        state, successors, ret_expr, fp_ret_expr, _ = _execute_dual_return_call(
+            callless=False,
+            result=result,
+            fp_bits=80,
+        )
+
+        ret_value = state.callstack.vars[ret_expr.varid]
+        fp_ret_value = state.callstack.vars[fp_ret_expr.varid]
+        assert isinstance(ret_value, claripy.ast.BV)
+        assert len(ret_value) == 64
+        assert any("unconstrained_call_result" in name for name in ret_value.variables)
+        assert fp_ret_value is result
+        assert len(successors.successors) == 1
+        assert successors.successors[0].addr == 0x400004
+
+    def test_resumed_dual_return_keeps_standard_width_bv_in_integer_candidate(self):
+        result = claripy.BVV(0x123456789ABCDEF0, 64)
+        state, successors, ret_expr, fp_ret_expr, _ = _execute_dual_return_call(
+            callless=False,
+            result=result,
+            ret_bits=32,
+            fp_bits=64,
+        )
+
+        ret_value = state.callstack.vars[ret_expr.varid]
+        fp_ret_value = state.callstack.vars[fp_ret_expr.varid]
+        assert isinstance(ret_value, claripy.ast.BV)
+        assert ret_value.concrete and ret_value.concrete_value == 0x9ABCDEF0
+        assert isinstance(fp_ret_value, claripy.ast.FP)
+        assert any("unconstrained_call_result" in name for name in fp_ret_value.variables)
+        assert len(successors.successors) == 1
+        assert successors.successors[0].addr == 0x400004
+
+    def test_dual_return_widened_fp_fixup_reinterprets_result_bits(self):
+        for callless, result in (
+            (True, None),
+            (False, claripy.BVV(0x12345678, 64)),
+            (False, claripy.FPV(3.5, claripy.FSORT_DOUBLE)),
+        ):
+            with self.subTest(callless=callless, result_type=type(result).__name__):
+                state, successors, _, fp_ret_expr, fp_final_expr = _execute_dual_return_call(
+                    callless=callless,
+                    result=result,
+                    widen_fp=True,
+                )
+
+                assert fp_final_expr is not None
+                fp_ret_value = state.callstack.vars[fp_ret_expr.varid]
+                fp_final_value = state.callstack.vars[fp_final_expr.varid]
+                assert isinstance(fp_ret_value, claripy.ast.FP)
+                assert isinstance(fp_final_value, claripy.ast.BV)
+                assert state.solver.is_true(fp_final_value[63:0] == fp_ret_value.raw_to_bv())
+                assert state.solver.is_true(fp_final_value[127:64] == claripy.BVV(0x1122334455667788, 64))
+                assert len(successors.successors) == 1
+                assert successors.successors[0].addr == 0x400004
 
     def test_statement_call_unused_return_is_ignored(self):
         # Regression test for SimEngineAILSimState._handle_stmt_Call: a Call statement may have no ret_expr even if the


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Draft validation status

This PR is not ready to merge. Its published implementation fixes three observed XMM0 SSA failures, but retrospective review found semantic paths that the original validation did not cover:

- Conservative potential-argument uses for unknown calls can look like a real XMM0 result use even when no machine instruction reads the result.
- Syscalls can carry provisional integer and floating-point outputs in native AIL even though syscall returns are not selected through XMM0.
- Windows `__chkstk` and `__alloca_probe` preserve XMM state, but a provisional XMM0 definition can make a later read look like a floating-point return and prevent stack-probe cleanup.
- The implementation tracks every SSA register read across every function, so its global time and memory cost has not been bounded.

A smaller replacement exists locally, but it has the same unresolved use-provenance, syscall, and stack-probe questions. It will not replace the published branch until those cases are handled and the expanded corpus and performance gates pass.

## Original problem

On AMD64, some calls initially carry both RAX and XMM0 return candidates before a guessed prototype selects the ABI result. The published implementation preserves both candidates through SSA instead of dropping XMM0, fixing three public DecBench decompilations that previously failed with `KeyError: 224`.

Preliminary exact-head results:

| Function | Before | After |
| --- | ---: | ---: |
| coreutils `sort/default_sort_size` | `KeyError: 224` | success |
| OpenSSH `scp/refresh_progress_meter` | `KeyError: 224` | success |
| OpenSSH `sftp/refresh_progress_meter` | `KeyError: 224` | success |

The 18-function A/B and focused SSA probes establish the original failure and show that the published patch can repair it. They do not rule out the semantic and performance risks listed above.

## Required validation before ready for review

- Distinguish explicit result reads from conservative potential-argument uses.
- Exclude or prove correct behavior for syscalls, `__chkstk`, `__alloca_probe`, and other preserved-register helpers.
- Cover cross-block uses, phis, loops, overwrites, consecutive calls, both-used and neither-used results, partial-width results, and repeated SSA.
- Validate AMD64 and ARM hard-float targets plus Windows, integer, void-return, known-prototype, and no-trigger controls.
- Measure SSA wall time and peak RSS on large zero-trigger functions.
- Review every public DecBench code, structure, and type delta against source ground truth.
- Pass the complete workspace gate on the exact replacement commit and pinned dependencies.
