### PR TITLE
AIL: Support processor-specific p-code memory spaces

### DIFF
--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -18,6 +18,28 @@ from .statement import Assignment, ConditionalJump, Jump, Return, SideEffectStat
 
 log = logging.getLogger(name=__name__)
 
+# P-code address spaces this converter renders as something other than addressable memory: `const`
+# becomes a Const, `register` a Register, and `unique` a Tmp. `join` holds SLEIGH's pieced-together
+# varnodes, and `fspec` and `iop` are Ghidra decompiler internals; an offset in any of the three
+# indexes a side table rather than memory, so they are named here to keep the catch-all below from
+# turning one into an address.
+#
+# Every other space is one a processor's SLEIGH specification declares, and every such declaration
+# is a ram_space whatever its name. `ram` and `mem` are the common names, but a Harvard or
+# memory-mapped-I/O architecture declares several: `csreg` on RISC-V, `io` on Z80, `packet` on BPF,
+# `CODE`/`INTMEM`/`SFR` on 8051. Those become AIL Loads and Stores carrying a `pcode_space` tag,
+# because an AIL address alone cannot tell Z80 io[0x10] apart from ram[0x10]. The tag holds the name
+# as the specification spells it, and specifications differ on case, so read it case-insensitively.
+_NON_MEMORY_SPACES = frozenset({"const", "fspec", "iop", "join", "register", "unique"})
+
+
+def _is_memory_space(space_name: str) -> bool:
+    """
+    Whether a p-code address space is processor memory, i.e. reachable through an AIL Load or Store.
+    """
+    return space_name.lower() not in _NON_MEMORY_SPACES
+
+
 # FIXME: Not all ops are mapped to AIL expressions!
 opcode_to_generic_name = {
     # OpCode.MULTIEQUAL        : '',
@@ -329,7 +351,7 @@ class PCodeIRSBConverter(Converter):
                 return Convert(self._manager.next_atom(), t.bits, size, False, t, ins_addr=self._manager.ins_addr)
 
             return Tmp(self._manager.next_atom(), offset, size)
-        if space_name.lower() in ["ram", "mem"]:
+        if _is_memory_space(space_name):
             assert not is_write
             addr = Const(self._manager.next_atom(), varnode.offset, self._irsb.arch.bits)
             # Note: Load takes bytes, not bits, for size
@@ -339,15 +361,17 @@ class PCodeIRSBConverter(Converter):
                 varnode.size,
                 self._irsb.arch.memory_endness,
                 ins_addr=self._manager.ins_addr,
+                pcode_space=space_name,
             )
-        raise NotImplementedError
+        raise NotImplementedError(f"read of a varnode in non-memory address space {space_name!r}")
 
     def _set_value(self, varnode: Varnode, value: Expression) -> Statement:
         """
         Create the appropriate assignment statement to store to a varnode
 
-        This method stores to the appropriate register, or unique space,
-        depending on the space indicated by the varnode.
+        This method stores to the register or unique space, or to any of the
+        processor's memory spaces, depending on the space indicated by the
+        varnode.
 
         :param varnode: Varnode to store into
         :param value:   Value to store
@@ -359,7 +383,7 @@ class PCodeIRSBConverter(Converter):
             return Assignment(
                 self._statement_idx, self._convert_varnode(varnode, True), value, ins_addr=self._manager.ins_addr
             )
-        if space_name.lower() in ["ram", "mem"]:
+        if _is_memory_space(space_name):
             addr = Const(self._manager.next_atom(), varnode.offset, self._irsb.arch.bits)
             return Store(
                 self._statement_idx,
@@ -368,15 +392,17 @@ class PCodeIRSBConverter(Converter):
                 varnode.size,
                 self._irsb.arch.memory_endness,
                 ins_addr=self._manager.ins_addr,
+                pcode_space=space_name,
             )
-        raise NotImplementedError
+        raise NotImplementedError(f"write to a varnode in non-memory address space {space_name!r}")
 
     def _get_value(self, varnode: Varnode) -> Expression:
         """
         Create the appropriate expression to load from a varnode
 
-        This method loads from the appropriate const, register, unique, or RAM
-        space, depending on the space indicated by the varnode.
+        This method loads from the const, register, or unique space, or from any
+        of the processor's memory spaces, depending on the space indicated by the
+        varnode.
 
         :param varnode: Varnode to load from.
         :return:        Value loaded
@@ -443,12 +469,11 @@ class PCodeIRSBConverter(Converter):
         spc = self._current_op.inputs[0].getSpaceFromConst()
         out = self._current_op.output
         spc_name = spc.name.lower()
-        assert spc_name in {"ram", "mem", "register"}
         if spc_name == "register":
             # load from register
             res = self._get_value(self._current_op.inputs[1])
             stmt = self._set_value(out, res)
-        else:
+        elif _is_memory_space(spc_name):
             # load from memory
             off = self._get_value(self._current_op.inputs[1])
             res = Load(
@@ -457,8 +482,11 @@ class PCodeIRSBConverter(Converter):
                 self._current_op.output.size,
                 self._irsb.arch.memory_endness,
                 ins_addr=self._manager.ins_addr,
+                pcode_space=spc.name,
             )
             stmt = self._set_value(out, res)
+        else:
+            raise NotImplementedError(f"load from non-memory address space {spc.name!r}")
         self._statements.append(stmt)
 
     def _convert_store(self) -> None:
@@ -467,13 +495,12 @@ class PCodeIRSBConverter(Converter):
         """
         spc = self._current_op.inputs[0].getSpaceFromConst()
         spc_name = spc.name.lower()
-        assert spc_name in {"ram", "mem", "register"}
         if spc_name == "register":
             # store to register
             out = self._current_op.inputs[2]
             res = self._get_value(self._current_op.inputs[1])
             stmt = self._set_value(out, res)
-        else:
+        elif _is_memory_space(spc_name):
             # store to memory
             off = self._get_value(self._current_op.inputs[1])
             data = self._get_value(self._current_op.inputs[2])
@@ -486,7 +513,10 @@ class PCodeIRSBConverter(Converter):
                 self._current_op.inputs[2].size,
                 self._irsb.arch.memory_endness,
                 ins_addr=self._manager.ins_addr,
+                pcode_space=spc.name,
             )
+        else:
+            raise NotImplementedError(f"store to non-memory address space {spc.name!r}")
         self._statements.append(stmt)
 
     def _convert_branch(self) -> None:

--- a/angr/ailment/tagged_object.py
+++ b/angr/ailment/tagged_object.py
@@ -30,6 +30,7 @@ class TagDict(TypedDict, total=False):
     is_prototype_guessed: bool
     keep_in_slice: bool
     orig_ins_addr: int
+    pcode_space: str
     reg_name: str
     uninitialized: bool
     vex_block_addr: int

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -159,10 +159,7 @@ class TestPcodeProcessorMemorySpaces(unittest.TestCase):
     def _convert(language, block_bytes, addr):
         arch = archinfo.ArchPcode(language)
         proj = angr.load_shellcode(block_bytes, arch, addr, addr, engine=angr.engines.UberEnginePcode)
-        return ailment.IRSBConverter.convert(
-            proj.factory.block(addr).vex,
-            ailment.Manager(arch=arch),  # pyright: ignore[reportArgumentType]
-        )
+        return ailment.IRSBConverter.convert(proj.factory.block(addr).vex, ailment.Manager())
 
     def test_processor_spaces_convert_to_tagged_loads_and_stores(self):
         for language, block_hex, addr, load_spaces, store_spaces in self.CASES:

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -81,6 +81,8 @@ class TestIrsb(unittest.TestCase):
         assert isinstance(store.addr, ailment.Expr.Const)
         assert store.addr.value == 0x5678
         assert store.size == 1
+        # The space tag keeps the name the specification chose, case included.
+        assert load.tags["pcode_space"] == store.tags["pcode_space"] == "RAM"
 
     def test_lift_path_matches_python_path(self):
         """The direct libVEX-lift fast path must produce the same AIL block as
@@ -93,6 +95,97 @@ class TestIrsb(unittest.TestCase):
         )
         assert from_py == from_lift
         assert from_py.statements  # non-empty
+
+
+class _LoadCollector(ailment.AILBlockWalker[None, None, list]):
+    """Collect every Load expression in a block, at any nesting depth."""
+
+    def __init__(self):
+        super().__init__()
+        self.loads = []
+
+    def _top(self, expr_idx, expr, stmt_idx, stmt, block):
+        del expr_idx, stmt_idx, stmt, block
+        if isinstance(expr, ailment.Expr.Load):
+            self.loads.append(expr)
+
+    def _stmt_top(self, stmt_idx, stmt, block):
+        del stmt_idx, stmt, block
+
+    def _handle_block_end(self, stmt_results, block):
+        del stmt_results, block
+        return self.loads
+
+
+class TestPcodeProcessorMemorySpaces(unittest.TestCase):
+    """A SLEIGH specification names its own address spaces, and most processors have more than one
+    addressable space: RISC-V puts control/status registers in ``csreg``, Z80 port I/O in ``io``, and
+    classic BPF packet reads in ``packet``. Every one of them has to convert to a Load or a Store
+    that records which space it came from."""
+
+    # (language, block bytes, block address, load spaces in order, store spaces in order)
+    CASES = [
+        (
+            # csrrw t0, mstatus, t1 ; ret
+            # The CSR is a csreg varnode operand, so the space reaches the converter on the varnode
+            # itself rather than on a p-code LOAD/STORE.
+            "RISCV:LE:64:default",
+            "f312033067800000",
+            0x1000,
+            ["csreg"],
+            ["csreg"],
+        ),
+        (
+            # in a,(0x10) ; out (0x10),a ; ret
+            # Port I/O becomes a p-code LOAD and STORE against the io space. The trailing ret pops
+            # from ram, so the ordinary memory space still has to convert alongside it.
+            "z80:LE:16:default",
+            "db10d310c9",
+            0x1000,
+            ["io", "ram"],
+            ["io"],
+        ),
+        (
+            # ld [0] ; ret
+            "BPF:LE:32:default",
+            "20000000000000000600000000000000",
+            0x0,
+            ["packet", "ram"],
+            [],
+        ),
+    ]
+
+    @staticmethod
+    def _convert(language, block_bytes, addr):
+        arch = archinfo.ArchPcode(language)
+        proj = angr.load_shellcode(block_bytes, arch, addr, addr, engine=angr.engines.UberEnginePcode)
+        return ailment.IRSBConverter.convert(
+            proj.factory.block(addr).vex,
+            ailment.Manager(arch=arch),  # pyright: ignore[reportArgumentType]
+        )
+
+    def test_processor_spaces_convert_to_tagged_loads_and_stores(self):
+        for language, block_hex, addr, load_spaces, store_spaces in self.CASES:
+            with self.subTest(language=language):
+                block = self._convert(language, bytes.fromhex(block_hex), addr)
+                loads = _LoadCollector().walk(block)
+                stores = [stmt for stmt in block.statements if isinstance(stmt, ailment.Stmt.Store)]
+                assert [load.tags["pcode_space"] for load in loads] == load_spaces
+                assert [store.tags["pcode_space"] for store in stores] == store_spaces
+
+    def test_identical_addresses_carry_different_space_tags(self):
+        # `in a,(0x10)` and `ld a,(0x10)` both become a one-byte load of address 0x10, from the io
+        # space and from ram respectively. Nothing in the two Loads other than the tag says which
+        # space each one reads.
+        io_loads = _LoadCollector().walk(self._convert("z80:LE:16:default", bytes.fromhex("db10"), 0x1000))
+        ram_loads = _LoadCollector().walk(self._convert("z80:LE:16:default", bytes.fromhex("3a1000"), 0x1000))
+        assert len(io_loads) == 1
+        assert len(ram_loads) == 1
+        io_load, ram_load = io_loads[0], ram_loads[0]
+
+        assert io_load.addr == ram_load.addr
+        assert io_load.tags["pcode_space"] == "io"
+        assert ram_load.tags["pcode_space"] == "ram"
 
 
 class TestNonConstRoundingMode(unittest.TestCase):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A SLEIGH specification names its own address spaces, and most processors declare more than one. The AIL p-code converter accepted only `ram` and `mem`, so converting a RISC-V block holding a control/status register — `csrrw t0, mstatus, t1` at `0x1000` — dies on an assert that names neither the space nor the instruction:

```
  File "angr/ailment/converter_pcode.py", line 315, in _convert_varnode
    assert unique_offset is not None, "Cannot find the source unique variable"
AssertionError: Cannot find the source unique variable
```

Z80 port I/O (`in a,(0x10)` / `out (0x10),a`) and a classic BPF packet read (`ld [0]`) die earlier and with no message at all:

```
  File "angr/ailment/converter_pcode.py", line 446, in _convert_load
    assert spc_name in {"ram", "mem", "register"}
AssertionError
```

No AIL block means no decompilation of any function that touches such a space: RISC-V CSRs, Z80 and 8051 port I/O, BPF packet loads.

### Root cause

Two paths, failing differently. `_convert_varnode` and `_set_value` tested `space_name.lower() in ["ram", "mem"]` and otherwise fell through to a bare `raise NotImplementedError` — which `_convert_current_op` catches and turns into a log warning. So on RISC-V the two ops that read and write `csreg:0x1800` are dropped in silence:

```
COPY -> unique:0x24b00:8   inputs: ['csreg:0x1800:8']
COPY -> csreg:0x1800:8     inputs: ['register:0x2030:8']
COPY -> register:0x2028:8  inputs: ['unique:0x24b00:8']
```

and the third op reads a unique variable that nothing defined, which is the assert above — two ops away from its cause. `_convert_load` and `_convert_store` instead assert the space name outright, which is not a `NotImplementedError` and so aborts the conversion where Z80 and BPF hit it.

### Fix

Every space a specification declares is a `ram_space`, whatever it is called, so the converter names the six that are not memory — `const`, `register`, `unique`, SLEIGH's `join`, and Ghidra's `fspec` and `iop` — and converts anything else to a `Load` or `Store` carrying a `pcode_space` tag holding the name as the specification spells it. The tag has to exist because an AIL address alone cannot tell the two apart:

```
    in a,(0x10)  -> Load(addr=16<16>, size=1, endness=Iend_LE)   pcode_space='io'
    ld a,(0x10)  -> Load(addr=16<16>, size=1, endness=Iend_LE)   pcode_space='ram'
```

The two space asserts and the two bare `NotImplementedError`s become errors naming the offending space. Nothing reads the tag yet: this makes the distinction expressible, and leaves consumers that do not need it unchanged.

### Testing

`tests/ailment/test_irsb.py::TestPcodeProcessorMemorySpaces` converts the three blocks above and asserts the space of every Load and Store in order, and asserts that the two z80 loads of address `0x10` differ only in their tag. On master every one of its cases fails, on the two asserts shown; the existing `ram` case in the same file gains an assertion on the tag.

Validation: https://github.com/angr/angr/pull/6798#issuecomment-5233302646

session: sharpen
