### PR TITLE
[Superseded by #6356] Decompiler: preserve VEX dirty effects through simplification

### DIFF
--- a/angr/ailment/block_walker.py
+++ b/angr/ailment/block_walker.py
@@ -470,6 +470,9 @@ class AILBlockWalker[ExprType, StmtType, BlockType]:
         guard = expr.guard
         if guard is not None:
             self._handle_expr(len(ops) + 1, guard, stmt_idx, stmt, block)
+        maddr = expr.maddr
+        if maddr is not None:
+            self._handle_expr(len(ops) + 2, maddr, stmt_idx, stmt, block)
         return self._top(expr_idx, expr, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
@@ -675,6 +678,9 @@ class AILBlockViewer(AILBlockWalker[None, None, None]):
         guard = expr.guard
         if guard is not None:
             self._handle_expr(len(ops) + 1, guard, stmt_idx, stmt, block)
+        maddr = expr.maddr
+        if maddr is not None:
+            self._handle_expr(len(ops) + 2, maddr, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
         self, expr_idx: int, expr: VEXCCallExpression, stmt_idx: int, stmt: Statement | None, block: Block | None
@@ -1139,11 +1145,17 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
         new_operands = [self._handle_expr(0, operand, stmt_idx, stmt, block) for operand in operands_in]
         changed = any(new is not old for new, old in zip(new_operands, operands_in))
 
-        new_guard = None
         guard_in = expr.guard
+        new_guard = guard_in
         if guard_in is not None:
             new_guard = self._handle_expr(2, guard_in, stmt_idx, stmt, block)
-            changed |= new_guard != guard_in
+            changed |= new_guard is not guard_in
+
+        maddr_in = expr.maddr
+        new_maddr = maddr_in
+        if maddr_in is not None:
+            new_maddr = self._handle_expr(3, maddr_in, stmt_idx, stmt, block)
+            changed |= new_maddr is not maddr_in
 
         if changed:
             return DirtyExpression(
@@ -1152,7 +1164,7 @@ class AILBlockRewriter(AILBlockWalker[Expression, Statement, Block]):
                 new_operands,
                 guard=new_guard,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/angr/ailment/utils.py
+++ b/angr/ailment/utils.py
@@ -7,7 +7,7 @@ import archinfo
 
 from angr import ailment
 from angr.ailment.block_walker import AILBlockViewer
-from angr.ailment.expression import DirtyExpression, Expression
+from angr.ailment.expression import BinaryOp, Convert, DirtyExpression, Expression, Let, Load
 from angr.ailment.statement import DirtyStatement, Statement
 
 try:
@@ -42,6 +42,37 @@ class _EffectfulDirtyExpressionFinder(AILBlockViewer):
         # A DirtyExpression whose own effect does not match may contain another
         # DirtyExpression in an operand, guard, or memory address that does.
         return super()._handle_DirtyExpression(expr_idx, expr, stmt_idx, stmt, block)
+
+    def _handle_Load(self, expr_idx, expr: Load, stmt_idx, stmt, block):
+        super()._handle_Load(expr_idx, expr, stmt_idx, stmt, block)
+        guard = expr.guard
+        if guard is not None:
+            self._handle_expr(1, guard, stmt_idx, stmt, block)
+        alt = expr.alt
+        if alt is not None:
+            self._handle_expr(2, alt, stmt_idx, stmt, block)
+
+    def _handle_BinaryOp(self, expr_idx, expr: BinaryOp, stmt_idx, stmt, block):
+        super()._handle_BinaryOp(expr_idx, expr, stmt_idx, stmt, block)
+        rounding_mode = expr.rounding_mode
+        if isinstance(rounding_mode, Expression):
+            self._handle_expr(2, rounding_mode, stmt_idx, stmt, block)
+
+    def _handle_Convert(self, expr_idx, expr: Convert, stmt_idx, stmt, block):
+        super()._handle_Convert(expr_idx, expr, stmt_idx, stmt, block)
+        rounding_mode = expr.rounding_mode
+        if isinstance(rounding_mode, Expression):
+            self._handle_expr(1, rounding_mode, stmt_idx, stmt, block)
+
+    def _handle_Let(self, expr_idx, expr: Let, stmt_idx, stmt, block):
+        for idx, def_stmt in enumerate(expr.defs):
+            self._handle_stmt(idx, def_stmt, None)
+        self._handle_expr(0, expr.src, stmt_idx, stmt, block)
+
+    def _top(self, expr_idx, expr, stmt_idx, stmt, block):
+        if isinstance(expr, Let):
+            # Let is not part of AILBlockViewer's default dispatch table.
+            self._handle_Let(expr_idx, expr, stmt_idx, stmt, block)
 
     def _handle_DirtyStatement(
         self,

--- a/angr/ailment/utils.py
+++ b/angr/ailment/utils.py
@@ -49,9 +49,14 @@ class _EffectfulDirtyExpressionFinder(AILBlockViewer):
         stmt: DirtyStatement,
         block,  # pylint:disable=unused-argument
     ):
-        # DirtyStatement is the opaque fallback for an unsupported VEX statement. Its placeholder DirtyExpression
-        # has mfx=None, but the missing statement semantics may include both memory and non-memory effects.
-        raise _EffectfulDirtyExpressionFound
+        if not is_effectful_dirty_expression(stmt.dirty):
+            # A DirtyStatement whose placeholder has mfx=None is the opaque fallback for an unsupported VEX statement.
+            # The missing statement semantics may include both memory and non-memory effects.
+            raise _EffectfulDirtyExpressionFound
+
+        # VEX IRDirty statements without a result temporary also use DirtyStatement, but retain their known mfx.
+        # Recurse so effect queries remain true while memory queries classify Ifx_Read/Write/Modify precisely.
+        return super()._handle_DirtyStatement(stmt_idx, stmt, block)
 
 
 def is_effectful_dirty_expression(expr: Expression) -> bool:

--- a/angr/ailment/utils.py
+++ b/angr/ailment/utils.py
@@ -9,6 +9,8 @@ from angr import ailment
 from angr.ailment.block_walker import AILBlockViewer
 from angr.ailment.expression import BinaryOp, Convert, DirtyExpression, Expression, Let, Load
 from angr.ailment.statement import DirtyStatement, Statement
+from angr.rustylib.ailment import Expression as RustExpression
+from angr.rustylib.ailment import Statement as RustStatement
 
 try:
     from claripy.ast import Bits
@@ -24,6 +26,10 @@ type GetBitsTypeParams = "ailment.expression.Expression"
 
 _DIRTY_MEMORY_READ_EFFECTS = frozenset({"Ifx_Read", "Ifx_Modify"})
 _DIRTY_MEMORY_WRITE_EFFECTS = frozenset({"Ifx_Write", "Ifx_Modify"})
+# Keep these protocol bits synchronized with ``native/angr/src/ailment/ail_expr.rs``.
+_DIRTY_EFFECT = 1 << 0
+_DIRTY_MEMORY_READ = 1 << 1
+_DIRTY_MEMORY_WRITE = 1 << 2
 
 
 class _EffectfulDirtyExpressionFound(Exception):
@@ -102,9 +108,22 @@ def is_effectful_dirty_expression(expr: Expression) -> bool:
 
 
 def _contains_effectful_dirty_expression(obj: Expression | Statement, memory_effects: Collection[str] | None) -> bool:
+    if type(obj) is RustExpression or type(obj) is RustStatement:
+        effects = obj._dirty_effects()  # pylint:disable=protected-access
+        if memory_effects is None:
+            return bool(effects & _DIRTY_EFFECT)
+        if memory_effects == _DIRTY_MEMORY_READ_EFFECTS:
+            return bool(effects & _DIRTY_MEMORY_READ)
+        if memory_effects == _DIRTY_MEMORY_WRITE_EFFECTS:
+            return bool(effects & _DIRTY_MEMORY_WRITE)
+
     finder = _EffectfulDirtyExpressionFinder(memory_effects)
     try:
-        if isinstance(obj, Expression):
+        if type(obj) is RustExpression:
+            finder.walk_expression(obj)
+        elif type(obj) is RustStatement:
+            finder.walk_statement(obj)
+        elif isinstance(obj, Expression):
             finder.walk_expression(obj)
         elif isinstance(obj, Statement):
             finder.walk_statement(obj)

--- a/angr/ailment/utils.py
+++ b/angr/ailment/utils.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import struct
+from collections.abc import Collection
 
 import archinfo
 
 from angr import ailment
+from angr.ailment.block_walker import AILBlockViewer
+from angr.ailment.expression import DirtyExpression, Expression
+from angr.ailment.statement import Statement
 
 try:
     from claripy.ast import Bits
@@ -17,6 +21,67 @@ except ImportError:
     import hashlib as md5lib
 
 type GetBitsTypeParams = "ailment.expression.Expression"
+
+_DIRTY_MEMORY_READ_EFFECTS = frozenset({"Ifx_Read", "Ifx_Modify"})
+_DIRTY_MEMORY_WRITE_EFFECTS = frozenset({"Ifx_Write", "Ifx_Modify"})
+
+
+class _EffectfulDirtyExpressionFound(Exception):
+    pass
+
+
+class _EffectfulDirtyExpressionFinder(AILBlockViewer):
+    def __init__(self, memory_effects: Collection[str] | None):
+        super().__init__()
+        self._memory_effects = memory_effects
+
+    def _handle_DirtyExpression(self, expr_idx, expr, stmt_idx, stmt, block):
+        if is_effectful_dirty_expression(expr) and (self._memory_effects is None or expr.mfx in self._memory_effects):
+            raise _EffectfulDirtyExpressionFound
+
+        # A DirtyExpression whose own effect does not match may contain another
+        # DirtyExpression in an operand, guard, or memory address that does.
+        return super()._handle_DirtyExpression(expr_idx, expr, stmt_idx, stmt, block)
+
+
+def is_effectful_dirty_expression(expr: Expression) -> bool:
+    """
+    Return whether ``expr`` directly represents a VEX dirty operation with effects.
+
+    A non-``None`` ``mfx`` marks expressions originating from VEX ``IRDirty``. This includes ``Ifx_None``: it means
+    that VEX declares no guest-memory access, not that the helper is pure. Dirty expressions used as placeholders for
+    unsupported pure arithmetic have ``mfx=None``.
+    """
+    return isinstance(expr, DirtyExpression) and expr.mfx is not None
+
+
+def _contains_effectful_dirty_expression(obj: Expression | Statement, memory_effects: Collection[str] | None) -> bool:
+    finder = _EffectfulDirtyExpressionFinder(memory_effects)
+    try:
+        if isinstance(obj, Expression):
+            finder.walk_expression(obj)
+        elif isinstance(obj, Statement):
+            finder.walk_statement(obj)
+        else:
+            raise TypeError(type(obj))
+    except _EffectfulDirtyExpressionFound:
+        return True
+    return False
+
+
+def has_effectful_dirty_expression(obj: Expression | Statement) -> bool:
+    """Return whether ``obj`` recursively contains an effectful :class:`DirtyExpression`."""
+    return _contains_effectful_dirty_expression(obj, None)
+
+
+def has_dirty_memory_read(obj: Expression | Statement) -> bool:
+    """Return whether ``obj`` recursively contains a dirty guest-memory read or modification."""
+    return _contains_effectful_dirty_expression(obj, _DIRTY_MEMORY_READ_EFFECTS)
+
+
+def has_dirty_memory_write(obj: Expression | Statement) -> bool:
+    """Return whether ``obj`` recursively contains a dirty guest-memory write or modification."""
+    return _contains_effectful_dirty_expression(obj, _DIRTY_MEMORY_WRITE_EFFECTS)
 
 
 def get_bits(expr: GetBitsTypeParams) -> int:

--- a/angr/ailment/utils.py
+++ b/angr/ailment/utils.py
@@ -8,7 +8,7 @@ import archinfo
 from angr import ailment
 from angr.ailment.block_walker import AILBlockViewer
 from angr.ailment.expression import DirtyExpression, Expression
-from angr.ailment.statement import Statement
+from angr.ailment.statement import DirtyStatement, Statement
 
 try:
     from claripy.ast import Bits
@@ -43,6 +43,16 @@ class _EffectfulDirtyExpressionFinder(AILBlockViewer):
         # DirtyExpression in an operand, guard, or memory address that does.
         return super()._handle_DirtyExpression(expr_idx, expr, stmt_idx, stmt, block)
 
+    def _handle_DirtyStatement(
+        self,
+        stmt_idx: int,
+        stmt: DirtyStatement,
+        block,  # pylint:disable=unused-argument
+    ):
+        # DirtyStatement is the opaque fallback for an unsupported VEX statement. Its placeholder DirtyExpression
+        # has mfx=None, but the missing statement semantics may include both memory and non-memory effects.
+        raise _EffectfulDirtyExpressionFound
+
 
 def is_effectful_dirty_expression(expr: Expression) -> bool:
     """
@@ -70,17 +80,17 @@ def _contains_effectful_dirty_expression(obj: Expression | Statement, memory_eff
 
 
 def has_effectful_dirty_expression(obj: Expression | Statement) -> bool:
-    """Return whether ``obj`` recursively contains an effectful :class:`DirtyExpression`."""
+    """Return whether ``obj`` recursively contains an effectful ``DirtyExpression`` or opaque ``DirtyStatement``."""
     return _contains_effectful_dirty_expression(obj, None)
 
 
 def has_dirty_memory_read(obj: Expression | Statement) -> bool:
-    """Return whether ``obj`` recursively contains a dirty guest-memory read or modification."""
+    """Return whether ``obj`` contains a dirty guest-memory read/modification or opaque ``DirtyStatement``."""
     return _contains_effectful_dirty_expression(obj, _DIRTY_MEMORY_READ_EFFECTS)
 
 
 def has_dirty_memory_write(obj: Expression | Statement) -> bool:
-    """Return whether ``obj`` recursively contains a dirty guest-memory write or modification."""
+    """Return whether ``obj`` contains a dirty guest-memory write/modification or opaque ``DirtyStatement``."""
     return _contains_effectful_dirty_expression(obj, _DIRTY_MEMORY_WRITE_EFFECTS)
 
 

--- a/angr/ailment/utils.py
+++ b/angr/ailment/utils.py
@@ -9,8 +9,12 @@ from angr import ailment
 from angr.ailment.block_walker import AILBlockViewer
 from angr.ailment.expression import BinaryOp, Convert, DirtyExpression, Expression, Let, Load
 from angr.ailment.statement import DirtyStatement, Statement
-from angr.rustylib.ailment import Expression as RustExpression
-from angr.rustylib.ailment import Statement as RustStatement
+from angr.rustylib.ailment import (  # pylint:disable=import-error,no-name-in-module
+    Expression as RustExpression,  # pyright: ignore[reportMissingModuleSource]
+)
+from angr.rustylib.ailment import (  # pylint:disable=import-error,no-name-in-module
+    Statement as RustStatement,  # pyright: ignore[reportMissingModuleSource]
+)
 
 try:
     from claripy.ast import Bits
@@ -70,7 +74,7 @@ class _EffectfulDirtyExpressionFinder(AILBlockViewer):
         if isinstance(rounding_mode, Expression):
             self._handle_expr(1, rounding_mode, stmt_idx, stmt, block)
 
-    def _handle_Let(self, expr_idx, expr: Let, stmt_idx, stmt, block):
+    def _handle_Let(self, _expr_idx, expr: Let, stmt_idx, stmt, block):
         for idx, def_stmt in enumerate(expr.defs):
             self._handle_stmt(idx, def_stmt, None)
         self._handle_expr(0, expr.src, stmt_idx, stmt, block)

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -2183,13 +2183,10 @@ class AILSimplifier(Analysis):
                     and isinstance(stmt.dst, VirtualVariable)
                     and (stmt.dst.was_reg or stmt.dst.was_tmp)
                 ):
-                    if isinstance(stmt.src, VEXCCallExpression):
+                    if has_effectful_dirty_expression(stmt.src):
+                        effectful_dirty_vvar_ids.add(stmt.dst.varid)
+                    elif isinstance(stmt.src, (DirtyExpression, VEXCCallExpression)):
                         dirty_vvar_ids.add(stmt.dst.varid)
-                    elif isinstance(stmt.src, DirtyExpression):
-                        if has_effectful_dirty_expression(stmt.src):
-                            effectful_dirty_vvar_ids.add(stmt.dst.varid)
-                        else:
-                            dirty_vvar_ids.add(stmt.dst.varid)
 
         phi_and_dirty_vvar_ids = (rd.phi_vvar_ids | dirty_vvar_ids).difference(dead_vvar_ids)
 

--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -40,6 +40,7 @@ from angr.ailment.statement import (
     Store,
     WeakAssignment,
 )
+from angr.ailment.utils import has_effectful_dirty_expression
 from angr.analyses.analysis import AnalysesHub, Analysis
 from angr.analyses.s_propagator import SPropagator
 from angr.analyses.s_reaching_definitions import SRDAModel, SReachingDefinitions
@@ -2170,6 +2171,7 @@ class AILSimplifier(Analysis):
 
         # find dirty vvars and vexccall vvars
         dirty_vvar_ids = set()
+        effectful_dirty_vvar_ids = set()
         for bb in self.func_graph:
             for stmt in bb.statements:
                 # reg/tmp = ccall(...)
@@ -2180,9 +2182,14 @@ class AILSimplifier(Analysis):
                     isinstance(stmt, Assignment)
                     and isinstance(stmt.dst, VirtualVariable)
                     and (stmt.dst.was_reg or stmt.dst.was_tmp)
-                    and isinstance(stmt.src, (DirtyExpression, VEXCCallExpression))
                 ):
-                    dirty_vvar_ids.add(stmt.dst.varid)
+                    if isinstance(stmt.src, VEXCCallExpression):
+                        dirty_vvar_ids.add(stmt.dst.varid)
+                    elif isinstance(stmt.src, DirtyExpression):
+                        if has_effectful_dirty_expression(stmt.src):
+                            effectful_dirty_vvar_ids.add(stmt.dst.varid)
+                        else:
+                            dirty_vvar_ids.add(stmt.dst.varid)
 
         phi_and_dirty_vvar_ids = (rd.phi_vvar_ids | dirty_vvar_ids).difference(dead_vvar_ids)
 
@@ -2213,6 +2220,9 @@ class AILSimplifier(Analysis):
         cyclic_dependent_phi_varids = set()
         for scc in networkx.strongly_connected_components(g):
             if len(scc) == 1:
+                continue
+            if not effectful_dirty_vvar_ids.isdisjoint(scc):
+                # Removing any definition in this cycle could remove or reorder the dirty operation.
                 continue
 
             bail = False

--- a/angr/analyses/decompiler/block_walkers.py
+++ b/angr/analyses/decompiler/block_walkers.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 from angr.ailment import AILBlockViewer
+from angr.ailment.utils import is_effectful_dirty_expression
 
 
 class HasCallNotification(Exception):
     """
-    Abort the walk on the first Call / SideEffectStatement encountered.
+    Abort the walk on the first call or other side effect encountered.
     """
 
 
 class HasCallExprWalker(AILBlockViewer):
     """
-    Singleton walker that raises ``HasCallNotification`` on the first Call / SideEffectStatement it visits.
+    Singleton walker that raises ``HasCallNotification`` on the first call or other side effect it visits.
     """
 
     def _handle_SideEffectStatement(self, stmt_idx, stmt, block):  # pylint:disable=unused-argument
@@ -22,3 +23,8 @@ class HasCallExprWalker(AILBlockViewer):
 
     def _handle_FunctionLikeMacro(self, expr_idx, expr, stmt_idx, stmt, block):  # pylint:disable=unused-argument
         raise HasCallNotification
+
+    def _handle_DirtyExpression(self, expr_idx, expr, stmt_idx, stmt, block):
+        if is_effectful_dirty_expression(expr):
+            raise HasCallNotification
+        return super()._handle_DirtyExpression(expr_idx, expr, stmt_idx, stmt, block)

--- a/angr/analyses/decompiler/block_walkers.py
+++ b/angr/analyses/decompiler/block_walkers.py
@@ -54,7 +54,7 @@ class HasCallExprWalker(AILBlockViewer):
         if isinstance(rounding_mode, Expression):
             self._handle_expr(1, rounding_mode, stmt_idx, stmt, block)
 
-    def _handle_Let(self, expr_idx, expr: Let, stmt_idx, stmt, block):
+    def _handle_Let(self, _expr_idx, expr: Let, stmt_idx, stmt, block):
         for idx, def_stmt in enumerate(expr.defs):
             self._handle_stmt(idx, def_stmt, None)
         self._handle_expr(0, expr.src, stmt_idx, stmt, block)

--- a/angr/analyses/decompiler/block_walkers.py
+++ b/angr/analyses/decompiler/block_walkers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from angr.ailment import AILBlockViewer
+from angr.ailment.expression import BinaryOp, Convert, Expression, Let, Load
 from angr.ailment.utils import is_effectful_dirty_expression
 
 
@@ -31,3 +32,34 @@ class HasCallExprWalker(AILBlockViewer):
         if is_effectful_dirty_expression(expr):
             raise HasCallNotification
         return super()._handle_DirtyExpression(expr_idx, expr, stmt_idx, stmt, block)
+
+    def _handle_Load(self, expr_idx, expr: Load, stmt_idx, stmt, block):
+        super()._handle_Load(expr_idx, expr, stmt_idx, stmt, block)
+        guard = expr.guard
+        if guard is not None:
+            self._handle_expr(1, guard, stmt_idx, stmt, block)
+        alt = expr.alt
+        if alt is not None:
+            self._handle_expr(2, alt, stmt_idx, stmt, block)
+
+    def _handle_BinaryOp(self, expr_idx, expr: BinaryOp, stmt_idx, stmt, block):
+        super()._handle_BinaryOp(expr_idx, expr, stmt_idx, stmt, block)
+        rounding_mode = expr.rounding_mode
+        if isinstance(rounding_mode, Expression):
+            self._handle_expr(2, rounding_mode, stmt_idx, stmt, block)
+
+    def _handle_Convert(self, expr_idx, expr: Convert, stmt_idx, stmt, block):
+        super()._handle_Convert(expr_idx, expr, stmt_idx, stmt, block)
+        rounding_mode = expr.rounding_mode
+        if isinstance(rounding_mode, Expression):
+            self._handle_expr(1, rounding_mode, stmt_idx, stmt, block)
+
+    def _handle_Let(self, expr_idx, expr: Let, stmt_idx, stmt, block):
+        for idx, def_stmt in enumerate(expr.defs):
+            self._handle_stmt(idx, def_stmt, None)
+        self._handle_expr(0, expr.src, stmt_idx, stmt, block)
+
+    def _top(self, expr_idx, expr, stmt_idx, stmt, block):
+        if isinstance(expr, Let):
+            # Let is not part of AILBlockViewer's default dispatch table.
+            self._handle_Let(expr_idx, expr, stmt_idx, stmt, block)

--- a/angr/analyses/decompiler/block_walkers.py
+++ b/angr/analyses/decompiler/block_walkers.py
@@ -18,6 +18,9 @@ class HasCallExprWalker(AILBlockViewer):
     def _handle_SideEffectStatement(self, stmt_idx, stmt, block):  # pylint:disable=unused-argument
         raise HasCallNotification
 
+    def _handle_DirtyStatement(self, stmt_idx, stmt, block):  # pylint:disable=unused-argument
+        raise HasCallNotification
+
     def _handle_Call(self, expr_idx, expr, stmt_idx, stmt, block):  # pylint:disable=unused-argument
         raise HasCallNotification
 

--- a/angr/analyses/decompiler/dephication/rewriting_engine.py
+++ b/angr/analyses/decompiler/dephication/rewriting_engine.py
@@ -442,10 +442,18 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
             else:
                 new_operands.append(o)
 
+        guard_in = expr.guard
         new_guard = None
-        if expr.guard is not None:
-            new_guard = self._expr(expr.guard)
+        if guard_in is not None:
+            new_guard = self._expr(guard_in)
             if new_guard is not None:
+                updated = True
+
+        maddr_in = expr.maddr
+        new_maddr = None
+        if maddr_in is not None:
+            new_maddr = self._expr(maddr_in)
+            if new_maddr is not None:
                 updated = True
 
         if updated:
@@ -453,9 +461,9 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 expr.idx,
                 expr.callee,
                 new_operands,
-                guard=new_guard,
+                guard=new_guard if new_guard is not None else guard_in,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr if new_maddr is not None else maddr_in,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/angr/analyses/decompiler/expression_narrower.py
+++ b/angr/analyses/decompiler/expression_narrower.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from angr.ailment.block import Block
     from angr.ailment.expression import (
         ITE,
-        DirtyExpression,
         Expression,
         Load,
         UnaryOp,
@@ -223,13 +222,6 @@ class EffectiveSizeExtractor(AILBlockWalker[None, None, None]):
         self._handle_expr(0, expr.cond, stmt_idx, stmt, block)
         self._handle_expr(1, expr.iftrue, stmt_idx, stmt, block)
         self._handle_expr(2, expr.iffalse, stmt_idx, stmt, block)
-
-    def _handle_DirtyExpression(
-        self, expr_idx: int, expr: DirtyExpression, stmt_idx: int, stmt: Statement | None, block: Block | None
-    ):
-        if expr.operands:
-            for i, op in enumerate(expr.operands):
-                self._handle_expr(i, op, stmt_idx, stmt, block)
 
     def _handle_VEXCCallExpression(
         self, expr_idx: int, expr: VEXCCallExpression, stmt_idx: int, stmt: Statement | None, block: Block | None

--- a/angr/analyses/decompiler/expression_narrower.py
+++ b/angr/analyses/decompiler/expression_narrower.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from angr.ailment import AILBlockRewriter, AILBlockWalker, Const
-from angr.ailment.expression import Atom, BinaryOp, Call, Convert, Extract, Phi, VirtualVariable
+from angr.ailment.expression import Atom, BinaryOp, Call, Convert, Extract, FunctionLikeMacro, Phi, VirtualVariable
 from angr.ailment.statement import Assignment, SideEffectStatement
 from angr.code_location import AILCodeLocation
 from angr.knowledge_plugins.key_definitions import atoms
@@ -167,7 +167,7 @@ class EffectiveSizeExtractor(AILBlockWalker[None, None, None]):
             self._handle_call_args(expr.args, stmt_idx, stmt, block)
 
     def _handle_SideEffectStatement(self, stmt_idx: int, stmt: SideEffectStatement, block: Block | None):
-        if stmt.expr.args is not None:
+        if isinstance(stmt.expr, (Call, FunctionLikeMacro)) and stmt.expr.args is not None:
             self._handle_call_args(stmt.expr.args, stmt_idx, stmt, block)
 
         if stmt.ret_expr is not None:
@@ -387,7 +387,13 @@ class ExpressionNarrower(AILBlockRewriter):
                 **tags,
             )
             self.replacement_core_vvars[new_ret_expr.varid].append(new_ret_expr)
-            new_stmt.ret_expr = new_ret_expr
+            new_stmt = SideEffectStatement(
+                new_stmt.idx,
+                new_stmt.expr,
+                ret_expr=new_ret_expr,
+                fp_ret_expr=new_stmt.fp_ret_expr,
+                **new_stmt.tags,
+            )
 
         if changed:
             self.narrowed_any = True

--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -521,10 +521,18 @@ class SimEngineSSARewriting(
             else:
                 new_operands.append(operand)
 
+        guard_in = expr.guard
         new_guard = None
-        if expr.guard is not None:
-            new_guard = self._expr(expr.guard)
+        if guard_in is not None:
+            new_guard = self._expr(guard_in)
             if new_guard is not None:
+                updated = True
+
+        maddr_in = expr.maddr
+        new_maddr = None
+        if maddr_in is not None:
+            new_maddr = self._expr(maddr_in)
+            if new_maddr is not None:
                 updated = True
 
         if updated:
@@ -532,9 +540,9 @@ class SimEngineSSARewriting(
                 expr.idx,
                 expr.callee,
                 new_operands,
-                guard=new_guard,
+                guard=new_guard if new_guard is not None else guard_in,
                 mfx=expr.mfx,
-                maddr=expr.maddr,
+                maddr=new_maddr if new_maddr is not None else maddr_in,
                 msize=expr.msize,
                 bits=expr.bits,
                 **expr.tags,

--- a/angr/analyses/s_propagator.py
+++ b/angr/analyses/s_propagator.py
@@ -23,6 +23,7 @@ from angr.ailment.expression import (
 )
 from angr.ailment.manager import Manager
 from angr.ailment.statement import Assignment, ConditionalJump, Jump, Return, Store
+from angr.ailment.utils import has_dirty_memory_write, has_effectful_dirty_expression
 from angr.analyses.analysis import Analysis, register_analysis
 from angr.code_location import AILCodeLocation
 from angr.knowledge_plugins.functions import Function
@@ -32,10 +33,10 @@ from angr.utils.ssa import (
     CONST_VVAR_TMP_WHITELIST,
     CONST_VVAR_WHITELIST,
     AILWhitelistExprTypeWalker,
+    check_in_between_stmts,
     get_uses_defs,
     has_ite_expr,
     has_ite_stmt,
-    has_store_stmt_in_between_stmts,
     has_tmp_expr,
     is_const_and_vvar_assignment,
     is_const_assignment,
@@ -80,6 +81,21 @@ def _whitelist_walker(whitelist: tuple[type, ...]) -> AILWhitelistExprTypeWalker
         walker = AILWhitelistExprTypeWalker(whitelist)
         cache[whitelist] = walker
     return walker
+
+
+def _has_memory_write_in_between_stmts(
+    graph: networkx.DiGraph,
+    blocks: dict[tuple[int, int | None], Block],
+    defloc: AILCodeLocation,
+    useloc: AILCodeLocation,
+) -> bool:
+    return check_in_between_stmts(
+        graph,
+        blocks,
+        defloc,
+        useloc,
+        lambda stmt: isinstance(stmt, Store) or has_dirty_memory_write(stmt),
+    )
 
 
 class SPropagatorModel:
@@ -208,15 +224,18 @@ class SPropagator:
 
             block = blocks[(defloc.block_addr, defloc.block_idx)]
             stmt = block.statements[defloc.stmt_idx]
-            if isinstance(stmt, Assignment) and not (
-                isinstance(stmt.dst, VirtualVariable) and stmt.dst.varid == vvar_id
-            ):
-                # come back later, this is not the def you're looking for
-                continue
-            if isinstance(stmt, Assignment) and isinstance(stmt.src, Insert):
-                # Do not propagate Inserts
-                # if this is not acceptable, just make sure we don't proagate inserts into the base of other inserts...
-                continue
+            if isinstance(stmt, Assignment):
+                if not (isinstance(stmt.dst, VirtualVariable) and stmt.dst.varid == vvar_id):
+                    # come back later, this is not the def you're looking for
+                    continue
+                if has_effectful_dirty_expression(stmt.src):
+                    # Propagating this expression would duplicate or move its side effect. This guard must precede
+                    # both ordinary constant propagation and forced stack-argument propagation.
+                    continue
+                if isinstance(stmt.src, Insert):
+                    # Do not propagate Inserts
+                    # if this is not acceptable, just make sure we don't proagate inserts into the base of other inserts...
+                    continue
             if is_phi_assignment(stmt):
                 assert isinstance(stmt, Assignment) and isinstance(stmt.src, Phi)
                 phi_varids[vvar_id] = {
@@ -312,6 +331,9 @@ class SPropagator:
                 ):
                     # come back later, this is not the def you're looking for
                     continue
+                if has_effectful_dirty_expression(stmt.src):
+                    # This loop has propagation paths independent of the initial constant/stack-argument pass.
+                    continue
 
                 if (
                     (vvar.was_reg or vvar.was_parameter)
@@ -326,7 +348,7 @@ class SPropagator:
                     #    }
                     can_replace = True
                     for vvar_useloc in vvar_useloc_to_count:
-                        if has_store_stmt_in_between_stmts(self.func_graph, blocks, defloc, vvar_useloc):
+                        if _has_memory_write_in_between_stmts(self.func_graph, blocks, defloc, vvar_useloc):
                             can_replace = False
 
                     if can_replace:
@@ -354,7 +376,7 @@ class SPropagator:
                             is_const_vvar_load_assignment(
                                 stmt, walker_cached=_whitelist_walker(CONST_VVAR_LOAD_WHITELIST)
                             )
-                            and not has_store_stmt_in_between_stmts(self.func_graph, blocks, defloc, vvar_useloc)
+                            and not _has_memory_write_in_between_stmts(self.func_graph, blocks, defloc, vvar_useloc)
                             and not has_tmp_expr(stmt.src)
                         ):
                             # we can propagate this load because there is no store between its def and use
@@ -499,6 +521,10 @@ class SPropagator:
 
                 stmt = block.statements[tmp_def_stmtidx]
                 if isinstance(stmt, Assignment):
+                    if has_effectful_dirty_expression(stmt.src):
+                        # Propagating this expression would duplicate or move its side effect.
+                        continue
+
                     r, v = is_const_assignment(stmt, self.only_consts)
                     if r:
                         # we can propagate it!
@@ -528,11 +554,11 @@ class SPropagator:
                                 block.statements[tmp_def_stmtidx].tags["ins_addr"]
                                 == block.statements[tmp_use_stmtidx].tags["ins_addr"]
                             )
-                            has_store = any(
-                                isinstance(stmt_, Store)
+                            has_memory_write = any(
+                                isinstance(stmt_, Store) or has_dirty_memory_write(stmt_)
                                 for stmt_ in block.statements[tmp_def_stmtidx + 1 : tmp_use_stmtidx]
                             )
-                            if same_inst or not has_store:
+                            if same_inst or not has_memory_write:
                                 # we can propagate this load because either we do not consider memory aliasing problem
                                 # within the same instruction (blocks must be originally lifted with
                                 # CROSS_INSN_OPT=False), or there is no store between its def and use.
@@ -561,6 +587,9 @@ class SPropagator:
 
             for idx in range(start_stmt_idx, end_stmt_idx):
                 stmt = block.statements[idx]
+                if has_dirty_memory_write(stmt):
+                    # A dirty write may alias any guest-memory location.
+                    return True
                 if isinstance(stmt, Store) and isinstance(stmt.addr, Const):
                     store_addr = stmt.addr.value
                     store_size = stmt.size

--- a/angr/analyses/s_propagator.py
+++ b/angr/analyses/s_propagator.py
@@ -565,19 +565,28 @@ class SPropagator:
                         stmt, walker_cached=_whitelist_walker(CONST_VVAR_LOAD_DIRTY_WHITELIST)
                     ):
                         for tmp_used, tmp_use_stmtidx in tmp_uses:
-                            same_inst = (
-                                block.statements[tmp_def_stmtidx].tags["ins_addr"]
-                                == block.statements[tmp_use_stmtidx].tags["ins_addr"]
-                            )
+                            def_ins_addr = block.statements[tmp_def_stmtidx].tags.get("ins_addr")
+                            same_inst = def_ins_addr is not None and def_ins_addr == block.statements[
+                                tmp_use_stmtidx
+                            ].tags.get("ins_addr")
                             use_has_dirty_memory_write = has_dirty_memory_write(block.statements[tmp_use_stmtidx])
-                            has_intervening_memory_write = any(
-                                isinstance(stmt_, Store) or has_dirty_memory_write(stmt_)
-                                for stmt_ in block.statements[tmp_def_stmtidx + 1 : tmp_use_stmtidx]
+                            intervening_statements = block.statements[tmp_def_stmtidx + 1 : tmp_use_stmtidx]
+                            has_intervening_dirty_memory_write = any(
+                                has_dirty_memory_write(stmt_) for stmt_ in intervening_statements
                             )
-                            if not use_has_dirty_memory_write and (same_inst or not has_intervening_memory_write):
+                            intervening_stores = [stmt_ for stmt_ in intervening_statements if isinstance(stmt_, Store)]
+                            stores_are_same_inst = same_inst and all(
+                                store.tags.get("ins_addr") == def_ins_addr for store in intervening_stores
+                            )
+                            if (
+                                not use_has_dirty_memory_write
+                                and not has_intervening_dirty_memory_write
+                                and (not intervening_stores or stores_are_same_inst)
+                            ):
                                 # we can propagate this load because either we do not consider memory aliasing problem
-                                # within the same instruction (blocks must be originally lifted with
-                                # CROSS_INSN_OPT=False), or there is no store between its def and use.
+                                # for ordinary stores within the same instruction (blocks must be originally lifted
+                                # with CROSS_INSN_OPT=False), or there is no store between its def and use. Dirty writes
+                                # remain barriers because an IRDirty helper may modify memory mid-instruction.
                                 loc = AILCodeLocation(block_loc[0], block_loc[1], tmp_use_stmtidx)
                                 self.replace(replacements, loc, tmp_used, stmt.src)
 

--- a/angr/analyses/s_propagator.py
+++ b/angr/analyses/s_propagator.py
@@ -89,6 +89,10 @@ def _has_memory_write_in_between_stmts(
     defloc: AILCodeLocation,
     useloc: AILCodeLocation,
 ) -> bool:
+    use_block = blocks[(useloc.addr, useloc.block_idx)]
+    if has_dirty_memory_write(use_block.statements[useloc.stmt_idx]):
+        # A MultiStatementExpression may perform this write before evaluating the vvar use in its result expression.
+        return True
     return check_in_between_stmts(
         graph,
         blocks,
@@ -357,7 +361,18 @@ class SPropagator:
                             self.replace(replacements, vvar_useloc, vvar_used, stmt.src)
                         continue
 
-                if (vvar.was_reg or vvar.was_stack) and len(vvar_uselocs_set) == 2 and not is_phi_assignment(stmt):
+                if (
+                    (vvar.was_reg or vvar.was_stack)
+                    and len(vvar_uselocs_set) == 2
+                    and not is_phi_assignment(stmt)
+                    and (
+                        not isinstance(stmt.src, Load)
+                        or not any(
+                            _has_memory_write_in_between_stmts(self.func_graph, blocks, defloc, useloc)
+                            for useloc in vvar_useloc_to_count
+                        )
+                    )
+                ):
                     # a special case: in a typical switch-case construct, a variable may be used once for comparison
                     # for the default case and then used again for constructing the jump target. we can propagate this
                     # variable for such cases.
@@ -554,11 +569,12 @@ class SPropagator:
                                 block.statements[tmp_def_stmtidx].tags["ins_addr"]
                                 == block.statements[tmp_use_stmtidx].tags["ins_addr"]
                             )
-                            has_memory_write = any(
+                            use_has_dirty_memory_write = has_dirty_memory_write(block.statements[tmp_use_stmtidx])
+                            has_intervening_memory_write = any(
                                 isinstance(stmt_, Store) or has_dirty_memory_write(stmt_)
                                 for stmt_ in block.statements[tmp_def_stmtidx + 1 : tmp_use_stmtidx]
                             )
-                            if same_inst or not has_memory_write:
+                            if not use_has_dirty_memory_write and (same_inst or not has_intervening_memory_write):
                                 # we can propagate this load because either we do not consider memory aliasing problem
                                 # within the same instruction (blocks must be originally lifted with
                                 # CROSS_INSN_OPT=False), or there is no store between its def and use.
@@ -573,6 +589,9 @@ class SPropagator:
     ) -> bool:
         defblock = block_dict[(defloc.block_addr, defloc.block_idx)]
         useblock = block_dict[(useloc.block_addr, useloc.block_idx)]
+        if has_dirty_memory_write(useblock.statements[useloc.stmt_idx]):
+            # A MultiStatementExpression may perform this write before evaluating the vvar use in its result expression.
+            return True
 
         # traverse a graph slice from the def block to the use block and check if the global variable is updated
         seen = {defblock}

--- a/angr/analyses/s_propagator.py
+++ b/angr/analyses/s_propagator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import threading
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
 import networkx
@@ -22,7 +22,7 @@ from angr.ailment.expression import (
     VirtualVariableCategory,
 )
 from angr.ailment.manager import Manager
-from angr.ailment.statement import Assignment, ConditionalJump, Jump, Return, Store
+from angr.ailment.statement import Assignment, ConditionalJump, Jump, Return, Statement, Store
 from angr.ailment.utils import has_dirty_memory_write, has_effectful_dirty_expression
 from angr.analyses.analysis import Analysis, register_analysis
 from angr.code_location import AILCodeLocation
@@ -88,9 +88,10 @@ def _has_memory_write_in_between_stmts(
     blocks: dict[tuple[int, int | None], Block],
     defloc: AILCodeLocation,
     useloc: AILCodeLocation,
+    has_dirty_write: Callable[[Statement], bool],
 ) -> bool:
     use_block = blocks[(useloc.addr, useloc.block_idx)]
-    if has_dirty_memory_write(use_block.statements[useloc.stmt_idx]):
+    if has_dirty_write(use_block.statements[useloc.stmt_idx]):
         # A MultiStatementExpression may perform this write before evaluating the vvar use in its result expression.
         return True
     return check_in_between_stmts(
@@ -98,7 +99,7 @@ def _has_memory_write_in_between_stmts(
         blocks,
         defloc,
         useloc,
-        lambda stmt: isinstance(stmt, Store) or has_dirty_memory_write(stmt),
+        lambda stmt: isinstance(stmt, Store) or has_dirty_write(stmt),
     )
 
 
@@ -154,6 +155,8 @@ class SPropagator:
         self._sp_tracker = stack_pointer_tracker
         self._ail_manager = ail_manager
         self.stack_arg_offsets = stack_arg_offsets
+        self._dirty_memory_write_cache: dict[int, tuple[Statement, bool]] = {}
+        self._effectful_assignment_src_cache: dict[int, tuple[Assignment, bool]] = {}
 
         bp_as_gpr = False
         the_func = None
@@ -171,6 +174,24 @@ class SPropagator:
         self.model = SPropagatorModel()
 
         self._analyze()
+
+    def _statement_has_dirty_memory_write(self, stmt: Statement) -> bool:
+        key = id(stmt)
+        cached = self._dirty_memory_write_cache.get(key)
+        if cached is not None and cached[0] is stmt:
+            return cached[1]
+        result = has_dirty_memory_write(stmt)
+        self._dirty_memory_write_cache[key] = stmt, result
+        return result
+
+    def _assignment_src_has_effectful_dirty(self, stmt: Assignment) -> bool:
+        key = id(stmt)
+        cached = self._effectful_assignment_src_cache.get(key)
+        if cached is not None and cached[0] is stmt:
+            return cached[1]
+        result = has_effectful_dirty_expression(stmt.src)
+        self._effectful_assignment_src_cache[key] = stmt, result
+        return result
 
     @property
     def replacements(self):
@@ -232,7 +253,7 @@ class SPropagator:
                 if not (isinstance(stmt.dst, VirtualVariable) and stmt.dst.varid == vvar_id):
                     # come back later, this is not the def you're looking for
                     continue
-                if has_effectful_dirty_expression(stmt.src):
+                if self._assignment_src_has_effectful_dirty(stmt):
                     # Propagating this expression would duplicate or move its side effect. This guard must precede
                     # both ordinary constant propagation and forced stack-argument propagation.
                     continue
@@ -335,7 +356,7 @@ class SPropagator:
                 ):
                     # come back later, this is not the def you're looking for
                     continue
-                if has_effectful_dirty_expression(stmt.src):
+                if self._assignment_src_has_effectful_dirty(stmt):
                     # This loop has propagation paths independent of the initial constant/stack-argument pass.
                     continue
 
@@ -352,7 +373,13 @@ class SPropagator:
                     #    }
                     can_replace = True
                     for vvar_useloc in vvar_useloc_to_count:
-                        if _has_memory_write_in_between_stmts(self.func_graph, blocks, defloc, vvar_useloc):
+                        if _has_memory_write_in_between_stmts(
+                            self.func_graph,
+                            blocks,
+                            defloc,
+                            vvar_useloc,
+                            self._statement_has_dirty_memory_write,
+                        ):
                             can_replace = False
 
                     if can_replace:
@@ -368,7 +395,13 @@ class SPropagator:
                     and (
                         not isinstance(stmt.src, Load)
                         or not any(
-                            _has_memory_write_in_between_stmts(self.func_graph, blocks, defloc, useloc)
+                            _has_memory_write_in_between_stmts(
+                                self.func_graph,
+                                blocks,
+                                defloc,
+                                useloc,
+                                self._statement_has_dirty_memory_write,
+                            )
                             for useloc in vvar_useloc_to_count
                         )
                     )
@@ -391,7 +424,13 @@ class SPropagator:
                             is_const_vvar_load_assignment(
                                 stmt, walker_cached=_whitelist_walker(CONST_VVAR_LOAD_WHITELIST)
                             )
-                            and not _has_memory_write_in_between_stmts(self.func_graph, blocks, defloc, vvar_useloc)
+                            and not _has_memory_write_in_between_stmts(
+                                self.func_graph,
+                                blocks,
+                                defloc,
+                                vvar_useloc,
+                                self._statement_has_dirty_memory_write,
+                            )
                             and not has_tmp_expr(stmt.src)
                         ):
                             # we can propagate this load because there is no store between its def and use
@@ -482,6 +521,7 @@ class SPropagator:
                                 stmt_src.size,
                                 defloc,
                                 vvar_useloc,
+                                has_dirty_write=self._statement_has_dirty_memory_write,
                             )
                         if not gv_updated:
                             for vvar_used, vvar_useloc in vvar_uselocs_set:
@@ -536,7 +576,7 @@ class SPropagator:
 
                 stmt = block.statements[tmp_def_stmtidx]
                 if isinstance(stmt, Assignment):
-                    if has_effectful_dirty_expression(stmt.src):
+                    if self._assignment_src_has_effectful_dirty(stmt):
                         # Propagating this expression would duplicate or move its side effect.
                         continue
 
@@ -569,10 +609,12 @@ class SPropagator:
                             same_inst = def_ins_addr is not None and def_ins_addr == block.statements[
                                 tmp_use_stmtidx
                             ].tags.get("ins_addr")
-                            use_has_dirty_memory_write = has_dirty_memory_write(block.statements[tmp_use_stmtidx])
+                            use_has_dirty_memory_write = self._statement_has_dirty_memory_write(
+                                block.statements[tmp_use_stmtidx]
+                            )
                             intervening_statements = block.statements[tmp_def_stmtidx + 1 : tmp_use_stmtidx]
                             has_intervening_dirty_memory_write = any(
-                                has_dirty_memory_write(stmt_) for stmt_ in intervening_statements
+                                self._statement_has_dirty_memory_write(stmt_) for stmt_ in intervening_statements
                             )
                             intervening_stores = [stmt_ for stmt_ in intervening_statements if isinstance(stmt_, Store)]
                             stores_are_same_inst = same_inst and all(
@@ -594,11 +636,21 @@ class SPropagator:
 
     @staticmethod
     def is_global_variable_updated(
-        func_graph, block_dict, varid: int, gv_addr: int, gv_size: int, defloc: AILCodeLocation, useloc: AILCodeLocation
+        func_graph,
+        block_dict,
+        varid: int,
+        gv_addr: int,
+        gv_size: int,
+        defloc: AILCodeLocation,
+        useloc: AILCodeLocation,
+        has_dirty_write: Callable[[Statement], bool] | None = None,
     ) -> bool:
+        if has_dirty_write is None:
+            has_dirty_write = has_dirty_memory_write
+
         defblock = block_dict[(defloc.block_addr, defloc.block_idx)]
         useblock = block_dict[(useloc.block_addr, useloc.block_idx)]
-        if has_dirty_memory_write(useblock.statements[useloc.stmt_idx]):
+        if has_dirty_write(useblock.statements[useloc.stmt_idx]):
             # A MultiStatementExpression may perform this write before evaluating the vvar use in its result expression.
             return True
 
@@ -615,7 +667,7 @@ class SPropagator:
 
             for idx in range(start_stmt_idx, end_stmt_idx):
                 stmt = block.statements[idx]
-                if has_dirty_memory_write(stmt):
+                if has_dirty_write(stmt):
                     # A dirty write may alias any guest-memory location.
                     return True
                 if isinstance(stmt, Store) and isinstance(stmt.addr, Const):

--- a/angr/rustylib/ailment.pyi
+++ b/angr/rustylib/ailment.pyi
@@ -192,6 +192,8 @@ class Expression:
     def pykind(self) -> int:
         """Cached ``Py<int>`` form of the kind tag. Pre-materialized at construction; access is a single ``clone_ref``."""
     def clear_hash(self) -> None: ...
+    def _dirty_effects(self) -> int:
+        """Recursive bit summary used by ``angr.ailment.utils``."""
     # ``variable`` / ``variable_offset`` are side-channel utility accessors
     # shared across the atom-shaped variants; kept on the base rather than
     # duplicated onto each atom.
@@ -393,6 +395,8 @@ class Statement:
     """True once a peephole-optimization pass has run this statement to fixpoint, letting later passes skip it.
     Runtime-only: never serialized, ignored by ``__eq__``/``__hash__``/``likes()``, and reset on clone."""
     def clear_hash(self) -> None: ...
+    def _dirty_effects(self) -> int:
+        """Recursive bit summary used by ``angr.ailment.utils``."""
     # Utility query available on any statement (true only for Assignments
     # whose source is a ``Phi``); kept on the base.
     @property

--- a/native/angr/src/ailment/ail_expr.rs
+++ b/native/angr/src/ailment/ail_expr.rs
@@ -34,6 +34,14 @@ use serde::de::{self, EnumAccess, SeqAccess, VariantAccess, Visitor};
 use serde::ser::{SerializeStruct, SerializeTupleVariant};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+/// Recursive dirty-operation summary bits shared with the statement side.
+///
+/// These deliberately describe only VEX dirty operations. Ordinary loads and
+/// stores are classified by their statement/expression kinds elsewhere.
+pub(crate) const DIRTY_EFFECT: u8 = 1 << 0;
+pub(crate) const DIRTY_MEMORY_READ: u8 = 1 << 1;
+pub(crate) const DIRTY_MEMORY_WRITE: u8 = 1 << 2;
+
 // ---------------------------------------------------------------------------
 // Header
 // ---------------------------------------------------------------------------
@@ -1027,6 +1035,128 @@ impl AilExpression {
 
     pub fn kind_str(&self) -> &'static str {
         self.inner.kind().as_str()
+    }
+
+    /// Summarize effectful VEX dirty operations in every evaluated child.
+    ///
+    /// Keep this traversal aligned with ``AILBlockViewer`` plus the extra
+    /// evaluated fields covered by ``angr.ailment.utils`` (load guards and
+    /// alternatives, rounding-mode expressions, and ``Let`` definitions).
+    /// Computing the summary in Rust avoids materializing a Python wrapper for
+    /// every node in the tree. Callers cache top-level query results when
+    /// useful, so this method intentionally stays uncached and cannot become
+    /// stale after an AIL mutation.
+    pub fn dirty_effects(&self) -> u8 {
+        let expr_effects = |exprs: &[AilExpression]| {
+            exprs
+                .iter()
+                .fold(0, |effects, expr| effects | expr.dirty_effects())
+        };
+        let arc_effects = |exprs: &[Arc<AilExpression>]| {
+            exprs
+                .iter()
+                .fold(0, |effects, expr| effects | expr.dirty_effects())
+        };
+        let opt_effects = |expr: &Option<Arc<AilExpression>>| {
+            expr.as_ref().map_or(0, |expr| expr.dirty_effects())
+        };
+        let target_effects = |target: &CFGTarget| match target {
+            CFGTarget::Expr(expr) => expr.dirty_effects(),
+            CFGTarget::Symbol(_) => 0,
+        };
+        let rounding_effects = |rounding_mode: &Option<RoundingModeOrExpr>| match rounding_mode {
+            Some(RoundingModeOrExpr::Expr(expr)) => expr.dirty_effects(),
+            Some(RoundingModeOrExpr::Mode(_)) | None => 0,
+        };
+
+        match &self.inner {
+            ExprInner::Const { .. }
+            | ExprInner::Tmp { .. }
+            | ExprInner::Register { .. }
+            | ExprInner::Phi { .. }
+            | ExprInner::VirtualVariable { .. }
+            | ExprInner::Macro { .. }
+            | ExprInner::StringLiteral { .. }
+            | ExprInner::BasePointerOffset { .. }
+            | ExprInner::StackBaseOffset { .. } => 0,
+            ExprInner::ComboRegister { registers } => expr_effects(registers),
+            ExprInner::UnaryOp { operand, .. } | ExprInner::Reinterpret { operand, .. } => {
+                operand.dirty_effects()
+            }
+            ExprInner::Convert {
+                operand,
+                rounding_mode,
+                ..
+            } => operand.dirty_effects() | rounding_effects(rounding_mode),
+            ExprInner::BinaryOp {
+                operands,
+                rounding_mode,
+                ..
+            } => {
+                operands[0].dirty_effects()
+                    | operands[1].dirty_effects()
+                    | rounding_effects(rounding_mode)
+            }
+            ExprInner::Load {
+                addr, guard, alt, ..
+            } => addr.dirty_effects() | opt_effects(guard) | opt_effects(alt),
+            ExprInner::Call { target, args, .. } => {
+                target_effects(target) | args.as_ref().map_or(0, |args| expr_effects(args))
+            }
+            ExprInner::DirtyExpression {
+                operands,
+                guard,
+                mfx,
+                maddr,
+                ..
+            } => {
+                let mut effects = expr_effects(operands) | opt_effects(guard) | opt_effects(maddr);
+                if let Some(mfx) = mfx.as_deref() {
+                    effects |= DIRTY_EFFECT;
+                    if matches!(mfx, "Ifx_Read" | "Ifx_Modify") {
+                        effects |= DIRTY_MEMORY_READ;
+                    }
+                    if matches!(mfx, "Ifx_Write" | "Ifx_Modify") {
+                        effects |= DIRTY_MEMORY_WRITE;
+                    }
+                }
+                effects
+            }
+            ExprInner::VEXCCallExpression { operands, .. } => expr_effects(operands),
+            ExprInner::MultiStatementExpression { stmts, expr } => {
+                stmts
+                    .iter()
+                    .fold(0, |effects, stmt| effects | stmt.dirty_effects())
+                    | expr.dirty_effects()
+            }
+            ExprInner::Struct { fields, .. } => fields
+                .values()
+                .fold(0, |effects, expr| effects | expr.dirty_effects()),
+            ExprInner::RustEnum { fields, .. } => arc_effects(fields),
+            ExprInner::Array { elements } => arc_effects(elements),
+            ExprInner::Let { defs, src } => {
+                defs.iter()
+                    .fold(0, |effects, stmt| effects | stmt.dirty_effects())
+                    | src.dirty_effects()
+            }
+            ExprInner::FunctionLikeMacro { args, .. } => {
+                args.as_ref().map_or(0, |args| arc_effects(args))
+            }
+            ExprInner::ITE {
+                cond,
+                iffalse,
+                iftrue,
+            } => cond.dirty_effects() | iffalse.dirty_effects() | iftrue.dirty_effects(),
+            ExprInner::Extract { base, offset, .. } => {
+                base.dirty_effects() | offset.dirty_effects()
+            }
+            ExprInner::Insert {
+                base,
+                offset,
+                value,
+                ..
+            } => base.dirty_effects() | offset.dirty_effects() | value.dirty_effects(),
+        }
     }
 
     /// Depth of this node recomputed from its *current* children, using
@@ -3391,6 +3521,11 @@ impl Expression {
 
     fn clear_hash(&self) {
         self.expr.header.cached_hash.clear();
+    }
+
+    /// Private fast path used by ``angr.ailment.utils``.
+    fn _dirty_effects(&self) -> u8 {
+        self.expr.dirty_effects()
     }
 
     // --- Per-variant accessors ----------------------------------------

--- a/native/angr/src/ailment/ail_stmt.rs
+++ b/native/angr/src/ailment/ail_stmt.rs
@@ -20,7 +20,10 @@ use pyo3::exceptions::{PyAttributeError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 
-use crate::ailment::ail_expr::{AilExpression, CFGTarget, Expression, VariantIdx, next};
+use crate::ailment::ail_expr::{
+    AilExpression, CFGTarget, DIRTY_EFFECT, DIRTY_MEMORY_READ, DIRTY_MEMORY_WRITE, ExprInner,
+    Expression, VariantIdx, next,
+};
 use crate::ailment::enums::StatementKind;
 use crate::ailment::tags::{Tags, TagsView};
 use crate::ailment::{CachedHash, CmpMode, hash_of};
@@ -247,6 +250,74 @@ impl AilStatement {
 
     pub fn kind_str(&self) -> &'static str {
         self.inner.kind().as_str()
+    }
+
+    /// Summarize effectful VEX dirty operations in every evaluated child.
+    pub fn dirty_effects(&self) -> u8 {
+        let expr_effects = |exprs: &[AilExpression]| {
+            exprs
+                .iter()
+                .fold(0, |effects, expr| effects | expr.dirty_effects())
+        };
+        let opt_effects = |expr: &Option<Arc<AilExpression>>| {
+            expr.as_ref().map_or(0, |expr| expr.dirty_effects())
+        };
+        let target_effects = |target: &CFGTarget| match target {
+            CFGTarget::Expr(expr) => expr.dirty_effects(),
+            CFGTarget::Symbol(_) => 0,
+        };
+        let opt_target_effects = |target: &Option<CFGTarget>| match target {
+            Some(target) => target_effects(target),
+            None => 0,
+        };
+
+        match &self.inner {
+            StmtInner::Assignment { dst, src } | StmtInner::WeakAssignment { dst, src } => {
+                dst.dirty_effects() | src.dirty_effects()
+            }
+            StmtInner::Label { .. } | StmtInner::NoOp => 0,
+            StmtInner::Store {
+                addr, data, guard, ..
+            } => addr.dirty_effects() | data.dirty_effects() | opt_effects(guard),
+            StmtInner::Jump { target, .. } => target_effects(target),
+            StmtInner::ConditionalJump {
+                condition,
+                true_target,
+                false_target,
+                ..
+            } => {
+                condition.dirty_effects()
+                    | opt_target_effects(true_target)
+                    | opt_target_effects(false_target)
+            }
+            StmtInner::SideEffectStatement { expr, .. } => expr.dirty_effects(),
+            StmtInner::Return { ret_exprs } => expr_effects(ret_exprs),
+            StmtInner::CAS {
+                addr,
+                data_lo,
+                data_hi,
+                expd_lo,
+                expd_hi,
+                old_lo,
+                old_hi,
+                ..
+            } => {
+                addr.dirty_effects()
+                    | data_lo.dirty_effects()
+                    | opt_effects(data_hi)
+                    | expd_lo.dirty_effects()
+                    | opt_effects(expd_hi)
+                    | old_lo.dirty_effects()
+                    | opt_effects(old_hi)
+            }
+            StmtInner::DirtyStatement { dirty } => match &dirty.inner {
+                ExprInner::DirtyExpression { mfx, .. } if mfx.is_some() => dirty.dirty_effects(),
+                // A placeholder with no mfx represents an unsupported VEX
+                // statement. Its missing semantics may include guest-memory
+                // reads, writes, and non-memory effects.
+                _ => DIRTY_EFFECT | DIRTY_MEMORY_READ | DIRTY_MEMORY_WRITE,
+            },
+        }
     }
 
     pub fn cached_hash_or_compute(&self) -> i64 {
@@ -1127,6 +1198,11 @@ impl Statement {
 
     fn clear_hash(&self) {
         self.stmt.header.cached_hash.clear();
+    }
+
+    /// Private fast path used by ``angr.ailment.utils``.
+    fn _dirty_effects(&self) -> u8 {
+        self.stmt.dirty_effects()
     }
 
     /// True once a peephole-optimization pass has run this statement to fixpoint, letting later

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -51,6 +51,8 @@ class ConstIncrementingRewriter(AILBlockRewriter):
 
 
 class RegisterRecordingViewer(AILBlockViewer):
+    """Record registers visited by a block viewer."""
+
     def __init__(self):
         super().__init__()
         self.registers = []
@@ -63,6 +65,8 @@ class RegisterRecordingViewer(AILBlockViewer):
 
 
 class ConstIndexRecordingRewriter(AILBlockRewriter):
+    """Record constant values and their expression child indices."""
+
     def __init__(self):
         super().__init__(update_block=False)
         self.const_indices = []

--- a/tests/ailment/test_block_walker.py
+++ b/tests/ailment/test_block_walker.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from collections import OrderedDict
 
-from angr.ailment import AILBlockRewriter, AILBlockWalker, Block
+from angr.ailment import AILBlockRewriter, AILBlockViewer, AILBlockWalker, Block
 from angr.ailment.expression import (
     Array,
     ComboRegister,
     Const,
+    DirtyExpression,
     Expression,
     FunctionLikeMacro,
     Register,
@@ -46,6 +47,28 @@ class ConstIncrementingRewriter(AILBlockRewriter):
     def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
         if expr.value == 1:
             return Const(expr.idx, 2, expr.bits, **expr.tags)
+        return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class RegisterRecordingViewer(AILBlockViewer):
+    def __init__(self):
+        super().__init__()
+        self.registers = []
+
+    def _handle_Register(
+        self, expr_idx: int, expr: Register, stmt_idx: int, stmt: Statement | None, block: Block | None
+    ):
+        self.registers.append(expr)
+        return super()._handle_Register(expr_idx, expr, stmt_idx, stmt, block)
+
+
+class ConstIndexRecordingRewriter(AILBlockRewriter):
+    def __init__(self):
+        super().__init__(update_block=False)
+        self.const_indices = []
+
+    def _handle_Const(self, expr_idx: int, expr: Const, stmt_idx: int, stmt: Statement | None, block: Block | None):
+        self.const_indices.append((expr.value, expr_idx))
         return super()._handle_Const(expr_idx, expr, stmt_idx, stmt, block)
 
 
@@ -100,3 +123,75 @@ def test_block_rewriter_rebuilds_rust_ail_expression_containers():
     assert not new_enum.likes(enum)
     assert not new_struct.likes(struct)
     assert new_struct.fields[0].value == 2
+
+
+def test_block_walkers_visit_dirty_memory_address():
+    maddr = Register(0, 24, 64)
+    dirty = DirtyExpression(
+        1,
+        "helper",
+        [Const(2, 3, 64)],
+        guard=Const(3, 1, 1),
+        mfx="Ifx_Read",
+        maddr=maddr,
+        msize=4,
+        bits=32,
+    )
+    dst = VirtualVariable(4, 1, 32, VirtualVariableCategory.REGISTER, 16)
+    block = Block(0x400020, 0, statements=[Assignment(5, dst, dirty)])
+
+    seen = RecordingWalker().walk(block)
+    assert seen.count("Register") == 1
+
+    viewer = RegisterRecordingViewer()
+    viewer.walk(block)
+    assert viewer.registers == [maddr]
+
+
+def test_block_rewriter_updates_dirty_memory_address_without_changing_other_metadata():
+    operand = Const(0, 3, 64)
+    guard = Const(1, 0, 1)
+    maddr = Const(2, 1, 64)
+    dirty = DirtyExpression(
+        3,
+        "load_linked_le",
+        [operand],
+        guard=guard,
+        mfx="Ifx_Read",
+        maddr=maddr,
+        msize=8,
+        bits=64,
+        ins_addr=0x400030,
+    )
+    dst = VirtualVariable(4, 1, 64, VirtualVariableCategory.REGISTER, 16)
+    block = Block(0x400030, 0, statements=[Assignment(5, dst, dirty)])
+
+    new_block = ConstIncrementingRewriter(update_block=False).walk(block)
+    new_stmt = new_block.statements[0]
+    assert isinstance(new_stmt, Assignment)
+    assert isinstance(new_stmt.src, DirtyExpression)
+    assert len(new_stmt.src.operands) == 1
+    assert new_stmt.src.operands[0].likes(operand)
+    assert new_stmt.src.guard is not None and new_stmt.src.guard.likes(guard)
+    assert new_stmt.src.idx == dirty.idx
+    assert new_stmt.src.callee == dirty.callee
+    assert new_stmt.src.mfx == dirty.mfx
+    assert new_stmt.src.msize == dirty.msize
+    assert new_stmt.src.bits == dirty.bits
+    assert new_stmt.src.tags == dirty.tags
+    new_maddr = new_stmt.src.maddr
+    assert isinstance(new_maddr, Const)
+    assert new_maddr.value == 2
+
+
+def test_block_rewriter_uses_distinct_dirty_guard_and_memory_address_slots():
+    guard = Const(0, 0, 1)
+    maddr = Const(1, 0x4000, 64)
+    dirty = DirtyExpression(2, "helper", [], guard=guard, mfx="Ifx_Read", maddr=maddr, msize=4, bits=32)
+    dst = VirtualVariable(3, 1, 32, VirtualVariableCategory.REGISTER, 16)
+    block = Block(0x400040, 0, statements=[Assignment(4, dst, dirty)])
+
+    rewriter = ConstIndexRecordingRewriter()
+    rewriter.walk(block)
+
+    assert rewriter.const_indices == [(0, 2), (0x4000, 3)]

--- a/tests/analyses/decompiler/test_dirty_effect_core_safety.py
+++ b/tests/analyses/decompiler/test_dirty_effect_core_safety.py
@@ -56,6 +56,17 @@ def _function_propagator(project, block: ailment.Block, manager: ailment.Manager
     return SPropagator(project, subject=function, func_graph=graph, ail_manager=manager)
 
 
+def _intervening_dirty_statement(idx: int, mfx: str | None, addr):
+    if mfx is None:
+        return ailment.Stmt.DirtyStatement(idx, _dirty(idx + 1, None), ins_addr=0x1001)
+    return ailment.Stmt.Assignment(
+        idx,
+        ailment.Expr.Tmp(idx + 1, 100 + idx, 64),
+        _dirty(idx + 2, mfx, maddr=addr),
+        ins_addr=0x1001,
+    )
+
+
 def test_dirty_effect_classification_preserves_vex_semantics():
     pure = _dirty(0, None)
     guest_state_effect = _dirty(1, "Ifx_None")
@@ -64,6 +75,9 @@ def test_dirty_effect_classification_preserves_vex_semantics():
     modify = _dirty(4, "Ifx_Modify")
 
     assert not is_effectful_dirty_expression(pure)
+    assert not has_effectful_dirty_expression(pure)
+    assert not has_dirty_memory_read(pure)
+    assert not has_dirty_memory_write(pure)
     assert is_effectful_dirty_expression(guest_state_effect)
     assert has_effectful_dirty_expression(guest_state_effect)
     assert not has_dirty_memory_read(guest_state_effect)
@@ -75,6 +89,16 @@ def test_dirty_effect_classification_preserves_vex_semantics():
     assert has_dirty_memory_write(write)
     assert has_dirty_memory_read(modify)
     assert has_dirty_memory_write(modify)
+
+    opaque_stmt = ailment.Stmt.DirtyStatement(5, pure)
+    assert has_effectful_dirty_expression(opaque_stmt)
+    assert has_dirty_memory_read(opaque_stmt)
+    assert has_dirty_memory_write(opaque_stmt)
+
+    nested_stmt = ailment.Expr.MultiStatementExpression(6, [opaque_stmt], ailment.Expr.Const(7, 0, 64))
+    assert has_effectful_dirty_expression(nested_stmt)
+    assert has_dirty_memory_read(nested_stmt)
+    assert has_dirty_memory_write(nested_stmt)
 
 
 def test_dirty_effect_search_recurses_through_nonmatching_dirty_fields():
@@ -97,10 +121,13 @@ def test_has_call_walker_treats_ifx_none_and_nested_dirty_as_effects():
     walker.walk_expression(_dirty(20, None))
 
     with pytest.raises(HasCallNotification):
-        walker.walk_expression(_dirty(21, "Ifx_None"))
+        walker.walk_statement(ailment.Stmt.DirtyStatement(21, _dirty(22, None)))
 
     with pytest.raises(HasCallNotification):
-        walker.walk_expression(_dirty(22, None, operands=(_dirty(23, "Ifx_Write"),)))
+        walker.walk_expression(_dirty(23, "Ifx_None"))
+
+    with pytest.raises(HasCallNotification):
+        walker.walk_expression(_dirty(24, None, operands=(_dirty(25, "Ifx_Write"),)))
 
 
 @pytest.mark.parametrize("nested_effectful", (False, True))
@@ -191,17 +218,23 @@ def test_spropagator_guards_forced_stack_and_independent_vvar_paths():
     assert vvar_def.varid not in vvar_prop.dead_vvar_ids
 
 
-def test_spropagator_does_not_propagate_effectful_dirty_tmp():
+@pytest.mark.parametrize("source_kind", ("ifx_none", "dirty_statement"))
+def test_spropagator_does_not_propagate_effectful_dirty_tmp(source_kind):
     project = _project()
     manager = ailment.Manager(arch=project.arch)
     tmp_def = ailment.Expr.Tmp(0, 0, 64)
     tmp_use = ailment.Expr.Tmp(1, 0, 64)
+    if source_kind == "ifx_none":
+        source = _dirty(3, "Ifx_None")
+    else:
+        opaque_stmt = ailment.Stmt.DirtyStatement(3, _dirty(4, None))
+        source = ailment.Expr.MultiStatementExpression(5, [opaque_stmt], ailment.Expr.Const(6, 0, 64))
     block = ailment.Block(
         0x1000,
         1,
         statements=[
-            ailment.Stmt.Assignment(2, tmp_def, _dirty(3, "Ifx_None"), ins_addr=0x1000),
-            ailment.Stmt.Assignment(4, ailment.Expr.Register(5, 16, 64), tmp_use, ins_addr=0x1001),
+            ailment.Stmt.Assignment(7, tmp_def, source, ins_addr=0x1000),
+            ailment.Stmt.Assignment(8, ailment.Expr.Register(9, 16, 64), tmp_use, ins_addr=0x1001),
         ],
         idx=0,
     )
@@ -210,7 +243,10 @@ def test_spropagator_does_not_propagate_effectful_dirty_tmp():
     assert not _has_replacement(propagator, (tmp_use,))
 
 
-@pytest.mark.parametrize("mfx, expected_replacement", (("Ifx_Read", True), ("Ifx_Write", False)))
+@pytest.mark.parametrize(
+    "mfx, expected_replacement",
+    (("Ifx_Read", True), ("Ifx_Write", False), (None, False)),
+)
 def test_spropagator_tmp_load_crosses_reads_but_not_dirty_writes(mfx, expected_replacement):
     project = _project()
     manager = ailment.Manager(arch=project.arch)
@@ -227,12 +263,7 @@ def test_spropagator_tmp_load_crosses_reads_but_not_dirty_writes(mfx, expected_r
                 ailment.Expr.Load(4, addr, 4, "Iend_LE"),
                 ins_addr=0x1000,
             ),
-            ailment.Stmt.Assignment(
-                5,
-                ailment.Expr.Tmp(6, 1, 64),
-                _dirty(7, mfx, maddr=addr),
-                ins_addr=0x1001,
-            ),
+            _intervening_dirty_statement(5, mfx, addr),
             ailment.Stmt.Assignment(8, ailment.Expr.Register(9, 16, 32), tmp_use, ins_addr=0x1002),
         ],
         idx=0,
@@ -243,7 +274,10 @@ def test_spropagator_tmp_load_crosses_reads_but_not_dirty_writes(mfx, expected_r
 
 
 @pytest.mark.parametrize("use_count", (1, 3))
-@pytest.mark.parametrize("mfx, expected_replacement", (("Ifx_Read", True), ("Ifx_Modify", False)))
+@pytest.mark.parametrize(
+    "mfx, expected_replacement",
+    (("Ifx_Read", True), ("Ifx_Modify", False), (None, False)),
+)
 def test_spropagator_function_load_crosses_reads_but_not_dirty_writes(mfx, expected_replacement, use_count):
     project = _project()
     manager = ailment.Manager(arch=project.arch)
@@ -259,12 +293,7 @@ def test_spropagator_function_load_crosses_reads_but_not_dirty_writes(mfx, expec
             ailment.Expr.Load(11, addr, 4, "Iend_LE"),
             ins_addr=0x1000,
         ),
-        ailment.Stmt.Assignment(
-            12,
-            ailment.Expr.Tmp(13, 0, 64),
-            _dirty(14, mfx, maddr=addr),
-            ins_addr=0x1001,
-        ),
+        _intervening_dirty_statement(12, mfx, addr),
     ]
     statements.extend(
         ailment.Stmt.Assignment(20 + idx, ailment.Expr.Register(30 + idx, 24 + idx * 4, 32), use, ins_addr=0x1002 + idx)

--- a/tests/analyses/decompiler/test_dirty_effect_core_safety.py
+++ b/tests/analyses/decompiler/test_dirty_effect_core_safety.py
@@ -4,8 +4,9 @@ import networkx
 import pytest
 
 import angr
+import angr.ailment.utils as ailment_utils
 from angr import ailment
-from angr.ailment.expression import DirtyExpression, VirtualVariable, VirtualVariableCategory
+from angr.ailment.expression import DirtyExpression, Expression, VirtualVariable, VirtualVariableCategory
 from angr.ailment.statement import Statement
 from angr.ailment.utils import (
     has_dirty_memory_read,
@@ -75,6 +76,210 @@ def _mse_use_with_dirty_write(idx: int, use, addr):
     return ailment.Expr.MultiStatementExpression(idx + 2, [write], use)
 
 
+def _legacy_dirty_effects(obj: Expression | Statement) -> int:
+    effects = 0
+    for memory_effects, bit in (
+        (None, 1 << 0),
+        (ailment_utils._DIRTY_MEMORY_READ_EFFECTS, 1 << 1),  # pylint:disable=protected-access
+        (ailment_utils._DIRTY_MEMORY_WRITE_EFFECTS, 1 << 2),  # pylint:disable=protected-access
+    ):
+        finder = ailment_utils._EffectfulDirtyExpressionFinder(memory_effects)  # pylint:disable=protected-access
+        try:
+            if isinstance(obj, Expression):
+                finder.walk_expression(obj)
+            else:
+                finder.walk_statement(obj)
+        except ailment_utils._EffectfulDirtyExpressionFound:  # pylint:disable=protected-access
+            effects |= bit
+    return effects
+
+
+def _dirty_expression_slot_roots():
+    clean = ailment.Expr.Const(100, 0, 64)
+    condition = ailment.Expr.Const(101, 1, 1)
+    dirty = _dirty(102, "Ifx_Modify")
+    dirty_condition = _dirty(103, "Ifx_Modify", bits=1)
+    dirty_stmt = ailment.Stmt.DirtyStatement(104, dirty)
+    return (
+        ("unary-operand", ailment.Expr.UnaryOp(110, "Not", dirty, bits=64)),
+        ("reinterpret-operand", ailment.Expr.Reinterpret(111, 64, "int", 64, "float", dirty)),
+        ("convert-operand", ailment.Expr.Convert(112, 64, 64, False, dirty)),
+        (
+            "convert-rounding",
+            ailment.Expr.Convert(113, 64, 64, False, clean, rounding_mode=dirty),
+        ),
+        ("binary-left", ailment.Expr.BinaryOp(114, "Add", (dirty, clean), bits=64)),
+        ("binary-right", ailment.Expr.BinaryOp(115, "Add", (clean, dirty), bits=64)),
+        (
+            "binary-rounding",
+            ailment.Expr.BinaryOp(116, "Add", (clean, clean), bits=64, rounding_mode=dirty),
+        ),
+        ("load-address", ailment.Expr.Load(117, dirty, 8, "Iend_LE")),
+        ("load-guard", ailment.Expr.Load(118, clean, 8, "Iend_LE", guard=dirty_condition)),
+        ("load-alt", ailment.Expr.Load(119, clean, 8, "Iend_LE", alt=dirty)),
+        ("call-target", ailment.Expr.Call(120, dirty, args=[], bits=64)),
+        ("call-argument", ailment.Expr.Call(121, "helper", args=[dirty], bits=64)),
+        ("dirty-operand", _dirty(122, None, operands=(dirty,))),
+        ("dirty-guard", _dirty(123, None, guard=dirty_condition)),
+        ("dirty-address", _dirty(124, None, maddr=dirty)),
+        ("vex-ccall-operand", ailment.Expr.VEXCCallExpression(125, "helper", [dirty], 64)),
+        (
+            "mse-statement",
+            ailment.Expr.MultiStatementExpression(126, [dirty_stmt], clean),
+        ),
+        ("mse-expression", ailment.Expr.MultiStatementExpression(127, [], dirty)),
+        ("struct-field", ailment.Expr.Struct(128, "S", {0: dirty}, {"value": 0}, 64)),
+        ("enum-field", ailment.Expr.RustEnum(129, "Some", [dirty], 64)),
+        ("array-element", ailment.Expr.Array(130, [dirty], 64)),
+        (
+            "let-definition",
+            ailment.Expr.Let(131, [ailment.Stmt.Assignment(132, ailment.Expr.Tmp(133, 0, 64), dirty)], clean),
+        ),
+        ("let-source", ailment.Expr.Let(134, [], dirty)),
+        ("macro-argument", ailment.Expr.FunctionLikeMacro(135, "format", [dirty], bits=64)),
+        ("ite-condition", ailment.Expr.ITE(136, dirty_condition, clean, clean)),
+        ("ite-false", ailment.Expr.ITE(137, condition, dirty, clean)),
+        ("ite-true", ailment.Expr.ITE(138, condition, clean, dirty)),
+        ("extract-base", ailment.Expr.Extract(139, 64, dirty, clean, "Iend_LE")),
+        ("extract-offset", ailment.Expr.Extract(140, 64, clean, dirty, "Iend_LE")),
+        ("insert-base", ailment.Expr.Insert(141, dirty, clean, clean, "Iend_LE")),
+        ("insert-offset", ailment.Expr.Insert(142, clean, dirty, clean, "Iend_LE")),
+        ("insert-value", ailment.Expr.Insert(143, clean, clean, dirty, "Iend_LE")),
+    )
+
+
+def _dirty_statement_slot_roots():
+    clean = ailment.Expr.Const(200, 0, 64)
+    condition = ailment.Expr.Const(201, 1, 1)
+    dirty = _dirty(202, "Ifx_Modify")
+    dirty_condition = _dirty(203, "Ifx_Modify", bits=1)
+    return (
+        ("assignment-destination", ailment.Stmt.Assignment(210, dirty, clean)),
+        ("assignment-source", ailment.Stmt.Assignment(211, clean, dirty)),
+        ("weak-destination", ailment.Stmt.WeakAssignment(212, dirty, clean)),
+        ("weak-source", ailment.Stmt.WeakAssignment(213, clean, dirty)),
+        ("store-address", ailment.Stmt.Store(214, dirty, clean, 8, "Iend_LE")),
+        ("store-data", ailment.Stmt.Store(215, clean, dirty, 8, "Iend_LE")),
+        ("store-guard", ailment.Stmt.Store(216, clean, clean, 8, "Iend_LE", guard=dirty_condition)),
+        ("jump-target", ailment.Stmt.Jump(217, dirty)),
+        ("cjump-condition", ailment.Stmt.ConditionalJump(218, dirty_condition, clean, clean)),
+        ("cjump-true", ailment.Stmt.ConditionalJump(219, condition, dirty, clean)),
+        ("cjump-false", ailment.Stmt.ConditionalJump(220, condition, clean, dirty)),
+        ("side-effect-expression", ailment.Stmt.SideEffectStatement(221, dirty)),
+        ("return-expression", ailment.Stmt.Return(222, [dirty])),
+        ("cas-address", ailment.Stmt.CAS(223, dirty, clean, None, clean, None, clean, None, "Iend_LE")),
+        ("cas-data-low", ailment.Stmt.CAS(224, clean, dirty, None, clean, None, clean, None, "Iend_LE")),
+        ("cas-data-high", ailment.Stmt.CAS(225, clean, clean, dirty, clean, None, clean, None, "Iend_LE")),
+        ("cas-expected-low", ailment.Stmt.CAS(226, clean, clean, None, dirty, None, clean, None, "Iend_LE")),
+        ("cas-expected-high", ailment.Stmt.CAS(227, clean, clean, None, clean, dirty, clean, None, "Iend_LE")),
+        ("cas-old-low", ailment.Stmt.CAS(228, clean, clean, None, clean, None, dirty, None, "Iend_LE")),
+        ("cas-old-high", ailment.Stmt.CAS(229, clean, clean, None, clean, None, clean, dirty, "Iend_LE")),
+        ("dirty-statement", ailment.Stmt.DirtyStatement(230, dirty)),
+    )
+
+
+@pytest.mark.parametrize("case", _dirty_expression_slot_roots(), ids=lambda case: case[0])
+def test_native_dirty_effect_summary_matches_python_expression_walker(case):
+    _, root = case
+
+    assert root._dirty_effects() == 0b111  # pylint:disable=protected-access
+    assert _legacy_dirty_effects(root) == 0b111
+    assert has_effectful_dirty_expression(root)
+    assert has_dirty_memory_read(root)
+    assert has_dirty_memory_write(root)
+
+
+@pytest.mark.parametrize("case", _dirty_statement_slot_roots(), ids=lambda case: case[0])
+def test_native_dirty_effect_summary_matches_python_statement_walker(case):
+    _, root = case
+
+    assert root._dirty_effects() == 0b111  # pylint:disable=protected-access
+    assert _legacy_dirty_effects(root) == 0b111
+    assert has_effectful_dirty_expression(root)
+    assert has_dirty_memory_read(root)
+    assert has_dirty_memory_write(root)
+
+
+@pytest.mark.parametrize(
+    "mfx, expected_mask",
+    (
+        (None, 0b000),
+        ("Ifx_None", 0b001),
+        ("Ifx_Read", 0b011),
+        ("Ifx_Write", 0b101),
+        ("Ifx_Modify", 0b111),
+        ("Ifx_Unknown", 0b001),
+    ),
+)
+def test_native_dirty_effect_mask_protocol(mfx, expected_mask):
+    root = _dirty(240, mfx)
+
+    assert root._dirty_effects() == expected_mask  # pylint:disable=protected-access
+    assert _legacy_dirty_effects(root) == expected_mask
+
+
+def test_native_dirty_effect_summary_ors_duplicate_bits():
+    left = _dirty(241, "Ifx_None")
+    right = _dirty(242, "Ifx_None")
+    root = ailment.Expr.Call(243, left, args=[right], bits=64)
+
+    assert root._dirty_effects() == 0b001  # pylint:disable=protected-access
+    assert _legacy_dirty_effects(root) == 0b001
+
+
+def test_native_dirty_effect_summary_ignores_unevaluated_metadata_slots():
+    clean = ailment.Expr.Const(244, 0, 64)
+    dirty = _dirty(245, "Ifx_Modify")
+    roots = (
+        ailment.Expr.Call(246, "helper", args=[clean], bits=64, arg_vvars=[dirty]),
+        ailment.Stmt.SideEffectStatement(247, clean, ret_expr=dirty, fp_ret_expr=dirty),
+    )
+
+    for root in roots:
+        assert root._dirty_effects() == 0  # pylint:disable=protected-access
+        assert _legacy_dirty_effects(root) == 0
+
+
+def test_native_dirty_effect_summary_treats_non_dirty_statement_payload_as_opaque():
+    root = ailment.Stmt.DirtyStatement(248, ailment.Expr.Const(249, 0, 64))
+
+    assert root._dirty_effects() == 0b111  # pylint:disable=protected-access
+    assert _legacy_dirty_effects(root) == 0b111
+
+
+def test_native_dirty_effect_summary_observes_mutations_without_stale_cache():
+    root = ailment.Expr.Load(250, ailment.Expr.Const(251, 0x3000, 64), 8, "Iend_LE")
+    assert root._dirty_effects() == 0  # pylint:disable=protected-access
+
+    root.guard = _dirty(252, "Ifx_Write", bits=1)
+    assert root._dirty_effects() == 0b101  # pylint:disable=protected-access
+
+    root.guard = None
+    assert root._dirty_effects() == 0  # pylint:disable=protected-access
+
+
+def test_native_dirty_effect_summary_survives_copy_and_serialization():
+    expr = ailment.Expr.MultiStatementExpression(
+        253,
+        [ailment.Stmt.DirtyStatement(254, _dirty(255, None))],
+        ailment.Expr.Const(256, 0, 64),
+    )
+    stmt = ailment.Stmt.Assignment(257, ailment.Expr.Tmp(258, 0, 64), _dirty(259, "Ifx_Read"))
+
+    for clone in (expr.copy(), Expression.from_bytes(expr.to_bytes())):
+        assert clone._dirty_effects() == 0b111  # pylint:disable=protected-access
+    for clone in (stmt.copy(), Statement.from_bytes(stmt.to_bytes())):
+        assert clone._dirty_effects() == 0b011  # pylint:disable=protected-access
+
+
+def test_native_dirty_effect_summary_handles_deep_expression_chain():
+    root = _dirty(260, "Ifx_Write")
+    for idx in range(261, 773):
+        root = ailment.Expr.UnaryOp(idx, "Not", root, bits=64)
+
+    assert root._dirty_effects() == 0b101  # pylint:disable=protected-access
+
+
 def test_dirty_effect_classification_preserves_vex_semantics():
     pure = _dirty(0, None)
     guest_state_effect = _dirty(1, "Ifx_None")
@@ -138,6 +343,93 @@ def test_dirty_effect_search_recurses_through_nonmatching_dirty_fields():
     assert not is_effectful_dirty_expression(roots[1])
 
 
+def test_clean_rust_expressions_skip_python_dirty_effect_walker(monkeypatch):
+    vvar = ailment.Expr.VirtualVariable(14, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    expressions = (
+        ailment.Expr.Const(15, 1, 64),
+        ailment.Expr.Tmp(16, 0, 64),
+        ailment.Expr.Register(17, 16, 64),
+        ailment.Expr.ComboRegister(
+            18,
+            [ailment.Expr.Register(19, 16, 32), ailment.Expr.Register(20, 20, 32)],
+        ),
+        ailment.Expr.Phi(21, 64, [((0x1000, 0), vvar)]),
+        vvar,
+        ailment.Expr.StringLiteral(22, "clean", 40),
+        ailment.Expr.VEXCCallExpression(23, "clean_helper", [ailment.Expr.Const(24, 0, 64)], 64),
+    )
+    assert all(expr.depth == 0 for expr in expressions)
+
+    def unexpected_finder(_memory_effects):
+        raise AssertionError("Rust expression constructed a Python dirty-effect walker")
+
+    monkeypatch.setattr(ailment_utils, "_EffectfulDirtyExpressionFinder", unexpected_finder)
+    for query in (has_effectful_dirty_expression, has_dirty_memory_read, has_dirty_memory_write):
+        assert all(not query(expr) for expr in expressions)
+
+
+def test_clean_rust_statements_skip_python_dirty_effect_walker(monkeypatch):
+    addr = ailment.Expr.Const(25, 0x3000, 64)
+    value = ailment.Expr.Const(26, 0, 32)
+    register = ailment.Expr.Register(27, 16, 32)
+    statements = (
+        ailment.Stmt.Assignment(28, register, value),
+        ailment.Stmt.WeakAssignment(29, register, value),
+        ailment.Stmt.Label(30, "clean"),
+        ailment.Stmt.Store(31, addr, value, 4, "Iend_LE", guard=ailment.Expr.Const(32, 1, 1)),
+        ailment.Stmt.Jump(33, addr),
+        ailment.Stmt.ConditionalJump(34, ailment.Expr.Const(35, 1, 1), addr, addr),
+        ailment.Stmt.SideEffectStatement(36, value, ret_expr=register, fp_ret_expr=register),
+        ailment.Stmt.Return(37, [value]),
+        ailment.Stmt.CAS(38, addr, value, value, value, value, register, register, "Iend_LE"),
+        ailment.Stmt.NoOp(39),
+    )
+    assert all(stmt.depth == 1 for stmt in statements if not isinstance(stmt, (ailment.Stmt.Label, ailment.Stmt.NoOp)))
+
+    def unexpected_finder(_memory_effects):
+        raise AssertionError("Rust statement constructed a Python dirty-effect walker")
+
+    monkeypatch.setattr(ailment_utils, "_EffectfulDirtyExpressionFinder", unexpected_finder)
+    for query in (has_effectful_dirty_expression, has_dirty_memory_read, has_dirty_memory_write):
+        assert all(not query(stmt) for stmt in statements)
+
+
+def _dirty_hidden_statement_roots():
+    addr = ailment.Expr.Const(50, 0x3000, 64)
+    value = ailment.Expr.Const(51, 0, 32)
+    register = ailment.Expr.Register(52, 16, 32)
+    condition = ailment.Expr.Const(53, 1, 1)
+    return (
+        ailment.Stmt.Store(54, addr, value, 4, "Iend_LE", guard=_dirty(55, "Ifx_Write", bits=1)),
+        ailment.Stmt.ConditionalJump(56, condition, _dirty(57, "Ifx_Write"), addr),
+        ailment.Stmt.ConditionalJump(58, condition, addr, _dirty(59, "Ifx_Write")),
+        ailment.Stmt.CAS(64, addr, value, _dirty(65, "Ifx_Write", bits=32), value, None, register, None, "Iend_LE"),
+        ailment.Stmt.CAS(66, addr, value, None, value, _dirty(67, "Ifx_Write", bits=32), register, None, "Iend_LE"),
+        ailment.Stmt.CAS(68, addr, value, None, value, None, register, _dirty(69, "Ifx_Write", bits=32), "Iend_LE"),
+    )
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    _dirty_hidden_statement_roots(),
+    ids=("store-guard", "cjump-true", "cjump-false", "cas-data", "cas-expected", "cas-old"),
+)
+def test_native_statement_summary_checks_hidden_evaluated_slots(stmt):
+    assert stmt.depth == 1
+    assert has_effectful_dirty_expression(stmt)
+    assert has_dirty_memory_write(stmt)
+
+
+def test_dirty_effect_queries_accept_python_statement_subclasses():
+    from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
+
+    stmt = IncompleteSwitchCaseHeadStatement(70, ailment.Expr.Const(71, 0, 32), [])
+    assert isinstance(stmt, Statement)
+    assert not has_effectful_dirty_expression(stmt)
+    assert not has_dirty_memory_read(stmt)
+    assert not has_dirty_memory_write(stmt)
+
+
 def _dirty_evaluated_slot_roots():
     addr = ailment.Expr.Const(30, 0x3000, 64)
     guard = ailment.Expr.Const(31, 1, 1)
@@ -196,6 +488,7 @@ def _dirty_evaluated_slot_roots():
     ids=("load-guard", "load-alt", "binary-rounding", "convert-rounding", "let-def", "let-src"),
 )
 def test_dirty_effect_search_covers_all_evaluated_child_slots(root):
+    assert root.depth > 0
     assert has_effectful_dirty_expression(root)
     assert has_dirty_memory_write(root)
 

--- a/tests/analyses/decompiler/test_dirty_effect_core_safety.py
+++ b/tests/analyses/decompiler/test_dirty_effect_core_safety.py
@@ -6,6 +6,7 @@ import pytest
 import angr
 from angr import ailment
 from angr.ailment.expression import DirtyExpression, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import Statement
 from angr.ailment.utils import (
     has_dirty_memory_read,
     has_dirty_memory_write,
@@ -137,6 +138,85 @@ def test_dirty_effect_search_recurses_through_nonmatching_dirty_fields():
     assert not is_effectful_dirty_expression(roots[1])
 
 
+def _dirty_evaluated_slot_roots():
+    addr = ailment.Expr.Const(30, 0x3000, 64)
+    guard = ailment.Expr.Const(31, 1, 1)
+    value = ailment.Expr.Const(32, 0, 32)
+    return (
+        ailment.Expr.Load(
+            33,
+            addr,
+            4,
+            "Iend_LE",
+            guard=_dirty(34, "Ifx_Write", maddr=addr, bits=1),
+            alt=value,
+        ),
+        ailment.Expr.Load(
+            35,
+            addr,
+            4,
+            "Iend_LE",
+            guard=guard,
+            alt=_dirty(36, "Ifx_Write", maddr=addr, bits=32),
+        ),
+        ailment.Expr.BinaryOp(
+            37,
+            "Add",
+            (value, value),
+            bits=32,
+            floating_point=True,
+            rounding_mode=_dirty(38, "Ifx_Write", maddr=addr, bits=32),
+        ),
+        ailment.Expr.Convert(
+            39,
+            32,
+            64,
+            False,
+            value,
+            rounding_mode=_dirty(40, "Ifx_Write", maddr=addr, bits=32),
+        ),
+        ailment.Expr.Let(
+            41,
+            [
+                ailment.Stmt.Assignment(
+                    42,
+                    ailment.Expr.Tmp(43, 0, 32),
+                    _dirty(44, "Ifx_Write", maddr=addr, bits=32),
+                )
+            ],
+            value,
+        ),
+        ailment.Expr.Let(45, [], _dirty(46, "Ifx_Write", maddr=addr, bits=32)),
+    )
+
+
+@pytest.mark.parametrize(
+    "root",
+    _dirty_evaluated_slot_roots(),
+    ids=("load-guard", "load-alt", "binary-rounding", "convert-rounding", "let-def", "let-src"),
+)
+def test_dirty_effect_search_covers_all_evaluated_child_slots(root):
+    assert has_effectful_dirty_expression(root)
+    assert has_dirty_memory_write(root)
+
+    with pytest.raises(HasCallNotification):
+        HasCallExprWalker().walk_expression(root)
+
+
+def test_has_call_walker_covers_evaluated_load_alt():
+    root = ailment.Expr.Load(
+        47,
+        ailment.Expr.Const(48, 0x3000, 64),
+        4,
+        "Iend_LE",
+        guard=ailment.Expr.Const(49, 1, 1),
+        alt=ailment.Expr.Call(50, "fallback", args=[], bits=32),
+    )
+
+    with pytest.raises(HasCallNotification):
+        HasCallExprWalker().walk_expression(root)
+
+
 def test_has_call_walker_treats_ifx_none_and_nested_dirty_as_effects():
     walker = HasCallExprWalker()
     walker.walk_expression(_dirty(20, None))
@@ -149,6 +229,42 @@ def test_has_call_walker_treats_ifx_none_and_nested_dirty_as_effects():
 
     with pytest.raises(HasCallNotification):
         walker.walk_expression(_dirty(24, None, operands=(_dirty(25, "Ifx_Write"),)))
+
+
+def test_lifted_cpuid_and_memory_fence_preserve_converter_effect_metadata():
+    project = angr.load_shellcode(b"\x0f\xa2\xc3", "AMD64", load_address=0x1000)
+    manager = ailment.Manager(arch=project.arch)
+    vex_block = project.factory.block(0x1000, size=2, opt_level=0).vex
+    block = ailment.IRSBConverter.convert(vex_block, manager)
+    dirty_statements = [stmt for stmt in block.statements if isinstance(stmt, ailment.Stmt.DirtyStatement)]
+    dirty_pairs: list[tuple[Statement, DirtyExpression]] = []
+    for stmt in dirty_statements:
+        dirty = stmt.dirty
+        assert isinstance(dirty, DirtyExpression)
+        dirty_pairs.append((stmt, dirty))
+
+    cpuid_stmt, cpuid = next(pair for pair in dirty_pairs if pair[1].callee.startswith("amd64g_dirtyhelper_CPUID"))
+    fence_stmt, fence = next(pair for pair in dirty_pairs if pair[1].callee.startswith("MBusEvent-"))
+    assert cpuid.mfx == "Ifx_None"
+    assert has_effectful_dirty_expression(cpuid_stmt)
+    assert not has_dirty_memory_read(cpuid_stmt)
+    assert not has_dirty_memory_write(cpuid_stmt)
+    assert fence.callee.startswith("MBusEvent-")
+    assert fence.mfx is None
+    assert has_effectful_dirty_expression(fence_stmt)
+    assert has_dirty_memory_read(fence_stmt)
+    assert has_dirty_memory_write(fence_stmt)
+
+    simplified = BlockSimplifier(project, block, manager, peephole_optimizations=[]).result_block
+    assert simplified is not None
+    simplified_effects = set()
+    for stmt in simplified.statements:
+        if isinstance(stmt, ailment.Stmt.DirtyStatement):
+            dirty = stmt.dirty
+            assert isinstance(dirty, DirtyExpression)
+            simplified_effects.add((dirty.callee, dirty.mfx))
+    assert (cpuid.callee, "Ifx_None") in simplified_effects
+    assert (fence.callee, None) in simplified_effects
 
 
 @pytest.mark.parametrize("dst_kind", ("tmp", "register"))
@@ -452,6 +568,130 @@ def test_spropagator_tmp_load_crosses_reads_but_not_dirty_writes(mfx, expected_r
     assert _has_replacement(propagator, (tmp_use,)) is expected_replacement
 
 
+@pytest.mark.parametrize("mfx", ("Ifx_Write", "Ifx_Modify", None))
+def test_spropagator_same_instruction_dirty_write_still_blocks_tmp_load(mfx):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    tmp_def = ailment.Expr.Tmp(1, 0, 32)
+    tmp_use = ailment.Expr.Tmp(2, 0, 32)
+    dirty_stmt = ailment.Stmt.DirtyStatement(
+        3,
+        _dirty(4, mfx, maddr=addr if mfx is not None else None),
+        ins_addr=0x1000,
+    )
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(
+                5,
+                tmp_def,
+                ailment.Expr.Load(6, addr, 4, "Iend_LE"),
+                ins_addr=0x1000,
+            ),
+            dirty_stmt,
+            ailment.Stmt.Assignment(7, ailment.Expr.Register(8, 16, 32), tmp_use, ins_addr=0x1000),
+        ],
+        idx=0,
+    )
+
+    propagator = SPropagator(project, subject=block, ail_manager=manager)
+    assert not _has_replacement(propagator, (tmp_use,))
+
+
+def test_spropagator_keeps_same_instruction_store_exemption_for_tmp_load():
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    tmp_def = ailment.Expr.Tmp(1, 0, 32)
+    tmp_use = ailment.Expr.Tmp(2, 0, 32)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(
+                3,
+                tmp_def,
+                ailment.Expr.Load(4, addr, 4, "Iend_LE"),
+                ins_addr=0x1000,
+            ),
+            ailment.Stmt.Store(
+                5,
+                addr,
+                ailment.Expr.Const(6, 1, 32),
+                4,
+                "Iend_LE",
+                ins_addr=0x1000,
+            ),
+            ailment.Stmt.Assignment(7, ailment.Expr.Register(8, 16, 32), tmp_use, ins_addr=0x1000),
+        ],
+        idx=0,
+    )
+
+    propagator = SPropagator(project, subject=block, ail_manager=manager)
+    assert _has_replacement(propagator, (tmp_use,))
+
+
+def test_spropagator_propagates_untagged_tmp_load_without_memory_write():
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    tmp_def = ailment.Expr.Tmp(1, 0, 32)
+    tmp_use = ailment.Expr.Tmp(2, 0, 32)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(3, tmp_def, ailment.Expr.Load(4, addr, 4, "Iend_LE")),
+            ailment.Stmt.Assignment(5, ailment.Expr.Register(6, 16, 32), tmp_use),
+        ],
+        idx=0,
+    )
+
+    propagator = SPropagator(project, subject=block, ail_manager=manager)
+    assert _has_replacement(propagator, (tmp_use,))
+
+
+@pytest.mark.parametrize(
+    "endpoint_ins_addr, store_ins_addr",
+    ((None, None), (0x1000, None), (0x1000, 0x1001)),
+)
+def test_spropagator_does_not_exempt_untagged_or_different_instruction_store(endpoint_ins_addr, store_ins_addr):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    tmp_def = ailment.Expr.Tmp(1, 0, 32)
+    tmp_use = ailment.Expr.Tmp(2, 0, 32)
+    endpoint_tags = {} if endpoint_ins_addr is None else {"ins_addr": endpoint_ins_addr}
+    store_tags = {} if store_ins_addr is None else {"ins_addr": store_ins_addr}
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(
+                3,
+                tmp_def,
+                ailment.Expr.Load(4, addr, 4, "Iend_LE"),
+                **endpoint_tags,
+            ),
+            ailment.Stmt.Store(
+                5,
+                addr,
+                ailment.Expr.Const(6, 1, 32),
+                4,
+                "Iend_LE",
+                **store_tags,
+            ),
+            ailment.Stmt.Assignment(7, ailment.Expr.Register(8, 16, 32), tmp_use, **endpoint_tags),
+        ],
+        idx=0,
+    )
+
+    propagator = SPropagator(project, subject=block, ail_manager=manager)
+    assert not _has_replacement(propagator, (tmp_use,))
+
+
 def test_spropagator_does_not_move_tmp_load_past_dirty_write_in_use_mse():
     project = _project()
     manager = ailment.Manager(arch=project.arch)
@@ -491,7 +731,7 @@ def test_spropagator_function_load_crosses_reads_but_not_dirty_writes(mfx, expec
     vvar_uses = [
         VirtualVariable(idx + 2, 1, 32, VirtualVariableCategory.REGISTER, oident=16) for idx in range(use_count)
     ]
-    statements = [
+    statements: list[Statement] = [
         ailment.Stmt.Assignment(
             10,
             vvar_def,
@@ -519,7 +759,7 @@ def test_spropagator_does_not_move_function_load_past_dirty_write_in_use_mse(use
     vvar_uses = [
         VirtualVariable(idx + 2, 1, 32, VirtualVariableCategory.REGISTER, oident=16) for idx in range(use_count)
     ]
-    statements = [
+    statements: list[Statement] = [
         ailment.Stmt.Assignment(
             10,
             vvar_def,

--- a/tests/analyses/decompiler/test_dirty_effect_core_safety.py
+++ b/tests/analyses/decompiler/test_dirty_effect_core_safety.py
@@ -13,6 +13,7 @@ from angr.ailment.utils import (
     is_effectful_dirty_expression,
 )
 from angr.analyses.decompiler.ail_simplifier import AILSimplifier
+from angr.analyses.decompiler.block_simplifier import BlockSimplifier
 from angr.analyses.decompiler.block_walkers import HasCallExprWalker, HasCallNotification
 from angr.analyses.s_propagator import SPropagator
 from angr.analyses.s_reaching_definitions import SRDAModel
@@ -148,6 +149,117 @@ def test_has_call_walker_treats_ifx_none_and_nested_dirty_as_effects():
 
     with pytest.raises(HasCallNotification):
         walker.walk_expression(_dirty(24, None, operands=(_dirty(25, "Ifx_Write"),)))
+
+
+@pytest.mark.parametrize("dst_kind", ("tmp", "register"))
+def test_block_simplifier_preserves_unused_ifx_none_dirty_assignment(dst_kind):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    dst = ailment.Expr.Tmp(0, 0, 64) if dst_kind == "tmp" else ailment.Expr.Register(0, 16, 64)
+    effect = _dirty(1, "Ifx_None")
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(2, dst, effect, ins_addr=0x1000),
+            ailment.Stmt.Return(3, [], ins_addr=0x1001),
+        ],
+        idx=0,
+    )
+
+    simplified = BlockSimplifier(project, block, manager, peephole_optimizations=[]).result_block
+
+    assert simplified is not None
+    assert any(
+        isinstance(stmt, ailment.Stmt.Assignment)
+        and isinstance(stmt.src, DirtyExpression)
+        and stmt.src.callee == effect.callee
+        for stmt in simplified.statements
+    )
+
+
+def test_block_simplifier_preserves_unused_mse_with_opaque_dirty_statement():
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    opaque_stmt = ailment.Stmt.DirtyStatement(0, _dirty(1, None), ins_addr=0x1000)
+    mse = ailment.Expr.MultiStatementExpression(2, [opaque_stmt], ailment.Expr.Const(3, 0, 64))
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(4, ailment.Expr.Tmp(5, 0, 64), mse, ins_addr=0x1000),
+            ailment.Stmt.Return(6, [], ins_addr=0x1001),
+        ],
+        idx=0,
+    )
+
+    simplified = BlockSimplifier(project, block, manager, peephole_optimizations=[]).result_block
+
+    assert simplified is not None
+    assert any(
+        isinstance(stmt, ailment.Stmt.Assignment) and isinstance(stmt.src, ailment.Expr.MultiStatementExpression)
+        for stmt in simplified.statements
+    )
+
+
+def test_block_simplifier_removes_unused_pure_dirty_expression():
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    pure = _dirty(0, None)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(1, ailment.Expr.Tmp(2, 0, 64), pure, ins_addr=0x1000),
+            ailment.Stmt.Return(3, [], ins_addr=0x1001),
+        ],
+        idx=0,
+    )
+
+    simplified = BlockSimplifier(project, block, manager, peephole_optimizations=[]).result_block
+
+    assert simplified is not None
+    assert not any(
+        isinstance(stmt, ailment.Stmt.Assignment)
+        and isinstance(stmt.src, DirtyExpression)
+        and stmt.src.callee == pure.callee
+        for stmt in simplified.statements
+    )
+
+
+def test_block_simplifier_propagates_pure_dirty_expression():
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    tmp_def = ailment.Expr.Tmp(0, 0, 64)
+    tmp_use = ailment.Expr.Tmp(1, 0, 64)
+    pure = _dirty(2, None)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(3, tmp_def, pure, ins_addr=0x1000),
+            ailment.Stmt.Assignment(4, ailment.Expr.Register(5, 16, 64), tmp_use, ins_addr=0x1001),
+            ailment.Stmt.Return(6, [], ins_addr=0x1002),
+        ],
+        idx=0,
+    )
+
+    simplified = BlockSimplifier(project, block, manager, peephole_optimizations=[]).result_block
+
+    assert simplified is not None
+    assert not any(
+        isinstance(stmt, ailment.Stmt.Assignment)
+        and isinstance(stmt.dst, ailment.Expr.Tmp)
+        and stmt.dst.tmp_idx == tmp_def.tmp_idx
+        for stmt in simplified.statements
+    )
+    assert any(
+        isinstance(stmt, ailment.Stmt.Assignment)
+        and isinstance(stmt.dst, ailment.Expr.Register)
+        and isinstance(stmt.src, DirtyExpression)
+        and stmt.src.callee == pure.callee
+        for stmt in simplified.statements
+    )
 
 
 @pytest.mark.parametrize("source_kind", ("pure", "nested_dirty", "converted_dirty", "dirty_statement_mse"))

--- a/tests/analyses/decompiler/test_dirty_effect_core_safety.py
+++ b/tests/analyses/decompiler/test_dirty_effect_core_safety.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import networkx
+import pytest
+
+import angr
+from angr import ailment
+from angr.ailment.expression import DirtyExpression, VirtualVariable, VirtualVariableCategory
+from angr.ailment.utils import (
+    has_dirty_memory_read,
+    has_dirty_memory_write,
+    has_effectful_dirty_expression,
+    is_effectful_dirty_expression,
+)
+from angr.analyses.decompiler.ail_simplifier import AILSimplifier
+from angr.analyses.decompiler.block_walkers import HasCallExprWalker, HasCallNotification
+from angr.analyses.s_propagator import SPropagator
+from angr.analyses.s_reaching_definitions import SRDAModel
+from angr.code_location import AILCodeLocation
+
+
+def _project():
+    return angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+
+
+def _dirty(
+    idx: int,
+    mfx: str | None,
+    *,
+    operands=(),
+    guard=None,
+    maddr=None,
+    bits: int = 64,
+) -> DirtyExpression:
+    return DirtyExpression(
+        idx,
+        f"helper_{idx}",
+        list(operands),
+        guard=guard,
+        mfx=mfx,
+        maddr=maddr,
+        msize=8 if maddr is not None else None,
+        bits=bits,
+    )
+
+
+def _has_replacement(propagator: SPropagator, expressions) -> bool:
+    return any(expr in replacements for replacements in propagator.replacements.values() for expr in expressions)
+
+
+def _function_propagator(project, block: ailment.Block, manager: ailment.Manager) -> SPropagator:
+    function = project.kb.functions.function(addr=block.addr, create=True)
+    assert function is not None
+    graph = networkx.DiGraph()
+    graph.add_node(block)
+    return SPropagator(project, subject=function, func_graph=graph, ail_manager=manager)
+
+
+def test_dirty_effect_classification_preserves_vex_semantics():
+    pure = _dirty(0, None)
+    guest_state_effect = _dirty(1, "Ifx_None")
+    read = _dirty(2, "Ifx_Read")
+    write = _dirty(3, "Ifx_Write")
+    modify = _dirty(4, "Ifx_Modify")
+
+    assert not is_effectful_dirty_expression(pure)
+    assert is_effectful_dirty_expression(guest_state_effect)
+    assert has_effectful_dirty_expression(guest_state_effect)
+    assert not has_dirty_memory_read(guest_state_effect)
+    assert not has_dirty_memory_write(guest_state_effect)
+
+    assert has_dirty_memory_read(read)
+    assert not has_dirty_memory_write(read)
+    assert not has_dirty_memory_read(write)
+    assert has_dirty_memory_write(write)
+    assert has_dirty_memory_read(modify)
+    assert has_dirty_memory_write(modify)
+
+
+def test_dirty_effect_search_recurses_through_nonmatching_dirty_fields():
+    nested_write = _dirty(10, "Ifx_Write")
+    roots = (
+        _dirty(11, "Ifx_Read", operands=(nested_write,)),
+        _dirty(12, None, guard=nested_write),
+        _dirty(13, "Ifx_None", maddr=nested_write),
+    )
+
+    for root in roots:
+        assert has_effectful_dirty_expression(root)
+        assert has_dirty_memory_write(root)
+
+    assert not is_effectful_dirty_expression(roots[1])
+
+
+def test_has_call_walker_treats_ifx_none_and_nested_dirty_as_effects():
+    walker = HasCallExprWalker()
+    walker.walk_expression(_dirty(20, None))
+
+    with pytest.raises(HasCallNotification):
+        walker.walk_expression(_dirty(21, "Ifx_None"))
+
+    with pytest.raises(HasCallNotification):
+        walker.walk_expression(_dirty(22, None, operands=(_dirty(23, "Ifx_Write"),)))
+
+
+@pytest.mark.parametrize("nested_effectful", (False, True))
+def test_effectful_dirty_definition_protects_entire_cyclic_vvar_component(nested_effectful):
+    project = _project()
+    vvar_1_def = VirtualVariable(0, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_1_use = VirtualVariable(1, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_2_def = VirtualVariable(2, 2, 64, VirtualVariableCategory.REGISTER, oident=24)
+    vvar_2_use = VirtualVariable(3, 2, 64, VirtualVariableCategory.REGISTER, oident=24)
+
+    operands = [vvar_2_use]
+    if nested_effectful:
+        operands.append(_dirty(4, "Ifx_None"))
+    dirty = _dirty(5, None, operands=operands)
+    phi = ailment.Expr.Phi(6, 64, [((0x1000, 0), vvar_1_use)])
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(7, vvar_1_def, dirty),
+            ailment.Stmt.Assignment(8, vvar_2_def, phi),
+        ],
+        idx=0,
+    )
+    graph = networkx.DiGraph()
+    graph.add_node(block)
+
+    rd = SRDAModel(graph, None, project.arch)
+    rd.varid_to_vvar = {1: vvar_1_def, 2: vvar_2_def}
+    rd.phi_vvar_ids = {2}
+    rd.phivarid_to_varids = {2: {1}}
+    rd.all_vvar_uses[1].append((vvar_1_use, AILCodeLocation(block.addr, block.idx, 1)))
+    rd.all_vvar_uses[2].append((vvar_2_use, AILCodeLocation(block.addr, block.idx, 0)))
+
+    simplifier = object.__new__(AILSimplifier)
+    simplifier.func_graph = graph
+    removable = simplifier._find_cyclic_dependent_phis_and_dirty_vvars(rd, set())
+
+    assert removable == (set() if nested_effectful else {1, 2})
+
+
+def test_spropagator_guards_forced_stack_and_independent_vvar_paths():
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+
+    stack_def = VirtualVariable(0, 1, 64, VirtualVariableCategory.STACK, oident=-8)
+    stack_use = VirtualVariable(1, 1, 64, VirtualVariableCategory.STACK, oident=-8)
+    stack_block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(2, stack_def, _dirty(3, "Ifx_None"), ins_addr=0x1000),
+            ailment.Stmt.Return(4, [stack_use], ins_addr=0x1001),
+        ],
+        idx=0,
+    )
+    stack_prop = SPropagator(
+        project,
+        subject=stack_block,
+        ail_manager=manager,
+        stack_arg_offsets={-8},
+    )
+    assert not _has_replacement(stack_prop, (stack_use,))
+
+    vvar_def = VirtualVariable(5, 2, 64, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_use_0 = VirtualVariable(6, 2, 64, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_use_1 = VirtualVariable(7, 2, 64, VirtualVariableCategory.REGISTER, oident=16)
+    nested_effect = _dirty(8, None, operands=(_dirty(9, "Ifx_Write"),))
+    vvar_block = ailment.Block(
+        0x2000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(10, vvar_def, nested_effect, ins_addr=0x2000),
+            ailment.Stmt.ConditionalJump(
+                11,
+                vvar_use_0,
+                ailment.Expr.Const(12, 0x2000, 64),
+                ailment.Expr.Const(13, 0x3000, 64),
+                true_target_idx=0,
+                ins_addr=0x2001,
+            ),
+            ailment.Stmt.Jump(14, vvar_use_1, ins_addr=0x2002),
+        ],
+        idx=0,
+    )
+    vvar_prop = _function_propagator(project, vvar_block, manager)
+    assert not _has_replacement(vvar_prop, (vvar_use_0, vvar_use_1))
+    assert vvar_def.varid not in vvar_prop.dead_vvar_ids
+
+
+def test_spropagator_does_not_propagate_effectful_dirty_tmp():
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    tmp_def = ailment.Expr.Tmp(0, 0, 64)
+    tmp_use = ailment.Expr.Tmp(1, 0, 64)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(2, tmp_def, _dirty(3, "Ifx_None"), ins_addr=0x1000),
+            ailment.Stmt.Assignment(4, ailment.Expr.Register(5, 16, 64), tmp_use, ins_addr=0x1001),
+        ],
+        idx=0,
+    )
+
+    propagator = SPropagator(project, subject=block, ail_manager=manager)
+    assert not _has_replacement(propagator, (tmp_use,))
+
+
+@pytest.mark.parametrize("mfx, expected_replacement", (("Ifx_Read", True), ("Ifx_Write", False)))
+def test_spropagator_tmp_load_crosses_reads_but_not_dirty_writes(mfx, expected_replacement):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    tmp_def = ailment.Expr.Tmp(1, 0, 32)
+    tmp_use = ailment.Expr.Tmp(2, 0, 32)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(
+                3,
+                tmp_def,
+                ailment.Expr.Load(4, addr, 4, "Iend_LE"),
+                ins_addr=0x1000,
+            ),
+            ailment.Stmt.Assignment(
+                5,
+                ailment.Expr.Tmp(6, 1, 64),
+                _dirty(7, mfx, maddr=addr),
+                ins_addr=0x1001,
+            ),
+            ailment.Stmt.Assignment(8, ailment.Expr.Register(9, 16, 32), tmp_use, ins_addr=0x1002),
+        ],
+        idx=0,
+    )
+
+    propagator = SPropagator(project, subject=block, ail_manager=manager)
+    assert _has_replacement(propagator, (tmp_use,)) is expected_replacement
+
+
+@pytest.mark.parametrize("use_count", (1, 3))
+@pytest.mark.parametrize("mfx, expected_replacement", (("Ifx_Read", True), ("Ifx_Modify", False)))
+def test_spropagator_function_load_crosses_reads_but_not_dirty_writes(mfx, expected_replacement, use_count):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    vvar_def = VirtualVariable(1, 1, 32, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_uses = [
+        VirtualVariable(idx + 2, 1, 32, VirtualVariableCategory.REGISTER, oident=16) for idx in range(use_count)
+    ]
+    statements = [
+        ailment.Stmt.Assignment(
+            10,
+            vvar_def,
+            ailment.Expr.Load(11, addr, 4, "Iend_LE"),
+            ins_addr=0x1000,
+        ),
+        ailment.Stmt.Assignment(
+            12,
+            ailment.Expr.Tmp(13, 0, 64),
+            _dirty(14, mfx, maddr=addr),
+            ins_addr=0x1001,
+        ),
+    ]
+    statements.extend(
+        ailment.Stmt.Assignment(20 + idx, ailment.Expr.Register(30 + idx, 24 + idx * 4, 32), use, ins_addr=0x1002 + idx)
+        for idx, use in enumerate(vvar_uses)
+    )
+    block = ailment.Block(0x1000, 1, statements=statements, idx=0)
+
+    propagator = _function_propagator(project, block, manager)
+    assert _has_replacement(propagator, vvar_uses) is expected_replacement

--- a/tests/analyses/decompiler/test_dirty_effect_core_safety.py
+++ b/tests/analyses/decompiler/test_dirty_effect_core_safety.py
@@ -17,6 +17,7 @@ from angr.ailment.utils import (
 from angr.analyses.decompiler.ail_simplifier import AILSimplifier
 from angr.analyses.decompiler.block_simplifier import BlockSimplifier
 from angr.analyses.decompiler.block_walkers import HasCallExprWalker, HasCallNotification
+from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
 from angr.analyses.s_propagator import SPropagator
 from angr.analyses.s_reaching_definitions import SRDAModel
 from angr.code_location import AILCodeLocation
@@ -421,8 +422,6 @@ def test_native_statement_summary_checks_hidden_evaluated_slots(stmt):
 
 
 def test_dirty_effect_queries_accept_python_statement_subclasses():
-    from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
-
     stmt = IncompleteSwitchCaseHeadStatement(70, ailment.Expr.Const(71, 0, 32), [])
     assert isinstance(stmt, Statement)
     assert not has_effectful_dirty_expression(stmt)
@@ -711,7 +710,7 @@ def test_effectful_dirty_definition_protects_entire_cyclic_vvar_component(source
 
     simplifier = object.__new__(AILSimplifier)
     simplifier.func_graph = graph
-    removable = simplifier._find_cyclic_dependent_phis_and_dirty_vvars(rd, set())
+    removable = simplifier._find_cyclic_dependent_phis_and_dirty_vvars(rd, set())  # pylint:disable=protected-access
 
     assert removable == ({1, 2} if source_kind == "pure" else set())
 

--- a/tests/analyses/decompiler/test_dirty_effect_core_safety.py
+++ b/tests/analyses/decompiler/test_dirty_effect_core_safety.py
@@ -57,14 +57,20 @@ def _function_propagator(project, block: ailment.Block, manager: ailment.Manager
 
 
 def _intervening_dirty_statement(idx: int, mfx: str | None, addr):
-    if mfx is None:
-        return ailment.Stmt.DirtyStatement(idx, _dirty(idx + 1, None), ins_addr=0x1001)
-    return ailment.Stmt.Assignment(
+    return ailment.Stmt.DirtyStatement(
         idx,
-        ailment.Expr.Tmp(idx + 1, 100 + idx, 64),
-        _dirty(idx + 2, mfx, maddr=addr),
+        _dirty(idx + 1, mfx, maddr=addr if mfx is not None else None),
         ins_addr=0x1001,
     )
+
+
+def _mse_use_with_dirty_write(idx: int, use, addr):
+    write = ailment.Stmt.DirtyStatement(
+        idx,
+        _dirty(idx + 1, "Ifx_Write", maddr=addr),
+        ins_addr=0x1001,
+    )
+    return ailment.Expr.MultiStatementExpression(idx + 2, [write], use)
 
 
 def test_dirty_effect_classification_preserves_vex_semantics():
@@ -91,14 +97,28 @@ def test_dirty_effect_classification_preserves_vex_semantics():
     assert has_dirty_memory_write(modify)
 
     opaque_stmt = ailment.Stmt.DirtyStatement(5, pure)
-    assert has_effectful_dirty_expression(opaque_stmt)
-    assert has_dirty_memory_read(opaque_stmt)
-    assert has_dirty_memory_write(opaque_stmt)
-
     nested_stmt = ailment.Expr.MultiStatementExpression(6, [opaque_stmt], ailment.Expr.Const(7, 0, 64))
     assert has_effectful_dirty_expression(nested_stmt)
     assert has_dirty_memory_read(nested_stmt)
     assert has_dirty_memory_write(nested_stmt)
+
+
+@pytest.mark.parametrize(
+    "mfx, expected_read, expected_write",
+    (
+        (None, True, True),
+        ("Ifx_None", False, False),
+        ("Ifx_Read", True, False),
+        ("Ifx_Write", False, True),
+        ("Ifx_Modify", True, True),
+    ),
+)
+def test_dirty_statement_memory_effect_truth_table(mfx, expected_read, expected_write):
+    stmt = ailment.Stmt.DirtyStatement(8, _dirty(9, mfx))
+
+    assert has_effectful_dirty_expression(stmt)
+    assert has_dirty_memory_read(stmt) is expected_read
+    assert has_dirty_memory_write(stmt) is expected_write
 
 
 def test_dirty_effect_search_recurses_through_nonmatching_dirty_fields():
@@ -130,25 +150,31 @@ def test_has_call_walker_treats_ifx_none_and_nested_dirty_as_effects():
         walker.walk_expression(_dirty(24, None, operands=(_dirty(25, "Ifx_Write"),)))
 
 
-@pytest.mark.parametrize("nested_effectful", (False, True))
-def test_effectful_dirty_definition_protects_entire_cyclic_vvar_component(nested_effectful):
+@pytest.mark.parametrize("source_kind", ("pure", "nested_dirty", "converted_dirty", "dirty_statement_mse"))
+def test_effectful_dirty_definition_protects_entire_cyclic_vvar_component(source_kind):
     project = _project()
     vvar_1_def = VirtualVariable(0, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
     vvar_1_use = VirtualVariable(1, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
     vvar_2_def = VirtualVariable(2, 2, 64, VirtualVariableCategory.REGISTER, oident=24)
     vvar_2_use = VirtualVariable(3, 2, 64, VirtualVariableCategory.REGISTER, oident=24)
 
-    operands = [vvar_2_use]
-    if nested_effectful:
-        operands.append(_dirty(4, "Ifx_None"))
-    dirty = _dirty(5, None, operands=operands)
+    if source_kind == "pure":
+        source = _dirty(4, None, operands=(vvar_2_use,))
+    elif source_kind == "nested_dirty":
+        source = _dirty(5, None, operands=(vvar_2_use, _dirty(6, "Ifx_None")))
+    elif source_kind == "converted_dirty":
+        inner = ailment.Expr.BinaryOp(7, "Add", [vvar_2_use, _dirty(8, "Ifx_None")], bits=64)
+        source = ailment.Expr.Convert(9, 64, 64, False, inner)
+    else:
+        opaque_stmt = ailment.Stmt.DirtyStatement(10, _dirty(11, None))
+        source = ailment.Expr.MultiStatementExpression(12, [opaque_stmt], vvar_2_use)
     phi = ailment.Expr.Phi(6, 64, [((0x1000, 0), vvar_1_use)])
     block = ailment.Block(
         0x1000,
         1,
         statements=[
-            ailment.Stmt.Assignment(7, vvar_1_def, dirty),
-            ailment.Stmt.Assignment(8, vvar_2_def, phi),
+            ailment.Stmt.Assignment(13, vvar_1_def, source),
+            ailment.Stmt.Assignment(14, vvar_2_def, phi),
         ],
         idx=0,
     )
@@ -166,7 +192,7 @@ def test_effectful_dirty_definition_protects_entire_cyclic_vvar_component(nested
     simplifier.func_graph = graph
     removable = simplifier._find_cyclic_dependent_phis_and_dirty_vvars(rd, set())
 
-    assert removable == (set() if nested_effectful else {1, 2})
+    assert removable == ({1, 2} if source_kind == "pure" else set())
 
 
 def test_spropagator_guards_forced_stack_and_independent_vvar_paths():
@@ -216,6 +242,47 @@ def test_spropagator_guards_forced_stack_and_independent_vvar_paths():
     vvar_prop = _function_propagator(project, vvar_block, manager)
     assert not _has_replacement(vvar_prop, (vvar_use_0, vvar_use_1))
     assert vvar_def.varid not in vvar_prop.dead_vvar_ids
+
+
+@pytest.mark.parametrize(
+    "mfx, expected_replacement",
+    (("Ifx_Read", True), ("Ifx_Write", False), (None, False)),
+)
+def test_spropagator_switch_path_does_not_bypass_load_memory_safety(mfx, expected_replacement):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    vvar_def = VirtualVariable(1, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_use_0 = VirtualVariable(2, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_use_1 = VirtualVariable(3, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    block = ailment.Block(
+        0x2000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(
+                4,
+                vvar_def,
+                ailment.Expr.Load(5, addr, 8, "Iend_LE"),
+                ins_addr=0x2000,
+            ),
+            _intervening_dirty_statement(6, mfx, addr),
+            ailment.Stmt.ConditionalJump(
+                8,
+                vvar_use_0,
+                ailment.Expr.Const(9, 0x2000, 64),
+                ailment.Expr.Const(10, 0x3000, 64),
+                true_target_idx=0,
+                ins_addr=0x2001,
+            ),
+            ailment.Stmt.Jump(11, vvar_use_1, ins_addr=0x2002),
+        ],
+        idx=0,
+    )
+
+    propagator = _function_propagator(project, block, manager)
+    assert _has_replacement(propagator, (vvar_use_0, vvar_use_1)) is expected_replacement
+    if not expected_replacement:
+        assert vvar_def.varid not in propagator.dead_vvar_ids
 
 
 @pytest.mark.parametrize("source_kind", ("ifx_none", "dirty_statement"))
@@ -273,6 +340,32 @@ def test_spropagator_tmp_load_crosses_reads_but_not_dirty_writes(mfx, expected_r
     assert _has_replacement(propagator, (tmp_use,)) is expected_replacement
 
 
+def test_spropagator_does_not_move_tmp_load_past_dirty_write_in_use_mse():
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    tmp_def = ailment.Expr.Tmp(1, 0, 32)
+    tmp_use = ailment.Expr.Tmp(2, 0, 32)
+    use_mse = _mse_use_with_dirty_write(3, tmp_use, addr)
+    block = ailment.Block(
+        0x1000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(
+                6,
+                tmp_def,
+                ailment.Expr.Load(7, addr, 4, "Iend_LE"),
+                ins_addr=0x1000,
+            ),
+            ailment.Stmt.Assignment(8, ailment.Expr.Register(9, 16, 32), use_mse, ins_addr=0x1001),
+        ],
+        idx=0,
+    )
+
+    propagator = SPropagator(project, subject=block, ail_manager=manager)
+    assert not _has_replacement(propagator, (tmp_use,))
+
+
 @pytest.mark.parametrize("use_count", (1, 3))
 @pytest.mark.parametrize(
     "mfx, expected_replacement",
@@ -303,3 +396,35 @@ def test_spropagator_function_load_crosses_reads_but_not_dirty_writes(mfx, expec
 
     propagator = _function_propagator(project, block, manager)
     assert _has_replacement(propagator, vvar_uses) is expected_replacement
+
+
+@pytest.mark.parametrize("use_count", (1, 3))
+def test_spropagator_does_not_move_function_load_past_dirty_write_in_use_mse(use_count):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    vvar_def = VirtualVariable(1, 1, 32, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_uses = [
+        VirtualVariable(idx + 2, 1, 32, VirtualVariableCategory.REGISTER, oident=16) for idx in range(use_count)
+    ]
+    statements = [
+        ailment.Stmt.Assignment(
+            10,
+            vvar_def,
+            ailment.Expr.Load(11, addr, 4, "Iend_LE"),
+            ins_addr=0x1000,
+        )
+    ]
+    statements.extend(
+        ailment.Stmt.Assignment(
+            20 + idx,
+            ailment.Expr.Register(30 + idx, 24 + idx * 4, 32),
+            _mse_use_with_dirty_write(40 + idx * 3, use, addr) if idx == 0 else use,
+            ins_addr=0x1001 + idx,
+        )
+        for idx, use in enumerate(vvar_uses)
+    )
+    block = ailment.Block(0x1000, 1, statements=statements, idx=0)
+
+    propagator = _function_propagator(project, block, manager)
+    assert not _has_replacement(propagator, vvar_uses)

--- a/tests/analyses/decompiler/test_dirty_expression_rewriting.py
+++ b/tests/analyses/decompiler/test_dirty_expression_rewriting.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from angr.ailment.expression import Const, DirtyExpression
+from angr.analyses.decompiler.dephication.rewriting_engine import SimEngineDephiRewriting
+from angr.analyses.decompiler.ssailification.rewriting_engine import SimEngineSSARewriting
+
+
+@pytest.mark.parametrize("engine_cls", (SimEngineSSARewriting, SimEngineDephiRewriting))
+@pytest.mark.parametrize("rewritten_fields", ({"maddr"}, {"operand"}, {"guard", "maddr"}))
+def test_dirty_rewriting_preserves_unchanged_fields(engine_cls, rewritten_fields):
+    operand = Const(0, 1, 64)
+    guard = Const(1, 1, 1)
+    maddr = Const(2, 0x4000, 64)
+    dirty = DirtyExpression(
+        3,
+        "helper",
+        [operand],
+        guard=guard,
+        mfx="Ifx_Modify",
+        maddr=maddr,
+        msize=4,
+        bits=32,
+        ins_addr=0x400000,
+    )
+    replacements = {
+        operand: Const(4, 2, 64),
+        guard: Const(5, 0, 1),
+        maddr: Const(6, 0x5000, 64),
+    }
+
+    engine = object.__new__(engine_cls)
+    engine._expr = lambda expr: (
+        replacements[expr]
+        if expr in replacements
+        and {
+            operand: "operand",
+            guard: "guard",
+            maddr: "maddr",
+        }[expr]
+        in rewritten_fields
+        else None
+    )
+
+    rewritten = engine._handle_expr_DirtyExpression(dirty)
+
+    assert rewritten is not None
+    expected_operand = replacements[operand] if "operand" in rewritten_fields else operand
+    expected_guard = replacements[guard] if "guard" in rewritten_fields else guard
+    expected_maddr = replacements[maddr] if "maddr" in rewritten_fields else maddr
+    assert rewritten.operands[0].likes(expected_operand)
+    assert rewritten.guard is not None and rewritten.guard.likes(expected_guard)
+    assert rewritten.maddr is not None and rewritten.maddr.likes(expected_maddr)
+    assert rewritten.idx == dirty.idx
+    assert rewritten.callee == dirty.callee
+    assert rewritten.mfx == dirty.mfx
+    assert rewritten.msize == dirty.msize
+    assert rewritten.bits == dirty.bits
+    assert rewritten.tags == dirty.tags

--- a/tests/analyses/decompiler/test_dirty_expression_rewriting.py
+++ b/tests/analyses/decompiler/test_dirty_expression_rewriting.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 from __future__ import annotations
 
 import pytest

--- a/tests/analyses/decompiler/test_narrowing_exprs.py
+++ b/tests/analyses/decompiler/test_narrowing_exprs.py
@@ -9,7 +9,15 @@ import os
 import unittest
 
 import angr
-from angr.ailment.expression import BinaryOp, Const, Extract, Insert, VirtualVariable, VirtualVariableCategory
+from angr.ailment.expression import (
+    BinaryOp,
+    Const,
+    DirtyExpression,
+    Extract,
+    Insert,
+    VirtualVariable,
+    VirtualVariableCategory,
+)
 from angr.ailment.statement import Assignment
 from angr.analyses.decompiler.expression_narrower import EffectiveSizeExtractor
 from tests.common import WORKER, bin_location, print_decompilation_result
@@ -20,6 +28,24 @@ l = logging.getLogger(__name__)
 
 
 class TestNarrowingExpressions(unittest.TestCase):
+    def test_dirty_memory_address_is_a_full_width_use(self):
+        maddr = VirtualVariable(0, 44, 64, VirtualVariableCategory.REGISTER, oident=16)
+        dirty = DirtyExpression(
+            1,
+            "helper",
+            [],
+            mfx="Ifx_Read",
+            maddr=maddr,
+            msize=1,
+            bits=8,
+        )
+        dst = VirtualVariable(2, 48, 8, VirtualVariableCategory.REGISTER, oident=24)
+
+        walker = EffectiveSizeExtractor()
+        walker.walk_statement(Assignment(3, dst, dirty))
+
+        assert walker.vvar_effective_bits[44][maddr.idx] == (0, 64)
+
     def test_insert_base_is_a_full_width_use(self):
         # the base of an Insert is consumed at full width: every byte outside the inserted range is
         # preserved into the result. EffectiveSizeExtractor used to skip the base entirely, so a vvar

--- a/tests/analyses/decompiler/test_spropagator_dirty_query_cache.py
+++ b/tests/analyses/decompiler/test_spropagator_dirty_query_cache.py
@@ -108,7 +108,7 @@ def test_effectful_assignment_source_query_is_cached_per_spropagator(monkeypatch
 
     first = _function_propagator(project, block, manager)
     assert calls == 1
-    cached_stmt, cached_result = first._effectful_assignment_src_cache[id(defining_stmt)]
+    cached_stmt, cached_result = first._effectful_assignment_src_cache[id(defining_stmt)]  # pylint:disable=protected-access
     assert cached_stmt is defining_stmt
     assert cached_result is (mfx is not None)
     assert _has_replacement(first, vvar_uses) is expected_replacement
@@ -117,7 +117,7 @@ def test_effectful_assignment_source_query_is_cached_per_spropagator(monkeypatch
 
     second = _function_propagator(project, block, manager)
     assert calls == 2
-    second_cached_stmt, second_cached_result = second._effectful_assignment_src_cache[id(defining_stmt)]
+    second_cached_stmt, second_cached_result = second._effectful_assignment_src_cache[id(defining_stmt)]  # pylint:disable=protected-access
     assert second_cached_stmt is defining_stmt
     assert second_cached_result == cached_result
     assert second.replacements == first.replacements
@@ -144,13 +144,13 @@ def test_dirty_write_statement_query_is_cached_per_spropagator(monkeypatch, mfx,
     assert set(calls_by_id.values()) == {1}
     for stmt in block.statements:
         if id(stmt) in calls_by_id:
-            assert first._dirty_memory_write_cache[id(stmt)][0] is stmt
+            assert first._dirty_memory_write_cache[id(stmt)][0] is stmt  # pylint:disable=protected-access
     assert _has_replacement(first, vvar_uses) is expected_replacement
 
     second = _function_propagator(project, block, manager)
     assert set(calls_by_id.values()) == {2}
     for stmt in block.statements:
         if id(stmt) in calls_by_id:
-            assert second._dirty_memory_write_cache[id(stmt)][0] is stmt
+            assert second._dirty_memory_write_cache[id(stmt)][0] is stmt  # pylint:disable=protected-access
     assert second.replacements == first.replacements
     assert second.dead_vvar_ids == first.dead_vvar_ids

--- a/tests/analyses/decompiler/test_spropagator_dirty_query_cache.py
+++ b/tests/analyses/decompiler/test_spropagator_dirty_query_cache.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+import networkx
+import pytest
+
+import angr
+import angr.analyses.s_propagator as spropagator_module
+from angr import ailment
+from angr.ailment.expression import DirtyExpression, VirtualVariable, VirtualVariableCategory
+from angr.analyses.s_propagator import SPropagator
+
+
+def _project():
+    return angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+
+
+def _dirty(idx: int, mfx: str | None, *, maddr=None, bits: int = 64) -> DirtyExpression:
+    return DirtyExpression(
+        idx,
+        f"helper_{idx}",
+        [],
+        mfx=mfx,
+        maddr=maddr,
+        msize=8 if maddr is not None else None,
+        bits=bits,
+    )
+
+
+def _function_propagator(project, block: ailment.Block, manager: ailment.Manager) -> SPropagator:
+    function = project.kb.functions.function(addr=block.addr, create=True)
+    assert function is not None
+    graph = networkx.DiGraph()
+    graph.add_node(block)
+    return SPropagator(project, subject=function, func_graph=graph, ail_manager=manager)
+
+
+def _has_replacement(propagator: SPropagator, expressions) -> bool:
+    return any(expr in replacements for replacements in propagator.replacements.values() for expr in expressions)
+
+
+def _effect_source_switch_block(mfx: str | None):
+    vvar_def = VirtualVariable(0, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_use_0 = VirtualVariable(1, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_use_1 = VirtualVariable(2, 1, 64, VirtualVariableCategory.REGISTER, oident=16)
+    block = ailment.Block(
+        0x2000,
+        1,
+        statements=[
+            ailment.Stmt.Assignment(3, vvar_def, _dirty(4, mfx), ins_addr=0x2000),
+            ailment.Stmt.ConditionalJump(
+                5,
+                vvar_use_0,
+                ailment.Expr.Const(6, 0x2000, 64),
+                ailment.Expr.Const(7, 0x3000, 64),
+                true_target_idx=0,
+                ins_addr=0x2001,
+            ),
+            ailment.Stmt.Jump(8, vvar_use_1, ins_addr=0x2002),
+        ],
+        idx=0,
+    )
+    return block, vvar_def, (vvar_use_0, vvar_use_1)
+
+
+def _global_load_block(mfx: str):
+    addr = ailment.Expr.Const(0, 0x3000, 64)
+    vvar_def = VirtualVariable(1, 1, 32, VirtualVariableCategory.REGISTER, oident=16)
+    vvar_uses = [VirtualVariable(idx + 2, 1, 32, VirtualVariableCategory.REGISTER, oident=16) for idx in range(3)]
+    statements = [
+        ailment.Stmt.Assignment(
+            10,
+            vvar_def,
+            ailment.Expr.Load(11, addr, 4, "Iend_LE"),
+            ins_addr=0x1000,
+        ),
+        ailment.Stmt.DirtyStatement(
+            12,
+            _dirty(13, mfx, maddr=addr),
+            ins_addr=0x1001,
+        ),
+    ]
+    statements.extend(
+        ailment.Stmt.Assignment(20 + idx, ailment.Expr.Register(30 + idx, 24 + idx * 4, 32), use)
+        for idx, use in enumerate(vvar_uses)
+    )
+    return ailment.Block(0x1000, 1, statements=statements, idx=0), vvar_uses
+
+
+@pytest.mark.parametrize("mfx, expected_replacement", ((None, True), ("Ifx_None", False)))
+def test_effectful_assignment_source_query_is_cached_per_spropagator(monkeypatch, mfx, expected_replacement):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    block, vvar_def, vvar_uses = _effect_source_switch_block(mfx)
+    defining_stmt = block.statements[0]
+    assert isinstance(defining_stmt, ailment.Stmt.Assignment)
+
+    original = spropagator_module.has_effectful_dirty_expression
+    calls = 0
+
+    def counting_query(expr):
+        nonlocal calls
+        calls += 1
+        return original(expr)
+
+    monkeypatch.setattr(spropagator_module, "has_effectful_dirty_expression", counting_query)
+
+    first = _function_propagator(project, block, manager)
+    assert calls == 1
+    cached_stmt, cached_result = first._effectful_assignment_src_cache[id(defining_stmt)]
+    assert cached_stmt is defining_stmt
+    assert cached_result is (mfx is not None)
+    assert _has_replacement(first, vvar_uses) is expected_replacement
+    if expected_replacement:
+        assert vvar_def.varid in first.dead_vvar_ids
+
+    second = _function_propagator(project, block, manager)
+    assert calls == 2
+    second_cached_stmt, second_cached_result = second._effectful_assignment_src_cache[id(defining_stmt)]
+    assert second_cached_stmt is defining_stmt
+    assert second_cached_result == cached_result
+    assert second.replacements == first.replacements
+    assert second.dead_vvar_ids == first.dead_vvar_ids
+
+
+@pytest.mark.parametrize("mfx, expected_replacement", (("Ifx_Read", True), ("Ifx_Write", False)))
+def test_dirty_write_statement_query_is_cached_per_spropagator(monkeypatch, mfx, expected_replacement):
+    project = _project()
+    manager = ailment.Manager(arch=project.arch)
+    block, vvar_uses = _global_load_block(mfx)
+
+    original = spropagator_module.has_dirty_memory_write
+    calls_by_id: defaultdict[int, int] = defaultdict(int)
+
+    def counting_query(stmt):
+        calls_by_id[id(stmt)] += 1
+        return original(stmt)
+
+    monkeypatch.setattr(spropagator_module, "has_dirty_memory_write", counting_query)
+
+    first = _function_propagator(project, block, manager)
+    assert calls_by_id
+    assert set(calls_by_id.values()) == {1}
+    for stmt in block.statements:
+        if id(stmt) in calls_by_id:
+            assert first._dirty_memory_write_cache[id(stmt)][0] is stmt
+    assert _has_replacement(first, vvar_uses) is expected_replacement
+
+    second = _function_propagator(project, block, manager)
+    assert set(calls_by_id.values()) == {2}
+    for stmt in block.statements:
+        if id(stmt) in calls_by_id:
+            assert second._dirty_memory_write_cache[id(stmt)][0] is stmt
+    assert second.replacements == first.replacements
+    assert second.dead_vvar_ids == first.dead_vvar_ids


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Superseded draft; do not merge.

Review-driven auditing showed that this branch’s generalized `IRDirty` effect model was broader than the demonstrated problem and lost one SAILR success. Of the 16 deterministic corpus deltas, only three functions contained any `IRDirty`; all 48 relevant statements were AMD64 x87 `fld m80fp` / `fstp m80fp` transfers represented by `amd64g_dirtyhelper_loadF80le` and `amd64g_dirtyhelper_storeF80le`. The other 13 deltas came from unrelated narrowing commit `760f184c3`.

The focused replacement is already owned by #6356, which lowers those helpers to explicit 10-byte long-double memory loads and stores as part of the broader x87 implementation. Replaying this branch would duplicate that work while restoring a rejected generalized model and unrelated stacked changes.

Historical producer, corpus, and validation evidence remains in:
- https://github.com/angr/angr/pull/6752#issuecomment-5161249810
- https://github.com/angr/angr/pull/6752#issuecomment-5162006458

This PR is retained only as an evidence record and should be closed.
