### PR TITLE
Decompiler: preserve outer-switch exits through nested switches

### DIFF
--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -225,7 +225,7 @@ class StructurerBase(Analysis):
                 self.node = node
                 self.original_error = original_error
 
-        def _node_outcomes(node: BaseNode | ailment.Block | None) -> int:
+        def _node_outcomes(node: BaseNode | MultiNode | ailment.Block | None) -> int:
             if node is None:
                 return _CONTINUES
 
@@ -323,11 +323,15 @@ class StructurerBase(Analysis):
         def _wrap_nested_switch(root, nested_switch: SwitchCaseNode):
             def _handle_nested_switch(node: SwitchCaseNode, parent=None, index=0, label=None):
                 if node is nested_switch:
+                    next_node = (
+                        parent.nodes[index + 1]
+                        if isinstance(parent, (SequenceNode, MultiNode)) and index + 1 < len(parent.nodes)
+                        else None
+                    )
                     if (
-                        isinstance(parent, (SequenceNode, MultiNode))
-                        and index + 1 < len(parent.nodes)
-                        and type(parent.nodes[index + 1]) is BreakNode
-                        and parent.nodes[index + 1].target == switch_end_addr
+                        isinstance(next_node, BreakNode)
+                        and type(next_node) is BreakNode
+                        and next_node.target == switch_end_addr
                     ):
                         return None
                     return SequenceNode(node.addr, nodes=[node, BreakNode(node.addr, switch_end_addr)])

--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -214,6 +214,72 @@ class StructurerBase(Analysis):
                     case_node.nodes.append(ailment.Block(cond_node.addr, 0, statements=[goto_stmt], idx=None))
 
         # rewrite all _goto switch_end_addr_ to _break_
+        _CONTINUES = 1
+        _OUTER_BREAK = 2
+        _TERMINATES = 4
+        _OTHER_EXIT = 8
+
+        class _CarryNestedSwitchOuterBreakError(Exception):
+            def __init__(self, node: SwitchCaseNode, original_error: TypeError):
+                super().__init__()
+                self.node = node
+                self.original_error = original_error
+
+        def _node_outcomes(node: BaseNode | ailment.Block | None) -> int:
+            if node is None:
+                return _CONTINUES
+
+            if isinstance(node, ailment.Block):
+                if not node.statements:
+                    return _CONTINUES
+                stmt = node.statements[-1]
+                if isinstance(stmt, ailment.Stmt.Return):
+                    return _TERMINATES
+                if isinstance(stmt, ailment.Stmt.Jump):
+                    targets = extract_jump_targets(stmt)
+                    return _TERMINATES if len(targets) == 1 and next(iter(targets)) == switch_end_addr else _OTHER_EXIT
+                return _OTHER_EXIT if isinstance(stmt, ailment.Stmt.ConditionalJump) else _CONTINUES
+
+            if isinstance(node, ConditionalBreakNode):
+                return _OTHER_EXIT
+            if isinstance(node, BreakNode):
+                return _OUTER_BREAK if node.target == switch_end_addr else _OTHER_EXIT
+            if isinstance(node, CodeNode):
+                outcomes = _node_outcomes(node.node)
+                if node.reaching_condition is not None and not claripy.is_true(node.reaching_condition):
+                    outcomes |= _CONTINUES
+                return outcomes
+            if isinstance(node, (SequenceNode, MultiNode)):
+                outcomes = _CONTINUES
+                for child in node.nodes:
+                    if outcomes & _CONTINUES:
+                        outcomes = (outcomes & ~_CONTINUES) | _node_outcomes(child)
+                return outcomes
+            if isinstance(node, ConditionNode):
+                outcomes = _node_outcomes(node.true_node) | _node_outcomes(node.false_node)
+                if node.reaching_condition is not None and not claripy.is_true(node.reaching_condition):
+                    outcomes |= _CONTINUES
+                return outcomes
+            if isinstance(node, CascadingConditionNode):
+                outcomes = _node_outcomes(node.else_node)
+                for _, child in node.condition_and_nodes:
+                    outcomes |= _node_outcomes(child)
+                return outcomes
+            return _OTHER_EXIT
+
+        def _switch_outcomes(node: SwitchCaseNode) -> int:
+            outcomes = _node_outcomes(node.default_node)
+            for case in node.cases.values():
+                outcomes |= _node_outcomes(case)
+            return outcomes
+
+        def _needs_outer_break(node: SwitchCaseNode) -> bool:
+            if node.default_node is None:
+                return False
+            outcomes = _switch_outcomes(node)
+            return bool(outcomes & _OUTER_BREAK) and not outcomes & (_CONTINUES | _OTHER_EXIT)
+
+        proven_nested_switches: set[int] = set()
 
         def _rewrite_gotos(block, parent=None, index=0, label=None):
             if block.statements and parent is not None:
@@ -224,7 +290,12 @@ class StructurerBase(Analysis):
                         # add a new a break statement to its parent
                         break_node = BreakNode(stmt.tags["ins_addr"], switch_end_addr)
                         # insert node
-                        insert_node(parent, "after", break_node, index)
+                        try:
+                            insert_node(parent, "after", break_node, index)
+                        except TypeError as exc:
+                            if isinstance(parent, SwitchCaseNode) and _needs_outer_break(parent):
+                                raise _CarryNestedSwitchOuterBreakError(parent, exc) from None
+                            raise
                         # remove the last statement
                         block.statements = block.statements[:-1]
 
@@ -237,11 +308,8 @@ class StructurerBase(Analysis):
             return walker._handle_Loop(node, parent=parent, index=index, label=label)
 
         def _handle_SwitchCase(node: SwitchCaseNode, parent=None, index=0, label=None):
-            # if a node inside this switch-case has a goto that goes to the end of the outer switch-case, we will
-            # convert the goto into a break node, and then add a break node at the end of this switch-case.
-            # of course, this only works if all nodes either end with a return or a goto that goes to the end of the
-            # outer switch-case. we detect it first.
-            # TODO: Implement the above logic
+            if id(node) in proven_nested_switches:
+                return None
             return walker._handle_SwitchCase(node, parent=parent, index=index, label=label)
 
         handlers = {
@@ -251,11 +319,44 @@ class StructurerBase(Analysis):
         }
 
         walker = SequenceWalker(handlers=handlers)
-        for case_node in cases.values():
-            walker.walk(case_node)
+
+        def _wrap_nested_switch(root, nested_switch: SwitchCaseNode):
+            def _handle_nested_switch(node: SwitchCaseNode, parent=None, index=0, label=None):
+                if node is nested_switch:
+                    if (
+                        isinstance(parent, (SequenceNode, MultiNode))
+                        and index + 1 < len(parent.nodes)
+                        and type(parent.nodes[index + 1]) is BreakNode
+                        and parent.nodes[index + 1].target == switch_end_addr
+                    ):
+                        return None
+                    return SequenceNode(node.addr, nodes=[node, BreakNode(node.addr, switch_end_addr)])
+                return wrapper._handle_SwitchCase(node, parent=parent, index=index, label=label)
+
+            wrapper = SequenceWalker(handlers={SwitchCaseNode: _handle_nested_switch})
+            rewritten_root = wrapper.walk(root)
+            return rewritten_root if rewritten_root is not None else root
+
+        def _walk_root(root, can_replace_root: bool):
+            while True:
+                try:
+                    rewritten_root = walker.walk(root)
+                except _CarryNestedSwitchOuterBreakError as exc:
+                    if exc.node is root and not can_replace_root:
+                        raise exc.original_error
+                    # A break inside the nested switch would leave only that switch. All non-returning paths have been
+                    # proven to target the outer switch end, so carry them through the owning scope with an outer break
+                    # while preserving the direct goto that triggered the legacy insertion failure.
+                    proven_nested_switches.add(id(exc.node))
+                    root = _wrap_nested_switch(root, exc.node)
+                    continue
+                return rewritten_root if rewritten_root is not None else root
+
+        for case_addr, case_node in list(cases.items()):
+            cases[case_addr] = _walk_root(case_node, can_replace_root=True)
 
         if default is not None:
-            walker.walk(default)
+            _walk_root(default, can_replace_root=False)
 
     @staticmethod
     def _remove_all_jumps(seq):

--- a/tests/analyses/decompiler/test_switch_handle_gotos_scope.py
+++ b/tests/analyses/decompiler/test_switch_handle_gotos_scope.py
@@ -1,12 +1,14 @@
+# pylint: disable=protected-access
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any, cast
 
 import archinfo
 import pytest
 
 from angr import ailment
-from angr.analyses.decompiler.structurer_nodes import BreakNode, SequenceNode, SwitchCaseNode
+from angr.analyses.decompiler.structurer_nodes import BaseNode, BreakNode, SequenceNode, SwitchCaseNode
 from angr.analyses.decompiler.structuring.structurer_base import StructurerBase
 
 SWITCH_END = 0x5000
@@ -30,7 +32,7 @@ def _jump_block(addr: int = 0x4000) -> ailment.Block:
 def _make_structurer() -> StructurerBase:
     arch = archinfo.ArchAMD64()
     structurer = object.__new__(StructurerBase)
-    structurer.project = SimpleNamespace(arch=arch)
+    structurer.project = cast(Any, SimpleNamespace(arch=arch))
     structurer.ail_manager = ailment.Manager(arch=arch)
     return structurer
 
@@ -56,7 +58,7 @@ def test_switch_goto_rewrite_carries_proven_outer_exit_through_nested_switch():
     )
     nested = SwitchCaseNode(
         ailment.Expr.Const(3, 0, 32),
-        {0: inner_break, 1: returning_case},
+        cast(Any, {0: inner_break, 1: returning_case}),
         exit_block,
         addr=0x4030,
     )
@@ -78,22 +80,25 @@ def test_switch_goto_rewrite_replaces_proven_nested_switch_case_root():
     exit_block = _jump_block()
     nested = SwitchCaseNode(
         ailment.Expr.Const(3, 0, 32),
-        {0: BreakNode(0x4010, SWITCH_END)},
+        cast(Any, {0: BreakNode(0x4010, SWITCH_END)}),
         exit_block,
         addr=0x4030,
     )
-    cases = {0: nested}
+    cases: dict[int, BaseNode] = {0: nested}
     structurer = _make_structurer()
 
     for _ in range(2):
         structurer._switch_handle_gotos(cases, None, SWITCH_END)
 
     assert len(exit_block.statements) == 1
-    rewritten = cases[0]
-    assert isinstance(rewritten, SequenceNode)
+    assert isinstance(cases[0], SequenceNode)
+    rewritten = cast(SequenceNode, cases[0])
+    # Pylint retains the pre-rewrite SwitchCaseNode type through the mutable dictionary lookup despite the guard above.
+    # pylint: disable=no-member
     assert rewritten.nodes[0] is nested
     assert type(rewritten.nodes[1]) is BreakNode
     assert rewritten.nodes[1].target == SWITCH_END
+    # pylint: enable=no-member
 
 
 def test_switch_goto_rewrite_preserves_existing_path_without_direct_switch_child():
@@ -101,7 +106,7 @@ def test_switch_goto_rewrite_preserves_existing_path_without_direct_switch_child
     inner_case = SequenceNode(exit_block.addr, [exit_block])
     nested = SwitchCaseNode(
         ailment.Expr.Const(3, 0, 32),
-        {0: inner_case},
+        cast(Any, {0: inner_case}),
         ailment.Block(0x4020, 1, statements=[]),
         addr=0x4030,
     )
@@ -118,7 +123,7 @@ def test_switch_goto_rewrite_rejects_unproven_nested_switch_exit():
     exit_block = _jump_block()
     nested = SwitchCaseNode(
         ailment.Expr.Const(3, 0, 32),
-        {0: ailment.Block(0x4010, 1, statements=[])},
+        cast(Any, {0: ailment.Block(0x4010, 1, statements=[])}),
         exit_block,
         addr=0x4030,
     )
@@ -133,7 +138,7 @@ def test_switch_goto_rewrite_does_not_drop_outer_break_for_default_root():
     exit_block = _jump_block()
     nested = SwitchCaseNode(
         ailment.Expr.Const(3, 0, 32),
-        {0: BreakNode(0x4010, SWITCH_END)},
+        cast(Any, {0: BreakNode(0x4010, SWITCH_END)}),
         exit_block,
         addr=0x4030,
     )

--- a/tests/analyses/decompiler/test_switch_handle_gotos_scope.py
+++ b/tests/analyses/decompiler/test_switch_handle_gotos_scope.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import archinfo
+import pytest
+
+from angr import ailment
+from angr.analyses.decompiler.structurer_nodes import BreakNode, SequenceNode, SwitchCaseNode
+from angr.analyses.decompiler.structuring.structurer_base import StructurerBase
+
+SWITCH_END = 0x5000
+
+
+def _jump_block(addr: int = 0x4000) -> ailment.Block:
+    return ailment.Block(
+        addr,
+        1,
+        statements=[
+            ailment.Stmt.Jump(
+                0,
+                ailment.Expr.Const(1, SWITCH_END, 64),
+                target_idx=None,
+                ins_addr=addr,
+            )
+        ],
+    )
+
+
+def _make_structurer() -> StructurerBase:
+    arch = archinfo.ArchAMD64()
+    structurer = object.__new__(StructurerBase)
+    structurer.project = SimpleNamespace(arch=arch)
+    structurer.ail_manager = ailment.Manager(arch=arch)
+    return structurer
+
+
+def test_switch_goto_rewrite_handles_direct_outer_case_exit():
+    exit_block = _jump_block()
+    case = SequenceNode(exit_block.addr, [exit_block])
+
+    _make_structurer()._switch_handle_gotos({0: case}, None, SWITCH_END)
+
+    assert exit_block.statements == []
+    assert type(case.nodes[1]) is BreakNode
+    assert case.nodes[1].target == SWITCH_END
+
+
+def test_switch_goto_rewrite_carries_proven_outer_exit_through_nested_switch():
+    exit_block = _jump_block()
+    inner_break = BreakNode(0x4010, SWITCH_END)
+    returning_case = ailment.Block(
+        0x4020,
+        1,
+        statements=[ailment.Stmt.Return(2, [], ins_addr=0x4020)],
+    )
+    nested = SwitchCaseNode(
+        ailment.Expr.Const(3, 0, 32),
+        {0: inner_break, 1: returning_case},
+        exit_block,
+        addr=0x4030,
+    )
+    outer_case = SequenceNode(nested.addr, [nested])
+    structurer = _make_structurer()
+
+    for _ in range(2):
+        structurer._switch_handle_gotos({0: outer_case}, None, SWITCH_END)
+
+    assert len(exit_block.statements) == 1
+    rewritten = outer_case.nodes[0]
+    assert isinstance(rewritten, SequenceNode)
+    assert rewritten.nodes[0] is nested
+    assert type(rewritten.nodes[1]) is BreakNode
+    assert rewritten.nodes[1].target == SWITCH_END
+
+
+def test_switch_goto_rewrite_replaces_proven_nested_switch_case_root():
+    exit_block = _jump_block()
+    nested = SwitchCaseNode(
+        ailment.Expr.Const(3, 0, 32),
+        {0: BreakNode(0x4010, SWITCH_END)},
+        exit_block,
+        addr=0x4030,
+    )
+    cases = {0: nested}
+    structurer = _make_structurer()
+
+    for _ in range(2):
+        structurer._switch_handle_gotos(cases, None, SWITCH_END)
+
+    assert len(exit_block.statements) == 1
+    rewritten = cases[0]
+    assert isinstance(rewritten, SequenceNode)
+    assert rewritten.nodes[0] is nested
+    assert type(rewritten.nodes[1]) is BreakNode
+    assert rewritten.nodes[1].target == SWITCH_END
+
+
+def test_switch_goto_rewrite_preserves_existing_path_without_direct_switch_child():
+    exit_block = _jump_block()
+    inner_case = SequenceNode(exit_block.addr, [exit_block])
+    nested = SwitchCaseNode(
+        ailment.Expr.Const(3, 0, 32),
+        {0: inner_case},
+        ailment.Block(0x4020, 1, statements=[]),
+        addr=0x4030,
+    )
+    outer_case = SequenceNode(nested.addr, [nested])
+
+    _make_structurer()._switch_handle_gotos({0: outer_case}, None, SWITCH_END)
+
+    assert exit_block.statements == []
+    assert type(inner_case.nodes[1]) is BreakNode
+    assert inner_case.nodes[1].target == SWITCH_END
+
+
+def test_switch_goto_rewrite_rejects_unproven_nested_switch_exit():
+    exit_block = _jump_block()
+    nested = SwitchCaseNode(
+        ailment.Expr.Const(3, 0, 32),
+        {0: ailment.Block(0x4010, 1, statements=[])},
+        exit_block,
+        addr=0x4030,
+    )
+
+    with pytest.raises(TypeError, match="Unsupported label value"):
+        _make_structurer()._switch_handle_gotos({0: nested}, None, SWITCH_END)
+
+    assert len(exit_block.statements) == 1
+
+
+def test_switch_goto_rewrite_does_not_drop_outer_break_for_default_root():
+    exit_block = _jump_block()
+    nested = SwitchCaseNode(
+        ailment.Expr.Const(3, 0, 32),
+        {0: BreakNode(0x4010, SWITCH_END)},
+        exit_block,
+        addr=0x4030,
+    )
+
+    with pytest.raises(TypeError, match="Unsupported label value"):
+        _make_structurer()._switch_handle_gotos({}, nested, SWITCH_END)
+
+    assert len(exit_block.statements) == 1


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Full-preset SAILR decompilation of `print_info` at `0x41d658` in `tests/x86_64/decompiler/gnutls_certtool_O0` ends the first case of the outer switch with a nested switch and no `break`, so the case falls through into the next one:

```c
    case 1:
        ...
        switch (v1)
        {
        case 2: case 3:
            ::0x41d06e::print_dh_info(a0, "Ephemeral ", a1);
            break;
        case 12: case 13:
            print_ecdh_info(a0, "Ephemeral ", a1, "Ephemeral ", v12, v13);
            break;
        default:
            break;
        }
    case 2:
```

In the source every one of those arms leaves the outer switch. `formatted_print_percent` at `0x4055a5` in `tests/x86_64/decompiler/morton` has the same shape in the else branch of case 74, which falls through into case 80. Until #7162 this shape aborted the whole function with `TypeError: Unsupported label value "None"`; since then it decompiles with the wrong control flow.

### Root cause

`_switch_handle_gotos()` rewrites every jump to the end of the switch being structured into a `BreakNode`. For a jump that is a direct arm of a nested switch, `insert_node()` puts the break inside that arm, so it leaves the nested switch only, and nothing carries the exit through the case that owns the nested switch.

### Fix

Before the arms of a nested switch are rewritten, `_switch_handle_gotos()` now checks that the nested switch has a default and that every arm either returns or exits to the end of the outer switch. When that holds it adds one `BreakNode` to the outer switch's end after the nested switch: inserted into a `SequenceNode` or `MultiNode` parent, or wrapping the nested switch in a `SequenceNode` for any other parent and for a case that is the nested switch itself. The result for `print_info`:

```c
        default:
            break;
        }
        break;
    case 2:
```

A nested switch with an arm that falls out of it or exits somewhere else, one inside a loop or inside another nested switch, and one that is the whole default node are left as they are, because a break after them would capture paths that do not leave the outer switch, or would leave the loop or the intervening switch instead.

### Testing

`test_switch_handle_gotos_scope.py` covers the accepted shapes (nested switch in a sequence, as the case root, under a condition), the rejected ones (an arm falls out, inside a loop, inside another nested switch, the default root), and that a second pass adds no second break. `test_structurer.py` gains two regressions that assert the `break` after the nested switch in `print_info` and in `formatted_print_percent`; both fail on master. [Full before/after output](#issuecomment-5457625192). [Validation record](https://github.com/angr/angr/pull/6745#issuecomment-5162008199).

Partial fix for #6737. Merge angr/binaries#207 first: it carries the certtool fixture.

sync: angr/binaries#207

session: sharpen