### PR TITLE
Calling conventions: validate stack canary provenance

### DIFF
--- a/angr/analyses/calling_convention/fact_collector.py
+++ b/angr/analyses/calling_convention/fact_collector.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Container, Iterator
+from collections.abc import Container, Iterator, Sequence
 from typing import TYPE_CHECKING
 
 import pyvex
@@ -12,6 +12,7 @@ from angr.block import Block
 from angr.calling_conventions import SimRegArg, SimStackArg, default_cc
 from angr.codenode import BlockNode, FuncNode, HookNode
 from angr.engines.light import SimEngineLight, SimEngineNostmtVEX
+from angr.errors import SimTranslationError
 from angr.knowledge_plugins.functions import Function
 from angr.sim_type import SimTypeBottom, SimTypeFunction
 from angr.utils.bits import u2s
@@ -321,6 +322,8 @@ class FactCollector(Analysis):
         self.pointer_arg_derefs: defaultdict[FactData, int] = defaultdict(int)
         self.extra_pop: int | None = None
         self._seen_reg_uses: defaultdict[int, int] = defaultdict(int)
+        self._stack_canary_retval_writes: set[tuple[BlockNode, int]] | None = None
+        self._stack_chk_fail_successors: dict[BlockNode, set[int]] | None = None
 
         self._analyze()
 
@@ -521,9 +524,30 @@ class FactCollector(Analysis):
         expr = cls._resolve_vex_tmp(expr, tmp_definitions)
         if not isinstance(expr, pyvex.IRExpr.Load):
             return False
-        addr_nodes = tuple(cls._walk_vex_expr(expr.addr, tmp_definitions))
-        return any(isinstance(node, pyvex.IRExpr.Get) and node.offset == tls_reg_offset for node in addr_nodes) and any(
-            isinstance(node, pyvex.IRExpr.Const) and node.con.value == canary_offset for node in addr_nodes
+        address = cls._resolve_vex_tmp(expr.addr, tmp_definitions)
+        if isinstance(address, pyvex.IRExpr.Binop) and address.op in {"Iop_Add32", "Iop_Add64"}:
+            operand_0 = cls._resolve_vex_tmp(address.args[0], tmp_definitions)
+            operand_1 = cls._resolve_vex_tmp(address.args[1], tmp_definitions)
+            if (
+                isinstance(operand_0, pyvex.IRExpr.Get)
+                and operand_0.offset == tls_reg_offset
+                and isinstance(operand_1, pyvex.IRExpr.Const)
+                and operand_1.con.value == canary_offset
+            ) or (
+                isinstance(operand_1, pyvex.IRExpr.Get)
+                and operand_1.offset == tls_reg_offset
+                and isinstance(operand_0, pyvex.IRExpr.Const)
+                and operand_0.con.value == canary_offset
+            ):
+                return True
+        address_nodes = tuple(cls._walk_vex_expr(address, tmp_definitions))
+        return (
+            any(
+                isinstance(node, pyvex.IRExpr.CCall) and node.callee.name == "x86g_use_seg_selector"
+                for node in address_nodes
+            )
+            and any(isinstance(node, pyvex.IRExpr.Get) and node.offset == tls_reg_offset for node in address_nodes)
+            and any(isinstance(node, pyvex.IRExpr.Const) and node.con.value == canary_offset for node in address_nodes)
         )
 
     @classmethod
@@ -541,26 +565,45 @@ class FactCollector(Analysis):
             for node in cls._walk_vex_expr(expr.addr, tmp_definitions)
         )
 
-    def _has_terminal_call_successor(self, node: BlockNode) -> bool:
+    def _find_stack_chk_fail_successors(self) -> dict[BlockNode, set[int]]:
+        if self._stack_chk_fail_successors is not None:
+            return self._stack_chk_fail_successors
+
+        successors = defaultdict(set)
         func_graph = self.function.transition_graph
-        for _, succ, data in func_graph.out_edges(node, data=True):
-            if data.get("type") != "transition" or data.get("outside", False) or not isinstance(succ, BlockNode):
-                continue
-            succ_block = self.project.factory.block(succ.addr, size=succ.size)
-            if succ_block.vex.jumpkind != "Ijk_Call":
-                continue
-            if not any(
-                edge_data.get("type") == "fake_return" for _, _, edge_data in func_graph.out_edges(succ, data=True)
+        for call_node, callee_node, call_data in func_graph.edges(data=True):
+            if (
+                call_data.get("type") != "call"
+                or not isinstance(call_node, BlockNode)
+                or self.function.get_node(call_node.addr) != call_node
+                or not self.kb.functions.contains_addr(callee_node.addr)
             ):
-                return True
-        return False
+                continue
+            callee = self.kb.functions.get_by_addr(callee_node.addr)
+            if callee.name != "__stack_chk_fail" or any(
+                edge_data.get("type") == "fake_return" for _, _, edge_data in func_graph.out_edges(call_node, data=True)
+            ):
+                continue
+            for predecessor, _, predecessor_data in func_graph.in_edges(call_node, data=True):
+                if (
+                    isinstance(predecessor, BlockNode)
+                    and self.function.get_node(predecessor.addr) == predecessor
+                    and predecessor_data.get("type") == "transition"
+                    and not predecessor_data.get("outside", False)
+                ):
+                    successors[predecessor].add(call_node.addr)
+
+        self._stack_chk_fail_successors = dict(successors)
+        return self._stack_chk_fail_successors
 
     def _is_stack_canary_retval_write(
         self,
         node: BlockNode,
-        block: Block,
         expr: pyvex.IRExpr.IRExpr,
         tmp_definitions: dict[int, pyvex.IRExpr.IRExpr],
+        statements: Sequence[pyvex.IRStmt.IRStmt],
+        stmt: pyvex.IRStmt.Put,
+        retreg_offset: int,
     ) -> bool:
         tls_location = self._stack_canary_tls_location()
         if tls_location is None:
@@ -590,18 +633,29 @@ class FactCollector(Analysis):
         ):
             return False
 
-        if not self._has_terminal_call_successor(node):
+        failure_successors = self._find_stack_chk_fail_successors()
+        if node not in failure_successors:
             return False
 
-        for stmt in block.vex.statements:
-            if not isinstance(stmt, pyvex.IRStmt.Exit):
-                continue
-            guard_nodes = tuple(self._walk_vex_expr(stmt.guard, tmp_definitions))
-            if any(
-                self._is_tls_canary_load(node, tmp_definitions, tls_reg_offset, canary_offset) for node in guard_nodes
-            ) and any(self._is_stack_load(node, tmp_definitions, stack_reg_offsets) for node in guard_nodes):
-                return True
-        return False
+        stmt_idx = next((idx for idx, candidate in enumerate(statements) if candidate is stmt), -1)
+        if stmt_idx == -1:
+            return False
+
+        if self._stack_canary_retval_writes is None:
+            from .stack_canary_tracker import _StackCanaryTracker  # pylint: disable=import-outside-toplevel
+
+            try:
+                self._stack_canary_retval_writes = _StackCanaryTracker(
+                    self.project,
+                    self.function,
+                    retreg_offset,
+                    tls_reg_offset,
+                    canary_offset,
+                    failure_successors,
+                ).analyze()
+            except SimTranslationError:
+                self._stack_canary_retval_writes = set()
+        return (node, stmt_idx) in self._stack_canary_retval_writes
 
     def _analyze_endpoints_for_retval_size(self, end_states):
         """
@@ -728,7 +782,8 @@ class FactCollector(Analysis):
                 # (e.g., rax) before returning.
                 block_retval_size = None
                 stack_canary_barrier = False
-                for stmt in reversed(block.vex.statements):
+                statements = block.vex.statements
+                for stmt in reversed(statements):
                     if isinstance(stmt, pyvex.IRStmt.Put):
                         assert block.vex.tyenv is not None
                         size = stmt.data.result_size(block.vex.tyenv) // self.project.arch.byte_width
@@ -748,7 +803,7 @@ class FactCollector(Analysis):
 
                         if stmt.offset == retreg_offset:
                             if isinstance(node, BlockNode) and self._is_stack_canary_retval_write(
-                                node, block, stmt.data, tmp_definitions
+                                node, stmt.data, tmp_definitions, statements, stmt, retreg_offset
                             ):
                                 stack_canary_barrier = True
                                 break

--- a/angr/analyses/calling_convention/stack_canary_tracker.py
+++ b/angr/analyses/calling_convention/stack_canary_tracker.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+from collections import deque
+
+import pyvex
+
+from angr.block import Block
+from angr.codenode import BlockNode
+from angr.knowledge_plugins.functions import Function
+from angr.utils.bits import u2s
+
+KIND_SP = 0
+KIND_REG = 1
+KIND_CONST = 3
+KIND_CANARY = 4
+KIND_SAVED_CANARY = 5
+KIND_CANARY_DIFFERENCE = 6
+KIND_CANARY_GUARD = 7
+
+SUBKIND_SP = 0
+SUBKIND_BP = 1
+
+type _CanaryFactData = (
+    tuple[int, int, int]
+    | tuple[int, int, int, BlockNode, int]
+    | tuple[int, int, int, BlockNode, int, BlockNode, int]
+    | tuple[int, int, int, BlockNode, int, BlockNode, int, bool]
+    | None
+)
+
+
+class _CanaryState:
+    __slots__ = ("bp_value", "regs", "sp_value", "stack", "stack_aliases", "tls_known")
+
+    def __init__(
+        self,
+        sp_value: int | None,
+        bp_value: int | None,
+        regs: dict[tuple[int, int], _CanaryFactData] | None = None,
+        stack: dict[int, int] | None = None,
+        stack_aliases: dict[tuple[int, int], _CanaryFactData] | None = None,
+        tls_known: bool = True,
+    ):
+        self.sp_value = sp_value
+        self.bp_value = bp_value
+        self.regs = {} if regs is None else regs
+        self.stack = {} if stack is None else stack
+        self.stack_aliases = {} if stack_aliases is None else stack_aliases
+        self.tls_known = tls_known
+
+    def copy(self) -> _CanaryState:
+        return _CanaryState(
+            self.sp_value,
+            self.bp_value,
+            self.regs.copy(),
+            self.stack.copy(),
+            self.stack_aliases.copy(),
+            self.tls_known,
+        )
+
+    def merge(self, other: _CanaryState) -> _CanaryState:
+        return _CanaryState(
+            self.sp_value if self.sp_value == other.sp_value else None,
+            self.bp_value if self.bp_value == other.bp_value else None,
+            {key: value for key, value in self.regs.items() if other.regs.get(key) == value},
+            {offset: size for offset, size in self.stack.items() if other.stack.get(offset) == size},
+            {key: value for key, value in self.stack_aliases.items() if other.stack_aliases.get(key) == value},
+            self.tls_known and other.tls_known,
+        )
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, _CanaryState)
+            and self.sp_value == other.sp_value
+            and self.bp_value == other.bp_value
+            and self.regs == other.regs
+            and self.stack == other.stack
+            and self.stack_aliases == other.stack_aliases
+            and self.tls_known == other.tls_known
+        )
+
+
+class _StackCanaryTracker:
+    """
+    Tracks stack slots that receive a direct TLS canary on every CFG path and
+    are not overwritten through a statically resolved stack address. Unknown
+    pointer writes are not must-overwrites: detecting those writes at runtime
+    is the reason the compiler emits a canary check. This is intentionally
+    smaller than a general reaching-definitions analysis because FactCollector
+    runs on many functions.
+    """
+
+    def __init__(
+        self,
+        project,
+        function: Function,
+        retreg_offset: int,
+        tls_reg_offset: int,
+        canary_offset: int,
+        failure_successors: dict[BlockNode, set[int]],
+    ):
+        self.project = project
+        self.function = function
+        self.retreg_offset = retreg_offset
+        self.tls_reg_offset = tls_reg_offset
+        self.canary_offset = canary_offset
+        self.failure_successors = failure_successors
+        self._blocks: dict[BlockNode, Block] = {}
+
+    @staticmethod
+    def _ranges_overlap(offset_0: int, size_0: int, offset_1: int, size_1: int) -> bool:
+        return offset_0 < offset_1 + size_1 and offset_1 < offset_0 + size_0
+
+    def _constant_delta(self, value: int) -> int:
+        return u2s(value, self.project.arch.bits)
+
+    def _eval_expr(
+        self,
+        expr: pyvex.IRExpr.IRExpr,
+        state: _CanaryState,
+        tmps: dict[int, _CanaryFactData],
+        tyenv: pyvex.IRTypeEnv,
+    ) -> _CanaryFactData:
+        if isinstance(expr, pyvex.IRExpr.Const):
+            return (KIND_CONST, 0, expr.con.value)
+        if isinstance(expr, pyvex.IRExpr.RdTmp):
+            return tmps.get(expr.tmp)
+        if isinstance(expr, pyvex.IRExpr.Get):
+            if expr.offset == self.project.arch.sp_offset:
+                return None if state.sp_value is None else (KIND_SP, SUBKIND_SP, state.sp_value)
+            if expr.offset == self.project.arch.bp_offset:
+                return None if state.bp_value is None else (KIND_SP, SUBKIND_BP, state.bp_value)
+            if expr.offset == self.tls_reg_offset:
+                return (KIND_REG, self.tls_reg_offset, 0) if state.tls_known else None
+            size = expr.result_size(tyenv) // self.project.arch.byte_width
+            return state.regs.get((expr.offset, size))
+        if isinstance(expr, pyvex.IRExpr.Load):
+            address = self._eval_expr(expr.addr, state, tmps, tyenv)
+            size = expr.result_size(tyenv) // self.project.arch.byte_width
+            if address == (KIND_REG, self.tls_reg_offset, self.canary_offset) and size == self.project.arch.bytes:
+                return (KIND_CANARY, 0, size)
+            if address is not None and address[0] == KIND_SP and state.stack.get(address[2]) == size:
+                return (KIND_SAVED_CANARY, address[2], size)
+            if address is not None and address[0] == KIND_SP:
+                return state.stack_aliases.get((address[2], size))
+            return None
+        if isinstance(expr, pyvex.IRExpr.Unop):
+            operand = self._eval_expr(expr.args[0], state, tmps, tyenv)
+            if (
+                operand is not None
+                and operand[0] == KIND_CANARY_GUARD
+                and expr.op in {"Iop_1Uto32", "Iop_1Uto64", "Iop_32to1", "Iop_64to1"}
+            ):
+                return operand
+            if (operand == (KIND_REG, self.tls_reg_offset, 0) and expr.op == "Iop_16Uto32") or (
+                operand == (KIND_REG, self.tls_reg_offset, self.canary_offset) and expr.op == "Iop_64to32"
+            ):
+                return operand
+            return None
+        if isinstance(expr, pyvex.IRExpr.CCall):
+            if expr.callee.name != "x86g_use_seg_selector" or len(expr.args) != 4:
+                return None
+            selector = self._eval_expr(expr.args[2], state, tmps, tyenv)
+            offset = self._eval_expr(expr.args[3], state, tmps, tyenv)
+            if (
+                selector == (KIND_REG, self.tls_reg_offset, 0)
+                and offset is not None
+                and offset[0] == KIND_CONST
+                and offset[2] == self.canary_offset
+            ):
+                return (KIND_REG, self.tls_reg_offset, self.canary_offset)
+            return None
+        if not isinstance(expr, pyvex.IRExpr.Binop):
+            return None
+
+        operand_0 = self._eval_expr(expr.args[0], state, tmps, tyenv)
+        operand_1 = self._eval_expr(expr.args[1], state, tmps, tyenv)
+        if expr.op.startswith("Iop_Add"):
+            if operand_0 is not None and operand_1 is not None:
+                if operand_0[0] in {KIND_SP, KIND_REG} and operand_1[0] == KIND_CONST:
+                    return (operand_0[0], operand_0[1], operand_0[2] + self._constant_delta(operand_1[2]))
+                if operand_1[0] in {KIND_SP, KIND_REG} and operand_0[0] == KIND_CONST:
+                    return (operand_1[0], operand_1[1], operand_1[2] + self._constant_delta(operand_0[2]))
+            return None
+        if expr.op.startswith("Iop_Sub"):
+            if (
+                operand_0 is not None
+                and operand_1 is not None
+                and operand_0[0] in {KIND_SP, KIND_REG}
+                and operand_1[0] == KIND_CONST
+            ):
+                return (operand_0[0], operand_0[1], operand_0[2] - self._constant_delta(operand_1[2]))
+            canary_difference = self._canary_pair(operand_0, operand_1)
+            if canary_difference is not None:
+                return (KIND_CANARY_DIFFERENCE, *canary_difference)
+            return None
+        if expr.op.startswith("Iop_Xor"):
+            canary_difference = self._canary_pair(operand_0, operand_1)
+            if canary_difference is not None:
+                return (KIND_CANARY_DIFFERENCE, *canary_difference)
+            return None
+        if expr.op.startswith(("Iop_CmpEQ", "Iop_CmpNE")):
+            canary_pair = self._canary_pair(operand_0, operand_1)
+            if canary_pair is not None:
+                return (KIND_CANARY_GUARD, *canary_pair, expr.op.startswith("Iop_CmpNE"))
+            for difference, constant in ((operand_0, operand_1), (operand_1, operand_0)):
+                if (
+                    difference is not None
+                    and difference[0] == KIND_CANARY_DIFFERENCE
+                    and len(difference) == 7
+                    and constant is not None
+                    and constant[0] == KIND_CONST
+                    and constant[2] == 0
+                ):
+                    return (KIND_CANARY_GUARD, *difference[1:], expr.op.startswith("Iop_CmpNE"))
+        return None
+
+    @staticmethod
+    def _canary_pair(
+        operand_0: _CanaryFactData, operand_1: _CanaryFactData
+    ) -> tuple[int, int, BlockNode, int, BlockNode, int] | None:
+        if operand_0 is None or operand_1 is None:
+            return None
+        if (
+            operand_0[0] == KIND_CANARY
+            and len(operand_0) == 5
+            and operand_1[0] == KIND_SAVED_CANARY
+            and len(operand_1) == 5
+        ):
+            return operand_1[1], operand_1[2], operand_1[3], operand_1[4], operand_0[3], operand_0[4]
+        if (
+            operand_1[0] == KIND_CANARY
+            and len(operand_1) == 5
+            and operand_0[0] == KIND_SAVED_CANARY
+            and len(operand_0) == 5
+        ):
+            return operand_0[1], operand_0[2], operand_0[3], operand_0[4], operand_1[3], operand_1[4]
+        return None
+
+    @staticmethod
+    def _bind_canary_value(value: _CanaryFactData, node: BlockNode, stmt_idx: int) -> _CanaryFactData:
+        if value is not None and value[0] in {KIND_CANARY, KIND_SAVED_CANARY} and len(value) == 3:
+            return value[0], value[1], value[2], node, stmt_idx
+        return value
+
+    def _write_register(self, state: _CanaryState, offset: int, size: int, value: _CanaryFactData) -> None:
+        for existing_offset, existing_size in list(state.regs):
+            if self._ranges_overlap(offset, size, existing_offset, existing_size):
+                del state.regs[existing_offset, existing_size]
+        if value is not None and value[0] in {
+            KIND_SP,
+            KIND_REG,
+            KIND_CANARY,
+            KIND_SAVED_CANARY,
+            KIND_CANARY_DIFFERENCE,
+            KIND_CANARY_GUARD,
+        }:
+            state.regs[offset, size] = value
+
+    def _kill_stack_range(self, state: _CanaryState, address: _CanaryFactData, size: int) -> None:
+        if address is None or address[0] != KIND_SP:
+            return
+        for existing_offset, existing_size in list(state.stack.items()):
+            if self._ranges_overlap(address[2], size, existing_offset, existing_size):
+                del state.stack[existing_offset]
+        for existing_offset, existing_size in list(state.stack_aliases):
+            if self._ranges_overlap(address[2], size, existing_offset, existing_size):
+                del state.stack_aliases[existing_offset, existing_size]
+
+    def _kill_tls_canary_provenance(
+        self,
+        state: _CanaryState,
+        tmps: dict[int, _CanaryFactData],
+        address: _CanaryFactData,
+        size: int,
+    ) -> None:
+        if (
+            address is None
+            or address[0] != KIND_REG
+            or address[1] != self.tls_reg_offset
+            or not self._ranges_overlap(address[2], size, self.canary_offset, self.project.arch.bytes)
+        ):
+            return
+        state.tls_known = False
+        for key, value in list(state.regs.items()):
+            if value is None or value[0] != KIND_SP:
+                del state.regs[key]
+        state.stack.clear()
+        tmps.clear()
+
+    def _block(self, node: BlockNode) -> Block:
+        block = self._blocks.get(node)
+        if block is None:
+            block = self.project.factory.block(node.addr, size=node.size)
+            self._blocks[node] = block
+        return block
+
+    def _transfer(self, node: BlockNode, input_state: _CanaryState) -> tuple[_CanaryState, set[tuple[BlockNode, int]]]:
+        state = input_state.copy()
+        block = self._block(node)
+        tyenv = block.vex.tyenv
+        if tyenv is None:
+            return _CanaryState(None, None, tls_known=False), set()
+        tmps: dict[int, _CanaryFactData] = {}
+        retval_writes: dict[tuple[int, int, BlockNode, int, BlockNode, int], tuple[BlockNode, int]] = {}
+        recognized_writes: set[tuple[BlockNode, int]] = set()
+        boring_exit_count = sum(
+            isinstance(stmt, pyvex.IRStmt.Exit) and stmt.jumpkind == "Ijk_Boring" for stmt in block.vex.statements
+        )
+        next_expr = block.vex.next
+        default_target = next_expr.con.value if isinstance(next_expr, pyvex.IRExpr.Const) else None
+        failure_successors = self.failure_successors.get(node, set())
+        saw_exit = False
+        path_dependent_state = False
+
+        for stmt_idx, stmt in enumerate(block.vex.statements):
+            if saw_exit and (
+                isinstance(
+                    stmt,
+                    (
+                        pyvex.IRStmt.Store,
+                        pyvex.IRStmt.StoreG,
+                        pyvex.IRStmt.CAS,
+                        pyvex.IRStmt.LLSC,
+                        pyvex.IRStmt.Dirty,
+                    ),
+                )
+                or (isinstance(stmt, pyvex.IRStmt.Put) and stmt.offset != self.project.arch.ip_offset)
+            ):
+                path_dependent_state = True
+
+            if isinstance(stmt, pyvex.IRStmt.WrTmp):
+                tmps[stmt.tmp] = self._bind_canary_value(self._eval_expr(stmt.data, state, tmps, tyenv), node, stmt_idx)
+            elif isinstance(stmt, pyvex.IRStmt.Store):
+                address = self._eval_expr(stmt.addr, state, tmps, tyenv)
+                data = self._eval_expr(stmt.data, state, tmps, tyenv)
+                size = stmt.data.result_size(tyenv) // self.project.arch.byte_width
+                self._kill_tls_canary_provenance(state, tmps, address, size)
+                if address is not None and address[0] == KIND_SP:
+                    self._kill_stack_range(state, address, size)
+                    if (
+                        data is not None
+                        and data[0] == KIND_CANARY
+                        and data[1] == 0
+                        and data[2] == self.project.arch.bytes
+                        and size == self.project.arch.bytes
+                    ):
+                        state.stack[address[2]] = size
+                    elif data is not None and data[0] == KIND_SP and size == self.project.arch.bytes:
+                        state.stack_aliases[address[2], size] = data
+            elif isinstance(stmt, pyvex.IRStmt.StoreG):
+                address = self._eval_expr(stmt.addr, state, tmps, tyenv)
+                size = stmt.data.result_size(tyenv) // self.project.arch.byte_width
+                self._kill_tls_canary_provenance(state, tmps, address, size)
+                self._kill_stack_range(state, address, size)
+            elif isinstance(stmt, pyvex.IRStmt.CAS):
+                address = self._eval_expr(stmt.addr, state, tmps, tyenv)
+                size = stmt.dataLo.result_size(tyenv) // self.project.arch.byte_width
+                if stmt.dataHi is not None:
+                    size += stmt.dataHi.result_size(tyenv) // self.project.arch.byte_width
+                self._kill_tls_canary_provenance(state, tmps, address, size)
+                self._kill_stack_range(state, address, size)
+                tmps[stmt.oldLo] = None
+                if stmt.oldHi is not None:
+                    tmps[stmt.oldHi] = None
+            elif isinstance(stmt, pyvex.IRStmt.LLSC):
+                if stmt.storedata is not None:
+                    address = self._eval_expr(stmt.addr, state, tmps, tyenv)
+                    size = stmt.storedata.result_size(tyenv) // self.project.arch.byte_width
+                    self._kill_tls_canary_provenance(state, tmps, address, size)
+                    self._kill_stack_range(state, address, size)
+                tmps[stmt.result] = None
+            elif isinstance(stmt, pyvex.IRStmt.Dirty):
+                if stmt.mFx in {"Ifx_Write", "Ifx_Modify"} and stmt.mAddr is not None:
+                    address = self._eval_expr(stmt.mAddr, state, tmps, tyenv)
+                    self._kill_tls_canary_provenance(state, tmps, address, stmt.mSize)
+                    self._kill_stack_range(state, address, stmt.mSize)
+                if stmt.nFxState:
+                    state.regs.clear()
+                if stmt.tmp not in {-1, 0xFFFFFFFF}:
+                    tmps[stmt.tmp] = None
+            elif isinstance(stmt, pyvex.IRStmt.Put):
+                value = self._bind_canary_value(self._eval_expr(stmt.data, state, tmps, tyenv), node, stmt_idx)
+                size = stmt.data.result_size(tyenv) // self.project.arch.byte_width
+                if stmt.offset == self.project.arch.sp_offset:
+                    state.sp_value = value[2] if value is not None and value[0] == KIND_SP else None
+                elif stmt.offset == self.project.arch.bp_offset:
+                    state.bp_value = value[2] if value is not None and value[0] == KIND_SP else None
+                elif stmt.offset == self.tls_reg_offset:
+                    state.tls_known = value == (KIND_REG, self.tls_reg_offset, 0)
+                else:
+                    self._write_register(state, stmt.offset, size, value)
+                if (
+                    stmt.offset == self.retreg_offset
+                    and value is not None
+                    and value[0] == KIND_CANARY_DIFFERENCE
+                    and len(value) == 7
+                ):
+                    retval_writes[value[1:]] = node, stmt_idx
+            elif isinstance(stmt, pyvex.IRStmt.Exit):
+                guard = self._eval_expr(stmt.guard, state, tmps, tyenv)
+                if (
+                    stmt.jumpkind == "Ijk_Boring"
+                    and guard is not None
+                    and guard[0] == KIND_CANARY_GUARD
+                    and len(guard) == 8
+                    and (
+                        (stmt.dst.value in failure_successors and guard[7])
+                        or (boring_exit_count == 1 and default_target in failure_successors and not guard[7])
+                    )
+                ):
+                    origin = guard[1:7]
+                    if origin in retval_writes:
+                        recognized_writes.add(retval_writes[origin])
+                if stmt.jumpkind == "Ijk_Boring":
+                    saw_exit = True
+
+        jumpkind = block.vex.jumpkind
+        if jumpkind == "Ijk_Call":
+            path_dependent_state |= saw_exit
+            state.regs.clear()
+            if state.sp_value is None:
+                state.stack.clear()
+                state.stack_aliases.clear()
+            elif self.project.arch.stack_change < 0:
+                state.stack = {offset: size for offset, size in state.stack.items() if offset > state.sp_value}
+                state.stack_aliases = {
+                    key: value for key, value in state.stack_aliases.items() if key[0] > state.sp_value
+                }
+            else:
+                state.stack = {offset: size for offset, size in state.stack.items() if offset < state.sp_value}
+                state.stack_aliases = {
+                    key: value for key, value in state.stack_aliases.items() if key[0] < state.sp_value
+                }
+            if self.project.arch.call_pushes_ret and state.sp_value is not None:
+                state.sp_value += self.project.arch.bytes
+        elif jumpkind is not None and jumpkind.startswith("Ijk_Sys"):
+            path_dependent_state |= saw_exit
+            state.regs.clear()
+        if path_dependent_state:
+            state = _CanaryState(None, None, tls_known=False)
+        return state, recognized_writes
+
+    def analyze(self) -> set[tuple[BlockNode, int]]:
+        startpoint = self.function.startpoint
+        if not isinstance(startpoint, BlockNode):
+            return set()
+
+        def is_local_block(node) -> bool:
+            return isinstance(node, BlockNode) and self.function.get_node(node.addr) == node
+
+        if any(
+            is_local_block(target)
+            and not data.get("outside", False)
+            and (not is_local_block(source) or data.get("type") not in {"transition", "fake_return"})
+            for source, target, data in self.function.transition_graph.edges(data=True)
+        ):
+            return set()
+        initial_sp = self.project.arch.bytes if self.project.arch.call_pushes_ret else 0
+        input_states = {startpoint: _CanaryState(initial_sp, None)}
+        output_states: dict[BlockNode, _CanaryState] = {}
+        recognized_by_node: dict[BlockNode, set[tuple[BlockNode, int]]] = {}
+        queue = deque([startpoint])
+        graph = self.function.transition_graph
+
+        while queue:
+            node = queue.popleft()
+            output_state, node_writes = self._transfer(node, input_states[node])
+            recognized_by_node[node] = node_writes
+            if output_states.get(node) == output_state:
+                continue
+            output_states[node] = output_state
+            for _, successor, data in graph.out_edges(node, data=True):
+                if (
+                    not isinstance(successor, BlockNode)
+                    or data.get("outside", False)
+                    or data.get("type") not in {"transition", "fake_return"}
+                ):
+                    continue
+                old_input = input_states.get(successor)
+                new_input = output_state.copy() if old_input is None else old_input.merge(output_state)
+                if old_input != new_input:
+                    input_states[successor] = new_input
+                    queue.append(successor)
+
+        return set().union(*recognized_by_node.values()) if recognized_by_node else set()

--- a/tests/analyses/test_fact_collector.py
+++ b/tests/analyses/test_fact_collector.py
@@ -14,27 +14,78 @@ from angr.calling_conventions import (
     SimCCSystemVAMD64,
     default_cc,
 )
+from angr.codenode import BlockNode, FuncNode
+from angr.sim_type import SimTypeBottom
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
+
+
+class _TerminalFailure(angr.SimProcedure):
+    NO_RET = True
+
+    def run(self):
+        self.exit(1)
 
 
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
 class TestFactCollector(unittest.TestCase):
     @staticmethod
-    def _collect_shellcode_facts(code: bytes, arch: str = "amd64"):
+    def _collect_shellcode(
+        code: bytes,
+        arch: str = "amd64",
+        failure_name: str | None = None,
+        reverse_entry_successors: bool = False,
+    ):
         base_addr = 0x400000
+        function_starts = [base_addr]
+        failure_addr = base_addr + len(code) if failure_name is not None else None
+        if failure_addr is not None:
+            code += b"\xcc"
         project = angr.load_shellcode(code, arch=arch, load_address=base_addr)
+        if failure_addr is not None:
+            project.hook(failure_addr, _TerminalFailure(display_name=failure_name))
+            function_starts.append(failure_addr)
         cfg = project.analyses.CFGFast(
             normalize=True,
             regions=[(base_addr, base_addr + len(code))],
-            function_starts=[base_addr],
+            function_starts=function_starts,
             start_at_entry=False,
             symbols=False,
             force_smart_scan=False,
         )
-        return project.analyses.FunctionFactCollector(cfg.kb.functions[base_addr])
+        function = cfg.kb.functions[base_addr]
+        if reverse_entry_successors:
+            graph = function.transition_graph
+            entry = function.startpoint
+            outgoing_edges = list(graph.out_edges(entry, data=True))
+            assert len(outgoing_edges) == 2
+            for source, target, _ in outgoing_edges:
+                graph.remove_edge(source, target)
+            for source, target, data in reversed(outgoing_edges):
+                graph.add_edge(source, target, **data)
+        facts = project.analyses.FunctionFactCollector(function)
+        return project, cfg, function, facts
+
+    @classmethod
+    def _collect_shellcode_facts(cls, code: bytes, arch: str = "amd64", failure_name: str | None = None):
+        return cls._collect_shellcode(code, arch=arch, failure_name=failure_name)[3]
+
+    @classmethod
+    def _assert_shellcode_return_type(
+        cls, code: bytes, expected_size: int | None, arch: str = "amd64", failure_name: str | None = None
+    ):
+        project, cfg, function, facts = cls._collect_shellcode(code, arch=arch, failure_name=failure_name)
+        cc_analysis = project.analyses.CallingConvention(
+            function,
+            cfg=cfg.model,
+            input_args=facts.input_args,
+            retval_size=facts.retval_size,
+        )
+        assert cc_analysis.prototype is not None
+        assert facts.retval_size == expected_size
+        assert isinstance(cc_analysis.prototype.returnty, SimTypeBottom) is (expected_size is None)
 
     def test_stack_canary_comparison_is_not_a_return_value(self):
         prefix = bytes.fromhex(
@@ -53,7 +104,9 @@ class TestFactCollector(unittest.TestCase):
 
         for operation in ("64482b042528000000", "644833042528000000"):  # sub/xor rax, qword ptr fs:[0x28]
             with self.subTest(operation=operation):
-                facts = self._collect_shellcode_facts(prefix + bytes.fromhex(operation) + void_tail)
+                facts = self._collect_shellcode_facts(
+                    prefix + bytes.fromhex(operation) + void_tail, failure_name="__stack_chk_fail"
+                )
                 self.assertIsNone(facts.retval_size)
 
     def test_x86_stack_canary_comparison_is_not_a_return_value(self):
@@ -70,7 +123,7 @@ class TestFactCollector(unittest.TestCase):
             "e800000000"  # call stack_chk_fail
         )
 
-        facts = self._collect_shellcode_facts(code, arch="x86")
+        facts = self._collect_shellcode_facts(code, arch="x86", failure_name="__stack_chk_fail")
 
         self.assertIsNone(facts.retval_size)
 
@@ -91,7 +144,9 @@ class TestFactCollector(unittest.TestCase):
         )
         for return_code, expected_size in cases:
             with self.subTest(expected_size=expected_size):
-                facts = self._collect_shellcode_facts(prefix + bytes.fromhex(return_code) + epilogue)
+                facts = self._collect_shellcode_facts(
+                    prefix + bytes.fromhex(return_code) + epilogue, failure_name="__stack_chk_fail"
+                )
                 self.assertEqual(facts.retval_size, expected_size)
 
     def test_tls_arithmetic_without_terminal_call_is_a_return_value(self):
@@ -110,6 +165,584 @@ class TestFactCollector(unittest.TestCase):
         )
 
         facts = self._collect_shellcode_facts(code)
+
+        self.assertEqual(facts.retval_size, 8)
+
+    def test_canary_retval_and_guard_must_use_the_same_saved_slot(self):
+        code = bytes.fromhex(
+            "4883ec28"  # sub rsp, 0x28
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442418"  # mov qword ptr [rsp + 0x18], rax
+            "48897c2408"  # mov qword ptr [rsp + 8], rdi
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "488b4c2418"  # mov rcx, qword ptr [rsp + 0x18]
+            "64482b0c2528000000"  # sub rcx, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c428"  # add rsp, 0x28
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_canary_retval_and_guard_must_use_the_same_value_definition(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "488b4c2408"  # mov rcx, qword ptr [rsp + 8]
+            "64482b0c2528000000"  # sub rcx, qword ptr fs:[0x28]
+            "4885c9"  # test rcx, rcx
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_indexed_tls_address_is_not_a_stack_canary(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "48897c2408"  # mov qword ptr [rsp + 8], rdi
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b4328"  # sub rax, qword ptr fs:[rbx + 0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_unsaved_stack_value_is_not_a_stack_canary(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "48897c2408"  # mov qword ptr [rsp + 8], rdi
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_unrelated_terminal_call_is_not_a_stack_canary_failure(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "31c0"  # xor eax, eax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne panic_now
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call panic_now
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="panic_now")
+
+    def test_canary_guard_must_control_stack_chk_fail_edge(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne alternate return
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "4883c418"  # alternate return: add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # unreachable call stack_chk_fail
+        )
+        project, _, function, _ = self._collect_shellcode(code, failure_name="__stack_chk_fail")
+        check_node = function.startpoint
+        assert isinstance(check_node, BlockNode)
+        fake_call = BlockNode(check_node.addr + len(code) - 5, 5)
+        function.transition_graph.add_edge(check_node, fake_call, type="transition", outside=False)
+        function.transition_graph.add_edge(
+            fake_call,
+            FuncNode(check_node.addr + len(code)),
+            type="call",
+            outside=True,
+        )
+
+        facts = project.analyses.FunctionFactCollector(function)
+
+        self.assertEqual(facts.retval_size, 8)
+
+    def test_stack_chk_fail_edge_must_represent_a_canary_mismatch(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7405"  # je stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_fallthrough_stack_chk_fail_must_represent_a_canary_mismatch(self):
+        prefix = (
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+        )
+        suffix = (
+            "e805000000"  # call stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+        )
+        for branch, expected_size in (("7405", None), ("7505", 8)):  # je/jne successful return
+            with self.subTest(branch=branch):
+                self._assert_shellcode_return_type(
+                    bytes.fromhex(prefix + branch + suffix),
+                    expected_size,
+                    failure_name="__stack_chk_fail",
+                )
+
+    def test_stack_chk_fail_call_block_must_belong_to_function(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "31c0"  # xor eax, eax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne alternate return
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "4883c418"  # alternate return: add rsp, 0x18
+            "c3"  # ret
+        )
+        project, _, function, _ = self._collect_shellcode(code, failure_name="__stack_chk_fail")
+        check_node = function.startpoint
+        assert isinstance(check_node, BlockNode)
+        target = next(
+            target
+            for _, target, _ in function.transition_graph.out_edges(check_node, data=True)
+            if isinstance(target, BlockNode)
+        )
+        fake_call = BlockNode(target.addr, target.size + 1)
+        self.assertNotEqual(function.get_node(fake_call.addr), fake_call)
+        function.transition_graph.add_edge(check_node, fake_call, type="transition", outside=False)
+        function.transition_graph.add_edge(
+            fake_call,
+            FuncNode(check_node.addr + len(code)),
+            type="call",
+            outside=True,
+        )
+
+        facts = project.analyses.FunctionFactCollector(function)
+
+        self.assertEqual(facts.retval_size, 8)
+
+    def test_canary_provenance_rejects_unknown_internal_edges(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+        project, _, function, _ = self._collect_shellcode(code, failure_name="__stack_chk_fail")
+        check_node = function.startpoint
+        assert isinstance(check_node, BlockNode)
+        unknown_source = BlockNode(check_node.addr + 0x1000, 1)
+        function.transition_graph.add_edge(unknown_source, check_node, type="unknown-internal-edge", outside=False)
+
+        facts = project.analyses.FunctionFactCollector(function)
+
+        self.assertEqual(facts.retval_size, 8)
+
+    def test_canary_provenance_rejects_transitions_from_outside_function(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+        for name in ("different_address", "same_address_different_size"):
+            with self.subTest(name=name):
+                project, _, function, _ = self._collect_shellcode(code, failure_name="__stack_chk_fail")
+                check_node = function.startpoint
+                assert isinstance(check_node, BlockNode)
+                external_source = (
+                    BlockNode(check_node.addr + 4, 1)
+                    if name == "different_address"
+                    else BlockNode(check_node.addr, check_node.size - 1)
+                )
+                self.assertNotEqual(function.get_node(external_source.addr), external_source)
+                function.transition_graph.add_edge(external_source, check_node, type="transition", outside=False)
+
+                facts = project.analyses.FunctionFactCollector(function)
+
+                self.assertEqual(facts.retval_size, 8)
+
+    def test_arithmetic_derived_canary_values_remain_return_values(self):
+        tails = {
+            "tls_plus_one": (
+                "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+                "4883c001"  # add rax, 1
+                "482b442408"  # sub rax, qword ptr [rsp + 8]
+            ),
+            "tls_minus_one": (
+                "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+                "4883e801"  # sub rax, 1
+                "482b442408"  # sub rax, qword ptr [rsp + 8]
+            ),
+            "saved_plus_one": (
+                "488b442408"  # mov rax, qword ptr [rsp + 8]
+                "4883c001"  # add rax, 1
+                "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            ),
+            "saved_minus_one": (
+                "488b442408"  # mov rax, qword ptr [rsp + 8]
+                "4883e801"  # sub rax, 1
+                "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            ),
+        }
+        prefix = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+        )
+        epilogue = bytes.fromhex(
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        for name, tail in tails.items():
+            with self.subTest(name=name):
+                self._assert_shellcode_return_type(
+                    prefix + bytes.fromhex(tail) + epilogue,
+                    8,
+                    failure_name="__stack_chk_fail",
+                )
+
+    def test_stored_arithmetic_derived_tls_value_is_a_return_value(self):
+        for operation in ("4883c001", "4883e801"):  # add/sub rax, 1
+            with self.subTest(operation=operation):
+                code = bytes.fromhex(
+                    "4883ec18"  # sub rsp, 0x18
+                    "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+                    + operation
+                    + "4889442408"  # mov qword ptr [rsp + 8], rax
+                    "488b442408"  # mov rax, qword ptr [rsp + 8]
+                    "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+                    "7505"  # jne stack_chk_fail
+                    "4883c418"  # add rsp, 0x18
+                    "c3"  # ret
+                    "e800000000"  # call stack_chk_fail
+                )
+
+                self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_dirty_helper_clobber_of_canary_register_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "0fa2"  # cpuid
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_syscall_clobber_of_canary_register_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "0f05"  # syscall
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_direct_tls_load_can_be_a_real_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b142528000000"  # mov rdx, qword ptr fs:[0x28]
+            "4889542408"  # mov qword ptr [rsp + 8], rdx
+            "31c0"  # xor eax, eax
+            "488b542408"  # mov rdx, qword ptr [rsp + 8]
+            "64482b142528000000"  # sub rdx, qword ptr fs:[0x28]
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_narrowed_canary_arithmetic_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "31c0"  # xor eax, eax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "0fb6c0"  # movzx eax, al
+            "85c0"  # test eax, eax
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_partially_overwritten_saved_canary_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "40887c240c"  # mov byte ptr [rsp + 0xc], dil
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_overwritten_tls_canary_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec28"  # sub rsp, 0x28
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442418"  # mov qword ptr [rsp + 0x18], rax
+            "6448893c2528000000"  # mov qword ptr fs:[0x28], rdi
+            "488b442418"  # mov rax, qword ptr [rsp + 0x18]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c428"  # add rsp, 0x28
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_same_stack_expression_after_stack_adjustment_is_not_the_saved_canary(self):
+        code = bytes.fromhex(
+            "4883ec28"  # sub rsp, 0x28
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442418"  # mov qword ptr [rsp + 0x18], rax
+            "4883c408"  # add rsp, 8
+            "488b442418"  # mov rax, qword ptr [rsp + 0x18]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c420"  # add rsp, 0x20
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_atomic_overwrite_of_saved_canary_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "f0480fb17c2408"  # lock cmpxchg qword ptr [rsp + 8], rdi
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_aliased_overwrite_of_saved_canary_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "488d4c2408"  # lea rcx, [rsp + 8]
+            "488939"  # mov qword ptr [rcx], rdi
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_spilled_alias_overwrite_of_saved_canary_is_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec28"  # sub rsp, 0x28
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442418"  # mov qword ptr [rsp + 0x18], rax
+            "488d4c2418"  # lea rcx, [rsp + 0x18]
+            "48894c2408"  # mov qword ptr [rsp + 8], rcx
+            "31c9"  # xor ecx, ecx
+            "488b4c2408"  # mov rcx, qword ptr [rsp + 8]
+            "488939"  # mov qword ptr [rcx], rdi
+            "488b442418"  # mov rax, qword ptr [rsp + 0x18]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c428"  # add rsp, 0x28
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_canary_saved_through_stack_alias_is_not_a_return_value(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "488d4c2408"  # lea rcx, [rsp + 8]
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "488901"  # mov qword ptr [rcx], rax
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        self._assert_shellcode_return_type(code, None, failure_name="__stack_chk_fail")
+
+    def test_dead_canary_slot_is_not_preserved_across_a_call(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "4883c420"  # add rsp, 0x20, moving the saved slot below rsp
+            "e81e000000"  # call helper
+            "4883ec20"  # sub rsp, 0x20
+            "488b442408"  # mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e801000000"  # call stack_chk_fail
+            "c3"  # helper: ret
+        )
+
+        self._assert_shellcode_return_type(code, 8, failure_name="__stack_chk_fail")
+
+    def test_canary_provenance_must_hold_on_every_path(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "85ff"  # test edi, edi
+            "7410"  # je ordinary_value
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "eb05"  # jmp shared_epilogue
+            "48897c2408"  # ordinary_value: mov qword ptr [rsp + 8], rdi
+            "488b442408"  # shared_epilogue: mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        for reverse_successors in (False, True):
+            with self.subTest(reverse_successors=reverse_successors):
+                project, cfg, function, facts = self._collect_shellcode(
+                    code,
+                    failure_name="__stack_chk_fail",
+                    reverse_entry_successors=reverse_successors,
+                )
+                cc_analysis = project.analyses.CallingConvention(
+                    function,
+                    cfg=cfg.model,
+                    input_args=facts.input_args,
+                    retval_size=facts.retval_size,
+                )
+                assert cc_analysis.prototype is not None
+                self.assertEqual(facts.retval_size, 8)
+                self.assertNotIsInstance(cc_analysis.prototype.returnty, SimTypeBottom)
+
+    def test_canary_provenance_is_preserved_across_equivalent_paths(self):
+        code = bytes.fromhex(
+            "4883ec18"  # sub rsp, 0x18
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "4889442408"  # mov qword ptr [rsp + 8], rax
+            "85ff"  # test edi, edi
+            "7402"  # je second_path
+            "eb01"  # jmp shared_epilogue
+            "90"  # second_path: nop
+            "488b442408"  # shared_epilogue: mov rax, qword ptr [rsp + 8]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c418"  # add rsp, 0x18
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+
+        for reverse_successors in (False, True):
+            with self.subTest(reverse_successors=reverse_successors):
+                _, _, _, facts = self._collect_shellcode(
+                    code,
+                    failure_name="__stack_chk_fail",
+                    reverse_entry_successors=reverse_successors,
+                )
+                self.assertIsNone(facts.retval_size)
+
+    def test_path_dependent_vex_updates_are_not_propagated_to_exit_edge(self):
+        code = bytes.fromhex(
+            "4883ec28"  # sub rsp, 0x28
+            "488d7c2418"  # lea rdi, [rsp + 0x18]
+            "64488b042528000000"  # mov rax, qword ptr fs:[0x28]
+            "f348ab"  # rep stosq
+            "488b442418"  # mov rax, qword ptr [rsp + 0x18]
+            "64482b042528000000"  # sub rax, qword ptr fs:[0x28]
+            "7505"  # jne stack_chk_fail
+            "4883c428"  # add rsp, 0x28
+            "c3"  # ret
+            "e800000000"  # call stack_chk_fail
+        )
+        project, _, function, _ = self._collect_shellcode(code, failure_name="__stack_chk_fail")
+        loop_edge = next((source, target) for source, target in function.transition_graph.edges() if source == target)
+        function.transition_graph.remove_edge(*loop_edge)
+
+        facts = project.analyses.FunctionFactCollector(function)
 
         self.assertEqual(facts.retval_size, 8)
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

This is a soundness follow-up to #6699. That change correctly stopped GCC stack-canary comparisons from becoming bogus function return values, but its local syntactic test was too permissive: a stack load and TLS-canary subtraction near a terminal call were enough. It did not prove that the stack value was the saved canary, that the same value reached the guard, that the failure edge represented a mismatch, or that the terminal callee was actually `__stack_chk_fail`. A coincidental match could therefore hide a real return value.

This change replaces that assumption with a conservative, all-path provenance check. It:

- requires an exact non-returning `__stack_chk_fail` successor;
- tracks a direct Linux x86/AMD64 TLS canary load into its saved stack slot;
- requires the return-register comparison and branch guard to use the same saved-slot and TLS-load definitions;
- joins CFG paths with must semantics and fails closed on unknown internal edges;
- invalidates provenance on partial/direct/aliased/atomic overwrites, TLS overwrites, calls, syscalls, dirty helpers, and path-dependent VEX effects; and
- verifies branch polarity for both taken and fall-through failure edges.

The tracker is lazily imported only after the existing x86 canary-shaped expression filter and exact failure-edge check. Non-x86 functions do not pay its import or analysis cost.

## DecBench before/after

The sealed A/B baseline was merged #6699 (`83d0061e12945abd722759a98d7cfb7f825ef980`). The candidate corpus tree has the same Python AST as final head `b9f5c7647e999fe48aea9b2d4e7dd7c0cee14343`; only Ruff formatting separates the recorded tree bytes from the commit. Every function ran in a fresh process with a 300-second hard limit, isolated caches, pinned input hashes, and `use_cache=False`.

| Full-Decompiler gate | Before | After | Source-attributable regression |
| --- | --- | --- | --- |
| Default SAILR, broad 2,002-case corpus | 1,981 success; 15 errors; 6 invalid inputs; 0 timeouts | 1,982 success; 14 errors; 6 invalid inputs; 0 timeouts | 0; the apparent gained success was nondeterministic under serial repeat |
| SAILR, role-swapped 250-case cross-architecture sample | 245 success; 1 error; 4 invalid inputs | identical in both tree orders | 0 status, code, structure, type, or persistent timing changes |
| Phoenix, role-swapped same 250 cases | 245 success; 1 error; 4 invalid inputs | identical in both tree orders | 0 status, code, structure, type, or persistent timing changes |
| DREAM, role-swapped same 250 cases | 243 success; 2 errors; 1 pre-existing hard timeout; 4 invalid inputs | identical in both tree orders | 0 status or persistent timing changes; 0 source-attributable output changes |

The 250-case sample spans 40 projects, 224 binaries, AMD64, X86, ARMEL, and Cortex-M, at O0, O2, and O2-noinline. The one apparent source-stable DREAM output delta was tested with four additional A/A pairs: both the unmodified baseline and this branch independently emitted the same two hashes against themselves, confirming pre-existing DREAM order sensitivity rather than a change-induced delta.

Across the 2,002-case gate, median candidate-minus-baseline wall time was +0.0024 seconds and median decompilation time was -0.0005 seconds. All one-shot timing flags were replayed serially in both tree orders; no case remained slower by both 0.1 seconds and 20% in both orders. A separate role-swapped ARM cohort showed mixed-sign noise with a +0.0028-second median, clearing the unrelated-architecture import overhead found in an earlier eager implementation.

The eight source-ground stack-protected `void` functions used for #6699 remain 8/8 source-correct before and 8/8 after. Their generated code, type data, prototypes, and return handling are byte-for-byte unchanged. Thus this follow-up retains the known accuracy gain while rejecting unsound generalizations of the pattern.

## Regression coverage

Twenty-eight focused tests were added. They cover the canonical AMD64 and x86 patterns plus real-return preservation, mismatched saved slots and definitions, indexed TLS addresses, unsaved values, unrelated terminal calls, wrong branch polarity, foreign/unknown CFG edges, derived or narrowed canary values, direct/partial/atomic/aliased/spilled-alias overwrites, stack adjustment, TLS overwrite, calls, dirty helpers, syscalls, equivalent and divergent paths, and VEX statements after conditional exits.

Validation:

- final formatted tree, focused FactCollector file: 35 passed, 18 subtests passed;
- identical pre-format Python AST, complete angr suite: 2,313 passed, 46 skipped, 2 expected xfailed, 228 subtests passed;
- final formatted tree, Ruff check and format check: clean;
- final formatted tree, Pyright: 0 errors, 0 warnings;
- final formatted tree, Pylint: 10.00/10; and
- final formatted tree, `git diff --check`: clean.

The workspace Nix wrapper was unavailable in this shell, so the complete angr suite was run directly against the pinned workspace dependency checkouts with the required compiler and Java toolchains. No dependency repository was modified.
