### PR TITLE
SimCGC: Keep the CGC defaults when a dump omits its optional backers.

### DIFF
--- a/angr/simos/cgc.py
+++ b/angr/simos/cgc.py
@@ -86,11 +86,13 @@ class SimCGC(SimUserland):
         state = super().state_entry(add_options=add_options, **kwargs)
 
         if isinstance(self.project.loader.main_object, BackedCGC):
-            # Update allocation base
-            state.cgc.allocation_base = self.project.loader.main_object.current_allocation_base
+            # The allocation base and the recorded writes are optional parts of a process dump. Keep the CGC
+            # plugin's own defaults for whichever of them the dump does not carry.
+            if self.project.loader.main_object.current_allocation_base is not None:
+                state.cgc.allocation_base = self.project.loader.main_object.current_allocation_base
 
             # Do all the writes
-            writes_backer = self.project.loader.main_object.writes_backer
+            writes_backer = self.project.loader.main_object.writes_backer or ()
             stdout = state.posix.get_fd(1)
             pos = 0
             for size in writes_backer:

--- a/tests/simos/test_backedcgc.py
+++ b/tests/simos/test_backedcgc.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from typing import cast
+
+import angr
+from angr.state_plugins import SimStateCGC
+from tests.common import bin_location
+
+BINARY = os.path.join(bin_location, "tests", "i386", "patchrex", "indirect_jump_test_Ofast")
+
+# The instruction pointer the dump was taken at, which differs from the file's own entry point.
+DUMP_EIP = 0x8048250
+
+# A region a CGC process dump carries that the file itself does not map.
+STACK_ADDR = 0xBAAAB000
+STACK_DATA = b"\x11" * 0x1000
+
+
+def backed_project(**main_opts) -> angr.Project:
+    """
+    A project built the way a CGC crash replay builds one: the binary plus a snapshot of the process it came from.
+    """
+    return angr.Project(
+        BINARY,
+        auto_load_libs=False,
+        main_opts={
+            "backend": "backedcgc",
+            "memory_backer": {STACK_ADDR: STACK_DATA},
+            "register_backer": {"eip": DUMP_EIP, "esp": STACK_ADDR, "eax": 0x1234},
+            **main_opts,
+        },
+    )
+
+
+def test_entry_state_without_recorded_writes_or_an_allocation_base():
+    # A dump that carries neither still has to produce an entry state, and has to leave the CGC defaults alone
+    # rather than replace them with None.
+    state = backed_project().factory.entry_state()
+
+    assert state.addr == DUMP_EIP
+    assert cast(SimStateCGC, state.cgc).allocation_base == SimStateCGC().allocation_base
+    assert state.posix.dumps(1) == b""
+
+
+def test_entry_state_replays_the_dumped_writes_and_allocation_base():
+    state = backed_project(writes_backer=[4, 8], current_allocation_base=0xB7000000).factory.entry_state()
+
+    assert cast(SimStateCGC, state.cgc).allocation_base == 0xB7000000
+    assert len(state.posix.dumps(1)) == 12


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`writes_backer` and `current_allocation_base` are optional parts of a CGC process dump: `BackedCGC.__init__` defaults both to `None`, and a crash replay that has no recorded stdout writes or no recorded heap top supplies neither. `SimCGC.state_entry()` read both unconditionally, so a `backedcgc` project on `binaries/tests/i386/patchrex/indirect_jump_test_Ofast` dumped at `0x8048250` could not produce an entry state:

```
  File "angr/factory.py", line 152, in entry_state
    return self.project.simos.state_entry(**kwargs)
  File "angr/simos/cgc.py", line 96, in state_entry
    for size in writes_backer:
TypeError: 'NoneType' object is not iterable
```

The other half is quieter and worse. A dump that does carry writes but no allocation base builds a state whose `state.cgc.allocation_base` is `None` instead of the plugin default `3087007744`, so the first `allocate` syscall on that state raises where `angr/procedures/cgc/allocate.py` evaluates `self.state.cgc.allocation_base - aligned_length`, a long way from the loader.

### Root cause

`angr/simos/cgc.py` treated both fields as though a dump always carries them:

```python
            # Update allocation base
            state.cgc.allocation_base = self.project.loader.main_object.current_allocation_base

            # Do all the writes
            writes_backer = self.project.loader.main_object.writes_backer
```

The assignment overwrites `SimStateCGC`'s own initialized `allocation_base` with whatever the dump has, including `None`, and the loop then iterates it. Neither field is validated on the cle side, because `None` is the correct representation of "this dump did not record it" — the consumer is what has to decide what absence means, and this is the only consumer.

### Fix

Keep the plugin's own defaults for whichever field the dump does not carry:

```python
            if self.project.loader.main_object.current_allocation_base is not None:
                state.cgc.allocation_base = self.project.loader.main_object.current_allocation_base

            writes_backer = self.project.loader.main_object.writes_backer or ()
```

All three dumps then produce an entry state at `0x8048250`; the two that omit a backer keep `allocation_base == 3087007744`, and a dump that carries both still replays them — `3070230528` and twelve bytes on stdout — so the guards do not discard a recorded value. Deliberately not done: nothing here validates or normalizes the dump in cle, and `SimStateCGC` is unchanged.

### Testing

`tests/simos/test_backedcgc.py` builds a `backedcgc` project the way a CGC crash replay does and asserts both halves: one test takes a dump with neither field and asserts the state's allocation base equals `SimStateCGC().allocation_base` with an empty stdout, the other supplies both and is the positive control. At the head the file is 2 passed. Reverting only the allocation-base guard makes the first report `assert None == 3087007744`; reverting only the `writes_backer` guard makes it raise the `TypeError` above at `angr/simos/cgc.py:96`.

The tests cannot construct a `backedcgc` project on cle master at all: `BackedCGC.__init__` calls `Clemory.remove_backer()` unconditionally and that bisects right, so it never finds the backer it is asked to remove and raises `ValueError: Can't find backer to remove`. That is cle's own defect, fixed and covered in the sibling below; this branch restates none of it.

Validation: https://github.com/angr/angr/pull/6795#issuecomment-5232486294

sync: angr/cle#718

session: sharpen