### PR TITLE
x86/amd64: fix das carry flag (borrow on old AL; don't drop block-1 CF)

### DIFF
--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -1292,13 +1292,14 @@ def x86g_calculate_daa_das_aaa_aas(state, flags_and_AX, opcode):
         old_C = r_C
 
         condition = claripy.Or((r_AL & 0xF) > 9, r_A == 1)
+        borrow = claripy.If(r_AL < 6, one, zero)   # test borrow on old AL, pre-subtract
         r_AL = claripy.If(condition, r_AL - 6, old_AL)
-        r_C = claripy.If(condition, claripy.If(r_AL < 6, one, zero), zero)
+        r_C = claripy.If(condition, old_C | borrow, zero)
         r_A = claripy.If(condition, one, zero)
 
         condition = claripy.Or(old_AL > 0x99, old_C == 1)
         r_AL = claripy.If(condition, r_AL - 0x60, r_AL)
-        r_C = claripy.If(condition, one, zero)
+        r_C = claripy.If(condition, one, r_C)      # preserve block-1 CF when cond false
 
         r_AL &= 0xFF
         r_O = zero

--- a/angr/engines/vex/claripy/ccall.py
+++ b/angr/engines/vex/claripy/ccall.py
@@ -1292,14 +1292,14 @@ def x86g_calculate_daa_das_aaa_aas(state, flags_and_AX, opcode):
         old_C = r_C
 
         condition = claripy.Or((r_AL & 0xF) > 9, r_A == 1)
-        borrow = claripy.If(r_AL < 6, one, zero)   # test borrow on old AL, pre-subtract
+        borrow = claripy.If(r_AL < 6, one, zero)  # test borrow on old AL, pre-subtract
         r_AL = claripy.If(condition, r_AL - 6, old_AL)
         r_C = claripy.If(condition, old_C | borrow, zero)
         r_A = claripy.If(condition, one, zero)
 
         condition = claripy.Or(old_AL > 0x99, old_C == 1)
         r_AL = claripy.If(condition, r_AL - 0x60, r_AL)
-        r_C = claripy.If(condition, one, r_C)      # preserve block-1 CF when cond false
+        r_C = claripy.If(condition, one, r_C)  # preserve block-1 CF when cond false
 
         r_AL &= 0xFF
         r_O = zero

--- a/tests/engines/vex/test_vex.py
+++ b/tests/engines/vex/test_vex.py
@@ -596,6 +596,29 @@ class TestVex(unittest.TestCase):
         solver.add(sm.one_deadended.regs.rax != target_func)
         assert not solver.satisfiable()
 
+    def test_x86_das_carry(self):
+        # DAS (0x2F): the low-nibble adjust `AL -= 6` borrows for AL in [0, 5]
+        # when AF is set, so CF must come out 1. Regression for the fix that
+        # tests the borrow on the pre-subtraction AL and preserves that carry
+        # through the high-nibble block. Exercises the daa/das ccall's 0x2F path.
+        p = load_shellcode(b"\x2f", arch="x86")
+        s = SimState(project=p)
+        off = s_ccall.data["X86"]["CondBitOffsets"]
+        sc, sa = off["G_CC_SHIFT_C"], off["G_CC_SHIFT_A"]
+
+        def das(al, af, cf_in):
+            fa = (al & 0xFF) | (af << (16 + sa)) | (cf_in << (16 + sc))
+            r = s_ccall.x86g_calculate_daa_das_aaa_aas(s, claripy.BVV(fa, 32), claripy.BVV(0x2F, 32))
+            return (s.solver.eval(r) >> (16 + sc)) & 1
+
+        # AL in [0,5], AF=1, CF=0 -> low-nibble borrow -> CF=1 (was wrongly 0)
+        assert das(0x00, 1, 0) == 1
+        assert das(0x01, 1, 0) == 1
+        assert das(0x05, 1, 0) == 1
+        # unaffected cases stay correct
+        assert das(0x10, 0, 0) == 0     # no adjust
+        assert das(0x9A, 0, 0) == 1     # high-nibble adjust sets CF
+
     def test_cmpltsd(self):
         p = load_shellcode(bytes.fromhex("f20fc2c101c3"), arch="amd64")
         # 0000000000000000 F20FC2C101                      CMPLTSD XMM0,XMM1

--- a/tests/engines/vex/test_vex.py
+++ b/tests/engines/vex/test_vex.py
@@ -616,8 +616,8 @@ class TestVex(unittest.TestCase):
         assert das(0x01, 1, 0) == 1
         assert das(0x05, 1, 0) == 1
         # unaffected cases stay correct
-        assert das(0x10, 0, 0) == 0     # no adjust
-        assert das(0x9A, 0, 0) == 1     # high-nibble adjust sets CF
+        assert das(0x10, 0, 0) == 0  # no adjust
+        assert das(0x9A, 0, 0) == 1  # high-nibble adjust sets CF
 
     def test_cmpltsd(self):
         p = load_shellcode(bytes.fromhex("f20fc2c101c3"), arch="amd64")


### PR DESCRIPTION
x86g_calculate_daa_das_aaa_aas computed the wrong CF for `das`. Two deviations from VEX's C helper (guest_x86_helpers.c):

  1. the low-nibble borrow was tested on the already-decremented value (`If(r_AL < 6, ...)` after `r_AL = r_AL - 6`) instead of the original `old_AL < 6` -- VEX tests the borrow before subtracting;
  2. the second (high-nibble) block reset `r_C = If(cond2, one, zero)`, which discards the carry set by the low-nibble block whenever cond2 (`old_AL > 0x99 or old_CF = 1`) is false -- VEX's second `if` has no `else`, so it preserves the carry. The low-nibble block also dropped VEX's `old_C |` term.

Net effect: `das` returned CF = 0 whenever cond2 was false, silently discarding a low-nibble borrow. Example (validated against native x86 hardware and the Intel SDM pseudocode): AL in [0x00, 0x05] with AF = 1, CF = 0 -> hardware CF = 1, angr CF = 0. `daa` (identical structure) is unaffected because its carry `AL + 6 >= 0x100` implies cond2.

Fix: test the borrow on the pre-subtraction AL, OR in the incoming carry, and preserve the low-nibble carry in the high-nibble block (mirroring VEX). Verified 400/400 against native x86 execution over edge-biased (AX, flags) inputs.

After `das`, angr leaves **CF = 0** in cases where the hardware sets **CF = 1**.
Concretely, for `AL ∈ [0x00, 0x05]` with `AF = 1`, `CF = 0` on entry, native
`das` yields CF = 1 (the low-nibble adjust `AL -= 6` borrows), but angr yields
CF = 0. A following `jc/jnc/sbb/adc` then takes the wrong path.

## Root cause

The DAS branch deviates from VEX's C reference (`guest_x86_helpers.c`) in two
places:

```python
elif opcode == 0x2F:  # DAS
    old_AL = r_AL; old_C = r_C
    condition = Or((r_AL & 0xF) > 9, r_A == 1)
    r_AL = If(condition, r_AL - 6, old_AL)
    r_C  = If(condition, If(r_AL < 6, one, zero), zero)   # (1) tests the NEW r_AL; drops old_C
    r_A  = If(condition, one, zero)
    condition = Or(old_AL > 0x99, old_C == 1)
    r_AL = If(condition, r_AL - 0x60, r_AL)
    r_C  = If(condition, one, zero)                        # (2) zeroes CF set by block 1
```

VEX's reference:

```c
case 0x2F: { /* DAS */
   UInt old_AL = r_AL, old_C = r_C;
   r_C = 0;
   if ((r_AL & 0xF) > 9 || r_A == 1) {
      Bool carry = r_AL < 6;          // borrow tested BEFORE the subtract
      r_AL = r_AL - 6;
      r_C  = old_C | (carry ? 1 : 0); // OR with old carry
      r_A  = 1;
   } else r_A = 0;
   if (old_AL > 0x99 || old_C == 1) { r_AL -= 0x60; r_C = 1; }  // no else: CF preserved
   ...
```

Two bugs:
1. **Borrow tested on the post-subtraction value.** angr reassigns `r_AL` to
   `r_AL - 6` and only *then* tests `r_AL < 6`; VEX tests `old_AL < 6` first. For
   `old_AL ∈ [0,5]` the true borrow is 1, but `(old_AL-6) & 0xFF ∈ [0xFA,0xFF]`,
   so angr's test yields 0.
2. **Second block zeroes CF.** `r_C = If(cond2, one, zero)` throws away the CF
   computed in block 1 whenever `cond2` (`old_AL > 0x99 or old_CF = 1`) is false.
   VEX's second `if` has no `else`, so it keeps block 1's CF.

(The first block also omits the `old_C |` term.) The **net** observable defect:
`das` returns CF = 0 whenever `cond2` is false, discarding any low-nibble borrow.

**Why `daa` (same structure) is correct:** DAA's block-1 carry is
`AL + 6 >= 0x100`, i.e. `old_AL >= 0xFA`, which *implies* `old_AL > 0x99` = cond2.
So DAA's `else zero` never discards a real 1. DAS's borrow (`old_AL < 6`) does
**not** imply cond2, so the discard is reachable. This asymmetry explains why DAS is affected while DAA is not.

## Reproduction (native 32-bit vs angr)

```python
import angr, claripy
def angr_das(al, flags_in):                      # AL in, (AL, CF) out
    st = angr.load_shellcode(b'\x2f', 'x86').factory.blank_state(addr=0)
    st.regs.eax = claripy.BVV(al & 0xff, 32)
    st.regs.eflags = claripy.BVV(flags_in, 32)
    s = st.step(num_inst=1).successors[0]
    return s.solver.eval(s.regs.eax) & 0xff, s.solver.eval(s.regs.eflags) & 1

for al in range(6):                              # flags_in = 0x12  (AF=1, CF=0)
    _, cf = angr_das(al, 0x12)
    print(f"das AL={al:#04x}, AF=1: angr CF={cf}  (hardware CF=1)")
```

Native ground truth (freestanding 32-bit ELF, `push/popf; das; pushf`) gives
CF = 1 for all of `AL ∈ [0,5]`; angr prints CF = 0. Over 400 edge-biased random
`(AX, flags)` samples, DAS is the only BCD op that diverges, and only on CF;
`daa/aaa/aas/aam/aad` all agree.

