### PR TITLE
Pcode: Disassemble lazily and match VEX's block cache size.

### DIFF
--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -136,8 +136,6 @@ class IRSB:
     _size: int | None
     _statements: Iterable  # Note: currently unused
     _disassembly: PcodeDisassemblerBlock | None
-    # The lifter that decoded this block and the bytes it decoded, kept to disassemble on demand. Both decodes go
-    # through one lifter because Sleigh reads the context variables its own instance recorded.
     _disassembly_source: tuple[PcodeBasicBlockLifter, bytes] | None
     addr: int
     arch: archinfo.Arch

--- a/angr/engines/pcode/lifter.py
+++ b/angr/engines/pcode/lifter.py
@@ -113,6 +113,7 @@ class IRSB:
     __slots__ = (
         "_direct_next",
         "_disassembly",
+        "_disassembly_source",
         "_exit_statements",
         "_instruction_addresses",
         "_ops",
@@ -135,6 +136,9 @@ class IRSB:
     _size: int | None
     _statements: Iterable  # Note: currently unused
     _disassembly: PcodeDisassemblerBlock | None
+    # The lifter that decoded this block and the bytes it decoded, kept to disassemble on demand. Both decodes go
+    # through one lifter because Sleigh reads the context variables its own instance recorded.
+    _disassembly_source: tuple[PcodeBasicBlockLifter, bytes] | None
     addr: int
     arch: archinfo.Arch
     behaviors: BehaviorFactory | None
@@ -211,6 +215,7 @@ class IRSB:
         self.jumpkind = None
         self.next = None
         self._disassembly = None
+        self._disassembly_source = None
 
         if data is not None:
             # This is the slower path (because we need to call _from_py() to copy the content in the returned IRSB to
@@ -287,6 +292,7 @@ class IRSB:
         )
 
         self._disassembly = None
+        self._disassembly_source = None
         return self
 
     def invalidate_direct_next(self) -> None:
@@ -509,7 +515,15 @@ class IRSB:
         # return self._statements
 
     @property
-    def disassembly(self) -> PcodeDisassemblerBlock:
+    def disassembly(self) -> PcodeDisassemblerBlock | None:
+        if self._disassembly is None and self._disassembly_source is not None:
+            block_lifter, data = self._disassembly_source
+            self._disassembly_source = None
+            try:
+                self._disassembly = block_lifter.disassemble(self.addr, data)
+            except (pypcode.BadDataError, pypcode.UnimplError, pypcode.LowlevelError):
+                # A block that will not decode simply has no disassembly. This property does not raise.
+                l.debug("Failed to disassemble block at %#x", self.addr)
         return self._disassembly
 
 
@@ -853,6 +867,21 @@ class PcodeBasicBlockLifter:
         self.context = pypcode.Context(langid)
         self.behaviors = BehaviorFactory()
 
+    def disassemble(self, addr: int, data: bytes) -> PcodeDisassemblerBlock:
+        """
+        Disassemble the instructions of a single block.
+
+        :param addr: The address the block starts at.
+        :param data: The bytes of the block, exactly as they were lifted.
+        """
+        disasm = self.context.disassemble(data, addr, max_instructions=MAX_INSTRUCTIONS, max_bytes=len(data))
+        return PcodeDisassemblerBlock(
+            addr=addr,
+            insns=[PcodeDisassemblerInsn(ins) for ins in disasm.instructions],
+            thumb=False,
+            arch=self.arch,
+        )
+
     def lift(
         self,
         irsb: IRSB,
@@ -945,19 +974,9 @@ class PcodeBasicBlockLifter:
                 elif op.opcode == pypcode.OpCode.RETURN and next_block is None:
                     next_block = (None, "Ijk_Ret")
 
-            # FIXME: Do this lazily
-            disasm = self.context.disassemble(
-                sliced_data,
-                irsb.addr,
-                max_instructions=max_inst,
-                max_bytes=fallthru_addr - irsb.addr,
-            )
-            irsb._disassembly = PcodeDisassemblerBlock(
-                addr=irsb.addr,
-                insns=[PcodeDisassemblerInsn(ins) for ins in disasm.instructions],
-                thumb=False,
-                arch=irsb.arch,
-            )
+            # Keep what IRSB.disassembly needs to run Sleigh over the block on demand
+            if fallthru_addr > irsb.addr:
+                irsb._disassembly_source = (self, sliced_data[: fallthru_addr - irsb.addr])
 
         except (pypcode.BadDataError, pypcode.UnimplError):
             next_block = (fallthru_addr, "Ijk_NoDecode")
@@ -1015,7 +1034,7 @@ class PcodeLifterEngineMixin(SimEngine):
         self,
         project=None,
         use_cache: bool | None = None,
-        cache_size: int = 50000,
+        cache_size: int = 5000,
         default_opt_level: int = 1,
         selfmodifying_code: bool | None = None,
         single_step: bool = False,

--- a/tests/engines/pcode/test_pcode.py
+++ b/tests/engines/pcode/test_pcode.py
@@ -5,12 +5,16 @@ import os
 import pickle
 import threading
 from unittest import TestCase, main
+from unittest.mock import patch
 
 import archinfo
+import pypcode
 import pyvex
 
 import angr
 from angr.block import Block
+from angr.engines.pcode.lifter import PcodeLifterEngineMixin
+from angr.engines.vex.lifter import VEXLifter
 
 test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "..", "binaries", "tests")
 
@@ -254,6 +258,72 @@ class TestPcodeEngine(TestCase):
         other_engine, other_lifter = seen[0]
         assert other_engine is not proj.factory.default_engine  # the factory really did hand out a second engine
         assert other_lifter is main_lifter
+
+    def test_disassembly_is_lazy(self):
+        """
+        Lifting a block must not disassemble it. CFG recovery never reads IRSB.disassembly, so decoding it eagerly
+        costs a second Sleigh pass and an object per instruction on every lift, all of it retained by the block cache.
+        """
+        proj = angr.Project(os.path.join(test_location, "sh4", "test-instr_sh4"), auto_load_libs=False)
+        assert isinstance(proj.arch, archinfo.ArchPcode)
+
+        real_disassemble = pypcode.Context.disassemble
+        calls = []
+
+        def counting_disassemble(self, *args, **kwargs):
+            calls.append(args)
+            return real_disassemble(self, *args, **kwargs)
+
+        with patch.object(pypcode.Context, "disassemble", counting_disassemble):
+            irsb = proj.factory.block(proj.entry).vex
+            assert irsb.size > 0
+            assert not calls
+
+            disasm = irsb.disassembly
+            assert len(calls) == 1
+            assert [insn.address for insn in disasm.insns] == list(irsb.instruction_addresses)
+            assert sum(insn.size for insn in disasm.insns) == irsb.size
+
+            # The disassembly is decoded once and kept
+            assert irsb.disassembly is disasm
+            assert len(calls) == 1
+
+        # A block that stopped early disassembles to what it lifted, not to whatever follows it
+        short = proj.factory.block(proj.entry, num_inst=1).vex
+        assert len(short.disassembly.insns) == 1
+        assert short.disassembly.insns[0].size == short.size
+
+    def test_disassembly_failure_is_not_raised(self):
+        """
+        IRSB.disassembly does not propagate a Sleigh decode error. A block that will not decode simply has no
+        disassembly, which is all its callers have ever had to handle.
+        """
+        proj = angr.Project(os.path.join(test_location, "sh4", "test-instr_sh4"), auto_load_libs=False)
+        irsb = proj.factory.block(proj.entry).vex
+
+        def failing_disassemble(self, *args, **kwargs):
+            raise pypcode.BadDataError("Unable to resolve constructor")
+
+        with patch.object(pypcode.Context, "disassemble", failing_disassemble):
+            assert irsb.disassembly is None
+
+        # Sleigh is not asked again; a second attempt here would succeed and return a block
+        assert irsb.disassembly is None
+
+    def test_block_cache_no_larger_than_vex(self):
+        """
+        A p-code block retains several times what the equivalent VEX block does, so the p-code engine must not cache
+        more blocks than the VEX engine.
+        """
+        binary_path = os.path.join(test_location, "x86_64", "fauxware")
+        vex_proj = angr.Project(binary_path, auto_load_libs=False)
+        pcode_proj = angr.Project(binary_path, auto_load_libs=False, engine=angr.engines.UberEnginePcode)
+
+        vex_engine = vex_proj.factory.default_engine
+        pcode_engine = pcode_proj.factory.default_engine
+        assert isinstance(vex_engine, VEXLifter)
+        assert isinstance(pcode_engine, PcodeLifterEngineMixin)
+        assert pcode_engine._cache_size <= vex_engine._cache_size  # pylint: disable=protected-access
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast(normalize=True)` on `binaries/tests/sh4/test-instr_sh4` exhausts an 850 MB address-space budget that the same recovery under VEX stays comfortably inside. With `resource.setrlimit(resource.RLIMIT_AS, ...)` applied before `import angr`:

```text
  File "angr/engines/pcode/lifter.py", line 892, in lift
    translation = self.context.translate(
MemoryError: std::bad_alloc
RESULT: MemoryError, no CFG
```

The lift that reports it is innocent, and which one reports it moves between runs — one run died under `_process_one_indirect_jump`, the next under `_generate_cfgnode`. The run is simply out of room by the time it gets there, and because the exception escapes `CFGFast.__init__` nothing is recovered at all: not a truncated CFG, no CFG.

### Root cause

Two things drive the footprint, and neither buys anything.

Every lift ran a second Sleigh pass to build a disassembly that CFG recovery never reads, one `PcodeDisassemblerInsn` per instruction, retained for as long as the IRSB is:

```python
            # FIXME: Do this lazily
            disasm = self.context.disassemble(
                sliced_data, irsb.addr, max_instructions=max_inst, max_bytes=fallthru_addr - irsb.addr,
            )
            irsb._disassembly = PcodeDisassemblerBlock(...)
```

And the engine kept ten times as many of those blocks as VEX does, while each p-code block retains several times as much:

```python
class PcodeLifterEngineMixin(SimEngine):
    def __init__(self, project=None, use_cache=None, cache_size: int = 50000, ...)
```

`VEXLifter.__init__` defaults `cache_size=5000`.

### Fix

`IRSB.disassembly` now keeps the lifter and the exact bytes that were lifted, and runs Sleigh on first access — from the block it lifted, so a `num_inst`-limited block disassembles to what it lifted rather than to whatever follows it. The property returns `None` instead of raising when Sleigh cannot decode, which is what its callers already handle. `cache_size` drops to VEX's 5000.

Same command, same 850 MB cap:

```text
RESULT: CFG completed, 3217 functions, 36850 nodes
peak RSS: 410 MB
```

### Testing

Three tests in `tests/engines/pcode/test_pcode.py`, all three failing on master:

- `test_disassembly_is_lazy` patches `pypcode.Context.disassemble` and asserts a lift calls it zero times, that reading `.disassembly` calls it once and caches, that the instruction addresses and sizes agree with the IRSB's own, and that a `num_inst=1` block yields exactly one instruction.
- `test_disassembly_failure_is_not_raised` asserts a `BadDataError` from Sleigh surfaces as `None`.
- `test_block_cache_no_larger_than_vex` asserts the p-code engine's cache is no larger than `VEXLifter`'s.

#6814 rearranges the same lifter; the two are independent.

Validation: https://github.com/angr/angr/pull/6817#issuecomment-5257882364

session: sharpen
