### PR TITLE
ReachingDefinitions: visit DirtyExpression inputs

### DIFF
--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -1186,9 +1186,12 @@ class SimEngineRDAIL(
         return self._top(expr.bits)  # TODO
 
     def _handle_expr_DirtyExpression(self, expr) -> MultiValues[claripy.ast.BV | claripy.ast.FP]:
-        if isinstance(expr.dirty_expr, ailment.expression.VEXCCallExpression):
-            for operand in expr.dirty_expr.operands:
-                self._expr(operand)
+        for operand in expr.operands:
+            self._expr(operand)
+        if expr.guard is not None:
+            self._expr(expr.guard)
+        if expr.maddr is not None:
+            self._expr(expr.maddr)
 
         return MultiValues(self.state.top(expr.bits))
 

--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -1184,9 +1184,12 @@ class SimEngineRDAIL(
         return self._top(expr.bits)  # TODO
 
     def _handle_expr_DirtyExpression(self, expr) -> MultiValues[claripy.ast.BV | claripy.ast.FP]:
-        if isinstance(expr.dirty_expr, ailment.expression.VEXCCallExpression):
-            for operand in expr.dirty_expr.operands:
-                self._expr(operand)
+        for operand in expr.operands:
+            self._expr(operand)
+        if expr.guard is not None:
+            self._expr(expr.guard)
+        if expr.maddr is not None:
+            self._expr(expr.maddr)
 
         return MultiValues(self.state.top(expr.bits))
 

--- a/tests/engines/light/test_light_engine.py
+++ b/tests/engines/light/test_light_engine.py
@@ -69,6 +69,40 @@ class TestLightEngine(TestCase):
         assert seen == [operand]
         assert isinstance(result, MultiValues)
 
+    def test_rda_dirty_expression_visits_inputs(self):
+        engine: Any = object.__new__(SimEngineRDAIL)
+        engine.state = SimpleNamespace(top=lambda bits: claripy.BVS("rda_dirty_top", bits))
+        operand = ailment.Expr.Const(0, 1, 32)
+        guard = ailment.Expr.Const(1, 1, 1)
+        memory_address = ailment.Expr.Const(2, 0x4000, 64)
+        cases = (
+            (guard, memory_address, [operand, guard, memory_address]),
+            (None, None, [operand]),
+        )
+
+        for current_guard, current_address, expected in cases:
+            with self.subTest(guard=current_guard, memory_address=current_address):
+                seen = []
+                engine._expr = seen.append
+                dirty_expr = ailment.Expr.DirtyExpression(
+                    3,
+                    "helper",
+                    [operand],
+                    guard=current_guard,
+                    mfx="read",
+                    maddr=current_address,
+                    msize=4,
+                    bits=32,
+                )
+
+                result = engine._handle_expr_DirtyExpression(dirty_expr)
+
+                self.assertEqual(seen, expected)
+                self.assertIsInstance(result, MultiValues)
+                value = result.one_value()
+                self.assertIsNotNone(value)
+                self.assertEqual(len(value), 32)
+
     def test_variable_recovery_abs_preserves_typevar(self):
         operand_typevar = TypeVariable(name="abs_operand")
         engine: Any = object.__new__(SimEngineVRAIL)

--- a/tests/engines/light/test_light_engine.py
+++ b/tests/engines/light/test_light_engine.py
@@ -69,6 +69,33 @@ class TestLightEngine(TestCase):
         assert seen == [operand]
         assert isinstance(result, MultiValues)
 
+    def test_rda_dirty_expression_visits_inputs(self):
+        engine: Any = object.__new__(SimEngineRDAIL)
+        seen = []
+        engine._expr = seen.append
+        engine.state = SimpleNamespace(top=lambda bits: claripy.BVS("rda_dirty_top", bits))
+        operand = ailment.Expr.Const(0, 1, 32)
+        guard = ailment.Expr.Const(1, 1, 1)
+        memory_address = ailment.Expr.Const(2, 0x4000, 64)
+        dirty_expr = ailment.Expr.DirtyExpression(
+            3,
+            "helper",
+            [operand],
+            guard=guard,
+            mfx="read",
+            maddr=memory_address,
+            msize=4,
+            bits=32,
+        )
+
+        result = engine._handle_expr_DirtyExpression(dirty_expr)
+
+        assert seen == [operand, guard, memory_address]
+        assert isinstance(result, MultiValues)
+        value = result.one_value()
+        assert value is not None
+        assert len(value) == 32
+
     def test_variable_recovery_abs_preserves_typevar(self):
         operand_typevar = TypeVariable(name="abs_operand")
         engine: Any = object.__new__(SimEngineVRAIL)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Rust-backed AIL exposes a `DirtyExpression`'s operands, guard, and memory address directly, but `SimEngineRDAIL` still expected the removed pre-Rust wrapper. Reaching definitions therefore raised `AttributeError` and aborted decompilation.

The handler now visits `operands`, `guard`, and `maddr`, matching variable-recovery traversal, and preserves the conservative unknown result at the expression's width. Regressions cover populated and absent optional fields.

Validation: https://github.com/angr/angr/pull/6747#issuecomment-5162006022

session: decbench
