### PR TITLE
UltraPage: Make the symbolic map an actual bitmap.

### DIFF
--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -177,8 +177,9 @@ class IcicleEngine(SuccessorsEngine):
         """
         page_size = state.memory.page_size
         addr = page_num * page_size
-        memory, bitmap = state.memory.concrete_load(addr, page_size, with_bitmap=True)
-        if any(bitmap):
+        # concrete_load stops at the first symbolic byte, so a short result means the page is not fully concrete
+        memory = state.memory.concrete_load(addr, page_size)
+        if len(memory) != page_size:
             memory = state.solver.eval(state.memory.load(addr, page_size), cast_to=bytes)
         emu.mem_write(addr, memory)
 

--- a/angr/engines/unicorn.py
+++ b/angr/engines/unicorn.py
@@ -353,7 +353,7 @@ class SimEngineUnicorn(SuccessorsEngine):
             for offset in range(mem_read_len):
                 page_num, page_off = state.memory._divide_addr(mem_read_addr + offset)
                 page_obj = state.memory._get_page(page_num, writing=False)
-                saved_taints.append(page_obj.symbolic_bitmap[page_off])
+                saved_taints.append(page_obj.symbolic_bitmap.get(page_off))
 
             restore_taints = False
             if saved_taints != taint_map:
@@ -363,7 +363,7 @@ class SimEngineUnicorn(SuccessorsEngine):
                     if expected_taint != -1:
                         page_num, page_off = state.memory._divide_addr(mem_read_addr + offset)
                         page_obj = state.memory._get_page(page_num, writing=False)
-                        page_obj.symbolic_bitmap[page_off] = expected_taint
+                        page_obj.symbolic_bitmap.set(page_off, expected_taint)
 
             curr_value = state.memory.load(
                 mem_read_addr, mem_read_len, endness=state.arch.memory_endness, inspect=False, disable_actions=True
@@ -372,7 +372,7 @@ class SimEngineUnicorn(SuccessorsEngine):
                 for offset, saved_taint in enumerate(saved_taints):
                     page_num, page_off = state.memory._divide_addr(mem_read_addr + offset)
                     page_obj = state.memory._get_page(page_num, writing=False)
-                    page_obj.symbolic_bitmap[page_off] = saved_taint
+                    page_obj.symbolic_bitmap.set(page_off, saved_taint)
 
             if taint_map.count(0) != 0:
                 # Update concrete bytes using values reported by native interface

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1107,13 +1107,10 @@ class Unicorn(SimStatePlugin):
         else:
             perm = perm.args[0]
 
-        # this should return two memoryviews
-        # if they are writable they are direct references to the state backing store and can be mapped directly
-        # writable_bitmap: if the page can hand us a writable buffer aliasing its own symbolic map, native unicorn maps
-        # it directly and writes taint back through it
-        data, bitmap = self.state.memory.concrete_load(
-            addr, 0x1000, with_bitmap=True, writable_bitmap=True, writing=(perm & 2) != 0
-        )
+        # this should return two memoryviews: the page data and its symbolic-ness bitmap, one bit per byte
+        # if they are writable they are direct references to the state backing store and can be mapped directly --
+        # native unicorn then writes taint straight back through the bitmap
+        data, bitmap = self.state.memory.concrete_load(addr, 0x1000, with_bitmap=True, writing=(perm & 2) != 0)
 
         if not bitmap:
             raise SimMemoryError("No bytes available in memory? when would this happen...")
@@ -1315,7 +1312,8 @@ class Unicorn(SimStatePlugin):
 
         # activate gdt page, which was written/mapped during set_regs
         if self.gdt is not None:
-            _UC_NATIVE.activate_page(self._uc_state, self.gdt.addr, bytes(0x1000), None)
+            # the taint bitmap holds one bit per page byte; the GDT page is entirely concrete
+            _UC_NATIVE.activate_page(self._uc_state, self.gdt.addr, bytes(0x1000 // 8), None)
 
         # Pass all concrete fd bytes to native interface so that it can handle relevant syscalls
         if fd_bytes is not None:

--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -1109,7 +1109,11 @@ class Unicorn(SimStatePlugin):
 
         # this should return two memoryviews
         # if they are writable they are direct references to the state backing store and can be mapped directly
-        data, bitmap = self.state.memory.concrete_load(addr, 0x1000, with_bitmap=True, writing=(perm & 2) != 0)
+        # writable_bitmap: if the page can hand us a writable buffer aliasing its own symbolic map, native unicorn maps
+        # it directly and writes taint back through it
+        data, bitmap = self.state.memory.concrete_load(
+            addr, 0x1000, with_bitmap=True, writable_bitmap=True, writing=(perm & 2) != 0
+        )
 
         if not bitmap:
             raise SimMemoryError("No bytes available in memory? when would this happen...")

--- a/angr/storage/memory_mixins/memory_mixin.py
+++ b/angr/storage/memory_mixins/memory_mixin.py
@@ -106,8 +106,7 @@ class MemoryMixin[InData, OutData, Addr](SimStatePlugin):
 
     def concrete_run_length(self, addr, size, **kwargs) -> int:
         """
-        Return the number of concrete bytes starting at ``addr``, capped at ``size``. Implementations that can answer
-        this without scanning a symbolic-ness bitmap should override it.
+        Return the number of concrete bytes starting at ``addr``, capped at ``size``.
         """
         _, bitmap = self.concrete_load(addr, size, with_bitmap=True, **kwargs)
         # the bitmap is packed: one bit per byte, least-significant bit first

--- a/angr/storage/memory_mixins/memory_mixin.py
+++ b/angr/storage/memory_mixins/memory_mixin.py
@@ -104,6 +104,14 @@ class MemoryMixin[InData, OutData, Addr](SimStatePlugin):
         """
         raise NotImplementedError
 
+    def concrete_run_length(self, addr, size, **kwargs) -> int:
+        """
+        Return the number of concrete bytes starting at ``addr``, capped at ``size``. Implementations that can answer
+        this without materializing a symbolic-ness byte map should override it.
+        """
+        _, bitmap = self.concrete_load(addr, size, with_bitmap=True, **kwargs)
+        return next((i for i, byte in enumerate(bitmap) if byte != 0), len(bitmap))
+
     def erase(self, addr: Addr, size: int | None = None, **kwargs) -> None:
         """
         Set [addr:addr+size) to uninitialized. In many cases this will be faster than overwriting those locations with

--- a/angr/storage/memory_mixins/memory_mixin.py
+++ b/angr/storage/memory_mixins/memory_mixin.py
@@ -107,10 +107,12 @@ class MemoryMixin[InData, OutData, Addr](SimStatePlugin):
     def concrete_run_length(self, addr, size, **kwargs) -> int:
         """
         Return the number of concrete bytes starting at ``addr``, capped at ``size``. Implementations that can answer
-        this without materializing a symbolic-ness byte map should override it.
+        this without scanning a symbolic-ness bitmap should override it.
         """
         _, bitmap = self.concrete_load(addr, size, with_bitmap=True, **kwargs)
-        return next((i for i, byte in enumerate(bitmap) if byte != 0), len(bitmap))
+        # the bitmap is packed: one bit per byte, least-significant bit first
+        n = min(size, len(bitmap) * 8)
+        return next((i for i in range(n) if bitmap[i >> 3] >> (i & 7) & 1), n)
 
     def erase(self, addr: Addr, size: int | None = None, **kwargs) -> None:
         """

--- a/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
@@ -487,7 +487,9 @@ class PagedMemoryMixin[PageType: PageBase](
             return memoryview(bytes(size)), memoryview(b"\x01" * size)
         return memoryview(b"")
 
-    def concrete_load(self, addr, size, writing=False, *, with_bitmap: bool = False, **kwargs):
+    def concrete_load(
+        self, addr, size, writing=False, *, with_bitmap: bool = False, writable_bitmap: bool = False, **kwargs
+    ):
         pageno, offset = self._divide_addr(addr)
         subsize = min(size, self.page_size - offset)
         try:
@@ -503,14 +505,17 @@ class PagedMemoryMixin[PageType: PageBase](
                 return self._load_to_memoryview(addr, size, True)
             return self._load_to_memoryview(addr, size, False)
 
-        data, bitmap = page.concrete_load(offset, subsize, with_bitmap=True, **kwargs)
         if with_bitmap:
-            return data, bitmap
+            return page.concrete_load(offset, subsize, with_bitmap=True, writable_bitmap=writable_bitmap, **kwargs)
 
         # everything from here on out has exactly one goal: to maximize the amount of concrete data
-        # we can return (up to the limit!)
-        i = next((i for i, byte in enumerate(bitmap) if byte != 0), len(bitmap))
+        # we can return (up to the limit!). ask the page how many concrete bytes it has instead of materializing and
+        # scanning its symbolic map.
+        i = page.concrete_run_length(offset, subsize, **kwargs)
+        if i == 0:
+            return memoryview(b"")
 
+        data = page.concrete_load(offset, subsize, **kwargs)
         if i != subsize:
             return data[:i]
 
@@ -526,11 +531,14 @@ class PagedMemoryMixin[PageType: PageBase](
             try:
                 page = self._get_page(pageno, writing, **kwargs)
                 concrete_load = page.concrete_load
+                concrete_run_length = page.concrete_run_length
             except (SimMemoryError, AttributeError):
                 break
             else:
-                newdata, bitmap = concrete_load(offset, subsize, with_bitmap=True, **kwargs)
-                i = next((i for i, byte in enumerate(bitmap) if byte != 0), len(bitmap))
+                i = concrete_run_length(offset, subsize, **kwargs)
+                if i == 0:
+                    break
+                newdata = concrete_load(offset, subsize, **kwargs)
 
                 # magic: check if the memory regions are physically adjacent
                 if physically_adjacent and ffi.cast(ffi.BVoidP, ffi.from_buffer(data)) + len(data) == ffi.cast(

--- a/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
@@ -418,8 +418,6 @@ class PagedMemoryMixin[PageType: PageBase](
     def _load_to_memoryview(self, addr, size, with_bitmap: Literal[False]) -> memoryview: ...
 
     def _load_to_memoryview(self, addr, size, with_bitmap):
-        # the bitmap is packed: one *bit* per byte of the region, least-significant bit first, matching the layout
-        # UltraPage stores natively and the native interfaces consume
         bitmap_size = (size + 7) // 8
         result = self.load(addr, size, endness="Iend_BE")
         if result.op == "BVV":
@@ -518,8 +516,7 @@ class PagedMemoryMixin[PageType: PageBase](
             return page.concrete_load(offset, subsize, with_bitmap=True, **kwargs)
 
         # everything from here on out has exactly one goal: to maximize the amount of concrete data
-        # we can return (up to the limit!). ask the page how many concrete bytes it has instead of materializing and
-        # scanning its symbolic map.
+        # we can return (up to the limit!).
         i = page.concrete_run_length(offset, subsize, **kwargs)
         if i == 0:
             return memoryview(b"")

--- a/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
+++ b/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py
@@ -418,14 +418,21 @@ class PagedMemoryMixin[PageType: PageBase](
     def _load_to_memoryview(self, addr, size, with_bitmap: Literal[False]) -> memoryview: ...
 
     def _load_to_memoryview(self, addr, size, with_bitmap):
+        # the bitmap is packed: one *bit* per byte of the region, least-significant bit first, matching the layout
+        # UltraPage stores natively and the native interfaces consume
+        bitmap_size = (size + 7) // 8
         result = self.load(addr, size, endness="Iend_BE")
         if result.op == "BVV":
             if with_bitmap:
-                return memoryview(result.args[0].to_bytes(size, "big")), memoryview(bytes(size))
+                return memoryview(result.args[0].to_bytes(size, "big")), memoryview(bytes(bitmap_size))
             return memoryview(result.args[0].to_bytes(size, "big"))
         if result.op == "Concat":
             bytes_out = bytearray(size)
-            bitmap_out = bytearray(size)
+            bitmap_out = bytearray(bitmap_size)
+
+            def mark_symbolic(i):
+                bitmap_out[i >> 3] |= 1 << (i & 7)
+
             bit_idx = 0
             byte_width = self.state.arch.byte_width
             for element in result.args:
@@ -438,7 +445,7 @@ class PagedMemoryMixin[PageType: PageBase](
                     bit_idx += len(element)
                     if not with_bitmap:
                         return memoryview(bytes(bytes_out))[:byte_idx]
-                    bitmap_out[byte_idx] = 1
+                    mark_symbolic(byte_idx)
                     continue
 
                 # if the current element has at least byte_width bits, the top `hi_chop` bits should be removed
@@ -453,11 +460,11 @@ class PagedMemoryMixin[PageType: PageBase](
                     bit_idx += len(element)
                     if not with_bitmap:
                         return memoryview(bytes(bytes_out))[:byte_idx]
-                    bitmap_out[byte_idx] = 1
+                    mark_symbolic(byte_idx)
                     continue
 
                 if hi_chop:
-                    bitmap_out[byte_idx] = 1
+                    mark_symbolic(byte_idx)
                     byte_idx += 1
 
                 if element.op == "BVV":
@@ -473,23 +480,25 @@ class PagedMemoryMixin[PageType: PageBase](
                     if not with_bitmap:
                         return memoryview(bytes(bytes_out))[:byte_idx]
                     for byte_i in range(byte_idx, byte_idx + byte_size):
-                        bitmap_out[byte_i] = 1
+                        mark_symbolic(byte_i)
 
                 bit_idx += len(element)
                 if bit_idx % byte_width != 0:
                     if not with_bitmap:
                         return memoryview(bytes(bytes_out))[: bit_idx // byte_width]
-                    bitmap_out[bit_idx // byte_width] = 1
+                    mark_symbolic(bit_idx // byte_width)
             if with_bitmap:
                 return memoryview(bytes(bytes_out)), memoryview(bytes(bitmap_out))
             return memoryview(bytes(bytes_out))
         if with_bitmap:
-            return memoryview(bytes(size)), memoryview(b"\x01" * size)
+            # every byte is symbolic; leave the bits past the end of the region clear
+            bitmap_out = bytearray(b"\xff" * bitmap_size)
+            if size & 7:
+                bitmap_out[-1] = (1 << (size & 7)) - 1
+            return memoryview(bytes(size)), memoryview(bytes(bitmap_out))
         return memoryview(b"")
 
-    def concrete_load(
-        self, addr, size, writing=False, *, with_bitmap: bool = False, writable_bitmap: bool = False, **kwargs
-    ):
+    def concrete_load(self, addr, size, writing=False, *, with_bitmap: bool = False, **kwargs):
         pageno, offset = self._divide_addr(addr)
         subsize = min(size, self.page_size - offset)
         try:
@@ -506,7 +515,7 @@ class PagedMemoryMixin[PageType: PageBase](
             return self._load_to_memoryview(addr, size, False)
 
         if with_bitmap:
-            return page.concrete_load(offset, subsize, with_bitmap=True, writable_bitmap=writable_bitmap, **kwargs)
+            return page.concrete_load(offset, subsize, with_bitmap=True, **kwargs)
 
         # everything from here on out has exactly one goal: to maximize the amount of concrete data
         # we can return (up to the limit!). ask the page how many concrete bytes it has instead of materializing and

--- a/angr/storage/memory_mixins/paged_memory/pages/symbolic_bitmap.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/symbolic_bitmap.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+# Expansion table: a byte value -> eight bytes, one per bit, least-significant bit first. Used to turn a slice of the
+# packed representation back into the one-byte-per-byte form that the native interfaces expect.
+_EXPAND: tuple[bytes, ...] = tuple(bytes((v >> i) & 1 for i in range(8)) for v in range(256))
+
+
+class SymbolicBitmap:
+    """
+    Tracks, for every byte of an :class:`UltraPage`, whether that byte is symbolic.
+
+    The map is stored as a real bitmap -- one *bit* per byte of the page, so a 4096-byte page needs 512 bytes instead
+    of the 4096 bytes that a byte-per-byte map would need. Bit ``i`` of the map lives in bit ``i & 7`` of byte
+    ``i >> 3`` (least-significant bit first), which makes ``int.from_bytes(..., "little")`` a direct view of the map as
+    a big integer and lets range scans be done with ``bit_length()`` instead of a Python-level loop.
+
+    On top of that, a page whose map is *uniform* -- every byte symbolic, or every byte concrete -- stores no per-byte
+    metadata at all: ``_bits`` is ``None`` and ``_uniform`` holds the single value. The backing store is only
+    materialized when a write actually makes the page non-uniform, and a range write that covers the whole page drops
+    back to the uniform representation. Freshly created pages are uniform, so in practice most pages never allocate.
+
+    All ranges are half-open ``[start, stop)`` and are assumed to lie within ``[0, size]``.
+    """
+
+    __slots__ = ("_bits", "_uniform", "size")
+
+    def __init__(self, size: int, value: int = 0):
+        self.size = size
+        self._bits: bytearray | None = None
+        self._uniform: int = 1 if value else 0
+
+    #
+    # Introspection
+    #
+
+    @property
+    def nbytes(self) -> int:
+        """
+        The number of bytes of backing store this map currently occupies (0 while uniform).
+        """
+        return 0 if self._bits is None else len(self._bits)
+
+    def uniform_value(self) -> int | None:
+        """
+        Return 0/1 if every byte of the page has that symbolic-ness, or None if the map is mixed.
+        """
+        return self._uniform if self._bits is None else None
+
+    def _materialize(self) -> bytearray:
+        n = (self.size + 7) >> 3
+        bits = bytearray(b"\xff" * n) if self._uniform else bytearray(n)
+        self._bits = bits
+        return bits
+
+    #
+    # Scalar access
+    #
+
+    def get(self, i: int) -> int:
+        """
+        Return 1 if byte ``i`` is symbolic, 0 otherwise.
+        """
+        bits = self._bits
+        if bits is None:
+            return self._uniform
+        return (bits[i >> 3] >> (i & 7)) & 1
+
+    def set(self, i: int, value: int) -> None:
+        """
+        Mark byte ``i`` as symbolic (``value`` truthy) or concrete.
+        """
+        bits = self._bits
+        if bits is None:
+            if bool(value) == bool(self._uniform):
+                return
+            bits = self._materialize()
+        if value:
+            bits[i >> 3] |= 1 << (i & 7)
+        else:
+            bits[i >> 3] &= ~(1 << (i & 7)) & 0xFF
+
+    #
+    # Range writes
+    #
+
+    def set_range(self, start: int, stop: int) -> None:
+        """
+        Mark ``[start, stop)`` as symbolic.
+        """
+        if start >= stop:
+            return
+        bits = self._bits
+        if start <= 0 and stop >= self.size:
+            # the whole page: collapse to the uniform representation and drop the backing store
+            self._bits = None
+            self._uniform = 1
+            return
+        if bits is None:
+            if self._uniform:
+                return
+            bits = self._materialize()
+
+        fb, fo = start >> 3, start & 7
+        lb, lo = stop >> 3, stop & 7
+        if fb == lb:
+            bits[fb] |= (0xFF << fo) & (0xFF >> (8 - lo)) & 0xFF
+            return
+        if fo:
+            bits[fb] |= (0xFF << fo) & 0xFF
+            fb += 1
+        if fb < lb:
+            bits[fb:lb] = b"\xff" * (lb - fb)
+        if lo:
+            bits[lb] |= 0xFF >> (8 - lo)
+
+    def clear_range(self, start: int, stop: int) -> None:
+        """
+        Mark ``[start, stop)`` as concrete.
+        """
+        if start >= stop:
+            return
+        bits = self._bits
+        if start <= 0 and stop >= self.size:
+            self._bits = None
+            self._uniform = 0
+            return
+        if bits is None:
+            if not self._uniform:
+                return
+            bits = self._materialize()
+
+        fb, fo = start >> 3, start & 7
+        lb, lo = stop >> 3, stop & 7
+        if fb == lb:
+            bits[fb] &= ~((0xFF << fo) & (0xFF >> (8 - lo))) & 0xFF
+            return
+        if fo:
+            bits[fb] &= ~(0xFF << fo) & 0xFF
+            fb += 1
+        if fb < lb:
+            bits[fb:lb] = bytes(lb - fb)
+        if lo:
+            bits[lb] &= ~(0xFF >> (8 - lo)) & 0xFF
+
+    #
+    # Range scans
+    #
+
+    def next_set(self, start: int, stop: int) -> int:
+        """
+        Return the smallest ``i`` in ``[start, stop)`` whose byte is symbolic, or ``stop`` if there is none.
+
+        A whole range is turned into one big integer and located with ``(w & -w).bit_length()`` rather than being
+        walked bit by bit. Long ranges are probed 64 bits at a time first, so that a hit near ``start`` -- the usual
+        case -- does not pay for converting the rest of the page.
+        """
+        if start >= stop:
+            return stop
+        bits = self._bits
+        if bits is None:
+            return start if self._uniform else stop
+        pos = start
+        window = 64
+        while pos < stop:
+            end = pos + window
+            if end > stop:
+                end = stop
+            n = end - pos
+            fb = pos >> 3
+            off = pos & 7
+            if fb == (end - 1) >> 3:
+                w = (bits[fb] >> off) & ((1 << n) - 1)
+            else:
+                w = (int.from_bytes(bits[fb : (end + 7) >> 3], "little") >> off) & ((1 << n) - 1)
+            if w:
+                return pos + (w & -w).bit_length() - 1
+            pos = end
+            window = stop  # after the initial probe, do the remainder in one shot
+        return stop
+
+    def next_clear(self, start: int, stop: int) -> int:
+        """
+        Return the smallest ``i`` in ``[start, stop)`` whose byte is concrete, or ``stop`` if there is none.
+        """
+        if start >= stop:
+            return stop
+        bits = self._bits
+        if bits is None:
+            return stop if self._uniform else start
+        pos = start
+        window = 64
+        while pos < stop:
+            end = pos + window
+            if end > stop:
+                end = stop
+            n = end - pos
+            fb = pos >> 3
+            off = pos & 7
+            if fb == (end - 1) >> 3:
+                w = (~bits[fb] >> off) & ((1 << n) - 1)
+            else:
+                w = (~int.from_bytes(bits[fb : (end + 7) >> 3], "little") >> off) & ((1 << n) - 1)
+            if w:
+                return pos + (w & -w).bit_length() - 1
+            pos = end
+            window = stop
+        return stop
+
+    def all_set(self, start: int, stop: int) -> bool:
+        """
+        Return True if every byte in ``[start, stop)`` is symbolic.
+        """
+        if start >= stop:
+            return True
+        if self._bits is None:
+            return bool(self._uniform)
+        return self.next_clear(start, stop) == stop
+
+    def any_set(self, start: int, stop: int) -> bool:
+        """
+        Return True if any byte in ``[start, stop)`` is symbolic.
+        """
+        return self.next_set(start, stop) != stop
+
+    #
+    # Conversion
+    #
+
+    def to_bytemap(self, start: int, stop: int) -> bytes:
+        """
+        Return ``[start, stop)`` expanded to one byte per byte of the page -- the representation the native unicorn
+        and icicle interfaces consume.
+        """
+        n = stop - start
+        if n <= 0:
+            return b""
+        bits = self._bits
+        if bits is None:
+            return (b"\x01" if self._uniform else b"\x00") * n
+        off = start & 7
+        raw = bits[start >> 3 : (stop + 7) >> 3]
+        return b"".join([_EXPAND[c] for c in raw])[off : off + n]
+
+    def expanded(self) -> ByteSymbolicBitmap:
+        """
+        Return a byte-per-byte map with the same contents. Used when a caller needs a *writable* buffer aliasing this
+        page (native unicorn's direct page mapping writes taint values back through it).
+        """
+        return ByteSymbolicBitmap(self.size, bytearray(self.to_bytemap(0, self.size)))
+
+    def copy(self) -> SymbolicBitmap:
+        o = SymbolicBitmap.__new__(SymbolicBitmap)
+        o.size = self.size
+        bits = self._bits
+        o._bits = None if bits is None else bytearray(bits)
+        o._uniform = self._uniform
+        return o
+
+
+class ByteSymbolicBitmap:
+    """
+    The legacy one-byte-per-byte representation of :class:`SymbolicBitmap`.
+
+    A page only switches to this representation when something asks for a writable buffer that aliases the page's map
+    -- in practice only native unicorn's direct page mapping, which writes ``taint_t`` values (including
+    ``TAINT_DIRTY``, which does not fit in one bit) straight into it. Everything else uses the packed representation.
+    """
+
+    __slots__ = ("_bytes", "size")
+
+    def __init__(self, size: int, data: bytearray | None = None):
+        self.size = size
+        self._bytes = bytearray(size) if data is None else data
+
+    @property
+    def nbytes(self) -> int:
+        return len(self._bytes)
+
+    def uniform_value(self) -> int | None:
+        b = self._bytes
+        if not b:
+            return None
+        first = 1 if b[0] else 0
+        for v in b:
+            if bool(v) != bool(first):
+                return None
+        return first
+
+    def get(self, i: int) -> int:
+        return self._bytes[i]
+
+    def set(self, i: int, value: int) -> None:
+        self._bytes[i] = value
+
+    def set_range(self, start: int, stop: int) -> None:
+        if start < stop:
+            self._bytes[start:stop] = b"\1" * (stop - start)
+
+    def clear_range(self, start: int, stop: int) -> None:
+        if start < stop:
+            self._bytes[start:stop] = bytes(stop - start)
+
+    def next_set(self, start: int, stop: int) -> int:
+        b = self._bytes
+        i = start
+        while i < stop and not b[i]:
+            i += 1
+        return i
+
+    def next_clear(self, start: int, stop: int) -> int:
+        b = self._bytes
+        i = start
+        while i < stop and b[i]:
+            i += 1
+        return i
+
+    def all_set(self, start: int, stop: int) -> bool:
+        return self.next_clear(start, stop) == stop
+
+    def any_set(self, start: int, stop: int) -> bool:
+        return self.next_set(start, stop) != stop
+
+    def to_bytemap(self, start: int, stop: int) -> bytes:
+        return bytes(self._bytes[start:stop])
+
+    def writable_view(self, start: int, stop: int) -> memoryview:
+        return memoryview(self._bytes)[start:stop]
+
+    def expanded(self) -> ByteSymbolicBitmap:
+        return self
+
+    def copy(self) -> ByteSymbolicBitmap:
+        return ByteSymbolicBitmap(self.size, bytearray(self._bytes))
+
+
+__all__ = ("ByteSymbolicBitmap", "SymbolicBitmap")

--- a/angr/storage/memory_mixins/paged_memory/pages/symbolic_bitmap.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/symbolic_bitmap.py
@@ -172,8 +172,7 @@ class SymbolicBitmap:
         window = 64
         while pos < stop:
             end = pos + window
-            if end > stop:
-                end = stop
+            end = min(end, stop)
             n = end - pos
             fb = pos >> 3
             off = pos & 7
@@ -200,8 +199,7 @@ class SymbolicBitmap:
         window = 64
         while pos < stop:
             end = pos + window
-            if end > stop:
-                end = stop
+            end = min(end, stop)
             n = end - pos
             fb = pos >> 3
             off = pos & 7
@@ -270,10 +268,10 @@ class SymbolicBitmap:
         o = SymbolicBitmap.__new__(SymbolicBitmap)
         o.size = self.size
         bits = self._bits
-        o._bits = None if bits is None else bytearray(bits)
-        o._uniform = self._uniform
+        o._bits = None if bits is None else bytearray(bits)  # pylint:disable=protected-access
+        o._uniform = self._uniform  # pylint:disable=protected-access
         # the copy is a fresh buffer that nobody holds a pointer into
-        o._pinned = False
+        o._pinned = False  # pylint:disable=protected-access
         return o
 
 

--- a/angr/storage/memory_mixins/paged_memory/pages/symbolic_bitmap.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/symbolic_bitmap.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-# Expansion table: a byte value -> eight bytes, one per bit, least-significant bit first. Used to turn a slice of the
-# packed representation back into the one-byte-per-byte form that the native interfaces expect.
-_EXPAND: tuple[bytes, ...] = tuple(bytes((v >> i) & 1 for i in range(8)) for v in range(256))
-
 
 class SymbolicBitmap:
     """
@@ -12,7 +8,8 @@ class SymbolicBitmap:
     The map is stored as a real bitmap -- one *bit* per byte of the page, so a 4096-byte page needs 512 bytes instead
     of the 4096 bytes that a byte-per-byte map would need. Bit ``i`` of the map lives in bit ``i & 7`` of byte
     ``i >> 3`` (least-significant bit first), which makes ``int.from_bytes(..., "little")`` a direct view of the map as
-    a big integer and lets range scans be done with ``bit_length()`` instead of a Python-level loop.
+    a big integer and lets range scans be done with ``bit_length()`` instead of a Python-level loop. This is also the
+    layout the native interfaces consume, so :meth:`view` can hand them the backing store as-is.
 
     On top of that, a page whose map is *uniform* -- every byte symbolic, or every byte concrete -- stores no per-byte
     metadata at all: ``_bits`` is ``None`` and ``_uniform`` holds the single value. The backing store is only
@@ -22,12 +19,15 @@ class SymbolicBitmap:
     All ranges are half-open ``[start, stop)`` and are assumed to lie within ``[0, size]``.
     """
 
-    __slots__ = ("_bits", "_uniform", "size")
+    __slots__ = ("_bits", "_pinned", "_uniform", "size")
 
     def __init__(self, size: int, value: int = 0):
         self.size = size
         self._bits: bytearray | None = None
         self._uniform: int = 1 if value else 0
+        # set once :meth:`view` hands out an aliasing buffer; see there for why the backing store may not be dropped
+        # afterwards
+        self._pinned: bool = False
 
     #
     # Introspection
@@ -91,9 +91,14 @@ class SymbolicBitmap:
             return
         bits = self._bits
         if start <= 0 and stop >= self.size:
-            # the whole page: collapse to the uniform representation and drop the backing store
-            self._bits = None
-            self._uniform = 1
+            # the whole page: collapse to the uniform representation and drop the backing store, unless someone is
+            # holding a pointer into it, in which case fill it in place
+            if self._pinned:
+                assert bits is not None
+                bits[:] = b"\xff" * len(bits)
+            else:
+                self._bits = None
+                self._uniform = 1
             return
         if bits is None:
             if self._uniform:
@@ -121,8 +126,12 @@ class SymbolicBitmap:
             return
         bits = self._bits
         if start <= 0 and stop >= self.size:
-            self._bits = None
-            self._uniform = 0
+            if self._pinned:
+                assert bits is not None
+                bits[:] = bytes(len(bits))
+            else:
+                self._bits = None
+                self._uniform = 0
             return
         if bits is None:
             if not self._uniform:
@@ -223,30 +232,39 @@ class SymbolicBitmap:
         return self.next_set(start, stop) != stop
 
     #
-    # Conversion
+    # Buffer access
     #
 
-    def to_bytemap(self, start: int, stop: int) -> bytes:
+    def view(self, start: int, stop: int) -> memoryview:
         """
-        Return ``[start, stop)`` expanded to one byte per byte of the page -- the representation the native unicorn
-        and icicle interfaces consume.
+        Return the packed bits covering ``[start, stop)``: bit ``i`` of the result is byte ``start + i`` of the page.
+
+        When ``start`` is byte-aligned the result is a *writable* view of this map's own backing store, so a native
+        consumer can update the page's symbolic-ness in place -- native unicorn maps whole pages this way and writes
+        taint straight back through the view. Handing out such a view pins the backing store: it may no longer be
+        dropped in favor of the uniform representation while someone might still hold a pointer into it.
+
+        An unaligned ``start`` cannot be expressed as a view of the backing store, so the bits are shifted into place
+        and returned read-only.
         """
+        if start & 7:
+            return memoryview(self._shifted(start, stop))
+        bits = self._bits
+        if bits is None:
+            bits = self._materialize()
+        self._pinned = True
+        return memoryview(bits)[start >> 3 : (stop + 7) >> 3]
+
+    def _shifted(self, start: int, stop: int) -> bytes:
         n = stop - start
         if n <= 0:
             return b""
         bits = self._bits
         if bits is None:
-            return (b"\x01" if self._uniform else b"\x00") * n
-        off = start & 7
-        raw = bits[start >> 3 : (stop + 7) >> 3]
-        return b"".join([_EXPAND[c] for c in raw])[off : off + n]
-
-    def expanded(self) -> ByteSymbolicBitmap:
-        """
-        Return a byte-per-byte map with the same contents. Used when a caller needs a *writable* buffer aliasing this
-        page (native unicorn's direct page mapping writes taint values back through it).
-        """
-        return ByteSymbolicBitmap(self.size, bytearray(self.to_bytemap(0, self.size)))
+            w = ((1 << n) - 1) if self._uniform else 0
+        else:
+            w = (int.from_bytes(bits[start >> 3 : (stop + 7) >> 3], "little") >> (start & 7)) & ((1 << n) - 1)
+        return w.to_bytes((n + 7) >> 3, "little")
 
     def copy(self) -> SymbolicBitmap:
         o = SymbolicBitmap.__new__(SymbolicBitmap)
@@ -254,83 +272,9 @@ class SymbolicBitmap:
         bits = self._bits
         o._bits = None if bits is None else bytearray(bits)
         o._uniform = self._uniform
+        # the copy is a fresh buffer that nobody holds a pointer into
+        o._pinned = False
         return o
 
 
-class ByteSymbolicBitmap:
-    """
-    The legacy one-byte-per-byte representation of :class:`SymbolicBitmap`.
-
-    A page only switches to this representation when something asks for a writable buffer that aliases the page's map
-    -- in practice only native unicorn's direct page mapping, which writes ``taint_t`` values (including
-    ``TAINT_DIRTY``, which does not fit in one bit) straight into it. Everything else uses the packed representation.
-    """
-
-    __slots__ = ("_bytes", "size")
-
-    def __init__(self, size: int, data: bytearray | None = None):
-        self.size = size
-        self._bytes = bytearray(size) if data is None else data
-
-    @property
-    def nbytes(self) -> int:
-        return len(self._bytes)
-
-    def uniform_value(self) -> int | None:
-        b = self._bytes
-        if not b:
-            return None
-        first = 1 if b[0] else 0
-        for v in b:
-            if bool(v) != bool(first):
-                return None
-        return first
-
-    def get(self, i: int) -> int:
-        return self._bytes[i]
-
-    def set(self, i: int, value: int) -> None:
-        self._bytes[i] = value
-
-    def set_range(self, start: int, stop: int) -> None:
-        if start < stop:
-            self._bytes[start:stop] = b"\1" * (stop - start)
-
-    def clear_range(self, start: int, stop: int) -> None:
-        if start < stop:
-            self._bytes[start:stop] = bytes(stop - start)
-
-    def next_set(self, start: int, stop: int) -> int:
-        b = self._bytes
-        i = start
-        while i < stop and not b[i]:
-            i += 1
-        return i
-
-    def next_clear(self, start: int, stop: int) -> int:
-        b = self._bytes
-        i = start
-        while i < stop and b[i]:
-            i += 1
-        return i
-
-    def all_set(self, start: int, stop: int) -> bool:
-        return self.next_clear(start, stop) == stop
-
-    def any_set(self, start: int, stop: int) -> bool:
-        return self.next_set(start, stop) != stop
-
-    def to_bytemap(self, start: int, stop: int) -> bytes:
-        return bytes(self._bytes[start:stop])
-
-    def writable_view(self, start: int, stop: int) -> memoryview:
-        return memoryview(self._bytes)[start:stop]
-
-    def expanded(self) -> ByteSymbolicBitmap:
-        return self
-
-    def copy(self) -> ByteSymbolicBitmap:
-        return ByteSymbolicBitmap(self.size, bytearray(self._bytes))
-
-
-__all__ = ("ByteSymbolicBitmap", "SymbolicBitmap")
+__all__ = ("SymbolicBitmap",)

--- a/angr/storage/memory_mixins/paged_memory/pages/symbolic_bitmap.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/symbolic_bitmap.py
@@ -3,18 +3,13 @@ from __future__ import annotations
 
 class SymbolicBitmap:
     """
-    Tracks, for every byte of an :class:`UltraPage`, whether that byte is symbolic.
+    Tracks, for every byte of an :class:`UltraPage`, whether that byte is symbolic or not.
 
-    The map is stored as a real bitmap -- one *bit* per byte of the page, so a 4096-byte page needs 512 bytes instead
-    of the 4096 bytes that a byte-per-byte map would need. Bit ``i`` of the map lives in bit ``i & 7`` of byte
-    ``i >> 3`` (least-significant bit first), which makes ``int.from_bytes(..., "little")`` a direct view of the map as
-    a big integer and lets range scans be done with ``bit_length()`` instead of a Python-level loop. This is also the
-    layout the native interfaces consume, so :meth:`view` can hand them the backing store as-is.
+    The map is stored as a bitmap where the i-th bit of the map lives in bit ``i & 7`` of byte ``i >> 3``
+    (least-significant bit first). This makes ``int.from_bytes(..., "little")`` a direct view of the map as
+    a big integer and lets range scans be done with ``bit_length()`` instead of a Python-level loop.
 
-    On top of that, a page whose map is *uniform* -- every byte symbolic, or every byte concrete -- stores no per-byte
-    metadata at all: ``_bits`` is ``None`` and ``_uniform`` holds the single value. The backing store is only
-    materialized when a write actually makes the page non-uniform, and a range write that covers the whole page drops
-    back to the uniform representation. Freshly created pages are uniform, so in practice most pages never allocate.
+    A page whose map is uniform (all bytes are symbolic or concrete) does not store any map.
 
     All ranges are half-open ``[start, stop)`` and are assumed to lie within ``[0, size]``.
     """
@@ -25,8 +20,7 @@ class SymbolicBitmap:
         self.size = size
         self._bits: bytearray | None = None
         self._uniform: int = 1 if value else 0
-        # set once :meth:`view` hands out an aliasing buffer; see there for why the backing store may not be dropped
-        # afterwards
+        # set once :meth:`view` hands out an aliasing buffer; the backing store may not be dropped afterwards.
         self._pinned: bool = False
 
     #
@@ -40,13 +34,14 @@ class SymbolicBitmap:
         """
         return 0 if self._bits is None else len(self._bits)
 
+    @property
     def uniform_value(self) -> int | None:
         """
         Return 0/1 if every byte of the page has that symbolic-ness, or None if the map is mixed.
         """
         return self._uniform if self._bits is None else None
 
-    def _materialize(self) -> bytearray:
+    def _concretize(self) -> bytearray:
         n = (self.size + 7) >> 3
         bits = bytearray(b"\xff" * n) if self._uniform else bytearray(n)
         self._bits = bits
@@ -73,7 +68,7 @@ class SymbolicBitmap:
         if bits is None:
             if bool(value) == bool(self._uniform):
                 return
-            bits = self._materialize()
+            bits = self._concretize()
         if value:
             bits[i >> 3] |= 1 << (i & 7)
         else:
@@ -92,7 +87,7 @@ class SymbolicBitmap:
         bits = self._bits
         if start <= 0 and stop >= self.size:
             # the whole page: collapse to the uniform representation and drop the backing store, unless someone is
-            # holding a pointer into it, in which case fill it in place
+            # holding a pointer into it.
             if self._pinned:
                 assert bits is not None
                 bits[:] = b"\xff" * len(bits)
@@ -103,7 +98,7 @@ class SymbolicBitmap:
         if bits is None:
             if self._uniform:
                 return
-            bits = self._materialize()
+            bits = self._concretize()
 
         fb, fo = start >> 3, start & 7
         lb, lo = stop >> 3, stop & 7
@@ -136,7 +131,7 @@ class SymbolicBitmap:
         if bits is None:
             if not self._uniform:
                 return
-            bits = self._materialize()
+            bits = self._concretize()
 
         fb, fo = start >> 3, start & 7
         lb, lo = stop >> 3, stop & 7
@@ -160,8 +155,7 @@ class SymbolicBitmap:
         Return the smallest ``i`` in ``[start, stop)`` whose byte is symbolic, or ``stop`` if there is none.
 
         A whole range is turned into one big integer and located with ``(w & -w).bit_length()`` rather than being
-        walked bit by bit. Long ranges are probed 64 bits at a time first, so that a hit near ``start`` -- the usual
-        case -- does not pay for converting the rest of the page.
+        walked bit by bit. Long ranges are probed 64 bits at a time first.
         """
         if start >= stop:
             return stop
@@ -237,19 +231,18 @@ class SymbolicBitmap:
         """
         Return the packed bits covering ``[start, stop)``: bit ``i`` of the result is byte ``start + i`` of the page.
 
-        When ``start`` is byte-aligned the result is a *writable* view of this map's own backing store, so a native
-        consumer can update the page's symbolic-ness in place -- native unicorn maps whole pages this way and writes
-        taint straight back through the view. Handing out such a view pins the backing store: it may no longer be
-        dropped in favor of the uniform representation while someone might still hold a pointer into it.
+        When ``start`` is byte-aligned, the result is a writable view of this map's own backing store, so a native
+        consumer (e.g., unicorn engine) can update the page's symbolic-ness in place. Returning such a view pins the
+        backing store: it may no longer be dropped in favor of the uniform representation.
 
         An unaligned ``start`` cannot be expressed as a view of the backing store, so the bits are shifted into place
-        and returned read-only.
+        and returned read-only. Consumers like unicorn engine should not use this view for writing!
         """
         if start & 7:
             return memoryview(self._shifted(start, stop))
         bits = self._bits
         if bits is None:
-            bits = self._materialize()
+            bits = self._concretize()
         self._pinned = True
         return memoryview(bits)[start >> 3 : (stop + 7) >> 3]
 
@@ -270,7 +263,6 @@ class SymbolicBitmap:
         bits = self._bits
         o._bits = None if bits is None else bytearray(bits)  # pylint:disable=protected-access
         o._uniform = self._uniform  # pylint:disable=protected-access
-        # the copy is a fresh buffer that nobody holds a pointer into
         o._pinned = False  # pylint:disable=protected-access
         return o
 

--- a/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
@@ -17,6 +17,8 @@ from .symbolic_bitmap import SymbolicBitmap
 
 l = logging.getLogger(name=__name__)
 
+DEFAULT_PAGE_SIZE = 4096
+
 
 class UltraPage(MemoryObjectMixin, PageBase):
     """
@@ -28,15 +30,10 @@ class UltraPage(MemoryObjectMixin, PageBase):
     def __init__(self, memory=None, init_zero=False, **kwargs):
         super().__init__(**kwargs)
 
-        if memory is not None:
-            # both the concrete backing store and the symbolic map are allocated lazily: a page that is entirely
-            # symbolic (the overwhelmingly common case) never reads concrete_data, and SymbolicBitmap keeps a uniform
-            # page as a single flag
-            self.concrete_data = None
-            self.symbolic_bitmap = SymbolicBitmap(memory.page_size, 0 if init_zero else 1)
-        else:
-            self.concrete_data = None
-            self.symbolic_bitmap = None
+        self.concrete_data = None
+        self.symbolic_bitmap = SymbolicBitmap(
+            memory.page_size if memory is not None else DEFAULT_PAGE_SIZE, 0 if init_zero else 1
+        )
 
         self.symbolic_data = SortedDict()
 
@@ -44,7 +41,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
     def new_from_shared(cls, data, memory=None, **kwargs):
         o = cls(**kwargs)
         o.concrete_data = data
-        o.symbolic_bitmap = SymbolicBitmap(memory.page_size, 0)
+        o.symbolic_bitmap = SymbolicBitmap(memory.page_size if memory is not None else DEFAULT_PAGE_SIZE, 0)
         o.refcount = 2  # pylint: disable=attribute-defined-outside-init
         return o
 
@@ -353,8 +350,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
 
     def concrete_run_length(self, addr, size, **kwargs) -> int:  # pylint: disable=unused-argument
         """
-        Return the number of concrete bytes at ``addr``, capped at ``size``. This is what callers that only want
-        concrete data need, and answering it from the bitmap directly avoids expanding it to a byte map.
+        Return the number of concrete bytes at ``addr``, capped at ``size``.
         """
         assert self.symbolic_bitmap is not None
         return self.symbolic_bitmap.next_set(addr, addr + size) - addr

--- a/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
@@ -358,7 +358,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
         assert self.symbolic_bitmap is not None
         return self.symbolic_bitmap.next_set(addr, addr + size) - addr
 
-    def concrete_load(self, addr, size, writing=False, with_bitmap=False, writable_bitmap=False, **kwargs):  # pylint: disable=arguments-differ
+    def concrete_load(self, addr, size, writing=False, with_bitmap=False, **kwargs):  # pylint: disable=arguments-differ
         assert self.symbolic_bitmap is not None
         concrete_data = self._concrete()
         mv_data = (
@@ -372,16 +372,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
         data = mv_data[addr : addr + size]
         if not with_bitmap:
             return data
-
-        if writable_bitmap:
-            # the caller wants a buffer that aliases this page's map and that it may write through (native unicorn's
-            # direct page mapping does exactly that). Switch the page over to the byte-per-byte representation.
-            bitmap = self.symbolic_bitmap
-            expanded = bitmap.expanded()
-            if expanded is not bitmap:
-                self.symbolic_bitmap = expanded
-            return data, expanded.writable_view(addr, addr + size)
-        return data, memoryview(self.symbolic_bitmap.to_bytemap(addr, addr + size))
+        return data, self.symbolic_bitmap.view(addr, addr + size)
 
     def changed_bytes(self, other, page_addr=None) -> set[int]:
         changed_candidates = super().changed_bytes(other)

--- a/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
@@ -13,6 +13,7 @@ from angr.errors import SimMemoryError
 
 from .base import PageBase
 from .cooperation import MemoryObjectMixin, SimMemoryObject
+from .symbolic_bitmap import SymbolicBitmap
 
 l = logging.getLogger(name=__name__)
 
@@ -28,11 +29,11 @@ class UltraPage(MemoryObjectMixin, PageBase):
         super().__init__(**kwargs)
 
         if memory is not None:
-            self.concrete_data = bytearray(memory.page_size)
-            if init_zero:
-                self.symbolic_bitmap = bytearray(memory.page_size)
-            else:
-                self.symbolic_bitmap = bytearray(b"\1" * memory.page_size)
+            # both the concrete backing store and the symbolic map are allocated lazily: a page that is entirely
+            # symbolic (the overwhelmingly common case) never reads concrete_data, and SymbolicBitmap keeps a uniform
+            # page as a single flag
+            self.concrete_data = None
+            self.symbolic_bitmap = SymbolicBitmap(memory.page_size, 0 if init_zero else 1)
         else:
             self.concrete_data = None
             self.symbolic_bitmap = None
@@ -43,16 +44,26 @@ class UltraPage(MemoryObjectMixin, PageBase):
     def new_from_shared(cls, data, memory=None, **kwargs):
         o = cls(**kwargs)
         o.concrete_data = data
-        o.symbolic_bitmap = bytearray(memory.page_size)
+        o.symbolic_bitmap = SymbolicBitmap(memory.page_size, 0)
         o.refcount = 2  # pylint: disable=attribute-defined-outside-init
         return o
 
     def copy(self, memo):
         o = super().copy(memo)
-        o.concrete_data = bytearray(self.concrete_data)
-        o.symbolic_bitmap = bytearray(self.symbolic_bitmap)
+        o.concrete_data = None if self.concrete_data is None else bytearray(self.concrete_data)
+        o.symbolic_bitmap = self.symbolic_bitmap.copy()
         o.symbolic_data = SortedDict(self.symbolic_data)
         return o
+
+    def _concrete(self):
+        """
+        Return the concrete backing store, allocating it (zero-filled) on first use.
+        """
+        data = self.concrete_data
+        if data is None:
+            data = bytearray(self.symbolic_bitmap.size)
+            self.concrete_data = data
+        return data
 
     def load(self, addr, size=None, page_addr=None, endness=None, memory=None, cooperate=False, **kwargs):  # pylint: disable=arguments-differ
         concrete_run = []
@@ -86,9 +97,10 @@ class UltraPage(MemoryObjectMixin, PageBase):
 
         subaddr = addr
         end = addr + size
+        bitmap = self.symbolic_bitmap
         while subaddr < end:
             realaddr = subaddr + page_addr
-            if self.symbolic_bitmap[subaddr]:
+            if bitmap.get(subaddr):
                 cur_val = self._get_object(subaddr, page_addr, memory=memory)
                 # it must be a different object
                 cycle(realaddr)
@@ -101,25 +113,20 @@ class UltraPage(MemoryObjectMixin, PageBase):
                     obj_end = subaddr + cur_val.length
                     obj_end = min(end, obj_end)
 
-                # determine how many bytes come from this object
-                # loop until: end of object or not symbolic or until next object
-                next_place = None
-                while next_addr < obj_end and self.symbolic_bitmap[next_addr]:
-                    if next_addr == subaddr + 1:  # first loop
-                        next_place = self._get_next_place(next_addr)
-                    if next_place is not None and next_place <= next_addr:
-                        break
-                    next_addr += 1
+                # determine how many bytes come from this object: scan forward until the end of the object, the first
+                # non-symbolic byte, or the start of the next object, whichever comes first
+                if next_addr < obj_end and bitmap.get(next_addr):
+                    next_place = self._get_next_place(next_addr)
+                    limit = obj_end if next_place is None or next_place > obj_end else next_place
+                    next_addr = bitmap.next_clear(next_addr, limit)
 
                 subaddr = next_addr
                 last_run = symbolic_run = cur_val
                 result.append((realaddr, cur_val))
 
             else:
-                max_concrete_read = subaddr
-                while max_concrete_read < end and not self.symbolic_bitmap[max_concrete_read]:
-                    max_concrete_read += 1
-                cur_val = self.concrete_data[subaddr:max_concrete_read]
+                max_concrete_read = bitmap.next_set(subaddr, end)
+                cur_val = self._concrete()[subaddr:max_concrete_read]
                 subaddr = max_concrete_read
                 # we know the last run was not a concrete one
                 cycle(realaddr)
@@ -178,7 +185,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
 
         if type(data) is int or (data.object.op == "BVV" and not data.object.annotations):
             # mark range as not symbolic
-            self.symbolic_bitmap[addr : addr + size] = b"\0" * size
+            self.symbolic_bitmap.clear_range(addr, addr + size)
 
             # store
             arange = range(addr, addr + size)
@@ -188,12 +195,13 @@ class UltraPage(MemoryObjectMixin, PageBase):
 
             assert memory.state.arch.byte_width == 8
             # TODO: Make UltraPage support architectures with greater byte_widths (but are still multiples of 8)
+            concrete_data = self._concrete()
             for subaddr in arange:
-                self.concrete_data[subaddr] = ival & 0xFF
+                concrete_data[subaddr] = ival & 0xFF
                 ival >>= 8
         else:
             # mark range as symbolic
-            self.symbolic_bitmap[addr : addr + size] = b"\1" * size
+            self.symbolic_bitmap.set_range(addr, addr + size)
 
             # set ending object
             try:
@@ -244,7 +252,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
             # first get a list of all memory objects at that location, and
             # all memories that don't have those bytes
             for pg, fv in zip(all_pages, merge_conditions):
-                if pg.symbolic_bitmap[b]:
+                if pg.symbolic_bitmap.get(b):
                     mo = pg._get_object(b, page_addr)
                     if mo is not None:
                         l.debug("... MO present in %s", fv)
@@ -256,7 +264,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
                         unconstrained_in.append((pg, fv))
                 else:
                     # concrete data
-                    concretes.append((pg.concrete_data[b], fv))
+                    concretes.append((pg._concrete()[b], fv))
 
             # fast path: no memory objects, no unconstrained positions, and only one concrete value
             if not memory_objects and not unconstrained_in and len({cv for cv, _ in concretes}) == 1:
@@ -342,32 +350,38 @@ class UltraPage(MemoryObjectMixin, PageBase):
 
         return merged_offsets
 
-    def concrete_load(self, addr, size, writing=False, with_bitmap=False, **kwargs):  # pylint: disable=arguments-differ
-        assert self.concrete_data is not None
+    def concrete_run_length(self, addr, size, **kwargs) -> int:  # pylint: disable=unused-argument
+        """
+        Return the number of concrete bytes at ``addr``, capped at ``size``. This is what callers that only want
+        concrete data need, and answering it from the bitmap directly avoids expanding it to a byte map.
+        """
         assert self.symbolic_bitmap is not None
+        return self.symbolic_bitmap.next_set(addr, addr + size) - addr
+
+    def concrete_load(self, addr, size, writing=False, with_bitmap=False, writable_bitmap=False, **kwargs):  # pylint: disable=arguments-differ
+        assert self.symbolic_bitmap is not None
+        concrete_data = self._concrete()
         mv_data = (
-            self.concrete_data
+            concrete_data
             if isinstance(
-                self.concrete_data,
+                concrete_data,
                 (memoryview, angr.storage.memory_mixins.paged_memory.page_backer_mixins.NotMemoryview),
             )
-            else memoryview(self.concrete_data)
+            else memoryview(concrete_data)
         )
-        mv_bitm = (
-            self.symbolic_bitmap
-            if isinstance(
-                self.symbolic_bitmap,
-                (memoryview, angr.storage.memory_mixins.paged_memory.page_backer_mixins.NotMemoryview),
-            )
-            else memoryview(self.symbolic_bitmap)
-        )
-        result = (
-            mv_data[addr : addr + size],
-            mv_bitm[addr : addr + size],
-        )
-        if with_bitmap:
-            return result
-        return result[0]
+        data = mv_data[addr : addr + size]
+        if not with_bitmap:
+            return data
+
+        if writable_bitmap:
+            # the caller wants a buffer that aliases this page's map and that it may write through (native unicorn's
+            # direct page mapping does exactly that). Switch the page over to the byte-per-byte representation.
+            bitmap = self.symbolic_bitmap
+            expanded = bitmap.expanded()
+            if expanded is not bitmap:
+                self.symbolic_bitmap = expanded
+            return data, expanded.writable_view(addr, addr + size)
+        return data, memoryview(self.symbolic_bitmap.to_bytemap(addr, addr + size))
 
     def changed_bytes(self, other, page_addr=None) -> set[int]:
         changed_candidates = super().changed_bytes(other)
@@ -375,12 +389,15 @@ class UltraPage(MemoryObjectMixin, PageBase):
             changed_candidates = self._ultra_changed_candidates(other)
 
         changes: set[int] = set()
+        self_bitmap = self.symbolic_bitmap
+        other_bitmap = other.symbolic_bitmap
 
         for addr in changed_candidates:
-            if self.symbolic_bitmap[addr] != other.symbolic_bitmap[addr]:
+            self_sym = self_bitmap.get(addr)
+            if bool(self_sym) != bool(other_bitmap.get(addr)):
                 changes.add(addr)
-            elif self.symbolic_bitmap[addr] == 0:
-                if self.concrete_data[addr] != other.concrete_data[addr]:
+            elif not self_sym:
+                if self._concrete()[addr] != other._concrete()[addr]:
                     changes.add(addr)
             else:
                 try:
@@ -439,16 +456,20 @@ class UltraPage(MemoryObjectMixin, PageBase):
 
         # calculate concrete offsets
         CHUNK_SIZE = 128
-        FULLY_SYMBOLIC = b"\1" * CHUNK_SIZE
-        for i in range(0, len(self.symbolic_bitmap), CHUNK_SIZE):
-            chunk_self = self.symbolic_bitmap[i : i + CHUNK_SIZE]
-            chunk_other = other.symbolic_bitmap[i : i + CHUNK_SIZE]
-            if not chunk_self == chunk_other == FULLY_SYMBOLIC:
-                candidate_offsets |= set(range(i, i + CHUNK_SIZE))
+        self_bitmap = self.symbolic_bitmap
+        other_bitmap = other.symbolic_bitmap
+        size = self_bitmap.size
+        if size % CHUNK_SIZE == 0 and self_bitmap.all_set(0, size) and other_bitmap.all_set(0, size):
+            # both pages are entirely symbolic; no concrete offsets are candidates
+            return candidate_offsets
+        for i in range(0, size, CHUNK_SIZE):
+            end = i + CHUNK_SIZE
+            if end > size or not (self_bitmap.all_set(i, end) and other_bitmap.all_set(i, end)):
+                candidate_offsets |= set(range(i, end))
         return candidate_offsets
 
     def _contains(self, start: int, page_addr: int):
-        if not self.symbolic_bitmap[start]:
+        if not self.symbolic_bitmap.get(start):
             # concrete data
             return True
         # symbolic data or does not exist

--- a/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/ultra_page.py
@@ -228,6 +228,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
         memory=None,
         changed_offsets: set[int] | None = None,
     ):
+        assert page_addr is not None
         all_pages = [self, *others]
         merged_to = None
         merged_objects = set()
@@ -253,7 +254,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
             # all memories that don't have those bytes
             for pg, fv in zip(all_pages, merge_conditions):
                 if pg.symbolic_bitmap.get(b):
-                    mo = pg._get_object(b, page_addr)
+                    mo = pg._get_object(b, page_addr)  # pylint: disable=protected-access
                     if mo is not None:
                         l.debug("... MO present in %s", fv)
                         memory_objects.append((mo, fv))
@@ -264,7 +265,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
                         unconstrained_in.append((pg, fv))
                 else:
                     # concrete data
-                    concretes.append((pg._concrete()[b], fv))
+                    concretes.append((pg._concrete()[b], fv))  # pylint: disable=protected-access
 
             # fast path: no memory objects, no unconstrained positions, and only one concrete value
             if not memory_objects and not unconstrained_in and len({cv for cv, _ in concretes}) == 1:
@@ -316,7 +317,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
                 min_size = min(mo.length - (page_addr + b - mo.base) for mo, _ in memory_objects)
                 for um, _ in unconstrained_in:
                     for i in range(min_size):
-                        if um._contains(b + i, page_addr):
+                        if um._contains(b + i, page_addr):  # pylint: disable=protected-access
                             min_size = i
                             break
                 merged_to = b + min_size
@@ -388,7 +389,7 @@ class UltraPage(MemoryObjectMixin, PageBase):
             if bool(self_sym) != bool(other_bitmap.get(addr)):
                 changes.add(addr)
             elif not self_sym:
-                if self._concrete()[addr] != other._concrete()[addr]:
+                if self._concrete()[addr] != other._concrete()[addr]:  # pylint: disable=protected-access
                     changes.add(addr)
             else:
                 try:
@@ -471,21 +472,19 @@ class UltraPage(MemoryObjectMixin, PageBase):
             place = next(self.symbolic_data.irange(maximum=start, reverse=True))
         except StopIteration:
             return None
-        else:
-            obj = self.symbolic_data[place]
-            if obj.includes(start + page_addr) or (
-                memory is not None and obj.includes(start + page_addr + (1 << memory.state.arch.bits))
-            ):
-                return obj
-            return None
+        obj = self.symbolic_data[place]
+        if obj.includes(start + page_addr) or (
+            memory is not None and obj.includes(start + page_addr + (1 << memory.state.arch.bits))
+        ):
+            return obj
+        return None
 
     def _get_next_place(self, start):
         try:
             place = next(self.symbolic_data.irange(minimum=start, reverse=False))
         except StopIteration:
             return None
-        else:
-            return place
+        return place
 
     def replace_all_with_offsets(self, offsets: Iterable[int], old: claripy.ast.BV, new: claripy.ast.BV, memory=None):
         memory_objects = set()
@@ -533,7 +532,12 @@ class UltraPage(MemoryObjectMixin, PageBase):
         ) != new_content.size():
             raise SimMemoryError("memory objects can only be replaced by the same length content")
 
-        new = SimMemoryObject(new_content, old.base, old.endness, byte_width=old._byte_width)
+        new = SimMemoryObject(
+            new_content,
+            old.base,
+            old.endness,
+            byte_width=old._byte_width,  # pylint: disable=protected-access
+        )
         for k in list(self.symbolic_data):
             if self.symbolic_data[k] is old:
                 self.symbolic_data[k] = new

--- a/native/unicornlib/sim_unicorn.cpp
+++ b/native/unicornlib/sim_unicorn.cpp
@@ -407,12 +407,15 @@ void State::rollback() {
 			break;
 		}
 		auto page = page_lookup(rit->address);
-		taint_t *bitmap = page.first;
 
 		uint64_t start = rit->address & 0xFFF;
 		int size = rit->size;
 		for (auto i = 0; i < size; i++) {
-			bitmap[start + i] = rit->previous_taint[i];
+			taint_t previous = rit->previous_taint[i];
+			bitmap_set(page.symbolic, start + i, previous == TAINT_SYMBOLIC);
+			if (page.dirty != NULL) {
+				bitmap_set(page.dirty, start + i, previous == TAINT_DIRTY);
+			}
 		}
 	}
 	mem_writes.clear();
@@ -425,14 +428,15 @@ void State::rollback() {
 }
 
 /*
- * return the PageBitmap only if the page is remapped for writing,
- * or initialized with symbolic variable, otherwise return NULL.
+ * return the taint bitmaps only if the page is remapped for writing,
+ * or initialized with symbolic variable, otherwise return NULLs.
  */
-std::pair<taint_t *, uint8_t *> State::page_lookup(address_t address) const {
+page_taint_t State::page_lookup(address_t address) const {
 	address &= ~0xFFFULL;
 	auto it = active_pages.find(address);
 	if (it == active_pages.end()) {
-		return std::pair<taint_t *, uint8_t *>(NULL, NULL);
+		page_taint_t missing = {NULL, NULL, NULL};
+		return missing;
 	}
 	return it->second;
 }
@@ -441,17 +445,21 @@ void State::page_activate(address_t address, uint8_t *taint, uint8_t *data) {
 	address &= ~0xFFFULL;
 	auto it = active_pages.find(address);
 	if (it == active_pages.end()) {
+		page_taint_t page;
+		page.data = data;
 		if (data == NULL) {
-			// We need to copy the taint bitmap
-			taint_t *bitmap = new PageBitmap;
-			memcpy(bitmap, taint, sizeof(PageBitmap));
-
-			active_pages.insert(std::pair<address_t, std::pair<taint_t*, uint8_t*>>(address, std::pair<taint_t*, uint8_t*>(bitmap, NULL)));
+			// The page is copied into unicorn: we need our own copy of the symbolic bitmap, plus a dirty bitmap to
+			// remember which bytes have to be synced back to angr.
+			page.symbolic = new PageBitmap;
+			memcpy(page.symbolic, taint, sizeof(PageBitmap));
+			page.dirty = new uint8_t[ANGR_PAGE_BITMAP_SIZE]();
 		} else {
-			// We can directly use the passed taint and data
-			taint_t *bitmap = (taint_t*)taint;
-			active_pages.insert(std::pair<uint64_t, std::pair<taint_t*, uint8_t*>>(address, std::pair<taint_t*, uint8_t*>(bitmap, data)));
+			// The page is direct-mapped: angr's symbolic bitmap is ours to update in place, and concrete writes go
+			// straight into angr's backing store, so nothing ever needs syncing.
+			page.symbolic = taint;
+			page.dirty = NULL;
 		}
+		active_pages.insert(std::pair<address_t, page_taint_t>(address, page));
 	} else {
 		// TODO: un-hardcode this address, or at least do this warning from python land
 		if (address == 0x4000) {
@@ -492,25 +500,23 @@ void State::page_activate(address_t address, uint8_t *taint, uint8_t *data) {
 
 mem_update_t *State::sync() {
 	for (auto it = active_pages.begin(); it != active_pages.end(); it++) {
-		uint8_t *data = it->second.second;
-		if (data != NULL) {
+		uint8_t *dirty = it->second.dirty;
+		if (dirty == NULL) {
 			// nothing to sync, direct mapped :)
 			continue;
 		}
-		taint_t *start = it->second.first;
-		taint_t *end = &it->second.first[0x1000];
-		//LOG_D("found active page %#lx (%p)", it->first, start);
-		for (taint_t *i = start; i < end; i++)
-			if ((*i) == TAINT_DIRTY) {
-				taint_t *j = i;
-				while (j < end && (*j) == TAINT_DIRTY) j++;
+		//LOG_D("found active page %#lx (%p)", it->first, dirty);
+		for (uint64_t i = 0; i < ANGR_PAGE_SIZE; i++)
+			if (bitmap_get(dirty, i)) {
+				uint64_t j = i;
+				while (j < ANGR_PAGE_SIZE && bitmap_get(dirty, j)) j++;
 
-				char buf[0x1000];
-				uc_mem_read(uc, it->first + (i - start), buf, j - i);
-				//LOG_D("sync [%#lx, %#lx] = %#lx", it->first + (i - start), it->first + (j - start), *(uint64_t *)buf);
+				char buf[ANGR_PAGE_SIZE];
+				uc_mem_read(uc, it->first + i, buf, j - i);
+				//LOG_D("sync [%#lx, %#lx] = %#lx", it->first + i, it->first + j, *(uint64_t *)buf);
 
 				mem_update_t *range = new mem_update_t;
-				range->address = it->first + (i - start);
+				range->address = it->first + i;
 				range->length = j - i;
 				range->next = mem_updates_head;
 				mem_updates_head = range;
@@ -632,7 +638,7 @@ bool State::in_cache(address_t address) const {
 // Finds tainted data in the provided range and returns the address.
 // Returns -1 if no tainted data is present.
 int64_t State::find_tainted(address_t address, int size) {
-	taint_t *bitmap = page_lookup(address).first;
+	uint8_t *bitmap = page_lookup(address).symbolic;
 
 	int start = address & 0xFFF;
 	int end = (address + size - 1) & 0xFFF;
@@ -640,7 +646,7 @@ int64_t State::find_tainted(address_t address, int size) {
 	if (end >= start) {
 		if (bitmap) {
 			for (auto i = start; i <= end; i++) {
-				if (bitmap[i] & TAINT_SYMBOLIC) {
+				if (bitmap_get(bitmap, i)) {
 					return (address & ~0xFFF) + i;
 				}
 			}
@@ -650,16 +656,16 @@ int64_t State::find_tainted(address_t address, int size) {
 		// cross page boundary
 		if (bitmap) {
 			for (auto i = start; i <= 0xFFF; i++) {
-				if (bitmap[i] & TAINT_SYMBOLIC) {
+				if (bitmap_get(bitmap, i)) {
 					return (address & ~0xFFF) + i;
 				}
 			}
 		}
 
-		bitmap = page_lookup(address + size - 1).first;
+		bitmap = page_lookup(address + size - 1).symbolic;
 		if (bitmap) {
 			for (auto i = 0; i <= end; i++) {
-				if (bitmap[i] & TAINT_SYMBOLIC) {
+				if (bitmap_get(bitmap, i)) {
 					return ((address + size - 1) & ~0xFFF) + i;
 				}
 			}
@@ -697,9 +703,10 @@ void State::handle_write(address_t address, int size, bool is_interrupt = false,
 		return;
 	}
 
-	auto pair = page_lookup(address);
-	taint_t *bitmap = pair.first;
-	uint8_t *data = pair.second;
+	auto page = page_lookup(address);
+	uint8_t *bitmap = page.symbolic;
+	uint8_t *dirty = page.dirty;
+	uint8_t *data = page.data;
 	int start = address & 0xFFF;
 	int end = (address + size - 1) & 0xFFF;
 	short clean;
@@ -864,32 +871,28 @@ void State::handle_write(address_t address, int size, bool is_interrupt = false,
 	}
 	if (data == NULL) {
 		for (auto i = start; i <= end; i++) {
-			record.previous_taint.push_back(bitmap[i]);
-			if (is_dst_symbolic) {
-				// Don't mark as TAINT_DIRTY since we don't want to sync it back to angr
-				// Also, no need to set clean: rollback will set it to TAINT_NONE which
-				// is fine for symbolic bytes and rollback is called when exiting unicorn
-				// due to an error encountered
-				bitmap[i] = TAINT_SYMBOLIC;
+			// a byte is never both symbolic and dirty, so the two bitmaps recover the previous taint between them
+			taint_t previous = TAINT_NONE;
+			if (bitmap_get(bitmap, i)) {
+				previous = TAINT_SYMBOLIC;
 			}
-			else if (bitmap[i] != TAINT_DIRTY) {
-				bitmap[i] = TAINT_DIRTY;
+			else if (bitmap_get(dirty, i)) {
+				previous = TAINT_DIRTY;
 			}
+			record.previous_taint.push_back(previous);
+			// Don't mark a symbolic write as TAINT_DIRTY since we don't want to sync it back to angr
+			// Also, no need to set clean: rollback will set it to TAINT_NONE which
+			// is fine for symbolic bytes and rollback is called when exiting unicorn
+			// due to an error encountered
+			bitmap_set(bitmap, i, is_dst_symbolic);
+			bitmap_set(dirty, i, !is_dst_symbolic);
 		}
 	}
 	else {
 		for (auto i = start; i <= end; i++) {
-			record.previous_taint.push_back(bitmap[i]);
-			if (is_dst_symbolic) {
-				// Don't mark as TAINT_DIRTY since we don't want to sync it back to angr
-				// Also, no need to set clean: rollback will set it to TAINT_NONE which
-				// is fine for symbolic bytes and rollback is called when exiting unicorn
-				// due to an error encountered
-				bitmap[i] = TAINT_SYMBOLIC;
-			}
-			else if (bitmap[i] != TAINT_NONE) {
-				bitmap[i] = TAINT_NONE;
-			}
+			// the page is direct-mapped, so concrete writes need no syncing and there is no dirty bitmap to update
+			record.previous_taint.push_back(bitmap_get(bitmap, i) ? TAINT_SYMBOLIC : TAINT_NONE);
+			bitmap_set(bitmap, i, is_dst_symbolic);
 		}
 	}
 	mem_writes.push_back(record);

--- a/native/unicornlib/sim_unicorn.hpp
+++ b/native/unicornlib/sim_unicorn.hpp
@@ -28,6 +28,9 @@ static const uint8_t MAX_REGISTER_BYTE_SIZE = 32;
 static const uint16_t ANGR_PAGE_SIZE = 0x1000;
 static const uint8_t PAGE_SHIFT = 12;
 
+// A page's taint maps are packed bitmaps: one bit per page byte, so a page needs ANGR_PAGE_SIZE / 8 bytes.
+static const uint16_t ANGR_PAGE_BITMAP_SIZE = ANGR_PAGE_SIZE / 8;
+
 typedef uint64_t address_t;
 typedef uint64_t unicorn_reg_id_t;
 typedef int64_t vex_reg_offset_t;
@@ -41,7 +44,7 @@ enum simos_t: uint8_t {
 
 enum taint_t: uint8_t {
 	TAINT_NONE = 0,
-	TAINT_SYMBOLIC = 1, // this should be 1 to match the UltraPage impl
+	TAINT_SYMBOLIC = 1, // this should be 1 to match the taint values angr passes in for file descriptor bytes
 	TAINT_DIRTY = 2,
 };
 
@@ -490,7 +493,41 @@ struct caches_t {
 	PageCache *page_cache;
 };
 
-typedef taint_t PageBitmap[ANGR_PAGE_SIZE];
+/*
+ * A packed bitmap over the bytes of a page: bit i of byte i >> 3, least significant bit first. This is the exact
+ * layout angr's UltraPage keeps its symbolic map in, so the map of a direct-mapped page can be aliased rather than
+ * expanded and copied.
+ */
+typedef uint8_t PageBitmap[ANGR_PAGE_BITMAP_SIZE];
+
+static inline bool bitmap_get(const uint8_t *bitmap, uint64_t idx) {
+	return (bitmap[idx >> 3] >> (idx & 7)) & 1;
+}
+
+static inline void bitmap_set(uint8_t *bitmap, uint64_t idx, bool value) {
+	if (value) {
+		bitmap[idx >> 3] |= (uint8_t)(1u << (idx & 7));
+	}
+	else {
+		bitmap[idx >> 3] &= (uint8_t)~(1u << (idx & 7));
+	}
+}
+
+/*
+ * The taint state of an active page. Symbolic-ness and dirtiness are tracked in separate bitmaps because a byte can
+ * only be one or the other, and because the symbolic map has to match angr's own layout exactly when it is aliased.
+ */
+struct page_taint_t {
+	// Bytes holding symbolic values. Aliases the UltraPage's own map when the page is direct-mapped, in which case
+	// updates here are immediately visible to angr; otherwise it is a copy owned by us.
+	uint8_t *symbolic;
+	// Bytes unicorn wrote concretely that have to be synced back to angr. NULL for direct-mapped pages: their writes
+	// land in angr's backing store already, so there is nothing to sync.
+	uint8_t *dirty;
+	// The direct-mapped page data, or NULL if the page was copied into unicorn.
+	uint8_t *data;
+};
+
 typedef std::unordered_map<address_t, block_taint_entry_t> BlockTaintCache;
 extern std::map<uint64_t, caches_t> global_cache;
 
@@ -583,9 +620,7 @@ class State {
 	// List of instructions that should be executed symbolically
 	std::vector<block_details_t> blocks_with_symbolic_stmts;
 
-	// the latter part of the pair is a pointer to the page data if the page is direct-mapped, otherwise NULL
-	std::map<address_t, std::pair<taint_t *, uint8_t *>> active_pages;
-	//std::map<uint64_t, taint_t *> active_pages;
+	std::map<address_t, page_taint_t> active_pages;
 	std::set<uint64_t> stop_points;
 
 	address_t trace_last_block_addr;
@@ -641,7 +676,7 @@ class State {
 
 	// Private functions
 
-	std::pair<taint_t *, uint8_t *> page_lookup(address_t address) const;
+	page_taint_t page_lookup(address_t address) const;
 
 	void compute_slice_of_stmt(vex_stmt_details_t &instr);
 	vex_stmt_details_t compute_vex_stmt_details(const vex_stmt_taint_entry_t &vex_stmt_taint_entry);
@@ -833,11 +868,12 @@ class State {
 
 		~State() {
 			for (auto it = active_pages.begin(); it != active_pages.end(); it++) {
-				// only delete if not direct-mapped
-				if (!it->second.second) {
-					// delete should use the bracket operator since PageBitmap is an array typedef
-					delete[] it->second.first;
+				// the symbolic map of a direct-mapped page belongs to angr; only a copied page's is ours to free
+				// delete should use the bracket operator since PageBitmap is an array typedef
+				if (!it->second.data) {
+					delete[] it->second.symbolic;
 				}
+				delete[] it->second.dirty;
 			}
 			mem_update_t *next;
 			for (mem_update_t *cur = mem_updates_head; cur; cur = next) {
@@ -870,7 +906,8 @@ class State {
 		void rollback();
 
 		/*
-		 * allocate a new PageBitmap and put into active_pages.
+		 * record the taint bitmaps of a page in active_pages. `taint` is a packed symbolic bitmap of
+		 * ANGR_PAGE_BITMAP_SIZE bytes, aliased if `data` is non-NULL and copied otherwise.
 		 */
 		void page_activate(address_t address, uint8_t *taint, uint8_t *data);
 

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -23,6 +23,7 @@ from angr.storage.memory_mixins import (
     UltraPagesMixin,
 )
 from angr.storage.memory_mixins.paged_memory.pages.multi_values import MultiValues
+from angr.storage.memory_mixins.paged_memory.pages.symbolic_bitmap import SymbolicBitmap
 
 
 class UltraPageMemory(
@@ -816,25 +817,29 @@ class TestMemory(unittest.TestCase):
         )
 
     def test_concrete_load(self):
+        # concrete_load's bitmap is packed: one bit per byte, least significant bit first
+        def is_symbolic(bitmap, i):
+            return bool(bitmap[i >> 3] >> (i & 7) & 1)
+
+        def concrete_bytes(data, bitmap):
+            return bytes(0 if is_symbolic(bitmap, i) else d for i, d in enumerate(data))
+
         for memcls in [UltraPageMemory, ListPageMemory]:
             state = SimState(arch="AMD64", mode="symbolic", plugins={"memory": memcls()})
             state.memory.store(0x20000, b"aaaabbbbccccdddd")
 
             data, bitmap = state.memory.concrete_load(0x20000, 4, with_bitmap=True)
-            data_bytes = bytes(d if b == 0 else 0 for d, b in zip(data, bitmap))
-            assert data_bytes == b"aaaa"
-            assert bitmap.tobytes() == b"\x00\x00\x00\x00"
+            assert concrete_bytes(data, bitmap) == b"aaaa"
+            assert bitmap.tobytes() == b"\x00"
 
             data, bitmap = state.memory.concrete_load(0x20004, 8, with_bitmap=True)
-            data_bytes = bytes(d if b == 0 else 0 for d, b in zip(data, bitmap))
-            assert data_bytes == b"bbbbcccc"
-            assert bitmap.tobytes() == b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            assert concrete_bytes(data, bitmap) == b"bbbbcccc"
+            assert bitmap.tobytes() == b"\x00"
 
             state.memory.store(0x20001, claripy.BVS("flag", 8))
             data, bitmap = state.memory.concrete_load(0x20000, 4, with_bitmap=True)
-            data_bytes = bytes(d if b == 0 else 0 for d, b in zip(data, bitmap))
-            assert data_bytes == b"a\x00aa"
-            assert bitmap.tobytes() == b"\x00\x01\x00\x00"
+            assert concrete_bytes(data, bitmap) == b"a\x00aa"
+            assert bitmap.tobytes() == b"\x02"
 
             expr = claripy.Concat(
                 claripy.BVS("flag_0", 1),
@@ -845,9 +850,8 @@ class TestMemory(unittest.TestCase):
             )
             state.memory.store(0x20001, expr)
             data, bitmap = state.memory.concrete_load(0x20000, 4, with_bitmap=True)
-            data_bytes = bytes(d if b == 0 else 0 for d, b in zip(data, bitmap))
-            assert data_bytes == b"a\x00\x00a"
-            assert bitmap.tobytes() == b"\x00\x01\x01\x00"
+            assert concrete_bytes(data, bitmap) == b"a\x00\x00a"
+            assert bitmap.tobytes() == b"\x06"
 
             expr = claripy.Concat(
                 claripy.BVS("flag_0", 1),
@@ -858,9 +862,8 @@ class TestMemory(unittest.TestCase):
             )
             state.memory.store(0x20005, expr)
             data, bitmap = state.memory.concrete_load(0x20004, 4, with_bitmap=True)
-            data_bytes = bytes(d if b == 0 else 0 for d, b in zip(data, bitmap))
-            assert data_bytes == b"b\x00\x00b"
-            assert bitmap.tobytes() == b"\x00\x01\x01\x00"
+            assert concrete_bytes(data, bitmap) == b"b\x00\x00b"
+            assert bitmap.tobytes() == b"\x06"
 
             expr = claripy.Concat(
                 claripy.BVV(7, 7),
@@ -869,9 +872,8 @@ class TestMemory(unittest.TestCase):
             )
             state.memory.store(0x20005, expr)
             data, bitmap = state.memory.concrete_load(0x20004, 4, with_bitmap=True)
-            data_bytes = bytes(d if b == 0 else 0 for d, b in zip(data, bitmap))
-            assert data_bytes == b"b\x00\x00b"
-            assert bitmap.tobytes() == b"\x00\x01\x01\x00"
+            assert concrete_bytes(data, bitmap) == b"b\x00\x00b"
+            assert bitmap.tobytes() == b"\x06"
 
             expr = claripy.Concat(
                 claripy.BVV(1, 1),
@@ -880,9 +882,8 @@ class TestMemory(unittest.TestCase):
             )
             state.memory.store(0x20005, expr)
             data, bitmap = state.memory.concrete_load(0x20004, 4, with_bitmap=True)
-            data_bytes = bytes(d if b == 0 else 0 for d, b in zip(data, bitmap))
-            assert data_bytes == b"b\x00\x00b"
-            assert bitmap.tobytes() == b"\x00\x01\x01\x00"
+            assert concrete_bytes(data, bitmap) == b"b\x00\x00b"
+            assert bitmap.tobytes() == b"\x06"
 
     def test_multivalued_list_page(self):
         state = SimState(arch="AMD64", mode="symbolic", plugins={"memory": MultiValuedMemory()})
@@ -916,6 +917,62 @@ class TestMemory(unittest.TestCase):
         val = state.memory.load(addr, size=4, condition=cond, endness=state.arch.memory_endness)
         assert set(state.solver.eval_upto(cond, 2)) == {True, False}
         assert (val == 0x12345678).is_true()
+
+
+class TestSymbolicBitmap(unittest.TestCase):
+    def test_view_is_packed(self):
+        bm = SymbolicBitmap(64)
+        bm.set_range(1, 3)
+        bm.set(9, 1)
+        assert bm.view(0, 64).tobytes() == b"\x06\x02" + bytes(6)
+
+    def test_view_of_uniform_map(self):
+        assert SymbolicBitmap(64, 0).view(0, 64).tobytes() == bytes(8)
+        assert SymbolicBitmap(64, 1).view(0, 64).tobytes() == b"\xff" * 8
+
+    def test_unaligned_view_is_shifted_and_readonly(self):
+        bm = SymbolicBitmap(64)
+        bm.set_range(5, 8)
+        view = bm.view(4, 12)
+        assert view.readonly
+        # bytes 5..7 of the page are bits 1..3 of a view starting at byte 4
+        assert view.tobytes() == b"\x0e"
+
+    def test_aligned_view_aliases_the_map(self):
+        bm = SymbolicBitmap(64)
+        view = bm.view(0, 64)
+        assert not view.readonly
+
+        # writes through the view are visible to the map...
+        view[0] = 0x05
+        assert [bm.get(i) for i in range(4)] == [1, 0, 1, 0]
+
+        # ...and writes to the map are visible through the view
+        bm.set(3, 1)
+        assert view[0] == 0x0D
+
+    def test_whole_page_write_keeps_an_aliased_buffer(self):
+        # native unicorn holds a pointer into the map of a page it direct-mapped, so a write covering the whole page
+        # must fill the backing store in place rather than drop it for the uniform representation
+        bm = SymbolicBitmap(64)
+        view = bm.view(0, 64)
+
+        bm.set_range(0, 64)
+        assert view.tobytes() == b"\xff" * 8
+        assert all(bm.get(i) for i in range(64))
+
+        bm.clear_range(0, 64)
+        assert view.tobytes() == bytes(8)
+        assert not any(bm.get(i) for i in range(64))
+
+    def test_copy_is_not_aliased(self):
+        bm = SymbolicBitmap(64)
+        view = bm.view(0, 64)
+        other = bm.copy()
+
+        other.set_range(0, 64)
+        assert view.tobytes() == bytes(8)
+        assert not any(bm.get(i) for i in range(64))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A bitmap is better for memory usage than a bytemap.