### PR TITLE
FastConstantPropagation: Stop lifting hook nodes as zero-byte blocks

### DIFF
--- a/angr/analyses/fcp/fcp.py
+++ b/angr/analyses/fcp/fcp.py
@@ -12,7 +12,7 @@ from angr.analyses.analysis import AnalysesHub, Analysis
 from angr.analyses.propagator.vex_vars import VEXReg, VEXTmp
 from angr.block import Block
 from angr.calling_conventions import SimStackArg
-from angr.codenode import BlockNode, FuncNode, HookNode
+from angr.codenode import BlockNode, CodeNode, FuncNode, HookNode
 from angr.engines.light import RegisterOffset, SimEngineLight, SimEngineNostmtVEX, SpOffset
 from angr.knowledge_plugins.functions import Function
 from angr.utils.bits import s2u
@@ -313,7 +313,7 @@ class FastConstantPropagation(Analysis):
         if self._blocks:
             block_addrs = {b.addr for b in self._blocks}
 
-        states: dict[BlockNode, FCPState] = {}
+        states: dict[CodeNode, FCPState] = {}
         for node in sorted_nodes:
             preds = func_graph.predecessors(node)
             input_states = [states[pred] for pred in preds if pred in states]
@@ -327,13 +327,8 @@ class FastConstantPropagation(Analysis):
             # process the block
             if isinstance(node, BlockNode) and node.size == 0:
                 continue
-            if isinstance(node, HookNode):
-                # attempt to convert it into a function
-                if self.kb.functions.contains_addr(node.addr):
-                    node = self.kb.functions.get_by_addr(node.addr, meta_only=True)
-                else:
-                    continue
-            if isinstance(node, FuncNode):
+            if isinstance(node, (FuncNode, HookNode)):
+                # a callee, not a block of this function
                 if self.kb.functions.contains_addr(node.addr):
                     callee = self.kb.functions.get_by_addr(node.addr, meta_only=True)
                     if callee.calling_convention is not None and callee.prototype is not None:

--- a/tests/analyses/test_fcp.py
+++ b/tests/analyses/test_fcp.py
@@ -9,6 +9,7 @@ import unittest
 
 import angr
 from angr.analyses.propagator.vex_vars import VEXReg
+from angr.codenode import HookNode
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
@@ -24,6 +25,19 @@ class TestFCP(unittest.TestCase):
         prop = p.analyses.FastConstantPropagation(func)
 
         assert len(prop.replacements) > 0
+
+    def test_hook_nodes_are_not_lifted(self):
+        # every SimProcedure stub is a function whose graph is a single hook node
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        p = angr.Project(bin_path, auto_load_libs=False)
+        cfg = p.analyses.CFGFast(normalize=True)
+
+        funcs = [func for func in cfg.functions.values() if any(isinstance(node, HookNode) for node in func.graph)]
+        assert funcs
+
+        for func in funcs:
+            prop = p.analyses.FastConstantPropagation(func)
+            assert not prop.replacements
 
     def test_register_propagation_across_calls(self):
         call_targets = [


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`CFGFast` aborts with `SimTranslationError: Unable to translate bytecode` when `ConstantResolver` runs `FastConstantPropagation` over a function whose graph holds a hook node. The node loop converts the hook into the knowledge-base `Function` and then tests it with `isinstance(node, FuncNode)`, which a `Function` can never satisfy, so the hook reaches `factory.block()` with the stub's size of zero. a31f3df8f replaced the `isinstance(node, Function)` test that the conversion used to feed.

A hook node names a callee rather than a block of the function under analysis, so it now takes the branch a `FuncNode` already takes: look the callee up in the knowledge base and lift nothing. The call-successor check below already pairs the two node kinds this way.

The regression runs the analysis over the SimProcedure stubs of `x86_64/fauxware`, each of whose graphs is a single hook node.

Validation: https://github.com/angr/angr/pull/6820#issuecomment-5258871932
