### PR TITLE
CFGFast: Stop aborting when a pre-executed block ends in a failure exit

### DIFF
--- a/angr/engines/failure.py
+++ b/angr/engines/failure.py
@@ -11,12 +11,22 @@ from .successors import SuccessorsEngine
 log = logging.getLogger(name=__name__)
 
 
+def is_failure_jumpkind(jumpkind: str | None) -> bool:
+    """
+    Check whether a jumpkind reports an emulation failure, a memory-mapping failure, or a signal.
+
+    SimEngineFailure refuses to step a state that arrived on one of these, so anything choosing a
+    successor to continue from has to skip them.
+    """
+    return jumpkind in ("Ijk_EmFail", "Ijk_MapFail") or (jumpkind is not None and jumpkind.startswith("Ijk_Sig"))
+
+
 class SimEngineFailure(SuccessorsEngine, ProcedureMixin):
     def process_successors(self, successors, **kwargs):
         state = self.state
         jumpkind = state.history.parent.jumpkind if state.history and state.history.parent else None
 
-        if jumpkind in ("Ijk_EmFail", "Ijk_MapFail") or (jumpkind is not None and jumpkind.startswith("Ijk_Sig")):
+        if is_failure_jumpkind(jumpkind):
             raise AngrExitError(f"Cannot execute following jumpkind {jumpkind}")
 
         if jumpkind == "Ijk_Exit":

--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -6,6 +6,7 @@ from cle import AT
 
 import angr
 from angr import claripy
+from angr.engines.failure import is_failure_jumpkind
 
 l = logging.getLogger(name=__name__)
 
@@ -242,10 +243,10 @@ class __libc_start_main(angr.SimProcedure):
         state = blank_state
         for b in blocks:
             irsb = self.project.factory.default_engine.process(state, irsb=b, force_addr=b.addr)
-            if irsb.successors:
-                state = irsb.successors[0]
-            else:
+            succ = next((s for s in irsb.successors if not is_failure_jumpkind(s.history.jumpkind)), None)
+            if succ is None:
                 break
+            state = succ
 
         cc = angr.default_cc(
             self.arch.name, platform=self.project.simos.name if self.project.simos is not None else None

--- a/angr/procedures/libc/error.py
+++ b/angr/procedures/libc/error.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import angr
+from angr.engines.failure import is_failure_jumpkind
 
 
 class error(angr.SimProcedure):
@@ -34,15 +35,16 @@ class error(angr.SimProcedure):
         state = blank_state
         for idx, b in enumerate(blocks):
             successors = self.project.factory.default_engine.process(state, irsb=b, force_addr=b.addr)
-            if successors.all_successors:
-                state = successors.all_successors[0]
+            steppable = [succ for succ in successors.all_successors if not is_failure_jumpkind(succ.history.jumpkind)]
+            if steppable:
+                state = steppable[0]
                 # if it was a call before reaching the last block, pick the one with Ijk_FakeRet
                 if (
                     idx < len(blocks) - 1
                     and b.jumpkind
                     and (b.jumpkind == "Ijk_Call" or b.jumpkind.startswith("Ijk_Sys"))
                 ):
-                    fakerets = [succ for succ in successors.all_successors if succ.history.jumpkind == "Ijk_FakeRet"]
+                    fakerets = [succ for succ in steppable if succ.history.jumpkind == "Ijk_FakeRet"]
                     if fakerets:
                         state = fakerets[0]
             else:

--- a/angr/procedures/posix/pthread.py
+++ b/angr/procedures/posix/pthread.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import angr
+from angr.engines.failure import is_failure_jumpkind
 
 # pylint: disable=arguments-differ,unused-argument,no-self-use,inconsistent-return-statements
 
@@ -30,10 +31,10 @@ class pthread_create(angr.SimProcedure):
         state = blank_state
         for b in blocks:
             irsb = self.project.factory.default_engine.process(state, b, force_addr=b.addr)
-            if irsb.successors:
-                state = irsb.successors[0]
-            else:
+            succ = next((s for s in irsb.successors if not is_failure_jumpkind(s.history.jumpkind)), None)
+            if succ is None:
                 break
+            state = succ
 
         callfunc = self.cc.get_args(state, self.prototype)[2]
         retaddr = state.memory.load(state.regs.sp, size=self.arch.bytes)

--- a/tests/analyses/cfg/test_cfg_simprocedure_exits.py
+++ b/tests/analyses/cfg/test_cfg_simprocedure_exits.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
+
+import struct
+import unittest
+
+import archinfo
+
+import angr
+
+BASE = 0x400000
+CALLBACK = object()  # stands in for the address of the callback, which is only known after layout
+
+
+def _segment_override_caller(args):
+    """
+    Build an x86 function that reads through %gs and then calls an imported function with ``args``,
+    and return the blob together with the addresses CFGFast will see.
+
+    A segment override lifts to an ``Ijk_MapFail`` exit guarded on the selector translation failing,
+    so the first block has a failure successor that the engine cannot step. That block is the
+    predecessor CFGFast hands to the callee's ``static_exits`` or ``dynamic_returns``.
+    """
+
+    code = bytearray()
+    code += b"\xbc\x00\x00\x41\x00"  # mov esp, 0x410000
+    code += b"\x65\xa1\x00\x00\x00\x00"  # mov eax, gs:[0]
+    code += b"\xeb\x00"  # jmp +0, ending the block
+    arg_operands = []
+    for arg in reversed(args):
+        code += b"\x68\x00\x00\x00\x00"  # push arg (patched below)
+        arg_operands.append((len(code) - 4, arg))
+    code += b"\xe8\x00\x00\x00\x00"  # call import (patched below)
+    call_operand = len(code) - 4
+    return_site = len(code)
+    code += bytes((0x83, 0xC4, 4 * len(args)))  # add esp, 4 * len(args)
+    code += b"\xc3"  # ret
+    callback = len(code)
+    code += b"\x31\xc0\xc3"  # xor eax, eax; ret
+    import_stub = len(code)
+    code += b"\xc3"  # ret, replaced by the hook
+
+    for operand, arg in arg_operands:
+        struct.pack_into("<I", code, operand, BASE + callback if arg is CALLBACK else arg)
+    struct.pack_into("<i", code, call_operand, import_stub - return_site)
+    return bytes(code), BASE + return_site, BASE + callback, BASE + import_stub
+
+
+def _cfg_calling(procedure_name, args):
+    """
+    Recover a CFG of a caller that passes ``args`` to ``procedure_name`` over a segment override.
+    """
+
+    code, return_site, callback, import_stub = _segment_override_caller(args)
+    arch = archinfo.arch_from_id("x86")
+    proj = angr.load_shellcode(code, arch, load_address=BASE)
+    proj.hook(import_stub, angr.SIM_LIBRARIES["libc.so.6"][0].get(procedure_name, arch))
+    return proj.analyses.CFGFast(normalize=True, resolve_indirect_jumps=True), return_site, callback
+
+
+class TestCfgSimProcedureExits(unittest.TestCase):
+    """
+    CFGFast asks a hooked SimProcedure to pre-execute the blocks leading up to a call site. Those
+    blocks can produce failure successors, and stepping one raises AngrExitError out of the whole
+    analysis unless the procedure keeps to successors that execution can continue from.
+    """
+
+    def test_pthread_create_static_exits_over_segment_override(self):
+        # pthread_create(thread, attr, start_routine, arg)
+        cfg, _, callback = _cfg_calling("pthread_create", (0, 0, CALLBACK, 0))
+
+        # static_exits recovered the thread entry point from the call site
+        assert callback in cfg.functions
+        assert cfg.kb.labels[callback] == "thread_entry"
+
+    def test_libc_start_main_static_exits_over_segment_override(self):
+        # __libc_start_main(main, argc, argv, init, fini)
+        cfg, _, callback = _cfg_calling("__libc_start_main", (CALLBACK, 1, 0, 0, 0))
+
+        # static_exits recovered main from the call site
+        assert callback in cfg.functions
+        assert cfg.kb.labels[callback] == "main"
+
+    def test_error_dynamic_returns_over_segment_override(self):
+        # error(status, errnum, fmt) does not return when status is nonzero
+        cfg, return_site, _ = _cfg_calling("error", (1, 0, 0))
+
+        # dynamic_returns read the nonzero status off the stack, so the call site does not return
+        caller = cfg.functions.get_by_addr(BASE)
+        assert caller.returning is False
+        assert return_site not in {block.addr for block in caller.blocks}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/cfg/test_cfg_simprocedure_exits.py
+++ b/tests/analyses/cfg/test_cfg_simprocedure_exits.py
@@ -4,61 +4,63 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
 
-import struct
+import os
 import unittest
 
 import archinfo
 
 import angr
+from tests.common import bin_location
 
-BASE = 0x400000
-CALLBACK = object()  # stands in for the address of the callback, which is only known after layout
+# A libgomp relocatable. gomp_team_start reads through %gs at many points, so the block preceding
+# several of its call sites ends in a failure exit guarded on the selector translation failing, and
+# the procedure at the call site is handed that block.
+BINARY = os.path.join(bin_location, "tests", "i386", "cfg_mapfail_static_member.o")
+ARCH = archinfo.arch_from_id("x86")
+
+# Offsets into gomp_team_start. The pthread_create call site and the block before it, which ends in
+# Ijk_Call:
+BEFORE_CALL = 0x32D
+CALL_SITE = 0x394
+# A call site whose predecessor ends in Ijk_Boring instead. error.dynamic_returns prefers an
+# Ijk_FakeRet successor when the predecessor ends in Ijk_Call, so only this shape reaches it:
+BEFORE_BORING = 0x68
+BORING_CALL_SITE = 0x153
 
 
-def _segment_override_caller(args):
+def _cfg(hooks):
     """
-    Build an x86 function that reads through %gs and then calls an imported function with ``args``,
-    and return the blob together with the addresses CFGFast will see.
-
-    A segment override lifts to an ``Ijk_MapFail`` exit guarded on the selector translation failing,
-    so the first block has a failure successor that the engine cannot step. That block is the
-    predecessor CFGFast hands to the callee's ``static_exits`` or ``dynamic_returns``.
-    """
-
-    code = bytearray()
-    code += b"\xbc\x00\x00\x41\x00"  # mov esp, 0x410000
-    code += b"\x65\xa1\x00\x00\x00\x00"  # mov eax, gs:[0]
-    code += b"\xeb\x00"  # jmp +0, ending the block
-    arg_operands = []
-    for arg in reversed(args):
-        code += b"\x68\x00\x00\x00\x00"  # push arg (patched below)
-        arg_operands.append((len(code) - 4, arg))
-    code += b"\xe8\x00\x00\x00\x00"  # call import (patched below)
-    call_operand = len(code) - 4
-    return_site = len(code)
-    code += bytes((0x83, 0xC4, 4 * len(args)))  # add esp, 4 * len(args)
-    code += b"\xc3"  # ret
-    callback = len(code)
-    code += b"\x31\xc0\xc3"  # xor eax, eax; ret
-    import_stub = len(code)
-    code += b"\xc3"  # ret, replaced by the hook
-
-    for operand, arg in arg_operands:
-        struct.pack_into("<I", code, operand, BASE + callback if arg is CALLBACK else arg)
-    struct.pack_into("<i", code, call_operand, import_stub - return_site)
-    return bytes(code), BASE + return_site, BASE + callback, BASE + import_stub
-
-
-def _cfg_calling(procedure_name, args):
-    """
-    Recover a CFG of a caller that passes ``args`` to ``procedure_name`` over a segment override.
+    Recover a CFG of the fixture, with each named import stub replaced by another procedure.
     """
 
-    code, return_site, callback, import_stub = _segment_override_caller(args)
-    arch = archinfo.arch_from_id("x86")
-    proj = angr.load_shellcode(code, arch, load_address=BASE)
-    proj.hook(import_stub, angr.SIM_LIBRARIES["libc.so.6"][0].get(procedure_name, arch))
-    return proj.analyses.CFGFast(normalize=True, resolve_indirect_jumps=True), return_site, callback
+    proj = angr.Project(BINARY, auto_load_libs=False)
+    for import_name, procedure in hooks.items():
+        symbol = proj.loader.find_symbol(import_name)
+        assert symbol is not None, import_name
+        proj.hook(symbol.rebased_addr, procedure, replace=True)
+    return proj.analyses.CFGFast(normalize=True, resolve_indirect_jumps=True)
+
+
+def _libc(name):
+    return angr.SIM_LIBRARIES["libc.so.6"][0].get(name, ARCH)
+
+
+def _assert_scanned(cfg, offsets):
+    """
+    The scan ran to completion: every symbol-seeded function start survives in the CFG, and
+    gomp_team_start covers the blocks whose pre-execution the procedure was handed.
+    """
+
+    loader = cfg.project.loader
+    defined = {symbol.rebased_addr for symbol in loader.main_object.symbols if symbol.is_function}
+    assert defined, "the fixture has no defined function symbols"
+    assert defined <= set(cfg.functions)
+
+    gomp_team_start = loader.find_symbol("gomp_team_start")
+    assert gomp_team_start is not None, "the fixture does not define gomp_team_start"
+    team_start = gomp_team_start.rebased_addr
+    blocks = {block.addr for block in cfg.functions[team_start].blocks}
+    assert {team_start + offset for offset in offsets} <= blocks
 
 
 class TestCfgSimProcedureExits(unittest.TestCase):
@@ -69,29 +71,27 @@ class TestCfgSimProcedureExits(unittest.TestCase):
     """
 
     def test_pthread_create_static_exits_over_segment_override(self):
-        # pthread_create(thread, attr, start_routine, arg)
-        cfg, _, callback = _cfg_calling("pthread_create", (0, 0, CALLBACK, 0))
-
-        # static_exits recovered the thread entry point from the call site
-        assert callback in cfg.functions
-        assert cfg.kb.labels[callback] == "thread_entry"
+        cfg = _cfg({})
+        # this case rests on angr's own default hook rather than on one the test installs
+        symbol = cfg.project.loader.find_symbol("pthread_create")
+        assert symbol is not None, "the fixture does not import pthread_create"
+        stub = symbol.rebased_addr
+        assert type(cfg.project.hooked_by(stub)).__name__ == "pthread_create"
+        _assert_scanned(cfg, (BEFORE_CALL, CALL_SITE))
 
     def test_libc_start_main_static_exits_over_segment_override(self):
-        # __libc_start_main(main, argc, argv, init, fini)
-        cfg, _, callback = _cfg_calling("__libc_start_main", (CALLBACK, 1, 0, 0, 0))
-
-        # static_exits recovered main from the call site
-        assert callback in cfg.functions
-        assert cfg.kb.labels[callback] == "main"
+        cfg = _cfg({"pthread_create": _libc("__libc_start_main")})
+        _assert_scanned(cfg, (BEFORE_CALL, CALL_SITE))
 
     def test_error_dynamic_returns_over_segment_override(self):
-        # error(status, errnum, fmt) does not return when status is nonzero
-        cfg, return_site, _ = _cfg_calling("error", (1, 0, 0))
-
-        # dynamic_returns read the nonzero status off the stack, so the call site does not return
-        caller = cfg.functions.get_by_addr(BASE)
-        assert caller.returning is False
-        assert return_site not in {block.addr for block in caller.blocks}
+        # defuse pthread_create so the only procedure that can reach a failure successor is error
+        cfg = _cfg(
+            {
+                "pthread_create": angr.SIM_PROCEDURES["stubs"]["ReturnUnconstrained"](),
+                "__libc_thr_self": _libc("error"),
+            }
+        )
+        _assert_scanned(cfg, (BEFORE_BORING, BORING_CALL_SITE))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` aborts with `AngrExitError` on ordinary i386 objects and loses every function found so far. On `tests/i386/cfg_mapfail_static_member.o`, the libgomp relocatable from the report, added by the binaries pull request this change depends on:

```
  File "angr/analyses/cfg/cfg_fast.py", line 3179, in _scan_procedure
    new_exits = procedure.static_exits(blocks_ahead, cfg=self)
  File "angr/procedures/posix/pthread.py", line 32, in static_exits
    irsb = self.project.factory.default_engine.process(state, b, force_addr=b.addr)
  File "angr/engines/failure.py", line 20, in process_successors
    raise AngrExitError(f"Cannot execute following jumpkind {jumpkind}")
angr.errors.AngrExitError: Cannot execute following jumpkind Ijk_MapFail
```

0 functions are recovered where the fix recovers 54.

### Root cause

`CFGFast` asks a hooked SimProcedure to pre-execute the blocks ahead of a call site. Here they are `0x4007e5` and `0x40084c` in `gomp_team_start`, and the first contains `mov eax, dword ptr gs:[0]` at `0x400815`, whose selector translation lifts to a guarded failure exit:

```
EXIT: if (t76) { PUT(offset=68) = 0x400815; Ijk_MapFail }
```

`static_exits` steps with `mode="fastpath"`, which does not solve the guard away, so both exits survive:

```
fastpath irsb.successors jumpkinds: ['Ijk_MapFail', 'Ijk_Call']
```

`pthread_create.static_exits`, `__libc_start_main.static_exits` and `error.dynamic_returns` each took `irsb.successors[0]` as the state for the next block. That is the `Ijk_MapFail` successor, and `SimEngineFailure` refuses to step a state whose parent arrived on one, so the next block raises out of the analysis.

### Fix

All three now continue from the first successor that is not a failure exit, using the engine's own rule, lifted out of `SimEngineFailure` as `engines.failure.is_failure_jumpkind` so the test and the refusal cannot drift apart. That is also what lets the pre-execution reach the arguments it was after: with the fix, `pthread_create.static_exits` reads the thread entry point off the stack and the scan completes.

`SimEngineFailure` still raises for a caller that genuinely asks to step such a state; only the successor these three procedures choose changes.

### Testing

`tests/analyses/cfg/test_cfg_simprocedure_exits.py` loads the fixture and covers the three implementations: one rests on angr's own default `pthread_create` hook and asserts it is in place, the other two replace one of the object's import stubs. Each asserts the scan runs to completion, every symbol-seeded function start surviving in the CFG and `gomp_team_start` covering the pair of blocks whose pre-execution the procedure was handed. All three fail on master with the same `AngrExitError` and no CFG at all. `error.dynamic_returns` prefers an `Ijk_FakeRet` successor when the predecessor block ends in `Ijk_Call`, so its case uses the call site at `0x40060b`, whose predecessor `0x400520` ends in `Ijk_Boring`. Deliberately not asserted: the recovered thread entry, `main` and `error` status, which are symbolic on this object because its arguments are register- and stack-sourced rather than immediates.

Reported in #6768. Needs angr/binaries#213 for the fixture. Validation: https://github.com/angr/angr/pull/6809#issuecomment-5247635580

sync: angr/binaries#213

session: sharpen