### PR TITLE
CFGFast: Fix the default exit of one-instruction blocks on delay-slot architectures

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3210,9 +3210,10 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         # default statement
         default_branch_ins_addr = None
         if irsb.instruction_addresses:
-            if self.project.arch.branch_delay_slot:
-                if len(irsb.instruction_addresses) > 1:
-                    default_branch_ins_addr = irsb.instruction_addresses[-2]
+            if self.project.arch.branch_delay_slot and len(irsb.instruction_addresses) > 1:
+                # the last instruction is the delay slot, so the branch is the one before it. a
+                # single-instruction block has no delay slot and is its own branch.
+                default_branch_ins_addr = irsb.instruction_addresses[-2]
             else:
                 default_branch_ins_addr = irsb.instruction_addresses[-1]
 

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1003,10 +1003,10 @@ class TestCfgfast(unittest.TestCase):
             assert addr not in cfg.kb.functions, f"{hex(addr)} should not be a separate function"
 
     @staticmethod
-    def _blob_project(data: bytes) -> angr.Project:
+    def _blob_project(data: bytes, arch: str | archinfo.Arch = "AMD64") -> angr.Project:
         return angr.Project(
             io.BytesIO(data),
-            main_opts={"backend": "blob", "arch": "AMD64", "base_addr": 0, "entry_point": 0},
+            main_opts={"backend": "blob", "arch": arch, "base_addr": 0, "entry_point": 0},
             auto_load_libs=False,
             use_sim_procedures=False,
         )
@@ -1062,6 +1062,39 @@ class TestCfgfast(unittest.TestCase):
             (0x4686A0, "_dl_runtime_resolve_xsavec"),
         ):
             assert addr in cfg.kb.functions, f"{name} at {addr:#x} was dropped"
+
+    def _check_single_instruction_indirect_jump(self, data: bytes, arch: str | archinfo.Arch) -> None:
+        # a lifter turns an instruction it cannot translate into a trap that leaves through a non-constant
+        # target, so the block is a single instruction long. CFGFast looks for the branch of a delay-slot
+        # block in the instruction before the last one, and used to abort the whole analysis when a block
+        # was too short to have one. See https://github.com/angr/angr/issues/6763.
+        proj = self._blob_project(data, arch=arch)
+        assert proj.arch.branch_delay_slot
+
+        trap_block = proj.factory.block(proj.entry)
+        assert len(trap_block.instruction_addrs) == 1
+        assert not trap_block.vex.constant_jump_targets  # so the scan takes the indirect jump path
+
+        cfg = proj.analyses.CFGFast()
+
+        assert cfg.model.get_any_node(0) is not None
+        assert 4 in cfg.kb.functions
+
+    def test_single_instruction_indirect_jump_on_sparc(self):
+        # 0x0: illtrap 0   - a run of zero bytes, which p-code lifts to a trap and an indirect goto
+        # 0x4: retl; nop   - a real function that the scan must still pick up afterwards
+        self._check_single_instruction_indirect_jump(
+            b"\x00\x00\x00\x00" + b"\x81\xc3\xe0\x08" + b"\x01\x00\x00\x00",
+            archinfo.ArchPcode("sparc:BE:32:default"),
+        )
+
+    def test_single_instruction_indirect_jump_on_mips(self):
+        # 0x0: trunc.l.s $f0, $f0   - an instruction VEX does not implement, so it lifts to Ijk_SigILL
+        # 0x4: jr $ra; nop          - a real function that the scan must still pick up afterwards
+        self._check_single_instruction_indirect_jump(
+            b"\x46\x00\x00\x09" + b"\x03\xe0\x00\x08" + b"\x00\x00\x00\x00",
+            "MIPS64",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1077,7 +1077,12 @@ class TestCfgfast(unittest.TestCase):
 
         cfg = proj.analyses.CFGFast()
 
-        assert cfg.model.get_any_node(0) is not None
+        node = cfg.model.get_any_node(0)
+        assert node is not None
+        # a block this short cannot hold both a branch and its delay slot, so the indirect goto is an artifact of
+        # the trap rather than a jump to anywhere: the node gets no successors and is not queued for resolution
+        assert not list(cfg.graph.successors(node))
+        assert 0 not in cfg.indirect_jumps
         assert 4 in cfg.kb.functions
 
     def test_single_instruction_indirect_jump_on_sparc(self):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` aborts as soon as the scan reaches a single-instruction block on a
delay-slot architecture. Twelve bytes of SPARC are enough: a zero word, which
p-code lifts to `illtrap` with a non-constant target, followed by a `retl`/`nop`
leaf function at `0x4`.

```
  File "angr/analyses/cfg/cfg_fast.py", line 3235, in _scan_irsb
    new_jobs = self._create_jobs(
  File "angr/analyses/cfg/cfg_fast.py", line 3343, in _create_jobs
    assert irsb is not None and ins_addr is not None and stmt_idx is not None
AssertionError
```

The exception leaves `CFGFast.__init__`, so the result is not a degraded CFG but
no CFG at all: the leaf function at `0x4`, which has nothing to do with the trap,
goes with it. A MIPS64 `trunc.l.s`, which VEX lifts to `Ijk_SigILL`, produces the
same abort.

### Root cause

`_scan_irsb()` derives the instruction address of a block's default exit from the
delay slot, and has no branch for a block too short to have one:

```python
default_branch_ins_addr = None
if irsb.instruction_addresses:
    if self.project.arch.branch_delay_slot:
        if len(irsb.instruction_addresses) > 1:
            default_branch_ins_addr = irsb.instruction_addresses[-2]
    else:
        default_branch_ins_addr = irsb.instruction_addresses[-1]
```

A one-instruction block matches neither inner arm, so `default_branch_ins_addr`
stays `None` and reaches the assert in `_create_jobs()`. That value has been
allowed to be `None` since `e3182003a` in 2020; it became fatal on 2025-11-02,
when `b0426c871` added the assert as a typing assertion inside an unrelated
change to function-stub detection.

Any lifter that renders an instruction it cannot translate as a trap with a
non-constant target produces a block of this shape, so a scan landing on
inter-function padding is enough to reach one.

### Fix

A single-instruction block has no delay slot and is its own branch, so it falls
back to the last instruction address — which is what the exit-statement paths
just above already do for the same case:

```python
if self.project.arch.branch_delay_slot and len(irsb.instruction_addresses) > 1:
    default_branch_ins_addr = irsb.instruction_addresses[-2]
else:
    default_branch_ins_addr = irsb.instruction_addresses[-1]
```

Both blobs then complete, with the trap block left as a dead end and the leaf
function recovered:

```
nodes:
  0x0000 size=4 successors=[]
  0x0004 size=8 successors=[]
functions:
  0x0000 _start blocks=['0x0']
  0x0004 sub_4 blocks=['0x4']
```

Deliberately not done: the block's indirect jump is still not offered to the
resolvers, because `CFGBase._indirect_jump_encountered()` returns early for a
delay-slot block with fewer than two instructions. The block becomes a dead end
instead of aborting the analysis, and that early return is left alone.

### Testing

`test_single_instruction_indirect_jump_on_sparc` and
`test_single_instruction_indirect_jump_on_mips` assert the entry block is one
instruction with no constant jump target, then that `CFGFast` completes, leaves
that block without successors, and still recovers the function at `0x4`. Both
fail on the merge base with `AssertionError` at `cfg_fast.py:3343` and pass here.

Fixes #6763. Validation: https://github.com/angr/angr/pull/6805#issuecomment-5247050665

session: mega-corpus
