### PR TITLE
JumpTableResolver: Follow the PowerPC branch alignment mask

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -72,6 +72,7 @@ class AddressTransformationTypes(int, enum.Enum):
     ShiftRight = 6
     Add = 7
     Load = 8
+    AlignmentMask = 9
 
 
 class AddressTransformation:
@@ -1022,14 +1023,18 @@ class JumpTableResolver(IndirectJumpResolver):
             elif not potential_call_table and not is_arm:
                 l.debug("Indirect jump at %#x does not look like a jump table. Skip.", addr)
                 return False, None
-            if (
-                potential_call_table
-                and transformations
-                and next(iter(transformations.values())).op != AddressTransformationTypes.Load
-            ):
-                # targets of call tables must be directly loaded from memory
-                l.debug("Indirect jump/call at %#x does not look like an indirect call from a call table. Skip", addr)
-                return False, None
+            if potential_call_table:
+                # the alignment mask that the lifter puts on the branch target is not part of the address
+                # computation, so it does not say anything about where the target came from
+                addr_trans = [
+                    tran for tran in transformations.values() if tran.op is not AddressTransformationTypes.AlignmentMask
+                ]
+                if addr_trans and addr_trans[0].op != AddressTransformationTypes.Load:
+                    # targets of call tables must be directly loaded from memory
+                    l.debug(
+                        "Indirect jump/call at %#x does not look like an indirect call from a call table. Skip", addr
+                    )
+                    return False, None
 
         # Debugging output
         if l.level == logging.DEBUG:
@@ -1494,6 +1499,34 @@ class JumpTableResolver(IndirectJumpResolver):
                             AddressTransformationTypes.ShiftRight, [AddressSingleton, stmt.data.args[1].con.value]
                         )
                         continue
+                    elif (
+                        stmt.data.op.startswith("Iop_And")
+                        and isinstance(stmt, pyvex.stmt.WrTmp)
+                        and isinstance(stmt.data.args[0], pyvex.IRExpr.RdTmp)
+                        and isinstance(stmt.data.args[1], pyvex.IRExpr.Const)
+                        and block.tyenv.sizeof(stmt.tmp) == self.project.arch.bits
+                        and stmt.data.args[1].con.value == self._instruction_alignment_mask()
+                    ):
+                        # PowerPC ignores the low two bits of the count and link registers, so the lifter masks the
+                        # target of every bcctr and bclr.
+                        # e.g.
+                        #        IRSB 0x4c6b38
+                        #  + 01 | t17 = GET:I32(gpr30)
+                        #  + 02 | t16 = Add32(t17,0xffffeb8c)
+                        #  + 03 | t18 = LDbe:I32(t16)
+                        #  + 05 | t1 = GET:I32(gpr9)
+                        #  + 06 | t2 = Shl32(t1,0x02)
+                        #  + 09 | t19 = Add32(t18,t2)
+                        #  + 10 | t22 = LDbe:I32(t19)
+                        #  + 13 | t8 = Add32(t22,t18)
+                        #    16 | PUT(ctr) = t8
+                        #  + 18 | t23 = And32(t8,0xfffffffc)
+                        #  + Next: t23
+                        stmts_to_remove.append(stmt_loc)
+                        transformations[(stmt_loc[0], stmt.tmp)] = AddressTransformation(
+                            AddressTransformationTypes.AlignmentMask, [AddressSingleton, stmt.data.args[1].con.value]
+                        )
+                        continue
                 elif isinstance(stmt.data, pyvex.IRExpr.Load):
                     assert isinstance(stmt, pyvex.stmt.WrTmp)
                     # Got it!
@@ -1746,6 +1779,9 @@ class JumpTableResolver(IndirectJumpResolver):
         def handle_or1(a):
             return a | 1
 
+        def handle_alignment_mask(con, a):
+            return a & con
+
         def handle_lshift(num_bits, a):
             return a << num_bits
 
@@ -1779,6 +1815,10 @@ class JumpTableResolver(IndirectJumpResolver):
                     raise NotImplementedError("Unsupported truncation operation.")
             elif tran_op is AddressTransformationTypes.Or1:
                 lam = handle_or1
+            elif tran_op is AddressTransformationTypes.AlignmentMask:
+                lam = functools.partial(
+                    handle_alignment_mask, next(iter(arg for arg in args if arg is not AddressSingleton))
+                )
             elif tran_op is AddressTransformationTypes.ShiftLeft:
                 lam = functools.partial(handle_lshift, next(iter(arg for arg in args if arg is not AddressSingleton)))
             elif tran_op is AddressTransformationTypes.ShiftRight:
@@ -1944,6 +1984,12 @@ class JumpTableResolver(IndirectJumpResolver):
         # we use this to differentiate between traditional jump tables (where each entry is some blocks that belong to
         # the current function) and vtables (where each entry is a function).
         if stride < load_size:
+            if load_size != project.arch.bytes or stmts_adding_base_addr:
+                # A vtable holds pointers that are jumped to as they are. These entries are narrower than a pointer, or
+                # a base address is added to them, so this is an offset table whose address interval came out too
+                # imprecise to tell where the table ends.
+                l.debug("The address of the jump table at %#x is too imprecise to bound the table. Skip.", addr)
+                return None
             stride = load_size
             total_cases = jumptable_addr.cardinality // load_size
             sort = "vtable"  # it's probably a vtable!
@@ -2590,6 +2636,18 @@ class JumpTableResolver(IndirectJumpResolver):
         if vex_block.jumpkind == "Ijk_NoDecode":
             return False
         return vex_block.size != 0
+
+    def _instruction_alignment_mask(self) -> int | None:
+        """
+        Build the mask that clears the bits an instruction address cannot use on this architecture.
+
+        :return:    The mask, or None if instructions may start at any byte.
+        """
+
+        alignment = self.project.arch.instruction_alignment
+        if alignment is None or alignment <= 1:
+            return None
+        return ((1 << self.project.arch.bits) - 1) & ~(alignment - 1)
 
     def _is_address_mapped(self, addr: int) -> bool:
         return (

--- a/tests/analyses/cfg/test_jumptables.py
+++ b/tests/analyses/cfg/test_jumptables.py
@@ -2826,6 +2826,117 @@ class TestJumpTableResolver(unittest.TestCase):
             0x40D1F8,
         ]
 
+    def test_ppc_jumptable_behind_bcctr_alignment_mask(self):
+        # PowerPC ignores the low two bits of the count register, so the lifter masks the target of every bcctr with
+        # ~3, and the jump table load sits behind that mask.
+        p = angr.Project(os.path.join(test_location, "ppc", "libc.so.6"), auto_load_libs=False)
+        # only the function that holds the dispatch, so that the test does not scan all of libc
+        cfg = p.analyses[CFGFast].prep()(regions=[(0x4C6A00, 0x4C6A00 + 0x47C4)])
+
+        assert 0x4C6B38 in cfg.model.jump_tables
+        assert cfg.indirect_jumps[0x4C6B38].type == IndirectJumpType.Jumptable_AddressLoadedFromMemory
+        jumptable = cfg.model.jump_tables[0x4C6B38]
+        assert jumptable.jumptable_addr == 0x55A054
+        assert jumptable.jumptable_entry_size == 4
+        # The switch has 60 cases. The table is bounded by the mask that truncates the index (clrlwi r9, r9, 0x18)
+        # instead of the comparison against 0x3b that follows it, so the entries past the 60th are read out of the
+        # tables that come after this one.
+        assert jumptable.jumptable_entries is not None
+        assert len(jumptable.jumptable_entries) == 256
+        assert jumptable.jumptable_entries[:60] == [
+            0x4C6DC0,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6E00,
+            0x4C6DC0,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D10,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6CD0,
+            0x4C6DC0,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6D1C,
+            0x4C6B90,
+            0x4C6B50,
+        ]
+
+    def test_ppc64_jumptable_behind_bcctr_alignment_mask(self):
+        # The same mask on PPC64, where the table holds 32-bit offsets. The entries are narrower than a pointer and a
+        # base address is added to them, so this table must not be taken for a vtable.
+        p = angr.Project(os.path.join(test_location, "ppc64el", "fauxware_static"), auto_load_libs=False)
+        # only read_encoded_value_with_base, which holds the dispatch
+        cfg = p.analyses[CFGFast].prep()(regions=[(0x10096D20, 0x10096F00)])
+
+        assert 0x10096D40 in cfg.model.jump_tables
+        assert cfg.indirect_jumps[0x10096D40].type == IndirectJumpType.Jumptable_AddressLoadedFromMemory
+        jumptable = cfg.model.jump_tables[0x10096D40]
+        assert jumptable.jumptable_addr == 0x10096D58
+        assert jumptable.jumptable_entry_size == 4
+        # The switch has 13 cases, and the table is bounded by the index mask as above.
+        assert jumptable.jumptable_entries is not None
+        assert len(jumptable.jumptable_entries) == 16
+        assert jumptable.jumptable_entries[:13] == [
+            0x10096D90,
+            0x10096E00,
+            0x10096E40,
+            0x10096E50,
+            0x10096D90,
+            0x10096EC4,
+            0x10096EC4,
+            0x10096EC4,
+            0x10096EC4,
+            0x10096E70,
+            0x10096DF0,
+            0x10096E60,
+            0x10096D90,
+        ]
+
     def test_amd64_fmt0_with_constant_propagation_r12(self):
         p = angr.Project(os.path.join(test_location, "x86_64", "fmt_0"), auto_load_libs=False)
         cfg = p.analyses[CFGFast].prep()()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` resolves no jump table on a PowerPC binary. A full run over `binaries/tests/ppc/libc.so.6` recovers 0 of them on master and 3 with this change. Two dispatches, the 60-case switch at `0x4c6b38` in that libc and the 13-case one at `0x10096d40` in `binaries/tests/ppc64el/fauxware_static`:

```text
ppc/libc.so.6: jump tables in the region: 0
ppc/libc.so.6: bcctr at 0x4c6b38: Unknown
ppc/libc.so.6: no jump table resolved at 0x4c6b38
ppc64el/fauxware_static: jump tables in the region: 0
ppc64el/fauxware_static: bcctr at 0x10096d40: Unknown
ppc64el/fauxware_static: no jump table resolved at 0x10096d40
```

An unresolved dispatch has no successors, so every case body goes unreached: the switch is a dead end in the CFG and nothing downstream of it — function boundaries, structuring, decompilation — sees the cases at all.

### Root cause

PowerPC ignores the low two bits of the count register, so the lifter ends every `bcctr` block with a mask. The block at `0x4c6b38`, abridged to the statements on the target's dataflow:

```text
   09 | t19 = Add32(t18,t2)
   10 | t22 = LDbe:I32(t19)
   13 | t8 = Add32(t22,t18)
   16 | PUT(ctr) = t8
   18 | t23 = And32(t8,0xfffffffc)
   NEXT: PUT(cia) = t23; Ijk_Boring
```

`_find_load_statement` walks that slice backwards from `NEXT`, taking one address transformation per statement: it has arms for `Iop_Add`, `Iop_Shl`, `Iop_Sar`, `Iop_Or` and the truncations, and none for `Iop_And`. So the walk stops at statement 18 and never reaches the `LDbe:I32` at statement 10 that reads the table. With no load statement there is no table, and the jump is recorded as `Unknown`.

### Fix

An `Iop_And` by exactly the architecture's instruction alignment mask, on a temporary the width of a pointer, becomes an `AlignmentMask` address transformation and is replayed over the recovered entries like the others. Pinning it to that one constant and that one width keeps it away from the `And`s real address arithmetic uses. The call-table check skips an `AlignmentMask` when it asks whether the target was loaded directly from memory, since the lifter's mask says nothing about where the target came from.

Behind that sat a second problem no PowerPC binary could reach before. Where the table's address interval is too imprecise to bound the table, `_check_jumptable_type` fell through to `sort = "vtable"` and read entries to the end of that interval — and every vtable entry becomes a function. A vtable holds pointers that are jumped to as they are, so that branch now requires pointer-sized entries with no base address added to them, and an offset table is skipped instead.

### Testing

`test_ppc_jumptable_behind_bcctr_alignment_mask` and `test_ppc64_jumptable_behind_bcctr_alignment_mask` resolve the two switches above and assert every case target: 60 cases from the table at `0x55a054`, and 13 from the one at `0x10096d58`. Both fail on the baseline, where neither table resolves at all. Each is scoped by `regions` to the single function holding the dispatch, so neither scans the whole of libc.

Both tables come out bounded by the mask that truncates the switch index rather than by the comparison that follows it, so they hold 256 and 16 entries for 60 and 13 cases, and the tests assert that as it stands rather than as it should be.

Validation: https://github.com/angr/angr/pull/6822#issuecomment-5260468993

session: sharpen
