### PR TITLE
CFGFast: Stop static_exits from running an unrelated SimProcedure and aborting the scan

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -29,8 +29,10 @@ from angr.analyses.forward_analysis import ForwardAnalysis
 from angr.codenode import FuncNode, HookNode
 from angr.errors import (
     AngrCFGError,
+    AngrError,
     AngrSkipJobNotice,
     SimEngineError,
+    SimError,
     SimIRSBNoDecodeError,
     SimMemoryError,
     SimTranslationError,
@@ -3094,7 +3096,12 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             blocks_ahead.append(self._lift(cfg_job.src_node.addr).vex)
             procedure.project = self.project
             procedure.arch = self.project.arch
-            new_exits = procedure.static_exits(blocks_ahead, cfg=self)
+            try:
+                new_exits = procedure.static_exits(blocks_ahead, cfg=self)
+            except (AngrError, SimError, claripy.ClaripyError):
+                # a procedure that cannot work out its extra exits loses those exits, like a block we fail to lift
+                l.warning("%s failed to determine its static exits.", name, exc_info=True)
+                new_exits = []
 
             for new_exit in new_exits:
                 addr_ = new_exit["address"]
@@ -6460,7 +6467,11 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 blocks_ahead.append(self._lift(callsite_cfgnode.addr).vex)
                 hooker.project = self.project
                 hooker.arch = self.project.arch
-                return hooker.dynamic_returns(blocks_ahead)
+                try:
+                    return hooker.dynamic_returns(blocks_ahead)
+                except (AngrError, SimError, claripy.ClaripyError):
+                    # fall through to the callee's own flag, as for a hook that does not decide dynamically
+                    l.warning("%s failed to determine whether it returns.", hooker.display_name, exc_info=True)
 
         if callee_func is not None:
             return callee_func.returning

--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -241,6 +241,8 @@ class __libc_start_main(angr.SimProcedure):
         # Execute each block
         state = blank_state
         for b in blocks:
+            # the engine dispatches hooks on the state's instruction pointer, not on the block it is handed
+            state.regs.ip = b.addr
             irsb = self.project.factory.default_engine.process(state, irsb=b, force_addr=b.addr)
             if irsb.successors:
                 state = irsb.successors[0]

--- a/angr/procedures/posix/pthread.py
+++ b/angr/procedures/posix/pthread.py
@@ -29,6 +29,8 @@ class pthread_create(angr.SimProcedure):
         # Execute each block
         state = blank_state
         for b in blocks:
+            # the engine dispatches hooks on the state's instruction pointer, not on the block it is handed
+            state.regs.ip = b.addr
             irsb = self.project.factory.default_engine.process(state, b, force_addr=b.addr)
             if irsb.successors:
                 state = irsb.successors[0]

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,52 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_failing_static_exits_only_lose_the_exits(self):
+        # a SimProcedure that adds exits recovers them by running the caller's blocks on a blank state, which fails on
+        # plenty of real binaries. Losing those exits is a local event, like failing to lift a block.
+        class BrokenExits(angr.SimProcedure):
+            ADDS_EXITS = True
+
+            def run(self):  # pylint:disable=arguments-differ
+                return 0
+
+            def static_exits(self, blocks, **kwargs):
+                raise angr.errors.SimProcedureError("cannot work out the exits of this call")
+
+        path = os.path.join(test_location, "i386", "fauxware")
+        expected = set(angr.Project(path, auto_load_libs=False).analyses.CFGFast(normalize=True).kb.functions)
+
+        proj = angr.Project(path, auto_load_libs=False)
+        # open() is called from authenticate(), so the scan reaches it with a predecessor block to execute
+        proj.hook_symbol("open", BrokenExits())
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        assert set(cfg.kb.functions) == expected
+
+    def test_failing_dynamic_returns_falls_back_to_the_callee(self):
+        # a SimProcedure that decides whether a call returns runs the caller's blocks the same way, and fails the same
+        # way. The scan then answers from the callee, as it does for a hook that does not decide dynamically.
+        class Deciding(angr.SimProcedure):
+            DYNAMIC_RET = True
+
+            def run(self):  # pylint:disable=arguments-differ
+                return 0
+
+            def dynamic_returns(self, blocks, **kwargs):
+                return True
+
+        class Failing(Deciding):
+            def dynamic_returns(self, blocks, **kwargs):
+                raise angr.errors.SimProcedureError("cannot work out whether this call returns")
+
+        def functions(procedure):
+            proj = angr.Project(os.path.join(test_location, "i386", "fauxware"), auto_load_libs=False)
+            # authenticate() is called directly from main(), so the scan asks the hook whether that call returns
+            proj.hook_symbol("authenticate", procedure)
+            return set(proj.analyses.CFGFast(normalize=True).kb.functions)
+
+        assert functions(Failing()) == functions(Deciding())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/procedures/test_static_exits.py
+++ b/tests/procedures/test_static_exits.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.procedures"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+# two consecutive blocks of authenticate() in i386/fauxware, the first ending in a call to open() and the second in a
+# call to read(). This is the shape CFGFast._scan_procedure hands to static_exits: the block of the call site, preceded
+# by the block that calls something else.
+FIRST_BLOCK = 0x8048564
+SECOND_BLOCK = 0x8048577
+# the PLT stub of open(), which the first block calls
+OPEN_PLT = 0x8048450
+# the three addresses _start pushes before calling __libc_start_main
+CSU_INIT = 0x80486F0
+MAIN = 0x80485FC
+CSU_FINI = 0x8048760
+
+
+class TestStaticExits(unittest.TestCase):
+    """
+    CFGFast._scan_procedure hands the blocks leading to an ADDS_EXITS SimProcedure to its static_exits(), which
+    executes them on a blank state to recover the arguments of the call.
+    """
+
+    def _project_and_blocks(self):
+        ran: list[int] = []
+
+        class CallTarget(angr.SimProcedure):
+            def run(self):  # pylint:disable=arguments-differ
+                ran.append(self.state.addr)
+                return 0
+
+        proj = angr.Project(os.path.join(test_location, "i386", "fauxware"), auto_load_libs=False)
+        # a relocatable object calls its imports directly, so the block before the call site regularly ends on a hooked
+        # address; hooking the PLT stub that the first block calls reproduces that shape here
+        proj.hook(OPEN_PLT, CallTarget())
+        blocks = [proj.factory.block(FIRST_BLOCK).vex, proj.factory.block(SECOND_BLOCK).vex]
+        return proj, blocks, ran
+
+    @staticmethod
+    def _procedure(proj: angr.Project, name: str) -> angr.SimProcedure:
+        lib = next(lib for lib in angr.SIM_LIBRARIES["libc.so.6"] if lib.has_implementation(name))
+        procedure = lib.get(name, proj.arch)
+        procedure.project = proj
+        procedure.arch = proj.arch
+        return procedure
+
+    def test_pthread_create_executes_the_blocks_it_is_given(self):
+        proj, blocks, ran = self._project_and_blocks()
+
+        exits = self._procedure(proj, "pthread_create").static_exits(blocks)
+
+        assert not ran, "static_exits ran the SimProcedure hooked at the previous block's call target"
+        assert [exit_["jumpkind"] for exit_ in exits] == ["Ijk_Call", "Ijk_Ret"]
+
+    def test_libc_start_main_executes_the_blocks_it_is_given(self):
+        proj, blocks, ran = self._project_and_blocks()
+
+        exits = self._procedure(proj, "__libc_start_main").static_exits(blocks)
+
+        assert not ran, "static_exits ran the SimProcedure hooked at the previous block's call target"
+        assert [exit_["namehint"] for exit_ in exits] == ["main"]
+
+    def test_libc_start_main_recovers_main_from_the_entry_block(self):
+        proj = angr.Project(os.path.join(test_location, "i386", "fauxware"), auto_load_libs=False)
+
+        exits = self._procedure(proj, "__libc_start_main").static_exits([proj.factory.block(proj.entry).vex])
+
+        assert [(exit_["namehint"], exit_["address"].concrete_value) for exit_ in exits] == [
+            ("init", CSU_INIT),
+            ("main", MAIN),
+            ("fini", CSU_FINI),
+        ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` aborts on a call to a hooked `pthread_create` or `__libc_start_main`, with the error raised from inside an unrelated SimProcedure — `printf` or `clock_gettime` on the binaries this was found on. Handing `pthread_create.static_exits()` the two consecutive blocks of `authenticate()` that the scan would hand it in `binaries/tests/i386/fauxware` — `0x8048564`, which ends in a call to `open@plt`, and `0x8048577` — with that stub at `0x8048450` hooked, as a relocatable object's direct call to an import would be:

```text
open hooked at open@plt -> SimSolverModeError: Claripy threw an error
printf hooked at open@plt -> SimProcedureError: Symbolic pointer to (format) string :(
clock_gettime hooked at open@plt -> SimProcedureError: clock_gettime doesn't know how to deal with a clock other than CLOCK_REALTIME
```

Nothing catches it between there and `CFGFast.__init__`, so the whole scan is lost rather than one call's exits. On fauxware that is 41 functions or none.

### Root cause

`static_exits()` executes the blocks it is given on a blank state, but never points the state at them:

```python
        state = blank_state
        for b in blocks:
            irsb = self.project.factory.default_engine.process(state, irsb=b, force_addr=b.addr)
```

`force_addr` names the successors; it does not move the instruction pointer, and the engine dispatches hooks on the pointer rather than on the block it is handed. So after the first block the pointer sits at whatever that block called, and the second `process()` runs the SimProcedure hooked there instead of the block it was passed. Two things go wrong at once: the block that pushes the call's arguments is never executed, and a SimProcedure written for a real state is run on a blank fastpath one, where a symbolic format pointer or an unconstrained clock id is what it finds.

### Fix

Both `static_exits()` implementations set `state.regs.ip = b.addr` before each block, so the block passed in is the block that runs.

Independently, `_scan_procedure` and `_is_call_returning` now treat a hook that raises the way the scan already treats a block it cannot lift: `AngrError`, `SimError` and `claripy.ClaripyError` are caught and logged, and the call loses only its extra exits, or falls back to the callee's own `returning` flag. A `static_exits()` that fails for its own reasons no longer ends the analysis.

```text
open hooked at open@plt -> ['Ijk_Call', 'Ijk_Ret']
printf hooked at open@plt -> ['Ijk_Call', 'Ijk_Ret']
clock_gettime hooked at open@plt -> ['Ijk_Call', 'Ijk_Ret']
RESULT: CFGFast completed, 41 functions, expected 41
```

### Testing

`tests/procedures/test_static_exits.py` puts a recording SimProcedure at `0x8048450` and asserts that neither `pthread_create.static_exits()` nor `__libc_start_main.static_exits()` enters it while running those two blocks, and that each returns its expected exits; a third test asserts `__libc_start_main` still recovers `init`, `main` and `fini` at `0x80486f0`, `0x80485fc` and `0x8048760` from fauxware's entry block, and that one passes on master. In `tests/analyses/cfg/test_cfgfast.py`, `test_failing_static_exits_only_lose_the_exits` and `test_failing_dynamic_returns_falls_back_to_the_callee` assert the recovered function set is identical to the unhooked run when the hook raises. Four of the five fail on master.

This touches the same loops as #6809 and #6818.

Validation: https://github.com/angr/angr/pull/6823#issuecomment-5260608407

session: sharpen
