### PR TITLE
PcodeLifter: Give each project its own Sleigh context

### DIFF
--- a/angr/block.py
+++ b/angr/block.py
@@ -472,7 +472,11 @@ class Block(Serializable):
         block_bytes = self.bytes
         if self.size is not None:
             block_bytes = block_bytes[: self.size]  # type: ignore
-        block_lifter = pcode.lifter.get_block_lifter(self._project, self.arch)  # type: ignore
+        block_lifter = (
+            self._project.pcode_block_lifter(self.arch)
+            if self._project is not None
+            else pcode.lifter.PcodeBasicBlockLifter(self.arch)  # type: ignore
+        )
         for cs_insn in block_lifter.context.disassemble(block_bytes, self.addr).instructions:
             insns.append(PCodeInsn(cs_insn))
         block = PCodeBlock(self.addr, insns, self.thumb, self.arch)

--- a/angr/block.py
+++ b/angr/block.py
@@ -472,8 +472,8 @@ class Block(Serializable):
         block_bytes = self.bytes
         if self.size is not None:
             block_bytes = block_bytes[: self.size]  # type: ignore
-        lifter = pcode.lifter.PcodeLifter.get_lifter(self.arch)  # type: ignore
-        for cs_insn in lifter.context.disassemble(block_bytes, self.addr).instructions:
+        block_lifter = pcode.lifter.get_block_lifter(self._project, self.arch)  # type: ignore
+        for cs_insn in block_lifter.context.disassemble(block_bytes, self.addr).instructions:
             insns.append(PCodeInsn(cs_insn))
         block = PCodeBlock(self.addr, insns, self.thumb, self.arch)
 

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -34,8 +34,6 @@ from .behavior import BehaviorFactory
 if TYPE_CHECKING:
     from pypcode import Context, PcodeOp
 
-    from angr.project import Project
-
 
 l = logging.getLogger(__name__)
 
@@ -829,7 +827,7 @@ class PcodeBasicBlockLifter:
     Lifts basic blocks to P-code
 
     Sleigh records context variables per address, so an instance must stay with one binary. See
-    :func:`get_block_lifter`.
+    :meth:`angr.project.Project.pcode_block_lifter`.
     """
 
     arch: archinfo.Arch
@@ -976,17 +974,6 @@ class PcodeBasicBlockLifter:
         const_cls = {8: U8, 16: U16, 32: U32, 64: U64}[irsb.arch.bits]
         irsb.next = Const(const_cls(next_block[0])) if next_block[0] is not None else None
         irsb.jumpkind = next_block[1]
-
-
-def get_block_lifter(project: Project | None, arch: archinfo.Arch) -> PcodeBasicBlockLifter:
-    """
-    Get the basic block lifter, and therefore the Sleigh context, that `project` decodes `arch` with.
-
-    Lifting with no project at all gets a context of its own. See :meth:`angr.project.Project.pcode_block_lifter`.
-    """
-    if project is None:
-        return PcodeBasicBlockLifter(arch)
-    return project.pcode_block_lifter(arch)
 
 
 class PcodeLifter(Lifter):
@@ -1305,7 +1292,7 @@ class PcodeLifterEngineMixin(SimEngine):
                     strict_block_end=strict_block_end,
                     skip_stmts=skip_stmts,
                     collect_data_refs=collect_data_refs,
-                    block_lifter=get_block_lifter(self.project, arch),
+                    block_lifter=self.project.pcode_block_lifter(arch) if self.project is not None else None,
                 )
 
                 if subphase == 0 and irsb.statements is not None:

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
+from weakref import WeakKeyDictionary
 
 import archinfo
 import cle
@@ -33,6 +34,8 @@ from .behavior import BehaviorFactory
 
 if TYPE_CHECKING:
     from pypcode import Context, PcodeOp
+
+    from angr.project import Project
 
 
 l = logging.getLogger(__name__)
@@ -647,6 +650,7 @@ def lift(
     inner: bool = False,
     skip_stmts: bool = False,
     collect_data_refs: bool = False,
+    block_lifter: PcodeBasicBlockLifter | None = None,
 ) -> IRSB:
     """
     Lift machine code in `data` to a P-code IRSB.
@@ -663,6 +667,8 @@ def lift(
     :param bytes_offset:    The offset into `data` to start lifting at.
     :param opt_level:       Unused by P-Code lifter
     :param traceflags:      Unused by P-Code lifter
+    :param block_lifter:    The basic block lifter, and therefore the Sleigh context, to decode with. A private one is
+                            created when it is not given.
 
     .. note:: Explicitly specifying the number of instructions to lift (`max_inst`) may not always work
               exactly as expected. For example, on MIPS, it is meaningless to lift a branch or jump
@@ -703,9 +709,13 @@ def lift(
         allow_arch_optimizations = False
         opt_level = 0
 
+    if block_lifter is None:
+        # the sub-lifts below are part of the same block, so they must all decode with this context
+        block_lifter = PcodeBasicBlockLifter(arch)
+
     u_data = data
     try:
-        final_irsb = PcodeLifter(arch, addr)._lift(
+        final_irsb = PcodeLifter(arch, addr, block_lifter)._lift(
             u_data,
             bytes_offset,
             max_bytes,
@@ -719,7 +729,7 @@ def lift(
         )
     except SkipStatementsError:
         assert skip_stmts is True
-        final_irsb = PcodeLifter(arch, addr)._lift(
+        final_irsb = PcodeLifter(arch, addr, block_lifter)._lift(
             u_data,
             bytes_offset,
             max_bytes,
@@ -778,6 +788,7 @@ def lift(
                 strict_block_end=strict_block_end,
                 skip_stmts=False,
                 collect_data_refs=collect_data_refs,
+                block_lifter=block_lifter,
             )
 
         next_addr = addr + final_irsb.size
@@ -800,6 +811,7 @@ def lift(
                 inner=True,
                 skip_stmts=False,
                 collect_data_refs=collect_data_refs,
+                block_lifter=block_lifter,
             )
             if more_irsb.size:
                 # Successfully decoded more bytes
@@ -817,6 +829,10 @@ def lift(
 class PcodeBasicBlockLifter:
     """
     Lifts basic blocks to P-code
+
+    Sleigh records context variables per address in the ``pypcode.Context``, so an instance decodes later blocks
+    differently depending on which blocks it decoded before: a branch leaves the delay slot context it sets behind
+    at the following address. An instance must therefore stay with a single binary; see :func:`get_block_lifter`.
     """
 
     context: Context
@@ -963,21 +979,45 @@ class PcodeBasicBlockLifter:
         irsb.jumpkind = next_block[1]
 
 
+_project_block_lifters: WeakKeyDictionary[Project, dict[archinfo.Arch, PcodeBasicBlockLifter]] = WeakKeyDictionary()
+
+
+def get_block_lifter(project: Project | None, arch: archinfo.Arch) -> PcodeBasicBlockLifter:
+    """
+    Get the basic block lifter, and therefore the Sleigh context, that `project` decodes `arch` with.
+
+    A project running the p-code engine keeps its lifters on that engine; any other project keeps them here. A
+    block with no project gets a lifter of its own. See :class:`PcodeBasicBlockLifter`.
+    """
+    if project is None:
+        return PcodeBasicBlockLifter(arch)
+    engine = project.factory.default_engine
+    if isinstance(engine, PcodeLifterEngineMixin):
+        return engine.get_block_lifter(arch)
+    block_lifters = _project_block_lifters.setdefault(project, {})
+    block_lifter = block_lifters.get(arch)
+    if block_lifter is None:
+        block_lifter = block_lifters[arch] = PcodeBasicBlockLifter(arch)
+    return block_lifter
+
+
 class PcodeLifter(Lifter):
     """
     Handles calling into pypcode to lift a block
     """
 
-    _lifter_cache = {}
+    __slots__ = ("block_lifter",)
 
-    @classmethod
-    def get_lifter(cls, arch):
-        if arch not in PcodeLifter._lifter_cache:
-            PcodeLifter._lifter_cache[arch] = PcodeBasicBlockLifter(arch)
-        return PcodeLifter._lifter_cache[arch]
+    block_lifter: PcodeBasicBlockLifter
+
+    def __init__(self, arch: archinfo.Arch, addr: int, block_lifter: PcodeBasicBlockLifter):
+        super().__init__(arch, addr)
+        self.block_lifter = block_lifter
 
     def lift(self) -> None:
-        self.get_lifter(self.arch).lift(
+        assert self.data is not None and not isinstance(self.data, str)
+        assert self.bytes_offset is not None
+        self.block_lifter.lift(
             self.irsb,
             self.addr,
             self.data,
@@ -1029,11 +1069,26 @@ class PcodeLifterEngineMixin(SimEngine):
             else:
                 self.selfmodifying_code = False
 
+        # basic block lifters
+        self._block_lifters: dict[archinfo.Arch, PcodeBasicBlockLifter] = {}
+
         # block cache
         self._block_cache = None
         self._block_cache_hits = 0
         self._block_cache_misses = 0
         self._initialize_block_cache()
+
+    def get_block_lifter(self, arch: archinfo.Arch) -> PcodeBasicBlockLifter:
+        """
+        Get the basic block lifter this engine decodes `arch` with, creating it on first use.
+
+        The factory keeps one engine per project and per thread, so an engine's lifters never decode blocks of
+        more than one binary. See :class:`PcodeBasicBlockLifter`.
+        """
+        block_lifter = self._block_lifters.get(arch)
+        if block_lifter is None:
+            block_lifter = self._block_lifters[arch] = PcodeBasicBlockLifter(arch)
+        return block_lifter
 
     def _initialize_block_cache(self) -> None:
         self._block_cache = LRUCache(maxsize=self._cache_size)
@@ -1149,6 +1204,7 @@ class PcodeLifterEngineMixin(SimEngine):
             raise ValueError("Must provide state or addr!")
         if arch is None:
             arch = clemory._arch if clemory else state.arch
+        assert arch is not None
         if arch.name.startswith("MIPS") and self._single_step:
             l.error("Cannot specify single-stepping on MIPS.")
             self._single_step = False
@@ -1278,6 +1334,7 @@ class PcodeLifterEngineMixin(SimEngine):
                     strict_block_end=strict_block_end,
                     skip_stmts=skip_stmts,
                     collect_data_refs=collect_data_refs,
+                    block_lifter=self.get_block_lifter(arch),
                 )
 
                 if subphase == 0 and irsb.statements is not None:
@@ -1427,6 +1484,9 @@ class PcodeLifterEngineMixin(SimEngine):
         self._single_step = s["_single_step"]
         self._cache_size = s["_cache_size"]
         self.default_strict_block_end = s["default_strict_block_end"]
+
+        # Sleigh contexts do not survive pickling; rebuild them on demand
+        self._block_lifters = {}
 
         # rebuild block cache
         self._initialize_block_cache()

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -984,15 +984,12 @@ def get_block_lifter(project: Project | None, arch: archinfo.Arch) -> PcodeBasic
     """
     Get the basic block lifter, and therefore the Sleigh context, that `project` decodes `arch` with.
 
-    A project running the p-code engine keeps its lifter on that engine, which the factory keeps per thread as
-    well as per project. Any other project keeps it on itself, in ``Project._pcode_block_lifter``. A block with
-    no project gets a lifter of its own. See :class:`PcodeBasicBlockLifter`.
+    A project keeps it on itself, in ``Project._pcode_block_lifter``, whichever engine it runs, so every block of
+    one binary decodes with one context and no block of another does. Lifting with no project at all gets a
+    context of its own. See :class:`PcodeBasicBlockLifter`.
     """
     if project is None:
         return PcodeBasicBlockLifter(arch)
-    engine = project.factory.default_engine
-    if isinstance(engine, PcodeLifterEngineMixin):
-        return engine.get_block_lifter(arch)
     block_lifter = project._pcode_block_lifter  # pylint:disable=protected-access
     if block_lifter is None or block_lifter.arch != arch:
         block_lifter = project._pcode_block_lifter = PcodeBasicBlockLifter(arch)  # pylint:disable=protected-access
@@ -1067,25 +1064,11 @@ class PcodeLifterEngineMixin(SimEngine):
             else:
                 self.selfmodifying_code = False
 
-        # basic block lifter
-        self._block_lifter: PcodeBasicBlockLifter | None = None
-
         # block cache
         self._block_cache = None
         self._block_cache_hits = 0
         self._block_cache_misses = 0
         self._initialize_block_cache()
-
-    def get_block_lifter(self, arch: archinfo.Arch) -> PcodeBasicBlockLifter:
-        """
-        Get the basic block lifter this engine decodes `arch` with, creating it on first use.
-
-        The factory keeps one engine per project and per thread, so an engine's lifter never decodes blocks of
-        more than one binary. See :class:`PcodeBasicBlockLifter`.
-        """
-        if self._block_lifter is None or self._block_lifter.arch != arch:
-            self._block_lifter = PcodeBasicBlockLifter(arch)
-        return self._block_lifter
 
     def _initialize_block_cache(self) -> None:
         self._block_cache = LRUCache(maxsize=self._cache_size)
@@ -1331,7 +1314,7 @@ class PcodeLifterEngineMixin(SimEngine):
                     strict_block_end=strict_block_end,
                     skip_stmts=skip_stmts,
                     collect_data_refs=collect_data_refs,
-                    block_lifter=self.get_block_lifter(arch),
+                    block_lifter=get_block_lifter(self.project, arch),
                 )
 
                 if subphase == 0 and irsb.statements is not None:
@@ -1481,9 +1464,6 @@ class PcodeLifterEngineMixin(SimEngine):
         self._single_step = s["_single_step"]
         self._cache_size = s["_cache_size"]
         self.default_strict_block_end = s["default_strict_block_end"]
-
-        # Sleigh contexts do not survive pickling; rebuild on demand
-        self._block_lifter = None
 
         # rebuild block cache
         self._initialize_block_cache()

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -709,7 +709,6 @@ def lift(
         opt_level = 0
 
     if block_lifter is None:
-        # the sub-lifts below are part of the same block, so they must all decode with this context
         block_lifter = PcodeBasicBlockLifter(arch)
 
     u_data = data
@@ -829,9 +828,8 @@ class PcodeBasicBlockLifter:
     """
     Lifts basic blocks to P-code
 
-    Sleigh records context variables per address in the ``pypcode.Context``, so an instance decodes later blocks
-    differently depending on which blocks it decoded before: a branch leaves the delay slot context it sets behind
-    at the following address. An instance must therefore stay with a single binary; see :func:`get_block_lifter`.
+    Sleigh records context variables per address, so an instance must stay with one binary. See
+    :func:`get_block_lifter`.
     """
 
     arch: archinfo.Arch
@@ -984,16 +982,11 @@ def get_block_lifter(project: Project | None, arch: archinfo.Arch) -> PcodeBasic
     """
     Get the basic block lifter, and therefore the Sleigh context, that `project` decodes `arch` with.
 
-    A project keeps it on itself, in ``Project._pcode_block_lifter``, whichever engine it runs, so every block of
-    one binary decodes with one context and no block of another does. Lifting with no project at all gets a
-    context of its own. See :class:`PcodeBasicBlockLifter`.
+    Lifting with no project at all gets a context of its own. See :meth:`angr.project.Project.pcode_block_lifter`.
     """
     if project is None:
         return PcodeBasicBlockLifter(arch)
-    block_lifter = project._pcode_block_lifter  # pylint:disable=protected-access
-    if block_lifter is None or block_lifter.arch != arch:
-        block_lifter = project._pcode_block_lifter = PcodeBasicBlockLifter(arch)  # pylint:disable=protected-access
-    return block_lifter
+    return project.pcode_block_lifter(arch)
 
 
 class PcodeLifter(Lifter):
@@ -1010,8 +1003,6 @@ class PcodeLifter(Lifter):
         self.block_lifter = block_lifter
 
     def lift(self) -> None:
-        assert self.data is not None and not isinstance(self.data, str)
-        assert self.bytes_offset is not None
         self.block_lifter.lift(
             self.irsb,
             self.addr,

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -834,10 +834,12 @@ class PcodeBasicBlockLifter:
     at the following address. An instance must therefore stay with a single binary; see :func:`get_block_lifter`.
     """
 
+    arch: archinfo.Arch
     context: Context
     behaviors: BehaviorFactory
 
     def __init__(self, arch: archinfo.Arch):
+        self.arch = arch
         if isinstance(arch, ArchPcode):
             langid = arch.name
         else:
@@ -982,8 +984,8 @@ def get_block_lifter(project: Project | None, arch: archinfo.Arch) -> PcodeBasic
     """
     Get the basic block lifter, and therefore the Sleigh context, that `project` decodes `arch` with.
 
-    A project running the p-code engine keeps its lifters on that engine, which the factory keeps per thread as
-    well as per project. Any other project keeps them on itself, in ``Project._pcode_block_lifters``. A block with
+    A project running the p-code engine keeps its lifter on that engine, which the factory keeps per thread as
+    well as per project. Any other project keeps it on itself, in ``Project._pcode_block_lifter``. A block with
     no project gets a lifter of its own. See :class:`PcodeBasicBlockLifter`.
     """
     if project is None:
@@ -991,10 +993,9 @@ def get_block_lifter(project: Project | None, arch: archinfo.Arch) -> PcodeBasic
     engine = project.factory.default_engine
     if isinstance(engine, PcodeLifterEngineMixin):
         return engine.get_block_lifter(arch)
-    block_lifters = project._pcode_block_lifters  # pylint:disable=protected-access
-    block_lifter = block_lifters.get(arch)
-    if block_lifter is None:
-        block_lifter = block_lifters[arch] = PcodeBasicBlockLifter(arch)
+    block_lifter = project._pcode_block_lifter  # pylint:disable=protected-access
+    if block_lifter is None or block_lifter.arch != arch:
+        block_lifter = project._pcode_block_lifter = PcodeBasicBlockLifter(arch)  # pylint:disable=protected-access
     return block_lifter
 
 
@@ -1066,8 +1067,8 @@ class PcodeLifterEngineMixin(SimEngine):
             else:
                 self.selfmodifying_code = False
 
-        # basic block lifters
-        self._block_lifters: dict[archinfo.Arch, PcodeBasicBlockLifter] = {}
+        # basic block lifter
+        self._block_lifter: PcodeBasicBlockLifter | None = None
 
         # block cache
         self._block_cache = None
@@ -1079,13 +1080,12 @@ class PcodeLifterEngineMixin(SimEngine):
         """
         Get the basic block lifter this engine decodes `arch` with, creating it on first use.
 
-        The factory keeps one engine per project and per thread, so an engine's lifters never decode blocks of
+        The factory keeps one engine per project and per thread, so an engine's lifter never decodes blocks of
         more than one binary. See :class:`PcodeBasicBlockLifter`.
         """
-        block_lifter = self._block_lifters.get(arch)
-        if block_lifter is None:
-            block_lifter = self._block_lifters[arch] = PcodeBasicBlockLifter(arch)
-        return block_lifter
+        if self._block_lifter is None or self._block_lifter.arch != arch:
+            self._block_lifter = PcodeBasicBlockLifter(arch)
+        return self._block_lifter
 
     def _initialize_block_cache(self) -> None:
         self._block_cache = LRUCache(maxsize=self._cache_size)
@@ -1482,8 +1482,8 @@ class PcodeLifterEngineMixin(SimEngine):
         self._cache_size = s["_cache_size"]
         self.default_strict_block_end = s["default_strict_block_end"]
 
-        # Sleigh contexts do not survive pickling; rebuild them on demand
-        self._block_lifters = {}
+        # Sleigh contexts do not survive pickling; rebuild on demand
+        self._block_lifter = None
 
         # rebuild block cache
         self._initialize_block_cache()

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
-from weakref import WeakKeyDictionary
 
 import archinfo
 import cle
@@ -979,22 +978,20 @@ class PcodeBasicBlockLifter:
         irsb.jumpkind = next_block[1]
 
 
-_project_block_lifters: WeakKeyDictionary[Project, dict[archinfo.Arch, PcodeBasicBlockLifter]] = WeakKeyDictionary()
-
-
 def get_block_lifter(project: Project | None, arch: archinfo.Arch) -> PcodeBasicBlockLifter:
     """
     Get the basic block lifter, and therefore the Sleigh context, that `project` decodes `arch` with.
 
-    A project running the p-code engine keeps its lifters on that engine; any other project keeps them here. A
-    block with no project gets a lifter of its own. See :class:`PcodeBasicBlockLifter`.
+    A project running the p-code engine keeps its lifters on that engine, which the factory keeps per thread as
+    well as per project. Any other project keeps them on itself, in ``Project._pcode_block_lifters``. A block with
+    no project gets a lifter of its own. See :class:`PcodeBasicBlockLifter`.
     """
     if project is None:
         return PcodeBasicBlockLifter(arch)
     engine = project.factory.default_engine
     if isinstance(engine, PcodeLifterEngineMixin):
         return engine.get_block_lifter(arch)
-    block_lifters = _project_block_lifters.setdefault(project, {})
+    block_lifters = project._pcode_block_lifters  # pylint:disable=protected-access
     block_lifter = block_lifters.get(arch)
     if block_lifter is None:
         block_lifter = block_lifters[arch] = PcodeBasicBlockLifter(arch)

--- a/angr/project.py
+++ b/angr/project.py
@@ -252,8 +252,6 @@ class Project:
         if not set(self.cache_limits.keys()).issubset(CACHE_CONFIG_KEYS):
             raise ValueError(f"Invalid cache configuration keys: {set(self.cache_limits.keys()) - CACHE_CONFIG_KEYS}")
 
-        # Sleigh records context variables per address, so a basic block lifter decodes later blocks differently
-        # depending on which blocks it decoded before. Blocks of this binary decode with this one and no other.
         self._pcode_block_lifter: PcodeBasicBlockLifter | None = None
 
         self._languages: list[str] | None = None
@@ -806,6 +804,24 @@ class Project:
         return hook_decorator
 
     #
+    # P-code
+    #
+
+    def pcode_block_lifter(self, arch: archinfo.Arch) -> PcodeBasicBlockLifter:
+        """
+        Get the p-code basic block lifter, and therefore the Sleigh context, this project decodes `arch` with.
+
+        Sleigh records context variables per address, so the blocks of one binary decode with one context and no
+        block of another binary touches it. `arch` is normally this project's own; a `Block` may name another, and
+        decoding that with this project's context would answer for the wrong architecture, so it gets its own.
+        """
+        from .engines.pcode.lifter import PcodeBasicBlockLifter  # pylint:disable=import-outside-toplevel
+
+        if self._pcode_block_lifter is None or self._pcode_block_lifter.arch != arch:
+            self._pcode_block_lifter = PcodeBasicBlockLifter(arch)
+        return self._pcode_block_lifter
+
+    #
     # Pickling
     #
 
@@ -822,7 +838,6 @@ class Project:
                 not in {
                     "analyses",
                     "_llm_client",
-                    # Sleigh contexts do not survive pickling
                     "_pcode_block_lifter",
                 }
             }

--- a/angr/project.py
+++ b/angr/project.py
@@ -8,7 +8,7 @@ import types
 from collections import defaultdict
 from io import BytesIO, IOBase
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import archinfo
 import cle
@@ -23,6 +23,9 @@ from .llm_client import LLMClient
 from .procedures import SIM_LIBRARIES, SIM_PROCEDURES
 from .sim_procedure import SimProcedure
 from .simos import SimOS, os_mapping
+
+if TYPE_CHECKING:
+    from .engines.pcode.lifter import PcodeBasicBlockLifter
 
 l = logging.getLogger(name=__name__)
 
@@ -248,6 +251,10 @@ class Project:
         self.cache_limits = cache_limits if cache_limits is not None else {}
         if not set(self.cache_limits.keys()).issubset(CACHE_CONFIG_KEYS):
             raise ValueError(f"Invalid cache configuration keys: {set(self.cache_limits.keys()) - CACHE_CONFIG_KEYS}")
+
+        # Sleigh records context variables per address, so a basic block lifter decodes later blocks differently
+        # depending on which blocks it decoded before. Blocks of this binary decode with these and no others.
+        self._pcode_block_lifters: dict[archinfo.Arch, PcodeBasicBlockLifter] = {}
 
         self._languages: list[str] | None = None
         self.is_java_project = isinstance(self.arch, ArchSoot)
@@ -815,6 +822,8 @@ class Project:
                 not in {
                     "analyses",
                     "_llm_client",
+                    # Sleigh contexts do not survive pickling
+                    "_pcode_block_lifters",
                 }
             }
         finally:
@@ -823,6 +832,7 @@ class Project:
     def __setstate__(self, s):
         self.__dict__.update(s)
         self._llm_client = _UNSET
+        self._pcode_block_lifters = {}
         try:
             self._initialize_analyses_hub()
         except AngrNoPluginError:

--- a/angr/project.py
+++ b/angr/project.py
@@ -253,8 +253,8 @@ class Project:
             raise ValueError(f"Invalid cache configuration keys: {set(self.cache_limits.keys()) - CACHE_CONFIG_KEYS}")
 
         # Sleigh records context variables per address, so a basic block lifter decodes later blocks differently
-        # depending on which blocks it decoded before. Blocks of this binary decode with these and no others.
-        self._pcode_block_lifters: dict[archinfo.Arch, PcodeBasicBlockLifter] = {}
+        # depending on which blocks it decoded before. Blocks of this binary decode with this one and no other.
+        self._pcode_block_lifter: PcodeBasicBlockLifter | None = None
 
         self._languages: list[str] | None = None
         self.is_java_project = isinstance(self.arch, ArchSoot)
@@ -823,7 +823,7 @@ class Project:
                     "analyses",
                     "_llm_client",
                     # Sleigh contexts do not survive pickling
-                    "_pcode_block_lifters",
+                    "_pcode_block_lifter",
                 }
             }
         finally:
@@ -832,7 +832,7 @@ class Project:
     def __setstate__(self, s):
         self.__dict__.update(s)
         self._llm_client = _UNSET
-        self._pcode_block_lifters = {}
+        self._pcode_block_lifter = None
         try:
             self._initialize_analyses_hub()
         except AngrNoPluginError:

--- a/angr/project.py
+++ b/angr/project.py
@@ -8,7 +8,7 @@ import types
 from collections import defaultdict
 from io import BytesIO, IOBase
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import archinfo
 import cle
@@ -17,15 +17,13 @@ from archinfo.arch_soot import ArchSoot, SootAddressDescriptor
 from angr.knowledge_base import KnowledgeBase
 
 from .analyses.analysis import AnalysesHub, AnalysesHubWithDefault
+from .engines.pcode.lifter import PcodeBasicBlockLifter
 from .errors import AngrNoPluginError
 from .factory import AngrObjectFactory
 from .llm_client import LLMClient
 from .procedures import SIM_LIBRARIES, SIM_PROCEDURES
 from .sim_procedure import SimProcedure
 from .simos import SimOS, os_mapping
-
-if TYPE_CHECKING:
-    from .engines.pcode.lifter import PcodeBasicBlockLifter
 
 l = logging.getLogger(name=__name__)
 
@@ -815,8 +813,6 @@ class Project:
         block of another binary touches it. `arch` is normally this project's own; a `Block` may name another, and
         decoding that with this project's context would answer for the wrong architecture, so it gets its own.
         """
-        from .engines.pcode.lifter import PcodeBasicBlockLifter  # pylint:disable=import-outside-toplevel
-
         if self._pcode_block_lifter is None or self._pcode_block_lifter.arch != arch:
             self._pcode_block_lifter = PcodeBasicBlockLifter(arch)
         return self._pcode_block_lifter

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -5,8 +5,10 @@ import os
 from unittest import TestCase, main
 
 import archinfo
+import pyvex
 
 import angr
+from angr.engines.pcode import lifter as pcode_lifter
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "..", "binaries", "tests")
 
@@ -144,6 +146,61 @@ class TestPcodeEngine(TestCase):
                 continue
             func_out = func.graph.out_degree(func_node)
             assert func_out > 0
+
+    def test_sleigh_context_is_not_shared_between_projects(self):
+        """
+        Test that a project's blocks do not depend on which other projects were lifted before it.
+
+        Sleigh records context variables per address, so a PA-RISC branch lifted in one project used to leave the
+        delay slot context it sets behind at the following address, and an unrelated project's instruction at that
+        address was then decoded as that branch's delay slot.
+        """
+        base_addr = 0x1000
+        nop = b"\x08\x00\x02\x40"  # or %r0, %r0, %r0
+        branch = b"\xe8\x00\x00\x10"  # b 0x1010, whose delay slot is the instruction at 0x1004
+        arch = archinfo.ArchPcode("pa-risc:BE:32:default")
+
+        def project(code):
+            return angr.load_shellcode(code, arch=arch, load_address=base_addr, engine=angr.engines.UberEnginePcode)
+
+        def delay_slot_block():
+            block = project(nop * 8).factory.block(base_addr + 4)
+            next_expr = block.vex.next
+            assert isinstance(next_expr, pyvex.expr.Const)
+            return block.size, block.vex.jumpkind, next_expr.con.value
+
+        before = delay_slot_block()
+        assert before == (28, "Ijk_Boring", 0x1020)
+
+        # Lift the branch in another project, writing its delay slot context at base_addr + 4. The branch and its
+        # delay slot are one two-instruction block, which is what leaves the context behind.
+        branch_block = project(branch + nop * 7).factory.block(base_addr)
+        assert (branch_block.size, branch_block.instructions) == (8, 2)
+
+        assert delay_slot_block() == before
+
+    def test_block_lifter_is_kept_per_project(self):
+        """
+        Test that a project decodes with one basic block lifter, and therefore one Sleigh context, per architecture.
+
+        Block.pcode reads that context, so a project whose engine is not the p-code engine must neither share one
+        with another project nor build one for every block.
+        """
+        code = b"\x13\x00\x00\x00" * 4  # four RISC-V nops
+        first = angr.load_shellcode(code, arch="RISCV64", load_address=0)
+        second = angr.load_shellcode(code, arch="RISCV64", load_address=0)
+
+        assert [insn.mnemonic for insn in first.factory.block(0).pcode.insns] == ["nop"] * 4
+
+        block_lifter = pcode_lifter.get_block_lifter(first, first.arch)
+        assert pcode_lifter.get_block_lifter(first, first.arch) is block_lifter
+        assert pcode_lifter.get_block_lifter(second, second.arch) is not block_lifter
+
+        arch = archinfo.ArchPcode("pa-risc:BE:32:default")
+        third = angr.load_shellcode(
+            b"\x08\x00\x02\x40" * 4, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode
+        )
+        assert pcode_lifter.get_block_lifter(third, arch) is third.factory.default_engine.get_block_lifter(arch)
 
 
 if __name__ == "__main__":

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import pickle
+import threading
 from unittest import TestCase, main
 
 import archinfo
@@ -16,6 +17,7 @@ test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", 
 
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
+# pylint: disable=protected-access
 class TestPcodeEngine(TestCase):
     def test_shellcode(self):
         """
@@ -206,11 +208,46 @@ class TestPcodeEngine(TestCase):
         restored = pickle.loads(pickle.dumps(first))
         assert [insn.mnemonic for insn in restored.factory.block(0).pcode.insns] == ["nop"] * 4
 
+        # a project running the p-code engine keeps it in the same place, so its engine and its Block.pcode decode
+        # with one context rather than one each
         arch = archinfo.ArchPcode("pa-risc:BE:32:default")
         third = angr.load_shellcode(
             b"\x08\x00\x02\x40" * 4, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode
         )
-        assert pcode_lifter.get_block_lifter(third, arch) is third.factory.default_engine.get_block_lifter(arch)
+        assert third._pcode_block_lifter is None
+        assert third.factory.block(0x1000).instructions == 4
+        assert third._pcode_block_lifter is not None
+        assert pcode_lifter.get_block_lifter(third, arch) is third._pcode_block_lifter
+
+    def test_block_lifter_is_shared_between_threads(self):
+        """
+        Test that a project decodes with one basic block lifter whichever thread lifts.
+
+        The factory hands out one engine per thread, so keeping the lifter on the engine gave each thread its own
+        Sleigh context and made a block's decoding depend on which thread reached it first.
+        """
+        arch = archinfo.ArchPcode("pa-risc:BE:32:default")
+        proj = angr.load_shellcode(
+            b"\x08\x00\x02\x40" * 4, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode
+        )
+        assert proj.factory.block(0x1000).instructions == 4
+        main_lifter = proj._pcode_block_lifter
+        assert main_lifter is not None
+
+        seen = []
+
+        def lift_in_thread():
+            proj.factory.block(0x1000)
+            seen.append((proj.factory.default_engine, pcode_lifter.get_block_lifter(proj, arch)))
+
+        thread = threading.Thread(target=lift_in_thread)
+        thread.start()
+        thread.join()
+
+        assert len(seen) == 1
+        other_engine, other_lifter = seen[0]
+        assert other_engine is not proj.factory.default_engine  # the factory really did hand out a second engine
+        assert other_lifter is main_lifter
 
 
 if __name__ == "__main__":

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -10,6 +10,7 @@ import archinfo
 import pyvex
 
 import angr
+from angr.block import Block
 from angr.engines.pcode import lifter as pcode_lifter
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "..", "binaries", "tests")
@@ -195,14 +196,20 @@ class TestPcodeEngine(TestCase):
 
         assert [insn.mnemonic for insn in first.factory.block(0).pcode.insns] == ["nop"] * 4
 
-        block_lifter = pcode_lifter.get_block_lifter(first, first.arch)
+        block_lifter = first.pcode_block_lifter(first.arch)
         assert pcode_lifter.get_block_lifter(first, first.arch) is block_lifter
         assert pcode_lifter.get_block_lifter(second, second.arch) is not block_lifter
 
-        # a lifter decodes one architecture, so asking for another replaces it rather than decoding with it
+        # a lifter decodes one architecture, so a Block naming another gets its own rather than this one, which
+        # would answer for the architecture the caller did not ask for
         other_arch = archinfo.ArchPcode("pa-risc:BE:32:default")
-        assert pcode_lifter.get_block_lifter(first, other_arch).arch == other_arch
-        assert pcode_lifter.get_block_lifter(first, first.arch) is not block_lifter
+        assert first.pcode_block_lifter(other_arch).arch == other_arch
+        assert first.pcode_block_lifter(first.arch) is not block_lifter
+
+        # Block.__init__ takes an architecture from the caller, so this is reachable: decoded through the
+        # project's own context these bytes read as RISC-V nops, which is not what the caller asked for
+        elsewhere = Block(0, project=first, arch=other_arch, size=len(code))
+        assert [insn.mnemonic for insn in elsewhere.pcode.insns] == ["SPOP0,0x0"] * 4
 
         # a Sleigh context cannot be pickled, so the lifter a project keeps must not go into its pickle
         restored = pickle.loads(pickle.dumps(first))

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import pickle
 from unittest import TestCase, main
 
 import archinfo
@@ -195,6 +196,10 @@ class TestPcodeEngine(TestCase):
         block_lifter = pcode_lifter.get_block_lifter(first, first.arch)
         assert pcode_lifter.get_block_lifter(first, first.arch) is block_lifter
         assert pcode_lifter.get_block_lifter(second, second.arch) is not block_lifter
+
+        # a Sleigh context cannot be pickled, so the lifters a project keeps must not go into its pickle
+        restored = pickle.loads(pickle.dumps(first))
+        assert [insn.mnemonic for insn in restored.factory.block(0).pcode.insns] == ["nop"] * 4
 
         arch = archinfo.ArchPcode("pa-risc:BE:32:default")
         third = angr.load_shellcode(

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -11,7 +11,6 @@ import pyvex
 
 import angr
 from angr.block import Block
-from angr.engines.pcode import lifter as pcode_lifter
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "..", "binaries", "tests")
 
@@ -197,8 +196,8 @@ class TestPcodeEngine(TestCase):
         assert [insn.mnemonic for insn in first.factory.block(0).pcode.insns] == ["nop"] * 4
 
         block_lifter = first.pcode_block_lifter(first.arch)
-        assert pcode_lifter.get_block_lifter(first, first.arch) is block_lifter
-        assert pcode_lifter.get_block_lifter(second, second.arch) is not block_lifter
+        assert first.pcode_block_lifter(first.arch) is block_lifter
+        assert second.pcode_block_lifter(second.arch) is not block_lifter
 
         # a lifter decodes one architecture, so a Block naming another gets its own rather than this one, which
         # would answer for the architecture the caller did not ask for
@@ -224,7 +223,7 @@ class TestPcodeEngine(TestCase):
         assert third._pcode_block_lifter is None
         assert third.factory.block(0x1000).instructions == 4
         assert third._pcode_block_lifter is not None
-        assert pcode_lifter.get_block_lifter(third, arch) is third._pcode_block_lifter
+        assert third.pcode_block_lifter(arch) is third._pcode_block_lifter
 
     def test_block_lifter_is_shared_between_threads(self):
         """
@@ -245,7 +244,7 @@ class TestPcodeEngine(TestCase):
 
         def lift_in_thread():
             proj.factory.block(0x1000)
-            seen.append((proj.factory.default_engine, pcode_lifter.get_block_lifter(proj, arch)))
+            seen.append((proj.factory.default_engine, proj.pcode_block_lifter(arch)))
 
         thread = threading.Thread(target=lift_in_thread)
         thread.start()

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -182,7 +182,7 @@ class TestPcodeEngine(TestCase):
 
     def test_block_lifter_is_kept_per_project(self):
         """
-        Test that a project decodes with one basic block lifter, and therefore one Sleigh context, per architecture.
+        Test that a project decodes with one basic block lifter, and therefore one Sleigh context.
 
         Block.pcode reads that context, so a project whose engine is not the p-code engine must neither share one
         with another project nor build one for every block.
@@ -197,7 +197,12 @@ class TestPcodeEngine(TestCase):
         assert pcode_lifter.get_block_lifter(first, first.arch) is block_lifter
         assert pcode_lifter.get_block_lifter(second, second.arch) is not block_lifter
 
-        # a Sleigh context cannot be pickled, so the lifters a project keeps must not go into its pickle
+        # a lifter decodes one architecture, so asking for another replaces it rather than decoding with it
+        other_arch = archinfo.ArchPcode("pa-risc:BE:32:default")
+        assert pcode_lifter.get_block_lifter(first, other_arch).arch == other_arch
+        assert pcode_lifter.get_block_lifter(first, first.arch) is not block_lifter
+
+        # a Sleigh context cannot be pickled, so the lifter a project keeps must not go into its pickle
         restored = pickle.loads(pickle.dumps(first))
         assert [insn.mnemonic for insn in restored.factory.block(0).pcode.insns] == ["nop"] * 4
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

On a p-code architecture, the block a project lifts depends on which other binaries were lifted earlier in the same process. Lift seven PA-RISC nops at `0x1004`; then, in a second, unrelated `Project`, lift `b 0x1010` at `0x1000`; then lift the same seven nops again:

```
project A -- seven nops at 0x1004, lifted first:
    Block(0x1004) size=28 instructions=7
    jumpkind=Ijk_Boring next=0x1020

project C -- the same seven nops at 0x1004, lifted after project B:
    Block(0x1004) size=4 instructions=1
    jumpkind=Ijk_Boring next=0x1010
```

Same bytes, same address, same architecture, two different blocks. Anything a CFG, a decompilation or a test asserts about the second binary therefore depends on the order the binaries were loaded, and a result that holds when the binary is analysed alone stops holding in a batch run.

### Root cause

`PcodeLifter` kept its `PcodeBasicBlockLifter` — and so its `pypcode.Context` — in a class-level dict keyed only by architecture:

```python
    _lifter_cache = {}

    @classmethod
    def get_lifter(cls, arch):
        if arch not in PcodeLifter._lifter_cache:
            PcodeLifter._lifter_cache[arch] = PcodeBasicBlockLifter(arch)
        return PcodeLifter._lifter_cache[arch]
```

Sleigh records context variables per address in that context. PA-RISC `b 0x1010` at `0x1000` is a two-instruction block covering `0x1000` and `0x1004`, because decoding it writes the delay-slot context at `0x1004`. That write stays in the shared context, so the next project's instruction at `0x1004` decodes as that branch's delay slot and ends its block after one instruction.

### Fix

The lifter becomes `Project.pcode_block_lifter(arch)`, so one project's blocks decode through one context and no block of another project touches it. `Block.pcode` and the p-code engine both go through it, which means a project running the VEX engine still decodes `Block.pcode` with one context rather than building one per block. A `Block` may name an architecture other than the project's, and a context answers for one architecture only, so that case gets its own. A Sleigh context cannot be pickled, so it is excluded from `Project.__getstate__` and rebuilt on demand. After:

```
project C -- the same seven nops at 0x1004, lifted after project B:
    Block(0x1004) size=28 instructions=7
    jumpkind=Ijk_Boring next=0x1020
```

### Testing

`tests/engines/pcode/test_pcode.py::TestPcodeEngine::test_sleigh_context_is_not_shared_between_projects` is the sequence above; on master it fails with `assert (4, 'Ijk_Boring', 4112) == (28, 'Ijk_Boring', 4128)`. `test_block_lifter_is_kept_per_project` pins the rest of the placement — one lifter per project, a separate one for a `Block` naming another architecture, and a project that survives a pickle round trip — and `test_block_lifter_is_shared_between_threads` covers the reason the lifter is not on the engine: the factory hands out one engine per thread, which would give each thread its own context.

Validation: https://github.com/angr/angr/pull/6814#issuecomment-5248723975

session: mega-corpus
