### PR TITLE
Typehoon: index subtype constraint components

### DIFF
--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import enum
 import logging
 from collections import defaultdict
+from collections.abc import Collection
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
@@ -709,18 +710,22 @@ class SimpleSolver:
                         constrained_typevars.add(t)
 
         constraintset2tvs = defaultdict(set)
+        endpoint_to_constraints = self._index_subtype_constraints(constraints) if constrained_typevars else {}
         tvs_seen = set()
         for idx, tv in enumerate(sorted(constrained_typevars, key=lambda x: x.idx)):
             _l.debug("Collecting constraints for type variable %r (%d/%d)", tv, idx + 1, len(constrained_typevars))
             if tv in tvs_seen:
                 continue
             # build a sub constraint set for the type variable
-            constraint_subset, related_tvs = self._generate_constraint_subset(constraints, {tv})
+            constraint_subset, related_tvs = self._generate_constraint_subset(
+                constraints, {tv}, endpoint_to_constraints=endpoint_to_constraints
+            )
             # drop all type vars outside constrained_typevars
             related_tvs = related_tvs.intersection(constrained_typevars)
             tvs_seen |= related_tvs
             frozen_constraint_subset = frozenset(constraint_subset)
             constraintset2tvs[frozen_constraint_subset] = related_tvs
+        del endpoint_to_constraints
 
         for idx, (constraint_subset, tvs) in enumerate(constraintset2tvs.items()):
             _l.debug(
@@ -1580,38 +1585,57 @@ class SimpleSolver:
     #
 
     @staticmethod
+    def _constraint_endpoint(
+        type_: TypeVariable | TypeConstant,
+    ) -> TypeVariable | TypeConstant | None:
+        """
+        Return the root used to connect subtype constraints. A derived type's root remains an endpoint even when it is
+        a type constant, while a plain type constant does not connect otherwise unrelated constraints.
+        """
+        if isinstance(type_, DerivedTypeVariable):
+            return type_.type_var
+        if isinstance(type_, TypeVariable):
+            return type_
+        return None
+
+    @staticmethod
+    def _index_subtype_constraints(
+        constraints: Collection[TypeConstraint],
+    ) -> dict[TypeVariable | TypeConstant, set[Subtype]]:
+        endpoint_to_constraints: dict[TypeVariable | TypeConstant, set[Subtype]] = defaultdict(set)
+        for constraint in constraints:
+            if not isinstance(constraint, Subtype):
+                continue
+            for type_ in (constraint.sub_type, constraint.super_type):
+                endpoint = SimpleSolver._constraint_endpoint(type_)
+                if endpoint is not None:
+                    endpoint_to_constraints[endpoint].add(constraint)
+        return endpoint_to_constraints
+
+    @staticmethod
     def _generate_constraint_subset(
-        constraints: set[TypeConstraint], typevars: set[TypeVariable]
-    ) -> tuple[set[TypeConstraint], set[TypeVariable]]:
-        subset = set()
+        constraints: Collection[TypeConstraint],
+        typevars: Collection[TypeVariable | TypeConstant],
+        *,
+        endpoint_to_constraints: dict[TypeVariable | TypeConstant, set[Subtype]] | None = None,
+    ) -> tuple[set[TypeConstraint], set[TypeVariable | TypeConstant]]:
+        if endpoint_to_constraints is None:
+            endpoint_to_constraints = SimpleSolver._index_subtype_constraints(constraints)
+
+        subset: set[TypeConstraint] = set()
         related_typevars = set(typevars)
-        while True:
-            new = set()
-            for constraint in constraints:
+        pending_typevars = list(typevars)
+        while pending_typevars:
+            typevar = pending_typevars.pop()
+            for constraint in endpoint_to_constraints.get(typevar, ()):
                 if constraint in subset:
                     continue
-                if isinstance(constraint, Subtype):
-                    if isinstance(constraint.sub_type, DerivedTypeVariable):
-                        subt = constraint.sub_type.type_var
-                    elif isinstance(constraint.sub_type, TypeVariable):
-                        subt = constraint.sub_type
-                    else:
-                        subt = None
-                    if isinstance(constraint.super_type, DerivedTypeVariable):
-                        supert = constraint.super_type.type_var
-                    elif isinstance(constraint.super_type, TypeVariable):
-                        supert = constraint.super_type
-                    else:
-                        supert = None
-                    if subt in related_typevars or supert in related_typevars:
-                        new.add(constraint)
-                        if subt is not None:
-                            related_typevars.add(subt)
-                        if supert is not None:
-                            related_typevars.add(supert)
-            if not new:
-                break
-            subset |= new
+                subset.add(constraint)
+                for type_ in (constraint.sub_type, constraint.super_type):
+                    endpoint = SimpleSolver._constraint_endpoint(type_)
+                    if endpoint is not None and endpoint not in related_typevars:
+                        related_typevars.add(endpoint)
+                        pending_typevars.append(endpoint)
         return subset, related_typevars
 
     def _generate_constraint_graph(

--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import enum
 import logging
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import Collection
 from contextlib import suppress
 from typing import TYPE_CHECKING
@@ -710,7 +710,8 @@ class SimpleSolver:
                         constrained_typevars.add(t)
 
         constraintset2tvs = defaultdict(set)
-        endpoint_to_constraints = self._index_subtype_constraints(constraints) if constrained_typevars else {}
+        # build a mapping from type variable to constraints for faster lookups during constraint subset generation
+        tv_to_constraints = self._index_subtype_constraints(constraints) if constrained_typevars else {}
         tvs_seen = set()
         for idx, tv in enumerate(sorted(constrained_typevars, key=lambda x: x.idx)):
             _l.debug("Collecting constraints for type variable %r (%d/%d)", tv, idx + 1, len(constrained_typevars))
@@ -718,14 +719,14 @@ class SimpleSolver:
                 continue
             # build a sub constraint set for the type variable
             constraint_subset, related_tvs = self._generate_constraint_subset(
-                constraints, {tv}, endpoint_to_constraints=endpoint_to_constraints
+                constraints, {tv}, tv_to_constraints=tv_to_constraints
             )
             # drop all type vars outside constrained_typevars
             related_tvs = related_tvs.intersection(constrained_typevars)
             tvs_seen |= related_tvs
             frozen_constraint_subset = frozenset(constraint_subset)
             constraintset2tvs[frozen_constraint_subset] = related_tvs
-        del endpoint_to_constraints
+        del tv_to_constraints
 
         for idx, (constraint_subset, tvs) in enumerate(constraintset2tvs.items()):
             _l.debug(
@@ -1585,57 +1586,55 @@ class SimpleSolver:
     #
 
     @staticmethod
-    def _constraint_endpoint(
-        type_: TypeVariable | TypeConstant,
-    ) -> TypeVariable | TypeConstant | None:
-        """
-        Return the root used to connect subtype constraints. A derived type's root remains an endpoint even when it is
-        a type constant, while a plain type constant does not connect otherwise unrelated constraints.
-        """
-        if isinstance(type_, DerivedTypeVariable):
-            return type_.type_var
-        if isinstance(type_, TypeVariable):
-            return type_
-        return None
-
-    @staticmethod
     def _index_subtype_constraints(
         constraints: Collection[TypeConstraint],
     ) -> dict[TypeVariable | TypeConstant, set[Subtype]]:
-        endpoint_to_constraints: dict[TypeVariable | TypeConstant, set[Subtype]] = defaultdict(set)
+        tv_to_constraints: dict[TypeVariable | TypeConstant, set[Subtype]] = defaultdict(set)
         for constraint in constraints:
             if not isinstance(constraint, Subtype):
                 continue
             for type_ in (constraint.sub_type, constraint.super_type):
-                endpoint = SimpleSolver._constraint_endpoint(type_)
-                if endpoint is not None:
-                    endpoint_to_constraints[endpoint].add(constraint)
-        return endpoint_to_constraints
+                tv = (
+                    type_.type_var
+                    if isinstance(type_, DerivedTypeVariable)
+                    else type_
+                    if isinstance(type_, TypeVariable)
+                    else None
+                )
+                if tv is not None:
+                    tv_to_constraints[tv].add(constraint)
+        return tv_to_constraints
 
     @staticmethod
     def _generate_constraint_subset(
         constraints: Collection[TypeConstraint],
         typevars: Collection[TypeVariable | TypeConstant],
         *,
-        endpoint_to_constraints: dict[TypeVariable | TypeConstant, set[Subtype]] | None = None,
+        tv_to_constraints: dict[TypeVariable | TypeConstant, set[Subtype]] | None = None,
     ) -> tuple[set[TypeConstraint], set[TypeVariable | TypeConstant]]:
-        if endpoint_to_constraints is None:
-            endpoint_to_constraints = SimpleSolver._index_subtype_constraints(constraints)
+        if tv_to_constraints is None:
+            tv_to_constraints = SimpleSolver._index_subtype_constraints(constraints)
 
         subset: set[TypeConstraint] = set()
         related_typevars = set(typevars)
-        pending_typevars = list(typevars)
+        pending_typevars = deque(typevars)
         while pending_typevars:
             typevar = pending_typevars.pop()
-            for constraint in endpoint_to_constraints.get(typevar, ()):
+            for constraint in tv_to_constraints.get(typevar, ()):
                 if constraint in subset:
                     continue
                 subset.add(constraint)
                 for type_ in (constraint.sub_type, constraint.super_type):
-                    endpoint = SimpleSolver._constraint_endpoint(type_)
-                    if endpoint is not None and endpoint not in related_typevars:
-                        related_typevars.add(endpoint)
-                        pending_typevars.append(endpoint)
+                    tv = (
+                        type_.type_var
+                        if isinstance(type_, DerivedTypeVariable)
+                        else type_
+                        if isinstance(type_, TypeVariable)
+                        else None
+                    )
+                    if tv is not None and tv not in related_typevars:
+                        related_typevars.add(tv)
+                        pending_typevars.append(tv)
         return subset, related_typevars
 
     def _generate_constraint_graph(

--- a/tests/analyses/test_typehoon_constraint_subset.py
+++ b/tests/analyses/test_typehoon_constraint_subset.py
@@ -1,0 +1,204 @@
+# pylint:disable=protected-access
+from __future__ import annotations
+
+import random
+from collections.abc import Collection, Iterator
+from unittest.mock import patch
+
+from angr.analyses.typehoon.simple_solver import SimpleSolver
+from angr.analyses.typehoon.typeconsts import Float32, Int8, Int32, TypeConstant
+from angr.analyses.typehoon.typevars import (
+    DerivedTypeVariable,
+    Existence,
+    Load,
+    Store,
+    Subtype,
+    TypeConstraint,
+    TypeVariable,
+)
+
+
+def _reference_generate_constraint_subset(
+    constraints: Collection[TypeConstraint],
+    typevars: Collection[TypeVariable | TypeConstant],
+) -> tuple[set[TypeConstraint], set[TypeVariable | TypeConstant]]:
+    """The scan-to-fixpoint implementation that the indexed traversal replaces."""
+    subset: set[TypeConstraint] = set()
+    related_typevars = set(typevars)
+    while True:
+        new: set[TypeConstraint] = set()
+        for constraint in constraints:
+            if constraint in subset or not isinstance(constraint, Subtype):
+                continue
+            if isinstance(constraint.sub_type, DerivedTypeVariable):
+                subtype = constraint.sub_type.type_var
+            elif isinstance(constraint.sub_type, TypeVariable):
+                subtype = constraint.sub_type
+            else:
+                subtype = None
+            if isinstance(constraint.super_type, DerivedTypeVariable):
+                supertype = constraint.super_type.type_var
+            elif isinstance(constraint.super_type, TypeVariable):
+                supertype = constraint.super_type
+            else:
+                supertype = None
+            if subtype in related_typevars or supertype in related_typevars:
+                new.add(constraint)
+                if subtype is not None:
+                    related_typevars.add(subtype)
+                if supertype is not None:
+                    related_typevars.add(supertype)
+        if not new:
+            break
+        subset |= new
+    return subset, related_typevars
+
+
+class _IterationCountingSet(set[TypeConstraint]):
+    def __init__(self, values: Collection[TypeConstraint]):
+        super().__init__(values)
+        self.iterations = 0
+
+    def __iter__(self) -> Iterator[TypeConstraint]:
+        self.iterations += 1
+        return super().__iter__()
+
+
+def test_constraint_subset_preserves_endpoint_semantics():
+    root = TypeVariable(name="root")
+    connected = TypeVariable(name="connected")
+    out_of_scope_bridge = TypeVariable(name="out_of_scope_bridge")
+    through_bridge = TypeVariable(name="through_bridge")
+    through_derived_constant = TypeVariable(name="through_derived_constant")
+    plain_constant_neighbor = TypeVariable(name="plain_constant_neighbor")
+    disconnected_a = TypeVariable(name="disconnected_a")
+    disconnected_b = TypeVariable(name="disconnected_b")
+
+    derived_root = Subtype(DerivedTypeVariable(root, Load()), connected)
+    bridge_in = Subtype(connected, out_of_scope_bridge)
+    bridge_out = Subtype(DerivedTypeVariable(out_of_scope_bridge, Store()), through_bridge)
+    derived_constant_in = Subtype(through_bridge, DerivedTypeVariable(Int32(), Load()))
+    derived_constant_out = Subtype(DerivedTypeVariable(Int32(), Store()), through_derived_constant)
+    plain_constant_in = Subtype(through_derived_constant, Float32())
+    plain_constant_out = Subtype(Float32(), plain_constant_neighbor)
+    constant_only = Subtype(Int8(), Float32())
+    ignored_non_subtype = Existence(DerivedTypeVariable(root, Store()))
+    disconnected = Subtype(disconnected_a, disconnected_b)
+    constraints: set[TypeConstraint] = {
+        derived_root,
+        bridge_in,
+        bridge_out,
+        derived_constant_in,
+        derived_constant_out,
+        plain_constant_in,
+        plain_constant_out,
+        constant_only,
+        ignored_non_subtype,
+        disconnected,
+    }
+
+    index = SimpleSolver._index_subtype_constraints(constraints)
+    subset, related = SimpleSolver._generate_constraint_subset(constraints, {root}, endpoint_to_constraints=index)
+
+    assert subset == {
+        derived_root,
+        bridge_in,
+        bridge_out,
+        derived_constant_in,
+        derived_constant_out,
+        plain_constant_in,
+    }
+    assert related == {
+        root,
+        connected,
+        out_of_scope_bridge,
+        through_bridge,
+        Int32(),
+        through_derived_constant,
+    }
+    assert plain_constant_neighbor not in related
+    assert disconnected_a not in related
+
+
+def test_constraint_subset_matches_reference_on_randomized_graphs():
+    rng = random.Random(0x5EED)
+
+    for trial in range(200):
+        typevars = [TypeVariable(idx=(trial, idx)) for idx in range(12)]
+        constants: list[TypeConstant] = [Int8(), Int32(), Float32()]
+        endpoints: list[TypeVariable | TypeConstant] = [*typevars, *constants]
+        endpoints += [
+            DerivedTypeVariable(typevar, Load() if idx % 2 == 0 else Store())
+            for idx, typevar in enumerate([*typevars, *constants])
+        ]
+
+        constraints: set[TypeConstraint] = {Subtype(rng.choice(endpoints), rng.choice(endpoints)) for _ in range(48)}
+        constraints.update(Existence(rng.choice(endpoints)) for _ in range(8))
+        seeds = set(rng.sample(typevars, rng.randint(1, 4)))
+
+        expected = _reference_generate_constraint_subset(constraints, seeds)
+        index = SimpleSolver._index_subtype_constraints(constraints)
+        indexed = SimpleSolver._generate_constraint_subset(constraints, seeds, endpoint_to_constraints=index)
+        on_demand = SimpleSolver._generate_constraint_subset(constraints, seeds)
+
+        assert indexed == expected
+        assert on_demand == expected
+
+
+def test_constraint_subset_unions_disconnected_seeds_and_preserves_orphans():
+    left_a = TypeVariable(name="left_a")
+    left_b = TypeVariable(name="left_b")
+    right_a = TypeVariable(name="right_a")
+    right_b = TypeVariable(name="right_b")
+    orphan = TypeVariable(name="orphan")
+    left = Subtype(left_a, left_b)
+    right = Subtype(right_a, right_b)
+    constraints: set[TypeConstraint] = {left, right}
+
+    subset, related = SimpleSolver._generate_constraint_subset(constraints, {left_a, right_a, orphan})
+
+    assert subset == constraints
+    assert related == {left_a, left_b, right_a, right_b, orphan}
+
+
+def test_constraint_index_is_reused_across_many_components():
+    typevars = [TypeVariable(idx=(0x400000, idx)) for idx in range(1024)]
+    constraints = _IterationCountingSet(
+        [Subtype(typevars[idx], typevars[idx + 1]) for idx in range(0, len(typevars), 2)]
+    )
+
+    index = SimpleSolver._index_subtype_constraints(constraints)
+    assert constraints.iterations == 1
+
+    for idx in range(0, len(typevars), 2):
+        subset, related = SimpleSolver._generate_constraint_subset(
+            constraints, {typevars[idx]}, endpoint_to_constraints=index
+        )
+        assert subset == {Subtype(typevars[idx], typevars[idx + 1])}
+        assert related == {typevars[idx], typevars[idx + 1]}
+
+    assert constraints.iterations == 1
+
+
+def test_simple_solver_builds_one_constraint_index_per_solve():
+    function_typevar = TypeVariable(name="function")
+    lower = TypeVariable(name="lower")
+    upper = TypeVariable(name="upper")
+    constraints = {function_typevar: {Subtype(lower, upper), Subtype(upper, Int32())}}
+    typevars = {function_typevar: {lower, upper}}
+
+    original_indexer = SimpleSolver._index_subtype_constraints
+    with patch.object(SimpleSolver, "_index_subtype_constraints", wraps=original_indexer) as indexer:
+        solver = SimpleSolver(64, constraints, typevars)
+
+    assert indexer.call_count == 1
+    assert solver.eqclass_constraints_count == [2]
+    assert solver.solution[lower] == Int32()
+    assert solver.solution[upper] == Int32()
+
+    unconstrained_function = TypeVariable(name="unconstrained_function")
+    unconstrained = TypeVariable(name="unconstrained")
+    with patch.object(SimpleSolver, "_index_subtype_constraints", wraps=original_indexer) as indexer:
+        SimpleSolver(64, {unconstrained_function: set()}, {unconstrained_function: {unconstrained}})
+
+    assert indexer.call_count == 0

--- a/tests/analyses/test_typehoon_constraint_subset.py
+++ b/tests/analyses/test_typehoon_constraint_subset.py
@@ -64,7 +64,7 @@ class _IterationCountingSet(set[TypeConstraint]):
         return super().__iter__()
 
 
-def test_constraint_subset_preserves_endpoint_semantics():
+def test_constraint_subset_preserves_tv_semantics():
     root = TypeVariable(name="root")
     connected = TypeVariable(name="connected")
     out_of_scope_bridge = TypeVariable(name="out_of_scope_bridge")
@@ -98,7 +98,7 @@ def test_constraint_subset_preserves_endpoint_semantics():
     }
 
     index = SimpleSolver._index_subtype_constraints(constraints)
-    subset, related = SimpleSolver._generate_constraint_subset(constraints, {root}, endpoint_to_constraints=index)
+    subset, related = SimpleSolver._generate_constraint_subset(constraints, {root}, tv_to_constraints=index)
 
     assert subset == {
         derived_root,
@@ -138,7 +138,7 @@ def test_constraint_subset_matches_reference_on_randomized_graphs():
 
         expected = _reference_generate_constraint_subset(constraints, seeds)
         index = SimpleSolver._index_subtype_constraints(constraints)
-        indexed = SimpleSolver._generate_constraint_subset(constraints, seeds, endpoint_to_constraints=index)
+        indexed = SimpleSolver._generate_constraint_subset(constraints, seeds, tv_to_constraints=index)
         on_demand = SimpleSolver._generate_constraint_subset(constraints, seeds)
 
         assert indexed == expected
@@ -172,7 +172,7 @@ def test_constraint_index_is_reused_across_many_components():
 
     for idx in range(0, len(typevars), 2):
         subset, related = SimpleSolver._generate_constraint_subset(
-            constraints, {typevars[idx]}, endpoint_to_constraints=index
+            constraints, {typevars[idx]}, tv_to_constraints=index
         )
         assert subset == {Subtype(typevars[idx], typevars[idx + 1])}
         assert related == {typevars[idx], typevars[idx + 1]}


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

Build one subtype-endpoint index per `SimpleSolver.solve()` and traverse connected constraint components through that index. This replaces repeated full-set scans for every disconnected type-variable component.

On public DecBench bzip2, this reduces median decompilation time by 26.8% for `BZ2_compressBlock` and 10.1% for `BZ2_decompress`, with identical generated code, C structure, inferred types, and Typehoon solutions.

## Root cause

`_generate_constraint_subset()` previously found each connected subtype component by repeatedly scanning the complete constraint set to a fixpoint. Large optimized functions can contain thousands of mostly disconnected components, so the same set was traversed thousands of times.

For bzip2 O2 `BZ2_compressBlock`, the solver made 2,579 subset queries. The old implementation spent 5.567s in those repeated scans alone.

## Fix

- Build a solve-local endpoint-to-`Subtype` adjacency index once, after equivalence rewriting.
- Traverse each connected component from its pending type-variable endpoints.
- Preserve the old endpoint semantics for derived type variables, derived type constants, plain constants, out-of-scope bridges, multiple seeds, orphan seeds, and non-`Subtype` constraints.
- Drop the index before the remaining solve phases, so it cannot become stale or retain constraint state.

The implementation is based only on the constraint graph and contains no function-, binary-, architecture-, or dataset-specific cases.

## Public DecBench results

Pinned baseline: `91cc026062142cf8dbbbefbb6c5aacd7f09f54f7`
Validated patch: `05316094879d2cd7c72771e8f67b6306d6312c99`

Each timing is the median of three uncontended, interleaved baseline/patch runs with a 300-second per-function ceiling.

| Function | Before | After | Change |
| --- | ---: | ---: | ---: |
| bzip2 O2 `BZ2_compressBlock` | 21.568s (21.338–21.999s) | 15.779s (15.739–15.835s) | 26.8% faster |
| bzip2 O2 `BZ2_decompress` | 15.893s (15.758–16.286s) | 14.296s (14.074–14.447s) | 10.1% faster |

- Full bzip2 sweep: 281/281 successful before and after; zero failures and zero timeouts.
- Semantic comparison: all generated-code, C-structure, Typehoon-solution, and final-type hashes matched.
- Component comparison: all 4,090/4,090 returned constraint components matched exactly, including order and returned fields.
- `BZ2_compressBlock` subset work: 5.567s of repeated scans before versus 0.00355s to build one index plus 0.00367s for all indexed traversals after, about 771 times less time in component collection.
- Peak RSS remained effectively flat: approximately 385 MiB for compression and 349 MiB for decompression.
- Multiarchitecture controls: 12/12 exact A/B pairs across AMD64, ARM Cortex-M, and X86 preserved code, C AST, structure, AIL topology, raw-block serialization, inferred types, and final Typehoon solutions. Three second-seed spot pairs, one per architecture, were also exact.
- Sealed comparison: 7,421/7,421 checks passed. Exact isolated revisions were used; all source trees were clean, and dataset manifests, binaries, runtime databases, native libraries, and shared environments were unchanged before and after both the bzip2 sweep and control runs.

One raw AIL block serialization hash varied across repeated runs of each commit. The same two values occur on both baseline and patch, while block topology, generated code, C structure, Typehoon solutions, and final types remain identical; the sealed evidence records this pre-existing serialization nondeterminism separately.

## Validation

- New constraint-subset regressions: 5 passed under five hash seeds.
- Typehoon suites: 39 tests and 16 subtests passed under two hash seeds.
- Randomized differential check: 2,000 generated constraint graphs matched the reference scan implementation exactly.
- Complete exact-head workspace gate: passed.
  - angr Python: 2,256 passed, 210 subtests passed, 46 skipped, 2 expected failures.
  - angr Rust: 30 passed.
  - angr-management GUI: 500 passed.
  - archinfo, pypcode, pyvex, cle, claripy, and workspace validation all passed.
- Formatting, changed-test lint, dependency checks, and `git diff --check` passed.
- Final adversarial review found no endpoint-semantic change, stale-index lifetime, or untested disconnected-component behavior.
