### PR TITLE
SimProcedures: Fix pthread_create.static_exits().

### DIFF
--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -247,9 +247,7 @@ class __libc_start_main(angr.SimProcedure):
             else:
                 break
 
-        cc = angr.default_cc(
-            self.arch.name, platform=self.project.simos.name if self.project.simos is not None else None
-        )(self.arch)
+        cc = self._resolve_cc()
         ty = angr.sim_type.parse_signature("void x(void*, void*, void*, void*, void*)").with_arch(self.arch)
         args = cc.get_args(state, ty)
         main, _, _, init, fini = self._extract_args(blank_state, *args)

--- a/angr/procedures/posix/pthread.py
+++ b/angr/procedures/posix/pthread.py
@@ -29,13 +29,13 @@ class pthread_create(angr.SimProcedure):
         # Execute each block
         state = blank_state
         for b in blocks:
-            irsb = self.project.factory.default_engine.process(state, b, force_addr=b.addr)
+            irsb = self.project.factory.default_engine.process(state, irsb=b, force_addr=b.addr)
             if irsb.successors:
                 state = irsb.successors[0]
             else:
                 break
 
-        callfunc = self.cc.get_args(state, self.prototype)[2]
+        callfunc = self._resolve_cc().get_args(state, self.prototype)[2]
         retaddr = state.memory.load(state.regs.sp, size=self.arch.bytes)
 
         return [

--- a/angr/sim_procedure.py
+++ b/angr/sim_procedure.py
@@ -196,6 +196,34 @@ class SimProcedure:
             " (stub)" if self.is_stub else "",
         )
 
+    def _resolve_cc(self) -> angr.SimCC:
+        """
+        Get the calling convention of this procedure, falling back to the architecture's default one and caching the
+        result in ``self.cc``.
+
+        :return:                    The calling convention to use.
+        :raises SimProcedureError:  If this procedure has no calling convention and the architecture has no default
+                                    one.
+        """
+        if self.cc is not None:
+            return self.cc
+
+        arch = self.arch
+        if arch is None:
+            raise SimProcedureError(f"{self} has no architecture. You must specify a calling convention.")
+        if arch.name not in DEFAULT_CC:
+            raise SimProcedureError(
+                f"There is no default calling convention for architecture {arch.name}."
+                " You must specify a calling convention."
+            )
+        cc_cls = default_cc(
+            arch.name,
+            platform=(self.project.simos.name if self.project is not None and self.project.simos is not None else None),
+        )
+        assert cc_cls is not None
+        self.cc = cc_cls(arch)
+        return self.cc
+
     def execute(self, state, successors=None, arguments=None, ret_to=None):
         """
         Call this method with a SimState and a SimSuccessors to execute the procedure.
@@ -210,21 +238,7 @@ class SimProcedure:
             self.arch = state.arch
         if self.project is None:
             self.project = state.project
-        if self.cc is None:
-            if self.arch.name in DEFAULT_CC:
-                cc_cls = default_cc(
-                    self.arch.name,
-                    platform=(
-                        self.project.simos.name if self.project is not None and self.project.simos is not None else None
-                    ),
-                )
-                assert cc_cls is not None
-                self.cc = cc_cls(self.arch)
-            else:
-                raise SimProcedureError(
-                    f"There is no default calling convention for architecture {self.arch.name}."
-                    " You must specify a calling convention."
-                )
+        self._resolve_cc()
         assert self.prototype is not None
         if self.prototype._arch is None:
             self.prototype = self.prototype.with_arch(self.arch)

--- a/tests/procedures/posix/test_pthread_create.py
+++ b/tests/procedures/posix/test_pthread_create.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.procedures.posix"  # pylint:disable=redefined-builtin
+
+import unittest
+
+import archinfo
+
+import angr
+
+BASE_ADDR = 0x400000
+
+
+def assemble(arch: archinfo.Arch, code: str, addr: int = BASE_ADDR) -> bytes:
+    encoded = arch.asm(code, addr)
+    assert isinstance(encoded, bytes)
+    return encoded
+
+
+def call_site(arch: archinfo.Arch, thread_entry: int, callee: int = BASE_ADDR) -> bytes:
+    """
+    Assemble a call to pthread_create passing ``thread_entry`` as its start_routine argument.
+    """
+    return assemble(
+        arch,
+        f"mov rdx, {thread_entry:#x}\nxor rcx, rcx\nxor rsi, rsi\nxor rdi, rdi\ncall {callee:#x}\nret\n",
+    )
+
+
+class TestPthreadCreateStaticExits(unittest.TestCase):
+    """
+    CFGFast calls pthread_create.static_exits() to recover the entry point of the spawned thread.
+    """
+
+    def test_static_exits_uses_the_blocks_it_is_given(self):
+        # hand static_exits() a block lifted from different bytes than memory holds, and see which start_routine
+        # comes back out
+        arch = archinfo.arch_from_id("AMD64")
+        proj = angr.load_shellcode(call_site(arch, 0x400800), arch=arch, load_address=BASE_ADDR)
+        block = proj.factory.block(BASE_ADDR, byte_string=call_site(arch, 0x400900)).vex
+
+        procedure = angr.SIM_PROCEDURES["posix"]["pthread_create"](
+            project=proj, cc=angr.calling_conventions.SimCCSystemVAMD64(arch)
+        )
+        exits = procedure.static_exits([block])
+
+        thread_exit = next(exit_ for exit_ in exits if exit_["jumpkind"] == "Ijk_Call")
+        assert thread_exit["address"].concrete_value == 0x400900
+
+    def test_static_exits_falls_back_to_the_default_calling_convention(self):
+        arch = archinfo.arch_from_id("AMD64")
+        proj = angr.load_shellcode(call_site(arch, 0x400800), arch=arch, load_address=BASE_ADDR)
+
+        procedure = angr.SIM_PROCEDURES["posix"]["pthread_create"](project=proj)
+        assert procedure.cc is None
+        exits = procedure.static_exits([proj.factory.block(BASE_ADDR).vex])
+
+        thread_exit = next(exit_ for exit_ in exits if exit_["jumpkind"] == "Ijk_Call")
+        assert thread_exit["address"].concrete_value == 0x400800
+
+    def test_pcode_cfg_recovers_the_thread_entry(self):
+        amd64 = archinfo.arch_from_id("AMD64")
+        # assemble once against a placeholder to measure the call site, then again with the real addresses
+        placeholder = call_site(amd64, BASE_ADDR)
+        hook_addr = BASE_ADDR + len(placeholder)
+        thread_entry = hook_addr + 1
+        code = call_site(amd64, thread_entry, hook_addr)
+        assert len(code) == len(placeholder)
+        code += assemble(amd64, "ret\n", hook_addr)
+        code += assemble(amd64, "xor rax, rax\nret\n", thread_entry)
+
+        arch = archinfo.ArchPcode("x86:LE:64:default")
+        proj = angr.load_shellcode(
+            code,
+            arch=arch,
+            load_address=BASE_ADDR,
+            start_offset=BASE_ADDR,
+            engine=angr.engines.UberEnginePcode,
+        )
+        proj.hook(hook_addr, angr.SIM_PROCEDURES["posix"]["pthread_create"]())
+
+        # the thread entry is unreachable by scanning, so only static_exits() can find it
+        cfg = proj.analyses.CFGFast(force_smart_scan=False, force_complete_scan=False)
+        assert cfg.kb.labels.get(thread_entry) == "thread_entry"
+        assert thread_entry in cfg.functions
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` on a p-code architecture aborts the moment its scan reaches a call to a hooked `pthread_create`. `binaries/tests/i386/ctf_nuclear` imports it, so it is hooked at `0x810005c` and reached through the PLT stub at `0x80488c0`:

```text
  File "angr/analyses/cfg/cfg_fast.py", line 3049, in _scan_procedure
    new_exits = procedure.static_exits(blocks_ahead, cfg=self)
  File "angr/procedures/posix/pthread.py", line 30, in static_exits
    irsb = self.project.factory.default_engine.process(state, b, force_addr=b.addr)
TypeError: SuccessorsEngine.process() takes 2 positional arguments but 3 were given
```

The exception escapes `CFGFast.__init__`, so the run yields no CFG at all rather than a CFG missing one thread entry.

### Root cause

`static_exits()` pre-executes the blocks ahead of the call site and hands each one to the engine positionally. On p-code, `process` resolves to `SuccessorsEngine.process(self, state, **kwargs)` and there is no second positional to take it.

VEX does not raise, and that is the worse half. There `process` resolves to `VEXSlicingMixin.process(self, state, block=None, ...)`, so the block is bound to `block`, forwarded into `**kwargs`, and never reaches the parameter that carries a pre-lifted block:

```python
    def process_successors(self, successors, irsb=None, ...):
        ...
            if irsb is None:
                irsb = self.lift_vex(insn_bytes=insn_bytes, addr=addr, state=self.state, ...)
```

The caller's block is dropped and the address is re-lifted from memory, which is a different block whenever the caller lifted from anything else.

The second defect is next to it: `static_exits()` read `self.cc` directly, while `execute()` is the only path that ever filled it in. A procedure instantiated without a calling convention — a hook whose library never saw this architecture — therefore had `self.cc is None` at `self.cc.get_args(...)`. `__libc_start_main.static_exits()` worked around it by rebuilding `angr.default_cc(...)` inline, a second copy of the logic in `execute()`.

### Fix

The block is passed as `irsb=`. The default-convention resolution moves out of `execute()` into `SimProcedure._resolve_cc()`, which caches into `self.cc` and raises `SimProcedureError` naming the architecture when there is no default; both `static_exits()` implementations call it, and `__libc_start_main`'s inline copy is deleted.

Same command as above:

```text
RESULT: CFG completed, 91 functions
  0x810005c: node <CFGNode pthread_create [0]>, called from 0x80488c0
```

### Testing

`tests/procedures/posix/test_pthread_create.py`, three tests, all three failing on master:

- `test_static_exits_uses_the_blocks_it_is_given` hands `static_exits()` a block lifted from bytes that differ from what memory holds, and asserts the start routine that comes back is the block's `0x400900` rather than memory's `0x400800` — the assertion the VEX path fails silently today.
- `test_static_exits_falls_back_to_the_default_calling_convention` builds the procedure with no `cc` and asserts `static_exits()` still returns `0x400800`.
- `test_pcode_cfg_recovers_the_thread_entry` runs `CFGFast` on a p-code project over a call to the hooked procedure and asserts the thread entry is labelled and present in the function manager.

Validation: https://github.com/angr/angr/pull/6818#issuecomment-5258697430

session: sharpen
