### PR TITLE
Soot: Analyze Java bytecode when no JNI library is loaded.

### DIFF
--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -157,9 +157,13 @@ class CFGFastSoot(CFGFast):
         # soot method
         method = self.project.loader.main_object.get_soot_method(function_id)
 
-        # native method has no soot block
-        if self.support_jni and block is None:
-            return self._native_method_successors(addr, method)
+        if block is None:
+            # A method without a Soot block has no bytecode body, which is what a native method looks like: its
+            # implementation lives in a JNI library. With JNI support we follow the call into the native code;
+            # without it there is nothing left to analyze here.
+            if self.support_jni:
+                return self._native_method_successors(addr, method)
+            return []
 
         block_id = block.idx
 

--- a/angr/knowledge_plugins/functions/soot_function.py
+++ b/angr/knowledge_plugins/functions/soot_function.py
@@ -8,7 +8,7 @@ import networkx
 
 from angr.codenode import BlockNode
 
-from .function import Function, FunctionInfo
+from .function import Function, FunctionInfo, PrototypeSource
 
 
 class SootFunction(Function):
@@ -21,6 +21,11 @@ class SootFunction(Function):
     def __init__(self, function_manager, addr, name=None, syscall=None):
         """
         Function constructor for Soot
+
+        A Soot address is a method descriptor rather than an integer, so this constructor replaces
+        :meth:`Function.__init__` instead of extending it. Because :class:`Function` uses ``__slots__``, every field it
+        declares has to be assigned here too; one left out only shows up as an ``AttributeError`` when something reads
+        it. ``tests/knowledge_plugins/functions/test_soot_function.py`` guards against that drift.
 
         :param addr:            The address of the function.
         :param name:            (Optional) The name of the function.
@@ -68,8 +73,12 @@ class SootFunction(Function):
             binary_name = os.path.basename(self.binary.binary)
 
         self._name = addr.__repr__()
+        # The name is the method signature Soot reports, not a placeholder derived from an address.
+        self.is_default_name = False
         self.binary_name = binary_name
 
+        # Register offsets of those arguments passed in registers
+        self._argument_registers = []
         # Stack offsets of those arguments passed in stack variables
         self._argument_stack_variables = []
 
@@ -84,6 +93,8 @@ class SootFunction(Function):
 
         # Function prototype
         self._prototype = None
+        self._prototype_libname = None
+        self._prototype_source = PrototypeSource.NONE
 
         # Whether this function returns or not. `None` means it's not determined yet
         self._returning = None
@@ -106,6 +117,10 @@ class SootFunction(Function):
         self._local_block_addrs = set()  # a set of addresses of all blocks inside the function
 
         self._info = FunctionInfo(self)
+        self._cyclomatic_complexity = None
+        self.ran_cca = False
+        self.meta_only = False
+        self.evicted = False
         self._dirty = False
         self.tags = ()  # store function tags. can be set manually by performing CodeTagging analysis.
 

--- a/angr/simos/javavm.py
+++ b/angr/simos/javavm.py
@@ -32,18 +32,32 @@ class SimJavaVM(SimOS):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, name="JavaVM", **kwargs)
 
-        # is the binary using JNI libraries?
-        self.is_javavm_with_jni_support = self.project.loader.main_object.jni_support
+        # Step 1: find all native libs
+        # CLE pulls JNI libraries in as dependencies of the Soot object, so they are only mapped when the loader
+        # follows dependencies at all.
+        self.native_libs = [
+            obj for obj in self.project.loader.initial_load_objects if not isinstance(obj.arch, ArchSoot)
+        ]
+
+        # JNI entry points exported by those libraries. Without JNI support it stays empty, so a native invoke finds
+        # no implementation and the Soot engine skips it instead of entering code that was never mapped.
+        self.native_symbols = {}
+
+        # JNI support needs the native libraries themselves, not merely a request for them.
+        jni_libs_requested = self.project.loader.main_object.jni_support
+        self.is_javavm_with_jni_support = jni_libs_requested and bool(self.native_libs)
+
+        if jni_libs_requested and not self.native_libs:
+            if self.project.loader.auto_load_libs:
+                # The loader looked for the libraries and came back empty-handed, which is a misconfiguration.
+                raise AngrSimOSError("No JNI lib was loaded. Is the jni_libs_ld_path set correctly?")
+            # The caller asked for no dependencies at all, so analyze the Java side alone instead of failing.
+            l.warning(
+                "No JNI library was loaded because auto_load_libs is disabled. Analyzing the Java bytecode alone; "
+                "enable auto_load_libs to load the native libraries."
+            )
 
         if self.is_javavm_with_jni_support:
-            # Step 1: find all native libs
-            self.native_libs = [
-                obj for obj in self.project.loader.initial_load_objects if not isinstance(obj.arch, ArchSoot)
-            ]
-
-            if len(self.native_libs) == 0:
-                raise AngrSimOSError("No JNI lib was loaded. Is the jni_libs_ld_path set correctly?")
-
             # Step 2: determine and set the native SimOS
 
             # for each native library get the Arch
@@ -66,7 +80,6 @@ class SimJavaVM(SimOS):
                 raise AngrSimOSError("Cannot instantiate SimOS for native libraries: No compatible SimOS found.")
 
             # Step 3: Match static JNI symbols from native libs
-            self.native_symbols = {}
             for lib in self.native_libs:
                 for name, symbol in lib.symbols_by_name.items():
                     if name.startswith("Java"):

--- a/tests/engines/test_java.py
+++ b/tests/engines/test_java.py
@@ -15,10 +15,12 @@ from archinfo.arch_soot import (
     SootArgument,
     SootMethodDescriptor,
 )
+from cle import Jar
 
 import angr
 from angr.engines.soot.method_dispatcher import resolve_method
 from angr.engines.soot.values import SimSootValue_ArrayRef, SimSootValue_ThisRef
+from angr.simos import SimJavaVM
 from angr.storage.memory_mixins import DefaultMemory, JavaVmMemory, KeyValueMemory
 
 try:
@@ -517,6 +519,38 @@ class TestJava(unittest.TestCase):
         # check if libmixedjava.so was loaded
         loaded_libs = [lib.provides for lib in project.loader.all_elf_objects]
         assert "libmixedjava.so" in loaded_libs
+
+    @unittest.skipUnless(pysoot, "pysoot not available")
+    def test_loading_jni_libs_without_auto_load_libs(self):
+        # JNI libraries reach the loader as dependencies of the JAR, so auto_load_libs=False keeps them out even
+        # though the caller named them. Analysis then has to fall back to the Java bytecode on its own.
+        native_libs_ld_path = os.path.join(self.test_location, "misc", "loading1", "libs")
+        jar_path = os.path.join(self.test_location, "misc", "loading1", "mixedjava.jar")
+        jni_options = {"jni_libs": ["libmixedjava.so"], "jni_libs_ld_path": native_libs_ld_path}
+
+        project = angr.Project(jar_path, main_opts=jni_options, auto_load_libs=False)
+        assert isinstance(project.loader.main_object, Jar)
+        assert project.loader.main_object.jni_support
+        assert not project.loader.all_elf_objects
+        assert isinstance(project.simos, SimJavaVM)
+        assert not project.simos.is_javavm_with_jni_support
+        assert not project.is_java_jni_project
+
+        cfg = project.analyses.CFGFastSoot()
+        # MixedJava.get_version is declared native, so it has no Soot block. Without a JNI library behind it, the
+        # CFG has to end there instead of resolving a native callee.
+        native_method = cfg.kb.functions["MixedJava.get_version()"]
+        native_nodes = [node for node in cfg.graph if node.function_address == native_method.addr]
+        assert len(native_nodes) == 1
+        assert list(cfg.graph.predecessors(native_nodes[0]))
+        assert not list(cfg.graph.successors(native_nodes[0]))
+
+        # Execution reaches the same method. With no native implementation to enter, the invoke is skipped and the
+        # remaining bytecode still runs to the end.
+        simgr = project.factory.simgr(project.factory.entry_state())
+        simgr.run()
+        assert len(simgr.deadended) == 1
+        assert type(simgr.deadended[0].addr) is SootAddressTerminator
 
     #
     # SimStates

--- a/tests/knowledge_plugins/functions/test_soot_function.py
+++ b/tests/knowledge_plugins/functions/test_soot_function.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+__package__ = __package__ or "tests.knowledge_plugins.functions"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from angr.knowledge_plugins.functions.function import Function
+from angr.knowledge_plugins.functions.soot_function import SootFunction
+
+try:
+    import pysoot
+except ModuleNotFoundError:
+    pysoot = None
+
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+@unittest.skipUnless(pysoot, "pysoot not available")
+class TestSootFunction(unittest.TestCase):
+    """
+    SootFunction replaces Function.__init__ rather than extending it, so the two can drift apart.
+    """
+
+    functions: list[Function]
+
+    @classmethod
+    def setUpClass(cls):
+        binary_path = os.path.join(test_location, "java", "simple1.jar")
+        project = angr.Project(binary_path, main_opts={"entry_point": "simple1.Class1.main"}, auto_load_libs=False)
+        cls.functions = list(project.analyses.CFGFastSoot().kb.functions.values())
+        assert cls.functions
+        assert all(isinstance(function, SootFunction) for function in cls.functions)
+
+    def test_every_function_field_is_initialized(self):
+        # SootFunction reimplements Function.__init__, so a field added to Function and forgotten there stays unset.
+        uninitialized = {
+            slot for function in self.functions for slot in Function.__slots__ if not hasattr(function, slot)
+        }
+        assert not uninitialized, f"SootFunction.__init__ leaves {sorted(uninitialized)} unset"
+
+    def test_function_attributes_are_readable(self):
+        # Each of these reads a field that SootFunction.__init__ used to leave unset, raising AttributeError.
+        for function in self.functions:
+            # Soot does not record where arguments live, so both argument lists stay empty.
+            assert function.num_arguments == 0
+            assert function.cyclomatic_complexity >= 1
+            assert function.prototype is None
+            assert function.is_prototype_guessed
+            # The name is the method signature Soot reports, not a generated placeholder.
+            assert not function.is_default_name
+            assert not function.ran_cca
+            assert not function.meta_only
+            assert not function.evicted
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

CLE reaches the JNI libraries a JAR or APK names through the Soot object's dependencies, so with `auto_load_libs` disabled none of them are mapped. `SimJavaVM` read that as a bad `jni_libs_ld_path` and raised before the project finished constructing, and `CFGFastSoot` dereferenced the Soot block a native method does not have.

JNI support now follows the libraries the loader actually mapped. The error stays for `auto_load_libs=True`, where an empty result really is a misconfiguration; otherwise the Java side is analyzed alone, with the CFG ending at the JNI boundary and the engine skipping native invokes.

The other commit assigns the `Function` fields `SootFunction.__init__` never mirrored, which made `num_arguments` and `cyclomatic_complexity` raise `AttributeError` on every recovered method.

Regressions use `mixedjava.jar` and `simple1.jar`. Validation: https://github.com/angr/angr/pull/6797#issuecomment-5232572055.
