### PR TITLE
AILSimplifier: Only store replaced blocks into self.blocks.

### DIFF
--- a/angr/analyses/decompiler/ail_simplifier.py
+++ b/angr/analyses/decompiler/ail_simplifier.py
@@ -935,7 +935,8 @@ class AILSimplifier(Analysis):
                 block, reps, self._ail_manager, gp=self._gp, replace_loads=replace_loads
             )
             replaced |= r
-            self.blocks[block] = new_block
+            if r:
+                self.blocks[block] = new_block
 
         if replaced:
             # blocks have been rebuilt - expression propagation results are no longer reliable


### PR DESCRIPTION
_rebuild_func_graph marks all blocks in self.blocks dirty, so adding unchanged blocks to self.blocks led to redundant simplification runs after.