### PR TITLE
Resolve referenced sibling pull requests in the coverage tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,43 @@ jobs:
           path: test_durations.json
           key: cov-test-durations-${{ github.sha }}
           restore-keys: cov-test-durations-
+      - name: Resolve referenced sibling pull requests
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          config=$RUNNER_TEMP/uv-sources.toml
+          packages=
+          requirements=
+          seen=
+          references=$(printf '%s' "$PR_BODY" |
+            grep -Eo '[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+|github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+' |
+            sed -E -e 's|^github\.com/||' -e 's|/pull/|#|' -e 's|[/#]| |g') || true
+          while read -r owner repo number; do
+            [ -n "$number" ] || continue
+            case " $seen " in *" $owner/$repo "*) continue ;; esac
+            seen="$seen $owner/$repo"
+            package=$(sed -n '/^\[tool\.uv\.sources\]/,/^\[/p' pyproject.toml |
+              grep -F -e "\"https://github.com/$owner/$repo\"" -e "\"https://github.com/$owner/$repo.git\"" |
+              sed -E 's/^ *([^ =]+).*/\1/' |
+              head -n 1) || true
+            [ -n "$package" ] || continue
+            state=$(gh api "repos/$owner/$repo/pulls/$number" --jq .state) || state=unavailable
+            if [ "$state" != open ]; then
+              echo "$owner/$repo#$number is $state, so it is not used"
+              continue
+            fi
+            echo "Installing $package from $owner/$repo#$number"
+            packages="$packages\"$package\","
+            requirements="$requirements\"$package @ git+https://github.com/$owner/$repo@refs/pull/$number/head\","
+          done <<<"$references"
+          if [ -z "$packages" ]; then
+            echo "No sibling pull request is referenced, so every sibling stays on master"
+            exit 0
+          fi
+          printf 'no-sources-package = [%s]\nupgrade-package = [%s]\n' "$packages" "$requirements" | tee "$config"
+          echo "UV_CONFIG_FILE=$config" >>"$GITHUB_ENV"
       - name: Build
         run: uv sync --managed-python -v -p 3.12 --all-groups
       - name: Archive environment

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,11 +60,34 @@ jobs:
         run: |
           tar -xpf $PWD/env.tzst -C /
           rm env.tzst
+      - name: Resolve the angr/binaries ref
+        id: binaries-ref
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ref=master
+          number=$(printf '%s' "$PR_BODY" |
+            grep -Eo '(angr/binaries#|github\.com/angr/binaries/pull/)[0-9]+' |
+            head -n 1 |
+            grep -Eo '[0-9]+$') || true
+          if [ -n "$number" ]; then
+            state=$(gh api "repos/angr/binaries/pulls/$number" --jq .state) || state=unavailable
+            if [ "$state" = open ]; then
+              ref="refs/pull/$number/head"
+            else
+              echo "angr/binaries#$number is $state, so it is not used"
+            fi
+          fi
+          echo "Checking out angr/binaries at $ref"
+          echo "ref=$ref" >>"$GITHUB_OUTPUT"
       - name: Download test binaries
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           repository: angr/binaries
           path: binaries
+          ref: ${{ steps.binaries-ref.outputs.ref }}
       - name: Relocate binaries directory
         run: mv binaries ..
       - name: Run tests


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The `ci` jobs angr inherits resolve a referenced sibling pull request out of the description; the coverage workflow, which this repository defines itself, did not. It took binaries from master, and its `uv sync` took every sibling Python package from the branch pinned in `[tool.uv.sources]`, so a change needing a sibling fix stayed red here until that fix merged.

The build job now reads the reference out of the body in the two spellings `resolve_refs.py` accepts and writes `no-sources-package` plus `upgrade-package` to a uv configuration file under the runner temporary directory. uv resolves that package from the pull request head inside its own resolver, keeps every other sibling on master, and writes nothing into the checkout. angr/cle#738 and angr/angr-management#1716 now carry this same mechanism.

Validation: https://github.com/angr/angr/pull/6821#issuecomment-5259365682.
