### PR TITLE
CFGFast: Do not record a call return site in an unmapped alignment hole

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3642,6 +3642,11 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         else:
             if self.project.arch.name != "Soot":
                 return_site = addr + irsb.size  # We assume the program will always return to the succeeding position
+                if self._fast_memory_load_byte(get_real_address_if_arm(self.project.arch, return_site)) is None:
+                    # A relocatable object is mapped one section at a time, so a call that ends an allocated
+                    # section returns into the alignment hole in front of the next one, where nothing is
+                    # mapped and no block can begin.
+                    return_site = None
             else:
                 # For Soot, we return to the next statement, which is not necessarily the next block (as Shimple does
                 # not break blocks at calls)

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -8,9 +8,12 @@ import io
 import logging
 import os
 import random
+import struct
+import tempfile
 import unittest
 
 import archinfo
+from elftools.elf.elffile import ELFFile
 
 import angr
 from angr.analyses.cfg.indirect_jump_resolvers import mips_elf_fast
@@ -1140,6 +1143,61 @@ class TestCfgfast(unittest.TestCase):
         assert block_size(4096, repeating_byte_run_threshold=0) == 99
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
+
+    def test_cfgfast_relocatable_object_with_alignment_hole(self):
+        # GitHub issue #6766. A relocatable object has no segments, so cle maps it one section at a time and
+        # aligns each section the way a linker would. That leaves a hole in front of every section whose
+        # alignment reaches past the end of the one before it. The hole sits inside the object's own
+        # min_addr/max_addr span with nothing behind it, so a call that is the last instruction of a section
+        # returns into unmapped memory. CFGFast recorded the hole as that call's return site and later died
+        # turning it into a code snippet: "No bytes in memory for block starting at ...".
+        #
+        # x86_64/decompiler/uname.o from the angr/binaries repository already has that layout, but the call
+        # that ends .text.startup goes to an external symbol, which angr hooks and therefore already knows
+        # returns. Shrinking .text.startup so it stops right after "call print_element" instead -- one field
+        # of one section header, no other byte touched -- reproduces the real shape: a section that ends on a
+        # call to a local function whose returning status is only settled after the scan.
+        section_name = ".text.startup"
+        call_site = 0x400C32
+
+        path = os.path.join(test_location, "x86_64", "decompiler", "uname.o")
+        pristine = angr.Project(path, auto_load_libs=False)
+        section = pristine.loader.main_object.sections_map[section_name]
+        call = pristine.factory.block(call_site)
+        assert call.vex.jumpkind == "Ijk_Call"
+        (callee,) = call.vex.constant_jump_targets
+        assert pristine.loader.main_object.min_addr <= callee < pristine.loader.main_object.max_addr
+
+        with open(path, "rb") as fixture:
+            elf = ELFFile(fixture)
+            index = next(i for i, s in enumerate(elf.iter_sections()) if s.name == section_name)
+            # sh_size is at offset 0x20 of an Elf64_Shdr
+            size_field = elf["e_shoff"] + index * elf["e_shentsize"] + 0x20
+            fixture.seek(0)
+            patched = bytearray(fixture.read())
+        struct.pack_into("<Q", patched, size_field, call.addr + call.size - section.vaddr)
+
+        with tempfile.TemporaryDirectory() as directory:
+            binary = os.path.join(directory, "uname.o")
+            with open(binary, "wb") as fp:
+                fp.write(patched)
+            proj = angr.Project(binary, auto_load_libs=False)
+
+            section = proj.loader.main_object.sections_map[section_name]
+            hole = section.vaddr + section.memsize
+            assert hole == call.addr + call.size
+            assert proj.loader.main_object.min_addr < hole < proj.loader.main_object.max_addr
+            assert hole not in proj.loader.memory
+
+            cfg = proj.analyses.CFGFast(normalize=True)
+
+            call_node = cfg.model.get_any_node(call_site)
+            assert call_node is not None
+            caller = cfg.kb.functions.get_by_addr(call_node.function_address)
+            assert call_site in set(caller.get_call_sites())
+            assert caller.get_call_return(call_site) is None
+            assert cfg.model.get_any_node(hole, anyaddr=True) is None
+            assert all(node.addr != hole for node in caller.transition_graph)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` dies on a relocatable object whose section ends on a call. Take
`binaries/tests/x86_64/decompiler/uname.o` and shrink `.text.startup` so it stops
right after the `call print_element` at `0x400c32` — one field of one section
header, no other byte touched. `CFGFast(normalize=True)` then ends the analysis
while turning that call's return site into a code snippet:

```
  File "angr/analyses/cfg/cfg_fast.py", line 4819, in _analyze_all_function_features
    return_to_snippet = self._to_snippet(addr=fr.return_to, base_state=self._base_state)
  File "angr/engines/vex/lifter.py", line 247, in lift_vex
    raise SimEngineError(f"No bytes in memory for block starting at {addr:#x}.")
angr.errors.SimEngineError: No bytes in memory for block starting at 0x400c3e.
```

`0x400c3e` is not past the object: it sits inside its own `0x400000`-`0x400f87`
span, with nothing mapped there. The exception escapes `CFGFast.__init__`, so the
whole result is lost, not just `main` — the same run recovers 108 nodes and 28
functions once the fix is in.

### Root cause

A relocatable has no segments, so cle maps it one section at a time and aligns
each section the way a linker would. That leaves a hole in front of every section
whose alignment reaches past the end of the one before it. `_create_job_call()`
assumes the byte after a call is always mapped:

```python
return_site = addr + irsb.size  # We assume the program will always return to the succeeding position
```

For a call that is the last instruction of a section, the succeeding position is
that hole. The call's `FunctionReturn` records it, and the analysis dies later,
in `_analyze_all_function_features()`, lifting an address no block can begin at.

### Fix

`_create_job_call()` leaves the return site unset when nothing is mapped at the
succeeding address, which is exactly the condition under which the assumption in
that comment does not hold. The call is then recorded with no return site rather
than with an unmappable one:

```
  call sites: ['0x400ba0', '0x400bd5', '0x400be6', '0x400bf9', '0x400c05', '0x400c11', '0x400c32']
  get_call_return(0x400c32) = None
  get_call_target(0x400c32) = 0x400210
  node at the alignment hole 0x400c3e: None
```

The guard is on the return site alone; the call edge, the callee and the rest of
`main` are unaffected, and a call whose successor byte is mapped takes the same
path as before.

### Testing

`test_cfgfast_relocatable_object_with_alignment_hole` performs that one-field
edit on a copy of `uname.o` in a temporary directory, asserts the hole is inside
the object's span and unmapped, and then asserts `CFGFast` recovers the call site
with no return site and creates no node at the hole. It fails on the merge base
with `SimEngineError: No bytes in memory for block starting at 0x400c3e` and
passes here.

Reported in #6766. Validation: https://github.com/angr/angr/pull/6810#issuecomment-5247731365

session: sharpen
