### PR TITLE
SpillingCFG: Index the nodes that an edge inserts into the graph

### DIFF
--- a/angr/knowledge_plugins/cfg/spilling_cfg.py
+++ b/angr/knowledge_plugins/cfg/spilling_cfg.py
@@ -23,7 +23,7 @@ from archinfo.arch_soot import SootAddressDescriptor
 from angr.protos import cfg_pb2
 
 from .block_id import BlockID
-from .cfg_node import CFGENode, CFGNode
+from .cfg_node import AddressType, CFGENode, CFGNode
 from .spilling_digraph import SpillingDiGraph
 from .types import CFG_ADDR_TYPES, CFGENODE_K, CFGNODE_K, SOOTNODE_K, K
 
@@ -802,7 +802,7 @@ class SpillingCFG:
             cache_limit=effective_cache_limit,
             db_batch_size=db_batch_size,
         )
-        self._keys_by_addr: dict[int, set[K]] = defaultdict(set)
+        self._keys_by_addr: dict[AddressType, set[K]] = defaultdict(set)
         self._call_dst_keys: set[K] = set()
         self._out_degree_cache: dict[K, int] = {}
         self._spilling_enabled = cache_limit is not None
@@ -990,10 +990,12 @@ class SpillingCFG:
         src_block_key = get_block_key(src)
         dst_block_key = get_block_key(dst)
 
-        # Always update _nodes with the passed nodes
-        # This is needed for node replacement during _shrink_node
+        # Always register the passed nodes: an edge replaces a node during _shrink_node, is the only insertion path
+        # for the successor node _shrink_node creates, and can reinsert a node that remove_node() has dropped
         self._nodes[src_block_key] = src
         self._nodes[dst_block_key] = dst
+        self._keys_by_addr[src.addr].add(src_block_key)
+        self._keys_by_addr[dst.addr].add(dst_block_key)
 
         self.add_edge_by_key(src_block_key, dst_block_key, **attr)
 

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,20 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_arm_nodes_inserted_by_an_edge_stay_indexed(self):
+        # a node reaches the graph through add_node() or through add_edge(), and get_any_node() has to answer for
+        # it either way. the windowed region holds no call edge, which is what makes
+        # _remove_redundant_overlapping_blocks dereference that lookup instead of skipping past it
+        path = os.path.join(test_location, "armel", "dbus-cleanup-sockets_stripped")
+        whole = angr.Project(path, auto_load_libs=False).analyses.CFGFast()
+        windowed = angr.Project(path, auto_load_libs=False).analyses.CFGFast(regions=[(0x1025E, 0x10288)])
+
+        for cfg in (whole, windowed):
+            node_addrs = {node.addr for node in cfg.model.nodes() if isinstance(node.addr, int)}
+            assert node_addrs, "CFGFast returned an empty CFG"
+            for addr in node_addrs:
+                assert cfg.model.get_any_node(addr) is not None, f"no CFG node at {addr:#x} in the index"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/knowledge_plugins/cfg/test_spilling_cfg_graph.py
+++ b/tests/knowledge_plugins/cfg/test_spilling_cfg_graph.py
@@ -11,6 +11,7 @@ import pickle
 import unittest
 
 import angr
+from angr.knowledge_plugins.cfg.cfg_model import CFGModel
 from angr.knowledge_plugins.cfg.cfg_node import CFGNode
 from tests.common import bin_location
 
@@ -176,6 +177,45 @@ class TestSpillingCFGGraph(unittest.TestCase):
 
             if out_list or in_list:
                 break
+
+
+class TestSpillingCFGAddressIndex(unittest.TestCase):
+    """Test cases for the address index that SpillingCFG keeps alongside its nodes."""
+
+    SRC_ADDR = 0x10
+    DST_ADDR = 0x20
+    SUCCESSOR_ADDR = 0x14
+
+    def _model_with_nodes(self) -> tuple[CFGModel, CFGNode, CFGNode]:
+        model = CFGModel("CFGFast")
+        src = CFGNode(self.SRC_ADDR, 4, model, block_id=self.SRC_ADDR)
+        dst = CFGNode(self.DST_ADDR, 4, model, block_id=self.DST_ADDR)
+        model.graph.add_node(src)
+        model.graph.add_node(dst)
+        return model, src, dst
+
+    def test_add_edge_indexes_a_removed_node_by_address(self):
+        """An edge that reintroduces a removed node must put it back into the address index."""
+        model, src, dst = self._model_with_nodes()
+
+        model.graph.remove_node(src)
+        assert not model.has_node_addr(self.SRC_ADDR)
+
+        model.graph.add_edge(src, dst, jumpkind="Ijk_Boring")
+
+        assert model.has_node_addr(self.SRC_ADDR)
+        assert list(model.nodes_by_addr(self.SRC_ADDR)) == [src]
+        assert model.get_any_node(self.SRC_ADDR) is src
+
+    def test_add_edge_indexes_a_never_added_node_by_address(self):
+        """An edge is the only insertion path for the successor node that CFGFast._shrink_node() creates."""
+        model, src, _ = self._model_with_nodes()
+        successor = CFGNode(self.SUCCESSOR_ADDR, 4, model, block_id=self.SUCCESSOR_ADDR)
+
+        model.graph.add_edge(src, successor, jumpkind="Ijk_Boring")
+
+        assert model.has_node_addr(self.SUCCESSOR_ADDR)
+        assert model.get_any_node(self.SUCCESSOR_ADDR) is successor
 
 
 class TestSpillingCFGGraphWithSpilling(unittest.TestCase):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`SpillingCFG` keeps an address index beside its node dict, and nodes inserted by
`add_edge()` never entered it, so `get_any_node()` returned `None` for nodes that
are in the graph. On `binaries/tests/armel/dbus-cleanup-sockets_stripped` a plain
`CFGFast()` ends with 4 of its 202 graph nodes invisible that way — `0x1022d`,
`0x10283`, `0x102ab` and `0x102dc`.

Where the CFG has no call edge at all, the same inconsistency is a crash rather
than a silent gap. `CFGFast(regions=[(0x1025e, 0x10288)])` on that fixture throws
away a CFG it had already finished building:

```
  File "angr/analyses/cfg/cfg_fast.py", line 2686, in _post_analysis
    self._remove_redundant_overlapping_blocks(function_alignment=4, is_arm=True)
  File "angr/analyses/cfg/cfg_fast.py", line 4526, in _remove_redundant_overlapping_blocks
    a_real_addr = a.addr & 0xFFFF_FFFE if is_arm else a.addr
AttributeError: 'NoneType' object has no attribute 'addr'
```

Where the CFG does have call edges, nothing crashes and the analysis pays for
work it throws away. `_remove_redundant_overlapping_blocks` hands the `None`
straight to `self.graph.in_edges()`, which reads it as *every* edge in the
graph. On `binaries/tests/armhf/amp_challenge_07.gcc` — an ARM fixture
angr/binaries tracks and `test_flirt.py` already loads — 426 such lookups walk
62,885,100 edges and load 97,254,800 `CFGNode`s out of the spilling store; with
this change none of those lookups happen and the pass loads 73,754. The
performance comment on this pull request carries the measurements and the
method.

### Root cause

`SpillingCFG.add_edge()` registers both endpoints in `self._nodes` but not in
`self._keys_by_addr`, which is the index `get_any_node()`, `nodes_by_addr()` and
`has_node_addr()` all read:

```python
self._nodes[src_block_key] = src
self._nodes[dst_block_key] = dst
```

An edge is a real insertion path, not a convenience: it is the only one for the
successor node `CFGFast._shrink_node()` builds, it is how a node replaced during
`_shrink_node()` gets into the graph, and it is how a pending job puts back a
block `_cascading_remove_lifted_blocks()` has removed. `add_node()` and
`__setstate__()` maintain the index; `add_edge()` did not.

Why the crash is rare while the cost is not: the dereference in
`_remove_redundant_overlapping_blocks` sits behind
`self.graph.in_edges(a, data=True)`, and `nbunch=None` makes the `Ijk_Call` test
true whenever the graph holds a call edge anywhere, so the body is skipped. The
analysis pays for the whole-graph scan and throws the answer away. Only a graph
with no call edges at all reaches the dereference.

### Fix

`add_edge()` maintains `_keys_by_addr` for both endpoints, the way `add_node()`
already does, so the index describes the graph after every insertion path rather
than after two of three.

This changes the recovered CFG, and that is the point of the change rather than a
side effect. An address the index cannot answer for is hidden from
`get_any_node()`, `nodes_by_addr()` and `has_node_addr()`, and so from everything
that reaches a node through them. On `binaries/tests/armel/btrfs.ko`, 109 of the
44,710 nodes master leaves in the graph cannot be reached through
`get_any_node()`, and all 109 are in `kb.functions` as well; with this change
that count is 0 of 45,042 and the analysis ends with 309 more functions.

The two graphs are not nested: they share 44,150 node addresses, master holds 560
this branch does not, and this branch holds 892 master does not. So the extra
functions are a different analysis rather than a longer list.

Running `dbus-cleanup-sockets_stripped` whole, the 4 unfindable nodes become 0
and the CFG grows from 202 nodes to 205 over the same 78 functions; running it
windowed, the analysis completes instead of raising:

```
recovered nodes (addr, size, successors) and the address-index lookup for each:
  0x10265 size=24 successors=[]   get_any_node(0x10265) -> <CFGNode 0x10265[24]>
```

`CFGModel._node_addrs`, the sorted list behind `floor_addr()`/`ceiling_addr()`,
is still maintained only by `CFGModel.add_node()`/`remove_node()`. That gap
predates this change and is left alone.

### Testing

`test_arm_nodes_inserted_by_an_edge_stay_indexed` loads
`tests/armel/dbus-cleanup-sockets_stripped`, runs both recipes above over it and
asserts that every node in each resulting graph is findable through
`get_any_node()`. `TestSpillingCFGAddressIndex` covers the two insertion shapes
directly, a node removed and reintroduced by an edge, and a node whose only
insertion is an edge. All three fail on the merge base — the end-to-end one
with the `AttributeError` above, the unit tests on `has_node_addr()` returning
`False` for a node that is in the graph — and pass here.

Fixes #6764. Validation: https://github.com/angr/angr/pull/6808#issuecomment-5247605017

session: sharpen
