### PR TITLE
ArmElfFastResolver: Stop aborting CFGFast on an add of two registers

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/arm_elf_fast.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/arm_elf_fast.py
@@ -88,6 +88,9 @@ class ArmElfFastResolver(IndirectJumpResolver):
                 and isinstance(next_stmt.data, pyvex.IRExpr.Binop)
                 and "Add" in next_stmt.data.op
             ):
+                if not next_stmt.constants:
+                    # this add takes two registers, so it is not one of the constant offsets above
+                    return False, []
                 load_addr += next_stmt.constants[0].value
                 count += 1
 

--- a/tests/analyses/cfg/test_arm_elf_fast_resolver.py
+++ b/tests/analyses/cfg/test_arm_elf_fast_resolver.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
+
+import os
+import tempfile
+import unittest
+
+import angr
+from angr.analyses.cfg.indirect_jump_resolvers.arm_elf_fast import ArmElfFastResolver
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+FAUXWARE = os.path.join(test_location, "armel", "fauxware")
+
+# armel/fauxware is loaded at 0x8000, so an address in it is also its offset in the file
+LOAD_BASE = 0x8000
+
+# strcmp's PLT stub, the sequence _resolve_put is written for:
+#
+#   8430  add ip, pc, #0
+#   8434  add ip, ip, #0x8000
+#   8438  ldr pc, [ip, #0xbd4]!
+STRCMP_STUB = 0x8430
+
+# Overwriting accepted(), a leaf function, puts an add of two registers in a block that still ends in
+# an indirect jump through r12.
+ACCEPTED = 0x85F0
+REGISTER_ADD_BODY = bytes.fromhex(
+    "11caa0e3"  # mov ip, #0x11000
+    "023081e0"  # add r3, r1, r2
+    "20c08ce2"  # add ip, ip, #0x20
+    "04f0bce5"  # ldr pc, [ip, #4]!
+)
+
+
+class TestArmElfFastResolver(unittest.TestCase):
+    def test_plt_stub_is_resolved(self):
+        proj = angr.Project(FAUXWARE, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast()
+
+        strcmp = proj.loader.find_symbol("strcmp")
+        assert strcmp is not None
+        stub = cfg.model.get_any_node(STRCMP_STUB)
+        assert stub is not None
+        assert sorted(successor.addr for successor in cfg.model.get_successors(stub)) == [strcmp.rebased_addr]
+
+    def test_block_with_a_register_add_is_declined(self):
+        with open(FAUXWARE, "rb") as f:
+            image = bytearray(f.read())
+        offset = ACCEPTED - LOAD_BASE
+        image[offset : offset + len(REGISTER_ADD_BODY)] = REGISTER_ADD_BODY
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "fauxware-register-add")
+            with open(path, "wb") as f:
+                f.write(image)
+            proj = angr.Project(path, auto_load_libs=False)
+            # the register add used to raise IndexError here and abort the whole scan
+            cfg = proj.analyses.CFGFast()
+
+            # 0x11000 + 0x20 + 4 holds a code address, so adding up only the constants hands back a target
+            # for a block whose r12 also depends on r1 and r2
+            block = proj.factory.block(ACCEPTED, cross_insn_opt=False).vex  # how CFGFast lifts
+            resolver = ArmElfFastResolver(proj)
+            assert resolver.resolve(cfg, ACCEPTED, ACCEPTED, block, block.jumpkind) == (False, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` dies with `IndexError` on ARM ELF objects that reach `ArmElfFastResolver`, and the whole scan goes with it. Overwriting `accepted` at `0x85f0` in a copy of `binaries/tests/armel/fauxware` with `mov ip, #0x11000` / `add r3, r1, r2` / `add ip, ip, #0x20` / `ldr pc, [ip, #4]!` reproduces it:

```
  File "angr/analyses/cfg/indirect_jump_resolvers/arm_elf_fast.py", line 91, in _resolve_put
    load_addr += next_stmt.constants[0].value
                 ~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

`proj.analyses.CFGFast()` recovers 0 functions where it otherwise recovers 36. Corpus ARM ELF objects hit this on ordinary jump-table blocks.

### Root cause

`_resolve_put` models a three-instruction PLT stub, `add ip, pc, #X` / `add ip, ip, #Y` / `ldr pc, [ip, #Z]!`, by summing the constant offset of every `Add` binop in the block:

```python
if (
    isinstance(next_stmt, pyvex.IRStmt.WrTmp)
    and isinstance(next_stmt.data, pyvex.IRExpr.Binop)
    and "Add" in next_stmt.data.op
):
    load_addr += next_stmt.constants[0].value
```

An add of two registers is also an `Add` binop, and it carries no constant, so `constants` is empty and `constants[0]` raises. The resolver runs from `_resolve_indirect_jump_timelessly` inside the CFG job loop, which catches nothing, so one such block aborts recovery of the entire object.

### Fix

Decline the block instead: a block containing an add that is not a constant offset is not the stub `_resolve_put` models, so it returns `(False, [])` and the jump goes on to the other resolvers. On the reproducer above the scan then completes, and the resolver's own answer for the block is `(False, [])`.

Summing only the adds that do carry a constant is the alternative, and it is worse than crashing: on the same block it returns `(True, [0x841c])`, a target read from an address the block never forms, and because this resolver is timeless that answer keeps `JumpTableResolver` from ever seeing the jump.

### Testing

`tests/analyses/cfg/test_arm_elf_fast_resolver.py` has `test_block_with_a_register_add_is_declined`, which patches those four instructions into a copy of `tests/armel/fauxware` in a temporary directory, so it needs no new fixture. It fails on master with the `IndexError` above out of `proj.analyses.CFGFast()`, and against a variant that merely skips the constant-less add it fails on `assert (True, [33820]) == (False, [])`. `test_plt_stub_is_resolved` holds the stub the resolver does model, `strcmp`'s PLT entry at `0x8430`.

Reported in #6769. Validation: https://github.com/angr/angr/pull/6813#issuecomment-5248253458

session: sharpen
