### PR TITLE
Ssailification: handle missing address-taken stack definitions

### DIFF
--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -571,7 +571,10 @@ class SimEngineSSARewriting(
         if expr in self.incomplete_defs and expr.offset in self.state.stackvars:
             self.def_to_udef.pop(expr, None)
 
-        vvar = self._expr_to_vvar(expr, True)
+        # A conditionally defined stack slot can be address-taken on a path where it has no reaching definition.
+        # Reuse the existing best-effort external-vvar fallback instead of treating that path as an SSA invariant
+        # failure.
+        vvar = self._expr_to_vvar(expr, True, allow_missing_stack=True)
         refers = UnaryOp(expr.idx, "Reference", vvar, bits=expr.bits, **expr.tags)
         if expr in self.def_to_udef:
             refers.tags["extra_def"] = True
@@ -678,13 +681,20 @@ class SimEngineSSARewriting(
     # Utils
     #
 
-    def _expr_to_vvar(self, expr: Def, def_is_implicit: bool) -> VirtualVariable:
+    def _expr_to_vvar(self, expr: Def, def_is_implicit: bool, *, allow_missing_stack: bool = False) -> VirtualVariable:
+        assert not allow_missing_stack or isinstance(expr, StackBaseOffset)
         # is this a use, not a def?
         if (udef := self.def_to_udef.get(expr, None)) is None:
             # in case of emergency, raise keyerror
             if isinstance(expr, StackBaseOffset):
                 assert isinstance(expr.offset, int)
-                if self._fail_fast or expr.offset in self.state.stackvars:
+                if self._fail_fast:
+                    try:
+                        return self.state.stackvars[expr.offset]
+                    except KeyError:
+                        if not allow_missing_stack:
+                            raise
+                elif expr.offset in self.state.stackvars:
                     return self.state.stackvars[expr.offset]
             elif isinstance(expr, Register):
                 if self._fail_fast or expr.reg_offset in self.state.registers:
@@ -694,7 +704,7 @@ class SimEngineSSARewriting(
 
             # we got here because expr refers to a non-existent stack offset or register offset.
             # raise a KeyError if fail_fast is specified because something else has gone wrong at this point.
-            if self._fail_fast:
+            if self._fail_fast and not allow_missing_stack:
                 raise KeyError(expr)
             # otherwise, we try our best to guesstimate the udef here
             kind = "stack" if isinstance(expr, StackBaseOffset) else "reg"

--- a/tests/analyses/decompiler/test_ssa_addr_taken_stackvar.py
+++ b/tests/analyses/decompiler/test_ssa_addr_taken_stackvar.py
@@ -7,6 +7,12 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 import unittest
 
 import angr
+from angr.ailment import Block, Manager
+from angr.ailment.expression import StackBaseOffset, UnaryOp, VirtualVariable
+from angr.ailment.statement import Return
+from angr.analyses.decompiler.ssailification.rewriting_engine import SimEngineSSARewriting
+from angr.analyses.decompiler.ssailification.rewriting_state import RewritingState
+from angr.code_location import AILCodeLocation
 
 
 class TestSSAAddrTakenStackVar(unittest.TestCase):
@@ -278,6 +284,43 @@ class TestSSAAddrTakenStackVar(unittest.TestCase):
         "45cc5056e8540000005959eb0232c08b4dfc5f5e33cd5be8ba31fcffc9c3"
     )
     BASE = 0x46AD1F
+
+    def test_rewrite_addr_taken_stack_slot_without_reaching_definition(self):
+        project = angr.load_shellcode(b"\xc3", arch="amd64", load_address=0)
+        function = project.kb.functions.function(addr=0, name="synthetic", create=True)
+        manager = Manager(arch=project.arch)
+        stack_addr = StackBaseOffset(manager.next_atom(), 64, -8, ins_addr=0x10)
+        block = Block(
+            0x10,
+            1,
+            statements=[Return(manager.next_atom(), [stack_addr], ins_addr=0x10)],
+            idx=0,
+        )
+        state = RewritingState(
+            AILCodeLocation(block.addr, block.idx, 0, block.addr),
+            project.arch,
+            function,
+            block,
+        )
+        engine = SimEngineSSARewriting(
+            project,
+            ail_manager=manager,
+            def_to_udef={},
+            incomplete_defs=set(),
+            stackvars=True,
+            fail_fast=True,
+        )
+        engine.process(state, block=block)
+
+        assert engine.out_block is not None
+        rewritten_return = engine.out_block.statements[0]
+        assert isinstance(rewritten_return, Return)
+        assert rewritten_return.ret_exprs is not None
+        reference = rewritten_return.ret_exprs[0]
+        assert isinstance(reference, UnaryOp)
+        assert reference.op == "Reference"
+        assert isinstance(reference.operand, VirtualVariable)
+        assert reference.operand.was_stack and reference.operand.stack_offset == -8
 
     def test_addr_taken_stack_slot_without_own_def(self):
         proj = angr.load_shellcode(self.FUNC_BYTES, "X86", load_address=self.BASE, start_offset=0)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

SSI rewriting raised `KeyError` when code took the address of a stack slot on a path without a reaching definition: `_handle_expr_StackBaseOffset` performed a fail-fast value lookup even though address-taking needs no stored value.

The handler may now use the rewriting engine's existing best-effort external stack-variable inference. The opt-in is private to address-taking; all other lookups remain fail-fast.

The regression builds the production engine with an empty stack state and a returned `StackBaseOffset`, reproducing the GnuTLS failure on the baseline and the implicit stack-variable reference on this head.

Validation: https://github.com/angr/angr/pull/6748#issuecomment-5162005960

session: decbench
