### PR TITLE
Preserve DirtyExpression guard and memory address during rewriting

### DIFF
--- a/angr/ailment/block_walker.py
+++ b/angr/ailment/block_walker.py
@@ -470,6 +470,9 @@ class AILBlockWalker[ExprType, StmtType, BlockType]:
         guard = expr.guard
         if guard is not None:
             self._handle_expr(len(ops) + 1, guard, stmt_idx, stmt, block)
+        maddr = expr.maddr
+        if maddr is not None:
+            self._handle_expr(len(ops) + 2, maddr, stmt_idx, stmt, block)
         return self._top(expr_idx, expr, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
@@ -675,6 +678,9 @@ class AILBlockViewer(AILBlockWalker[None, None, None]):
         guard = expr.guard
         if guard is not None:
             self._handle_expr(len(ops) + 1, guard, stmt_idx, stmt, block)
+        maddr = expr.maddr
+        if maddr is not None:
+            self._handle_expr(len(ops) + 2, maddr, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
         self, expr_idx: int, expr: VEXCCallExpression, stmt_idx: int, stmt: Statement | None, block: Block | None
@@ -1139,11 +1145,17 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
         new_operands = [self._handle_expr(0, operand, stmt_idx, stmt, block) for operand in operands_in]
         changed = any(new is not old for new, old in zip(new_operands, operands_in))
 
-        new_guard = None
         guard_in = expr.guard
+        new_guard = guard_in
         if guard_in is not None:
             new_guard = self._handle_expr(2, guard_in, stmt_idx, stmt, block)
-            changed |= new_guard != guard_in
+            changed |= new_guard is not guard_in
+
+        maddr_in = expr.maddr
+        new_maddr = maddr_in
+        if maddr_in is not None:
+            new_maddr = self._handle_expr(3, maddr_in, stmt_idx, stmt, block)
+            changed |= new_maddr is not maddr_in
 
         if changed:
             return DirtyExpression(
@@ -1152,7 +1164,7 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
                 new_operands,
                 guard=new_guard,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/angr/ailment/block_walker.py
+++ b/angr/ailment/block_walker.py
@@ -1142,19 +1142,21 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
         self, expr_idx: int, expr: DirtyExpression, stmt_idx: int, stmt: Statement | None, block: Block | None
     ) -> Expression:
         operands_in = expr.operands
-        new_operands = [self._handle_expr(0, operand, stmt_idx, stmt, block) for operand in operands_in]
+        new_operands = [
+            self._handle_expr(idx, operand, stmt_idx, stmt, block) for idx, operand in enumerate(operands_in)
+        ]
         changed = any(new is not old for new, old in zip(new_operands, operands_in))
 
         guard_in = expr.guard
         new_guard = guard_in
         if guard_in is not None:
-            new_guard = self._handle_expr(2, guard_in, stmt_idx, stmt, block)
+            new_guard = self._handle_expr(len(operands_in) + 1, guard_in, stmt_idx, stmt, block)
             changed |= new_guard is not guard_in
 
         maddr_in = expr.maddr
         new_maddr = maddr_in
         if maddr_in is not None:
-            new_maddr = self._handle_expr(3, maddr_in, stmt_idx, stmt, block)
+            new_maddr = self._handle_expr(len(operands_in) + 2, maddr_in, stmt_idx, stmt, block)
             changed |= new_maddr is not maddr_in
 
         if changed:

--- a/angr/ailment/block_walker.py
+++ b/angr/ailment/block_walker.py
@@ -470,6 +470,9 @@ class AILBlockWalker[ExprType, StmtType, BlockType]:
         guard = expr.guard
         if guard is not None:
             self._handle_expr(len(ops) + 1, guard, stmt_idx, stmt, block)
+        maddr = expr.maddr
+        if maddr is not None:
+            self._handle_expr(len(ops) + 2, maddr, stmt_idx, stmt, block)
         return self._top(expr_idx, expr, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
@@ -675,6 +678,9 @@ class AILBlockViewer(AILBlockWalker[None, None, None]):
         guard = expr.guard
         if guard is not None:
             self._handle_expr(len(ops) + 1, guard, stmt_idx, stmt, block)
+        maddr = expr.maddr
+        if maddr is not None:
+            self._handle_expr(len(ops) + 2, maddr, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
         self, expr_idx: int, expr: VEXCCallExpression, stmt_idx: int, stmt: Statement | None, block: Block | None
@@ -1136,14 +1142,22 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
         self, expr_idx: int, expr: DirtyExpression, stmt_idx: int, stmt: Statement | None, block: Block | None
     ) -> Expression:
         operands_in = expr.operands
-        new_operands = [self._handle_expr(0, operand, stmt_idx, stmt, block) for operand in operands_in]
+        new_operands = [
+            self._handle_expr(idx, operand, stmt_idx, stmt, block) for idx, operand in enumerate(operands_in)
+        ]
         changed = any(new != old for new, old in zip(new_operands, operands_in))
 
-        new_guard = None
         guard_in = expr.guard
+        new_guard = guard_in
         if guard_in is not None:
-            new_guard = self._handle_expr(2, guard_in, stmt_idx, stmt, block)
+            new_guard = self._handle_expr(len(operands_in) + 1, guard_in, stmt_idx, stmt, block)
             changed |= new_guard != guard_in
+
+        maddr_in = expr.maddr
+        new_maddr = maddr_in
+        if maddr_in is not None:
+            new_maddr = self._handle_expr(len(operands_in) + 2, maddr_in, stmt_idx, stmt, block)
+            changed |= new_maddr != maddr_in
 
         if changed:
             return DirtyExpression(
@@ -1152,7 +1166,7 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
                 new_operands,
                 guard=new_guard,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/angr/analyses/decompiler/dephication/rewriting_engine.py
+++ b/angr/analyses/decompiler/dephication/rewriting_engine.py
@@ -442,10 +442,18 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
             else:
                 new_operands.append(o)
 
+        guard_in = expr.guard
         new_guard = None
-        if expr.guard is not None:
-            new_guard = self._expr(expr.guard)
+        if guard_in is not None:
+            new_guard = self._expr(guard_in)
             if new_guard is not None:
+                updated = True
+
+        maddr_in = expr.maddr
+        new_maddr = None
+        if maddr_in is not None:
+            new_maddr = self._expr(maddr_in)
+            if new_maddr is not None:
                 updated = True
 
         if updated:
@@ -453,9 +461,9 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 expr.idx,
                 expr.callee,
                 new_operands,
-                guard=new_guard,
+                guard=new_guard if new_guard is not None else guard_in,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr if new_maddr is not None else maddr_in,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/angr/analyses/decompiler/dephication/rewriting_engine.py
+++ b/angr/analyses/decompiler/dephication/rewriting_engine.py
@@ -449,10 +449,18 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
             else:
                 new_operands.append(o)
 
+        guard_in = expr.guard
         new_guard = None
-        if expr.guard is not None:
-            new_guard = self._expr(expr.guard)
+        if guard_in is not None:
+            new_guard = self._expr(guard_in)
             if new_guard is not None:
+                updated = True
+
+        maddr_in = expr.maddr
+        new_maddr = None
+        if maddr_in is not None:
+            new_maddr = self._expr(maddr_in)
+            if new_maddr is not None:
                 updated = True
 
         if updated:
@@ -460,9 +468,9 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 expr.idx,
                 expr.callee,
                 new_operands,
-                guard=new_guard,
+                guard=new_guard if new_guard is not None else guard_in,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr if new_maddr is not None else maddr_in,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/angr/analyses/decompiler/expression_narrower.py
+++ b/angr/analyses/decompiler/expression_narrower.py
@@ -167,8 +167,14 @@ class EffectiveSizeExtractor(AILBlockWalker[None, None, None]):
             self._handle_call_args(expr.args, stmt_idx, stmt, block)
 
     def _handle_SideEffectStatement(self, stmt_idx: int, stmt: SideEffectStatement, block: Block | None):
-        if stmt.expr.args is not None:
-            self._handle_call_args(stmt.expr.args, stmt_idx, stmt, block)
+        # SideEffectStatement expressions are call-shaped here, but the flattened AIL stub exposes Expression.
+        if stmt.expr.args is not None:  # pyright: ignore[reportAttributeAccessIssue]
+            self._handle_call_args(
+                stmt.expr.args,  # pyright: ignore[reportAttributeAccessIssue]
+                stmt_idx,
+                stmt,
+                block,
+            )
 
         if stmt.ret_expr is not None:
             self._handle_expr(0, stmt.ret_expr, stmt_idx, stmt, block)

--- a/angr/analyses/decompiler/expression_narrower.py
+++ b/angr/analyses/decompiler/expression_narrower.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from angr.ailment.block import Block
     from angr.ailment.expression import (
         ITE,
-        DirtyExpression,
         Expression,
         Load,
         UnaryOp,
@@ -223,13 +222,6 @@ class EffectiveSizeExtractor(AILBlockWalker[None, None, None]):
         self._handle_expr(0, expr.cond, stmt_idx, stmt, block)
         self._handle_expr(1, expr.iftrue, stmt_idx, stmt, block)
         self._handle_expr(2, expr.iffalse, stmt_idx, stmt, block)
-
-    def _handle_DirtyExpression(
-        self, expr_idx: int, expr: DirtyExpression, stmt_idx: int, stmt: Statement | None, block: Block | None
-    ):
-        if expr.operands:
-            for i, op in enumerate(expr.operands):
-                self._handle_expr(i, op, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
         self, expr_idx: int, expr: VEXCCallExpression, stmt_idx: int, stmt: Statement | None, block: Block | None

--- a/angr/analyses/decompiler/expression_narrower.py
+++ b/angr/analyses/decompiler/expression_narrower.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from angr.ailment.block import Block
     from angr.ailment.expression import (
         ITE,
-        DirtyExpression,
         Expression,
         Load,
         UnaryOp,
@@ -168,7 +167,7 @@ class EffectiveSizeExtractor(AILBlockWalker[None, None, None]):
             self._handle_call_args(expr.args, stmt_idx, stmt, block)
 
     def _handle_SideEffectStatement(self, stmt_idx: int, stmt: SideEffectStatement, block: Block | None):
-        if stmt.expr.args is not None:
+        if isinstance(stmt.expr, Call) and stmt.expr.args is not None:
             self._handle_call_args(stmt.expr.args, stmt_idx, stmt, block)
 
         if stmt.ret_expr is not None:
@@ -223,13 +222,6 @@ class EffectiveSizeExtractor(AILBlockWalker[None, None, None]):
         self._handle_expr(0, expr.cond, stmt_idx, stmt, block)
         self._handle_expr(1, expr.iftrue, stmt_idx, stmt, block)
         self._handle_expr(2, expr.iffalse, stmt_idx, stmt, block)
-
-    def _handle_DirtyExpression(
-        self, expr_idx: int, expr: DirtyExpression, stmt_idx: int, stmt: Statement | None, block: Block | None
-    ):
-        if expr.operands:
-            for i, op in enumerate(expr.operands):
-                self._handle_expr(i, op, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
         self, expr_idx: int, expr: VEXCCallExpression, stmt_idx: int, stmt: Statement | None, block: Block | None

--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -522,10 +522,18 @@ class SimEngineSSARewriting(
             else:
                 new_operands.append(operand)
 
+        guard_in = expr.guard
         new_guard = None
-        if expr.guard is not None:
-            new_guard = self._expr(expr.guard)
+        if guard_in is not None:
+            new_guard = self._expr(guard_in)
             if new_guard is not None:
+                updated = True
+
+        maddr_in = expr.maddr
+        new_maddr = None
+        if maddr_in is not None:
+            new_maddr = self._expr(maddr_in)
+            if new_maddr is not None:
                 updated = True
 
         if updated:
@@ -533,9 +541,9 @@ class SimEngineSSARewriting(
                 expr.idx,
                 expr.callee,
                 new_operands,
-                guard=new_guard,
+                guard=new_guard if new_guard is not None else guard_in,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr if new_maddr is not None else maddr_in,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -521,10 +521,18 @@ class SimEngineSSARewriting(
             else:
                 new_operands.append(operand)
 
+        guard_in = expr.guard
         new_guard = None
-        if expr.guard is not None:
-            new_guard = self._expr(expr.guard)
+        if guard_in is not None:
+            new_guard = self._expr(guard_in)
             if new_guard is not None:
+                updated = True
+
+        maddr_in = expr.maddr
+        new_maddr = None
+        if maddr_in is not None:
+            new_maddr = self._expr(maddr_in)
+            if new_maddr is not None:
                 updated = True
 
         if updated:
@@ -532,9 +540,9 @@ class SimEngineSSARewriting(
                 expr.idx,
                 expr.callee,
                 new_operands,
-                guard=new_guard,
+                guard=new_guard if new_guard is not None else guard_in,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr if new_maddr is not None else maddr_in,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import unittest
 from collections import OrderedDict
+from typing import Any, cast
 
-from angr.ailment import AILBlockRewriter, AILBlockWalker, Block
+from angr.ailment import AILBlockRewriter, AILBlockViewer, AILBlockWalker, Block
 from angr.ailment.expression import (
     Array,
     ComboRegister,
     Const,
+    DirtyExpression,
     Expression,
     FunctionLikeMacro,
     Register,
@@ -47,6 +50,107 @@ class ConstIncrementingRewriter(AILBlockRewriter):
         if expr.value == 1:
             return Const(expr.idx, 2, expr.bits, **expr.tags)
         return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class _RecordingDirtyWalker(AILBlockWalker[None, None, None]):
+    def __init__(self):
+        super().__init__()
+        self.const_slots = []
+
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        self.const_slots.append((expr.value, expr_idx))
+        return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+    def _top(self, expr_idx: int, expr: Expression, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        return None
+
+    def _stmt_top(self, stmt_idx: int, stmt: Statement, block: Block | None):
+        return None
+
+    def _handle_block_end(self, stmt_results: list[None], block: Block):
+        return None
+
+
+class _RecordingDirtyViewer(AILBlockViewer):
+    def __init__(self):
+        super().__init__()
+        self.const_slots = []
+
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        self.const_slots.append((expr.value, expr_idx))
+        return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class _RecordingDirtyRewriter(AILBlockRewriter):
+    def __init__(self):
+        super().__init__()
+        self.const_slots = []
+
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        self.const_slots.append((expr.value, expr_idx))
+        return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class _ReplacingDirtyRewriter(AILBlockRewriter):
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        replacements = {0x100: 0x101, 0x300: 0x301}
+        if expr.value in replacements:
+            return Const(expr.idx, replacements[expr.value], expr.bits, **expr.tags)
+        return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class _EquivalentConstRewriter(AILBlockRewriter):
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        return Const(expr.idx, expr.value, expr.bits, **expr.tags)
+
+
+class TestDirtyExpressionWalking(unittest.TestCase):
+    """Tests traversal and rebuilding of DirtyExpression children."""
+
+    @staticmethod
+    def _dirty_expression() -> DirtyExpression:
+        return DirtyExpression(
+            5,
+            "helper",
+            [Const(0, 0x100, 64), Const(1, 0x101, 64)],
+            guard=Const(2, 0x200, 1),
+            mfx="Ifx_Modify",
+            maddr=Const(3, 0x300, 64),
+            msize=8,
+            bits=64,
+            ins_addr=0x400000,
+        )
+
+    def test_walkers_use_consistent_child_slots(self):
+        dirty = self._dirty_expression()
+        expected = [(0x100, 0), (0x101, 1), (0x200, 3), (0x300, 4)]
+
+        for walker_cls in (_RecordingDirtyWalker, _RecordingDirtyViewer, _RecordingDirtyRewriter):
+            with self.subTest(walker=walker_cls.__name__):
+                walker = walker_cls()
+                walker.walk_expression(dirty)
+                self.assertEqual(walker.const_slots, expected)
+
+    def test_rewriter_preserves_guard_and_rewrites_memory_address(self):
+        dirty = self._dirty_expression()
+        rewritten = _ReplacingDirtyRewriter(update_block=False).walk_expression(dirty)
+
+        self.assertIsInstance(rewritten, DirtyExpression)
+        rewritten_dirty = cast(Any, rewritten)
+        self.assertEqual([operand.value for operand in rewritten_dirty.operands], [0x101, 0x101])
+        self.assertEqual(rewritten_dirty.guard, dirty.guard)
+        self.assertEqual(rewritten_dirty.maddr.value, 0x301)
+        self.assertEqual(rewritten_dirty.callee, dirty.callee)
+        self.assertEqual(rewritten_dirty.mfx, dirty.mfx)
+        self.assertEqual(rewritten_dirty.msize, dirty.msize)
+        self.assertEqual(rewritten_dirty.bits, dirty.bits)
+        self.assertEqual(rewritten_dirty.tags, dirty.tags)
+
+    def test_rewriter_compares_rebuilt_children_by_value(self):
+        dirty = self._dirty_expression()
+        rewritten = _EquivalentConstRewriter(update_block=False).walk_expression(dirty)
+
+        self.assertIs(rewritten, dirty)
 
 
 def test_block_walker_visits_rust_ail_expression_children():

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -51,6 +51,8 @@ class ConstIncrementingRewriter(AILBlockRewriter):
 
 
 class RegisterRecordingViewer(AILBlockViewer):
+    """Record registers visited by a block viewer."""
+
     def __init__(self):
         super().__init__()
         self.registers = []
@@ -63,8 +65,43 @@ class RegisterRecordingViewer(AILBlockViewer):
 
 
 class ConstIndexRecordingRewriter(AILBlockRewriter):
+    """Record constant values and their expression child indices while rewriting."""
+
     def __init__(self):
         super().__init__(update_block=False)
+        self.const_indices = []
+
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        self.const_indices.append((expr.value, expr_idx))
+        return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class ConstIndexRecordingWalker(AILBlockWalker[None, None, None]):
+    """Record constant values and their expression child indices while walking."""
+
+    def __init__(self):
+        super().__init__()
+        self.const_indices = []
+
+    def _top(self, expr_idx, expr, stmt_idx, stmt, block):
+        return None
+
+    def _stmt_top(self, stmt_idx, stmt, block):
+        return None
+
+    def _handle_block_end(self, stmt_results, block):
+        return None
+
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        self.const_indices.append((expr.value, expr_idx))
+        return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class ConstIndexRecordingViewer(AILBlockViewer):
+    """Record constant values and their expression child indices while viewing."""
+
+    def __init__(self):
+        super().__init__()
         self.const_indices = []
 
     def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
@@ -184,14 +221,28 @@ def test_block_rewriter_updates_dirty_memory_address_without_changing_other_meta
     assert new_maddr.value == 2
 
 
-def test_block_rewriter_uses_distinct_dirty_guard_and_memory_address_slots():
-    guard = Const(0, 0, 1)
-    maddr = Const(1, 0x4000, 64)
-    dirty = DirtyExpression(2, "helper", [], guard=guard, mfx="Ifx_Read", maddr=maddr, msize=4, bits=32)
-    dst = VirtualVariable(3, 1, 32, VirtualVariableCategory.REGISTER, 16)
-    block = Block(0x400040, 0, statements=[Assignment(4, dst, dirty)])
+def test_block_walkers_use_consistent_dirty_expression_child_slots():
+    for operand_count in (0, 1, 3):
+        operands = [Const(idx, 0x100 + idx, 64) for idx in range(operand_count)]
+        guard = Const(10, 0x200, 1)
+        maddr = Const(11, 0x300, 64)
+        dirty = DirtyExpression(
+            12,
+            "helper",
+            operands,
+            guard=guard,
+            mfx="Ifx_Read",
+            maddr=maddr,
+            msize=4,
+            bits=32,
+        )
+        expected = [
+            *((operand.value, idx) for idx, operand in enumerate(operands)),
+            (guard.value, operand_count + 1),
+            (maddr.value, operand_count + 2),
+        ]
 
-    rewriter = ConstIndexRecordingRewriter()
-    rewriter.walk(block)
-
-    assert rewriter.const_indices == [(0, 2), (0x4000, 3)]
+        for walker_cls in (ConstIndexRecordingWalker, ConstIndexRecordingViewer, ConstIndexRecordingRewriter):
+            walker = walker_cls()
+            walker.walk_expression(dirty)
+            assert walker.const_indices == expected

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from collections import OrderedDict
 
-from angr.ailment import AILBlockRewriter, AILBlockWalker, Block
+from angr.ailment import AILBlockRewriter, AILBlockViewer, AILBlockWalker, Block
 from angr.ailment.expression import (
     Array,
     ComboRegister,
     Const,
+    DirtyExpression,
     Expression,
     FunctionLikeMacro,
     Register,
@@ -46,6 +47,28 @@ class ConstIncrementingRewriter(AILBlockRewriter):
     def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
         if expr.value == 1:
             return Const(expr.idx, 2, expr.bits, **expr.tags)
+        return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class RegisterRecordingViewer(AILBlockViewer):
+    def __init__(self):
+        super().__init__()
+        self.registers = []
+
+    def _handle_Register(
+        self, expr_idx: int, expr: Register, stmt_idx: int, stmt: Statement | None, block: Block | None
+    ):
+        self.registers.append(expr)
+        return super()._handle_Register(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class ConstIndexRecordingRewriter(AILBlockRewriter):
+    def __init__(self):
+        super().__init__(update_block=False)
+        self.const_indices = []
+
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        self.const_indices.append((expr.value, expr_idx))
         return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
 
 
@@ -100,3 +123,75 @@ def test_block_rewriter_rebuilds_rust_ail_expression_containers():
     assert not new_enum.likes(enum)
     assert not new_struct.likes(struct)
     assert new_struct.fields[0].value == 2
+
+
+def test_block_walkers_visit_dirty_memory_address():
+    maddr = Register(0, 24, 64)
+    dirty = DirtyExpression(
+        1,
+        "helper",
+        [Const(2, 3, 64)],
+        guard=Const(3, 1, 1),
+        mfx="Ifx_Read",
+        maddr=maddr,
+        msize=4,
+        bits=32,
+    )
+    dst = VirtualVariable(4, 1, 32, VirtualVariableCategory.REGISTER, 16)
+    block = Block(0x400020, 0, statements=[Assignment(5, dst, dirty)])
+
+    seen = RecordingWalker().walk(block)
+    assert seen.count("Register") == 1
+
+    viewer = RegisterRecordingViewer()
+    viewer.walk(block)
+    assert viewer.registers == [maddr]
+
+
+def test_block_rewriter_updates_dirty_memory_address_without_changing_other_metadata():
+    operand = Const(0, 3, 64)
+    guard = Const(1, 0, 1)
+    maddr = Const(2, 1, 64)
+    dirty = DirtyExpression(
+        3,
+        "load_linked_le",
+        [operand],
+        guard=guard,
+        mfx="Ifx_Read",
+        maddr=maddr,
+        msize=8,
+        bits=64,
+        ins_addr=0x400030,
+    )
+    dst = VirtualVariable(4, 1, 64, VirtualVariableCategory.REGISTER, 16)
+    block = Block(0x400030, 0, statements=[Assignment(5, dst, dirty)])
+
+    new_block = ConstIncrementingRewriter(update_block=False).walk(block)
+    new_stmt = new_block.statements[0]
+    assert isinstance(new_stmt, Assignment)
+    assert isinstance(new_stmt.src, DirtyExpression)
+    assert len(new_stmt.src.operands) == 1
+    assert new_stmt.src.operands[0].likes(operand)
+    assert new_stmt.src.guard is not None and new_stmt.src.guard.likes(guard)
+    assert new_stmt.src.idx == dirty.idx
+    assert new_stmt.src.callee == dirty.callee
+    assert new_stmt.src.mfx == dirty.mfx
+    assert new_stmt.src.msize == dirty.msize
+    assert new_stmt.src.bits == dirty.bits
+    assert new_stmt.src.tags == dirty.tags
+    new_maddr = new_stmt.src.maddr
+    assert isinstance(new_maddr, Const)
+    assert new_maddr.value == 2
+
+
+def test_block_rewriter_uses_distinct_dirty_guard_and_memory_address_slots():
+    guard = Const(0, 0, 1)
+    maddr = Const(1, 0x4000, 64)
+    dirty = DirtyExpression(2, "helper", [], guard=guard, mfx="Ifx_Read", maddr=maddr, msize=4, bits=32)
+    dst = VirtualVariable(3, 1, 32, VirtualVariableCategory.REGISTER, 16)
+    block = Block(0x400040, 0, statements=[Assignment(4, dst, dirty)])
+
+    rewriter = ConstIndexRecordingRewriter()
+    rewriter.walk(block)
+
+    assert rewriter.const_indices == [(0, 2), (0x4000, 3)]

--- a/tests/analyses/decompiler/test_dirty_expression_rewriting.py
+++ b/tests/analyses/decompiler/test_dirty_expression_rewriting.py
@@ -1,0 +1,115 @@
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import unittest
+from functools import partial
+from types import SimpleNamespace
+from typing import Any, cast
+
+import archinfo
+
+from angr.ailment import Block
+from angr.ailment.expression import Const, DirtyExpression, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import DirtyStatement
+from angr.analyses.decompiler.dephication.rewriting_engine import SimEngineDephiRewriting
+from angr.analyses.decompiler.ssailification.rewriting_engine import SimEngineSSARewriting
+
+
+def _replace_selected(expr, *, replacements, fields, rewritten_fields):
+    return replacements[expr] if fields[expr] in rewritten_fields else None
+
+
+class TestDirtyExpressionRewriting(unittest.TestCase):
+    """Tests metadata-preserving DirtyExpression rewrites."""
+
+    def test_engines_preserve_unchanged_children(self):
+        for engine_cls in (SimEngineSSARewriting, SimEngineDephiRewriting):
+            for rewritten_fields in ({"maddr"}, {"operand"}, {"guard", "maddr"}):
+                with self.subTest(engine=engine_cls.__name__, fields=rewritten_fields):
+                    operand = Const(0, 1, 64)
+                    guard = Const(1, 1, 1)
+                    maddr = Const(2, 0x4000, 64)
+                    dirty = DirtyExpression(
+                        3,
+                        "helper",
+                        [operand],
+                        guard=guard,
+                        mfx="Ifx_Modify",
+                        maddr=maddr,
+                        msize=4,
+                        bits=32,
+                        ins_addr=0x400000,
+                    )
+                    replacements = {
+                        operand: Const(4, 2, 64),
+                        guard: Const(5, 0, 1),
+                        maddr: Const(6, 0x5000, 64),
+                    }
+                    fields = {operand: "operand", guard: "guard", maddr: "maddr"}
+
+                    engine = object.__new__(engine_cls)
+                    engine._expr = partial(
+                        _replace_selected,
+                        replacements=replacements,
+                        fields=fields,
+                        rewritten_fields=rewritten_fields,
+                    )
+
+                    rewritten = engine._handle_expr_DirtyExpression(dirty)
+
+                    self.assertIsNotNone(rewritten)
+                    assert rewritten is not None
+                    expected_operand = replacements[operand] if "operand" in rewritten_fields else operand
+                    expected_guard = replacements[guard] if "guard" in rewritten_fields else guard
+                    expected_maddr = replacements[maddr] if "maddr" in rewritten_fields else maddr
+                    self.assertEqual(rewritten.operands[0], expected_operand)
+                    self.assertEqual(rewritten.guard, expected_guard)
+                    self.assertEqual(rewritten.maddr, expected_maddr)
+                    self.assertEqual(rewritten.callee, dirty.callee)
+                    self.assertEqual(rewritten.mfx, dirty.mfx)
+                    self.assertEqual(rewritten.msize, dirty.msize)
+                    self.assertEqual(rewritten.bits, dirty.bits)
+                    self.assertEqual(rewritten.tags, dirty.tags)
+
+    def test_dephication_rewrites_memory_address_through_engine(self):
+        operand = VirtualVariable(0, 10, 64, VirtualVariableCategory.REGISTER, oident=16)
+        unchanged_operand = VirtualVariable(1, 11, 64, VirtualVariableCategory.REGISTER, oident=24)
+        guard = VirtualVariable(2, 12, 1, VirtualVariableCategory.TMP, oident=0)
+        maddr = VirtualVariable(3, 14, 64, VirtualVariableCategory.REGISTER, oident=32)
+        dirty = DirtyExpression(
+            4,
+            "helper",
+            [operand, unchanged_operand],
+            guard=guard,
+            mfx="Ifx_Modify",
+            maddr=maddr,
+            msize=8,
+            bits=64,
+            ins_addr=0x400000,
+        )
+        block = Block(0x400000, 1, statements=[DirtyStatement(5, dirty)])
+
+        engine = SimEngineDephiRewriting(
+            SimpleNamespace(arch=archinfo.ArchAMD64()),
+            {operand.varid: 110, maddr.varid: 114},
+        )
+        engine.process(None, block=block)
+
+        self.assertIsNotNone(engine.out_block)
+        assert engine.out_block is not None
+        new_stmt = engine.out_block.statements[0]
+        self.assertIsInstance(new_stmt, DirtyStatement)
+        new_dirty = cast(Any, new_stmt).dirty
+        self.assertIsInstance(new_dirty, DirtyExpression)
+        self.assertEqual([new_operand.varid for new_operand in new_dirty.operands], [110, unchanged_operand.varid])
+        self.assertEqual(new_dirty.guard.varid, guard.varid)
+        self.assertEqual(new_dirty.maddr.varid, 114)
+        self.assertEqual(new_dirty.callee, dirty.callee)
+        self.assertEqual(new_dirty.mfx, dirty.mfx)
+        self.assertEqual(new_dirty.msize, dirty.msize)
+        self.assertEqual(new_dirty.bits, dirty.bits)
+        self.assertEqual(new_dirty.tags, dirty.tags)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_dirty_expression_rewriting.py
+++ b/tests/analyses/decompiler/test_dirty_expression_rewriting.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from angr.ailment.expression import Const, DirtyExpression
+from angr.analyses.decompiler.dephication.rewriting_engine import SimEngineDephiRewriting
+from angr.analyses.decompiler.ssailification.rewriting_engine import SimEngineSSARewriting
+
+
+@pytest.mark.parametrize("engine_cls", (SimEngineSSARewriting, SimEngineDephiRewriting))
+@pytest.mark.parametrize("rewritten_fields", ({"maddr"}, {"operand"}, {"guard", "maddr"}))
+def test_dirty_rewriting_preserves_unchanged_fields(engine_cls, rewritten_fields):
+    operand = Const(0, 1, 64)
+    guard = Const(1, 1, 1)
+    maddr = Const(2, 0x4000, 64)
+    dirty = DirtyExpression(
+        3,
+        "helper",
+        [operand],
+        guard=guard,
+        mfx="Ifx_Modify",
+        maddr=maddr,
+        msize=4,
+        bits=32,
+        ins_addr=0x400000,
+    )
+    replacements = {
+        operand: Const(4, 2, 64),
+        guard: Const(5, 0, 1),
+        maddr: Const(6, 0x5000, 64),
+    }
+
+    engine = object.__new__(engine_cls)
+    engine._expr = lambda expr: (
+        replacements[expr]
+        if expr in replacements
+        and {
+            operand: "operand",
+            guard: "guard",
+            maddr: "maddr",
+        }[expr]
+        in rewritten_fields
+        else None
+    )
+
+    rewritten = engine._handle_expr_DirtyExpression(dirty)
+
+    assert rewritten is not None
+    expected_operand = replacements[operand] if "operand" in rewritten_fields else operand
+    expected_guard = replacements[guard] if "guard" in rewritten_fields else guard
+    expected_maddr = replacements[maddr] if "maddr" in rewritten_fields else maddr
+    assert rewritten.operands[0].likes(expected_operand)
+    assert rewritten.guard is not None and rewritten.guard.likes(expected_guard)
+    assert rewritten.maddr is not None and rewritten.maddr.likes(expected_maddr)
+    assert rewritten.idx == dirty.idx
+    assert rewritten.callee == dirty.callee
+    assert rewritten.mfx == dirty.mfx
+    assert rewritten.msize == dirty.msize
+    assert rewritten.bits == dirty.bits
+    assert rewritten.tags == dirty.tags

--- a/tests/analyses/decompiler/test_dirty_expression_rewriting.py
+++ b/tests/analyses/decompiler/test_dirty_expression_rewriting.py
@@ -1,8 +1,14 @@
+# pylint: disable=protected-access
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import archinfo
 import pytest
 
-from angr.ailment.expression import Const, DirtyExpression
+from angr.ailment import Block
+from angr.ailment.expression import Const, DirtyExpression, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import DirtyStatement
 from angr.analyses.decompiler.dephication.rewriting_engine import SimEngineDephiRewriting
 from angr.analyses.decompiler.ssailification.rewriting_engine import SimEngineSSARewriting
 
@@ -58,3 +64,47 @@ def test_dirty_rewriting_preserves_unchanged_fields(engine_cls, rewritten_fields
     assert rewritten.msize == dirty.msize
     assert rewritten.bits == dirty.bits
     assert rewritten.tags == dirty.tags
+
+
+def test_dephication_rewrites_dirty_memory_address_through_engine():
+    operand = VirtualVariable(0, 10, 64, VirtualVariableCategory.REGISTER, oident=16)
+    unchanged_operand = VirtualVariable(1, 11, 64, VirtualVariableCategory.REGISTER, oident=24)
+    guard = VirtualVariable(2, 12, 1, VirtualVariableCategory.TMP, oident=0)
+    maddr = VirtualVariable(3, 14, 64, VirtualVariableCategory.REGISTER, oident=32)
+    dirty = DirtyExpression(
+        4,
+        "helper",
+        [operand, unchanged_operand],
+        guard=guard,
+        mfx="Ifx_Modify",
+        maddr=maddr,
+        msize=8,
+        bits=64,
+        ins_addr=0x400000,
+    )
+    block = Block(0x400000, 1, statements=[DirtyStatement(5, dirty)])
+
+    engine = SimEngineDephiRewriting(
+        SimpleNamespace(arch=archinfo.ArchAMD64()),
+        {
+            operand.varid: 110,
+            maddr.varid: 114,
+        },
+    )
+    engine.process(None, block=block)
+
+    assert engine.out_block is not None
+    new_stmt = engine.out_block.statements[0]
+    assert isinstance(new_stmt, DirtyStatement)
+    new_dirty = new_stmt.dirty
+    assert isinstance(new_dirty, DirtyExpression)
+    assert [operand_.varid for operand_ in new_dirty.operands] == [110, unchanged_operand.varid]
+    assert isinstance(new_dirty.guard, VirtualVariable)
+    assert new_dirty.guard.varid == guard.varid
+    assert isinstance(new_dirty.maddr, VirtualVariable)
+    assert new_dirty.maddr.varid == 114
+    assert new_dirty.callee == dirty.callee
+    assert new_dirty.mfx == dirty.mfx
+    assert new_dirty.msize == dirty.msize
+    assert new_dirty.bits == dirty.bits
+    assert new_dirty.tags == dirty.tags

--- a/tests/analyses/decompiler/test_narrowing_exprs.py
+++ b/tests/analyses/decompiler/test_narrowing_exprs.py
@@ -9,7 +9,15 @@ import os
 import unittest
 
 import angr
-from angr.ailment.expression import BinaryOp, Const, Extract, Insert, VirtualVariable, VirtualVariableCategory
+from angr.ailment.expression import (
+    BinaryOp,
+    Const,
+    DirtyExpression,
+    Extract,
+    Insert,
+    VirtualVariable,
+    VirtualVariableCategory,
+)
 from angr.ailment.statement import Assignment
 from angr.analyses.decompiler.expression_narrower import EffectiveSizeExtractor
 from tests.common import WORKER, bin_location, print_decompilation_result
@@ -20,6 +28,24 @@ l = logging.getLogger(__name__)
 
 
 class TestNarrowingExpressions(unittest.TestCase):
+    def test_dirty_memory_address_is_a_full_width_use(self):
+        maddr = VirtualVariable(0, 44, 64, VirtualVariableCategory.REGISTER, oident=16)
+        dirty = DirtyExpression(
+            1,
+            "helper",
+            [],
+            mfx="Ifx_Read",
+            maddr=maddr,
+            msize=1,
+            bits=8,
+        )
+        dst = VirtualVariable(2, 48, 8, VirtualVariableCategory.REGISTER, oident=24)
+
+        walker = EffectiveSizeExtractor()
+        walker.walk_statement(Assignment(3, dst, dirty))
+
+        assert walker.vvar_effective_bits[44][maddr.idx] == (0, 64)
+
     def test_insert_base_is_a_full_width_use(self):
         # the base of an Insert is consumed at full width: every byte outside the inserted range is
         # preserved into the result. EffectiveSizeExtractor used to skip the base entirely, so a vvar

--- a/tests/analyses/decompiler/test_narrowing_exprs.py
+++ b/tests/analyses/decompiler/test_narrowing_exprs.py
@@ -9,8 +9,19 @@ import os
 import unittest
 
 import angr
-from angr.ailment.expression import BinaryOp, Const, Extract, Insert, VirtualVariable, VirtualVariableCategory
-from angr.ailment.statement import Assignment
+from angr.ailment.expression import (
+    BinaryOp,
+    Call,
+    Const,
+    Convert,
+    DirtyExpression,
+    Extract,
+    FunctionLikeMacro,
+    Insert,
+    VirtualVariable,
+    VirtualVariableCategory,
+)
+from angr.ailment.statement import Assignment, SideEffectStatement
 from angr.analyses.decompiler.expression_narrower import EffectiveSizeExtractor
 from tests.common import WORKER, bin_location, print_decompilation_result
 
@@ -20,6 +31,52 @@ l = logging.getLogger(__name__)
 
 
 class TestNarrowingExpressions(unittest.TestCase):
+    def test_dirty_expression_children_are_full_width_uses(self):
+        operand = VirtualVariable(0, 41, 64, VirtualVariableCategory.REGISTER, oident=8)
+        guard = VirtualVariable(1, 42, 1, VirtualVariableCategory.TMP, oident=0)
+        maddr = VirtualVariable(2, 43, 64, VirtualVariableCategory.REGISTER, oident=16)
+        dirty = DirtyExpression(
+            3,
+            "helper",
+            [operand],
+            guard=guard,
+            mfx="Ifx_Read",
+            maddr=maddr,
+            msize=8,
+            bits=64,
+        )
+        dst = VirtualVariable(4, 44, 64, VirtualVariableCategory.REGISTER, oident=24)
+
+        walker = EffectiveSizeExtractor()
+        walker.walk_statement(Assignment(5, dst, dirty))
+
+        self.assertEqual(walker.vvar_effective_bits[operand.varid][operand.idx], (0, 64))
+        self.assertEqual(walker.vvar_effective_bits[guard.varid][guard.idx], (0, 1))
+        self.assertEqual(walker.vvar_effective_bits[maddr.varid][maddr.idx], (0, 64))
+
+    def test_side_effect_statement_ignores_non_call_expression(self):
+        operand = VirtualVariable(0, 45, 64, VirtualVariableCategory.REGISTER, oident=8)
+        dirty = DirtyExpression(1, "helper", [operand], bits=64)
+
+        walker = EffectiveSizeExtractor()
+        walker.walk_statement(SideEffectStatement(2, dirty))
+
+        self.assertNotIn(operand.varid, walker.vvar_effective_bits)
+        self.assertNotIn(operand.varid, walker.vvar_call_arg_effective_bits)
+
+    def test_side_effect_statement_preserves_call_argument_handling(self):
+        for expr_type in (Call, FunctionLikeMacro):
+            with self.subTest(expr_type=expr_type.__name__):
+                argument = VirtualVariable(0, 46, 64, VirtualVariableCategory.REGISTER, oident=8)
+                converted_argument = Convert(1, 64, 32, False, argument)
+                call = expr_type(2, "callee", args=[converted_argument], bits=64)
+
+                walker = EffectiveSizeExtractor()
+                walker.walk_statement(SideEffectStatement(3, call))
+
+                self.assertEqual(walker.vvar_call_arg_effective_bits[argument.varid], (0, 32))
+                self.assertNotIn(argument.varid, walker.vvar_effective_bits)
+
     def test_insert_base_is_a_full_width_use(self):
         # the base of an Insert is consumed at full width: every byte outside the inserted range is
         # preserved into the result. EffectiveSizeExtractor used to skip the base entirely, so a vvar


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Rewriting one child of a `DirtyExpression` can discard an unchanged guard, while its memory-address child is not traversed at all:

```text
operand vvar_10 -> vvar_110; guard becomes None; maddr stays vvar_14
```

The affected path occurs in public DecBench `gzip/gzip`, function `printf_fetchargs`, at the `fld`/`fstp` pair beginning at `0x410cf4`, although the final C output remains unchanged.

### Root cause

The shared AIL walker omits `maddr`, and the generic, SSA, and dephication rewriters rebuild a dirty expression from replacement results without falling back to unchanged guard and address children.

### Fix

Operands, guard, and memory address now have stable traversal slots. Rewriters preserve unchanged children and apply replacements to `maddr` through the normal engine path:

```text
operand vvar_10 -> vvar_110; guard stays vvar_12; maddr vvar_14 -> vvar_114
```

### Testing

Regressions cover walker, viewer, generic rewriter, SSA, dephication, effective-size extraction, and non-call side effects. The corpus evidence is non-regression only; no final-C improvement is claimed. Validation: https://github.com/angr/angr/pull/6751#issuecomment-5162006538

session: sharpen
