### PR TITLE
Support p-code architectures whose address width is not 32 or 64 bits

### DIFF
--- a/angr/analyses/typehoon/simple_solver.py
+++ b/angr/analyses/typehoon/simple_solver.py
@@ -29,17 +29,21 @@ from .typeconsts import (
     Int,
     Int8,
     Int16,
+    Int24,
     Int32,
     Int64,
     Int128,
     Int256,
     Int512,
     Pointer,
+    Pointer16,
+    Pointer24,
     Pointer32,
     Pointer64,
     RustEnum,
     SInt8,
     SInt16,
+    SInt24,
     SInt32,
     SInt64,
     Struct,
@@ -47,9 +51,11 @@ from .typeconsts import (
     TypeConstant,
     UInt8,
     UInt16,
+    UInt24,
     UInt32,
     UInt64,
     int_type,
+    pointer_type,
 )
 from .typevars import (
     Add,
@@ -89,11 +95,14 @@ Int256_ = Int256()
 Int128_ = Int128()
 Int64_ = Int64()
 Int32_ = Int32()
+Int24_ = Int24()
 Int16_ = Int16()
 Int8_ = Int8()
 Bottom_ = BottomType()
-Pointer64_ = Pointer64()
+Pointer16_ = Pointer16()
+Pointer24_ = Pointer24()
 Pointer32_ = Pointer32()
+Pointer64_ = Pointer64()
 Struct_ = Struct()
 Array_ = Array()
 Float_ = Float()
@@ -105,6 +114,8 @@ SInt8_ = SInt8()
 UInt8_ = UInt8()
 SInt16_ = SInt16()
 UInt16_ = UInt16()
+SInt24_ = SInt24()
+UInt24_ = UInt24()
 SInt32_ = SInt32()
 UInt32_ = UInt32()
 SInt64_ = SInt64()
@@ -117,6 +128,7 @@ PRIMITIVE_TYPES = {
     Int_,
     Int8_,
     Int16_,
+    Int24_,
     Int32_,
     Int64_,
     Int128_,
@@ -126,10 +138,14 @@ PRIMITIVE_TYPES = {
     UInt8_,
     SInt16_,
     UInt16_,
+    SInt24_,
+    UInt24_,
     SInt32_,
     UInt32_,
     SInt64_,
     UInt64_,
+    Pointer16_,
+    Pointer24_,
     Pointer32_,
     Pointer64_,
     Bottom_,
@@ -198,6 +214,7 @@ BASE_LATTICE_64_g.add_edge(Int_, Int256_)
 BASE_LATTICE_64_g.add_edge(Int_, Int128_)
 BASE_LATTICE_64_g.add_edge(Int_, Int64_)
 BASE_LATTICE_64_g.add_edge(Int_, Int32_)
+BASE_LATTICE_64_g.add_edge(Int_, Int24_)
 BASE_LATTICE_64_g.add_edge(Int_, Int16_)
 BASE_LATTICE_64_g.add_edge(Int_, Int8_)
 BASE_LATTICE_64_g.add_edge(Int512_, Bottom_)
@@ -213,6 +230,11 @@ BASE_LATTICE_64_g.add_edge(Int16_, SInt16_)
 BASE_LATTICE_64_g.add_edge(Int16_, UInt16_)
 BASE_LATTICE_64_g.add_edge(SInt16_, Bottom_)
 BASE_LATTICE_64_g.add_edge(UInt16_, Bottom_)
+# Int24: signed/unsigned children
+BASE_LATTICE_64_g.add_edge(Int24_, SInt24_)
+BASE_LATTICE_64_g.add_edge(Int24_, UInt24_)
+BASE_LATTICE_64_g.add_edge(SInt24_, Bottom_)
+BASE_LATTICE_64_g.add_edge(UInt24_, Bottom_)
 # Int32: signed/unsigned children + Enum, Fd
 BASE_LATTICE_64_g.add_edge(Int32_, SInt32_)
 BASE_LATTICE_64_g.add_edge(Int32_, UInt32_)
@@ -239,6 +261,7 @@ BASE_LATTICE_32_g.add_edge(Int_, Int256_)
 BASE_LATTICE_32_g.add_edge(Int_, Int128_)
 BASE_LATTICE_32_g.add_edge(Int_, Int64_)
 BASE_LATTICE_32_g.add_edge(Int_, Int32_)
+BASE_LATTICE_32_g.add_edge(Int_, Int24_)
 BASE_LATTICE_32_g.add_edge(Int_, Int16_)
 BASE_LATTICE_32_g.add_edge(Int_, Int8_)
 BASE_LATTICE_32_g.add_edge(Int512_, Bottom_)
@@ -254,6 +277,11 @@ BASE_LATTICE_32_g.add_edge(Int16_, SInt16_)
 BASE_LATTICE_32_g.add_edge(Int16_, UInt16_)
 BASE_LATTICE_32_g.add_edge(SInt16_, Bottom_)
 BASE_LATTICE_32_g.add_edge(UInt16_, Bottom_)
+# Int24: signed/unsigned children
+BASE_LATTICE_32_g.add_edge(Int24_, SInt24_)
+BASE_LATTICE_32_g.add_edge(Int24_, UInt24_)
+BASE_LATTICE_32_g.add_edge(SInt24_, Bottom_)
+BASE_LATTICE_32_g.add_edge(UInt24_, Bottom_)
 # Int32: signed/unsigned children + Pointer32, Enum, Fd
 BASE_LATTICE_32_g.add_edge(Int32_, SInt32_)
 BASE_LATTICE_32_g.add_edge(Int32_, UInt32_)
@@ -272,7 +300,24 @@ BASE_LATTICE_32_g.add_edge(SInt64_, Bottom_)
 BASE_LATTICE_32_g.add_edge(UInt64_, Bottom_)
 BASE_LATTICE_32 = TypeLattice(BASE_LATTICE_32_g)
 
+# lattice for 16-bit binaries: the same scalar hierarchy, with the pointer branch moved under Int16 so that a pointer
+# still unifies with an integer of its own width.
+BASE_LATTICE_16_g = BASE_LATTICE_32_g.copy()
+BASE_LATTICE_16_g.remove_node(Pointer32_)
+BASE_LATTICE_16_g.add_edge(Int16_, Pointer16_)
+BASE_LATTICE_16_g.add_edge(Pointer16_, Bottom_)
+BASE_LATTICE_16 = TypeLattice(BASE_LATTICE_16_g)
+
+# lattice for 24-bit binaries, e.g. AVR8 with extended (24-bit) code addresses
+BASE_LATTICE_24_g = BASE_LATTICE_32_g.copy()
+BASE_LATTICE_24_g.remove_node(Pointer32_)
+BASE_LATTICE_24_g.add_edge(Int24_, Pointer24_)
+BASE_LATTICE_24_g.add_edge(Pointer24_, Bottom_)
+BASE_LATTICE_24 = TypeLattice(BASE_LATTICE_24_g)
+
 BASE_LATTICES = {
+    16: BASE_LATTICE_16,
+    24: BASE_LATTICE_24,
     32: BASE_LATTICE_32,
     64: BASE_LATTICE_64,
 }
@@ -658,8 +703,8 @@ class SimpleSolver:
         stackvar_max_sizes: dict[TypeVariable, int] | None = None,
         tv_manager: TypeVariableManager | None = None,
     ):
-        if bits not in (32, 64):
-            raise ValueError(f"Pointer size {bits} is not supported. Expect 32 or 64.")
+        if bits not in BASE_LATTICES:
+            raise ValueError(f"Pointer size {bits} is not supported. Expect one of {sorted(BASE_LATTICES)}.")
 
         self.bits = bits
         self._constraints: dict[TypeVariable, set[TypeConstraint]] = constraints
@@ -1882,7 +1927,9 @@ class SimpleSolver:
             return True
         if isinstance(typevar, Array) and Array_ in typevar_set:
             return SimpleSolver._typevar_inside_set(typevar.element, typevar_set)
-        if isinstance(typevar, Pointer) and (Pointer32_ in typevar_set or Pointer64_ in typevar_set):
+        if isinstance(typevar, Pointer) and any(
+            pointer in typevar_set for pointer in (Pointer16_, Pointer24_, Pointer32_, Pointer64_)
+        ):
             return SimpleSolver._typevar_inside_set(typevar.basetype, typevar_set)
         return False
 
@@ -2002,7 +2049,7 @@ class SimpleSolver:
         cls, t1: SimType, t2: SimType, arch: archinfo.Arch, lattices: dict[int, TypeLattice], unit: TypeConstant
     ) -> SimType:
         if arch.bits not in lattices:
-            raise ValueError(f"Pointer size {arch.bits} is not supported. Expect 32 or 64.")
+            raise ValueError(f"Pointer size {arch.bits} is not supported. Expect one of {sorted(lattices)}.")
 
         translator = angr.analyses.typehoon.TypeTranslator(arch)
         tc1 = translator.simtype2tc(t1)
@@ -2013,10 +2060,8 @@ class SimpleSolver:
 
     @staticmethod
     def abstract(t: TypeConstant | TypeVariable) -> TypeConstant | TypeVariable:
-        if isinstance(t, Pointer32):
-            return Pointer32()
-        if isinstance(t, Pointer64):
-            return Pointer64()
+        if isinstance(t, (Pointer16, Pointer24, Pointer32, Pointer64)):
+            return type(t)()
         if isinstance(t, Enum):
             return Enum_
         return t
@@ -2353,12 +2398,8 @@ class SimpleSolver:
 
         return paths
 
-    def _pointer_class(self) -> type[Pointer32 | Pointer64]:
-        if self.bits == 32:
-            return Pointer32
-        if self.bits == 64:
-            return Pointer64
-        raise NotImplementedError(f"Unsupported bits {self.bits}")
+    def _pointer_class(self) -> type[Pointer16 | Pointer24 | Pointer32 | Pointer64]:
+        return pointer_type(self.bits)
 
     @staticmethod
     def dump_constraint_graph(graph: networkx.DiGraph, filename: str) -> None:

--- a/angr/analyses/typehoon/translator.py
+++ b/angr/analyses/typehoon/translator.py
@@ -137,15 +137,9 @@ class TypeTranslator:
     # Typehoon type handlers
     #
 
-    def _translate_Pointer64(self, tc):
-        if isinstance(tc.basetype, typeconsts.BottomType):
-            # void *
-            internal = sim_type.SimTypeBottom(label="void").with_arch(self.arch)
-        else:
-            internal = self._tc2simtype(tc.basetype)
-        return sim_type.SimTypePointer(internal, label=tc.name).with_arch(self.arch)
-
-    def _translate_Pointer32(self, tc):
+    def _translate_Pointer(self, tc):
+        # every pointer width translates the same way: SimTypePointer takes its width from the arch, not from the
+        # type constant
         if isinstance(tc.basetype, typeconsts.BottomType):
             # void *
             internal = sim_type.SimTypeBottom(label="void").with_arch(self.arch)
@@ -223,6 +217,9 @@ class TypeTranslator:
             return sim_type.SimTypeWideChar(label=tc.name).with_arch(self.arch)
         return sim_type.SimTypeShort(signed=False, label=tc.name).with_arch(self.arch)
 
+    def _translate_Int24(self, tc):
+        return sim_type.SimTypeNum(24, signed=False, label=tc.name).with_arch(self.arch)
+
     def _translate_Int32(self, tc):
         return sim_type.SimTypeInt(signed=False, label=tc.name).with_arch(self.arch)
 
@@ -277,6 +274,12 @@ class TypeTranslator:
     def _translate_UInt16(self, tc):
         return sim_type.SimTypeShort(signed=False, label=tc.name).with_arch(self.arch)
 
+    def _translate_SInt24(self, tc):
+        return sim_type.SimTypeNum(24, signed=True, label=tc.name).with_arch(self.arch)
+
+    def _translate_UInt24(self, tc):
+        return sim_type.SimTypeNum(24, signed=False, label=tc.name).with_arch(self.arch)
+
     def _translate_SInt32(self, tc):
         return sim_type.SimTypeInt(signed=True, label=tc.name).with_arch(self.arch)
 
@@ -316,7 +319,7 @@ class TypeTranslator:
     #
 
     def _translate_SimTypeNum(self, st: sim_type.SimTypeNum) -> typeconsts.TypeConstant:
-        if st.size not in {8, 16, 32, 64}:
+        if st.size not in {8, 16, 24, 32, 64}:
             return typeconsts.BottomType()
 
         tc = typeconsts.signed_int_type(st.size) if st.signed else typeconsts.unsigned_int_type(st.size)
@@ -457,13 +460,11 @@ class TypeTranslator:
         elem_type = self._simtype2tc(st.elem_type)
         return typeconsts.Array(elem_type, count=st.length, name=st.label)
 
-    def _translate_SimTypePointer(self, st: sim_type.SimTypePointer) -> typeconsts.Pointer32 | typeconsts.Pointer64:
+    def _translate_SimTypePointer(
+        self, st: sim_type.SimTypePointer
+    ) -> typeconsts.Pointer16 | typeconsts.Pointer24 | typeconsts.Pointer32 | typeconsts.Pointer64:
         base = self._simtype2tc(st.pts_to)
-        if self.arch.bits == 32:
-            return typeconsts.Pointer32(base, name=st.label)
-        if self.arch.bits == 64:
-            return typeconsts.Pointer64(base, name=st.label)
-        raise TypeError(f"Unsupported pointer size {self.arch.bits}")
+        return typeconsts.pointer_type(self.arch.bits)(base, name=st.label)
 
     def _translate_SimTypeFloat(self, st: sim_type.SimTypeFloat) -> typeconsts.Float32:
         return typeconsts.Float32(name=st.label)
@@ -486,14 +487,18 @@ class TypeTranslator:
         return typeconsts.Fd(name=st.label)
 
 
+# pylint:disable=protected-access
 TypeConstHandlers = {
-    typeconsts.Pointer64: TypeTranslator._translate_Pointer64,
-    typeconsts.Pointer32: TypeTranslator._translate_Pointer32,
+    typeconsts.Pointer64: TypeTranslator._translate_Pointer,
+    typeconsts.Pointer32: TypeTranslator._translate_Pointer,
+    typeconsts.Pointer24: TypeTranslator._translate_Pointer,
+    typeconsts.Pointer16: TypeTranslator._translate_Pointer,
     typeconsts.Array: TypeTranslator._translate_Array,
     typeconsts.Struct: TypeTranslator._translate_Struct,
     typeconsts.Enum: TypeTranslator._translate_Enum,
     typeconsts.Int8: TypeTranslator._translate_Int8,
     typeconsts.Int16: TypeTranslator._translate_Int16,
+    typeconsts.Int24: TypeTranslator._translate_Int24,
     typeconsts.Int32: TypeTranslator._translate_Int32,
     typeconsts.Int64: TypeTranslator._translate_Int64,
     typeconsts.Int128: TypeTranslator._translate_Int128,
@@ -503,6 +508,8 @@ TypeConstHandlers = {
     typeconsts.UInt8: TypeTranslator._translate_UInt8,
     typeconsts.SInt16: TypeTranslator._translate_SInt16,
     typeconsts.UInt16: TypeTranslator._translate_UInt16,
+    typeconsts.SInt24: TypeTranslator._translate_SInt24,
+    typeconsts.UInt24: TypeTranslator._translate_UInt24,
     typeconsts.SInt32: TypeTranslator._translate_SInt32,
     typeconsts.UInt32: TypeTranslator._translate_UInt32,
     typeconsts.SInt64: TypeTranslator._translate_SInt64,
@@ -512,6 +519,7 @@ TypeConstHandlers = {
     typeconsts.Float64: TypeTranslator._translate_Float64,
     typeconsts.Fd: TypeTranslator._translate_Fd,
 }
+# pylint:enable=protected-access
 
 
 SimTypeHandlers = {

--- a/angr/analyses/typehoon/typeconsts.py
+++ b/angr/analyses/typehoon/typeconsts.py
@@ -108,6 +108,13 @@ class Int16(Int):
         return "int16"
 
 
+class Int24(Int):
+    SIZE = 3
+
+    def __repr__(self, memo=None) -> str:
+        return "int24"
+
+
 class Int32(Int):
     SIZE = 4
 
@@ -147,6 +154,16 @@ class SInt16(Int16):
 class UInt16(Int16):
     def __repr__(self, memo=None) -> str:
         return "uint16"
+
+
+class SInt24(Int24):
+    def __repr__(self, memo=None) -> str:
+        return "sint24"
+
+
+class UInt24(Int24):
+    def __repr__(self, memo=None) -> str:
+        return "uint24"
 
 
 class SInt32(Int32):
@@ -254,6 +271,38 @@ class Pointer(TypeConstant):
         if new_basetype is self.basetype:
             return self
         return self.new(new_basetype, name=self.name)
+
+
+class Pointer16(Pointer, Int16):
+    """
+    16-bit pointers.
+    """
+
+    def __init__(self, basetype=None, name: str | None = None):
+        Pointer.__init__(self, basetype, name=name)
+        Int16.__init__(self, name=name)
+
+    @memoize
+    def __repr__(self, memo=None):
+        bt = self.basetype.__repr__(memo=memo) if isinstance(self.basetype, TypeConstant) else repr(self.basetype)
+        name_str = f"{self.name}#" if self.name else ""
+        return f"{name_str}ptr16({bt})"
+
+
+class Pointer24(Pointer, Int24):
+    """
+    24-bit pointers.
+    """
+
+    def __init__(self, basetype=None, name: str | None = None):
+        Pointer.__init__(self, basetype, name=name)
+        Int24.__init__(self, name=name)
+
+    @memoize
+    def __repr__(self, memo=None):
+        bt = self.basetype.__repr__(memo=memo) if isinstance(self.basetype, TypeConstant) else repr(self.basetype)
+        name_str = f"{self.name}#" if self.name else ""
+        return f"{name_str}ptr24({bt})"
 
 
 class Pointer32(Pointer, Int32):
@@ -596,6 +645,7 @@ def int_type(bits: int) -> Int:
         1: Int1,
         8: Int8,
         16: Int16,
+        24: Int24,
         32: Int32,
         64: Int64,
         128: Int128,
@@ -605,13 +655,20 @@ def int_type(bits: int) -> Int:
     return mapping[bits]() if bits in mapping else IntVar(bits)
 
 
+def pointer_type(bits: int) -> type[Pointer16 | Pointer24 | Pointer32 | Pointer64]:
+    mapping = {16: Pointer16, 24: Pointer24, 32: Pointer32, 64: Pointer64}
+    if bits not in mapping:
+        raise NotImplementedError(f"No pointer type constant for a {bits}-bit address")
+    return mapping[bits]
+
+
 def signed_int_type(bits: int) -> Int:
-    mapping = {8: SInt8, 16: SInt16, 32: SInt32, 64: SInt64}
+    mapping = {8: SInt8, 16: SInt16, 24: SInt24, 32: SInt32, 64: SInt64}
     return mapping[bits]() if bits in mapping else int_type(bits)
 
 
 def unsigned_int_type(bits: int) -> Int:
-    mapping = {8: UInt8, 16: UInt16, 32: UInt32, 64: UInt64}
+    mapping = {8: UInt8, 16: UInt16, 24: UInt24, 32: UInt32, 64: UInt64}
     return mapping[bits]() if bits in mapping else int_type(bits)
 
 

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -15,11 +15,12 @@ import cle
 import pypcode
 from archinfo import ArchARM, ArchPcode
 from cachetools import LRUCache
+from pyvex.const import vex_int_class
 
 # FIXME: Reusing these errors from pyvex for compatibility. Eventually these
 # should be refactored to use common error classes.
 from pyvex.errors import LiftingException, PyVEXError, SkipStatementsError
-from pyvex.expr import U8, U16, U32, U64, Const, IRExpr
+from pyvex.expr import Const, IRExpr
 
 from angr import sim_options as o
 from angr.block import DisassemblerBlock, DisassemblerInsn
@@ -474,7 +475,7 @@ class IRSB:
         # pylint: disable=unused-argument
         self._statements = statements if statements is not None else []
         if isinstance(nxt, int):
-            const_cls = {8: U8, 16: U16, 32: U32, 64: U64}[self.arch.bits]
+            const_cls = vex_int_class(self.arch.bits)
             self.next = Const(const_cls(nxt))
         else:
             self.next = nxt
@@ -816,7 +817,7 @@ def lift(
             # We have no more bytes left. Mark the jumpkind of the IRSB as Ijk_Boring
             if final_irsb.size > 0 and final_irsb.jumpkind == "Ijk_NoDecode":
                 final_irsb.jumpkind = "Ijk_Boring"
-                const_cls = {8: U8, 16: U16, 32: U32, 64: U64}[arch.bits]
+                const_cls = vex_int_class(arch.bits)
                 final_irsb.next = Const(const_cls(final_irsb.addr + final_irsb.size))
 
     return final_irsb
@@ -971,7 +972,7 @@ class PcodeBasicBlockLifter:
             next_block = (fallthru_addr, "Ijk_Boring")
 
         irsb._size = fallthru_addr - irsb.addr
-        const_cls = {8: U8, 16: U16, 32: U32, 64: U64}[irsb.arch.bits]
+        const_cls = vex_int_class(irsb.arch.bits)
         irsb.next = Const(const_cls(next_block[0])) if next_block[0] is not None else None
         irsb.jumpkind = next_block[1]
 

--- a/angr/rust/typehoon/translator.py
+++ b/angr/rust/typehoon/translator.py
@@ -38,21 +38,27 @@ class RustTypeTranslator(TypeTranslator):
     # TypeConstant -> RustSimType (tc2simtype direction)
     # ----------------------------------------------------------------
 
-    def _translate_Pointer64(self, tc):
+    def _translate_Pointer(self, tc):
         if isinstance(tc.basetype, typeconsts.BottomType):
             internal = sim_type.SimTypeBottom(label="void").with_arch(self.arch)
         else:
             internal = self._tc2simtype(tc.basetype)
         return RustSimTypeReference(internal).with_arch(self.arch)
 
-    def _translate_Pointer32(self, tc):
-        return self._translate_Pointer64(tc)
-
     def _translate_Int8(self, tc):  # type: ignore[override]
         return RustSimTypeInt(size=8, signed=False).with_arch(self.arch)
 
     def _translate_Int16(self, tc):  # type: ignore[override]
         return RustSimTypeInt(size=16, signed=False).with_arch(self.arch)
+
+    def _translate_Int24(self, tc):
+        return RustSimTypeInt(size=24, signed=False).with_arch(self.arch)
+
+    def _translate_SInt24(self, tc):
+        return RustSimTypeInt(size=24, signed=True).with_arch(self.arch)
+
+    def _translate_UInt24(self, tc):
+        return RustSimTypeInt(size=24, signed=False).with_arch(self.arch)
 
     def _translate_Int32(self, tc):
         return RustSimTypeInt(size=32, signed=False).with_arch(self.arch)
@@ -187,6 +193,8 @@ class RustTypeTranslator(TypeTranslator):
             return typeconsts.Int8()
         if ty.size == 16:
             return typeconsts.Int16()
+        if ty.size == 24:
+            return typeconsts.Int24()
         if ty.size == 32:
             return typeconsts.Int32()
         if ty.size == 64:
@@ -229,9 +237,7 @@ class RustTypeTranslator(TypeTranslator):
 
     def _translate_RustSimTypeReference(self, ty: RustSimTypeReference):
         base = self._simtype2tc(ty.pts_to)
-        if self.arch.bits == 32:
-            return typeconsts.Pointer32(base)
-        return typeconsts.Pointer64(base)
+        return typeconsts.pointer_type(self.arch.bits)(base)
 
     def _translate_RustSimTypeArray(self, ty: RustSimTypeArray):
         elem_type = self._simtype2tc(ty.elem_type)
@@ -250,13 +256,19 @@ class RustTypeTranslator(TypeTranslator):
         return self.tc2simtype(tc)[0]
 
 
+# pylint:disable=protected-access
 RustTypeConstHandlers = {
-    typeconsts.Pointer64: RustTypeTranslator._translate_Pointer64,
-    typeconsts.Pointer32: RustTypeTranslator._translate_Pointer32,
+    typeconsts.Pointer64: RustTypeTranslator._translate_Pointer,
+    typeconsts.Pointer32: RustTypeTranslator._translate_Pointer,
+    typeconsts.Pointer24: RustTypeTranslator._translate_Pointer,
+    typeconsts.Pointer16: RustTypeTranslator._translate_Pointer,
     typeconsts.Array: RustTypeTranslator._translate_Array,
     typeconsts.Struct: RustTypeTranslator._translate_Struct,
     typeconsts.Int8: RustTypeTranslator._translate_Int8,
     typeconsts.Int16: RustTypeTranslator._translate_Int16,
+    typeconsts.Int24: RustTypeTranslator._translate_Int24,
+    typeconsts.SInt24: RustTypeTranslator._translate_SInt24,
+    typeconsts.UInt24: RustTypeTranslator._translate_UInt24,
     typeconsts.Int32: RustTypeTranslator._translate_Int32,
     typeconsts.Int64: RustTypeTranslator._translate_Int64,
     typeconsts.Int128: RustTypeTranslator._translate_Int128,
@@ -264,6 +276,7 @@ RustTypeConstHandlers = {
     typeconsts.TypeVariableReference: RustTypeTranslator._translate_TypeVariableReference,
     typeconsts.RustEnum: RustTypeTranslator._translate_RustEnum,
 }
+# pylint:enable=protected-access
 
 
 RustSimTypeHandlers = {

--- a/tests/analyses/test_rust_sim_type.py
+++ b/tests/analyses/test_rust_sim_type.py
@@ -80,6 +80,24 @@ class TestRustSimType(unittest.TestCase):
         assert normalized.is_arg0_retbuf is False
         assert prototype.normalize() is not prototype
 
+    def test_narrow_type_constants_reach_rust_types(self):
+        # RustTypeConstHandlers dispatches on the exact type-constant class, so every class the type solver can
+        # produce needs an entry; a missing one silently degrades to a bottom type in the generated Rust
+        arch = archinfo.ArchPcode("z80:LE:16:default")
+        tx = RustTypeTranslator(arch)
+
+        for tc in (typeconsts.Pointer16(typeconsts.Int8()), typeconsts.Pointer24(typeconsts.Int8())):
+            restored, _ = tx.tc2simtype(tc)
+            assert isinstance(restored, RustSimTypeReference)
+            assert isinstance(restored.pts_to, RustSimTypeInt)
+
+        # int_type/signed_int_type/unsigned_int_type all answer 24-bit accesses now, on every architecture
+        for tc, signed in ((typeconsts.Int24(), False), (typeconsts.SInt24(), True), (typeconsts.UInt24(), False)):
+            restored, _ = tx.tc2simtype(tc)
+            assert isinstance(restored, RustSimTypeInt)
+            assert restored.size == 24
+            assert restored.signed is signed
+
     def test_rust_scalar_reference_and_array_repr_json_roundtrip(self):
         arch = archinfo.ArchAMD64()
         u32 = RustSimTypeInt(32, signed=False, label="len").with_arch(arch)

--- a/tests/analyses/test_typehoon.py
+++ b/tests/analyses/test_typehoon.py
@@ -27,6 +27,8 @@ from angr.analyses.typehoon.typeconsts import (
     Int8,
     Int32,
     IntVar,
+    Pointer16,
+    Pointer24,
     Pointer64,
     SInt32,
     SInt64,
@@ -54,6 +56,7 @@ from angr.sim_type import (
     SimTypeInt,
     SimTypeNum,
     SimTypePointer,
+    SimTypeShort,
 )
 from tests.common import bin_location, print_decompilation_result
 
@@ -459,6 +462,32 @@ class TestTypeTranslator(unittest.TestCase):
         tc = tx.simtype2tc(st)
         assert isinstance(tc, Float32)
 
+    def test_16bit_pointer_round_trip(self):
+        arch = archinfo.ArchPcode("z80:LE:16:default")
+        tx = TypeTranslator(arch)
+
+        tc = tx.simtype2tc(SimTypePointer(SimTypeChar()).with_arch(arch))
+        assert isinstance(tc, Pointer16)
+        assert tc.size == 2
+
+        restored, has_nonexistent_ref = tx.tc2simtype(tc)
+        assert not has_nonexistent_ref
+        assert isinstance(restored, SimTypePointer)
+        assert restored.size == 16
+
+    def test_24bit_pointer_round_trip(self):
+        arch = archinfo.ArchPcode("avr8:LE:16:extended")
+        tx = TypeTranslator(arch)
+
+        tc = tx.simtype2tc(SimTypePointer(SimTypeChar()).with_arch(arch))
+        assert isinstance(tc, Pointer24)
+        assert tc.size == 3
+
+        restored, has_nonexistent_ref = tx.tc2simtype(tc)
+        assert not has_nonexistent_ref
+        assert isinstance(restored, SimTypePointer)
+        assert restored.size == 24
+
     def test_simtypenum_struct_round_trip(self):
         arch = archinfo.arch_from_id("amd64")
         st = SimTypePointer(
@@ -499,7 +528,7 @@ class TestTypeTranslator(unittest.TestCase):
         arch = archinfo.arch_from_id("amd64")
         tx = TypeTranslator(arch)
 
-        for bits in (1, 9, 24, 128):
+        for bits in (1, 9, 128):
             for signed in (False, True):
                 with self.subTest(bits=bits, signed=signed):
                     tc = tx.simtype2tc(SimTypeNum(bits, signed=signed, label=f"int{bits}_t").with_arch(arch))
@@ -517,7 +546,7 @@ class TestTypeTranslator(unittest.TestCase):
         arch = archinfo.arch_from_id("amd64")
         tx = TypeTranslator(arch)
 
-        for bits in (8, 16, 32, 64):
+        for bits in (8, 16, 24, 32, 64):
             for signed in (False, True):
                 with self.subTest(bits=bits, signed=signed):
                     label = f"{'u' if not signed else ''}int{bits}_t"
@@ -648,6 +677,49 @@ class TestSimpleSolverLatticeOps(unittest.TestCase):
         )
         assert isinstance(joined, SimTypePointer)
         assert isinstance(joined.pts_to, SimTypeChar)
+
+    def test_solver_accepts_narrow_pointer_widths(self):
+        # SimpleSolver refused any width it had no lattice for, which is where decompiling a 16-bit
+        # function stopped: "Pointer size 16 is not supported. Expect 32 or 64."
+        for bits in (16, 24, 32, 64):
+            with self.subTest(bits=bits):
+                tv = TypeVariable()
+                assert SimpleSolver(bits, {tv: set()}, {tv: {tv}}).bits == bits
+        with self.assertRaises(ValueError):
+            SimpleSolver(48, {}, {})
+
+    def test_join_same_pointer_16bit(self):
+        arch = archinfo.ArchPcode("z80:LE:16:default")
+        joined = SimpleSolver.join_simtypes(
+            SimTypePointer(SimTypeChar()).with_arch(arch),
+            SimTypePointer(SimTypeChar()).with_arch(arch),
+            arch,
+        )
+        assert isinstance(joined, SimTypePointer)
+        assert joined.size == 16
+        assert isinstance(joined.pts_to, SimTypeChar)
+
+    def test_join_same_pointer_24bit(self):
+        arch = archinfo.ArchPcode("avr8:LE:16:extended")
+        joined = SimpleSolver.join_simtypes(
+            SimTypePointer(SimTypeChar()).with_arch(arch),
+            SimTypePointer(SimTypeChar()).with_arch(arch),
+            arch,
+        )
+        assert isinstance(joined, SimTypePointer)
+        assert joined.size == 24
+        assert isinstance(joined.pts_to, SimTypeChar)
+
+    def test_join_narrow_pointer_and_same_width_int(self):
+        # a pointer hangs off the integer of its own width, so joining the two lands on that integer rather than
+        # falling all the way to the generic Int (which has no SimType and would come back as bottom)
+        arch = archinfo.ArchPcode("z80:LE:16:default")
+        joined = SimpleSolver.join_simtypes(
+            SimTypePointer(SimTypeChar()).with_arch(arch),
+            SimTypeShort(signed=False).with_arch(arch),
+            arch,
+        )
+        assert isinstance(joined, SimTypeShort)
 
     def test_join_same_struct_pointer_preserves_struct(self):
         # join(struct A *, struct A *) -> struct A *

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -8,6 +8,7 @@ from unittest import TestCase, main
 
 import archinfo
 import pyvex
+from pyvex.expr import Const
 
 import angr
 from angr.block import Block
@@ -254,6 +255,63 @@ class TestPcodeEngine(TestCase):
         other_engine, other_lifter = seen[0]
         assert other_engine is not proj.factory.default_engine  # the factory really did hand out a second engine
         assert other_lifter is main_lifter
+
+    def test_lift_architecture_whose_word_is_not_a_power_of_two(self):
+        """
+        A SLEIGH language may declare a word size VEX has no named constant for: the PIC and dsPIC
+        families are 24-bit. Lifting one used to raise KeyError on the width itself.
+        """
+        for language in ("dsPIC33F:LE:24:default", "PIC-24E:LE:24:default"):
+            with self.subTest(language=language):
+                arch = archinfo.ArchPcode(language)
+                assert arch.bits == 24
+                project = angr.load_shellcode(
+                    b"\x00" * 6, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode
+                )
+                irsb = project.factory.block(0x1000).vex
+                assert isinstance(irsb.next, Const)
+                assert irsb.next.con.__class__.__name__ == f"U{arch.bits}"
+
+    def test_narrow_arch_jump_targets(self):
+        """
+        The lifter builds a block's jump target at three separate sites, one reached only by an
+        undecodable block and one only by a fallthrough. Extended AVR8 addresses are 24 bits wide.
+        """
+        arch = archinfo.ArchPcode("avr8:LE:16:extended")
+        assert arch.bits == 24
+
+        p = angr.load_shellcode(
+            bytes.fromhex("01e00895"),  # ldi r16, 1 ; ret
+            arch=arch,
+            load_address=0x100,
+            engine=angr.engines.UberEnginePcode,
+        )
+        assert p.factory.block(0x100).vex.jumpkind == "Ijk_Ret"
+
+        undecodable = angr.load_shellcode(
+            b"\xff\xff", arch=arch, load_address=0x100, engine=angr.engines.UberEnginePcode
+        )
+        block = undecodable.factory.block(0x100).vex
+        assert block.jumpkind == "Ijk_NoDecode"
+        assert isinstance(block.next, Const)
+        assert block.next.con.value == 0x100
+        assert block.next.con.type == "Ity_I24"
+
+        fallthrough = angr.load_shellcode(
+            bytes.fromhex("01e012e00895"),  # ldi r16, 1 ; ldi r17, 2 ; ret
+            arch=arch,
+            load_address=0x100,
+            engine=angr.engines.UberEnginePcode,
+        )
+        block = fallthrough.factory.block(0x100, num_inst=1).vex
+        assert block.jumpkind == "Ijk_Boring"
+        assert isinstance(block.next, Const)
+        assert block.next.con.value == 0x102
+        assert block.next.con.type == "Ity_I24"
+
+        state = fallthrough.factory.blank_state(addr=0x100)
+        successors = fallthrough.factory.successors(state, num_inst=1).successors
+        assert [(s.solver.eval(s.regs.ip), s.regs.ip.size()) for s in successors] == [(0x102, 24)]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

No 24-bit SLEIGH language lifts at all. Six zero bytes at `0x1000` under `dsPIC33F:LE:24:default`, through `angr.load_shellcode(..., engine=angr.engines.UberEnginePcode)`, raise before an instruction is decoded:

```
  File "angr/engines/pcode/lifter.py", line 961, in lift
    const_cls = {8: U8, 16: U16, 32: U32, 64: U64}[irsb.arch.bits]
KeyError: 24
```

`PIC-24E:LE:24:default` and `avr8:LE:16:extended` (24-bit addresses) fail the same way, so on those languages there is no block, and therefore no CFG, no simulation and no decompilation. A 16-bit language lifts and then stops one layer up, in type inference:

```
  File "angr/analyses/typehoon/translator.py", line 466, in _translate_SimTypePointer
    raise TypeError(f"Unsupported pointer size {self.arch.bits}")
TypeError: Unsupported pointer size 16
```
```
  File "angr/analyses/typehoon/simple_solver.py", line 662, in __init__
    raise ValueError(f"Pointer size {bits} is not supported. Expect 32 or 64.")
ValueError: Pointer size 16 is not supported. Expect 32 or 64.
```

### Root cause

`angr/engines/pcode/lifter.py` builds a block's jump-target constant at three sites, each from the same literal map of the four widths VEX names, `{8: U8, 16: U16, 32: U32, 64: U64}`. A width the map does not list has no constant class. One of the three sites is reached only by an undecodable block and one only by a fallthrough, so the failure is not confined to one kind of block.

Typehoon is the same shape one layer up: `BASE_LATTICES` was keyed `{32, 64}` and `_translate_SimTypePointer` produced only `Pointer32` and `Pointer64`, so `SimpleSolver.__init__` rejects any other width outright and `_simtype_lattice_op` rejects it again on every join and meet.

### Fix

`vex_int_class(arch.bits)` from pyvex replaces the map at all three sites. It is the same object for the four widths the map covered, so a 24-bit target stays 24 bits rather than acquiring eight bits of padding. Typehoon gains `Pointer16`, `Pointer24` and the 24-bit integer constants, and a 16- and a 24-bit lattice in which the pointer branch hangs off the integer of its own width, so a pointer still unifies with an integer of the same width instead of falling to bottom:

```
    dsPIC33F:LE:24:default: jumpkind=Ijk_Boring next=(0x1008 :: Ity_I24) (U24)
    avr8:LE:16:extended: undecodable 0xffff at 0x100: next=(0x100 :: Ity_I24) type=Ity_I24
    avr8:LE:16:extended: successors: [('0x102', 24)]
    z80:LE:16:default (16-bit): SimTypePointer -> Pointer16(size=2) -> char* size=16
```

Not done here: loading a real 24-bit object end to end. Most stop one layer down, in cle's unpacking of a pointer whose width no `struct` format describes.

### Testing

`tests/engines/pcode/test_pcode.py::TestPcodeEngine::test_lift_architecture_whose_word_is_not_a_power_of_two` and `test_narrow_arch_jump_targets` lift the two PIC languages and reach all three constant sites plus the simulator, whose successor IP is 24 bits wide; both fail on master with `KeyError: 24`. `tests/analyses/test_typehoon.py` and `tests/analyses/test_rust_sim_type.py` add the 16- and 24-bit pointer round trips, the solver widths and the narrow joins, which fail on master with the two errors above.

The cle side is angr/cle#721 — it unpacks a pointer of a width `struct` has no format character for. Supersedes #6932, which rewrote the same three lines by a different means and could not merge beside this.

Validation: https://github.com/angr/angr/pull/6793#issuecomment-5232376121

sync: angr/cle#721

session: sharpen