### PR TITLE
reaching_definitions: reject mismatched conversion widths

### DIFF
--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -562,11 +562,13 @@ class SimEngineRDAIL(
         bits = expr.to_bits
         size = bits // self.arch.byte_width
 
+        # Reject inconsistent analysis values before performing Claripy slicing or extension.
         if (
             to_conv.count() == 1
             and 0 in to_conv
             and expr.from_type == ailment.Expr.Convert.TYPE_INT
             and expr.to_type == ailment.Expr.Convert.TYPE_INT
+            and all(len(value) == expr.from_bits for value in to_conv[0])
         ):
             values = to_conv[0]
         else:

--- a/tests/analyses/reaching_definitions/test_engine_ail.py
+++ b/tests/analyses/reaching_definitions/test_engine_ail.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import claripy
+from archinfo import Endness
+
+import angr
+from angr import ailment
+from angr.analyses.reaching_definitions.engine_ail import SimEngineRDAIL
+from angr.analyses.reaching_definitions.function_handler import FunctionHandler
+
+
+class _ConstantState:
+    class _CodeLocation:
+        context = None
+
+    codeloc = _CodeLocation()
+
+    @staticmethod
+    def mark_const(_value: int, _size: int) -> None:
+        pass
+
+    @staticmethod
+    def top(bits: int) -> claripy.ast.BV:
+        return claripy.BVS("TOP", bits)
+
+    @staticmethod
+    def annotate_with_def(value: claripy.ast.BV, _definition) -> claripy.ast.BV:
+        return value
+
+    @staticmethod
+    def add_memory_use_by_def(_definition, *, expr) -> None:
+        pass
+
+
+def test_convert_handles_operand_width_mismatches():
+    project = angr.load_shellcode(b"\xc3", arch="amd64")
+    engine = SimEngineRDAIL(project, FunctionHandler())
+    engine.state = _ConstantState()
+
+    base = ailment.Expr.Const(0, 0x0123456789ABCDEF, 64)
+    offset = ailment.Expr.Const(1, 0, 64)
+
+    extracted = ailment.Expr.Extract(2, 32, base, offset, Endness.LE)
+    widened = ailment.Expr.Convert(3, 32, 64, False, extracted)
+    widened_result = engine._expr(widened)
+    assert len(widened_result) == widened.bits
+    widened_value = widened_result.one_value()
+    assert widened_value is not None and widened_value.symbolic
+
+    inserted = ailment.Expr.Insert(4, base, offset, ailment.Expr.Const(5, 1, 8), Endness.LE)
+    narrowed = ailment.Expr.Convert(6, 64, 32, False, inserted)
+    narrowed_result = engine._expr(narrowed)
+    assert len(narrowed_result) == narrowed.bits
+    narrowed_value = narrowed_result.one_value()
+    assert narrowed_value is not None and narrowed_value.symbolic

--- a/tests/analyses/reaching_definitions/test_engine_ail.py
+++ b/tests/analyses/reaching_definitions/test_engine_ail.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import claripy
 from archinfo import Endness
 
@@ -7,6 +9,7 @@ import angr
 from angr import ailment
 from angr.analyses.reaching_definitions.engine_ail import SimEngineRDAIL
 from angr.analyses.reaching_definitions.function_handler import FunctionHandler
+from angr.analyses.reaching_definitions.rd_state import ReachingDefinitionsState
 
 
 class _ConstantState:
@@ -35,21 +38,21 @@ class _ConstantState:
 def test_convert_handles_operand_width_mismatches():
     project = angr.load_shellcode(b"\xc3", arch="amd64")
     engine = SimEngineRDAIL(project, FunctionHandler())
-    engine.state = _ConstantState()
+    engine.state = cast(ReachingDefinitionsState, _ConstantState())
 
     base = ailment.Expr.Const(0, 0x0123456789ABCDEF, 64)
     offset = ailment.Expr.Const(1, 0, 64)
 
     extracted = ailment.Expr.Extract(2, 32, base, offset, Endness.LE)
     widened = ailment.Expr.Convert(3, 32, 64, False, extracted)
-    widened_result = engine._expr(widened)
+    widened_result = engine._expr(widened)  # pylint: disable=protected-access
     assert len(widened_result) == widened.bits
     widened_value = widened_result.one_value()
     assert widened_value is not None and widened_value.symbolic
 
     inserted = ailment.Expr.Insert(4, base, offset, ailment.Expr.Const(5, 1, 8), Endness.LE)
     narrowed = ailment.Expr.Convert(6, 64, 32, False, inserted)
-    narrowed_result = engine._expr(narrowed)
+    narrowed_result = engine._expr(narrowed)  # pylint: disable=protected-access
     assert len(narrowed_result) == narrowed.bits
     narrowed_value = narrowed_result.one_value()
     assert narrowed_value is not None and narrowed_value.symbolic


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The reaching-definitions AIL engine assumed every concrete value returned for an integer `Convert` matches the declared `from_bits`, but some expression handlers produce analysis values with a different Claripy width. Slicing or extending such a value with the declared width yields a wrong-width result or a later decompilation failure.

The engine now validates each candidate value and, when any contradicts `from_bits`, uses the same conservative TOP fallback it already applies to unsupported conversions; consistent values follow the existing path unchanged. A broader producer-side change was discarded after it caused repeatable, source-backed output regressions, so only the conversion boundary is hardened.

The regression drives the real `Extract -> Convert` and `Insert -> Convert` paths that produced inconsistent widths; it fails on exact master and passes here.

Validation: https://github.com/angr/angr/pull/6749#issuecomment-5162005880
