### PR TITLE
Decompiler: Preserve indirect store addresses across type casts

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -3368,15 +3368,18 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
         lvalue: bool,
         renegotiate_type: Callable[[SimType, SimType], SimType] = lambda old, proposed: old,
     ) -> CExpression:
-        def _force_type_cast(src_type_: SimType, dst_type_: SimType, expr_: CExpression) -> CUnaryOp:
+        def _force_type_cast(
+            src_type_: SimType, dst_type_: SimType, expr_: CExpression, take_reference: bool
+        ) -> CUnaryOp:
             src_type_ptr = SimTypePointer(src_type_).with_arch(self.project.arch)
             dst_type_ptr = SimTypePointer(dst_type_).with_arch(self.project.arch)
+            cast_expr = CUnaryOp("Reference", expr_, codegen=self) if take_reference else expr_
             return CUnaryOp(
                 "Dereference",
                 CTypeCast(
                     src_type_ptr,
                     dst_type_ptr,
-                    CUnaryOp("Reference", expr_, codegen=self),
+                    cast_expr,
                     codegen=self,
                 ),
                 codegen=self,
@@ -3409,11 +3412,11 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
                 # case 2: we're done because we can never find it and we might as well stop early
                 if base_expr:
                     if not type_equals(base_type, data_type):
-                        return _force_type_cast(base_type, data_type, base_expr)
+                        return _force_type_cast(base_type, data_type, base_expr, True)
                     return base_expr
 
                 if not type_equals(base_type, data_type):
-                    return _force_type_cast(base_type, data_type, expr)
+                    return _force_type_cast(base_type, data_type, expr, False)
                 return CUnaryOp("Dereference", expr, codegen=self)
 
         stride = 1 if base_type.size is None else base_type.size // self.project.arch.byte_width or 1

--- a/tests/analyses/decompiler/test_structured_codegen.py
+++ b/tests/analyses/decompiler/test_structured_codegen.py
@@ -384,7 +384,7 @@ class TestStoreRendering(unittest.TestCase):
         cls.codegen = _make_codegen()
 
     def test_mismatched_store_cast_distinguishes_pointer_from_storage(self):
-        manager = Manager(arch=self.codegen.project.arch)
+        manager = Manager()
         addr = Expr.VirtualVariable(
             manager.next_atom(), 1, self.codegen.project.arch.bits, VirtualVariableCategory.REGISTER
         )

--- a/tests/analyses/decompiler/test_structured_codegen.py
+++ b/tests/analyses/decompiler/test_structured_codegen.py
@@ -11,7 +11,8 @@ import unittest
 from types import SimpleNamespace
 
 import angr
-from angr.ailment import Expr, Stmt
+from angr.ailment import Expr, Manager, Stmt
+from angr.ailment.expression import VirtualVariableCategory
 from angr.analyses.decompiler.structured_codegen.c import (
     CAssignment,
     CExpression,
@@ -21,11 +22,13 @@ from angr.analyses.decompiler.structured_codegen.c import (
     CUnaryOp,
     type_to_c_repr_chunks,
 )
+from angr.analyses.decompiler.variable_map import VariableMap
 from angr.calling_conventions import SimComboArg
 from angr.sim_type import (
     SimCppClass,
     SimStruct,
     SimTypeBottom,
+    SimTypeChar,
     SimTypeFloat,
     SimTypeFunction,
     SimTypeInt,
@@ -35,6 +38,7 @@ from angr.sim_type import (
     SimUnion,
     parse_cpp_file,
 )
+from angr.sim_variable import SimRegisterVariable, SimStackVariable
 from tests.common import WORKER, bin_location, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -54,14 +58,20 @@ class _RenderedExpression(CExpression):
         yield self.text, self
 
 
+def _make_codegen() -> CStructuredCodeGenerator:
+    proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+    cfg = proj.analyses.CFGFast(normalize=True)
+    codegen = proj.analyses.Decompiler(cfg.functions["main"], cfg=cfg).codegen
+    assert isinstance(codegen, CStructuredCodeGenerator)
+    return codegen
+
+
 class TestConvertRendering(unittest.TestCase):
     """How CStructuredCodeGenerator renders Convert expressions of assorted widths."""
 
     @classmethod
     def setUpClass(cls):
-        proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
-        cfg = proj.analyses.CFGFast(normalize=True)
-        cls.codegen = proj.analyses.Decompiler(cfg.functions["main"], cfg=cfg).codegen
+        cls.codegen = _make_codegen()
 
     def _render(self, from_bits: int, to_bits: int, value: int = 0x1234) -> str:
         conv = Expr.Convert(0, from_bits, to_bits, False, Expr.Const(0, value, from_bits))
@@ -366,6 +376,48 @@ class TestMultiRegisterReturnEndToEnd(unittest.TestCase):
         # decoderune's error path is Go's `return RuneError, 1`, so rax holds 0xfffd and rbx the size.
         # rbx is the second location, which is the high half, so it is the first operand.
         assert "return CONCAT(a2 + 1, 0xfffd);" in text, text
+
+
+class TestStoreRendering(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.codegen = _make_codegen()
+
+    def test_mismatched_store_cast_distinguishes_pointer_from_storage(self):
+        manager = Manager(arch=self.codegen.project.arch)
+        addr = Expr.VirtualVariable(
+            manager.next_atom(), 1, self.codegen.project.arch.bits, VirtualVariableCategory.REGISTER
+        )
+        data = Expr.Const(manager.next_atom(), 0x11223344, 32)
+        pointer_store = Stmt.Store(
+            manager.next_atom(), addr, data, 4, self.codegen.project.arch.memory_endness, ins_addr=0x401000
+        )
+        direct_store = Stmt.Store(
+            manager.next_atom(), addr, data, 4, self.codegen.project.arch.memory_endness, ins_addr=0x401004
+        )
+        addr_variable = SimRegisterVariable(0x28, self.codegen.project.arch.bytes, ident="ir_test", name="iter")
+        storage_variable = SimStackVariable(-0x10, 4, ident="is_test", name="storage")
+        variable_map = VariableMap()
+        variable_map.set_variable(addr, addr_variable)
+        variable_map.set_variable(direct_store, storage_variable)
+
+        variable_manager = self.codegen.kb.dec_variables[self.codegen._func.addr]
+        variable_manager.set_unified_variable(addr_variable, addr_variable)
+        variable_manager.set_unified_variable(storage_variable, storage_variable)
+        variable_manager.set_variable_type(
+            addr_variable, SimTypePointer(SimTypeChar()).with_arch(self.codegen.project.arch)
+        )
+        variable_manager.set_variable_type(storage_variable, SimTypeChar().with_arch(self.codegen.project.arch))
+        old_variable_map = self.codegen._variable_map
+        self.codegen._variable_map = variable_map
+        try:
+            pointer_rendered = self.codegen._handle(pointer_store, is_expr=False).c_repr()
+            direct_rendered = self.codegen._handle(direct_store, is_expr=False).c_repr()
+        finally:
+            self.codegen._variable_map = old_variable_map
+
+        assert direct_rendered == "*((unsigned int *)&storage) = 287454020;\n"
+        assert pointer_rendered == "*((unsigned int *)iter) = 287454020;\n"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

In DecBench Crazyflie O2-noinline [`cf2.elf`](https://huggingface.co/datasets/noelo-lab/decbench-dataset/blob/4b42a0dc6158913db0648a9123e76d6ddd9ab9cf/binaries/O2-noinline/crazyflie/cf2.elf), full SAILR decompilation of `kalmanCoreUpdateWithPose` at Thumb `0x802ebf9` rendered a zero-offset store through the pointer `iter` as a store to the pointer variable itself:

```c
*((unsigned int *)&iter) = 1.0;
```

### Root cause

`CStructuredCodeGenerator._handle_Store()` used the same forced-type-cast helper for both a recovered storage variable and an address expression that was already a pointer. The helper always wrapped its input in `Reference`, so the already-pointer path gained an extra address-of operation.

### Fix

The cast helper now takes an explicit `take_reference` flag. Direct storage still becomes a referenced pointer before the cast, while an address expression is cast as-is:

```c
*((unsigned int *)iter) = 1.0;
```

### Testing

The regression constructs both forms on the compiler-produced `fauxware` fixture and asserts that direct storage retains `&storage` while the pointer form renders `iter`. The public DecBench function was decompiled before and after the change on the current baseline.

Validation: https://github.com/angr/angr/pull/6850#issuecomment-5302358604

session: sharpen
