### PR TITLE
Decompiler: Keep the provisional call return read by machine code

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -50,6 +50,7 @@ from angr.calling_conventions import (
     SimRegArg,
     SimStackArg,
     SimStructArg,
+    is_stack_probe,
 )
 from angr.code_location import ExternalCodeLocation
 from angr.codenode import BlockNode, FuncNode
@@ -1932,6 +1933,15 @@ class Clinic(Analysis, Serializable):
             if not self.kb.functions.contains_addr(target):
                 continue
             target_func = self.kb.functions.get_by_addr(target)
+            if is_stack_probe(target_func) and last_stmt.fp_ret_expr is not None:
+                block.statements[-1] = ailment.Stmt.SideEffectStatement(
+                    last_stmt.idx,
+                    last_stmt.expr,
+                    ret_expr=last_stmt.ret_expr,
+                    fp_ret_expr=None,
+                    **last_stmt.tags,
+                )
+                continue
             if target_func.name == "_security_check_cookie" and self.project.arch.name in {"X86", "AMD64"}:
                 arg = SimRegArg("ecx", 32) if self.project.arch.bits == 32 else SimRegArg("rcx", 64)
                 arg_offset, arg_bits = self.project.arch.registers[arg.reg_name]

--- a/angr/analyses/decompiler/ssailification/rewriting.py
+++ b/angr/analyses/decompiler/ssailification/rewriting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Iterable, MutableMapping
+from collections.abc import Callable, Collection, Iterable, MutableMapping
 from functools import partial
 from itertools import chain
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -50,6 +50,8 @@ class RewritingAnalysis:
         def_to_udef: MutableMapping[Def, UDef],
         extern_defs: set[UDef],
         incomplete_defs: set[Def],
+        provisional_call_return_defs: Collection[Def] = (),
+        used_provisional_call_return_defs: Collection[Def] = (),
         vvar_id_start: int = 0,
         stackvars: bool = False,
         fail_fast: bool = False,
@@ -72,6 +74,8 @@ class RewritingAnalysis:
             ail_manager=ail_manager,
             vvar_id_start=vvar_id_start,
             def_to_udef=def_to_udef,
+            provisional_call_return_defs=provisional_call_return_defs,
+            used_provisional_call_return_defs=used_provisional_call_return_defs,
             stackvars=stackvars,
             fail_fast=self._fail_fast,
         )

--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import MutableMapping
+from collections.abc import Collection, MutableMapping
 from typing import TYPE_CHECKING
 
 import archinfo
@@ -45,7 +45,7 @@ from angr.ailment.statement import (
 )
 from angr.ailment.tagged_object import TaggedObject
 from angr.analyses.decompiler.variable_map import variable_map_of
-from angr.calling_conventions import call_clobbered_regs
+from angr.calling_conventions import call_clobbered_regs, default_cc, is_stack_probe
 from angr.engines.light.engine import SimEngineNostmtAIL
 
 from .consts import MAX_STACK_VAR_SIZE
@@ -73,6 +73,8 @@ class SimEngineSSARewriting(
         ail_manager: Manager,
         def_to_udef: MutableMapping[Def, UDef],
         incomplete_defs: set[Def],
+        provisional_call_return_defs: Collection[Def] = (),
+        used_provisional_call_return_defs: Collection[Def] = (),
         vvar_id_start: int = 0,
         rewrite_tmps: bool = False,
         stackvars: bool = False,
@@ -87,6 +89,8 @@ class SimEngineSSARewriting(
         self.hclb_side_exit_state: RewritingState | None = None
         self.out_block: Block | None = None
         self.def_to_udef = def_to_udef
+        self.provisional_call_return_defs = provisional_call_return_defs
+        self.used_provisional_call_return_defs = used_provisional_call_return_defs
         self.stackvars = stackvars
         self.incomplete_defs = incomplete_defs
         self._fail_fast = fail_fast
@@ -293,14 +297,26 @@ class SimEngineSSARewriting(
         return None
 
     def _handle_stmt_SideEffectStatement(self, stmt: SideEffectStatement) -> Statement | None:
+        assert isinstance(stmt.expr, Call)
         new_expr = self._expr(stmt.expr)
         vm = variable_map_of(self.ail_manager)
         cc = vm.calling_convention(stmt.expr)
 
         # resolve the callee so that we honor its own calling convention (matching the traversal engine)
         target = self._resolve_call_target(stmt.expr)
+        is_syscall = (isinstance(stmt.expr.target, DirtyExpression) and stmt.expr.target.callee == "syscall") or (
+            target is not None and target.is_syscall
+        )
 
-        if cc is None and target is not None and target.calling_convention is not None:
+        if is_syscall:
+            cc_cls = default_cc(
+                self.arch.name,
+                platform=self.project.simos.name if self.project.simos is not None else None,
+                syscall=True,
+            )
+            assert cc_cls is not None
+            cc = cc_cls(self.arch)
+        elif cc is None and target is not None and target.calling_convention is not None:
             # honor the callee's own calling convention before falling back to the platform default
             cc = target.calling_convention
         if cc is None:
@@ -314,19 +330,47 @@ class SimEngineSSARewriting(
                 for suboff in range(base_off, base_off + base_size):
                     self.state.registers.pop(suboff, None)
 
+        original_ret_expr = stmt.ret_expr
+        original_fp_ret_expr = stmt.fp_ret_expr
+        ret_expr = original_ret_expr
+        fp_ret_expr = original_fp_ret_expr
+        if is_syscall or (target is not None and is_stack_probe(target)):
+            fp_ret_expr = None
+        if (
+            original_ret_expr in self.provisional_call_return_defs
+            and original_fp_ret_expr in self.provisional_call_return_defs
+        ):
+            ret_used = original_ret_expr in self.used_provisional_call_return_defs
+            fp_ret_used = original_fp_ret_expr in self.used_provisional_call_return_defs
+            if ret_used != fp_ret_used:
+                if ret_used:
+                    fp_ret_expr = None
+                else:
+                    ret_expr = None
+        if ret_expr is not None and ret_expr not in self.def_to_udef:
+            ret_expr = None
+        if fp_ret_expr is not None and fp_ret_expr not in self.def_to_udef:
+            fp_ret_expr = None
+        outputs_changed = ret_expr != original_ret_expr or fp_ret_expr != original_fp_ret_expr
+
         new_stmt = None
-        if stmt.ret_expr is not None:
-            assert isinstance(stmt.ret_expr, Atom)
-            new_stmt = self._replace_def_expr(stmt.ret_expr, new_expr if new_expr is not None else stmt.expr, stmt)
+        if ret_expr is not None:
+            assert isinstance(ret_expr, Atom)
+            new_stmt = self._replace_def_expr(ret_expr, new_expr if new_expr is not None else stmt.expr, stmt)
             # becomes an Assignment
-        elif stmt.fp_ret_expr is not None:
-            assert isinstance(stmt.fp_ret_expr, Atom)
-            new_stmt = self._replace_def_expr(stmt.fp_ret_expr, new_expr if new_expr is not None else stmt.expr, stmt)
+        elif fp_ret_expr is not None:
+            assert isinstance(fp_ret_expr, Atom)
+            new_stmt = self._replace_def_expr(fp_ret_expr, new_expr if new_expr is not None else stmt.expr, stmt)
             # becomes an Assignment
 
-        if new_stmt is None and new_expr is not None:
-            # only create a new SideEffectStatement if we get a new inner expr
-            new_stmt = SideEffectStatement(self.ail_manager.next_atom(), new_expr, **stmt.tags)
+        if new_stmt is None and (new_expr is not None or outputs_changed):
+            new_stmt = SideEffectStatement(
+                self.ail_manager.next_atom(),
+                stmt.expr if new_expr is None else new_expr,
+                ret_expr=ret_expr,
+                fp_ret_expr=fp_ret_expr,
+                **stmt.tags,
+            )
 
         return new_stmt
 

--- a/angr/analyses/decompiler/ssailification/ssailification.py
+++ b/angr/analyses/decompiler/ssailification/ssailification.py
@@ -166,6 +166,8 @@ class Ssailification(Analysis):  # pylint:disable=abstract-method
             def_to_udef,
             extern_defs,
             incomplete_defs=incomplete_defs,
+            provisional_call_return_defs=traversal.provisional_call_return_defs,
+            used_provisional_call_return_defs=traversal.used_provisional_call_return_defs,
             vvar_id_start=next(phi_id_ctr),
             stackvars=self._ssa_stackvars,
             fail_fast=self._fail_fast,

--- a/angr/analyses/decompiler/ssailification/traversal.py
+++ b/angr/analyses/decompiler/ssailification/traversal.py
@@ -63,6 +63,8 @@ class TraversalAnalysis:
         self._analyze()
 
         self.def_info = self._engine_ail.def_info
+        self.provisional_call_return_defs = self._engine_ail.provisional_call_return_defs
+        self.used_provisional_call_return_defs = self._engine_ail.used_provisional_call_return_defs
 
     #
     # Main analysis routines

--- a/angr/analyses/decompiler/ssailification/traversal_engine.py
+++ b/angr/analyses/decompiler/ssailification/traversal_engine.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 from angr.ailment.expression import (
     ITE,
+    Call,
     Const,
     Convert,
     DirtyExpression,
@@ -98,6 +99,10 @@ class SimEngineSSATraversal(SimEngineLightAIL[TraversalState, Value, None, None]
         self.functions = functions
         self.variable_map: VariableMap | None = variable_map
         self.def_info: dict[Def, DefInfo] = {}
+        # VEX lifts ordinary calls with both the integer and floating-point ABI return locations. These are
+        # alternatives until an explicit AIL register read identifies which result the machine code consumes.
+        self.provisional_call_return_defs: set[Def] = set()
+        self.used_provisional_call_return_defs: set[Def] = set()
         # stack offset -> code location, StackBaseOffset expr, set of (offset, size) tuples, required, no_reaching_def
         self.pending_ptr_defines_nonlocal: dict[
             int, tuple[AILCodeLocation, StackBaseOffset, set[tuple[int, int]], bool, bool]
@@ -440,6 +445,11 @@ class SimEngineSSATraversal(SimEngineLightAIL[TraversalState, Value, None, None]
             def_as = defs
 
         if def_as is not None:
+            # ``def_ is None`` denotes a conservative ABI probe, not an explicit AIL register read. In particular,
+            # an unknown following call must not select a preceding call's floating-point return merely because XMM0
+            # is a potential argument register.
+            if def_ is not None and self.provisional_call_return_defs:
+                self.used_provisional_call_return_defs.update(def_as & self.provisional_call_return_defs)
             for suboff in range(full_offset, full_offset + full_size):
                 self.state.register_defs[suboff] = def_as
 
@@ -514,12 +524,30 @@ class SimEngineSSATraversal(SimEngineLightAIL[TraversalState, Value, None, None]
             self.hclb_side_exit_state = self.state.copy()
 
     def _handle_stmt_SideEffectStatement(self, stmt: SideEffectStatement):
+        assert isinstance(stmt.expr, Call)
         result = self._handle_expr_Call(stmt.expr)
+
+        target = self._resolve_call_target(stmt.expr)
+        is_syscall = self._is_syscall(stmt.expr, target)
+        if isinstance(stmt.ret_expr, Register) and isinstance(stmt.fp_ret_expr, Register) and not is_syscall:
+            self.provisional_call_return_defs.update((stmt.ret_expr, stmt.fp_ret_expr))
 
         if stmt.ret_expr is not None and isinstance(stmt.ret_expr, Register):
             self.register_set(stmt.ret_expr.reg_offset, stmt.ret_expr.size, result, stmt.ret_expr)
-        if stmt.fp_ret_expr is not None and isinstance(stmt.fp_ret_expr, Register):
+        if stmt.fp_ret_expr is not None and isinstance(stmt.fp_ret_expr, Register) and not is_syscall:
             self.register_set(stmt.fp_ret_expr.reg_offset, stmt.fp_ret_expr.size, result, stmt.fp_ret_expr)
+
+    def _resolve_call_target(self, expr: Call) -> Function | None:
+        target = expr.target
+        if isinstance(target, Const) and isinstance(target.value, int):
+            target = target.value
+        return self.functions(target) if self.functions is not None and isinstance(target, (str, int)) else None
+
+    @staticmethod
+    def _is_syscall(expr: Call, target: Function | None = None) -> bool:
+        return (isinstance(expr.target, DirtyExpression) and expr.target.callee == "syscall") or (
+            target is not None and target.is_syscall
+        )
 
     def _handle_expr_Call(self, expr):
         target = expr.target
@@ -536,9 +564,7 @@ class SimEngineSSATraversal(SimEngineLightAIL[TraversalState, Value, None, None]
                 def_size = max(def_size_values)[1]
                 def_size_arg = expr.args[2]
 
-        if isinstance(target, Const) and isinstance(target.value, int):
-            target = target.value
-        target = self.functions(target) if self.functions is not None and isinstance(target, (str, int)) else None
+        target = self._resolve_call_target(expr)
         expr_prototype = self.variable_map.prototype(expr) if self.variable_map is not None else None
         if expr_prototype is not None:
             proto = expr_prototype
@@ -591,8 +617,17 @@ class SimEngineSSATraversal(SimEngineLightAIL[TraversalState, Value, None, None]
         # kill caller-saved registers
 
         # determine the calling convention of the call
+        is_syscall = self._is_syscall(expr, target)
         expr_cc = self.variable_map.calling_convention(expr) if self.variable_map is not None else None
-        if expr_cc is not None:
+        if is_syscall:
+            cc = default_cc(
+                self.arch.name,
+                platform=self.simos.name if self.simos is not None else None,
+                syscall=True,
+            )
+            assert cc is not None
+            cc = cc(self.arch)
+        elif expr_cc is not None:
             cc = expr_cc
         elif target is not None and target.calling_convention is not None:
             cc = target.calling_convention

--- a/native/angr/src/ailment/convert_vex.rs
+++ b/native/angr/src/ailment/convert_vex.rs
@@ -1307,7 +1307,10 @@ impl<'py, 'r, R: IrReader> Conv<'py, 'r, R> {
         };
 
         let fp_ret_offset: Option<i64> = self.arch.arch.getattr("fp_ret_offset")?.extract()?;
-        let fp_ret_expr: Option<AilExpression> = if let Some(fp_ret_offset) = fp_ret_offset {
+        // A syscall's provisional return is owned by its own semantics, so only a real call gets one.
+        let fp_ret_expr: Option<AilExpression> = if jk != "Ijk_Call" {
+            None
+        } else if let Some(fp_ret_offset) = fp_ret_offset {
             if fp_ret_offset == ret_offset {
                 None
             } else {

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -87,13 +87,13 @@ class TestIrsb(unittest.TestCase):
         block_bytes = bytes.fromhex("0f05")
         from_py = VEXIRSBConverter.convert(
             pyvex.IRSB(block_bytes, 0x1000, arch, opt_level=0),  # pyright: ignore[reportArgumentType]
-            ailment.Manager(arch=arch),  # pyright: ignore[reportArgumentType]
+            ailment.Manager(),
         )
         from_lift = VEXIRSBConverter.convert_from_lift(
             arch,  # pyright: ignore[reportArgumentType]
             0x1000,
             block_bytes,
-            ailment.Manager(arch=arch),  # pyright: ignore[reportArgumentType]
+            ailment.Manager(),
             opt_level=0,
         )
         assert from_py == from_lift

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -82,6 +82,30 @@ class TestIrsb(unittest.TestCase):
         assert from_py == from_lift
         assert from_py.statements  # non-empty
 
+    def test_syscall_has_no_floating_point_return(self):
+        arch = archinfo.ArchAMD64()
+        block_bytes = bytes.fromhex("0f05")
+        from_py = VEXIRSBConverter.convert(
+            pyvex.IRSB(block_bytes, 0x1000, arch, opt_level=0),
+            ailment.Manager(arch=arch),  # pyright: ignore[reportArgumentType]
+        )
+        from_lift = VEXIRSBConverter.convert_from_lift(
+            arch,
+            0x1000,
+            block_bytes,
+            ailment.Manager(arch=arch),  # pyright: ignore[reportArgumentType]
+            opt_level=0,
+        )
+        assert from_py == from_lift
+
+        for syscall in (from_py.statements[-1], from_lift.statements[-1]):
+            assert isinstance(syscall, ailment.Stmt.SideEffectStatement)
+            assert isinstance(syscall.expr, ailment.Expr.Call)
+            assert isinstance(syscall.expr.target, ailment.Expr.DirtyExpression)
+            assert syscall.expr.target.callee == "syscall"
+            assert isinstance(syscall.ret_expr, ailment.Expr.Register)
+            assert syscall.fp_ret_expr is None
+
 
 class TestNonConstRoundingMode(unittest.TestCase):
     """VEX sometimes carries the rounding mode in a tmp (e.g. ARM ``vcvtr``

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -86,11 +86,11 @@ class TestIrsb(unittest.TestCase):
         arch = archinfo.ArchAMD64()
         block_bytes = bytes.fromhex("0f05")
         from_py = VEXIRSBConverter.convert(
-            pyvex.IRSB(block_bytes, 0x1000, arch, opt_level=0),
+            pyvex.IRSB(block_bytes, 0x1000, arch, opt_level=0),  # pyright: ignore[reportArgumentType]
             ailment.Manager(arch=arch),  # pyright: ignore[reportArgumentType]
         )
         from_lift = VEXIRSBConverter.convert_from_lift(
-            arch,
+            arch,  # pyright: ignore[reportArgumentType]
             0x1000,
             block_bytes,
             ailment.Manager(arch=arch),  # pyright: ignore[reportArgumentType]

--- a/tests/analyses/decompiler/test_ssa_call_return_selection.py
+++ b/tests/analyses/decompiler/test_ssa_call_return_selection.py
@@ -89,7 +89,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_selects_explicit_floating_return_read(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         call_stmt, _, fp_ret_expr = self._make_return_call(project, manager)
         use = self._make_register_copy(project, manager, "xmm0", "xmm1")
 
@@ -105,7 +105,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_selects_explicit_integer_return_read(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         call_stmt, ret_expr, _ = self._make_return_call(project, manager)
         use = self._make_register_copy(project, manager, "rax", "rbx")
 
@@ -119,7 +119,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
         project = angr.load_shellcode(b"\x1e\xff\x2f\xe1", archinfo.ArchARMHF(), load_address=0x1000)
         for source, destination, select_fp in (("r0", "r1", False), ("s0", "s2", True)):
             with self.subTest(source=source):
-                manager = ailment.Manager(arch=project.arch)
+                manager = ailment.Manager()
                 call_stmt, ret_expr, fp_ret_expr = self._make_return_call(project, manager, bits=32)
                 use = self._make_register_copy(project, manager, source, destination, bits=32)
 
@@ -132,7 +132,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_selects_floating_return_across_blocks(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         call_stmt, _, fp_ret_expr = self._make_return_call(project, manager)
         use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1010)
         call_block = ailment.Block(0x1000, 6, statements=[call_stmt])
@@ -147,7 +147,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_argument_probe_does_not_select_return(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         first_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1000)
         second_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1005, args=None)
         second_call = ailment.Stmt.SideEffectStatement(
@@ -166,7 +166,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_explicit_call_argument_selects_floating_return(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         first_call, _, fp_ret_expr = self._make_return_call(project, manager, ins_addr=0x1000)
         fp_ret_offset = project.arch.fp_ret_offset
         assert fp_ret_offset is not None
@@ -191,7 +191,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_overwritten_floating_return_is_not_selected(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         call_stmt, _, _ = self._make_return_call(project, manager)
         xmm0_offset = project.arch.registers["xmm0"][0]
         overwrite = ailment.Stmt.Assignment(
@@ -210,7 +210,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_neither_return_candidate_preserves_integer_fallback(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         call_stmt, _, _ = self._make_return_call(project, manager, args=None)
 
         graph = self._ssailify(project, manager, [ailment.Block(0x1000, 1, statements=[call_stmt])])
@@ -221,7 +221,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_selects_returns_independently_across_consecutive_calls(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         first_call, ret_expr, _ = self._make_return_call(project, manager, ins_addr=0x1000)
         integer_use = self._make_register_copy(project, manager, "rax", "rbx", ins_addr=0x1001)
         second_call, _, fp_ret_expr = self._make_return_call(project, manager, ins_addr=0x1002)
@@ -239,7 +239,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_selects_integer_partial_alias_and_widens_floating_return(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         integer_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1000)
         integer_use = self._make_register_copy(project, manager, "eax", "ebx", bits=32, ins_addr=0x1001)
         floating_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1002)
@@ -259,7 +259,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_selects_floating_return_that_reaches_a_phi(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         entry = ailment.Block(0x1000, 1, statements=[])
         call_stmt, _, fp_ret_expr = self._make_return_call(project, manager, ins_addr=0x1010)
         call_block = ailment.Block(0x1010, 1, statements=[call_stmt])
@@ -292,7 +292,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_selects_floating_return_that_reaches_a_loop_phi(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         call_stmt, _, fp_ret_expr = self._make_return_call(project, manager, ins_addr=0x1000)
         entry = ailment.Block(0x1000, 1, statements=[call_stmt])
         use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1010)
@@ -326,7 +326,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_repeated_ssa_does_not_duplicate_selected_call(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         call_stmt, _, _ = self._make_return_call(project, manager)
         use = self._make_register_copy(project, manager, "xmm0", "xmm1")
         first_graph = self._ssailify(project, manager, [ailment.Block(0x1000, 6, statements=[call_stmt, use])])
@@ -356,7 +356,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
         for probe_name, use_metadata_flag in (("__chkstk", False), ("helper", True)):
             with self.subTest(probe_name=probe_name, use_metadata_flag=use_metadata_flag):
-                manager = ailment.Manager(arch=project.arch)
+                manager = ailment.Manager()
                 probe = project.kb.functions.function(addr=0x2000, create=True)
                 assert probe is not None
                 probe.name = probe_name
@@ -405,7 +405,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
         )
         for name, return_type, source, destination, expected_offset in cases:
             with self.subTest(return_type=name):
-                manager = ailment.Manager(arch=project.arch)
+                manager = ailment.Manager()
                 call_stmt, _, _ = self._make_return_call(project, manager)
                 variable_map = variable_map_of(manager)
                 variable_map.set_calling_convention(call_stmt.expr, SimCCSystemVAMD64(project.arch))
@@ -425,7 +425,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_zero_trigger_graph_keeps_provisional_tracking_empty(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         ret_offset = project.arch.ret_offset
         assert ret_offset is not None
         statements = []
@@ -462,7 +462,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
     @unittest.expectedFailure
     def test_both_explicit_returns(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         call_stmt, _, _ = self._make_return_call(project, manager)
         integer_use = self._make_register_copy(project, manager, "rax", "rbx", ins_addr=0x1001)
         floating_use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1002)
@@ -476,7 +476,7 @@ class TestSSACallReturnSelection(unittest.TestCase):
 
     def test_syscall_uses_only_integer_return_candidate(self):
         project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
         ret_offset = project.arch.ret_offset
         fp_ret_offset = project.arch.fp_ret_offset
         assert ret_offset is not None and fp_ret_offset is not None

--- a/tests/analyses/decompiler/test_ssa_call_return_selection.py
+++ b/tests/analyses/decompiler/test_ssa_call_return_selection.py
@@ -1,0 +1,527 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import archinfo
+import networkx
+
+import angr
+from angr import ailment
+from angr.analyses.decompiler import Decompiler
+from angr.analyses.decompiler.clinic import Clinic
+from angr.analyses.decompiler.ssailification import Ssailification
+from angr.analyses.decompiler.ssailification.traversal import TraversalAnalysis
+from angr.analyses.decompiler.variable_map import variable_map_of
+from angr.calling_conventions import SimCCSystemVAMD64
+from angr.sim_type import SimTypeBottom, SimTypeDouble, SimTypeFunction, SimTypeLongLong
+from tests.common import bin_location
+
+
+class TestSSACallReturnSelection(unittest.TestCase):
+    """Test SSA selection of provisional integer and floating-point call returns."""
+
+    @staticmethod
+    def _make_return_call(project, manager, *, ins_addr=0x1000, args=(), bits=64):
+        ret_expr = ailment.Expr.Register(manager.next_atom(), project.arch.ret_offset, bits, ins_addr=ins_addr)
+        fp_ret_expr = ailment.Expr.Register(manager.next_atom(), project.arch.fp_ret_offset, bits, ins_addr=ins_addr)
+        call = ailment.Expr.Call(
+            manager.next_atom(),
+            ailment.Expr.Const(manager.next_atom(), 0x2000, project.arch.bits),
+            args=args,
+            bits=bits,
+            ins_addr=ins_addr,
+        )
+        return (
+            ailment.Stmt.SideEffectStatement(
+                manager.next_atom(),
+                call,
+                ret_expr=ret_expr,
+                fp_ret_expr=fp_ret_expr,
+                ins_addr=ins_addr,
+            ),
+            ret_expr,
+            fp_ret_expr,
+        )
+
+    @staticmethod
+    def _make_register_copy(project, manager, source, destination, *, bits=64, ins_addr=0x1005):
+        return ailment.Stmt.Assignment(
+            manager.next_atom(),
+            ailment.Expr.Register(manager.next_atom(), project.arch.registers[destination][0], bits, ins_addr=ins_addr),
+            ailment.Expr.Register(manager.next_atom(), project.arch.registers[source][0], bits, ins_addr=ins_addr),
+            ins_addr=ins_addr,
+        )
+
+    @staticmethod
+    def _ssailify(project, manager, blocks, edges=()):
+        function = project.kb.functions.function(addr=blocks[0].addr, create=True)
+        assert function is not None
+        graph = networkx.DiGraph()
+        graph.add_nodes_from(blocks)
+        graph.add_edges_from(edges)
+        result = project.analyses[Ssailification].prep(fail_fast=True)(
+            function,
+            graph,
+            entry=blocks[0],
+            ail_manager=manager,
+        )
+        assert result.out_graph is not None
+        return result.out_graph
+
+    @staticmethod
+    def _count_calls(graph):
+        class CallCounter(ailment.AILBlockViewer):
+            """Count calls in an AIL graph."""
+
+            def __init__(self):
+                super().__init__()
+                self.count = 0
+
+            def _handle_Call(self, expr_idx, expr, stmt_idx, stmt, block):
+                self.count += 1
+                super()._handle_Call(expr_idx, expr, stmt_idx, stmt, block)
+
+        counter = CallCounter()
+        for block in graph:
+            counter.walk(block)
+        return counter.count
+
+    def test_selects_explicit_floating_return_read(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        call_stmt, _, fp_ret_expr = self._make_return_call(project, manager)
+        use = self._make_register_copy(project, manager, "xmm0", "xmm1")
+
+        graph = self._ssailify(project, manager, [ailment.Block(0x1000, 6, statements=[call_stmt, use])])
+
+        rewritten = next(iter(graph))
+        rewritten_call, rewritten_use = rewritten.statements
+        self.assertIsInstance(rewritten_call, ailment.Stmt.Assignment)
+        self.assertIsInstance(rewritten_call.dst, ailment.Expr.VirtualVariable)
+        self.assertEqual(rewritten_call.dst.reg_offset, fp_ret_expr.reg_offset)
+        self.assertIsInstance(rewritten_use.src, ailment.Expr.VirtualVariable)
+        self.assertEqual(rewritten_use.src.varid, rewritten_call.dst.varid)
+
+    def test_selects_explicit_integer_return_read(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        call_stmt, ret_expr, _ = self._make_return_call(project, manager)
+        use = self._make_register_copy(project, manager, "rax", "rbx")
+
+        graph = self._ssailify(project, manager, [ailment.Block(0x1000, 6, statements=[call_stmt, use])])
+
+        rewritten_call = next(iter(graph)).statements[0]
+        self.assertIsInstance(rewritten_call, ailment.Stmt.Assignment)
+        self.assertEqual(rewritten_call.dst.reg_offset, ret_expr.reg_offset)
+
+    def test_selects_arm_hard_float_returns(self):
+        project = angr.load_shellcode(b"\x1e\xff\x2f\xe1", archinfo.ArchARMHF(), load_address=0x1000)
+        for source, destination, select_fp in (("r0", "r1", False), ("s0", "s2", True)):
+            with self.subTest(source=source):
+                manager = ailment.Manager(arch=project.arch)
+                call_stmt, ret_expr, fp_ret_expr = self._make_return_call(project, manager, bits=32)
+                use = self._make_register_copy(project, manager, source, destination, bits=32)
+
+                graph = self._ssailify(project, manager, [ailment.Block(0x1000, 4, statements=[call_stmt, use])])
+
+                rewritten_call = next(iter(graph)).statements[0]
+                self.assertIsInstance(rewritten_call, ailment.Stmt.Assignment)
+                expected = fp_ret_expr if select_fp else ret_expr
+                self.assertEqual(rewritten_call.dst.reg_offset, expected.reg_offset)
+
+    def test_selects_floating_return_across_blocks(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        call_stmt, _, fp_ret_expr = self._make_return_call(project, manager)
+        use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1010)
+        call_block = ailment.Block(0x1000, 6, statements=[call_stmt])
+        use_block = ailment.Block(0x1010, 1, statements=[use])
+
+        graph = self._ssailify(project, manager, [call_block, use_block], [(call_block, use_block)])
+
+        rewritten_call_block = next(block for block in graph if block.addr == call_block.addr)
+        rewritten_call = rewritten_call_block.statements[0]
+        self.assertIsInstance(rewritten_call, ailment.Stmt.Assignment)
+        self.assertEqual(rewritten_call.dst.reg_offset, fp_ret_expr.reg_offset)
+
+    def test_argument_probe_does_not_select_return(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        first_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1000)
+        second_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1005, args=None)
+        second_call = ailment.Stmt.SideEffectStatement(
+            second_call.idx,
+            second_call.expr,
+            ret_expr=None,
+            fp_ret_expr=None,
+            **second_call.tags,
+        )
+
+        graph = self._ssailify(project, manager, [ailment.Block(0x1000, 10, statements=[first_call, second_call])])
+
+        rewritten_call = next(iter(graph)).statements[0]
+        self.assertIsInstance(rewritten_call, ailment.Stmt.Assignment)
+        self.assertEqual(rewritten_call.dst.reg_offset, project.arch.ret_offset)
+
+    def test_explicit_call_argument_selects_floating_return(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        first_call, _, fp_ret_expr = self._make_return_call(project, manager, ins_addr=0x1000)
+        fp_ret_offset = project.arch.fp_ret_offset
+        assert fp_ret_offset is not None
+        argument = ailment.Expr.Register(manager.next_atom(), fp_ret_offset, 64, ins_addr=0x1005)
+        second_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1005, args=(argument,))
+        second_call = ailment.Stmt.SideEffectStatement(
+            second_call.idx,
+            second_call.expr,
+            ret_expr=None,
+            fp_ret_expr=None,
+            **second_call.tags,
+        )
+
+        graph = self._ssailify(project, manager, [ailment.Block(0x1000, 10, statements=[first_call, second_call])])
+
+        rewritten_first, rewritten_second = next(iter(graph)).statements
+        self.assertIsInstance(rewritten_first, ailment.Stmt.Assignment)
+        self.assertEqual(rewritten_first.dst.reg_offset, fp_ret_expr.reg_offset)
+        self.assertIsInstance(rewritten_second, ailment.Stmt.SideEffectStatement)
+        self.assertIsInstance(rewritten_second.expr.args[0], ailment.Expr.VirtualVariable)
+        self.assertEqual(rewritten_second.expr.args[0].varid, rewritten_first.dst.varid)
+
+    def test_overwritten_floating_return_is_not_selected(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        call_stmt, _, _ = self._make_return_call(project, manager)
+        xmm0_offset = project.arch.registers["xmm0"][0]
+        overwrite = ailment.Stmt.Assignment(
+            manager.next_atom(),
+            ailment.Expr.Register(manager.next_atom(), xmm0_offset, 64, ins_addr=0x1002),
+            ailment.Expr.Const(manager.next_atom(), 0, 64, ins_addr=0x1002),
+            ins_addr=0x1002,
+        )
+        use = self._make_register_copy(project, manager, "xmm0", "xmm1")
+
+        graph = self._ssailify(project, manager, [ailment.Block(0x1000, 6, statements=[call_stmt, overwrite, use])])
+
+        rewritten_call = next(iter(graph)).statements[0]
+        self.assertIsInstance(rewritten_call, ailment.Stmt.Assignment)
+        self.assertEqual(rewritten_call.dst.reg_offset, project.arch.ret_offset)
+
+    def test_neither_return_candidate_preserves_integer_fallback(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        call_stmt, _, _ = self._make_return_call(project, manager, args=None)
+
+        graph = self._ssailify(project, manager, [ailment.Block(0x1000, 1, statements=[call_stmt])])
+
+        rewritten_call = next(iter(graph)).statements[0]
+        self.assertIsInstance(rewritten_call, ailment.Stmt.Assignment)
+        self.assertEqual(rewritten_call.dst.reg_offset, project.arch.ret_offset)
+
+    def test_selects_returns_independently_across_consecutive_calls(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        first_call, ret_expr, _ = self._make_return_call(project, manager, ins_addr=0x1000)
+        integer_use = self._make_register_copy(project, manager, "rax", "rbx", ins_addr=0x1001)
+        second_call, _, fp_ret_expr = self._make_return_call(project, manager, ins_addr=0x1002)
+        floating_use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1003)
+
+        graph = self._ssailify(
+            project,
+            manager,
+            [ailment.Block(0x1000, 6, statements=[first_call, integer_use, second_call, floating_use])],
+        )
+
+        statements = next(iter(graph)).statements
+        self.assertEqual(statements[0].dst.reg_offset, ret_expr.reg_offset)
+        self.assertEqual(statements[2].dst.reg_offset, fp_ret_expr.reg_offset)
+
+    def test_selects_integer_partial_alias_and_widens_floating_return(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        integer_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1000)
+        integer_use = self._make_register_copy(project, manager, "eax", "ebx", bits=32, ins_addr=0x1001)
+        floating_call, _, _ = self._make_return_call(project, manager, ins_addr=0x1002)
+        floating_use = self._make_register_copy(project, manager, "xmm0", "xmm1", bits=128, ins_addr=0x1003)
+
+        graph = self._ssailify(
+            project,
+            manager,
+            [ailment.Block(0x1000, 6, statements=[integer_call, integer_use, floating_call, floating_use])],
+        )
+
+        statements = next(iter(graph)).statements
+        self.assertEqual(statements[0].dst.reg_offset, project.arch.ret_offset)
+        self.assertEqual(statements[2].dst.reg_offset, project.arch.fp_ret_offset)
+        self.assertEqual(statements[2].dst.bits, 128)
+        self.assertIsInstance(statements[2].src, ailment.Expr.Insert)
+
+    def test_selects_floating_return_that_reaches_a_phi(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        entry = ailment.Block(0x1000, 1, statements=[])
+        call_stmt, _, fp_ret_expr = self._make_return_call(project, manager, ins_addr=0x1010)
+        call_block = ailment.Block(0x1010, 1, statements=[call_stmt])
+        fp_ret_offset = project.arch.fp_ret_offset
+        assert fp_ret_offset is not None
+        other_def = ailment.Stmt.Assignment(
+            manager.next_atom(),
+            ailment.Expr.Register(manager.next_atom(), fp_ret_offset, 64, ins_addr=0x1020),
+            ailment.Expr.Const(manager.next_atom(), 0, 64, ins_addr=0x1020),
+            ins_addr=0x1020,
+        )
+        other_block = ailment.Block(0x1020, 1, statements=[other_def])
+        use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1030)
+        join = ailment.Block(0x1030, 1, statements=[use])
+
+        graph = self._ssailify(
+            project,
+            manager,
+            [entry, call_block, other_block, join],
+            [(entry, call_block), (entry, other_block), (call_block, join), (other_block, join)],
+        )
+
+        rewritten_call = next(block for block in graph if block.addr == call_block.addr).statements[0]
+        rewritten_join = next(block for block in graph if block.addr == join.addr)
+        self.assertEqual(rewritten_call.dst.reg_offset, fp_ret_expr.reg_offset)
+        self.assertIsInstance(rewritten_join.statements[0], ailment.Stmt.Assignment)
+        self.assertIsInstance(rewritten_join.statements[0].src, ailment.Expr.Phi)
+        phi_varids = {vvar.varid for _, vvar in rewritten_join.statements[0].src.src_and_vvars if vvar is not None}
+        self.assertIn(rewritten_call.dst.varid, phi_varids)
+
+    def test_selects_floating_return_that_reaches_a_loop_phi(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        call_stmt, _, fp_ret_expr = self._make_return_call(project, manager, ins_addr=0x1000)
+        entry = ailment.Block(0x1000, 1, statements=[call_stmt])
+        use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1010)
+        header = ailment.Block(0x1010, 1, statements=[use])
+        fp_ret_offset = project.arch.fp_ret_offset
+        assert fp_ret_offset is not None
+        latch_def = ailment.Stmt.Assignment(
+            manager.next_atom(),
+            ailment.Expr.Register(manager.next_atom(), fp_ret_offset, 64, ins_addr=0x1020),
+            ailment.Expr.Const(manager.next_atom(), 1, 64, ins_addr=0x1020),
+            ins_addr=0x1020,
+        )
+        latch = ailment.Block(0x1020, 1, statements=[latch_def])
+        exit_block = ailment.Block(0x1030, 1, statements=[])
+
+        graph = self._ssailify(
+            project,
+            manager,
+            [entry, header, latch, exit_block],
+            [(entry, header), (header, latch), (latch, header), (header, exit_block)],
+        )
+
+        rewritten_call = next(block for block in graph if block.addr == entry.addr).statements[0]
+        rewritten_header = next(block for block in graph if block.addr == header.addr)
+        phi_stmt = rewritten_header.statements[0]
+        self.assertEqual(rewritten_call.dst.reg_offset, fp_ret_expr.reg_offset)
+        self.assertIsInstance(phi_stmt, ailment.Stmt.Assignment)
+        self.assertIsInstance(phi_stmt.src, ailment.Expr.Phi)
+        phi_varids = {vvar.varid for _, vvar in phi_stmt.src.src_and_vvars if vvar is not None}
+        self.assertIn(rewritten_call.dst.varid, phi_varids)
+
+    def test_repeated_ssa_does_not_duplicate_selected_call(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        call_stmt, _, _ = self._make_return_call(project, manager)
+        use = self._make_register_copy(project, manager, "xmm0", "xmm1")
+        first_graph = self._ssailify(project, manager, [ailment.Block(0x1000, 6, statements=[call_stmt, use])])
+        first_blocks = list(first_graph)
+        first_edges = list(first_graph.edges())
+
+        second_graph = self._ssailify(project, manager, first_blocks, first_edges)
+
+        self.assertEqual(self._count_calls(first_graph), 1)
+        self.assertEqual(self._count_calls(second_graph), 1)
+        rewritten = next(iter(second_graph))
+        self.assertIsInstance(rewritten.statements[0], ailment.Stmt.Assignment)
+        self.assertIsInstance(rewritten.statements[0].dst, ailment.Expr.VirtualVariable)
+        self.assertIsInstance(rewritten.statements[1].src, ailment.Expr.VirtualVariable)
+        self.assertEqual(rewritten.statements[1].src.varid, rewritten.statements[0].dst.varid)
+        self.assertFalse(
+            any(
+                isinstance(stmt, ailment.Stmt.SideEffectStatement)
+                and stmt.ret_expr is not None
+                and stmt.fp_ret_expr is not None
+                for block in second_graph
+                for stmt in block.statements
+            )
+        )
+
+    def test_stack_probe_drops_provisional_fp_return_and_preserves_prior_fp_state(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        for probe_name, use_metadata_flag in (("__chkstk", False), ("helper", True)):
+            with self.subTest(probe_name=probe_name, use_metadata_flag=use_metadata_flag):
+                manager = ailment.Manager(arch=project.arch)
+                probe = project.kb.functions.function(addr=0x2000, create=True)
+                assert probe is not None
+                probe.name = probe_name
+                probe.info["is_alloca_probe"] = use_metadata_flag
+                call_stmt, ret_expr, _ = self._make_return_call(project, manager)
+                fp_ret_offset = project.arch.fp_ret_offset
+                assert fp_ret_offset is not None
+                prior = ailment.Stmt.Assignment(
+                    manager.next_atom(),
+                    ailment.Expr.Register(manager.next_atom(), fp_ret_offset, 64, ins_addr=0x0FFF),
+                    ailment.Expr.Const(manager.next_atom(), 1, 64, ins_addr=0x0FFF),
+                    ins_addr=0x0FFF,
+                )
+                use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1001)
+                call_block = ailment.Block(0x1000, 1, statements=[prior, call_stmt])
+                use_block = ailment.Block(0x1001, 1, statements=[use])
+                graph = networkx.DiGraph()
+                graph.add_edge(call_block, use_block)
+                clinic = object.__new__(Clinic)
+                clinic.kb = project.kb
+                clinic.project = project
+
+                fixed_graph = clinic._fix_special_call_calling_conventions(graph)  # pylint: disable=protected-access
+                fixed_call_block = next(block for block in fixed_graph if block.addr == call_block.addr)
+                fixed_call = fixed_call_block.statements[1]
+
+                self.assertEqual(fixed_call.ret_expr, ret_expr)
+                self.assertIsNone(fixed_call.fp_ret_expr)
+                rewritten = self._ssailify(project, manager, list(fixed_graph), fixed_graph.edges())
+                rewritten_call_block = next(block for block in rewritten if block.addr == call_block.addr)
+                rewritten_use_block = next(block for block in rewritten if block.addr == use_block.addr)
+                self.assertIsInstance(rewritten_call_block.statements[0], ailment.Stmt.Assignment)
+                self.assertIsInstance(rewritten_call_block.statements[0].dst, ailment.Expr.VirtualVariable)
+                self.assertIsInstance(rewritten_use_block.statements[0].src, ailment.Expr.VirtualVariable)
+                self.assertEqual(
+                    rewritten_use_block.statements[0].src.varid,
+                    rewritten_call_block.statements[0].dst.varid,
+                )
+
+    def test_known_prototypes_preserve_machine_read_selection(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        cases = (
+            ("integer", SimTypeLongLong(), "rax", "rbx", project.arch.ret_offset),
+            ("floating", SimTypeDouble(), "xmm0", "xmm1", project.arch.fp_ret_offset),
+            ("void", SimTypeBottom(label="void"), None, None, project.arch.ret_offset),
+        )
+        for name, return_type, source, destination, expected_offset in cases:
+            with self.subTest(return_type=name):
+                manager = ailment.Manager(arch=project.arch)
+                call_stmt, _, _ = self._make_return_call(project, manager)
+                variable_map = variable_map_of(manager)
+                variable_map.set_calling_convention(call_stmt.expr, SimCCSystemVAMD64(project.arch))
+                prototype = SimTypeFunction([], return_type).with_arch(project.arch)
+                assert isinstance(prototype, SimTypeFunction)
+                variable_map.set_prototype(call_stmt.expr, prototype)
+                call_stmt.expr.tags["is_prototype_guessed"] = False
+                statements: list[ailment.Statement] = [call_stmt]
+                if source is not None and destination is not None:
+                    statements.append(self._make_register_copy(project, manager, source, destination))
+
+                graph = self._ssailify(project, manager, [ailment.Block(0x1000, 6, statements=statements)])
+
+                rewritten_call = next(iter(graph)).statements[0]
+                self.assertIsInstance(rewritten_call, ailment.Stmt.Assignment)
+                self.assertEqual(rewritten_call.dst.reg_offset, expected_offset)
+
+    def test_zero_trigger_graph_keeps_provisional_tracking_empty(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        ret_offset = project.arch.ret_offset
+        assert ret_offset is not None
+        statements = []
+        for idx in range(256):
+            statements.append(
+                ailment.Stmt.Assignment(
+                    manager.next_atom(),
+                    ailment.Expr.Register(manager.next_atom(), ret_offset, 64),
+                    ailment.Expr.Const(manager.next_atom(), idx, 64),
+                )
+            )
+        block = ailment.Block(0x1000, 1, statements=statements)
+        graph = networkx.DiGraph()
+        graph.add_node(block)
+        function = project.kb.functions.function(addr=block.addr, create=True)
+        assert function is not None
+
+        traversal = TraversalAnalysis(
+            project,
+            function,
+            graph,
+            None,
+            False,
+            False,
+            False,
+            set(),
+            project.kb.functions.get,
+            variable_map=variable_map_of(manager),
+        )
+
+        self.assertFalse(traversal.provisional_call_return_defs)
+        self.assertFalse(traversal.used_provisional_call_return_defs)
+
+    @unittest.expectedFailure
+    def test_both_explicit_returns(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        call_stmt, _, _ = self._make_return_call(project, manager)
+        integer_use = self._make_register_copy(project, manager, "rax", "rbx", ins_addr=0x1001)
+        floating_use = self._make_register_copy(project, manager, "xmm0", "xmm1", ins_addr=0x1002)
+
+        graph = self._ssailify(
+            project,
+            manager,
+            [ailment.Block(0x1000, 6, statements=[call_stmt, integer_use, floating_use])],
+        )
+        self.assertEqual(self._count_calls(graph), 1)
+
+    def test_syscall_uses_only_integer_return_candidate(self):
+        project = angr.load_shellcode(b"\xc3", "AMD64", load_address=0x1000)
+        manager = ailment.Manager(arch=project.arch)
+        ret_offset = project.arch.ret_offset
+        fp_ret_offset = project.arch.fp_ret_offset
+        assert ret_offset is not None and fp_ret_offset is not None
+        ret_expr = ailment.Expr.Register(manager.next_atom(), ret_offset, 64)
+        fp_ret_expr = ailment.Expr.Register(manager.next_atom(), fp_ret_offset, 64)
+        call = ailment.Expr.Call(
+            manager.next_atom(),
+            ailment.Expr.DirtyExpression(manager.next_atom(), "syscall", [], bits=64),
+            args=None,
+            bits=64,
+        )
+        stmt = ailment.Stmt.SideEffectStatement(manager.next_atom(), call, ret_expr=ret_expr, fp_ret_expr=fp_ret_expr)
+        variable_map_of(manager).set_calling_convention(call, SimCCSystemVAMD64(project.arch))
+
+        graph = self._ssailify(project, manager, [ailment.Block(0x1000, 2, statements=[stmt])])
+
+        rewritten = next(iter(graph)).statements[0]
+        self.assertIsInstance(rewritten, ailment.Stmt.Assignment)
+        self.assertEqual(rewritten.dst.reg_offset, ret_expr.reg_offset)
+
+    def test_refresh_progress_meter_uses_floating_point_call_return(self):
+        binary = Path(bin_location) / "tests" / "x86_64" / "decompiler" / "openssh_scp_O2_noinline"
+        project = angr.Project(binary, auto_load_libs=False)
+        cfg = project.analyses.CFGFast(
+            normalize=True,
+            function_starts=[0x40C120],
+            regions=[(0x40C120, 0x40C680)],
+            fail_fast=True,
+            show_progressbar=False,
+        )
+        function = cfg.kb.functions[0x40C120]
+
+        for structurer in ("sailr", "phoenix"):
+            with self.subTest(structurer=structurer):
+                result = project.analyses[Decompiler].prep(fail_fast=True)(
+                    function,
+                    cfg=cfg.model,
+                    preset="full",
+                    options=[("structurer_cls", structurer)],
+                    use_cache=False,
+                )
+
+                assert result.codegen is not None and result.codegen.text is not None
+                self.assertIn("= monotime_double();", result.codegen.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling OpenSSH `scp`'s `refresh_progress_meter` at `0x40c120` in `binaries/tests/x86_64/decompiler/openssh_scp_O2_noinline` crashes: a read of `XMM0` after an unknown call has no reaching definition, and the decompiler raises rather than emitting a body.

### Root cause

An unknown AMD64 call is lifted with two provisional return locations, an integer one and a floating-point one, because the callee's prototype is unknown. SSA then kept only `RAX`. The `XMM0` half was never given a definition, so a real floating-point return read pointed at nothing.

### Fix

SSA records explicit reads of both provisional definitions during the traversal it already performs, and selects the sole *used* return when rewriting. A conservative ABI probe selects no result, and syscalls and stack probes keep their own semantics. A call whose machine code consumes both candidates is still unsupported, and is left alone rather than guessed at.

### Testing

`test_ssa_call_return_selection.py` decompiles `refresh_progress_meter` under the full SAILR and Phoenix presets; it fails on the baseline with the reaching-definition error. The before/after output is in the comment below.

Fixes #6724. Validation: https://github.com/angr/angr/pull/6829#issuecomment-5282139682

sync: angr/binaries#179

session: sharpen
