### PR TITLE
CFGFast: Keep a function whose block ends in an undefined instruction

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -899,6 +899,9 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         self._remaining_eh_frame_addrs: list[int] | None = None
         self._remaining_function_prologue_addrs: list[int] | None = None
         self._used_function_prologue_addrs: set[int] = set()
+        # blocks whose Ijk_NoDecode is an undefined instruction that _generate_cfgnode recognized, and not bytes it
+        # failed to decode
+        self._undefined_instruction_blocks: set[int] = set()
         self._ptr_hints: SortedDict | None = None
         self._processed_eh_prolog3_callsites: set[int] = set()
         self._processed_cxx_frame_handler3_callsites: set[int] = set()
@@ -4788,7 +4791,11 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             func = self.kb.functions.get_by_addr(func_addr)
             for block_addr in sorted(func.block_addrs, reverse=True):
                 cfg_node = self.model.get_any_node(block_addr)
-                if cfg_node is not None and cfg_node.size > 0:
+                if (
+                    cfg_node is not None
+                    and cfg_node.size > 0
+                    and cfg_node.addr not in self._undefined_instruction_blocks
+                ):
                     out_degree = self.model.graph.out_degree[cfg_node]
                     # is it jumping to data?
                     if out_degree == 0:
@@ -5911,6 +5918,8 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
                     if irsb_size == 0:
                         return None, None, None, None
+                else:
+                    self._undefined_instruction_blocks.add(addr)
 
                 self._seg_list.occupy(real_addr, irsb_size, "code")
                 if nodecode_size > 0:

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,15 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_function_ending_in_an_undefined_instruction_is_kept(self):
+        # rcsbuf_getrevnum.cold is a three-block function whose last block ends in the ud2 that gcc emits after a
+        # call to a noreturn function; drop_bad_functions() used to read that as the function running into data
+        proj = angr.Project(os.path.join(test_location, "x86_64", "cvs"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        assert 0x404D30 in cfg.kb.functions
+        assert {0x404D30, 0x404D39, 0x404D51} <= cfg.kb.functions[0x404D30].block_addrs_set
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1142,13 +1142,16 @@ class TestCfgfast(unittest.TestCase):
         assert block_size(4096, filler=b"\x90") is not None
 
     def test_function_ending_in_an_undefined_instruction_is_kept(self):
-        # rcsbuf_getrevnum.cold is a three-block function whose last block ends in the ud2 that gcc emits after a
-        # call to a noreturn function; drop_bad_functions() used to read that as the function running into data
-        proj = angr.Project(os.path.join(test_location, "x86_64", "cvs"), auto_load_libs=False)
+        # split-rust is stripped, so no symbol names these three functions, and the ud2 that ends each one is
+        # reached by a jump inside the function rather than as the fall-through of a call. Each is a real
+        # 200-300 byte function that drop_bad_functions() deletes outright, reading the ud2 that rustc emits
+        # for an unreachable path as the function running into data.
+        proj = angr.Project(os.path.join(test_location, "x86_64", "split-rust"), auto_load_libs=False)
         cfg = proj.analyses.CFGFast(normalize=True)
 
-        assert 0x404D30 in cfg.kb.functions
-        assert {0x404D30, 0x404D39, 0x404D51} <= cfg.kb.functions[0x404D30].block_addrs_set
+        for addr in (0x501610, 0x5019B0, 0x501B20):
+            assert addr in cfg.kb.functions, f"{addr:#x} was dropped"
+            assert cfg.model.get_any_node(addr) is not None, f"no block covers {addr:#x}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`drop_bad_functions()` deletes a function whose last block ends in an undefined instruction. On `binaries/tests/x86_64/split-rust`, which is stripped, the functions at `0x501610`, `0x5019b0` and `0x501b20` are gone after `CFGFast(normalize=True)`:

```text
functions recovered: 18108
0x501610: not in the function manager
0x501610: CFG node absent, bytes classified as 'unknown'
```

Nothing downstream can recover them: the removal also re-occupies every block of the function as `unknown`, so the bytes are not code to any later consumer. gcc and clang end a `.cold` partition with `ud2` after a call to a `noreturn` function, so this fires on ordinary release binaries.

### Root cause

`_generate_cfgnode` recognizes `ud0`, `ud1`, `ud2` and the ARM `UND` encodings and accepts the resulting `Ijk_NoDecode` as a real instruction, which is why the block became a CFG node at all. `drop_bad_functions` re-lifts the same block and applies a test that does not share that knowledge:

```python
if out_degree < 2:
    block = self._lift(block_addr)
    if block.vex.jumpkind == "Ijk_NoDecode":
        full_funcs_to_remove.append(func_addr)
```

A block ending in a recognized undefined instruction and a block that ran into undecodable data lift to the same jumpkind, so the predicate cannot tell them apart and takes the whole function.

### Fix

`_generate_cfgnode` records the addresses whose `Ijk_NoDecode` it accepted in `self._undefined_instruction_blocks`, and `drop_bad_functions` leaves those blocks out of its jumps-to-data test. A block that really did run into undecodable bytes is treated exactly as before:

```text
functions recovered: 18143
0x501610: function present, 1 block(s), 234 bytes, last instruction call
0x501610: CFG node present, bytes classified as 'code'
```

The guard deliberately does not also require a real instruction ahead of the trap, so one-block `ud2` stubs are kept too; say if you would rather it did.

### Testing

`test_function_ending_in_an_undefined_instruction_is_kept` asserts that all three addresses are in the function manager with a CFG node covering each. It fails on the baseline, where all three are absent. Recovery on this binary goes from 18108 functions to 18143.

Validation: https://github.com/angr/angr/pull/6828#issuecomment-5279919433

session: sharpen
