### PR TITLE
PcodeLifter: Stop a block from running past the bytes it was given

### DIFF
--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -853,6 +853,24 @@ class PcodeBasicBlockLifter:
         self.context = pypcode.Context(langid)
         self.behaviors = BehaviorFactory()
 
+    @staticmethod
+    def _drop_incomplete_instruction(ops: list[PcodeOp], end_addr: int) -> list[PcodeOp]:
+        """
+        Drop the trailing instruction, if there is one, that Sleigh decoded past the end of the data.
+
+        Sleigh reads ahead at every instruction boundary and pypcode's load image zero-fills the part of such
+        a read it cannot satisfy, so a translation may end in an instruction decoded from bytes that were
+        never given to the lifter. A block covers only the bytes it was handed.
+
+        :param ops:         The p-code ops of one translation, in order.
+        :param end_addr:    The address one past the last byte given to Sleigh.
+        :return:            The ops up to and including the last instruction that fits.
+        """
+        for op_idx, op in enumerate(ops):
+            if op.opcode == pypcode.OpCode.IMARK and op.inputs[-1].offset + op.inputs[-1].size > end_addr:
+                return ops[:op_idx]
+        return ops
+
     def lift(
         self,
         irsb: IRSB,
@@ -909,7 +927,7 @@ class PcodeBasicBlockLifter:
                 max_bytes=max_bytes,
                 flags=pypcode.TranslateFlags.BB_TERMINATING,
             )
-            irsb._ops = translation.ops
+            irsb._ops = self._drop_incomplete_instruction(translation.ops, irsb.addr + len(sliced_data))
 
             last_decode_addr = irsb.addr
             last_imark_idx = 0
@@ -945,19 +963,22 @@ class PcodeBasicBlockLifter:
                 elif op.opcode == pypcode.OpCode.RETURN and next_block is None:
                     next_block = (None, "Ijk_Ret")
 
-            # FIXME: Do this lazily
-            disasm = self.context.disassemble(
-                sliced_data,
-                irsb.addr,
-                max_instructions=max_inst,
-                max_bytes=fallthru_addr - irsb.addr,
-            )
-            irsb._disassembly = PcodeDisassemblerBlock(
-                addr=irsb.addr,
-                insns=[PcodeDisassemblerInsn(ins) for ins in disasm.instructions],
-                thumb=False,
-                arch=irsb.arch,
-            )
+            # pypcode reads max_bytes=0 as "no limit" rather than as an empty request, so only ask for a
+            # disassembly once something has decoded.
+            if fallthru_addr > irsb.addr:
+                # FIXME: Do this lazily
+                disasm = self.context.disassemble(
+                    sliced_data,
+                    irsb.addr,
+                    max_instructions=max_inst,
+                    max_bytes=fallthru_addr - irsb.addr,
+                )
+                irsb._disassembly = PcodeDisassemblerBlock(
+                    addr=irsb.addr,
+                    insns=[PcodeDisassemblerInsn(ins) for ins in disasm.instructions],
+                    thumb=False,
+                    arch=irsb.arch,
+                )
 
         except (pypcode.BadDataError, pypcode.UnimplError):
             next_block = (fallthru_addr, "Ijk_NoDecode")

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -11,6 +11,7 @@ import pyvex
 
 import angr
 from angr.block import Block
+from angr.engines.pcode.lifter import IRSB_MAX_SIZE
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "..", "binaries", "tests")
 
@@ -102,6 +103,71 @@ class TestPcodeEngine(TestCase):
 
         assert simgr.active[0].regs.t6.concrete
         assert simgr.active[0].regs.t6.concrete_value == 1
+
+    def test_block_stops_at_the_last_fully_mapped_instruction(self):
+        """
+        Test that a block does not run past the end of the image.
+        """
+        # 0xe8 opens a five-byte "call rel32", so the last byte of this image starts an instruction whose
+        # remaining four bytes are not mapped at all. Sleigh reads ahead at every instruction boundary and
+        # pypcode zero-fills whatever part of that read the buffer cannot satisfy, so the call decodes from
+        # bytes that are not in memory.
+        code = b"\x90\x90\xe8"
+        base_address = 0x400000
+
+        arch = archinfo.ArchPcode("x86:LE:64:default")
+        p = angr.load_shellcode(code, arch=arch, load_address=base_address, engine=angr.engines.UberEnginePcode)
+        assert p.loader.main_object.max_addr == base_address + len(code) - 1
+
+        block = p.factory.block(base_address)
+        assert block.size == 2
+        assert block.bytes == b"\x90\x90"
+        assert list(block.instruction_addrs) == [base_address, base_address + 1]
+        assert [insn.mnemonic for insn in block.disassembly.insns] == ["NOP", "NOP"]
+
+        # There are not enough bytes for the instruction the block stopped in front of, so no block starts
+        # there either.
+        truncated = p.factory.block(base_address + 2)
+        assert truncated.size == 0
+        assert truncated.vex.jumpkind == "Ijk_NoDecode"
+
+    def test_block_stops_in_front_of_an_instruction_spanning_the_byte_cap(self):
+        """
+        Test that a block ends before an instruction that runs past the lifter's byte cap.
+        """
+        # The same zero-fill applies to a fully mapped image, because the lifter hands Sleigh at most
+        # IRSB_MAX_SIZE bytes at a time. This "call rel32" starts two bytes before that cap, so three of its
+        # five bytes are outside the buffer and decoding it there yields the wrong target.
+        call = b"\xe8\x11\x22\x33\x44"
+        base_address = 0x400000
+        arch = archinfo.ArchPcode("x86:LE:64:default")
+
+        p = angr.load_shellcode(
+            b"\x90" * (IRSB_MAX_SIZE - 2) + call + b"\xc3" * 16,
+            arch=arch,
+            load_address=base_address,
+            engine=angr.engines.UberEnginePcode,
+        )
+        block = p.factory.block(base_address)
+        assert block.size == IRSB_MAX_SIZE - 2
+        assert block.vex.jumpkind == "Ijk_Boring"
+
+        call_address = base_address + block.size
+        call_block = p.factory.block(call_address)
+        assert call_block.size == len(call)
+        assert call_block.vex.jumpkind == "Ijk_Call"
+        next_expr = call_block.vex.next
+        assert isinstance(next_expr, pyvex.expr.Const)
+        assert next_expr.con.value == call_address + len(call) + 0x44332211
+
+        # An instruction that ends exactly on the cap is still one the lifter was given.
+        aligned = angr.load_shellcode(
+            b"\x90" * IRSB_MAX_SIZE + b"\xc3" * 16,
+            arch=arch,
+            load_address=base_address,
+            engine=angr.engines.UberEnginePcode,
+        )
+        assert aligned.factory.block(base_address).size == IRSB_MAX_SIZE
 
     def test_callless_function_graph_consistency(self):
         binary_path = os.path.join(test_location, "x86_64", "fauxware")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

On a p-code architecture a block can report more bytes than the lifter was given and end in an instruction angr never read. Lifting `binaries/tests/x86_64/fauxware` as `x86:LE:64:default`, ten bytes from `0x4008b6` — the shape `CFGFast` produces whenever it caps a lift at a region boundary:

```
bytes handed to the lifter, 0x4008b6 + 10: 90 90 48 83 ec 08 e8 0f fd ff
block.size        = 11
instruction addrs = ['0x4008b6', '0x4008b7', '0x4008b8', '0x4008bc']
jumpkind          = Ijk_Call
exit target       = 0x14005d0
target is mapped  = False
```

The `call` at `0x4008bc` is five bytes long and four of them were handed over. The block claims a byte outside its own window, and its call target is `0x14005d0` where the instruction really targets `0x4005d0`, so recovery follows an edge to an address no object in the binary contains.

### Root cause

Sleigh reads ahead at every instruction boundary, and pypcode's load image zero-fills whatever part of that read the buffer cannot satisfy. The missing fifth byte therefore decodes as `00`: `e8 0f fd ff 00` is `CALL 0x14005d0`, while the real `e8 0f fd ff ff` is `CALL 0x4005d0`.

`PcodeBasicBlockLifter.lift` took the translation as given —

```python
irsb._ops = translation.ops
```

— and nothing compared the last `IMARK` against the end of `sliced_data`, so an instruction decoded partly from zero fill entered the IRSB with its bogus target, its jumpkind and its size.

### Fix

`_drop_incomplete_instruction` scans the ops for the first `IMARK` whose address plus size passes `irsb.addr + len(sliced_data)` and truncates there, so a block covers only bytes angr actually read:

```
block.size        = 6
instruction addrs = ['0x4008b6', '0x4008b7', '0x4008b8']
jumpkind          = Ijk_Boring
exit target       = 0x4008bc
```

The block now falls through to `0x4008bc`, where the `call` is lifted from all five of its bytes and reaches `0x4005d0`. Dropping the last instruction can leave nothing decoded at all, and pypcode reads `max_bytes=0` as "no limit" rather than as an empty request, so the disassembly call is skipped when `fallthru_addr == irsb.addr`; that block is empty with jumpkind `Ijk_NoDecode`.

### Testing

`test_block_stops_at_the_last_fully_mapped_instruction` lifts shellcode that runs off the end of its image and `test_block_stops_in_front_of_an_instruction_spanning_the_byte_cap` lifts a `call` straddling `IRSB_MAX_SIZE`, both in `tests/engines/pcode/test_pcode.py`. With `angr/engines/pcode/lifter.py` reverted they fail on `assert 7 == 2` and `assert 403 == (400 - 2)`.

Validation: https://github.com/angr/angr/pull/6816#issuecomment-5257453376

session: sharpen
