### PR TITLE
Decompiler: simplify ARM floating-point comparisons

### DIFF
--- a/angr/ailment/expression.py
+++ b/angr/ailment/expression.py
@@ -657,7 +657,11 @@ def negate(expr: Expression, manager) -> Expression:
     """Negate a comparison or boolean expression."""
     if isinstance(expr, UnaryOp) and expr.op == "Not":
         return expr.operand
-    if isinstance(expr, BinaryOp) and expr.op in BinaryOp.COMPARISON_NEGATION:
+    if (
+        isinstance(expr, BinaryOp)
+        and expr.op in BinaryOp.COMPARISON_NEGATION
+        and (not expr.floating_point or expr.op in {"CmpEQ", "CmpNE"})
+    ):
         return BinaryOp(
             expr.idx,
             BinaryOp.COMPARISON_NEGATION[expr.op],

--- a/angr/analyses/decompiler/condition_processor.py
+++ b/angr/analyses/decompiler/condition_processor.py
@@ -952,6 +952,27 @@ class ConditionProcessor:
         if isinstance(condition, (claripy.ast.Bits, claripy.ast.Bool)):  # pylint:disable=isinstance-second-argument-not-valid-type
             return condition
 
+        if (
+            isinstance(condition, ailment.Expr.BinaryOp)
+            and condition.floating_point
+            and condition.op in {"CmpEQ", "CmpNE", "CmpLT", "CmpLE", "CmpGT", "CmpGE"}
+        ):
+            # Claripy comparisons operate on integers or bitvectors. Translating a floating-point comparison into one
+            # would let boolean simplification apply integer complement rules such as !(a > b) == a <= b, which are
+            # invalid for unordered floating-point values. Keep the comparison opaque and recover the original AIL
+            # expression after condition simplification instead.
+            if nobool and not must_bool:
+                return _dummy_bvs(
+                    condition,
+                    self._condition_mapping,
+                    name_suffix=f"-{ins_addr:x}",
+                )
+            return _dummy_bools(
+                condition,
+                self._condition_mapping,
+                name_suffix=f"-{ins_addr:x}",
+            )
+
         if isinstance(
             condition,
             (ailment.Expr.VEXCCallExpression, ailment.Expr.BasePointerOffset, ailment.Expr.ITE, StringLiteral),

--- a/angr/analyses/decompiler/peephole_optimizations/arm_cmpf.py
+++ b/angr/analyses/decompiler/peephole_optimizations/arm_cmpf.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from angr.ailment.expression import BinaryOp, Const, Convert
+from angr.ailment.expression import BinaryOp, Const, Convert, Tmp, UnaryOp, VirtualVariable
+from angr.ailment.statement import Assignment, ConditionalJump
 
 from .base import PeepholeOptimizationExprBase
 
@@ -13,9 +14,57 @@ class ARMCmpF(PeepholeOptimizationExprBase):
     __slots__ = ()
 
     NAME = "Simplifying CmpF on ARM"
-    expr_classes = (Convert,)  # all expressions are allowed
+    expr_classes = (BinaryOp, Convert, UnaryOp)
 
-    def optimize(self, expr: Convert, **kwargs):
+    _CMP_OUTCOMES = {
+        "CmpEQ": (False, True, False, False),
+        "CmpNE": (True, False, True, True),
+        "CmpLT": (False, False, True, False),
+        "CmpLE": (False, True, True, False),
+        "CmpGT": (True, False, False, False),
+        "CmpGE": (True, True, False, False),
+    }
+    _FPSCR_FLAGS = (0x2000_0000, 0x6000_0000, 0x8000_0000, 0x3000_0000)
+    _OUTCOME_COMPARISONS = {
+        (False, True, False, False): ("CmpEQ", False),
+        (True, False, True, True): ("CmpNE", False),
+        (False, False, True, False): ("CmpLT", False),
+        (False, True, True, False): ("CmpLE", False),
+        (True, False, False, False): ("CmpGT", False),
+        (True, True, False, False): ("CmpGE", False),
+        # ARM condition codes can include the unordered result. Keep the explicit
+        # negation because, for example, !(a > b) is true for NaN while a <= b is not.
+        (True, True, False, True): ("CmpLT", True),
+        (True, False, False, True): ("CmpLE", True),
+        (False, True, True, True): ("CmpGT", True),
+        (False, False, True, True): ("CmpGE", True),
+    }
+
+    def optimize(self, expr: BinaryOp | Convert | UnaryOp, *, stmt_idx=None, block=None, **kwargs):
+        if self.project is not None and self.project.arch.name not in {"ARMEL", "ARMHF", "ARMCortexM"}:
+            return None
+
+        if (
+            expr.bits == 1
+            and block is not None
+            and stmt_idx is not None
+            and isinstance(block.statements[stmt_idx], ConditionalJump)
+            and not (isinstance(expr, BinaryOp) and expr.floating_point and expr.op in self._CMP_OUTCOMES)
+            and not (
+                isinstance(expr, UnaryOp)
+                and expr.op == "Not"
+                and isinstance(expr.operand, BinaryOp)
+                and expr.operand.floating_point
+                and expr.operand.op in self._CMP_OUTCOMES
+            )
+        ):
+            simplified = self._simplify_fpscr_condition(expr, stmt_idx, block)
+            if simplified is not None:
+                return simplified
+
+        if not isinstance(expr, Convert):
+            return None
+
         # CmpF values
         # - 0x45 Unordered
         # - 0x01 LT
@@ -74,19 +123,324 @@ class ARMCmpF(PeepholeOptimizationExprBase):
                 if isinstance(irRes, BinaryOp) and irRes.op == "CmpF":
                     # everything matches
                     if bit_mask == 1:
-                        op = "CmpGT" if negate else "CmpLE"
-                    else:
-                        raise NotImplementedError
-                    return BinaryOp(
-                        expr.idx,
-                        op,
-                        irRes.operands[::],
-                        False,
-                        floating_point=True,
-                        **expr.tags,
-                    )
+                        comparison = BinaryOp(
+                            expr.idx,
+                            "CmpGT",
+                            irRes.operands[::],
+                            False,
+                            floating_point=True,
+                            **expr.tags,
+                        )
+                        if negate:
+                            return comparison
+                        return UnaryOp(self.manager.next_atom(), "Not", comparison, **expr.tags)
+                    raise NotImplementedError
 
         return None
+
+    @classmethod
+    def _simplify_fpscr_condition(cls, expr, stmt_idx, block):
+        tmp_definitions = {}
+        for stmt in block.statements[:stmt_idx]:
+            if not isinstance(stmt, Assignment):
+                continue
+            if isinstance(stmt.dst, Tmp):
+                tmp_definitions[("tmp", stmt.dst.tmp_idx)] = stmt.src
+            elif isinstance(stmt.dst, VirtualVariable):
+                tmp_definitions[("vvar", stmt.dst.varid)] = stmt.src
+
+        outcomes = []
+        source_comparison = None
+        for outcome, flags in enumerate(cls._FPSCR_FLAGS):
+            evaluated = cls._evaluate_condition(expr, outcome, flags, tmp_definitions)
+            if evaluated is None:
+                return None
+            value, comparison = evaluated
+            if comparison is None:
+                return None
+            if source_comparison is None:
+                source_comparison = comparison
+            elif not cls._same_comparison_operands(source_comparison, comparison):
+                return None
+            outcomes.append(bool(value))
+
+        replacement = cls._OUTCOME_COMPARISONS.get(tuple(outcomes))
+        if replacement is None or source_comparison is None:
+            return None
+
+        op, negate = replacement
+        comparison = BinaryOp(
+            expr.idx,
+            op,
+            source_comparison.operands[::],
+            False,
+            floating_point=True,
+            **expr.tags,
+        )
+        if negate:
+            return UnaryOp(expr.idx, "Not", comparison, **expr.tags)
+        return comparison
+
+    @classmethod
+    def _evaluate_condition(cls, expr, outcome, fpscr_flags, tmp_definitions):
+        expr = cls._resolve_tmp(expr, tmp_definitions)
+
+        comparison = cls._match_fpscr_high_bits(expr, tmp_definitions)
+        if comparison is not None:
+            return fpscr_flags, comparison
+
+        if isinstance(expr, Const):
+            if not isinstance(expr.value, int):
+                return None
+            return expr.value & cls._mask(expr.bits), None
+
+        if isinstance(expr, Convert):
+            evaluated = cls._evaluate_condition(expr.operand, outcome, fpscr_flags, tmp_definitions)
+            if evaluated is None:
+                return None
+            value, comparison = evaluated
+            value &= cls._mask(expr.from_bits)
+            if expr.is_signed and expr.to_bits > expr.from_bits:
+                value = cls._to_signed(value, expr.from_bits)
+            return value & cls._mask(expr.to_bits), comparison
+
+        if isinstance(expr, UnaryOp):
+            if expr.op != "Not":
+                return None
+            evaluated = cls._evaluate_condition(expr.operand, outcome, fpscr_flags, tmp_definitions)
+            if evaluated is None:
+                return None
+            value, comparison = evaluated
+            return (~value) & cls._mask(expr.bits), comparison
+
+        if not isinstance(expr, BinaryOp):
+            return None
+
+        if expr.floating_point and expr.op in cls._CMP_OUTCOMES:
+            return int(cls._CMP_OUTCOMES[expr.op][outcome]), expr
+
+        evaluated_operands = [
+            cls._evaluate_condition(operand, outcome, fpscr_flags, tmp_definitions) for operand in expr.operands
+        ]
+        if any(evaluated is None for evaluated in evaluated_operands):
+            return None
+        values = [evaluated[0] for evaluated in evaluated_operands]
+        comparisons = [evaluated[1] for evaluated in evaluated_operands if evaluated[1] is not None]
+        comparison = comparisons[0] if comparisons else None
+        if any(not cls._same_comparison_operands(comparison, other) for other in comparisons[1:]):
+            return None
+
+        op = expr.op
+        if op == "Add":
+            value = values[0] + values[1]
+        elif op == "Sub":
+            value = values[0] - values[1]
+        elif op == "Mul":
+            value = values[0] * values[1]
+        elif op in {"And", "LogicalAnd"}:
+            value = values[0] & values[1]
+        elif op in {"Or", "LogicalOr"}:
+            value = values[0] | values[1]
+        elif op in {"Xor", "LogicalXor"}:
+            value = values[0] ^ values[1]
+        elif op == "Shl":
+            value = values[0] << values[1]
+        elif op == "Shr":
+            value = (values[0] & cls._mask(expr.operands[0].bits)) >> values[1]
+        elif op == "Sar":
+            value = cls._to_signed(values[0], expr.operands[0].bits) >> values[1]
+        elif op in {"CmpEQ", "CmpNE", "CmpLT", "CmpLE", "CmpGT", "CmpGE"}:
+            lhs, rhs = values
+            if expr.signed:
+                lhs = cls._to_signed(lhs, expr.operands[0].bits)
+                rhs = cls._to_signed(rhs, expr.operands[1].bits)
+            if op == "CmpEQ":
+                value = lhs == rhs
+            elif op == "CmpNE":
+                value = lhs != rhs
+            elif op == "CmpLT":
+                value = lhs < rhs
+            elif op == "CmpLE":
+                value = lhs <= rhs
+            elif op == "CmpGT":
+                value = lhs > rhs
+            else:
+                value = lhs >= rhs
+        else:
+            return None
+
+        return int(value) & cls._mask(expr.bits), comparison
+
+    @classmethod
+    def _match_fpscr_high_bits(cls, expr, tmp_definitions):
+        fpscr_update = cls._match_binop_const(expr, "And", 0xF000_0000, tmp_definitions)
+        if fpscr_update is None:
+            return None
+        fpscr_update = cls._resolve_tmp(fpscr_update, tmp_definitions)
+        if not isinstance(fpscr_update, BinaryOp) or fpscr_update.op != "Or":
+            return None
+
+        for low_bits, high_bits in (
+            fpscr_update.operands,
+            fpscr_update.operands[::-1],
+        ):
+            if cls._match_binop_const(low_bits, "And", 0x0FFF_FFFF, tmp_definitions) is None:
+                continue
+            nzcv = cls._match_scaled_nzcv(high_bits, tmp_definitions)
+            if nzcv is None:
+                continue
+            comparison = cls._match_nzcv_value(nzcv, tmp_definitions)
+            if comparison is not None:
+                return comparison
+        return None
+
+    @classmethod
+    def _match_nzcv_value(cls, expr, tmp_definitions):
+        expr = cls._resolve_tmp(expr, tmp_definitions)
+        if not isinstance(expr, BinaryOp) or expr.op != "Sub":
+            return None
+
+        ix_left = cls._match_term_left(expr.operands[0], tmp_definitions)
+        ix_right = cls._match_term_right(expr.operands[1], tmp_definitions)
+        if ix_left is None or ix_right is None:
+            return None
+
+        comparison_left = cls._match_ix_value(ix_left, tmp_definitions)
+        comparison_right = cls._match_ix_value(ix_right, tmp_definitions)
+        if (
+            comparison_left is not None
+            and comparison_right is not None
+            and cls._same_comparison_operands(comparison_left, comparison_right)
+        ):
+            return comparison_left
+        return None
+
+    @classmethod
+    def _match_term_left(cls, expr, tmp_definitions):
+        expr = cls._match_binop_const(expr, "Add", 1, tmp_definitions)
+        if expr is None:
+            return None
+        expr = cls._match_ordered_binop_const(expr, "Shr", 29, tmp_definitions)
+        if expr is None:
+            return None
+        expr = cls._match_ordered_binop_const(expr, "Sub", 1, tmp_definitions)
+        if expr is None:
+            return None
+        expr = cls._match_scaled_value(expr, 30, 0x4000_0000, tmp_definitions)
+        if expr is None:
+            return None
+        return cls._match_binop_const(expr, "Xor", 1, tmp_definitions)
+
+    @classmethod
+    def _match_term_right(cls, expr, tmp_definitions):
+        expr = cls._match_binop_const(expr, "And", 1, tmp_definitions)
+        expr = cls._resolve_tmp(expr, tmp_definitions) if expr is not None else None
+        if not isinstance(expr, BinaryOp) or expr.op != "And":
+            return None
+
+        for value, shifted in (expr.operands, expr.operands[::-1]):
+            shifted_value = cls._match_ordered_binop_const(shifted, "Shr", 1, tmp_definitions)
+            if shifted_value is not None and cls._same_expression(value, shifted_value, tmp_definitions):
+                return value
+        return None
+
+    @classmethod
+    def _match_ix_value(cls, expr, tmp_definitions):
+        expr = cls._resolve_tmp(expr, tmp_definitions)
+        if not isinstance(expr, BinaryOp) or expr.op != "Or":
+            return None
+
+        for shifted_part, low_part in (expr.operands, expr.operands[::-1]):
+            shifted_part = cls._match_binop_const(shifted_part, "And", 3, tmp_definitions)
+            if shifted_part is None:
+                continue
+            comparison_left = cls._match_ordered_binop_const(shifted_part, "Shr", 5, tmp_definitions)
+            comparison_right = cls._match_binop_const(low_part, "And", 1, tmp_definitions)
+            comparison_left = cls._resolve_tmp(comparison_left, tmp_definitions)
+            comparison_right = cls._resolve_tmp(comparison_right, tmp_definitions)
+            if (
+                isinstance(comparison_left, BinaryOp)
+                and comparison_left.op == "CmpF"
+                and isinstance(comparison_right, BinaryOp)
+                and comparison_right.op == "CmpF"
+                and cls._same_comparison_operands(comparison_left, comparison_right)
+            ):
+                return comparison_left
+        return None
+
+    @classmethod
+    def _match_scaled_nzcv(cls, expr, tmp_definitions):
+        return cls._match_scaled_value(expr, 28, 0x1000_0000, tmp_definitions)
+
+    @classmethod
+    def _match_scaled_value(cls, expr, shift, multiplier, tmp_definitions):
+        expr = cls._resolve_tmp(expr, tmp_definitions)
+        shifted = cls._match_ordered_binop_const(expr, "Shl", shift, tmp_definitions)
+        if shifted is not None:
+            return shifted
+        return cls._match_binop_const(expr, "Mul", multiplier, tmp_definitions)
+
+    @classmethod
+    def _match_binop_const(cls, expr, op, value, tmp_definitions):
+        expr = cls._resolve_tmp(expr, tmp_definitions)
+        if not isinstance(expr, BinaryOp) or expr.op != op:
+            return None
+        left = cls._resolve_tmp(expr.operands[0], tmp_definitions)
+        right = cls._resolve_tmp(expr.operands[1], tmp_definitions)
+        if isinstance(right, Const) and right.value == value:
+            return left
+        if isinstance(left, Const) and left.value == value:
+            return right
+        return None
+
+    @classmethod
+    def _match_ordered_binop_const(cls, expr, op, value, tmp_definitions):
+        expr = cls._resolve_tmp(expr, tmp_definitions)
+        if (
+            isinstance(expr, BinaryOp)
+            and expr.op == op
+            and isinstance(expr.operands[1], Const)
+            and expr.operands[1].value == value
+        ):
+            return expr.operands[0]
+        return None
+
+    @classmethod
+    def _resolve_tmp(cls, expr, tmp_definitions, seen=frozenset()):
+        while isinstance(expr, (Tmp, VirtualVariable)):
+            key = ("tmp", expr.tmp_idx) if isinstance(expr, Tmp) else ("vvar", expr.varid)
+            if key in seen:
+                break
+            definition = tmp_definitions.get(key)
+            if definition is None:
+                break
+            seen |= {key}
+            expr = definition
+        return expr
+
+    @classmethod
+    def _same_expression(cls, left, right, tmp_definitions):
+        left = cls._resolve_tmp(left, tmp_definitions)
+        right = cls._resolve_tmp(right, tmp_definitions)
+        return left.likes(right)
+
+    @staticmethod
+    def _same_comparison_operands(left, right):
+        if left is None or right is None or len(left.operands) != len(right.operands):
+            return False
+        return all(
+            left_operand.likes(right_operand) for left_operand, right_operand in zip(left.operands, right.operands)
+        )
+
+    @staticmethod
+    def _mask(bits):
+        return (1 << bits) - 1
+
+    @classmethod
+    def _to_signed(cls, value, bits):
+        value &= cls._mask(bits)
+        sign_bit = 1 << (bits - 1)
+        return value - (1 << bits) if value & sign_bit else value
 
     @staticmethod
     def _match_nzcv_bits_extraction(expr: BinaryOp):

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_conversions.py
@@ -21,6 +21,12 @@ class RemoveRedundantConversions(PeepholeOptimizationExprBase):
         return None
 
     def _optimize_BinaryOp(self, expr: BinaryOp):
+        if expr.floating_point:
+            # The rules below reason about integer extensions, truncations, and constant ranges. Applying them to a
+            # floating-point comparison can change its precision and also drops the comparison's floating-point
+            # semantics when rebuilding it.
+            return None
+
         # TODO make this lhs/rhs agnostic
         if isinstance(expr.operands[0], Convert):  # noqa: SIM102
             # check: is the lhs convert an up-cast and is rhs a const?

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_nots.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_nots.py
@@ -19,6 +19,8 @@ class RemoveRedundantNots(PeepholeOptimizationExprBase):
                     return expr.operand.operand
             elif isinstance(expr.operand, BinaryOp) and expr.operand.op in BinaryOp.COMPARISON_NEGATION:
                 inner = expr.operand
+                if inner.floating_point and inner.op not in {"CmpEQ", "CmpNE"}:
+                    return None
                 negated_op = BinaryOp.COMPARISON_NEGATION[expr.operand.op]
                 return BinaryOp(
                     inner.idx,

--- a/angr/rustylib/ailment.pyi
+++ b/angr/rustylib/ailment.pyi
@@ -609,7 +609,7 @@ class Const(Atom):
     @property
     def sign_bit(self) -> int:
         """``Const.sign_bit`` -- the top bit of the int value at the Const's declared width. Computed as a bit-extract (not an arithmetic shift) so values stored as their u64 two's-complement form -- e.g. ``-8`` carried as ``2^64 - 8`` from the lifter -- correctly report ``1``."""
-    def __init__(self, idx: int | None, value: int, bits: int, **tags: Any) -> None: ...
+    def __init__(self, idx: int | None, value: float, bits: int, **tags: Any) -> None: ...
 
 class Tmp(Atom):
     @property

--- a/tests/ailment/test_expression.py
+++ b/tests/ailment/test_expression.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
-import angr.ailment as ailment
+from angr import ailment
 from angr.ailment.expression import (
     Array,
     BasePointerOffset,
@@ -38,6 +38,42 @@ class TestExpression(unittest.TestCase):
         )
         h = hash(phi_expr)  # should not crash
         assert h is not None
+
+    def test_negate_preserves_ordered_floating_point_semantics(self):
+        manager = ailment.Manager()
+        lhs = Register(manager.next_atom(), 0, 32)
+        rhs = Register(manager.next_atom(), 4, 32)
+
+        integer_lt = ailment.expression.BinaryOp(manager.next_atom(), "CmpLT", (lhs, rhs), False, bits=1)
+        negated_integer = ailment.expression.negate(integer_lt, manager)
+        assert isinstance(negated_integer, ailment.expression.BinaryOp)
+        assert negated_integer.op == "CmpGE"
+
+        floating_lt = ailment.expression.BinaryOp(
+            manager.next_atom(),
+            "CmpLT",
+            (lhs, rhs),
+            False,
+            bits=1,
+            floating_point=True,
+        )
+        negated_floating = ailment.expression.negate(floating_lt, manager)
+        assert isinstance(negated_floating, ailment.expression.UnaryOp)
+        assert negated_floating.op == "Not"
+        assert negated_floating.operand.likes(floating_lt)
+
+        floating_eq = ailment.expression.BinaryOp(
+            manager.next_atom(),
+            "CmpEQ",
+            (lhs, rhs),
+            False,
+            bits=1,
+            floating_point=True,
+        )
+        negated_equality = ailment.expression.negate(floating_eq, manager)
+        assert isinstance(negated_equality, ailment.expression.BinaryOp)
+        assert negated_equality.op == "CmpNE"
+        assert negated_equality.floating_point
 
     def test_rust_composite_return_deep_copy(self):
         field = ailment.expression.VirtualVariable(

--- a/tests/analyses/decompiler/test_arm_cmpf.py
+++ b/tests/analyses/decompiler/test_arm_cmpf.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import angr
+from angr import ailment
+from angr.ailment.expression import (
+    BinaryOp,
+    Const,
+    Convert,
+    Register,
+    Tmp,
+    UnaryOp,
+    VirtualVariable,
+    VirtualVariableCategory,
+)
+from angr.ailment.statement import Assignment, ConditionalJump
+from angr.analyses.decompiler.peephole_optimizations import ARMCmpF
+
+
+def _const(manager, value, bits=32):
+    return Const(manager.next_atom(), value, bits)
+
+
+def _binop(manager, op, lhs, rhs, *, bits=32, signed=False):
+    return BinaryOp(manager.next_atom(), op, (lhs, rhs), signed, bits=bits)
+
+
+def _scale(manager, expr, shift, *, use_multiplication):
+    if use_multiplication:
+        return _binop(manager, "Mul", expr, _const(manager, 1 << shift))
+    return _binop(manager, "Shl", expr, _const(manager, shift, 8))
+
+
+def _fpscr_high_bits(manager, *, use_multiplication):
+    lhs = Convert(manager.next_atom(), 32, 64, False, Register(manager.next_atom(), 184, 32))
+    rhs = Convert(manager.next_atom(), 32, 64, False, Register(manager.next_atom(), 188, 32))
+    cmpf = _binop(manager, "CmpF", lhs, rhs)
+
+    ix = _binop(
+        manager,
+        "Or",
+        _binop(manager, "And", _binop(manager, "Shr", cmpf, _const(manager, 5, 8)), _const(manager, 3)),
+        _binop(manager, "And", cmpf, _const(manager, 1)),
+    )
+    term_l = _binop(
+        manager,
+        "Add",
+        _binop(
+            manager,
+            "Shr",
+            _binop(
+                manager,
+                "Sub",
+                _scale(
+                    manager,
+                    _binop(manager, "Xor", ix, _const(manager, 1)),
+                    30,
+                    use_multiplication=use_multiplication,
+                ),
+                _const(manager, 1),
+            ),
+            _const(manager, 29, 8),
+        ),
+        _const(manager, 1),
+    )
+    term_r = _binop(
+        manager,
+        "And",
+        _binop(manager, "And", ix, _binop(manager, "Shr", ix, _const(manager, 1, 8))),
+        _const(manager, 1),
+    )
+    nzcv = _binop(manager, "Sub", term_l, term_r)
+    fpscr = _binop(
+        manager,
+        "Or",
+        _binop(manager, "And", Register(manager.next_atom(), 384, 32), _const(manager, 0x0FFF_FFFF)),
+        _scale(manager, nzcv, 28, use_multiplication=use_multiplication),
+    )
+    return _binop(manager, "And", fpscr, _const(manager, 0xF000_0000)), cmpf
+
+
+def _optimize_condition(condition_builder, *, use_multiplication=False):
+    project = angr.load_shellcode(b"\x00\xbf", "ARMCortexM")
+    manager = ailment.Manager(arch=project.arch)
+    high_bits, cmpf = _fpscr_high_bits(manager, use_multiplication=use_multiplication)
+
+    high_tmp = Tmp(manager.next_atom(), 0, 32)
+    high_vvar = VirtualVariable(
+        manager.next_atom(),
+        1,
+        32,
+        VirtualVariableCategory.TMP,
+        oident=0,
+    )
+    condition = condition_builder(manager, high_vvar)
+    block = ailment.Block(
+        0x1000,
+        0,
+        statements=[
+            Assignment(manager.next_atom(), high_tmp, high_bits),
+            Assignment(manager.next_atom(), high_vvar, high_tmp),
+            ConditionalJump(
+                manager.next_atom(),
+                condition,
+                _const(manager, 0x1010),
+                _const(manager, 0x1020),
+            ),
+        ],
+    )
+
+    optimized = ARMCmpF(project, project.kb, manager).optimize(condition, stmt_idx=2, block=block)
+    return optimized, cmpf
+
+
+def test_arm_fpscr_mi_becomes_ordered_less_than():
+    def mi(manager, high_bits):
+        negative = _binop(manager, "And", high_bits, _const(manager, 0x8000_0000))
+        return _binop(manager, "CmpNE", negative, _const(manager, 0), bits=1)
+
+    optimized, cmpf = _optimize_condition(mi)
+
+    assert isinstance(optimized, BinaryOp)
+    assert optimized.op == "CmpLT"
+    assert optimized.floating_point
+    assert all(actual.likes(expected) for actual, expected in zip(optimized.operands, cmpf.operands))
+
+
+def test_arm_fpscr_le_keeps_unordered_case():
+    def le(manager, high_bits):
+        zero = _binop(
+            manager,
+            "CmpNE",
+            _binop(manager, "And", high_bits, _const(manager, 0x4000_0000)),
+            _const(manager, 0),
+            bits=1,
+        )
+        negative = _binop(
+            manager,
+            "And",
+            _binop(manager, "Shr", high_bits, _const(manager, 31, 8)),
+            _const(manager, 1),
+        )
+        overflow = _binop(
+            manager,
+            "And",
+            _binop(manager, "Shr", high_bits, _const(manager, 28, 8)),
+            _const(manager, 1),
+        )
+        return _binop(
+            manager,
+            "LogicalOr",
+            zero,
+            _binop(manager, "CmpNE", negative, overflow, bits=1),
+            bits=1,
+        )
+
+    optimized, cmpf = _optimize_condition(le, use_multiplication=True)
+
+    assert isinstance(optimized, UnaryOp)
+    assert optimized.op == "Not"
+    assert isinstance(optimized.operand, BinaryOp)
+    assert optimized.operand.op == "CmpGT"
+    assert optimized.operand.floating_point
+    assert all(actual.likes(expected) for actual, expected in zip(optimized.operand.operands, cmpf.operands))
+
+
+def test_arm_cmpf_ignores_unrelated_floating_constant_conditions():
+    project = angr.load_shellcode(b"\x00\xbf", "ARMCortexM")
+    manager = ailment.Manager(arch=project.arch)
+    condition = _binop(
+        manager,
+        "CmpLT",
+        Register(manager.next_atom(), 0, 32),
+        Const(manager.next_atom(), 1.0, 32),
+        bits=1,
+    )
+    block = ailment.Block(
+        0x1000,
+        0,
+        statements=[
+            ConditionalJump(
+                manager.next_atom(),
+                condition,
+                _const(manager, 0x1010),
+                _const(manager, 0x1020),
+            )
+        ],
+    )
+
+    assert ARMCmpF(project, project.kb, manager).optimize(condition, stmt_idx=0, block=block) is None

--- a/tests/analyses/decompiler/test_condition_processor.py
+++ b/tests/analyses/decompiler/test_condition_processor.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
 import archinfo
+import claripy
 
 from angr import ailment
-from angr.ailment.expression import Const, Extract, VirtualVariable, VirtualVariableCategory
+from angr.ailment.expression import (
+    BinaryOp,
+    Const,
+    Extract,
+    Register,
+    UnaryOp,
+    VirtualVariable,
+    VirtualVariableCategory,
+)
 from angr.analyses.decompiler.condition_processor import ConditionProcessor
 
 
@@ -27,3 +36,22 @@ def test_extract_placeholders_include_semantic_properties():
     assert condition_processor.convert_claripy_bool_ast(byte_ast) is extract_byte
     assert condition_processor.convert_claripy_bool_ast(word_ast) is extract_word
     assert condition_processor.convert_claripy_bool_ast(byte_be_ast) is extract_byte_be
+
+
+def test_floating_comparisons_remain_opaque_during_boolean_simplification():
+    arch = archinfo.ArchARM()
+    manager = ailment.Manager(arch=arch)
+    condition_processor = ConditionProcessor(arch, manager)
+
+    lhs = Register(0, arch.registers["s0"][0], 32)
+    rhs = Register(1, arch.registers["s1"][0], 32)
+    comparison = BinaryOp(2, "CmpGT", (lhs, rhs), False, bits=1, floating_point=True)
+
+    comparison_ast = condition_processor.claripy_ast_from_ail_condition(comparison, must_bool=True)
+    assert comparison_ast.op == "BoolS"
+    assert condition_processor.convert_claripy_bool_ast(comparison_ast) is comparison
+
+    negated = condition_processor.convert_claripy_bool_ast(claripy.Not(comparison_ast))
+    assert isinstance(negated, UnaryOp)
+    assert negated.op == "Not"
+    assert negated.operand.likes(comparison)

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -21,6 +21,7 @@ from angr.analyses.decompiler.peephole_optimizations import (
     ConstantDereferences,
     EagerEvaluation,
     OptimizedDivisionSimplifier,
+    RemoveRedundantConversions,
     RemoveRedundantShifts,
     SimplifyBitwiseInserts,
 )
@@ -160,6 +161,41 @@ class TestPeepholeOptimizations(unittest.TestCase):
                     floating_point=True,
                 )
                 assert opt.optimize(expr) is None
+
+    def test_remove_redundant_conversions_skips_floating_point_comparisons(self):
+        project = angr.load_shellcode(b"\x90", "AMD64")
+        manager = Manager()
+        opt = RemoveRedundantConversions(project, project.kb, manager)
+        value = Register(manager.next_atom(), 0, 32)
+
+        integer_comparison = BinaryOp(
+            manager.next_atom(),
+            "CmpLT",
+            (
+                Convert(manager.next_atom(), 32, 64, False, value),
+                Const(manager.next_atom(), 0, 64),
+            ),
+            False,
+            bits=1,
+        )
+        optimized = opt.optimize(integer_comparison)
+        assert isinstance(optimized, BinaryOp)
+        assert optimized.op == "CmpLT"
+        assert optimized.operands[0].likes(value)
+        assert optimized.operands[1].bits == 32
+
+        floating_comparison = BinaryOp(
+            manager.next_atom(),
+            "CmpLT",
+            (
+                Convert(manager.next_atom(), 32, 64, False, value),
+                Const(manager.next_atom(), 0.0, 64),
+            ),
+            False,
+            bits=1,
+            floating_point=True,
+        )
+        assert opt.optimize(floating_comparison) is None
 
     def test_cmp_masked_shift(self):
         proj = angr.load_shellcode(b"\x90", "AMD64")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Draft validation status

This PR is not ready to merge. Retrospective review found a correctness bug in the published head: the FPSCR matcher keeps only the last definition of each temporary in a block prefix. If a temporary is copied and then redefined, an earlier alias can be resolved to the later value and the decompiler can emit a comparison with the wrong operands.

The original 252-function A/B result below was also too narrow to establish corpus safety. Only 134 cases contained `CmpF`, all came from three Cortex-M projects, and the run omitted most of the 1,158 public ARM DecBench functions whose saved output contains `CmpF`. It had no broad integer-only or cross-architecture control population.

A local correction uses statement-indexed reaching definitions and moves the new matcher from expression-wide dispatch to a conditional-jump optimizer. That correction has not been pushed. This PR will remain a draft until the corrected implementation passes the expanded gate described below.

## Intended change

libVEX represents ARM VFP comparisons as a `CmpF` result that is transformed into FPSCR flags and then tested as an integer condition. The existing peephole recognizes only one narrow, already-propagated topology, so real decompilations often retain repeated `CmpF(...)` calls and FPSCR arithmetic.

The proposed matcher evaluates the exact encoding over greater-than, equal, less-than, and unordered outcomes, then emits the corresponding floating-point AIL comparison. Predicates that include unordered values retain an explicit negation; integer complement rules such as `!(a > b) == a <= b` are invalid for NaNs.

The relevant architecture scope is ARMEL, ARMHF, and ARMCortexM. It is not restricted by operating system.

## Preliminary evidence

At baseline `91cc026062142cf8dbbbefbb6c5aacd7f09f54f7` versus published candidate `c761153b651fff42d55dc345c420cef6ff093c82`:

| Cohort | Before | After |
| --- | ---: | ---: |
| Successful functions | 252/252 | 252/252 |
| Failures / timeouts | 0 / 0 | 0 / 0 |
| `CmpF` calls | 4,176 | 2,358 |
| Functions containing `CmpF` | 134 | 72 |
| Maximum elapsed time | 30.42s | 29.75s |

These numbers show that the matcher fires, but they are not a regression gate and should not be read as merge-readiness evidence.

## Required validation before ready for review

- Add a regression for temporary reassignment and prove that aliases use the definition that reaches them.
- Test every representable predicate over greater-than, equal, less-than, and unordered outcomes, plus malformed, cyclic, unknown, and unrepresentable expressions that must fail closed.
- Run current master against the corrected candidate over the full 250-function public DecBench sample, all public ARM `CmpF` functions, all public cross-architecture `CmpF` functions, and integer-only controls.
- Review every generated-code, structure, and type delta against source ground truth; accept no unexplained degradation.
- Repeat paired cold-process timings and compare failures, five-minute timeouts, median, p95, maximum, and peak RSS.
- Pass the complete angr workspace gate on the exact candidate and dependency revisions.

CI on the published head is useful but does not replace this corpus validation.
