### PR TITLE
aarch64: fix adcs/sbcs carry flag (select on cc_dep3, not cc_dep2)

### DIFF
--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -1902,11 +1902,11 @@ def arm64g_calculate_flag_c(state, cc_op, cc_dep1, cc_dep2, cc_dep3):
     elif concrete_op in (ARM64G_CC_OP_ADC32, ARM64G_CC_OP_ADC64):
         res = cc_dep1 + cc_dep2 + cc_dep3
         flag = claripy.If(
-            cc_dep2 != 0, boolean_extend(claripy.ULE, res, cc_dep1, 64), boolean_extend(claripy.ULT, res, cc_dep1, 64)
+            cc_dep3 != 0, boolean_extend(claripy.ULE, res, cc_dep1, 64), boolean_extend(claripy.ULT, res, cc_dep1, 64)
         )
     elif concrete_op in (ARM64G_CC_OP_SBC32, ARM64G_CC_OP_SBC64):
         flag = claripy.If(
-            cc_dep2 != 0,
+            cc_dep3 != 0,
             boolean_extend(claripy.UGE, cc_dep1, cc_dep2, 64),
             boolean_extend(claripy.UGT, cc_dep1, cc_dep2, 64),
         )


### PR DESCRIPTION
arm64g_calculate_flag_c selected the ADC*/SBC* carry-in with `cc_dep2 != 0` (the second operand). The arm64 flag thunk layout puts the old carry in cc_dep3 (angr's own comment: "DEP3 = oldC (in LSB)", matching VEX's guest_arm64_helpers.c). So the C flag after adcs/sbcs was computed from an operand value instead of the incoming carry.

Random operands usually mask it (cc_dep2 != 0 nearly always holds); the equal-operand case exposes it, e.g. `sbcs x,y,y` must give C = oldC but returned a value keyed on y. flag_n/z/v and the arm32 port (which correctly uses cc_dep3) were unaffected.


## Impact

Wrong C flag out of `adcs`/`sbcs` (and thus any multi-word add/subtract chain,
and conditional branches that consume C). The `boolean_extend(ULE/UGE ...)` vs
`(ULT/UGT ...)` boundary only differs at operand equality, so **random**
operands usually mask it — but the equal-operand case exposes it cleanly.

## Reproduction

```python
import angr, claripy
import angr.engines.vex.claripy.ccall as S
st = angr.load_shellcode(b'\x1f\x20\x03\xd5', arch='aarch64').factory.blank_state(addr=0)
bv = lambda x: claripy.BVV(x & ((1<<64)-1), 64)

# sbcs x,y,y : subtract equal operands with carry-in -> result 0/-1, and C == oldC
for y in (0, 1, 5, 0xdeadbeef, (1<<64)-1):
    for oldC in (0, 1):
        c = st.solver.eval(S.arm64g_calculate_flag_c(
                st, claripy.BVV(S.ARM64G_CC_OP_SBC64,64), bv(y), bv(y), bv(oldC))) & 1
        assert c == oldC, f"y={y:#x} oldC={oldC} -> C={c} (want {oldC})"
```

Fails, e.g. `y=1 oldC=0 -> C=1 (want 0)`, `y=0 oldC=1 -> C=0 (want 1)` — the
result tracks `y`, not `oldC`. 5/10 of the enumerated cases are wrong.

## Root cause

```python
elif concrete_op in (ARM64G_CC_OP_ADC32, ARM64G_CC_OP_ADC64):
    res = cc_dep1 + cc_dep2 + cc_dep3
    flag = claripy.If(cc_dep2 != 0, boolean_extend(ULE, res, cc_dep1, 64),
                                    boolean_extend(ULT, res, cc_dep1, 64))
elif concrete_op in (ARM64G_CC_OP_SBC32, ARM64G_CC_OP_SBC64):
    flag = claripy.If(cc_dep2 != 0, boolean_extend(UGE, cc_dep1, cc_dep2, 64),
                                    boolean_extend(UGT, cc_dep1, cc_dep2, 64))
```

The `If(cc_dep2 != 0, ...)` selector is meant to pick "carry-in set" vs "clear";
it must test **`cc_dep3`** (old C), not `cc_dep2`. `arm64g_calculate_flag_n/z/v`
and the arm32 port (`armg_calculate_flag_c`, which correctly uses `cc_dep3`) are
fine — only the arm64 carry transcription slipped.