### PR TITLE
Decompiler: terminate trailing C labels with null statements

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -915,6 +915,11 @@ class CStatements(CStatement):
             yield from stmt.c_repr_chunks(indent=indent, asexpr=asexpr)
             if asexpr:
                 yield ", ", None
+        if not asexpr and self.statements and isinstance(self.statements[-1], CLabel):
+            # A C label prefixes a statement; it is not a complete statement itself. Finish a trailing label run
+            # locally so that the next statement in an outer sequence cannot become its labeled statement.
+            yield indent_str, None
+            yield ";\n", None
 
 
 class CAILBlock(CStatement):

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1057,6 +1057,11 @@ class CStatements(CStatement):
             yield from stmt.c_repr_chunks(indent=indent, asexpr=asexpr)
             if asexpr:
                 yield ", ", None
+        if not asexpr and self.statements and isinstance(self.statements[-1], CLabel):
+            # A C label prefixes a statement; it is not a complete statement itself. Finish a trailing label run
+            # locally so that the next statement in an outer sequence cannot become its labeled statement.
+            yield indent_str, None
+            yield ";\n", None
 
 
 class CAILBlock(CStatement):

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -906,20 +906,37 @@ class CStatements(CStatement):
         self.addr = addr
 
     def c_repr_chunks(self, indent=0, asexpr=False):
+        yield from self._c_repr_chunks(indent=indent, asexpr=asexpr, terminate_trailing_label=True)
+
+    def _c_repr_chunks(self, indent=0, asexpr=False, *, terminate_trailing_label):
         indent_str = self.indent_str(indent)
         if self.codegen.display_block_addrs:
             yield indent_str, None
             yield f"/* Block {hex(self.addr) if self.addr is not None else 'unknown'} */", None
             yield "\n", None
         for stmt in self.statements:
-            yield from stmt.c_repr_chunks(indent=indent, asexpr=asexpr)
+            if isinstance(stmt, CStatements):
+                # CStatements may be a transparent sequence nested inside another sequence. A label at the end of
+                # the inner sequence still labels the next statement in the outer sequence.
+                yield from stmt._c_repr_chunks(indent=indent, asexpr=asexpr, terminate_trailing_label=False)
+            else:
+                yield from stmt.c_repr_chunks(indent=indent, asexpr=asexpr)
             if asexpr:
                 yield ", ", None
-        if not asexpr and self.statements and isinstance(self.statements[-1], CLabel):
-            # A C label prefixes a statement; it is not a complete statement itself. Finish a trailing label run
-            # locally so that the next statement in an outer sequence cannot become its labeled statement.
+        if not asexpr and terminate_trailing_label and isinstance(self._last_nonempty_statement(), CLabel):
+            # A C label prefixes a statement; it is not a complete statement itself. Finish it only at the boundary
+            # of the enclosing sequence, after looking through transparent nested sequences.
             yield indent_str, None
             yield ";\n", None
+
+    def _last_nonempty_statement(self) -> CStatement | None:
+        for stmt in reversed(self.statements):
+            if isinstance(stmt, CStatements):
+                stmt = stmt._last_nonempty_statement()
+                if stmt is None:
+                    continue
+            return stmt
+        return None
 
 
 class CAILBlock(CStatement):

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1048,20 +1048,37 @@ class CStatements(CStatement):
         self.addr = addr
 
     def c_repr_chunks(self, indent=0, asexpr=False):
+        yield from self._c_repr_chunks(indent=indent, asexpr=asexpr, terminate_trailing_label=True)
+
+    def _c_repr_chunks(self, indent=0, asexpr=False, *, terminate_trailing_label):
         indent_str = self.indent_str(indent)
         if self.codegen.display_block_addrs:
             yield indent_str, None
             yield f"/* Block {hex(self.addr) if self.addr is not None else 'unknown'} */", None
             yield "\n", None
         for stmt in self.statements:
-            yield from stmt.c_repr_chunks(indent=indent, asexpr=asexpr)
+            if isinstance(stmt, CStatements):
+                # CStatements may be a transparent sequence nested inside another sequence. A label at the end of
+                # the inner sequence still labels the next statement in the outer sequence.
+                yield from stmt._c_repr_chunks(indent=indent, asexpr=asexpr, terminate_trailing_label=False)
+            else:
+                yield from stmt.c_repr_chunks(indent=indent, asexpr=asexpr)
             if asexpr:
                 yield ", ", None
-        if not asexpr and self.statements and isinstance(self.statements[-1], CLabel):
-            # A C label prefixes a statement; it is not a complete statement itself. Finish a trailing label run
-            # locally so that the next statement in an outer sequence cannot become its labeled statement.
+        if not asexpr and terminate_trailing_label and isinstance(self._last_nonempty_statement(), CLabel):
+            # A C label prefixes a statement; it is not a complete statement itself. Finish it only at the boundary
+            # of the enclosing sequence, after looking through transparent nested sequences.
             yield indent_str, None
             yield ";\n", None
+
+    def _last_nonempty_statement(self) -> CStatement | None:
+        for stmt in reversed(self.statements):
+            if isinstance(stmt, CStatements):
+                stmt = stmt._last_nonempty_statement()
+                if stmt is None:
+                    continue
+            return stmt
+        return None
 
 
 class CAILBlock(CStatement):

--- a/tests/analyses/decompiler/test_structured_codegen_c.py
+++ b/tests/analyses/decompiler/test_structured_codegen_c.py
@@ -57,6 +57,32 @@ def test_trailing_label_run_has_one_null_statement():
     assert _render(statements, indent=4) == "LABEL_400000:\nLABEL_400010:\n    ;\n"
 
 
+def test_nested_trailing_label_prefixes_next_outer_statement():
+    codegen = _codegen()
+    statements = CStatements(
+        [
+            CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen),
+            CReturn(None, codegen=codegen),
+        ],
+        codegen=codegen,
+    )
+
+    assert _render(statements) == "LABEL_400000:\nreturn;\n"
+
+
+def test_nested_terminal_label_has_null_statement():
+    codegen = _codegen()
+    statements = CStatements(
+        [
+            CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen),
+            CStatements([], codegen=codegen),
+        ],
+        codegen=codegen,
+    )
+
+    assert _render(statements, indent=4) == "LABEL_400000:\n    ;\n"
+
+
 def test_trailing_label_does_not_capture_outer_statement():
     codegen = _codegen()
     conditional = CIfElse(

--- a/tests/analyses/decompiler/test_structured_codegen_c.py
+++ b/tests/analyses/decompiler/test_structured_codegen_c.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import unittest
+
 from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
 from angr.analyses.decompiler.structured_codegen.c import CExpression, CIfElse, CLabel, CReturn, CStatements
 
@@ -37,38 +39,67 @@ def _render(node, indent=0):
     return "".join(text for text, _ in node.c_repr_chunks(indent=indent))
 
 
-def test_trailing_label_has_null_statement():
-    codegen = _codegen()
-    statements = CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen)
+class TestCStatementsRendering(unittest.TestCase):
+    """How C statement sequences render labels at nested and enclosing boundaries."""
 
-    assert _render(statements, indent=4) == "LABEL_400000:\n    ;\n"
+    def test_trailing_label_has_null_statement(self):
+        codegen = _codegen()
+        statements = CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen)
 
+        self.assertEqual(_render(statements, indent=4), "LABEL_400000:\n    ;\n")
 
-def test_trailing_label_run_has_one_null_statement():
-    codegen = _codegen()
-    statements = CStatements(
-        [
-            CLabel("LABEL_400000", codegen=codegen),
-            CLabel("LABEL_400010", codegen=codegen),
-        ],
-        codegen=codegen,
-    )
+    def test_trailing_label_run_has_one_null_statement(self):
+        codegen = _codegen()
+        statements = CStatements(
+            [
+                CLabel("LABEL_400000", codegen=codegen),
+                CLabel("LABEL_400010", codegen=codegen),
+            ],
+            codegen=codegen,
+        )
 
-    assert _render(statements, indent=4) == "LABEL_400000:\nLABEL_400010:\n    ;\n"
+        self.assertEqual(_render(statements, indent=4), "LABEL_400000:\nLABEL_400010:\n    ;\n")
 
-
-def test_trailing_label_does_not_capture_outer_statement():
-    codegen = _codegen()
-    conditional = CIfElse(
-        [
-            (
-                _Condition(codegen=codegen),
+    def test_nested_trailing_label_prefixes_next_outer_statement(self):
+        codegen = _codegen()
+        statements = CStatements(
+            [
                 CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen),
-            )
-        ],
-        cstyle_ifs=True,
-        codegen=codegen,
-    )
-    statements = CStatements([conditional, CReturn(None, codegen=codegen)], codegen=codegen)
+                CReturn(None, codegen=codegen),
+            ],
+            codegen=codegen,
+        )
 
-    assert _render(statements) == "if (condition)\nLABEL_400000:\n    ;\nreturn;\n"
+        self.assertEqual(_render(statements), "LABEL_400000:\nreturn;\n")
+
+    def test_nested_terminal_label_has_null_statement(self):
+        codegen = _codegen()
+        statements = CStatements(
+            [
+                CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen),
+                CStatements([], codegen=codegen),
+            ],
+            codegen=codegen,
+        )
+
+        self.assertEqual(_render(statements, indent=4), "LABEL_400000:\n    ;\n")
+
+    def test_trailing_label_does_not_capture_outer_statement(self):
+        codegen = _codegen()
+        conditional = CIfElse(
+            [
+                (
+                    _Condition(codegen=codegen),
+                    CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen),
+                )
+            ],
+            cstyle_ifs=True,
+            codegen=codegen,
+        )
+        statements = CStatements([conditional, CReturn(None, codegen=codegen)], codegen=codegen)
+
+        self.assertEqual(_render(statements), "if (condition)\nLABEL_400000:\n    ;\nreturn;\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_structured_codegen_c.py
+++ b/tests/analyses/decompiler/test_structured_codegen_c.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
+from angr.analyses.decompiler.structured_codegen.c import CExpression, CIfElse, CLabel, CReturn, CStatements
+
+
+class _Condition(CExpression):
+    @property
+    def type(self):
+        return None
+
+    def c_repr_chunks(self, indent=0, asexpr=False):
+        yield "condition", None
+
+
+class _Codegen(DummyStructuredCodeGenerator):
+    braces_on_own_lines: bool
+    display_block_addrs: bool
+    indent_delta: int
+
+
+def _codegen():
+    codegen = _Codegen(
+        "c",
+        expr_comments={},
+        stmt_comments={},
+        configuration={},
+        const_formats={},
+    )
+    codegen.braces_on_own_lines = False
+    codegen.display_block_addrs = False
+    codegen.indent_delta = 4
+    return codegen
+
+
+def _render(node, indent=0):
+    return "".join(text for text, _ in node.c_repr_chunks(indent=indent))
+
+
+def test_trailing_label_has_null_statement():
+    codegen = _codegen()
+    statements = CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen)
+
+    assert _render(statements, indent=4) == "LABEL_400000:\n    ;\n"
+
+
+def test_trailing_label_run_has_one_null_statement():
+    codegen = _codegen()
+    statements = CStatements(
+        [
+            CLabel("LABEL_400000", codegen=codegen),
+            CLabel("LABEL_400010", codegen=codegen),
+        ],
+        codegen=codegen,
+    )
+
+    assert _render(statements, indent=4) == "LABEL_400000:\nLABEL_400010:\n    ;\n"
+
+
+def test_trailing_label_does_not_capture_outer_statement():
+    codegen = _codegen()
+    conditional = CIfElse(
+        [
+            (
+                _Condition(codegen=codegen),
+                CStatements([CLabel("LABEL_400000", codegen=codegen)], codegen=codegen),
+            )
+        ],
+        cstyle_ifs=True,
+        codegen=codegen,
+    )
+    statements = CStatements([conditional, CReturn(None, codegen=codegen)], codegen=codegen)
+
+    assert _render(statements) == "if (condition)\nLABEL_400000:\n    ;\nreturn;\n"


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Phoenix emits a terminal `LABEL_401d11` with no following statement in `GREYMATTER` function `cgc_request_document` at `0x401b80`. The resulting pre-C23 C is invalid, and a trailing label in a control body can instead capture the next outer statement.

```c
LABEL_401d11:
}
```

### Root cause

`CStatements` rendered each nested sequence independently, although an inner sequence may be transparent and its final label may legitimately prefix the next statement in the enclosing sequence. Conversely, a genuine top-level or control-body boundary did not ensure that its final label had a statement.

### Fix

Rendering now propagates terminal-label state through transparent nested sequences and inserts an indented null statement only at the enclosing boundary that must terminate it.

```c
LABEL_401d11:
    ;
}
```

### Testing

Regressions cover terminal and consecutive labels, transparent and empty nested sequences, and control-body boundaries. The exact-head hosted corpus artifact changes only the required null statement in this function; the complete before-and-after output is preserved in the output comment.

Validation: https://github.com/angr/angr/pull/6731#issuecomment-5162008414

session: sharpen
