### PR TITLE
CFGFast: Resolve pending indirect jumps in address order

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -27,7 +27,7 @@ from cle import (
     TLSObject,
 )
 from cle.backends import NamedRegion
-from sortedcontainers import SortedDict
+from sortedcontainers import SortedDict, SortedSet
 
 from angr.analyses.analysis import Analysis
 from angr.analyses.stack_pointer_tracker import StackPointerTracker
@@ -179,7 +179,9 @@ class CFGBase(Analysis):
         # IndirectJump object that describe all indirect exits found in the binary
         # stores as a map between addresses and IndirectJump objects
         self.indirect_jumps: dict[int, IndirectJump] = {}
-        self._indirect_jumps_to_resolve = set()
+        # a sorted set, not a set: resolving one indirect jump builds blocks and occupies bytes that the next
+        # resolver reads, so the order they come out of here decides the CFG. IndirectJump orders by address.
+        self._indirect_jumps_to_resolve: SortedSet = SortedSet()
         # indirect jumps whose resolution was postponed because the data references that bound an unbounded jump
         # table were not collected yet. only used when _defer_unbounded_jumptables is enabled (CFGFast).
         self._deferred_indirect_jumps: set[IndirectJump] = set()

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -20,7 +20,7 @@ from archinfo import Endness
 from archinfo.arch_arm import get_real_address_if_arm, is_arm_arch
 from archinfo.arch_soot import SootAddressDescriptor
 from cle.address_translator import AT
-from sortedcontainers import SortedDict
+from sortedcontainers import SortedDict, SortedSet
 
 import angr
 from angr import claripy
@@ -6680,9 +6680,9 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                     del self.functions[existing_node.addr]
 
                 # update indirect_jumps_to_resolve
-                self._indirect_jumps_to_resolve = {
+                self._indirect_jumps_to_resolve = SortedSet(
                     ij for ij in self._indirect_jumps_to_resolve if ij.addr != existing_node.addr
-                }
+                )
 
                 self._remove_jobs_by_source_node_addr(existing_node.addr)
 

--- a/angr/knowledge_plugins/cfg/indirect_jump.py
+++ b/angr/knowledge_plugins/cfg/indirect_jump.py
@@ -186,6 +186,20 @@ class IndirectJump(Serializable):
             obj.jumptables.append(ji)
         return obj
 
+    # a jump site is identified by the address of the block that ends in it, which is how
+    # CFGBase.indirect_jumps keys them.
+
+    def __eq__(self, other):
+        return isinstance(other, IndirectJump) and self.addr == other.addr
+
+    def __lt__(self, other):
+        if not isinstance(other, IndirectJump):
+            return NotImplemented
+        return self.addr < other.addr
+
+    def __hash__(self):
+        return hash(self.addr)
+
     def __repr__(self):
         status = ""
         if self.jumptable or self.jumptable_entries:

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -16,6 +16,8 @@ import angr
 from angr.analyses.cfg.indirect_jump_resolvers import mips_elf_fast
 from angr.codenode import FuncNode
 from angr.knowledge_plugins.cfg import CFGModel, CFGNode
+from angr.knowledge_plugins.cfg.indirect_jump import IndirectJump
+from angr.utils.constants import DEFAULT_STATEMENT
 from tests.common import bin_location, broken
 
 l = logging.getLogger("angr.tests.test_cfgfast")
@@ -490,6 +492,37 @@ class TestCfgfast(unittest.TestCase):
     #
 
     # For test cases for jump table resolver, please refer to test_jumptables.py
+
+    def test_pending_indirect_jumps_are_resolved_in_address_order(self):
+        # pylint:disable=protected-access
+        # resolving one indirect jump builds blocks and occupies bytes that the next resolver reads, so the order
+        # they come out of the pending collection decides the answer and must not depend on where their objects
+        # happen to sit in memory
+        path = os.path.join(test_location, "x86_64", "fauxware")
+        proj = angr.Project(path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast()
+
+        addresses = [0x400000 + ((index * 0x2801) % 0x10000) for index in range(64)]
+        assert addresses != sorted(addresses)
+        pending = cfg._indirect_jumps_to_resolve
+        pending.clear()
+        pending.update(IndirectJump(addr, addr, 0x400000, "Ijk_Boring", DEFAULT_STATEMENT) for addr in addresses)
+        # a second object describing a jump site that is already pending is the same jump site
+        pending.add(IndirectJump(addresses[0], addresses[0], 0x400000, "Ijk_Boring", DEFAULT_STATEMENT))
+        queued = len(pending)
+
+        resolved = []
+
+        def record(jump, func_graph_complete=True):  # pylint:disable=unused-argument
+            resolved.append(jump.addr)
+            return set()
+
+        cfg._process_one_indirect_jump = record
+        cfg._process_unresolved_indirect_jumps()
+
+        assert resolved == sorted(addresses)
+        assert queued == len(addresses)
+        assert not pending
 
     def test_resolve_x86_elf_pic_plt(self):
         path = os.path.join(test_location, "i386", "fauxware_pie")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` does not return the same CFG for the same input. Two runs in one process on `binaries/tests/x86_64/libc.so.6`, with nothing between them, recover different block sets:

```
run 1: 88367 blocks
run 2: 88366 blocks
only in run 1: ['0x491f58']
only in run 2: []
the two runs disagree
```

Nothing about the run has to change for the answer to change — allocating anything before `import angr` is also enough. Every consumer inherits it: a jump table is resolved one way or the other, and a decompilation, a corpus comparison or a test that depends on the affected blocks flips with it.

### Root cause

`CFGBase._process_unresolved_indirect_jumps` iterates `self._indirect_jumps_to_resolve`, a `set` of `IndirectJump`:

```python
for idx, jump in enumerate(self._indirect_jumps_to_resolve):
    if self.should_abort:
        break
    if self._low_priority:
        self._release_gil(idx, 50, 0.000001)
    all_targets |= self._process_one_indirect_jump(jump)
```

`IndirectJump` defines neither `__eq__` nor `__hash__`, so the set hashes its members by identity and iterates them in the order their objects happen to sit in memory. That order is not neutral: resolving one jump inserts jobs, builds blocks and occupies bytes in the segment list, and both the next jump's resolver and the linear scan read that state.

### Fix

Give `IndirectJump` `__eq__`, `__lt__` and `__hash__` on `addr` — the address of the block that ends in the jump, which is already how `CFGBase.indirect_jumps` keys them and what `_indirect_jump_encountered` looks a jump up by — and make `_indirect_jumps_to_resolve` a `sortedcontainers.SortedSet`. The pending jumps then come out in address order, and a second `IndirectJump` describing a site that is already pending no longer adds a second entry. The order is fixed by the set rather than recomputed, so nothing is sorted per call.

The hash is `hash(self.addr)`, an `int` hash, which is the same in every process; a hash built from `id()` or from a string would put the ordering back.

This makes the answer stable. It does not make it right, and on the two public fixtures where the right answer is established it settles on the wrong one: `binaries/tests/x86_64/static`, where three stanzas of `__memcmp_sse4_1` are cut short by the jump-table over-read in #6838, and `binaries/tests/armel/tenda-httpd`, where the recovered function `0xd4930` is the literal-pool misread in #7088. Neither is this change's to fix. A wrong answer that arrives every run is one a bisect can find; the same wrong answer half the time is not.

### Testing

`test_pending_indirect_jumps_are_resolved_in_address_order` puts 64 `IndirectJump`s whose addresses are deliberately not in ascending order into the pending set, adds a second object for an address already there, hands the set to `_process_unresolved_indirect_jumps` through a recording stub, and asserts the sequence that reaches the resolver. On master that assertion fails on both counts at once, reporting a mismatch at index 0 and one extra item; the addresses it names differ from process to process, because that is the defect. In a real recovery of `binaries/tests/aarch64/libc.so.6`, instrumenting the loop shows batches reaching the resolver out of address order on master — the count varies per process — and none out of order here, in every run.

Fixes #6840. Validation: https://github.com/angr/angr/pull/6844#issuecomment-5296512585

session: sharpen
