### PR TITLE
Calling conventions: ignore stack canary comparisons as returns

### DIFF
--- a/angr/analyses/calling_convention/fact_collector.py
+++ b/angr/analyses/calling_convention/fact_collector.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Container, Iterator
 from typing import TYPE_CHECKING
 
 import pyvex
@@ -467,6 +468,141 @@ class FactCollector(Analysis):
             state.register_written(offset, self.project.arch.registers[reg_name][1])
             state.simple_regs[offset] = None
 
+    @staticmethod
+    def _resolve_vex_tmp(
+        expr: pyvex.IRExpr.IRExpr,
+        tmp_definitions: dict[int, pyvex.IRExpr.IRExpr],
+        seen_tmps: frozenset[int] = frozenset(),
+    ) -> pyvex.IRExpr.IRExpr:
+        while isinstance(expr, pyvex.IRExpr.RdTmp) and expr.tmp not in seen_tmps:
+            definition = tmp_definitions.get(expr.tmp)
+            if definition is None:
+                break
+            seen_tmps |= {expr.tmp}
+            expr = definition
+        return expr
+
+    @classmethod
+    def _walk_vex_expr(
+        cls,
+        expr: pyvex.IRExpr.IRExpr,
+        tmp_definitions: dict[int, pyvex.IRExpr.IRExpr],
+        seen_tmps: frozenset[int] = frozenset(),
+    ) -> Iterator[pyvex.IRExpr.IRExpr]:
+        if isinstance(expr, pyvex.IRExpr.RdTmp):
+            if expr.tmp in seen_tmps:
+                return
+            definition = tmp_definitions.get(expr.tmp)
+            if definition is not None:
+                yield from cls._walk_vex_expr(definition, tmp_definitions, seen_tmps | {expr.tmp})
+                return
+
+        yield expr
+        for child in expr.child_expressions:
+            yield from cls._walk_vex_expr(child, tmp_definitions, seen_tmps)
+
+    def _stack_canary_tls_location(self) -> tuple[int, int] | None:
+        if self.project.arch.name == "AMD64":
+            reg_name, offset = "fs", 0x28
+        elif self.project.arch.name == "X86":
+            reg_name, offset = "gs", 0x14
+        else:
+            return None
+        return self.project.arch.registers[reg_name][0], offset
+
+    @classmethod
+    def _is_tls_canary_load(
+        cls,
+        expr: pyvex.IRExpr.IRExpr,
+        tmp_definitions: dict[int, pyvex.IRExpr.IRExpr],
+        tls_reg_offset: int,
+        canary_offset: int,
+    ) -> bool:
+        expr = cls._resolve_vex_tmp(expr, tmp_definitions)
+        if not isinstance(expr, pyvex.IRExpr.Load):
+            return False
+        addr_nodes = tuple(cls._walk_vex_expr(expr.addr, tmp_definitions))
+        return any(isinstance(node, pyvex.IRExpr.Get) and node.offset == tls_reg_offset for node in addr_nodes) and any(
+            isinstance(node, pyvex.IRExpr.Const) and node.con.value == canary_offset for node in addr_nodes
+        )
+
+    @classmethod
+    def _is_stack_load(
+        cls,
+        expr: pyvex.IRExpr.IRExpr,
+        tmp_definitions: dict[int, pyvex.IRExpr.IRExpr],
+        stack_reg_offsets: Container[int | None],
+    ) -> bool:
+        expr = cls._resolve_vex_tmp(expr, tmp_definitions)
+        if not isinstance(expr, pyvex.IRExpr.Load):
+            return False
+        return any(
+            isinstance(node, pyvex.IRExpr.Get) and node.offset in stack_reg_offsets
+            for node in cls._walk_vex_expr(expr.addr, tmp_definitions)
+        )
+
+    def _has_terminal_call_successor(self, node: BlockNode) -> bool:
+        func_graph = self.function.transition_graph
+        for _, succ, data in func_graph.out_edges(node, data=True):
+            if data.get("type") != "transition" or data.get("outside", False) or not isinstance(succ, BlockNode):
+                continue
+            succ_block = self.project.factory.block(succ.addr, size=succ.size)
+            if succ_block.vex.jumpkind != "Ijk_Call":
+                continue
+            if not any(
+                edge_data.get("type") == "fake_return" for _, _, edge_data in func_graph.out_edges(succ, data=True)
+            ):
+                return True
+        return False
+
+    def _is_stack_canary_retval_write(
+        self,
+        node: BlockNode,
+        block: Block,
+        expr: pyvex.IRExpr.IRExpr,
+        tmp_definitions: dict[int, pyvex.IRExpr.IRExpr],
+    ) -> bool:
+        tls_location = self._stack_canary_tls_location()
+        if tls_location is None:
+            return False
+
+        expr = self._resolve_vex_tmp(expr, tmp_definitions)
+        if not isinstance(expr, pyvex.IRExpr.Binop) or expr.op not in {
+            "Iop_Sub32",
+            "Iop_Sub64",
+            "Iop_Xor32",
+            "Iop_Xor64",
+        }:
+            return False
+
+        tls_reg_offset, canary_offset = tls_location
+        stack_reg_offsets = {self.project.arch.sp_offset, self.project.arch.bp_offset}
+        op0, op1 = expr.args
+        if not (
+            (
+                self._is_tls_canary_load(op0, tmp_definitions, tls_reg_offset, canary_offset)
+                and self._is_stack_load(op1, tmp_definitions, stack_reg_offsets)
+            )
+            or (
+                self._is_tls_canary_load(op1, tmp_definitions, tls_reg_offset, canary_offset)
+                and self._is_stack_load(op0, tmp_definitions, stack_reg_offsets)
+            )
+        ):
+            return False
+
+        if not self._has_terminal_call_successor(node):
+            return False
+
+        for stmt in block.vex.statements:
+            if not isinstance(stmt, pyvex.IRStmt.Exit):
+                continue
+            guard_nodes = tuple(self._walk_vex_expr(stmt.guard, tmp_definitions))
+            if any(
+                self._is_tls_canary_load(node, tmp_definitions, tls_reg_offset, canary_offset) for node in guard_nodes
+            ) and any(self._is_stack_load(node, tmp_definitions, stack_reg_offsets) for node in guard_nodes):
+                return True
+        return False
+
     def _analyze_endpoints_for_retval_size(self, end_states):
         """
         Analyze all endpoints to determine the return value size.
@@ -591,6 +727,7 @@ class FactCollector(Analysis):
                 # to account for the common case where the shorter register (e.g., al) is extended to the full register
                 # (e.g., rax) before returning.
                 block_retval_size = None
+                stack_canary_barrier = False
                 for stmt in reversed(block.vex.statements):
                     if isinstance(stmt, pyvex.IRStmt.Put):
                         assert block.vex.tyenv is not None
@@ -610,12 +747,19 @@ class FactCollector(Analysis):
                                 size = 4
 
                         if stmt.offset == retreg_offset:
+                            if isinstance(node, BlockNode) and self._is_stack_canary_retval_write(
+                                node, block, stmt.data, tmp_definitions
+                            ):
+                                stack_canary_barrier = True
+                                break
                             block_retval_size = max(size, 1)
                         if stmt.offset == overflow_retreg_offset:
                             overflow_retval_sizes.append(max(size, 1))
 
                 if block_retval_size is not None:
                     retval_sizes.append(block_retval_size)
+                    continue
+                if stack_canary_barrier:
                     continue
 
                 for pred, _, data in func_graph.in_edges(node, data=True):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3639,7 +3639,8 @@ class TestDecompiler(unittest.TestCase):
 
         print_decompilation_result(d)
         text = d.codegen.text
-        good_if_return_pattern = r"if \(\!a2\)\s+return .*;"
+        # bridge_print_opt is void; do not accept a stack-canary comparison as its return value.
+        good_if_return_pattern = r"if \(\!a2\)\s+return;"
         good_if_return = re.search(good_if_return_pattern, text)
         assert good_if_return is not None
 

--- a/tests/analyses/test_fact_collector.py
+++ b/tests/analyses/test_fact_collector.py
@@ -6,14 +6,14 @@ __package__ = __package__ or "tests.analyses"  # pylint:disable=redefined-builti
 import os
 import unittest
 
-import archinfo
-
 import angr
+import archinfo
 from angr.calling_conventions import (
     SimCCCdecl,
     SimCCSystemVAMD64,
     default_cc,
 )
+
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
@@ -22,6 +22,97 @@ test_location = os.path.join(bin_location, "tests")
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
 class TestFactCollector(unittest.TestCase):
+    @staticmethod
+    def _collect_shellcode_facts(code: bytes, arch: str = "amd64"):
+        base_addr = 0x400000
+        project = angr.load_shellcode(code, arch=arch, load_address=base_addr)
+        cfg = project.analyses.CFGFast(
+            normalize=True,
+            regions=[(base_addr, base_addr + len(code))],
+            function_starts=[base_addr],
+            start_at_entry=False,
+            symbols=False,
+            force_smart_scan=False,
+        )
+        return project.analyses.FunctionFactCollector(cfg.kb.functions[base_addr])
+
+    def test_stack_canary_comparison_is_not_a_return_value(self):
+        prefix = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "31c0"  # xor eax, eax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+        )
+        void_tail = bytes.fromhex(
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        for operation in ("64482b042528000000", "644833042528000000"):  # sub/xor rax, qword ptr fs:[0x28]
+            with self.subTest(operation=operation):
+                facts = self._collect_shellcode_facts(prefix + bytes.fromhex(operation) + void_tail)
+                self.assertIsNone(facts.retval_size)
+
+    def test_x86_stack_canary_comparison_is_not_a_return_value(self):
+        code = bytes.fromhex(
+            "83ec0c"  # sub esp, 0xc
+            "65a114000000"  # mov eax, dword ptr gs:[0x14]
+            "89442404"  # mov dword ptr [esp + 4], eax
+            "31c0"  # xor eax, eax
+            "8b442404"  # mov eax, dword ptr [esp + 4]
+            "652b0514000000"  # sub eax, dword ptr gs:[0x14]
+            "7504"  # jne stack_chk_fail
+            "83c40c"  # add esp, 0xc
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        facts = self._collect_shellcode_facts(code, arch="x86")
+
+        self.assertIsNone(facts.retval_size)
+
+    def test_stack_canary_comparison_preserves_real_return_value(self):
+        prefix = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "31c0"  # xor eax, eax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+        )
+        epilogue = bytes.fromhex("4883c418c3e800000000")  # add rsp, 0x18; ret; call stack_chk_fail
+
+        cases = (
+            ("750ab82a000000", 4),  # jne +10; mov eax, 42
+            ("750f48b82a00000078563412", 8),  # jne +15; movabs rax, 0x123456780000002a
+        )
+        for return_code, expected_size in cases:
+            with self.subTest(expected_size=expected_size):
+                facts = self._collect_shellcode_facts(prefix + bytes.fromhex(return_code) + epilogue)
+                self.assertEqual(facts.retval_size, expected_size)
+
+    def test_tls_arithmetic_without_terminal_call_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "31c0"  # xor eax, eax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne alternate return
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+        )
+
+        facts = self._collect_shellcode_facts(code)
+
+        self.assertEqual(facts.retval_size, 8)
+
     def _run_fauxware(self, arch, function_and_cc_list):
         binary_path = os.path.join(test_location, arch, "fauxware")
         fauxware = angr.Project(binary_path, auto_load_libs=False)

--- a/tests/analyses/test_fact_collector.py
+++ b/tests/analyses/test_fact_collector.py
@@ -6,14 +6,14 @@ __package__ = __package__ or "tests.analyses"  # pylint:disable=redefined-builti
 import os
 import unittest
 
-import angr
 import archinfo
+
+import angr
 from angr.calling_conventions import (
     SimCCCdecl,
     SimCCSystemVAMD64,
     default_cc,
 )
-
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

Do not infer a function return value from a proven GCC stack-canary comparison on Linux x86 or AMD64.

`FactCollector` scans backwards from function endpoints for writes to the ABI return register. GCC stack-protector epilogues commonly write `saved_canary - fs:0x28` (AMD64) or `saved_canary - gs:0x14` (x86) into that register before branching to `__stack_chk_fail`. That comparison was therefore inferred as an 8-byte return value. The decompiler then changed source `void` functions into `long long` functions and emitted the canary comparison as a bogus `return` expression.

This change recognizes the comparison as a return-inference barrier only when all of the following hold:

- the architecture and TLS offset match the Linux x86/AMD64 ABI;
- the return-register value is a 32- or 64-bit subtraction/XOR between a stack load and the TLS canary load;
- those operands feed an exit guard in the same VEX block; and
- the guarded edge reaches a terminal call block with no fake-return edge.

The narrow match avoids treating generic TLS arithmetic, ordinary branches, or real protected return values as void.

## DecBench before/after

The sealed A/B used baseline `91cc026062142cf8dbbbefbb6c5aacd7f09f54f7` and this PR's `0e4ed796f3fd6e8aae7af684ab13a102e6d0084a`. Each primary case ran in three isolated processes with stable input and output hashes (48 processes total).

| Ground-truth case | Before | After | Median decompile time, before → after |
| --- | --- | --- | --- |
| sysvinit O0 `hardsleep` | false 8-byte return; `long long` | no return value; source-correct `void` | 0.085 s → 0.092 s |
| sysvinit O2 `hardsleep` | false 8-byte return; `long long` | no return value; source-correct `void` | 0.093 s → 0.081 s |
| sysvinit O2-noinline `hardsleep` | false 8-byte return; `long long` | no return value; source-correct `void` | 0.152 s → 0.077 s |
| sysvinit O0 `issue_warn` | false 8-byte return; `long long` | no return value; source-correct `void` | 0.115 s → 0.118 s |
| sysvinit O2 `issue_warn` | false 8-byte return; `long long` | no return value; source-correct `void` | 0.121 s → 0.124 s |
| sysvinit O2-noinline `issue_warn` | false 8-byte return; `long long` | no return value; source-correct `void` | 0.192 s → 0.207 s |
| bzip2 O0 `uInt64_toAscii` | false 8-byte return; `long long` | no return value; source-correct `void` | 0.132 s → 0.132 s |
| coreutils O2 `print_only_size` | false 8-byte return; `long long` | no return value; source-correct `void` | 0.070 s → 0.068 s |

Result: **8/8 false return values before, 0/8 after; 0/8 source-correct return signatures before, 8/8 after.**

For context, the existing published DecBench output contains 3,314 instances of this exact bogus canary-return shape across 2,369 output/function records, 902 unique function identities, and 24 projects. This is a visible-symptom lower bound, not a claim that every matching function has a `void` source signature. In the published scores, `hardsleep` has a return-type match of 0.333 and GED 3 in all three optimization configurations; the patched live A/B recovers the source `void` return in all three.

## Regression controls

- 8/8 DecBench controls retained exact generated code, type output, prototype, return lines, and `FactCollector` return size (16 isolated processes). These include stack-protected real returns, unrelated integer returns, and an ARM ChibiOS function.
- A broader public-corpus scan covered 11,081 x86 and 11,108 AMD64 PE functions; all 22,189 retained the same `FactCollector` result.
- Full public CFG scans across sysvinit, bzip2, coreutils, Mirai Windows, and ChibiOS completed without analysis failures. Changes were limited to the expected AMD64 canary-derived false returns; ARM results were unchanged.

## Tests

- Added AMD64 subtraction and XOR protected-void cases.
- Added an x86 protected-void case.
- Added 32- and 64-bit protected real-return controls.
- Added a TLS-arithmetic branch without a terminal failure call as a false-positive control.
- Corrected the existing `bridge_print_opt` integration expectation: its source signature is `static void`, so a bare `return;` is correct and the prior test was accepting the bug.
- Complete workspace gate:
  - angr: 2,255 passed, 46 skipped, 2 expected xfailed, 214 subtests passed
  - native Rust: 30 passed
  - angr-management: 500 passed
- Ruff, Pylint, and Pyright checks pass for the changed production code and focused tests.
