### PR TITLE
Fix unbounded recursion when reading an unset instruction pointer

### DIFF
--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -4,7 +4,7 @@ import logging
 
 from angr import claripy
 from angr import sim_options as options
-from angr.errors import SimMemoryMissingError
+from angr.errors import SimMemoryMissingError, SimSolverError
 from angr.misc.ux import once
 from angr.storage.memory_mixins.memory_mixin import MemoryMixin
 
@@ -12,6 +12,25 @@ l = logging.getLogger(__name__)
 
 
 class DefaultFillerMixin(MemoryMixin):
+    def _refplace(self, addr: int, size: int) -> tuple[int, str]:
+        """
+        Where execution is, to name in the warning about filling ``size`` bytes at ``addr``.
+
+        :return: The address held by the instruction pointer and a description of it, or ``0`` and
+                 ``"symbolic"`` when it holds no single address.
+        """
+        ip_offset, ip_size = self.state.arch.registers.get("ip", (0, 0))
+        if self.category == "reg" and addr < ip_offset + ip_size and ip_offset < addr + size:
+            # The instruction pointer is what is being filled, so there is nowhere to ask. It does
+            # not have to begin on a register slot boundary, so a fill can cover part of it.
+            return 0, "symbolic"
+        ip: claripy.ast.BV = self.state._ip
+        try:
+            refplace_int = self.state.solver.eval(ip)
+        except SimSolverError:
+            return 0, "symbolic"
+        return refplace_int, self.state.project.loader.describe_addr(refplace_int)
+
     def _default_value(
         self, addr, size, *, name=None, inspect=True, events=True, key=None, fill_missing: bool = True, **kwargs
     ):
@@ -62,9 +81,8 @@ class DefaultFillerMixin(MemoryMixin):
                     "to suppress these messages."
                 )
 
+            refplace_int, refplace_str = self._refplace(addr, size)
             if is_mem:
-                refplace_int = self.state.solver.eval(self.state._ip)
-                refplace_str = self.state.project.loader.describe_addr(refplace_int)
                 l.warning(
                     "Filling memory at %#x with %d unconstrained bytes referenced from %#x (%s)",
                     addr,
@@ -73,12 +91,6 @@ class DefaultFillerMixin(MemoryMixin):
                     refplace_str,
                 )
             else:
-                if addr == self.state.arch.ip_offset:
-                    refplace_int = 0
-                    refplace_str = "symbolic"
-                else:
-                    refplace_int = self.state.solver.eval(self.state._ip)
-                    refplace_str = self.state.project.loader.describe_addr(refplace_int)
                 reg_str = self.state.arch.translate_register_name(addr, size=size)
                 l.warning(
                     "Filling register %s with %d unconstrained bytes referenced from %#x (%s)",

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -48,7 +48,7 @@ class DefaultFillerMixin(MemoryMixin):
 
         if self.category == "reg" and type(addr) is int and addr == self.state.arch.ip_offset:
             # short-circuit this pathological case
-            return claripy.BVV(0, self.state.arch.bits)
+            return claripy.BVV(0, bits)
 
         is_mem = (
             self.category == "mem"

--- a/tests/sim/test_state.py
+++ b/tests/sim/test_state.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 __package__ = __package__ or "tests.sim"  # pylint:disable=redefined-builtin
 
 import gc
+import io
 import os
 import pickle
 import unittest
 
+import archinfo
 import cle
 
 import angr
@@ -226,6 +228,19 @@ class TestState(unittest.TestCase):
         gc.collect()
         s = pickle.loads(sp)
         assert s.solver.eval(s.memory.load(100, 10), cast_to=bytes) == b"AAABAABABC"
+
+    def test_unconstrained_fill_is_reported(self):
+        # Filling the slots that dsPIC33F's program counter straddles is warned about one slot at a
+        # time, and the warning names the address execution is at. That address is the program
+        # counter being filled, which a fastpath state cannot evaluate once it holds a symbol.
+        arch = archinfo.ArchPcode("dsPIC33F:LE:24:default")
+        proj = angr.Project(io.BytesIO(b"\x00"), main_opts={"backend": "blob", "arch": arch})
+
+        with self.assertLogs("angr.storage.memory_mixins.default_filler_mixin", "WARNING") as logs:
+            state = proj.factory.blank_state(mode="fastpath")
+
+        self.assertTrue(any("Filling register" in line and "(symbolic)" in line for line in logs.output))
+        self.assertEqual(state.solver.eval(state.regs.ip), proj.entry)
 
     def test_successors_catch_arbitrary_interrupts(self):
         # int 0xd2 should fail on x86/amd64 since it's an unsupported interrupt

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -2,12 +2,13 @@
 # pylint: disable=missing-class-docstring,no-self-use,line-too-long
 from __future__ import annotations
 
+import os
 import time
 import unittest
 
 from archinfo import ArchAMD64
 
-from angr import SIM_PROCEDURES, SimState, claripy
+from angr import SIM_PROCEDURES, Project, SimState, claripy
 from angr import options as o
 from angr.claripy.annotation import UninitializedAnnotation
 from angr.errors import SimMemoryError
@@ -25,7 +26,7 @@ from angr.storage.memory_mixins import (
 )
 from angr.storage.memory_mixins.paged_memory.pages.multi_values import MultiValues
 from angr.storage.memory_mixins.paged_memory.pages.symbolic_bitmap import SymbolicBitmap
-from tests.common import minimal_project
+from tests.common import bin_location, minimal_project
 
 
 class UltraPageMemory(
@@ -480,6 +481,31 @@ class TestMemory(unittest.TestCase):
         expr = s.registers.load("rax")
         assert not s.solver.symbolic(expr)
         assert s.solver.eval(expr) == 0x00000031
+
+    def test_partial_instruction_pointer_read_then_whole_register(self):
+        proj = Project(os.path.join(bin_location, "tests", "x86_64", "fauxware"), auto_load_libs=False)
+        ip_offset, ip_size = proj.arch.registers["ip"]
+
+        # A read that covers part of the instruction pointer fills only what it covers, so the
+        # bytes above it are still missing when the next read asks for the whole register.
+        for size in range(1, ip_size + 1):
+            with self.subTest(size=size):
+                s = SimState(project=proj)
+                assert s.registers.load(ip_offset, size).size() == size * proj.arch.byte_width
+                assert s.registers.load("ip").size() == ip_size * proj.arch.byte_width
+
+    def test_instruction_pointer_wider_than_the_address_space(self):
+        # MIPS n32 keeps the 64-bit MIPS64 register file behind 32-bit pointers, so its instruction
+        # pointer is 8 bytes wide while arch.bits is 32.
+        proj = Project(os.path.join(bin_location, "tests", "mipsn32", "n32_be_static"), auto_load_libs=False)
+        ip_bits = proj.arch.registers["ip"][1] * proj.arch.byte_width
+        assert ip_bits > proj.arch.bits
+
+        s = SimState(project=proj)
+        assert s.registers.load("ip").size() == ip_bits
+        assert s.registers.load("ip").size() == ip_bits
+        # Asking a fresh state where it is reads the whole register through the solver.
+        assert SimState(project=proj).addr == 0
 
     def test_fullpage_write(self):
         s = SimState(project=minimal_project("AMD64"))


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Reading an instruction pointer nobody has written yet recurses until CPython gives up. `proj.factory.blank_state(mode="fastpath")` on a blob loaded as `dsPIC33F:LE:24:default` or `PIC-24F:LE:24:default`, and `angr.SimState(project=proj).addr` on `binaries/tests/mipsn32/n32_be_static`, both end here:

```
  File "angr/storage/memory_mixins/default_filler_mixin.py", line 80, in _default_value
    refplace_int = self.state.solver.eval(self.state._ip)
  File "angr/sim_state.py", line 349, in _ip
    return self.regs._ip
  File "angr/state_plugins/view.py", line 47, in __getattr__
    return state.registers.load(k, inspect=inspect, disable_actions=disable_actions, events=events)
RecursionError: maximum recursion depth exceeded
```

Both fill CPython's default 1000-frame limit: 99 turns of a 10-frame cycle on dsPIC33F, 45 turns of a 22-frame one on MIPS n32.

The scope is narrower than the traceback suggests. On PIC-24 and dsPIC only `mode="fastpath"` recurses; `blank_state()`, `entry_state()` and a `SimulationManager` all build on master. On MIPS n32 constructing a state is fine — asking one where it is before anything wrote its program counter is not, and `registers.load("ip")` there asks for the 8-byte `pc` and gets `(_ bv0 32)` even when it does not recurse. 26 of the 172 p-code languages with an instruction pointer have one wider than `arch.bits`, as does `archinfo.ArchMIPSN32`.

### Root cause

Two guards in `DefaultFillerMixin._default_value` decide whether the fill is the instruction pointer, and both ask whether it *starts* at `arch.ip_offset`.

The warning names where execution is, and getting that means reading the program counter:

```python
if addr == self.state.arch.ip_offset:
    refplace_int = 0
    refplace_str = "symbolic"
else:
    refplace_int = self.state.solver.eval(self.state._ip)
```

On `dsPIC33F:LE:24:default` `ip` is 3 bytes at `0x2e` and register slots are 3 bytes wide, so it begins one byte inside a slot and reading it fills the slots at `0x2d` and `0x30`. Neither equals `ip_offset`, so `eval(self.state._ip)` loads the register being filled.

The other guard returns a concrete zero instead of a symbol, sized from `arch.bits` where the function's two other returns use the requested size, `bits = size * self.state.arch.byte_width`:

```python
if self.category == "reg" and type(addr) is int and addr == self.state.arch.ip_offset:
    # short-circuit this pathological case
    return claripy.BVV(0, self.state.arch.bits)
```

`archinfo.ArchMIPSN32` keeps the 64-bit MIPS64 register file behind 32-bit pointers, so `arch.bits` is 32 and `pc` is 8 bytes. An 8-byte read of `ip` is answered with 4, the 4 bytes at `ip_offset + 4` stay missing, and the read that fills *them* starts at `ip_offset + 4` — the first guard's blind spot again.

### Fix

`_refplace` compares the fill against the whole register — `self.category == "reg" and addr < ip_offset + ip_size and ip_offset < addr + size` — so any register fill overlapping the instruction pointer reports `symbolic` and asks nothing. The first conjunct is what keeps a memory fill at a low address off that path. A fastpath state also cannot evaluate an unconstrained pointer once one exists, so a `SimSolverError` from `eval` is reported as `symbolic` rather than propagating. The short-circuit returns `claripy.BVV(0, bits)`, the size that was asked for.

Neither half stands alone, which is why they are one change. `SimState(project=proj)` on `n32_be_static`:

| | master | overlap test only | width only | both |
| --- | --- | --- | --- | --- |
| `registers.load("ip")` | `(_ bv0 32)` | `(_ bv0 32)` | `(_ bv0 64)` | `(_ bv0 64)` |
| read it again | `RecursionError` | `((_ zero_extend 32) reg_114_0_32)` | `(_ bv0 64)` | `(_ bv0 64)` |
| `state.addr` | `RecursionError` | `SimValueError` | `0x0` | `0x0` |

That table is MIPS n32 only. Elsewhere the width fix is the dangerous half on its own: master's over-wide return accidentally covers a whole register on a partial read, so an honest width leaves a hole that only the overlap test closes. Reading part of the instruction pointer and then all of it raises `RecursionError` on all seven architectures I measured — AMD64, X86, ARMEL, PPC32, MIPS32, MIPS64 and MIPS n32 — at every size below the register's own width, so 1 to 3 bytes where the pointer is 4 bytes wide and 1 to 7 where it is 8.

One snippet separates all three revisions, on plain AMD64 and on the object the new test loads:

```python
proj = angr.Project("binaries/tests/x86_64/fauxware", auto_load_libs=False)
s = SimState(project=proj)
s.registers.load(proj.arch.ip_offset, 4)   # (_ bv0 32) on all three
s.registers.load("ip")
```

master answers `(_ bv0 64)`, the width fix alone raises `RecursionError`, and this change answers `(concat reg_bc_0_32 (_ bv0 32))`. The last is a visible behaviour change and the honest one: four bytes were filled and four were not, where master reported all eight as zero. It shows up the same way through a narrower named register at the same offset, `eip` then `ip` under `x86:LE:64:default`.

### Testing

`test_unconstrained_fill_is_reported` in `tests/sim/test_state.py` builds a dsPIC33F fastpath state and asserts a `Filling register` warning naming `(symbolic)`. Two new tests in `tests/storage/test_memory.py` load objects `angr/binaries` already tracks. `test_partial_instruction_pointer_read_then_whole_register` reads 1 to 8 bytes at `arch.ip_offset` of `tests/x86_64/fauxware` and then the whole register; with the overlap test reverted, 7 of its 8 sizes raise `RecursionError`. `test_instruction_pointer_wider_than_the_address_space` reads `ip` twice on `tests/mipsn32/n32_be_static` and evaluates `SimState(project=proj).addr`; with the width fix reverted it fails `assert 32 == 64`. No test in `tests/` read part of the instruction pointer and then all of it before these two, which is why nothing covered the interaction.

Validation: https://github.com/angr/angr/pull/6807#issuecomment-5247058068

session: sharpen
