### PR TITLE
SimWindows: Add the Windows ARM and AArch64 syscall calling conventions.

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2094,6 +2094,30 @@ class SimCCARMLinuxSyscall(SimCCSyscall):
         return state.regs.r7
 
 
+class SimCCARMWindowsSyscall(SimCCSyscall):
+    """
+    The system call convention of Windows on 32-bit ARM.
+
+    An ntdll stub loads the service index into r12 and traps with svc #1; arguments follow the ordinary ARM
+    convention. See https://codemachine.com/articles/arm_assembler_primer.html.
+    """
+
+    ARG_REGS = ["r0", "r1", "r2", "r3"]
+    FP_ARG_REGS = []
+    RETURN_ADDR = SimRegArg("ip_at_syscall", 4)
+    RETURN_VAL = SimRegArg("r0", 4)
+    ARCH = archinfo.ArchARM
+
+    @classmethod
+    def _match(cls, arch, args, sp_delta, unused_hint=None, extra_pop=None):  # pylint: disable=unused-argument
+        # never appears anywhere except syscalls
+        return False
+
+    @staticmethod
+    def syscall_num(state):
+        return state.regs.r12
+
+
 class SimCCAArch64(SimCC):
     ARG_REGS = ["x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"]
     FP_ARG_REGS = []  # TODO: ???
@@ -2118,6 +2142,35 @@ class SimCCAArch64LinuxSyscall(SimCCSyscall):
     @staticmethod
     def syscall_num(state):
         return state.regs.x8
+
+
+class SimCCAArch64WindowsSyscall(SimCCSyscall):
+    """
+    The system call convention of Windows on AArch64.
+
+    An ntdll stub is a bare "svc #index; ret": Windows encodes the service index in the SVC immediate rather than
+    in a register, and the kernel recovers it from ESR_EL1 as the low 12 bits. Arguments follow the ordinary AArch64
+    convention. See https://gracefulbits.wordpress.com/2018/07/26/system-call-dispatching-for-windows-on-arm64/.
+    """
+
+    ARG_REGS = ["x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"]
+    FP_ARG_REGS = []
+    RETURN_VAL = SimRegArg("x0", 8)
+    RETURN_ADDR = SimRegArg("ip_at_syscall", 8)
+    ARCH = archinfo.ArchAArch64
+
+    @classmethod
+    def _match(cls, arch, args, sp_delta, unused_hint=None, extra_pop=None):  # pylint: disable=unused-argument
+        # never appears anywhere except syscalls
+        return False
+
+    @staticmethod
+    def syscall_num(state):  # type: ignore
+        insn = state.mem[state.regs.ip_at_syscall - 4].dword.resolved
+        if not ((insn & 0xFFE0001F) == 0xD4000001).is_true():
+            l.error("AArch64 syscall number being queried at an address which is not an SVC")
+            return claripy.BVV(0, 64)
+        return ((insn >> 5) & 0xFFF).zero_extend(32)
 
 
 class SimCCRISCV64(SimCC):
@@ -2800,6 +2853,7 @@ SYSCALL_CC: dict[str, dict[str, type[SimCCSyscall]]] = {
     "ARMEL": {
         "default": SimCCARMLinuxSyscall,
         "Linux": SimCCARMLinuxSyscall,
+        "Win32": SimCCARMWindowsSyscall,
     },
     "ARMCortexM": {
         # FIXME: TODO: This is wrong.  Fill in with a real CC when we support CM syscalls
@@ -2808,10 +2862,12 @@ SYSCALL_CC: dict[str, dict[str, type[SimCCSyscall]]] = {
     "ARMHF": {
         "default": SimCCARMLinuxSyscall,
         "Linux": SimCCARMLinuxSyscall,
+        "Win32": SimCCARMWindowsSyscall,
     },
     "AARCH64": {
         "default": SimCCAArch64LinuxSyscall,
         "Linux": SimCCAArch64LinuxSyscall,
+        "Win32": SimCCAArch64WindowsSyscall,
     },
     "MIPS32": {
         "default": SimCCO32LinuxSyscall,

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -55,7 +55,11 @@ class SimWindows(SimOS):
 
         self.fastfail = L["ntoskrnl.exe"][0].get("__fastfail", self.arch)
         self.fastfail.addr = self._find_or_make(self.fastfail.display_name)
-        self.fastfail.cc = SYSCALL_CC[self.arch.name]["Win32"](self.arch)
+        # __fastfail is delivered as a trap, so its handler takes the Windows syscall convention. cle labels every
+        # PE os="windows", so machine types Windows has no syscall ABI for arrive here too and keep the convention
+        # the procedure library assigned above.
+        if windows_syscall_cc := SYSCALL_CC.get(self.arch.name, {}).get("Win32"):
+            self.fastfail.cc = windows_syscall_cc(self.arch)
         self._syscall_handlers = {self.fastfail.addr: self.fastfail}
 
     def configure_project(self):

--- a/angr/simos/windows.py
+++ b/angr/simos/windows.py
@@ -55,11 +55,7 @@ class SimWindows(SimOS):
 
         self.fastfail = L["ntoskrnl.exe"][0].get("__fastfail", self.arch)
         self.fastfail.addr = self._find_or_make(self.fastfail.display_name)
-        # __fastfail is delivered as a trap, so its handler takes the Windows syscall convention. cle labels every
-        # PE os="windows", so machine types Windows has no syscall ABI for arrive here too and keep the convention
-        # the procedure library assigned above.
-        if windows_syscall_cc := SYSCALL_CC.get(self.arch.name, {}).get("Win32"):
-            self.fastfail.cc = windows_syscall_cc(self.arch)
+        self.fastfail.cc = SYSCALL_CC[self.arch.name]["Win32"](self.arch)
         self._syscall_handlers = {self.fastfail.addr: self.fastfail}
 
     def configure_project(self):

--- a/tests/simos/windows/test_windows_fastfail.py
+++ b/tests/simos/windows/test_windows_fastfail.py
@@ -46,6 +46,7 @@ class TestWindowsFastfail(unittest.TestCase):
         ):
             with self.subTest(path=path):
                 project = angr.Project(os.path.join(test_location, path), auto_load_libs=False)
+                assert isinstance(project.simos, SimWindows)
                 simgr = project.factory.simulation_manager(project.factory.call_state(project.simos.fastfail.addr, 0))
                 simgr.run()
 

--- a/tests/simos/windows/test_windows_fastfail.py
+++ b/tests/simos/windows/test_windows_fastfail.py
@@ -11,7 +11,6 @@ from angr.calling_conventions import (
     SimCCAArch64WindowsSyscall,
     SimCCAMD64WindowsSyscall,
     SimCCARMWindowsSyscall,
-    SimCCRISCV64,
     SimCCX86WindowsSyscall,
 )
 from angr.simos import SimWindows
@@ -36,13 +35,6 @@ class TestWindowsFastfail(unittest.TestCase):
                 project = angr.load_shellcode(b"\x00" * 4, arch=arch, simos="windows")
                 assert isinstance(project.simos, SimWindows)
                 assert isinstance(project.simos.fastfail.cc, expected_cc)
-
-    def test_fastfail_falls_back_where_windows_has_no_syscall_convention(self):
-        # cle labels every PE os="windows", so a machine type Windows has no syscall ABI for still reaches
-        # SimWindows. RISC-V PEs are real -- UEFI ships them -- and building the project must still work.
-        project = angr.load_shellcode(b"\x00" * 4, arch="riscv64", simos="windows")
-        assert isinstance(project.simos, SimWindows)
-        assert isinstance(project.simos.fastfail.cc, SimCCRISCV64)
 
     def test_arm_syscall_number_comes_from_r12(self):
         # A Windows ARM stub loads the service index into r12 and traps with svc #1, where Linux uses r7.

--- a/tests/simos/windows/test_windows_fastfail.py
+++ b/tests/simos/windows/test_windows_fastfail.py
@@ -37,6 +37,25 @@ class TestWindowsFastfail(unittest.TestCase):
                 assert isinstance(project.simos, SimWindows)
                 assert isinstance(project.simos.fastfail.cc, expected_cc)
 
+    def test_fastfail_runs_on_a_real_windows_arm_binary(self):
+        # Selecting the convention is not the same as being able to use it. Run the handler on both images, which
+        # covers ARMNT end to end -- the shellcode test above only executes the AArch64 one.
+        for path in (
+            os.path.join("aarch64", "windows", "fastfail_arm64.exe"),
+            os.path.join("armel", "windows", "fastfail_armnt.exe"),
+        ):
+            with self.subTest(path=path):
+                project = angr.Project(os.path.join(test_location, path), auto_load_libs=False)
+                simgr = project.factory.simulation_manager(project.factory.call_state(project.simos.fastfail.addr, 0))
+                simgr.run()
+
+                assert len(simgr.deadended) == 1
+                state = simgr.deadended[0]
+                assert state.history.jumpkind == "Ijk_Exit"
+                terminations = [event for event in state.history.events if event.type == "terminate"]
+                assert len(terminations) == 1
+                assert state.solver.eval_one(terminations[0].objects["exit_code"]) == 0xC0000409
+
     def test_fastfail_uses_the_windows_syscall_convention(self):
         # Windows runs on ARM and AArch64 too, so every architecture that has __fastfail has a Windows syscall
         # convention for its handler.

--- a/tests/simos/windows/test_windows_fastfail.py
+++ b/tests/simos/windows/test_windows_fastfail.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.simos.windows"  # pylint:disable=redefined-builtin
 
+import os
 import unittest
 
 import angr
@@ -14,12 +15,27 @@ from angr.calling_conventions import (
     SimCCX86WindowsSyscall,
 )
 from angr.simos import SimWindows
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
 
 
 class TestWindowsFastfail(unittest.TestCase):
     """
     Tests for the __fastfail handler SimWindows installs.
     """
+
+    def test_fastfail_on_a_real_windows_arm_binary(self):
+        # The convention has to be reachable from a real PE, not only from load_shellcode: cle sets os="windows"
+        # for every PE, so SimWindows is selected from the file's own machine type rather than from an argument.
+        for path, expected_cc in (
+            (os.path.join("aarch64", "windows", "fastfail_arm64.exe"), SimCCAArch64WindowsSyscall),
+            (os.path.join("armel", "windows", "fastfail_armnt.exe"), SimCCARMWindowsSyscall),
+        ):
+            with self.subTest(path=path):
+                project = angr.Project(os.path.join(test_location, path), auto_load_libs=False)
+                assert isinstance(project.simos, SimWindows)
+                assert isinstance(project.simos.fastfail.cc, expected_cc)
 
     def test_fastfail_uses_the_windows_syscall_convention(self):
         # Windows runs on ARM and AArch64 too, so every architecture that has __fastfail has a Windows syscall

--- a/tests/simos/windows/test_windows_fastfail.py
+++ b/tests/simos/windows/test_windows_fastfail.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.simos.windows"  # pylint:disable=redefined-builtin
+
+import unittest
+
+import angr
+from angr.calling_conventions import (
+    SimCCAArch64WindowsSyscall,
+    SimCCAMD64WindowsSyscall,
+    SimCCARMWindowsSyscall,
+    SimCCRISCV64,
+    SimCCX86WindowsSyscall,
+)
+from angr.simos import SimWindows
+
+
+class TestWindowsFastfail(unittest.TestCase):
+    """
+    Tests for the __fastfail handler SimWindows installs.
+    """
+
+    def test_fastfail_uses_the_windows_syscall_convention(self):
+        # Windows runs on ARM and AArch64 too, so every architecture that has __fastfail has a Windows syscall
+        # convention for its handler.
+        for arch, expected_cc in (
+            ("x86", SimCCX86WindowsSyscall),
+            ("amd64", SimCCAMD64WindowsSyscall),
+            ("armel", SimCCARMWindowsSyscall),
+            ("armhf", SimCCARMWindowsSyscall),
+            ("aarch64", SimCCAArch64WindowsSyscall),
+        ):
+            with self.subTest(arch=arch):
+                project = angr.load_shellcode(b"\x00" * 4, arch=arch, simos="windows")
+                assert isinstance(project.simos, SimWindows)
+                assert isinstance(project.simos.fastfail.cc, expected_cc)
+
+    def test_fastfail_falls_back_where_windows_has_no_syscall_convention(self):
+        # cle labels every PE os="windows", so a machine type Windows has no syscall ABI for still reaches
+        # SimWindows. RISC-V PEs are real -- UEFI ships them -- and building the project must still work.
+        project = angr.load_shellcode(b"\x00" * 4, arch="riscv64", simos="windows")
+        assert isinstance(project.simos, SimWindows)
+        assert isinstance(project.simos.fastfail.cc, SimCCRISCV64)
+
+    def test_arm_syscall_number_comes_from_r12(self):
+        # A Windows ARM stub loads the service index into r12 and traps with svc #1, where Linux uses r7.
+        project = angr.load_shellcode(b"\x01\x00\x00\xef", arch="armel", simos="windows")  # svc #1
+        state = project.factory.blank_state()
+        state.regs.ip_at_syscall = project.entry + 4
+        state.regs.r7 = 0x11
+        state.regs.r12 = 0x22
+        assert state.solver.eval_one(SimCCARMWindowsSyscall(project.arch).syscall_num(state)) == 0x22
+
+    def test_aarch64_syscall_number_comes_from_the_svc_immediate(self):
+        # A Windows AArch64 stub carries the service index in the SVC immediate itself, so no register holds it.
+        project = angr.load_shellcode(b"\xe1\x00\x00\xd4", arch="aarch64", simos="windows")  # svc #7
+        state = project.factory.blank_state()
+        state.regs.ip_at_syscall = project.entry + 4
+        state.regs.x8 = 0x33
+        assert state.solver.eval_one(SimCCAArch64WindowsSyscall(project.arch).syscall_num(state)) == 7
+
+    def test_fastfail_terminates_state_on_aarch64(self):
+        # The convention installed on AArch64 must be usable, not just present.
+        project = angr.load_shellcode(b"\x00" * 4, arch="aarch64", simos="windows")
+        assert isinstance(project.simos, SimWindows)
+        simgr = project.factory.simulation_manager(project.factory.call_state(project.simos.fastfail.addr, 0))
+        simgr.run()
+
+        assert len(simgr.deadended) == 1
+        state = simgr.deadended[0]
+        assert state.history.jumpkind == "Ijk_Exit"
+        terminations = [event for event in state.history.events if event.type == "terminate"]
+        assert len(terminations) == 1
+        assert state.solver.eval_one(terminations[0].objects["exit_code"]) == 0xC0000409
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`cle` reports `os == "windows"` for every PE, so a Windows binary for ARM or AArch64 reaches `SimWindows`, which had a `Win32` syscall calling convention only for X86 and AMD64. `angr.Project` on `binaries/tests/aarch64/windows/fastfail_arm64.exe` raises inside the constructor, before any analysis runs:

```
  File "angr/project.py", line 249, in __init__
    self.simos = os_mapping[self.loader.main_object.os](self)
  File "angr/simos/windows.py", line 58, in __init__
    self.fastfail.cc = SYSCALL_CC[self.arch.name]["Win32"](self.arch)
KeyError: 'Win32'
```

`binaries/tests/armel/windows/fastfail_armnt.exe` fails identically, and so does `angr.load_shellcode(b"\x00" * 4, arch="aarch64", simos="windows")`. Because it fires in `Project.__init__`, nothing downstream — CFG, simulation, decompilation — is reachable for such a file.

### Root cause

`SYSCALL_CC` in `angr/calling_conventions.py` had no `Win32` key for the ARM machine types a PE `Machine` field resolves to (`ARMEL`, `ARMHF`, `AARCH64`):

```python
    "AARCH64": {
        "default": SimCCAArch64LinuxSyscall,
        "Linux": SimCCAArch64LinuxSyscall,
    },
```

`SimWindows.__init__` indexes that table with a bare `["Win32"]`, so the missing entry is a hard failure rather than a fallback. Nothing else could have supplied it either: `angr/engines/successors.py` and `angr/engines/syscall.py` look the OS name up in the same table and fall back to `"default"`, so even had the constructor survived, a syscall on a Windows ARM binary would have been decoded with the Linux convention.

### Fix

Add the two conventions and register them under `Win32` for ARMEL, ARMHF and AARCH64. They are not the Linux ones renamed. On 32-bit ARM an ntdll stub loads the service index into `r12` and traps with `svc #1`, where the Linux convention reads `r7`:

```python
    @staticmethod
    def syscall_num(state):
        return state.regs.r12
```

On AArch64 no register carries it at all — the stub is a bare `svc #index; ret` and the kernel recovers the index from `ESR_EL1` — so `SimCCAArch64WindowsSyscall.syscall_num` decodes the SVC immediate:

```python
        insn = state.mem[state.regs.ip_at_syscall - 4].dword.resolved
        if not ((insn & 0xFFE0001F) == 0xD4000001).is_true():
            l.error("AArch64 syscall number being queried at an address which is not an SVC")
            return claripy.BVV(0, 64)
        return ((insn >> 5) & 0xFFF).zero_extend(32)
```

Both PEs then load and their `__fastfail` handler runs to completion:

```
    __fastfail cc         = SimCCAArch64WindowsSyscall
    final jumpkind        = Ijk_Exit
    exit code             = 0xc0000409
```

Deliberately not done: a `Machine` field also resolves to MIPS32, PPC32 and RISCV64, and Windows never defined a syscall ABI for any of them. Those still raise `KeyError: 'Win32'` exactly as on master; `angr/simos/windows.py` is not in this diff, and this change only adds table entries.

### Testing

`tests/simos/windows/test_windows_fastfail.py` loads each of the two ARM PEs through `angr.Project`, asserts the convention selected from the file's own machine type, runs `__fastfail` on both and checks each ends in `Ijk_Exit` with `0xC0000409`; the `load_shellcode` cases cover the register-level decoding of the service index on both architectures. At the head that module is 6 passed, 9 subtests passed. On master it cannot even be collected — `ImportError: cannot import name 'SimCCAArch64WindowsSyscall' from 'angr.calling_conventions'` — and the behaviour it asserts is the `KeyError` above.

The two ARM PEs are freestanding MSVC builds added in angr/binaries#191 with their source and build script, so this branch stays red until that one merges.

Validation: https://github.com/angr/angr/pull/6794#issuecomment-5232468108

session: mega-corpus