### PR TITLE
x86/amd64: fix UMUL CF/OF flags (widen before multiply)

### DIFF
--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -551,9 +551,9 @@ def pc_actions_ROR(state, nbits, res, _, cc_ndep, platform=None):
 
 
 def pc_actions_UMUL(state, nbits, cc_dep1, cc_dep2, cc_ndep, platform=None):
-    lo = (cc_dep1 * cc_dep2)[nbits - 1 : 0]
-    rr = lo
-    hi = (rr >> nbits)[nbits - 1 : 0]
+    rr = cc_dep1.zero_extend(nbits) * cc_dep2.zero_extend(nbits)
+    hi = rr[2 * nbits - 1 : nbits]
+    lo = rr[nbits - 1 : 0]
     cf = claripy.If(hi != 0, claripy.BVV(1, 1), claripy.BVV(0, 1))
     zf = calc_zerobit(lo)
     pf = calc_paritybit(lo)


### PR DESCRIPTION
`pc_actions_UMUL` computes CF/OF as the sign bit of the low product instead of "high half nonzero". Widen before extracting the high half, mirroring pc_actions_SMUL. Fixes #6067.

`pc_actions_UMUL` never widens the operands before extracting the high half, and
then shifts an `nbits`-wide value right by `nbits` — with claripy's **arithmetic**
`>>`:

```python
def pc_actions_UMUL(state, nbits, cc_dep1, cc_dep2, cc_ndep, platform=None):
    lo = (cc_dep1 * cc_dep2)[nbits - 1 : 0]   # low product, nbits wide
    rr = lo
    hi = (rr >> nbits)[nbits - 1 : 0]         # claripy >> is ARITHMETIC (SAR)
    cf = claripy.If(hi != 0, ...)
    of = cf
```

Because `rr` is exactly `nbits` wide, `rr >> nbits` is a full-width arithmetic
shift: it yields `0` when `rr`'s top bit is clear and **all-ones** when it is set
(e.g. `claripy.BVV(0xffffffff,32) >> 32` evaluates to `0xffffffff`, *not* `0`).
So `hi != 0` reduces to `rr[nbits-1]`, and **CF = OF = the sign bit of the low half of the product — not "high half nonzero".**


Compare the sibling `pc_actions_SMUL`, which is correct because it **widens
first**: `ir = cc_dep1.sign_extend(nbits) * cc_dep2.sign_extend(nbits)` then
`hi = ir[2*nbits-1 : nbits]`. Only `mul` (UMUL) is broken; `imul` (SMUL) is fine.

## Reproduction

Full-pipeline, both widths — CF must be 1 (high half is nonzero), angr gives the
sign bit of the low half instead:

```python
import angr, claripy
def cf_of(insn_bytes, a, b):
    st = angr.load_shellcode(insn_bytes, 'amd64').factory.blank_state(addr=0)
    st.regs.rax = claripy.BVV(a, 64); st.regs.rsi = claripy.BVV(b, 64)
    st.regs.eflags = claripy.BVV(2, 64)
    ef = st.solver.eval(st.step(num_inst=1).successors[0].regs.eflags)
    return ef & 1, (ef >> 11) & 1
print(cf_of(b'\xf7\xe6', 0x10000, 0x10000))       # mul %esi : 0x1_0000_0000 -> want (1,1); angr (0,0)
print(cf_of(b'\x48\xf7\xe6', 1<<40, 1<<40))       # mul %rsi : 2^80        -> want (1,1); angr (0,0)
```

(The #6067 reporter's case: `mul %ebx` with `rax=0x8311D56CD539CF3`,
`rbx=0xEDE7C0935F39F809` — CF should be set; angr's value tracks `MSB(lo)` and
mispredicts a following `jc` on inputs where that differs.)
