### PR TITLE
CFGBase: Leave overlapping blocks alone when their decodings conflict.

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1363,7 +1363,7 @@ class CFGBase(Analysis):
                 smallest_node = all_nodes[0]  # take the one that has the highest address
                 other_nodes = all_nodes[1:]
 
-                self._normalize_core(
+                unsplittable_pairs += self._normalize_core(
                     graph, callstack_key, smallest_node, other_nodes, smallest_nodes, end_addr_to_nodes
                 )
 
@@ -1431,12 +1431,23 @@ class CFGBase(Analysis):
         other_nodes,
         smallest_nodes,
         end_addr_to_nodes,
-    ):
+    ) -> int:
+        smallest_addr = get_real_address_if_arm(self.project.arch, smallest_node.addr)
+        unsplittable_pairs = 0
+        splittable_nodes = []
+        for n in other_nodes:
+            if get_real_address_if_arm(self.project.arch, n.addr) != smallest_addr and _conflicting_decodings(
+                self.project.arch, n, smallest_node
+            ):
+                l.debug("Cannot break %s where %s starts: they decode into different instructions.", n, smallest_node)
+                unsplittable_pairs += 1
+                continue
+            splittable_nodes.append(n)
+        other_nodes = splittable_nodes
+
         # Break other nodes
         for n in other_nodes:
-            new_size = get_real_address_if_arm(self.project.arch, smallest_node.addr) - get_real_address_if_arm(
-                self.project.arch, n.addr
-            )
+            new_size = smallest_addr - get_real_address_if_arm(self.project.arch, n.addr)
             if new_size == 0:
                 # This node has the same size as the smallest one. Don't touch it.
                 continue
@@ -1587,6 +1598,8 @@ class CFGBase(Analysis):
             for n in other_nodes:
                 if n.addr in self.indirect_jumps:
                     del self.indirect_jumps[n.addr]
+
+        return unsplittable_pairs
 
     #
     # Job management

--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -64,6 +64,25 @@ if TYPE_CHECKING:
 l = logging.getLogger(name=__name__)
 
 
+def _conflicting_decodings(arch: archinfo.Arch, node: CFGNode, other: CFGNode) -> bool:
+    """
+    Check if node and other overlap and decode the bytes they share into different instructions. Breaking node where
+    other starts would then cut an instruction in half, so normalization has to leave both of them alone: one of the
+    two decodings is wrong, and normalize() cannot tell which one.
+    """
+
+    node_addr = get_real_address_if_arm(arch, node.addr)
+    other_addr = get_real_address_if_arm(arch, other.addr)
+    if not node_addr <= other_addr < node_addr + node.size:
+        return False
+    node_ins = [get_real_address_if_arm(arch, addr) for addr in node.instruction_addrs]
+    other_ins = [get_real_address_if_arm(arch, addr) for addr in other.instruction_addrs]
+    if not node_ins or not other_ins or other_addr not in node_ins[1:]:
+        return True
+    shared = node_ins[node_ins.index(other_addr) :]
+    return shared[: len(other_ins)] != other_ins[: len(shared)]
+
+
 class CFGBase(Analysis):
     """
     The base class for control flow graphs.
@@ -1291,7 +1310,8 @@ class CFGBase(Analysis):
 
     def normalize(self):
         """
-        Normalize the CFG, making sure that there are no overlapping basic blocks.
+        Normalize the CFG, making sure that there are no overlapping basic blocks. self.normalized is set only if
+        every overlapping block was split; blocks that cannot be split leave the CFG unnormalized.
 
         Note that this method will not alter transition graphs of each function in self.kb.functions. You may call
         normalize() on each Function object to normalize their transition graphs.
@@ -1301,6 +1321,7 @@ class CFGBase(Analysis):
 
         graph = self.graph
 
+        unsplittable_pairs = 0
         smallest_nodes = {}  # indexed by end address of the node
         end_addr_to_node = {}  # a dictionary from node key to node *if* only one node exists for the key
         end_addr_to_nodes = defaultdict(list)  # a dictionary from node key to nodes *if* more than one node exist
@@ -1347,8 +1368,9 @@ class CFGBase(Analysis):
                 )
 
                 del end_addr_to_nodes[key_to_find]
-                # make sure the smallest node is stored in end_addresses
-                smallest_nodes[key_to_find] = smallest_node
+                # make sure the smallest node is stored in smallest_nodes under its own end address: the corner case
+                # below re-queues nodes that end at different addresses under the same key
+                smallest_nodes[smallest_node.addr + smallest_node.size, callstack_key] = smallest_node
 
                 # corner case
                 # sometimes two overlapping blocks may not end at the instruction. this might happen when one of the
@@ -1370,18 +1392,16 @@ class CFGBase(Analysis):
                                 break
                             next_node = lst[i + 1]
                             if node is not next_node and node.addr <= next_node.addr < node.addr + node.size:
-                                # umm, those nodes are overlapping, but they must have different end addresses
+                                # umm, those nodes are overlapping
                                 nodekey_a = node.addr + node.size, callstack_key
                                 nodekey_b = next_node.addr + next_node.size, callstack_key
-                                if nodekey_a == nodekey_b:
-                                    # error handling: this will only happen if we have completely overlapping nodes
-                                    # caused by different jumps (one of the jumps is probably incorrect), which usually
-                                    # indicates an error in CFG recovery. we print a warning and skip this node
-                                    l.warning(
-                                        "Found completely overlapping nodes %s. It usually indicates an error in CFG "
-                                        "recovery. Skip.",
+                                if _conflicting_decodings(self.project.arch, node, next_node):
+                                    l.debug(
+                                        "Cannot break %s where %s starts: they decode into different instructions.",
                                         node,
+                                        next_node,
                                     )
+                                    unsplittable_pairs += 1
                                     continue
 
                                 if nodekey_a in smallest_nodes and nodekey_b in smallest_nodes:
@@ -1395,7 +1415,13 @@ class CFGBase(Analysis):
                                 smallest_nodes.pop(nodekey_a, None)
                                 smallest_nodes.pop(nodekey_b, None)
 
-        self.normalized = True
+        if unsplittable_pairs:
+            l.warning(
+                "%d pairs of overlapping nodes decode into different instructions and could not be split. It usually "
+                "indicates an error in CFG recovery.",
+                unsplittable_pairs,
+            )
+        self.normalized = not unsplittable_pairs
 
     def _normalize_core(
         self,

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1051,6 +1051,13 @@ class TestCfgfast(unittest.TestCase):
         proj = angr.Project(path, auto_load_libs=False)
         cfg = proj.analyses.CFGFast(normalize=True)
 
+        # the block at 0xc0154a ends at 0xc01555, and so does a block starting at 0xc01553, three bytes into the
+        # six-byte instruction at 0xc0154f. normalize() used to break the first block there.
+        node = cfg.model.get_any_node(0xC0154A)
+        assert node is not None
+        assert node.size == 11
+        assert list(node.instruction_addrs) == [0xC0154A, 0xC0154C, 0xC0154F]
+
         nodes = sorted((n for n in cfg.model.nodes() if not n.is_simprocedure), key=lambda n: n.addr)
         assert any(a.addr < b.addr < a.addr + a.size for a, b in zip(nodes, nodes[1:]))
         assert not cfg.normalized

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1003,6 +1003,59 @@ class TestCfgfast(unittest.TestCase):
             assert addr not in cfg.kb.functions, f"{hex(addr)} should not be a separate function"
 
     @staticmethod
+    def _nodes_ending_mid_instruction(proj: angr.Project, model: CFGModel) -> set[tuple[int, int]]:
+        # address and size of every node whose last instruction runs past the end of the node. Instruction addresses
+        # at or past the end of a node are not part of it: VEX records one there for an instruction it could not
+        # decode.
+        truncated = set()
+        for n in model.nodes():
+            if n.is_simprocedure:
+                continue
+            end_addr = n.addr + n.size
+            covered = [i for i in n.instruction_addrs if i < end_addr]
+            if not covered:
+                continue
+            last_addr = covered[-1]
+            last_size = proj.factory.block(last_addr, num_inst=1).size
+            assert last_size is not None
+            if last_addr + last_size > end_addr:
+                truncated.add((n.addr, n.size))
+        return truncated
+
+    def test_normalize_keeps_blocks_whose_decodings_conflict(self):
+        # 0x16808 holds three ARM instructions that a Thumb decoding of the same bytes overlaps. normalize() used to
+        # break the ARM block two bytes into its first instruction to make room for the Thumb block.
+        path = os.path.join(test_location, "armel", "sha224sum")
+        proj = angr.Project(path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        node = cfg.model.get_any_node(0x16808)
+        assert node is not None
+        assert node.size == 12
+        assert list(node.instruction_addrs) == [0x16808, 0x1680C, 0x16810]
+
+        # block recovery can end a node in the middle of an instruction on its own, so the nodes that come out of
+        # normalization are compared against the ones recovery produces when normalize() never runs
+        recovery_proj = angr.Project(path, auto_load_libs=False)
+        recovered = recovery_proj.analyses.CFGFast(normalize=False)
+        cut_by_normalization = self._nodes_ending_mid_instruction(proj, cfg.model) - self._nodes_ending_mid_instruction(
+            recovery_proj, recovered.model
+        )
+        assert not cut_by_normalization, (
+            f"normalize() cut instructions in half at {sorted(hex(addr) for addr, _ in cut_by_normalization)}"
+        )
+
+    def test_normalize_reports_unnormalized_cfg_when_blocks_cannot_be_split(self):
+        # the packed code decodes some bytes in more than one way, so normalize() cannot remove every overlap here
+        path = os.path.join(test_location, "i386", "packed_elf32")
+        proj = angr.Project(path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        nodes = sorted((n for n in cfg.model.nodes() if not n.is_simprocedure), key=lambda n: n.addr)
+        assert any(a.addr < b.addr < a.addr + a.size for a, b in zip(nodes, nodes[1:]))
+        assert not cfg.normalized
+
+    @staticmethod
     def _blob_project(data: bytes, arch: str | archinfo.Arch = "AMD64") -> angr.Project:
         return angr.Project(
             io.BytesIO(data),


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGBase.normalize()` cuts instructions in half. On `binaries/tests/armel/sha224sum`, `CFGFast(normalize=True)` leaves this around `0x16808`, where the twelve bytes hold three ARM instructions — `mov r0, r1`, `str r1, [sp, #0x1c]`, `bl #0x18d10`:

```
      0x16804 size  4  instructions ['0x16804']
      0x16808 size  6  instructions ['0x16808']
      0x1680f size  2  instructions ['0x1680f']
      0x16814 size 14  instructions ['0x16814', '0x16818', '0x1681c']
```

The ARM block ends two bytes into its second instruction, its neighbour at `0x16814` is down from 48 bytes to 14, and a two-byte Thumb fragment sits at `0x1680f`. `normalize()` runs immediately before `_remove_redundant_overlapping_blocks`, which on ARM exists to decide such conflicts; that fragment is still in the graph afterwards. `binaries/tests/i386/packed_elf32` shows the other half: twelve overlapping pairs are left in the graph and `cfg.normalized` is `True` anyway.

### Root cause

`_normalize_core` breaks a node wherever the next one starts, with no test that the two agree on the instructions they share:

```python
new_size = get_real_address_if_arm(self.project.arch, smallest_node.addr) - get_real_address_if_arm(
    self.project.arch, n.addr
)
```

When the new boundary falls inside an instruction, the code notices and truncates the record instead of refusing: *"this means we break an existing instruction in the middle! we need to drop the last instruction address"*. Two decodings of the same bytes are exactly the case where that boundary is meaningless — one of them is wrong, and `normalize()` cannot tell which.

### Fix

`_conflicting_decodings()` compares the instruction addresses the two nodes share and reports a pair that disagrees; those pairs are left alone, counted, reported in one warning, and leave `self.normalized` false. The same run then gives:

```
      0x16804 size  4  instructions ['0x16804']
      0x16808 size 12  instructions ['0x16808', '0x1680c', '0x16810']
      0x16814 size 48  instructions ['0x16814', '0x16818', '0x1681c', '0x16820', '0x16824', '0x16828', '0x1682c', '0x16830', '0x16834', '0x16838', '0x1683c', '0x16840']
```

and `packed_elf32` reports `cfg.normalized: False`. The diff also indexes a node in `smallest_nodes` under its own end address rather than under the key being processed; reverting that line alone leaves both fixtures above unchanged, so it is a separate correctness fix and not what these two show.

### Testing

`test_normalize_keeps_blocks_whose_decodings_conflict` checks the block at `0x16808` and compares every node against the same recovery with `normalize=False`, so a node that block recovery itself ended mid-instruction is not counted. `test_normalize_reports_unnormalized_cfg_when_blocks_cannot_be_split` checks the eleven-byte block at `0xc0154a` and that an overlap remains with `cfg.normalized` false. On the baseline they fail with `assert 6 == 12` and `assert 9 == 11`.

Validation: https://github.com/angr/angr/pull/6826#issuecomment-5261704325

session: sharpen
