### PR TITLE
CFGFast: Do not build a zero-size node for an undefined instruction

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -6226,18 +6226,11 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                     # VEX decodes ud2 on both x86 and AMD64 and counts it towards the block size.
                     valid_ins = True
                     nodecode_size = 0
-                elif (
-                    lifted_block is not None
-                    and is_x86_x64_arch
-                    and lifted_block.bytes is not None
-                    and len(lifted_block.bytes) - irsb_size > 2
-                    and lifted_block.bytes[irsb_size : irsb_size + 2]
-                    in {
-                        b"\x0f\xff",  # ud0
-                        b"\x0f\xb9",  # ud1
-                        b"\x0f\x0b",  # ud2
-                    }
-                ):
+                elif is_x86_x64_arch and self._fast_memory_load_bytes(real_addr + irsb_size, 2) in {
+                    b"\x0f\xff",  # ud0
+                    b"\x0f\xb9",  # ud1
+                    b"\x0f\x0b",  # ud2
+                }:
                     # ud0, ud1, and ud2 are actually valid instructions.
                     valid_ins = True
                     # VEX decodes none of ud0/ud1 here, so they are not part of the block size. ud2 only
@@ -6304,6 +6297,11 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 self._seg_list.occupy(real_addr, irsb_size, "code")
                 if nodecode_size > 0:
                     self._seg_list.occupy(real_addr + irsb_size, nodecode_size, "nodecode")
+
+                if irsb_size == 0:
+                    # the undefined instruction is the whole block, so there is nothing to turn into a node.
+                    # its extent is recorded above, which is what keeps the scan from restarting inside it.
+                    return None, None, None, None
 
             if (
                 irsb is not None

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -6151,9 +6151,10 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                     except SimTranslationError:
                         nodecode = True
 
-                    irsb_string = lifted_block.bytes[: irsb.size] if irsb is not None else lifted_block.bytes
+                    lifted_block_bytes = lifted_block.bytes if lifted_block.bytes is not None else b""
+                    irsb_string = lifted_block_bytes[: irsb.size] if irsb is not None else lifted_block_bytes
 
-                    if not (nodecode or irsb.size == 0 or irsb.jumpkind == "Ijk_NoDecode"):
+                    if not (nodecode or irsb is None or irsb.size == 0 or irsb.jumpkind == "Ijk_NoDecode"):
                         # it is decodeable
                         if current_function_addr == addr:
                             current_function_addr = addr_0

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1004,6 +1004,22 @@ class TestCfgfast(unittest.TestCase):
         for addr in not_separate_functions:
             assert addr not in cfg.kb.functions, f"{hex(addr)} should not be a separate function"
 
+    def test_an_undefined_instruction_that_is_the_whole_block_makes_no_node(self):
+        # The Thumb UND at 0x7ea lifts to an empty IRSB, so there is no block to turn into a node.
+        # _generate_cfgnode recognized it and recorded its two bytes, then built a CFGNode of size
+        # zero with no instructions anyway, and the scan seeded a function on the instruction after it.
+        path = os.path.join(test_location, "armel", "lwip_tcpecho_bm.elf")
+        proj = angr.Project(path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        assert proj.loader.memory.load(0x7EA, 2) == b"\xff\xde"  # UND, inside __udivmoddi4
+        nodes = [n for n in cfg.model.nodes() if not n.is_simprocedure]
+        assert nodes
+        extentless = [n for n in nodes if not n.size]
+        assert not extentless, f"extentless nodes recorded: {extentless}"
+        # the instruction after the UND belongs to the function around it, not to one of its own
+        assert 0x7ED not in cfg.kb.functions
+
     @staticmethod
     def _blob_project(data: bytes, arch: str | archinfo.Arch = "AMD64") -> angr.Project:
         return angr.Project(


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An undefined instruction that is the whole block leaves a `CFGNode` with no instructions and a size of zero, and the linear scan then seeds a function on the instruction after it, splitting the function it sat in. In `angr/binaries` `tests/armel/lwip_tcpecho_bm.elf` the Thumb `UND` at `0x7ea` sits inside `__udivmoddi4`, and on master:

```text
bytes at 0x7ea: b'\xff\xde'
node 0x7eb  <CFGNode __udivmoddi4+0xe6 [0]>  size 0, instruction_addrs ()
func 0x705  __udivmoddi4  blocks=48
func 0x7ed  sub_7ed       blocks=24          <- the rest of __udivmoddi4
```

With this change there is no node at `0x7eb`, no `sub_7ed`, and `__udivmoddi4` is one function of 71 blocks. Every block is still recovered; the only node that disappears is the extentless one.

Six more objects already in `angr/binaries` record an extentless node on master: `armel/btrfs.ko` 443 of them, `armel/libc-2.31.so` and `armhf/kepler_server` 4 each, `armel/lwip_udpecho_bm.elf`, `armel/fpijr_cortexm_console` and `armel/fpijr_cortexm_console_stripped` 1 each. `btrfs.ko`'s 443 are the ARM-mode `UND` word `e7f001f2`; the other 12 are the Thumb `ff de` above.

### Root cause

`_generate_cfgnode` recognizes an undefined instruction from the two bytes after the part of the block VEX could decode — `UND` on ARM, `ud0`/`ud1`/`ud2` on x86 — and records its extent in the segment list. When the instruction is the whole block there is nothing left to build a node from, but the function carries on and builds one anyway, with no instructions and a size of zero, and the scan treats the address after it as a new function start. That is the ARM case above.

The x86 arm of the same recognition has a second defect, which is why it is in this change: it cannot run at all in the default configuration.

```python
and len(lifted_block.bytes) - irsb_size > 2
and lifted_block.bytes[irsb_size : irsb_size + 2] in {...}
```

CFGFast lifts with an explicit size and reads `Block.vex_nostmt` before `Block.bytes`. `_parse_vex_info` has reset `Block.size` to the IRSB size by then, so the lazy load returns exactly the bytes VEX consumed and the subtraction is zero. Hand CFGFast a `base_state` and the same expression does fire, because `Block.__init__` fills `_bytes` eagerly at the size that was asked for and nothing shortens it again:

| `Block(0x4081b9, size=1024)` on `x86_64/ALLSTAR_9base_awk`, read as CFGFast reads it | `block.size` | `len(block.bytes)` | bytes tested | fires |
| --- | ---: | ---: | --- | --- |
| default | 0 | 0 | `b""` | no |
| `backup_state=blank_state()` | 0 | 1024 | `b"\x0f\xff"` | yes |

So whether the check runs depends on a setting that has nothing to do with it. angr#7129 repairs that asymmetry in `block.py`, which would leave the check dead in both configurations rather than one.

One correction to what this description used to say: `ud0` and `ud1` do still lift to a zero-size `Ijk_NoDecode`, but `ud2` does not. libVEX 3.27.1 decodes it on 32-bit x86, so a block ending on a `ud2` is caught by the branch above this one and only a mid-block `ud2` reaches here.

### Fix

Read the two bytes from memory, the way the ARM `UND` branch just below already reads them, so whether the check runs does not depend on how the block was lifted. And when the undefined instruction is the whole block, return once its extent is recorded: there is nothing to make a node from, and the recorded extent is what keeps the scan from restarting inside the instruction.

Not done here: the instructions VEX cannot decode that are neither `ud0`/`ud1`/`ud2` nor ARM `UND` still get one byte marked and the scan still restarts inside them. That needs a length oracle rather than a byte comparison, and it is #6837.

### Testing

`tests/analyses/cfg/test_cfgfast.py::TestCfgfast::test_an_undefined_instruction_that_is_the_whole_block_makes_no_node` runs `CFGFast(normalize=True)` over `armel/lwip_tcpecho_bm.elf` and asserts that no non-SimProcedure node has size zero and that `0x7ed` is not a function. On master it fails with `assert not [<CFGNode __udivmoddi4+0xe6 [0]>]`; it passes here.

Across all seven ARM objects the extentless count goes to zero, and `armel/btrfs.ko` goes from 20 blocks starting at a non-leading instruction of another block to 1, and the only node and function that disappear on `lwip_tcpecho_bm.elf` are `0x7eb` and `0x7ed`. The x86 half has no public reproducer and changes nothing measurable: over the 342 files at the top level of `binaries/tests/i386` and `binaries/tests/x86_64`, 73 of which carry `0f ff` or `0f b9` bytes in an executable section, 67 ran on both sides and the node, function and `nodecode` segment sets are identical on every one. They hold 1,888 `nodecode` segments between them and 1,321 of those start on an undefined instruction, every single one a `ud2`; nothing swept has a `ud0` or a `ud1` where this branch would see it. The same run reports the ARM change, so the instrument is not blind.

Related: #6837. Validation: https://github.com/angr/angr/pull/6839#issuecomment-5287246026

session: sharpen
