### PR TITLE
CFG: Warn when the regions to analyze cover no bytes

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -255,6 +255,7 @@ class CFGBase(Analysis):
                 '"auto_load_libs" disabled, or specify "regions" to limit the scope of CFG recovery.'
             )
 
+        regions_derived_from_objects = regions is None
         if regions is None:
             regions = self._exec_mem_regions
             if not self._skip_unmapped_addrs and not regions:
@@ -283,6 +284,14 @@ class CFGBase(Analysis):
         l.debug("CFG recovery covers %d regions:", len(self._regions))
         for start, end in self._regions.items():
             l.debug("... %#x - %#x", start, end)
+
+        if regions_derived_from_objects and not self._regions_size:
+            l.warning(
+                "CFG recovery has nothing to scan: the regions to analyze cover 0 bytes. If %s does contain code, "
+                'pass the address ranges that hold it in "regions", or set "force_segment" to derive regions from '
+                "segments instead of sections.",
+                self._binary,
+            )
 
     def __contains__(self, cfg_node):
         return cfg_node in self.graph
@@ -324,6 +333,15 @@ class CFGBase(Analysis):
         :rtype: angr.knowledge_plugins.FunctionManager
         """
         return self.kb.functions
+
+    @property
+    def regions(self) -> list[tuple[int, int]]:
+        """
+        The memory regions that this analysis covers. An empty list means it had nothing to scan.
+
+        :return: A sorted list of (start address, end address) tuples.
+        """
+        return list(self._regions.items())
 
     #
     # Methods
@@ -890,6 +908,9 @@ class CFGBase(Analysis):
 
         if not memory_regions and not has_executable:
             memory_regions = [(start, start + len(backer)) for start, backer in self.project.loader.memory.backers()]
+
+        # A section or segment that maps no bytes, such as the empty .text of a data-only relocatable, is not a region.
+        memory_regions = [(start, end) for start, end in memory_regions if end > start]
 
         return sorted(memory_regions, key=lambda x: x[0])
 

--- a/tests/analyses/cfg/test_cfg_no_executable_regions.py
+++ b/tests/analyses/cfg/test_cfg_no_executable_regions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
 
+import logging
 import os
 import unittest
 
@@ -19,14 +20,29 @@ class TestCfgNoExeutableRegions(unittest.TestCase):
             test_location, "x86_64", "windows", "65e25ea21a2f873affee8034e2c3381df48ff4129d447fa288fbd92307647582"
         )
         p = angr.Project(bin_path)
-        cfg = p.analyses.CFG()
+        with self.assertLogs("angr.analyses.cfg.cfg_base", level=logging.WARNING) as logs:
+            cfg = p.analyses.CFG()
         assert len(cfg.kb.functions) == 0
+        assert cfg.regions == []
+        assert any("nothing to scan" in record for record in logs.output)
+
+    def test_cfg_empty_executable_section_is_not_a_region(self):
+        # riscv-reloc-64-pic.o only carries data: its .text is SHF_EXECINSTR with sh_size 0, so it maps no bytes.
+        bin_path = os.path.join(test_location, "riscv64", "riscv-reloc-64-pic.o")
+        p = angr.Project(bin_path, auto_load_libs=False)
+        with self.assertLogs("angr.analyses.cfg.cfg_base", level=logging.WARNING) as logs:
+            cfg = p.analyses.CFGFast()
+        assert len(cfg.kb.functions) == 0
+        assert cfg.regions == []
+        assert any("nothing to scan" in record for record in logs.output)
 
     def test_cfg_elf_no_section_headers(self):
         # Regression test for #6409: stripped ELFs with no section headers fall back to segments.
         bin_path = os.path.join(test_location, "armel", "dbus-cleanup-sockets_stripped")
         p = angr.Project(bin_path)
-        cfg = p.analyses.CFG()
+        # Regions come from segments here, so there are bytes to scan.
+        with self.assertNoLogs("angr.analyses.cfg.cfg_base", level=logging.WARNING):
+            cfg = p.analyses.CFG()
         assert len(cfg.kb.functions) > 0
 
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`CFGFast` can finish with zero functions without saying anywhere above DEBUG that the regions it derived from the loaded objects cover nothing, so a caller cannot tell "this object holds no code" from "recovery missed the code that is there". A zero-size executable section hides that further: an `SHF_EXECINSTR` section with `sh_size` 0 gives an `(addr, addr)` interval that survives every filter, so the region list is non-empty while covering no bytes.

`CFGBase` now drops those empty intervals, warns when the regions it derived cover nothing and names the escape hatches, and exposes the covered regions as a property. Regions passed in by the caller are left alone.

The regression covers `riscv64/riscv-reloc-64-pic.o`, a relocatable whose `.text` is empty.

Validation: https://github.com/angr/angr/pull/6825#issuecomment-5261289470
