### PR TITLE
Decompiler: recognize convergent conditional exits

### DIFF
--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -26,6 +26,7 @@ from .structurer_nodes import (
     ConditionNode,
     ContinueNode,
     EmptyBlockNotice,
+    IncompleteSwitchCaseHeadStatement,
     IncompleteSwitchCaseNode,
     LoopNode,
     MultiNode,
@@ -754,6 +755,38 @@ class ConditionProcessor:
 
     EXC_COUNTER = 1000
 
+    @staticmethod
+    def _is_unconditional_hcl_edge(src_block: ailment.Block, dst_block) -> bool:
+        """
+        Check whether every way out of a head-controlled-loop block reaches ``dst_block``.
+        """
+        terminal_stmt = src_block.statements[-1]
+        dst_is_block = isinstance(dst_block, ailment.Block)
+        if (
+            not isinstance(terminal_stmt, ailment.Stmt.Jump)
+            or not isinstance(terminal_stmt.target, ailment.Expr.Const)
+            or terminal_stmt.target.value != dst_block.addr
+            or (dst_is_block and terminal_stmt.target_idx != dst_block.idx)
+        ):
+            return False
+
+        for stmt in src_block.statements[:-1]:
+            if isinstance(stmt, (ailment.Stmt.Jump, ailment.Stmt.Return, IncompleteSwitchCaseHeadStatement)):
+                return False
+            if not isinstance(stmt, ailment.Stmt.ConditionalJump):
+                continue
+            for target, target_idx in (
+                (stmt.true_target, stmt.true_target_idx),
+                (stmt.false_target, stmt.false_target_idx),
+            ):
+                if target is not None and (
+                    not isinstance(target, ailment.Expr.Const)
+                    or target.value != dst_block.addr
+                    or (dst_is_block and target_idx != dst_block.idx)
+                ):
+                    return False
+        return True
+
     def _extract_predicate(self, src_block, dst_block, edge_type) -> claripy.ast.Bool:
         if edge_type == "exception":
             # TODO: THIS IS ABSOLUTELY A HACK. AT THIS MOMENT YOU SHOULD NOT ATTEMPT TO MAKE SENSE OF EXCEPTION EDGES.
@@ -783,6 +816,8 @@ class ConditionProcessor:
 
         # sometimes the last statement is the conditional jump. sometimes it's the first statement of the block
         if isinstance(src_block, ailment.Block) and src_block.statements and is_head_controlled_loop_block(src_block):
+            if self._is_unconditional_hcl_edge(src_block, dst_block):
+                return claripy.true()
             last_stmt = next(
                 iter(stmt for stmt in src_block.statements[:-1] if isinstance(stmt, ailment.Stmt.ConditionalJump)), None
             )

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -761,12 +761,12 @@ class ConditionProcessor:
         Check whether every way out of a head-controlled-loop block reaches ``dst_block``.
         """
         terminal_stmt = src_block.statements[-1]
-        dst_is_block = isinstance(dst_block, ailment.Block)
+        dst_is_indexed = isinstance(dst_block, (ailment.Block, MultiNode))
         if (
             not isinstance(terminal_stmt, ailment.Stmt.Jump)
             or not isinstance(terminal_stmt.target, ailment.Expr.Const)
             or terminal_stmt.target.value != dst_block.addr
-            or (dst_is_block and terminal_stmt.target_idx != dst_block.idx)
+            or (dst_is_indexed and terminal_stmt.target_idx != dst_block.idx)
         ):
             return False
 
@@ -782,7 +782,7 @@ class ConditionProcessor:
                 if target is not None and (
                     not isinstance(target, ailment.Expr.Const)
                     or target.value != dst_block.addr
-                    or (dst_is_block and target_idx != dst_block.idx)
+                    or (dst_is_indexed and target_idx != dst_block.idx)
                 ):
                     return False
         return True

--- a/tests/analyses/decompiler/test_condition_processor.py
+++ b/tests/analyses/decompiler/test_condition_processor.py
@@ -1,10 +1,157 @@
 from __future__ import annotations
 
 import archinfo
+import claripy
+import networkx
+import pytest
 
-from angr import ailment
+from angr import ailment, load_shellcode
 from angr.ailment.expression import Const, Extract, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import ConditionalJump, Jump
 from angr.analyses.decompiler.condition_processor import ConditionProcessor
+from angr.analyses.decompiler.decompiler import Decompiler
+
+
+def _recover_edge_condition_with_internal_side_exits(
+    side_exits: tuple[int | None, ...],
+    *,
+    side_exit_target_indices: tuple[int | None, ...] | None = None,
+    terminal_target: int | None = 0x5000,
+    terminal_target_idx: int | None = None,
+    dst_idx: int | None = None,
+    internal_jump_target: int | None = None,
+) -> claripy.ast.Bool:
+    arch = archinfo.ArchAMD64()
+    manager = ailment.Manager(arch=arch)
+    condition_processor = ConditionProcessor(arch, manager)
+    src_addr = 0x4000
+    dst_addr = 0x5000
+    side_exit_target_indices = side_exit_target_indices or (None,) * len(side_exits)
+    assert len(side_exit_target_indices) == len(side_exits)
+
+    statements = []
+    for side_exit, side_exit_target_idx in zip(side_exits, side_exit_target_indices, strict=True):
+        condition = VirtualVariable(
+            manager.next_atom(),
+            1,
+            1,
+            VirtualVariableCategory.REGISTER,
+            oident=arch.registers["rax"][0],
+        )
+        side_exit_target = (
+            Const(manager.next_atom(), side_exit, arch.bits)
+            if side_exit is not None
+            else VirtualVariable(
+                manager.next_atom(),
+                arch.bits,
+                2,
+                VirtualVariableCategory.REGISTER,
+                oident=arch.registers["rbx"][0],
+            )
+        )
+        statements.append(
+            ConditionalJump(
+                manager.next_atom(),
+                condition,
+                side_exit_target,
+                None,
+                true_target_idx=side_exit_target_idx,
+                ins_addr=src_addr,
+            )
+        )
+
+    if internal_jump_target is not None:
+        statements.append(
+            Jump(
+                manager.next_atom(),
+                Const(manager.next_atom(), internal_jump_target, arch.bits),
+                ins_addr=src_addr + 1,
+            )
+        )
+
+    direct_target = (
+        Const(manager.next_atom(), terminal_target, arch.bits)
+        if terminal_target is not None
+        else VirtualVariable(
+            manager.next_atom(),
+            arch.bits,
+            3,
+            VirtualVariableCategory.REGISTER,
+            oident=arch.registers["rcx"][0],
+        )
+    )
+    statements.append(
+        Jump(
+            manager.next_atom(),
+            direct_target,
+            target_idx=terminal_target_idx,
+            ins_addr=src_addr + 1,
+        )
+    )
+    src = ailment.Block(
+        src_addr,
+        4,
+        statements=statements,
+    )
+    dst = ailment.Block(dst_addr, 4, idx=dst_idx)
+    graph = networkx.DiGraph([(src, dst)])
+
+    return condition_processor.recover_edge_condition(graph, src, dst)
+
+
+def test_internal_side_exit_and_terminal_jump_converge():
+    predicate = _recover_edge_condition_with_internal_side_exits(
+        (0x5000, 0x5000),
+        side_exit_target_indices=(1, 1),
+        terminal_target_idx=1,
+        dst_idx=1,
+    )
+
+    assert claripy.is_true(predicate)
+
+
+def test_internal_side_exit_differs_from_terminal_jump():
+    predicate = _recover_edge_condition_with_internal_side_exits((0x6000,))
+
+    assert predicate.symbolic
+    assert predicate.op == "Not"
+
+
+def test_second_internal_side_exit_differs_from_terminal_jump():
+    predicate = _recover_edge_condition_with_internal_side_exits((0x5000, 0x6000))
+
+    assert predicate.symbolic
+
+
+@pytest.mark.parametrize(
+    ("side_exits", "terminal_target"),
+    [
+        pytest.param((None,), 0x5000, id="indirect-side-exit"),
+        pytest.param((0x5000,), 0x6000, id="different-terminal-target"),
+        pytest.param((0x5000,), None, id="indirect-terminal-target"),
+    ],
+)
+def test_convergence_requires_direct_matching_targets(side_exits, terminal_target):
+    predicate = _recover_edge_condition_with_internal_side_exits(side_exits, terminal_target=terminal_target)
+
+    assert predicate.symbolic
+
+
+def test_convergence_requires_matching_target_indices():
+    predicate = _recover_edge_condition_with_internal_side_exits(
+        (0x5000,),
+        side_exit_target_indices=(2,),
+        terminal_target_idx=1,
+        dst_idx=1,
+    )
+
+    assert predicate.symbolic
+
+
+def test_convergence_rejects_internal_jump():
+    predicate = _recover_edge_condition_with_internal_side_exits((0x5000,), internal_jump_target=0x6000)
+
+    assert predicate.symbolic
 
 
 def test_extract_placeholders_include_semantic_properties():
@@ -27,3 +174,59 @@ def test_extract_placeholders_include_semantic_properties():
     assert condition_processor.convert_claripy_bool_ast(byte_ast) is extract_byte
     assert condition_processor.convert_claripy_bool_ast(word_ast) is extract_word
     assert condition_processor.convert_claripy_bool_ast(byte_be_ast) is extract_byte_be
+
+
+# Exact 134-byte _crt0_entry bodies from the public DecBench ChibiOS binaries. Only PC-relative call offsets differ.
+@pytest.mark.parametrize(
+    ("optimization", "code"),
+    [
+        pytest.param(
+            "O0",
+            bytes.fromhex(
+                "72b6264880f30888254880f30988254825490860022080f31488bff36f8f00f0d5f901f001fd4ff0553020491b4a"
+                "91423cbf41f8040bfae71d49194a91423cbf41f8040bfae71b491b4a1c4b9a423ebf51f8040b42f8040bf8e70020"
+                "1849194a91423cbf41f8040bfae700f0bff900f0b3f9154c154dac4203da54f8041b8847f9e70ff0c7f9"
+            ),
+            id="O0",
+        ),
+        pytest.param(
+            "O2",
+            bytes.fromhex(
+                "72b6264880f30888254880f30988254825490860022080f31488bff36f8f00f0d5f900f0c7fe4ff0553020491b4a"
+                "91423cbf41f8040bfae71d49194a91423cbf41f8040bfae71b491b4a1c4b9a423ebf51f8040b42f8040bf8e70020"
+                "1849194a91423cbf41f8040bfae700f0b5f900f0aff9154c154dac4203da54f8041b8847f9e709f0a9fb"
+            ),
+            id="O2",
+        ),
+        pytest.param(
+            "O2-noinline",
+            bytes.fromhex(
+                "72b6264880f30888254880f30988254825490860022080f31488bff36f8f00f0d5f900f05bff4ff0553020491b4a"
+                "91423cbf41f8040bfae71d49194a91423cbf41f8040bfae71b491b4a1c4b9a423ebf51f8040b42f8040bf8e70020"
+                "1849194a91423cbf41f8040bfae700f0b5f900f0aff9154c154dac4203da54f8041b8847f9e709f08ffb"
+            ),
+            id="O2-noinline",
+        ),
+    ],
+)
+def test_chibios_crt0_entry_convergent_side_exits(optimization, code):
+    project = load_shellcode(code, arch="ARMCortexM", load_address=0x80001E0)
+    cfg = project.analyses.CFGFast(
+        normalize=True,
+        regions=[(0x80001E0, 0x8000266)],
+        function_starts=[0x80001E1],
+        start_at_entry=False,
+        symbols=False,
+        force_smart_scan=False,
+        show_progressbar=False,
+    )
+    function = cfg.kb.functions.get_by_addr(0x80001E1)
+
+    decompilation = project.analyses[Decompiler].prep(fail_fast=True)(
+        function,
+        cfg=cfg.model,
+        use_cache=False,
+    )
+
+    assert decompilation.codegen is not None, optimization
+    assert not decompilation.errors, optimization

--- a/tests/analyses/decompiler/test_condition_processor.py
+++ b/tests/analyses/decompiler/test_condition_processor.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import archinfo
 import claripy
 import networkx
@@ -7,30 +9,37 @@ import pytest
 
 from angr import ailment, load_shellcode
 from angr.ailment.expression import Const, Extract, VirtualVariable, VirtualVariableCategory
-from angr.ailment.statement import ConditionalJump, Jump
+from angr.ailment.statement import ConditionalJump, Jump, Return
 from angr.analyses.decompiler.condition_processor import ConditionProcessor
 from angr.analyses.decompiler.decompiler import Decompiler
+from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
 
 
 def _recover_edge_condition_with_internal_side_exits(
     side_exits: tuple[int | None, ...],
     *,
+    false_side_exits: tuple[int | None, ...] | None = None,
     side_exit_target_indices: tuple[int | None, ...] | None = None,
     terminal_target: int | None = 0x5000,
     terminal_target_idx: int | None = None,
     dst_idx: int | None = None,
     internal_jump_target: int | None = None,
+    internal_control: Literal["return", "switch"] | None = None,
 ) -> claripy.ast.Bool:
     arch = archinfo.ArchAMD64()
     manager = ailment.Manager(arch=arch)
     condition_processor = ConditionProcessor(arch, manager)
     src_addr = 0x4000
     dst_addr = 0x5000
+    false_side_exits = false_side_exits if false_side_exits is not None else (None,) * len(side_exits)
     side_exit_target_indices = side_exit_target_indices or (None,) * len(side_exits)
+    assert len(false_side_exits) == len(side_exits)
     assert len(side_exit_target_indices) == len(side_exits)
 
     statements = []
-    for side_exit, side_exit_target_idx in zip(side_exits, side_exit_target_indices, strict=True):
+    for side_exit, false_side_exit, side_exit_target_idx in zip(
+        side_exits, false_side_exits, side_exit_target_indices, strict=True
+    ):
         condition = VirtualVariable(
             manager.next_atom(),
             1,
@@ -49,12 +58,15 @@ def _recover_edge_condition_with_internal_side_exits(
                 oident=arch.registers["rbx"][0],
             )
         )
+        false_side_exit_target = (
+            Const(manager.next_atom(), false_side_exit, arch.bits) if false_side_exit is not None else None
+        )
         statements.append(
             ConditionalJump(
                 manager.next_atom(),
                 condition,
                 side_exit_target,
-                None,
+                false_side_exit_target,
                 true_target_idx=side_exit_target_idx,
                 ins_addr=src_addr,
             )
@@ -65,6 +77,20 @@ def _recover_edge_condition_with_internal_side_exits(
             Jump(
                 manager.next_atom(),
                 Const(manager.next_atom(), internal_jump_target, arch.bits),
+                ins_addr=src_addr + 1,
+            )
+        )
+
+    if internal_control == "return":
+        statements.append(Return(manager.next_atom(), [], ins_addr=src_addr + 1))
+    elif internal_control == "switch":
+        case_block = ailment.Block(0x6000, 4)
+        switch_expr = Const(manager.next_atom(), 0, arch.bits)
+        statements.append(
+            IncompleteSwitchCaseHeadStatement(
+                manager.next_atom(),
+                switch_expr,
+                [(case_block, 0, case_block.addr, case_block.idx, 0x6004)],
                 ins_addr=src_addr + 1,
             )
         )
@@ -150,6 +176,36 @@ def test_convergence_requires_matching_target_indices():
 
 def test_convergence_rejects_internal_jump():
     predicate = _recover_edge_condition_with_internal_side_exits((0x5000,), internal_jump_target=0x6000)
+
+    assert predicate.symbolic
+
+
+@pytest.mark.parametrize("internal_control", ["return", "switch"])
+def test_convergence_rejects_internal_control(internal_control):
+    predicate = _recover_edge_condition_with_internal_side_exits((0x5000,), internal_control=internal_control)
+
+    assert predicate.symbolic
+
+
+def test_explicit_false_side_exit_converges():
+    predicate = _recover_edge_condition_with_internal_side_exits((0x5000,), false_side_exits=(0x5000,))
+
+    assert claripy.is_true(predicate)
+
+
+def test_explicit_false_side_exit_differs():
+    predicate = _recover_edge_condition_with_internal_side_exits((0x5000,), false_side_exits=(0x6000,))
+
+    assert predicate.symbolic
+
+
+def test_convergence_requires_matching_terminal_target_idx():
+    predicate = _recover_edge_condition_with_internal_side_exits(
+        (0x5000,),
+        side_exit_target_indices=(1,),
+        terminal_target_idx=2,
+        dst_idx=1,
+    )
 
     assert predicate.symbolic
 

--- a/tests/analyses/decompiler/test_condition_processor.py
+++ b/tests/analyses/decompiler/test_condition_processor.py
@@ -250,6 +250,7 @@ def test_extract_placeholders_include_semantic_properties():
 
 
 # Exact 134-byte _crt0_entry bodies from the public DecBench ChibiOS binaries. Only PC-relative call offsets differ.
+@pytest.mark.parametrize("structurer", ["sailr", "phoenix"])
 @pytest.mark.parametrize(
     ("optimization", "code"),
     [
@@ -282,7 +283,7 @@ def test_extract_placeholders_include_semantic_properties():
         ),
     ],
 )
-def test_chibios_crt0_entry_convergent_side_exits(optimization, code):
+def test_chibios_crt0_entry_convergent_side_exits(structurer, optimization, code):
     project = load_shellcode(code, arch="ARMCortexM", load_address=0x80001E0)
     cfg = project.analyses.CFGFast(
         normalize=True,
@@ -298,6 +299,8 @@ def test_chibios_crt0_entry_convergent_side_exits(optimization, code):
     decompilation = project.analyses[Decompiler].prep(fail_fast=True)(
         function,
         cfg=cfg.model,
+        options=[("structurer_cls", structurer)],
+        preset="full",
         use_cache=False,
     )
 

--- a/tests/analyses/decompiler/test_condition_processor.py
+++ b/tests/analyses/decompiler/test_condition_processor.py
@@ -12,7 +12,7 @@ from angr.ailment.expression import Const, Extract, VirtualVariable, VirtualVari
 from angr.ailment.statement import ConditionalJump, Jump, Return
 from angr.analyses.decompiler.condition_processor import ConditionProcessor
 from angr.analyses.decompiler.decompiler import Decompiler
-from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
+from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement, MultiNode
 
 
 def _recover_edge_condition_with_internal_side_exits(
@@ -25,6 +25,7 @@ def _recover_edge_condition_with_internal_side_exits(
     dst_idx: int | None = None,
     internal_jump_target: int | None = None,
     internal_control: Literal["return", "switch"] | None = None,
+    wrap_destination: bool = False,
 ) -> claripy.ast.Bool:
     arch = archinfo.ArchAMD64()
     manager = ailment.Manager(arch=arch)
@@ -120,17 +121,21 @@ def _recover_edge_condition_with_internal_side_exits(
         statements=statements,
     )
     dst = ailment.Block(dst_addr, 4, idx=dst_idx)
+    if wrap_destination:
+        dst = MultiNode([dst])
     graph = networkx.DiGraph([(src, dst)])
 
     return condition_processor.recover_edge_condition(graph, src, dst)
 
 
-def test_internal_side_exit_and_terminal_jump_converge():
+@pytest.mark.parametrize("wrap_destination", [False, True], ids=["block", "multinode"])
+def test_internal_side_exit_and_terminal_jump_converge(wrap_destination: bool):
     predicate = _recover_edge_condition_with_internal_side_exits(
         (0x5000, 0x5000),
         side_exit_target_indices=(1, 1),
         terminal_target_idx=1,
         dst_idx=1,
+        wrap_destination=wrap_destination,
     )
 
     assert claripy.is_true(predicate)
@@ -205,6 +210,18 @@ def test_convergence_requires_matching_terminal_target_idx():
         side_exit_target_indices=(1,),
         terminal_target_idx=2,
         dst_idx=1,
+    )
+
+    assert predicate.symbolic
+
+
+def test_convergence_requires_matching_multinode_target_idx():
+    predicate = _recover_edge_condition_with_internal_side_exits(
+        (0x5000,),
+        side_exit_target_indices=(1,),
+        terminal_target_idx=1,
+        dst_idx=2,
+        wrap_destination=True,
     )
 
     assert predicate.symbolic


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling the `_crt0_entry` prefix at `0x080001e1` in [`tests/armel/chibios_crt0_entry/O0.bin`](https://github.com/angr/binaries/blob/099277e5f1ee5af651b7e1b659032f7a319eff4f/tests/armel/chibios_crt0_entry/O0.bin) aborts in both SAILR and Phoenix instead of producing C:

```text
TypeError: Unexpected last_src_stmt type <class 'angr.rustylib.ailment.Statement'>
```

The same failure affects all three committed ChibiOS optimization variants.

### Root cause

ARM conditional execution can leave an AIL block with internal `ConditionalJump` statements followed by a direct `Jump`. `ConditionProcessor` used the first internal conditional as the graph-edge predicate even when every path in that block converged on the terminal jump's destination, so structuring later received an edge condition that did not describe the edge.

### Fix

Treat the edge as unconditional only when the terminal direct jump and every internal conditional target have the same destination and block index. Indirect or divergent targets retain the existing predicate. The reproducer now completes and emits the converged call sequence:

```c
if (!((0 ? v8 : 1) & 1))
    goto LABEL_8000203;
134219181();
LABEL_8000203:
134224905();
```

### Testing

The regression loads each compiler-produced fixture from `angr/binaries` through CLE's Blob backend and asserts successful decompilation with both structurers; it fails on the baseline at the exception above and passes on this head. A graph regression also merges indexed successors into sequence nodes and checks that distinct exits stay conditional. Full counts are in the validation record.

Validation: https://github.com/angr/angr/pull/6697#issuecomment-5162004357

sync: angr/binaries#203

session: sharpen
