### PR TITLE
Decompiler: Preserve virtual-variable bindings across index collisions

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -431,8 +431,9 @@ class Clinic(Analysis, Serializable):
         # True once _recover_and_link_variables has populated kb.dec_variables for this function this run
         self._variables_recovered = False
         # VariableMap is a side container that holds variable/variable_offset/custom_string/reference_values and the
-        # sibling reference_variable/reference_variable_offset for AIL atoms, keyed by their .idx. It supersedes
-        # storing this information directly on AIL Statement/Expression objects.
+        # sibling reference_variable/reference_variable_offset for AIL atoms. Variable associations use a separate
+        # VirtualVariable namespace; other metadata is keyed by .idx. It supersedes storing this information directly
+        # on AIL Statement/Expression objects.
         self.variable_map: VariableMap = variable_map if variable_map is not None else VariableMap()
         self.externs: set[SimMemoryVariable] = set()
         self.data_refs: dict[int, list[DataRefDesc]] = {}  # data address to data reference description
@@ -2830,8 +2831,8 @@ class Clinic(Analysis, Serializable):
 
         # combo-register argument vvars only appear inside Reference expressions (created by
         # _rewrite_combo_reg_param_references), which variable recovery does not track, so no accesses were recorded
-        # for them; link them to their argument variables directly. the variable map is keyed by expression idx and
-        # every occurrence in the graph is the same expression object, so one call covers all of them.
+        # for them; link them to their argument variables directly. Every occurrence in the graph is the same
+        # expression object, so one occurrence association (and its stable varid default) covers all of them.
         if arg_vvars is not None:
             for vvar, var in arg_vvars.values():
                 if vvar.parameter_category == ailment.Expr.VirtualVariableCategory.COMBO_REGISTER:

--- a/angr/analyses/decompiler/dephication/rewriting_engine.py
+++ b/angr/analyses/decompiler/dephication/rewriting_engine.py
@@ -110,6 +110,8 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 oident=stmt.dst.oident,
                 **stmt.dst.tags,
             )
+            if self.variable_map is not None:
+                self.variable_map.transfer(stmt.dst, new_dst)
 
         # ensure we do not generate vvar_A = vvar_A or var_A = var_A (even if lhs and rhs are different vvars, they
         # can be mapped to the same variable)
@@ -288,7 +290,7 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
 
     def _handle_expr_VirtualVariable(self, expr: VirtualVariable) -> VirtualVariable | None:
         if expr.varid in self.vvar_to_vvar:
-            return VirtualVariable(
+            new_expr = VirtualVariable(
                 expr.idx,
                 self.vvar_to_vvar[expr.varid],
                 expr.bits,
@@ -296,6 +298,9 @@ class SimEngineDephiRewriting(SimEngineNostmtAIL[None, Expression | None, Statem
                 oident=expr.oident,
                 **expr.tags,
             )
+            if self.variable_map is not None:
+                self.variable_map.transfer(expr, new_expr)
+            return new_expr
         return None
 
     def _handle_stmt_Return(self, stmt):

--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_base.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import networkx
 
@@ -16,6 +16,9 @@ from angr.analyses.decompiler.structurer_nodes import ConditionNode, MultiNode
 from angr.analyses.decompiler.utils import calls_in_graph, remove_labels, to_ail_supergraph
 from angr.utils.ail import is_phi_assignment
 
+if TYPE_CHECKING:
+    from angr.analyses.decompiler.variable_map import VariableMap
+
 _l = logging.getLogger(name=__name__)
 
 
@@ -24,10 +27,11 @@ class FreshVirtualVariableRewriter(AILBlockRewriter):
     Helper class to rewrite virtual variables so that they will use fresh virtual variables.
     """
 
-    def __init__(self, vvar_id_start: int, vvar_mapping: dict[int, int]):
+    def __init__(self, vvar_id_start: int, vvar_mapping: dict[int, int], *, variable_map: VariableMap | None = None):
         super().__init__()
         self.vvar_idx = vvar_id_start
         self.vvar_mapping = vvar_mapping
+        self.variable_map = variable_map
         self.new_block = None
 
     def _handle_Assignment(self, stmt_idx: int, stmt: Assignment, block: Block | None):
@@ -38,7 +42,7 @@ class FreshVirtualVariableRewriter(AILBlockRewriter):
             self.vvar_mapping[dst.varid] = self.vvar_idx
             self.vvar_idx += 1
 
-            dst = VirtualVariable(
+            new_dst = VirtualVariable(
                 dst.idx,
                 self.vvar_mapping[dst.varid],
                 dst.bits,
@@ -46,8 +50,10 @@ class FreshVirtualVariableRewriter(AILBlockRewriter):
                 dst.oident,
                 **dst.tags,
             )
+            if self.variable_map is not None:
+                self.variable_map.transfer(dst, new_dst)
 
-            return Assignment(stmt.idx, dst, src, **stmt.tags)
+            return Assignment(stmt.idx, new_dst, src, **stmt.tags)
 
         return new_stmt
 
@@ -55,7 +61,7 @@ class FreshVirtualVariableRewriter(AILBlockRewriter):
         self, expr_idx: int, expr: VirtualVariable, stmt_idx: int, stmt, block: Block | None
     ) -> VirtualVariable:
         if expr.varid in self.vvar_mapping:
-            return VirtualVariable(
+            new_expr = VirtualVariable(
                 expr.idx,
                 self.vvar_mapping[expr.varid],
                 expr.bits,
@@ -63,6 +69,9 @@ class FreshVirtualVariableRewriter(AILBlockRewriter):
                 expr.oident,
                 **expr.tags,
             )
+            if self.variable_map is not None:
+                self.variable_map.transfer(expr, new_expr)
+            return new_expr
         return expr
 
 
@@ -317,7 +326,7 @@ class ReturnDuplicatorBase:
                 node.statements[idx] = Assignment(stmt.idx, stmt.dst, new_phi, **stmt.tags)
 
     def _use_fresh_virtual_variables(self, node: Block, vvar_map: dict[int, int]) -> Block:
-        rewriter = FreshVirtualVariableRewriter(self.vvar_id_start, vvar_map)
+        rewriter = FreshVirtualVariableRewriter(self.vvar_id_start, vvar_map, variable_map=self._manager.variable_map)
         rewriter.walk(node)
         self.vvar_id_start = rewriter.vvar_idx + 1
         return rewriter.new_block if rewriter.new_block is not None else node

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -185,8 +185,8 @@ class RegionSimplifier(Analysis):
 
             if isinstance(definition, ailment.Stmt.SideEffectStatement):
                 # clear the existing variable since we no longer write to this variable after expression folding.
-                # deep_copy the ret_expr so it gets a fresh .idx; otherwise clearing its VariableMap entry (which is
-                # idx-keyed) would also clear the variable of the original ret_expr, which shares the same .idx.
+                # deep_copy the ret_expr so it gets a fresh .idx; otherwise clearing its occurrence-specific
+                # VariableMap entry would also clear the original ret_expr, whose occurrence key shares the same .idx.
                 definition = definition.copy()
                 if definition.ret_expr is not None:
                     definition.ret_expr = definition.ret_expr.deep_copy(self.ail_manager)

--- a/angr/analyses/decompiler/variable_map.py
+++ b/angr/analyses/decompiler/variable_map.py
@@ -43,8 +43,7 @@ def variable_map_of(manager: Manager) -> VariableMap:
 
 class VariableMap:
     """
-    A side container that maps the ``.idx`` of AIL :class:`Statement` and :class:`Expression` objects to
-    variable-related information.
+    A side container that maps AIL :class:`Statement` and :class:`Expression` objects to variable-related information.
 
     The following pieces of information are tracked:
 
@@ -62,9 +61,11 @@ class VariableMap:
     - ``variant`` (an ``EnumVariant``): the enum variant that a Rust ``Let`` expression binds.
     - ``returnty`` (a :class:`SimType`): the return type of a Rust ``FunctionLikeMacro`` call.
 
-    Keys are the integer ``.idx`` values of AIL Statement/Expression objects. Because :class:`Clinic` builds one
-    :class:`ailment.Manager` per invocation, ``.idx`` values are unique within a single Clinic. So a VariableMap is
-    scoped to one Clinic instance and is stored in the corresponding :class:`DecompilationCache`.
+    Most information is keyed by the integer ``.idx`` of an AIL atom. Variable and variable-offset information uses a
+    separate namespace for ``VirtualVariable`` atoms: a stable ``.varid`` default plus occurrence-specific overrides
+    and tombstones keyed by ``(.varid, .idx)``. Transformation passes can create different atom kinds with the same
+    ``.idx``, while duplicate ``VirtualVariable`` wrappers may have different ``.idx`` values for the same ``.varid``.
+    A VariableMap is scoped to one Clinic instance and is stored in the corresponding :class:`DecompilationCache`.
     """
 
     __slots__ = (
@@ -80,7 +81,12 @@ class VariableMap:
         "_variants",
         "_vvar_id_to_variable",
         "_vvar_id_to_variable_offset",
+        "_vvar_occurrence_tombstones",
+        "_vvar_occurrence_variable_offsets",
+        "_vvar_occurrence_variables",
     )
+
+    SERIALIZATION_VERSION = 2
 
     def __init__(self):
         self._variables: dict[int, SimVariable] = {}
@@ -95,13 +101,13 @@ class VariableMap:
         self._variants: dict[int, Any] = {}
         # ``returnty`` (a :class:`SimType`): the return type of a Rust ``FunctionLikeMacro`` call.
         self._returntys: dict[int, SimType] = {}
-        # Secondary index for VirtualVariable atoms keyed by their stable ``varid``. Intermediate passes that don't
-        # propagate variable_map entries via ``transfer`` create fresh Expression wrappers (each carrying a new
-        # ``.idx``); without this fallback those later vvar wrappers render as raw ``vvar_X`` in the C output even
-        # though their varid was registered at variable-recovery time.
-        # TODO: Identify these cases, fix them, and get rid of this fallback.
+        # VirtualVariable atoms use a stable varid default plus occurrence-specific overrides. A tombstone suppresses
+        # the stable default for one explicitly cleared wrapper without affecting other wrappers for the same varid.
         self._vvar_id_to_variable: dict[int, SimVariable] = {}
         self._vvar_id_to_variable_offset: dict[int, int] = {}
+        self._vvar_occurrence_variables: dict[tuple[int, int], SimVariable] = {}
+        self._vvar_occurrence_variable_offsets: dict[tuple[int, int], int] = {}
+        self._vvar_occurrence_tombstones: set[tuple[int, int]] = set()
 
     #
     # Key helper
@@ -111,27 +117,38 @@ class VariableMap:
     def _key(obj: AILObject | int) -> int:
         return obj if isinstance(obj, int) else obj.idx
 
+    @staticmethod
+    def _varid(obj: AILObject | int) -> int | None:
+        return None if isinstance(obj, int) else getattr(obj, "varid", None)
+
+    @classmethod
+    def _vvar_key(cls, obj: AILObject | int) -> tuple[int, int] | None:
+        varid = cls._varid(obj)
+        return None if varid is None else (varid, cls._key(obj))
+
     #
     # Accessors
     #
 
     def variable(self, obj: AILObject | int) -> SimVariable | None:
-        v = self._variables.get(self._key(obj))
-        if v is not None:
-            return v
-        varid = getattr(obj, "varid", None)
-        if varid is not None:
-            return self._vvar_id_to_variable.get(varid)
-        return None
+        vvar_key = self._vvar_key(obj)
+        if vvar_key is not None:
+            if vvar_key in self._vvar_occurrence_tombstones:
+                return None
+            if vvar_key in self._vvar_occurrence_variables:
+                return self._vvar_occurrence_variables[vvar_key]
+            return self._vvar_id_to_variable.get(vvar_key[0])
+        return self._variables.get(self._key(obj))
 
     def variable_offset(self, obj: AILObject | int) -> int:
-        key = self._key(obj)
-        if key in self._variable_offsets:
-            return self._variable_offsets[key]
-        varid = getattr(obj, "varid", None)
-        if varid is not None and varid in self._vvar_id_to_variable_offset:
-            return self._vvar_id_to_variable_offset[varid]
-        return 0
+        vvar_key = self._vvar_key(obj)
+        if vvar_key is not None:
+            if vvar_key in self._vvar_occurrence_tombstones:
+                return 0
+            if vvar_key in self._vvar_occurrence_variable_offsets:
+                return self._vvar_occurrence_variable_offsets[vvar_key]
+            return self._vvar_id_to_variable_offset.get(vvar_key[0], 0)
+        return self._variable_offsets.get(self._key(obj), 0)
 
     def custom_string(self, obj: AILObject | int) -> bool:
         return self._custom_strings.get(self._key(obj), False)
@@ -146,10 +163,12 @@ class VariableMap:
         return self._reference_variable_offsets.get(self._key(obj), 0)
 
     def has_variable(self, obj: AILObject | int) -> bool:
-        if self._key(obj) in self._variables:
-            return True
-        varid = getattr(obj, "varid", None)
-        return varid is not None and varid in self._vvar_id_to_variable
+        vvar_key = self._vvar_key(obj)
+        if vvar_key is not None:
+            if vvar_key in self._vvar_occurrence_tombstones:
+                return False
+            return vvar_key in self._vvar_occurrence_variables or vvar_key[0] in self._vvar_id_to_variable
+        return self._key(obj) in self._variables
 
     def prototype(self, obj: AILObject | int) -> SimTypeFunction | None:
         return self._prototypes.get(self._key(obj))
@@ -171,6 +190,20 @@ class VariableMap:
         """Set the variable information for an AIL atom. If ``variable`` is ``None``, the variable information for
         this atom is cleared."""
 
+        vvar_key = self._vvar_key(obj)
+        if vvar_key is not None:
+            if variable is None:
+                self._vvar_occurrence_variables.pop(vvar_key, None)
+                self._vvar_occurrence_variable_offsets.pop(vvar_key, None)
+                self._vvar_occurrence_tombstones.add(vvar_key)
+            else:
+                self._vvar_occurrence_variables[vvar_key] = variable
+                self._vvar_occurrence_variable_offsets[vvar_key] = offset
+                self._vvar_occurrence_tombstones.discard(vvar_key)
+                self._vvar_id_to_variable[vvar_key[0]] = variable
+                self._vvar_id_to_variable_offset[vvar_key[0]] = offset
+            return
+
         key = self._key(obj)
         if variable is None:
             self._variables.pop(key, None)
@@ -178,17 +211,13 @@ class VariableMap:
         else:
             self._variables[key] = variable
             self._variable_offsets[key] = offset
-        varid = getattr(obj, "varid", None)
-        if varid is not None:
-            if variable is None:
-                self._vvar_id_to_variable.pop(varid, None)
-                self._vvar_id_to_variable_offset.pop(varid, None)
-            else:
-                self._vvar_id_to_variable[varid] = variable
-                self._vvar_id_to_variable_offset[varid] = offset
 
     def set_variable_offset(self, obj: AILObject | int, offset: int) -> None:
-        self._variable_offsets[self._key(obj)] = offset
+        vvar_key = self._vvar_key(obj)
+        if vvar_key is not None:
+            self._vvar_occurrence_variable_offsets[vvar_key] = offset
+        else:
+            self._variable_offsets[self._key(obj)] = offset
 
     def set_custom_string(self, obj: AILObject | int, value: bool = True) -> None:
         self._custom_strings[self._key(obj)] = value
@@ -247,14 +276,71 @@ class VariableMap:
         else:
             self._returntys[key] = returnty
 
-    def transfer(self, src: TaggedObject | int, dst: TaggedObject | int) -> None:
+    def transfer(self, src: AILObject | int, dst: AILObject | int, vvar_id: int | None = None) -> None:
         """
         Copy all variable information associated with ``src`` to ``dst``. Used when an AIL atom is deep-copied to a new
         ``.idx`` (e.g. during structuring/duplication) so that the new atom keeps the same variable association.
+
+        Native AIL deep-copy passes integer indices. For a ``VirtualVariable`` it also supplies ``vvar_id`` so this
+        method uses the VVar occurrence namespace and cannot copy state owned by a colliding non-VVar atom.
         """
 
         src_key = self._key(src)
         dst_key = self._key(dst)
+        src_varid = vvar_id if vvar_id is not None else self._varid(src)
+        dst_varid = vvar_id if vvar_id is not None else self._varid(dst)
+
+        if src_varid is not None or dst_varid is not None:
+            src_vvar_key = (src_varid, src_key) if src_varid is not None else None
+            dst_vvar_key = (dst_varid, dst_key) if dst_varid is not None else None
+            if src_vvar_key is not None and src_vvar_key in self._vvar_occurrence_tombstones:
+                if dst_vvar_key is not None:
+                    self._vvar_occurrence_variables.pop(dst_vvar_key, None)
+                    self._vvar_occurrence_variable_offsets.pop(dst_vvar_key, None)
+                    self._vvar_occurrence_tombstones.add(dst_vvar_key)
+                else:
+                    self.set_variable(dst, None)
+                return
+
+            variable = None
+            has_variable = False
+            offset = 0
+            has_offset = False
+            if src_vvar_key is not None:
+                if src_vvar_key in self._vvar_occurrence_variables:
+                    variable = self._vvar_occurrence_variables[src_vvar_key]
+                    has_variable = True
+                elif src_varid in self._vvar_id_to_variable:
+                    variable = self._vvar_id_to_variable[src_varid]
+                    has_variable = True
+                if src_vvar_key in self._vvar_occurrence_variable_offsets:
+                    offset = self._vvar_occurrence_variable_offsets[src_vvar_key]
+                    has_offset = True
+                elif src_varid in self._vvar_id_to_variable_offset:
+                    offset = self._vvar_id_to_variable_offset[src_varid]
+                    has_offset = True
+            else:
+                if src_key in self._variables:
+                    variable = self._variables[src_key]
+                    has_variable = True
+                if src_key in self._variable_offsets:
+                    offset = self._variable_offsets[src_key]
+                    has_offset = True
+
+            if dst_vvar_key is not None:
+                if has_variable:
+                    self._vvar_occurrence_variables[dst_vvar_key] = variable  # type: ignore[assignment]
+                if has_offset:
+                    self._vvar_occurrence_variable_offsets[dst_vvar_key] = offset
+                if has_variable or has_offset:
+                    self._vvar_occurrence_tombstones.discard(dst_vvar_key)
+            else:
+                if has_variable:
+                    self.set_variable(dst, variable, offset)  # type: ignore[arg-type]
+                elif has_offset:
+                    self.set_variable_offset(dst, offset)
+            return
+
         if src_key == dst_key:
             return
         for d in (
@@ -329,8 +415,24 @@ class VariableMap:
         """
 
         return {
+            "version": self.SERIALIZATION_VERSION,
             "variables": {idx: (v.ident if v is not None else None) for idx, v in self._variables.items()},
             "variable_offsets": dict(self._variable_offsets),
+            "vvar_id_to_variable": {
+                varid: (v.ident if v is not None else None) for varid, v in self._vvar_id_to_variable.items()
+            },
+            "vvar_id_to_variable_offset": dict(self._vvar_id_to_variable_offset),
+            "vvar_occurrence_variables": [
+                {"varid": varid, "idx": idx, "variable": variable.ident}
+                for (varid, idx), variable in sorted(self._vvar_occurrence_variables.items())
+            ],
+            "vvar_occurrence_variable_offsets": [
+                {"varid": varid, "idx": idx, "offset": offset}
+                for (varid, idx), offset in sorted(self._vvar_occurrence_variable_offsets.items())
+            ],
+            "vvar_occurrence_tombstones": [
+                {"varid": varid, "idx": idx} for varid, idx in sorted(self._vvar_occurrence_tombstones)
+            ],
             "custom_strings": dict(self._custom_strings),
             "reference_values": {idx: self._reference_values_to_json(d) for idx, d in self._reference_values.items()},
             "reference_variables": {
@@ -355,19 +457,78 @@ class VariableMap:
                                  ``None`` if it cannot be resolved).
         """
 
+        version = data.get("version", 1)
+        if version not in (1, cls.SERIALIZATION_VERSION):
+            raise ValueError(f"Unsupported VariableMap serialization version {version}")
+        if version == 1:
+            _l.warning(
+                "Deserializing legacy VariableMap serialization version 1; atom kinds were not recorded, so "
+                "discarding all variable and offset bindings"
+            )
+
         vm = cls()
 
         def _resolve(ident) -> SimVariable | None:
             return resolve_variable(ident) if ident is not None else None
 
-        for idx, ident in data.get("variables", {}).items():
-            v = _resolve(ident)
-            if v is not None:
-                vm._variables[int(idx)] = v
-            else:
-                _l.warning("Variable with ident %s could not be resolved during VariableMap deserialization", ident)
-        for idx, offset in data.get("variable_offsets", {}).items():
-            vm._variable_offsets[int(idx)] = offset
+        if version == cls.SERIALIZATION_VERSION:
+            for idx, ident in data.get("variables", {}).items():
+                v = _resolve(ident)
+                if v is not None:
+                    vm._variables[int(idx)] = v
+                else:
+                    _l.warning("Variable with ident %s could not be resolved during VariableMap deserialization", ident)
+            for idx, offset in data.get("variable_offsets", {}).items():
+                vm._variable_offsets[int(idx)] = offset
+
+            resolved_vvar_ids: set[int] = set()
+            for varid, ident in data.get("vvar_id_to_variable", {}).items():
+                varid = int(varid)
+                v = _resolve(ident)
+                if v is not None:
+                    vm._vvar_id_to_variable[varid] = v
+                    resolved_vvar_ids.add(varid)
+                else:
+                    _l.warning("Variable with ident %s could not be resolved during VariableMap deserialization", ident)
+            for varid, offset in data.get("vvar_id_to_variable_offset", {}).items():
+                varid = int(varid)
+                if varid in resolved_vvar_ids:
+                    vm._vvar_id_to_variable_offset[varid] = offset
+
+            resolved_occurrence_keys: set[tuple[int, int]] = set()
+            unresolved_occurrence_keys: set[tuple[int, int]] = set()
+            for entry in data.get("vvar_occurrence_variables", []):
+                vvar_key = (int(entry["varid"]), int(entry["idx"]))
+                v = _resolve(entry.get("variable"))
+                if v is not None:
+                    vm._vvar_occurrence_variables[vvar_key] = v
+                    resolved_occurrence_keys.add(vvar_key)
+                else:
+                    _l.warning(
+                        "Variable with ident %s could not be resolved during VariableMap deserialization",
+                        entry.get("variable"),
+                    )
+                    unresolved_occurrence_keys.add(vvar_key)
+            occurrence_offsets = {
+                (int(entry["varid"]), int(entry["idx"])): entry["offset"]
+                for entry in data.get("vvar_occurrence_variable_offsets", [])
+            }
+            resolved_occurrence_offset_keys = resolved_occurrence_keys | {
+                vvar_key
+                for vvar_key in occurrence_offsets
+                if vvar_key[0] in resolved_vvar_ids and vvar_key not in unresolved_occurrence_keys
+            }
+            for vvar_key in resolved_occurrence_offset_keys:
+                vm._vvar_occurrence_variable_offsets[vvar_key] = occurrence_offsets.get(vvar_key, 0)
+            for vvar_key in unresolved_occurrence_keys:
+                vm._vvar_occurrence_variables.pop(vvar_key, None)
+                vm._vvar_occurrence_variable_offsets.pop(vvar_key, None)
+                vm._vvar_occurrence_tombstones.add(vvar_key)
+            for entry in data.get("vvar_occurrence_tombstones", []):
+                vvar_key = (int(entry["varid"]), int(entry["idx"]))
+                vm._vvar_occurrence_variables.pop(vvar_key, None)
+                vm._vvar_occurrence_variable_offsets.pop(vvar_key, None)
+                vm._vvar_occurrence_tombstones.add(vvar_key)
         for idx, value in data.get("custom_strings", {}).items():
             vm._custom_strings[int(idx)] = value
         for idx, items in data.get("reference_values", {}).items():

--- a/angr/rust/optimization_passes/redundant_block_remover.py
+++ b/angr/rust/optimization_passes/redundant_block_remover.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from angr.ailment.expression import VirtualVariable
 from angr.ailment.statement import Assignment, ConditionalJump, Jump, Label
 from angr.analyses.decompiler.optimization_passes.optimization_pass import OptimizationPass, OptimizationPassStage
+from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.rust.mixins import CFAMixin, CFGTransformationMixin
 from angr.rust.utils.ail import has_call
 from angr.utils.ssa import VVarUsesCollector
@@ -28,7 +29,9 @@ class RedundantBlockRemover(OptimizationPass, CFAMixin, CFGTransformationMixin):
         return self.project.is_rust_binary, None
 
     def _transform_graph_from_ssa(self, graph):
-        dephication = self.project.analyses.GraphDephication(self._func, graph, rewrite=True, kb=self.kb)
+        dephication = self.project.analyses.GraphDephication(
+            self._func, graph, rewrite=True, kb=self.kb, variable_map=variable_map_of(self.manager)
+        )
         return dephication.output
 
     def _remove_redundant_blocks(self, dephicate=False):

--- a/native/angr/src/ailment/ail_expr.rs
+++ b/native/angr/src/ailment/ail_expr.rs
@@ -166,7 +166,10 @@ impl<'py> IntoPyObject<'py> for &RoundingModeOrExpr {
 /// Layout note: operand subtrees are owned via ``Arc<AilExpression>``
 /// (one heap allocation per subtree). Variable information used to live
 /// on each variant (``variable`` / ``variable_offset``); it now lives in
-/// a side ``VariableMap`` keyed on ``ExprHeader::idx``.
+/// a side ``VariableMap``. Non-``VirtualVariable`` metadata and variable
+/// bindings are keyed by ``.idx``. ``VirtualVariable`` variable/offset
+/// state uses stable ``.varid`` defaults plus occurrence entries keyed by
+/// ``(.varid, .idx)``.
 #[derive(Clone, Debug)]
 pub enum ExprInner {
     Const {
@@ -1667,14 +1670,19 @@ impl AilExpression {
     /// fields are cloned via Python ``copy.deepcopy``.
     pub fn deep_copy_ail(&self, manager: &Bound<'_, PyAny>) -> PyResult<AilExpression> {
         let new_idx: i64 = manager.call_method0("next_atom")?.extract()?;
-        // Mirror master's TaggedObject._transfer_varmap: when the
-        // manager carries a VariableMap, copy any side-container entries
-        // (variable, variable_offset, variant, returnty, ...) from the
-        // old idx to the new one so deep-copied atoms keep their
-        // associations.
+        // Mirror master's TaggedObject._transfer_varmap: when the manager carries a VariableMap, copy side-container
+        // entries from the old idx to the new one. VirtualVariables pass their stable varid as an explicit namespace
+        // discriminator because a transformed non-VVar atom may carry the same idx.
         let vmap = manager.getattr("variable_map")?;
         if !vmap.is_none() {
-            vmap.call_method1("transfer", (self.header.idx, new_idx))?;
+            match &self.inner {
+                ExprInner::VirtualVariable { varid, .. } => {
+                    vmap.call_method1("transfer", (self.header.idx, new_idx, *varid))?;
+                }
+                _ => {
+                    vmap.call_method1("transfer", (self.header.idx, new_idx))?;
+                }
+            }
         }
         let new_header = ExprHeader::new(
             new_idx,

--- a/tests/analyses/decompiler/test_dephication_rewriting.py
+++ b/tests/analyses/decompiler/test_dephication_rewriting.py
@@ -203,6 +203,7 @@ class TestDephicationRewriting(unittest.TestCase):
         assert out.cond.varid == 6
         assert out.iftrue.value == 0x11
         assert out.iffalse.value == 0xFFFFFFFF
+
     def test_redundant_block_remover_dephication_preserves_occurrence_binding(self):
         proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
         func = proj.kb.functions.function(addr=proj.entry, create=True)

--- a/tests/analyses/decompiler/test_dephication_rewriting.py
+++ b/tests/analyses/decompiler/test_dephication_rewriting.py
@@ -37,8 +37,8 @@ class TestDephicationRewriting(unittest.TestCase):
 
     def test_remapped_assignment_dst_transfers_occurrence_binding(self):
         vm = VariableMap()
-        proj, engine = self._engine({11: 21, 12: 22}, vm)
-        m = Manager(arch=proj.arch)
+        _, engine = self._engine({11: 21, 12: 22}, vm)
+        m = Manager()
         src = VirtualVariable(7, 11, 64, VirtualVariableCategory.REGISTER)
         src_var = SimRegisterVariable(8, 8, ident="reg_src")
         dst_default = VirtualVariable(70, 21, 64, VirtualVariableCategory.REGISTER)
@@ -209,7 +209,7 @@ class TestDephicationRewriting(unittest.TestCase):
         func = proj.kb.functions.function(addr=proj.entry, create=True)
         assert func is not None
         vm = VariableMap()
-        manager = Manager(arch=proj.arch)
+        manager = Manager()
         manager.variable_map = vm
 
         source_for_phi = VirtualVariable(1, 100, 64, VirtualVariableCategory.REGISTER)

--- a/tests/analyses/decompiler/test_dephication_rewriting.py
+++ b/tests/analyses/decompiler/test_dephication_rewriting.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-class-docstring,no-self-use,no-member
+# pylint: disable=missing-class-docstring,no-self-use,no-member,protected-access
 from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
@@ -7,11 +7,16 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 import os
 import unittest
 
+import networkx
+
 import angr
-from angr.ailment import Manager
-from angr.ailment.expression import ITE, Const, UnaryOp, VirtualVariable, VirtualVariableCategory
-from angr.ailment.statement import Assignment
+from angr.ailment import Block, Manager
+from angr.ailment.expression import ITE, Const, Phi, UnaryOp, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import Assignment, Return
 from angr.analyses.decompiler.dephication.rewriting_engine import SimEngineDephiRewriting
+from angr.analyses.decompiler.variable_map import VariableMap
+from angr.rust.optimization_passes.redundant_block_remover import RedundantBlockRemover
+from angr.sim_variable import SimConstantVariable, SimRegisterVariable
 from tests.common import bin_location, load_project_with_scoped_cfg, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -25,10 +30,101 @@ class TestDephicationRewriting(unittest.TestCase):
     """
 
     @staticmethod
-    def _engine(mapping):
+    def _engine(mapping, variable_map=None):
         # a project is only needed for the arch; no CFG or analyses required
         proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
-        return proj, SimEngineDephiRewriting(proj, mapping)
+        return proj, SimEngineDephiRewriting(proj, mapping, variable_map=variable_map)
+
+    def test_remapped_assignment_dst_transfers_occurrence_binding(self):
+        vm = VariableMap()
+        proj, engine = self._engine({11: 21, 12: 22}, vm)
+        m = Manager(arch=proj.arch)
+        src = VirtualVariable(7, 11, 64, VirtualVariableCategory.REGISTER)
+        src_var = SimRegisterVariable(8, 8, ident="reg_src")
+        dst_default = VirtualVariable(70, 21, 64, VirtualVariableCategory.REGISTER)
+        dst_default_var = SimRegisterVariable(16, 8, ident="reg_dst_default")
+        colliding_const = Const(src.idx, 1, 64)
+        colliding_const_var = SimConstantVariable(8, value=1, ident="const_collision")
+        vm.set_variable(src, src_var, 3)
+        vm.set_variable(dst_default, dst_default_var, 4)
+        vm.set_variable(colliding_const, colliding_const_var, 5)
+        vm.set_custom_string(colliding_const)
+        stmt = Assignment(m.next_atom(), src, Const(m.next_atom(), 0, 64))
+
+        out = engine._handle_stmt_Assignment(stmt)
+
+        assert isinstance(out, Assignment)
+        rewritten_dst = out.dst
+        assert isinstance(rewritten_dst, VirtualVariable)
+        self.assertIs(vm.variable(rewritten_dst), src_var)
+        self.assertEqual(vm.variable_offset(rewritten_dst), 3)
+        fresh_wrapper = VirtualVariable(71, 21, 64, VirtualVariableCategory.REGISTER)
+        self.assertIs(vm.variable(fresh_wrapper), dst_default_var)
+        self.assertEqual(vm.variable_offset(fresh_wrapper), 4)
+        self.assertIs(vm.variable(colliding_const), colliding_const_var)
+        self.assertEqual(vm.variable_offset(colliding_const), 5)
+        self.assertTrue(vm.custom_string(colliding_const))
+
+        tombstoned_src = VirtualVariable(17, 12, 64, VirtualVariableCategory.REGISTER)
+        tombstoned_dst_default = VirtualVariable(72, 22, 64, VirtualVariableCategory.REGISTER)
+        tombstoned_dst_default_var = SimRegisterVariable(24, 8, ident="reg_tombstone_default")
+        vm.set_variable(tombstoned_src, src_var, 6)
+        vm.set_variable(tombstoned_src, None)
+        vm.set_variable(tombstoned_dst_default, tombstoned_dst_default_var, 7)
+        tombstoned_stmt = Assignment(m.next_atom(), tombstoned_src, Const(m.next_atom(), 0, 64))
+
+        tombstoned_out = engine._handle_stmt_Assignment(tombstoned_stmt)
+
+        assert isinstance(tombstoned_out, Assignment)
+        rewritten_tombstone = tombstoned_out.dst
+        assert isinstance(rewritten_tombstone, VirtualVariable)
+        self.assertIsNone(vm.variable(rewritten_tombstone))
+        self.assertEqual(vm.variable_offset(rewritten_tombstone), 0)
+        self.assertFalse(vm.has_variable(rewritten_tombstone))
+        fresh_tombstone_wrapper = VirtualVariable(73, 22, 64, VirtualVariableCategory.REGISTER)
+        self.assertIs(vm.variable(fresh_tombstone_wrapper), tombstoned_dst_default_var)
+
+    def test_remapped_vvar_expr_transfers_occurrence_binding(self):
+        vm = VariableMap()
+        _, engine = self._engine({31: 41, 32: 42}, vm)
+        src = VirtualVariable(27, 31, 64, VirtualVariableCategory.REGISTER)
+        src_var = SimRegisterVariable(8, 8, ident="reg_src")
+        dst_default = VirtualVariable(80, 41, 64, VirtualVariableCategory.REGISTER)
+        dst_default_var = SimRegisterVariable(16, 8, ident="reg_dst_default")
+        colliding_const = Const(src.idx, 1, 64)
+        colliding_const_var = SimConstantVariable(8, value=1, ident="const_collision")
+        vm.set_variable(src, src_var, 3)
+        vm.set_variable(dst_default, dst_default_var, 4)
+        vm.set_variable(colliding_const, colliding_const_var, 5)
+        vm.set_custom_string(colliding_const)
+
+        rewritten = engine._handle_expr_VirtualVariable(src)
+
+        assert isinstance(rewritten, VirtualVariable)
+        self.assertIs(vm.variable(rewritten), src_var)
+        self.assertEqual(vm.variable_offset(rewritten), 3)
+        fresh_wrapper = VirtualVariable(81, 41, 64, VirtualVariableCategory.REGISTER)
+        self.assertIs(vm.variable(fresh_wrapper), dst_default_var)
+        self.assertEqual(vm.variable_offset(fresh_wrapper), 4)
+        self.assertIs(vm.variable(colliding_const), colliding_const_var)
+        self.assertEqual(vm.variable_offset(colliding_const), 5)
+        self.assertTrue(vm.custom_string(colliding_const))
+
+        tombstoned_src = VirtualVariable(37, 32, 64, VirtualVariableCategory.REGISTER)
+        tombstoned_dst_default = VirtualVariable(82, 42, 64, VirtualVariableCategory.REGISTER)
+        tombstoned_dst_default_var = SimRegisterVariable(24, 8, ident="reg_tombstone_default")
+        vm.set_variable(tombstoned_src, src_var, 6)
+        vm.set_variable(tombstoned_src, None)
+        vm.set_variable(tombstoned_dst_default, tombstoned_dst_default_var, 7)
+
+        rewritten_tombstone = engine._handle_expr_VirtualVariable(tombstoned_src)
+
+        assert isinstance(rewritten_tombstone, VirtualVariable)
+        self.assertIsNone(vm.variable(rewritten_tombstone))
+        self.assertEqual(vm.variable_offset(rewritten_tombstone), 0)
+        self.assertFalse(vm.has_variable(rewritten_tombstone))
+        fresh_tombstone_wrapper = VirtualVariable(83, 42, 64, VirtualVariableCategory.REGISTER)
+        self.assertIs(vm.variable(fresh_tombstone_wrapper), tombstoned_dst_default_var)
 
     def test_remapped_dst_survives_non_vvar_src(self):
         _, engine = self._engine({2759: 1330})
@@ -107,6 +203,52 @@ class TestDephicationRewriting(unittest.TestCase):
         assert out.cond.varid == 6
         assert out.iftrue.value == 0x11
         assert out.iffalse.value == 0xFFFFFFFF
+    def test_redundant_block_remover_dephication_preserves_occurrence_binding(self):
+        proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        func = proj.kb.functions.function(addr=proj.entry, create=True)
+        assert func is not None
+        vm = VariableMap()
+        manager = Manager(arch=proj.arch)
+        manager.variable_map = vm
+
+        source_for_phi = VirtualVariable(1, 100, 64, VirtualVariableCategory.REGISTER)
+        source_use = VirtualVariable(2, 100, 64, VirtualVariableCategory.REGISTER)
+        phi_dst = VirtualVariable(3, 200, 64, VirtualVariableCategory.REGISTER)
+        block = Block(
+            func.addr,
+            4,
+            statements=[
+                Assignment(4, phi_dst, Phi(5, 64, [((func.addr, None), source_for_phi)])),
+                Return(6, [source_use]),
+            ],
+            idx=None,
+        )
+        graph = networkx.DiGraph()
+        graph.add_node(block)
+
+        source_default = VirtualVariable(10, 100, 64, VirtualVariableCategory.REGISTER)
+        destination_default = VirtualVariable(11, 200, 64, VirtualVariableCategory.REGISTER)
+        source_override_var = SimRegisterVariable(8, 8, ident="reg_source_override")
+        source_default_var = SimRegisterVariable(16, 8, ident="reg_source_default")
+        destination_default_var = SimRegisterVariable(24, 8, ident="reg_destination_default")
+        vm.set_variable(source_use, source_override_var, 3)
+        vm.set_variable(source_default, source_default_var, 4)
+        vm.set_variable(destination_default, destination_default_var, 5)
+
+        remover = RedundantBlockRemover(func, manager, graph=graph)
+        remover._remove_redundant_blocks(dephicate=True)
+
+        rewritten_block = next(iter(remover._graph.nodes))
+        self.assertEqual(len(rewritten_block.statements), 1)
+        rewritten_return = rewritten_block.statements[0]
+        self.assertIsInstance(rewritten_return, Return)
+        rewritten_use = rewritten_return.ret_exprs[0]
+        self.assertIsInstance(rewritten_use, VirtualVariable)
+        self.assertEqual(rewritten_use.varid, phi_dst.varid)
+        self.assertIs(vm.variable(rewritten_use), source_override_var)
+        self.assertEqual(vm.variable_offset(rewritten_use), 3)
+        self.assertIs(vm.variable(destination_default), destination_default_var)
+        self.assertEqual(vm.variable_offset(destination_default), 5)
 
     def test_bbbq_rust_flavor_keeps_string_constants(self):
         """

--- a/tests/analyses/decompiler/test_variable_map.py
+++ b/tests/analyses/decompiler/test_variable_map.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-# pylint:disable=missing-class-docstring,no-self-use
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
 from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
 
 import json
 import unittest
+from typing import cast
 
+from angr.ailment import Block, Manager
+from angr.ailment.expression import Const, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import Assignment, Return, SideEffectStatement
+from angr.analyses.decompiler.optimization_passes.return_duplicator_base import ReturnDuplicatorBase
 from angr.analyses.decompiler.variable_map import VariableMap
 from angr.sim_type import SimTypeChar, SimTypePointer
-from angr.sim_variable import SimRegisterVariable, SimStackVariable
+from angr.sim_variable import SimConstantVariable, SimRegisterVariable, SimStackVariable
 
 
 class _FakeAtom:
@@ -67,6 +72,221 @@ class TestVariableMap(unittest.TestCase):
         assert vm.variable_offset(2) == 4
         assert vm.custom_string(2) is True
 
+        # A VVar transfer uses the VVar namespace and must not copy colliding Const state.
+        vvar = VirtualVariable(3, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        duplicate_vvar = VirtualVariable(4, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        const = Const(3, 0, 64)
+        const_var = SimConstantVariable(8, value=0, ident="const_0")
+        vm.set_variable(vvar, var, 5)
+        vm.set_variable(const, const_var, 6)
+        vm.set_custom_string(const)
+        vm.transfer(vvar, duplicate_vvar)
+        self.assertIs(vm.variable(duplicate_vvar), var)
+        self.assertEqual(vm.variable_offset(duplicate_vvar), 5)
+        self.assertFalse(vm.custom_string(duplicate_vvar))
+        self.assertIsNone(vm.variable(Const(duplicate_vvar.idx, 0, 64)))
+
+    def test_cross_varid_transfer_is_occurrence_local(self):
+        vm = VariableMap()
+        src = VirtualVariable(7, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        dst = VirtualVariable(8, 200, 64, VirtualVariableCategory.REGISTER, oident=24)
+        src_var = SimRegisterVariable(16, 8, ident="reg_src")
+        src_const = Const(src.idx, 0, 64)
+        dst_const = Const(dst.idx, 1, 64)
+        src_const_var = SimConstantVariable(8, value=0, ident="const_src")
+        dst_const_var = SimConstantVariable(8, value=1, ident="const_dst")
+        vm.set_variable(src, src_var, 3)
+        vm.set_variable(src_const, src_const_var, 5)
+        vm.set_variable(dst_const, dst_const_var, 6)
+        vm.set_custom_string(src_const)
+
+        vm.transfer(src, dst)
+
+        self.assertIs(vm.variable(dst), src_var)
+        self.assertEqual(vm.variable_offset(dst), 3)
+        self.assertTrue(vm.has_variable(dst))
+        fresh_dst_wrapper = VirtualVariable(10, 200, 64, VirtualVariableCategory.REGISTER, oident=24)
+        self.assertIsNone(vm.variable(fresh_dst_wrapper))
+        self.assertEqual(vm.variable_offset(fresh_dst_wrapper), 0)
+        self.assertFalse(vm.has_variable(fresh_dst_wrapper))
+        self.assertIs(vm.variable(src_const), src_const_var)
+        self.assertIs(vm.variable(dst_const), dst_const_var)
+        self.assertEqual(vm.variable_offset(dst_const), 6)
+        self.assertTrue(vm.custom_string(src_const))
+        self.assertFalse(vm.custom_string(dst_const))
+
+        tombstoned_src = VirtualVariable(17, 101, 64, VirtualVariableCategory.REGISTER, oident=32)
+        tombstoned_dst = VirtualVariable(18, 201, 64, VirtualVariableCategory.REGISTER, oident=40)
+        dst_sibling = VirtualVariable(19, 201, 64, VirtualVariableCategory.REGISTER, oident=40)
+        tombstoned_src_var = SimRegisterVariable(32, 8, ident="reg_tombstoned_src")
+        dst_sibling_var = SimRegisterVariable(40, 8, ident="reg_dst_sibling")
+        vm.set_variable(tombstoned_src, tombstoned_src_var, 7)
+        vm.set_variable(tombstoned_src, None)
+        vm.set_variable(dst_sibling, dst_sibling_var, 8)
+
+        vm.transfer(tombstoned_src, tombstoned_dst)
+
+        self.assertIsNone(vm.variable(tombstoned_dst))
+        self.assertEqual(vm.variable_offset(tombstoned_dst), 0)
+        self.assertFalse(vm.has_variable(tombstoned_dst))
+        fresh_tombstone_wrapper = VirtualVariable(20, 201, 64, VirtualVariableCategory.REGISTER, oident=40)
+        self.assertIs(vm.variable(fresh_tombstone_wrapper), dst_sibling_var)
+        self.assertEqual(vm.variable_offset(fresh_tombstone_wrapper), 8)
+
+    def test_return_duplicator_fresh_vvars_keep_occurrence_bindings(self):
+        vm = VariableMap()
+        manager = Manager()
+        manager.variable_map = vm
+        dst = VirtualVariable(7, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        ret_expr = VirtualVariable(9, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        dst_var = SimRegisterVariable(16, 8, ident="reg_dst")
+        ret_var = SimRegisterVariable(24, 8, ident="reg_ret")
+        vm.set_variable(dst, dst_var, 1)
+        vm.set_variable(ret_expr, ret_var, 2)
+        block = Block(
+            0x400000,
+            4,
+            statements=[Assignment(1, dst, Const(8, 0, 64)), Return(2, [ret_expr])],
+            idx=0,
+        )
+
+        copied_block = block.deep_copy(manager)
+        copied_dst = cast(Assignment, copied_block.statements[0]).dst
+        self.assertIsInstance(copied_dst, VirtualVariable)
+        colliding_const = Const(copied_dst.idx, 1, 64)
+        colliding_const_var = SimConstantVariable(8, value=1, ident="const_collision")
+        vm.set_variable(colliding_const, colliding_const_var, 3)
+
+        duplicator = object.__new__(ReturnDuplicatorBase)
+        duplicator._manager = manager
+        duplicator.vvar_id_start = 1000
+        rewritten_block = duplicator._use_fresh_virtual_variables(copied_block, {})
+
+        rewritten_assignment = cast(Assignment, rewritten_block.statements[0])
+        rewritten_return = cast(Return, rewritten_block.statements[1])
+        rewritten_dst = cast(VirtualVariable, rewritten_assignment.dst)
+        rewritten_ret_expr = cast(VirtualVariable, rewritten_return.ret_exprs[0])
+        self.assertEqual(rewritten_dst.varid, 1000)
+        self.assertEqual(rewritten_ret_expr.varid, 1000)
+        self.assertIs(vm.variable(rewritten_dst), dst_var)
+        self.assertEqual(vm.variable_offset(rewritten_dst), 1)
+        self.assertIs(vm.variable(rewritten_ret_expr), ret_var)
+        self.assertEqual(vm.variable_offset(rewritten_ret_expr), 2)
+        fresh_wrapper = VirtualVariable(99, 1000, 64, VirtualVariableCategory.REGISTER, oident=16)
+        self.assertIsNone(vm.variable(fresh_wrapper))
+        self.assertEqual(vm.variable_offset(fresh_wrapper), 0)
+        self.assertFalse(vm.has_variable(fresh_wrapper))
+        self.assertIs(vm.variable(colliding_const), colliding_const_var)
+        self.assertEqual(vm.variable_offset(colliding_const), 3)
+
+    def test_vvar_deep_copy_does_not_transfer_colliding_idx_mapping(self):
+        vm = VariableMap()
+        manager = Manager()
+        manager.variable_map = vm
+        vvar = VirtualVariable(7, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        const = Const(7, 0, 64)
+        vvar_var = SimRegisterVariable(16, 8, ident="reg_1")
+        const_var = SimConstantVariable(8, value=0, ident="const_0")
+        vm.set_variable(vvar, vvar_var, 1)
+        vm.set_variable(const, const_var, 2)
+
+        copied_vvar = vvar.deep_copy(manager)
+
+        self.assertNotEqual(copied_vvar.idx, vvar.idx)
+        self.assertIs(vm.variable(copied_vvar), vvar_var)
+        self.assertEqual(vm.variable_offset(copied_vvar), 1)
+        self.assertTrue(vm.has_variable(copied_vvar))
+        self.assertIsNone(vm.variable(copied_vvar.idx))
+        self.assertEqual(vm.variable_offset(copied_vvar.idx), 0)
+        self.assertFalse(vm.has_variable(copied_vvar.idx))
+        self.assertIs(vm.variable(const), const_var)
+
+    def test_side_effect_ret_expr_clear_is_occurrence_local(self):
+        vm = VariableMap()
+        manager = Manager()
+        manager.variable_map = vm
+        vvar = VirtualVariable(7, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        vvar_var = SimRegisterVariable(16, 8, ident="reg_1")
+        vm.set_variable(vvar, vvar_var, 1)
+        definition = SideEffectStatement(8, Const(9, 0, 64), ret_expr=vvar)
+
+        copied_definition = definition.deep_copy(manager)
+        copied_ret_expr = cast(VirtualVariable, copied_definition.ret_expr)
+        self.assertIsInstance(copied_ret_expr, VirtualVariable)
+        vm.set_variable(copied_ret_expr, None)
+
+        self.assertIs(vm.variable(vvar), vvar_var)
+        self.assertEqual(vm.variable_offset(vvar), 1)
+        self.assertTrue(vm.has_variable(vvar))
+        self.assertIsNone(vm.variable(copied_ret_expr))
+        self.assertEqual(vm.variable_offset(copied_ret_expr), 0)
+        self.assertFalse(vm.has_variable(copied_ret_expr))
+        fresh_wrapper = VirtualVariable(99, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        self.assertIs(vm.variable(fresh_wrapper), vvar_var)
+        self.assertEqual(vm.variable_offset(fresh_wrapper), 1)
+        self.assertTrue(vm.has_variable(fresh_wrapper))
+
+    def test_vvar_and_idx_atom_variable_namespaces(self):
+        vm = VariableMap()
+        vvar = VirtualVariable(7, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        duplicate_vvar = VirtualVariable(99, 100, 64, VirtualVariableCategory.REGISTER, oident=16)
+        unmapped_vvar = VirtualVariable(7, 101, 64, VirtualVariableCategory.REGISTER, oident=24)
+        const = Const(7, 0, 64)
+        stmt = Assignment(
+            8,
+            VirtualVariable(9, 102, 64, VirtualVariableCategory.REGISTER, oident=32),
+            Const(10, 1, 64),
+        )
+        vvar_var = SimRegisterVariable(16, 8, ident="reg_1")
+        const_var = SimConstantVariable(8, value=0, ident="const_0")
+        stmt_var = SimStackVariable(-0x10, 8, ident="stack_1")
+
+        vm.set_variable(vvar, vvar_var, 1)
+        vm.set_variable(const, const_var, 2)
+        vm.set_variable(stmt, stmt_var, 3)
+
+        # VirtualVariables use a stable varid default plus occurrence overrides. Duplicate wrappers with fresh idx
+        # values must not consume a same-numbered idx mapping owned by another atom when their varid is unknown.
+        self.assertIs(vm.variable(vvar), vvar_var)
+        self.assertEqual(vm.variable_offset(vvar), 1)
+        self.assertIs(vm.variable(duplicate_vvar), vvar_var)
+        self.assertEqual(vm.variable_offset(duplicate_vvar), 1)
+        self.assertIsNone(vm.variable(unmapped_vvar))
+        self.assertEqual(vm.variable_offset(unmapped_vvar), 0)
+        self.assertFalse(vm.has_variable(unmapped_vvar))
+
+        # Non-VVar expressions, statements, and raw integer keys retain the existing idx-keyed behavior.
+        self.assertIs(vm.variable(const), const_var)
+        self.assertEqual(vm.variable_offset(const), 2)
+        self.assertIs(vm.variable(7), const_var)
+        self.assertIs(vm.variable(stmt), stmt_var)
+        self.assertEqual(vm.variable_offset(stmt), 3)
+        self.assertIs(vm.variable(8), stmt_var)
+
+        # Clearing either namespace must leave the colliding entry in the other namespace intact.
+        vm.set_variable(vvar, None)
+        self.assertIsNone(vm.variable(vvar))
+        self.assertEqual(vm.variable_offset(vvar), 0)
+        self.assertFalse(vm.has_variable(vvar))
+        self.assertIs(vm.variable(duplicate_vvar), vvar_var)
+        self.assertEqual(vm.variable_offset(duplicate_vvar), 1)
+        self.assertTrue(vm.has_variable(duplicate_vvar))
+        self.assertIs(vm.variable(const), const_var)
+        vm.set_variable(vvar, vvar_var, 1)
+        self.assertIs(vm.variable(const), const_var)
+        vm.set_variable(const, None)
+        self.assertIs(vm.variable(vvar), vvar_var)
+        self.assertIsNone(vm.variable(const))
+
+        # The two namespaces are independent in the reverse insertion order as well.
+        reverse_vm = VariableMap()
+        reverse_vm.set_variable(const, const_var, 2)
+        reverse_vm.set_variable(vvar, vvar_var, 1)
+        self.assertIs(reverse_vm.variable(vvar), vvar_var)
+        self.assertEqual(reverse_vm.variable_offset(vvar), 1)
+        self.assertIs(reverse_vm.variable(const), const_var)
+        self.assertEqual(reverse_vm.variable_offset(const), 2)
+
     def test_json_round_trip(self):
         vm = VariableMap()
         v1 = SimRegisterVariable(8, 8, ident="reg_1")
@@ -77,12 +297,27 @@ class TestVariableMap(unittest.TestCase):
         vm.set_reference_variable(4, v2, 2)
         char_ptr = SimTypePointer(SimTypeChar())
         vm.set_reference_values(5, {char_ptr: "hello"})
+        vvar = VirtualVariable(6, 100, 64, VirtualVariableCategory.REGISTER, oident=8)
+        duplicate_vvar = VirtualVariable(60, 100, 64, VirtualVariableCategory.REGISTER, oident=8)
+        override_vvar = VirtualVariable(61, 100, 64, VirtualVariableCategory.REGISTER, oident=8)
+        cleared_vvar = VirtualVariable(62, 100, 64, VirtualVariableCategory.REGISTER, oident=8)
+        const = Const(6, 0, 64)
+        v3 = SimRegisterVariable(16, 8, ident="reg_3")
+        v4 = SimConstantVariable(8, value=0, ident="const_4")
+        v5 = SimRegisterVariable(24, 8, ident="reg_5")
+        vm.set_variable(vvar, v3, 3)
+        vm.set_variable(const, v4, 4)
+        vm.set_variable(override_vvar, v5, 5)
+        vm.set_variable_offset(duplicate_vvar, 6)
+        vm.set_variable(cleared_vvar, None)
+        vm.set_variable_offset(cleared_vvar, 7)
 
         # ensure the result is JSON-serializable
         blob = json.dumps(vm.to_json())
         data = json.loads(blob)
+        self.assertEqual(data["version"], 2)
 
-        idents = {"reg_1": v1, "stack_2": v2}
+        idents = {"reg_1": v1, "stack_2": v2, "reg_3": v3, "const_4": v4, "reg_5": v5}
         restored = VariableMap.from_json(data, idents.get)
 
         assert restored.variable(1) is v1
@@ -92,6 +327,17 @@ class TestVariableMap(unittest.TestCase):
         assert restored.custom_string(3) is True
         assert restored.reference_variable(4) is v2
         assert restored.reference_variable_offset(4) == 2
+        self.assertIs(restored.variable(vvar), v3)
+        self.assertEqual(restored.variable_offset(vvar), 3)
+        self.assertIs(restored.variable(duplicate_vvar), v5)
+        self.assertEqual(restored.variable_offset(duplicate_vvar), 6)
+        self.assertIs(restored.variable(override_vvar), v5)
+        self.assertEqual(restored.variable_offset(override_vvar), 5)
+        self.assertIsNone(restored.variable(cleared_vvar))
+        self.assertEqual(restored.variable_offset(cleared_vvar), 0)
+        self.assertFalse(restored.has_variable(cleared_vvar))
+        self.assertIs(restored.variable(const), v4)
+        self.assertEqual(restored.variable_offset(const), 4)
 
         ref_vals = restored.reference_values(5)
         assert ref_vals is not None
@@ -99,6 +345,74 @@ class TestVariableMap(unittest.TestCase):
         (ty, val) = next(iter(ref_vals.items()))
         assert isinstance(ty, SimTypePointer)
         assert val == "hello"
+
+    def test_legacy_json_discards_ambiguous_variable_entries(self):
+        var = SimRegisterVariable(8, 8, ident="reg_1")
+        data = {
+            "variables": {"7": "reg_1"},
+            "variable_offsets": {"7": 4},
+            "custom_strings": {"9": True},
+        }
+
+        with self.assertLogs("angr.analyses.decompiler.variable_map", level="WARNING") as logs:
+            restored = VariableMap.from_json(data, {"reg_1": var}.get)
+
+        self.assertIn("discarding all variable and offset bindings", " ".join(logs.output).lower())
+        self.assertIsNone(restored.variable(7))
+        self.assertEqual(restored.variable_offset(7), 0)
+        self.assertFalse(restored.has_variable(7))
+        legacy_const = Const(7, 0, 64)
+        self.assertIsNone(restored.variable(legacy_const))
+        self.assertEqual(restored.variable_offset(legacy_const), 0)
+        self.assertFalse(restored.has_variable(legacy_const))
+        legacy_vvar = VirtualVariable(7, 100, 64, VirtualVariableCategory.REGISTER, oident=8)
+        self.assertIsNone(restored.variable(legacy_vvar))
+        self.assertEqual(restored.variable_offset(legacy_vvar), 0)
+        self.assertFalse(restored.has_variable(legacy_vvar))
+        self.assertTrue(restored.custom_string(9))
+
+        with self.assertRaisesRegex(ValueError, "VariableMap serialization version"):
+            VariableMap.from_json({"version": 999}, {"reg_1": var}.get)
+
+    def test_json_unresolved_vvar_bindings_fail_closed_atomically(self):
+        vm = VariableMap()
+        vvar_a = VirtualVariable(6, 100, 64, VirtualVariableCategory.REGISTER, oident=8)
+        vvar_b = VirtualVariable(7, 100, 64, VirtualVariableCategory.REGISTER, oident=8)
+        fresh_vvar = VirtualVariable(8, 100, 64, VirtualVariableCategory.REGISTER, oident=8)
+        var_a = SimRegisterVariable(8, 8, ident="reg_a")
+        var_b = SimRegisterVariable(16, 8, ident="reg_b")
+        vm.set_variable(vvar_a, var_a, 1)
+        vm.set_variable(vvar_b, var_b, 2)
+        data = json.loads(json.dumps(vm.to_json()))
+
+        # The first occurrence cannot silently fall through to the resolved stable default for the same varid.
+        with self.assertLogs("angr.analyses.decompiler.variable_map", level="WARNING"):
+            restored = VariableMap.from_json(data, {"reg_b": var_b}.get)
+        self.assertIsNone(restored.variable(vvar_a))
+        self.assertEqual(restored.variable_offset(vvar_a), 0)
+        self.assertFalse(restored.has_variable(vvar_a))
+        self.assertIs(restored.variable(vvar_b), var_b)
+        self.assertEqual(restored.variable_offset(vvar_b), 2)
+        self.assertTrue(restored.has_variable(vvar_b))
+        self.assertIs(restored.variable(fresh_vvar), var_b)
+        self.assertEqual(restored.variable_offset(fresh_vvar), 2)
+
+        # If the stable variable cannot be resolved, neither its stable offset nor an offset-only occurrence may
+        # survive.
+        stable_only_data = {
+            "version": 2,
+            "vvar_id_to_variable": {"101": "reg_a"},
+            "vvar_id_to_variable_offset": {"101": 3},
+            "vvar_occurrence_variable_offsets": [{"varid": 101, "idx": 10, "offset": 4}],
+        }
+        with self.assertLogs("angr.analyses.decompiler.variable_map", level="WARNING"):
+            stable_unresolved = VariableMap.from_json(stable_only_data, {}.get)
+        unresolved_vvar = VirtualVariable(11, 101, 64, VirtualVariableCategory.REGISTER, oident=8)
+        offset_only_vvar = VirtualVariable(10, 101, 64, VirtualVariableCategory.REGISTER, oident=8)
+        for candidate in (unresolved_vvar, offset_only_vvar):
+            self.assertIsNone(stable_unresolved.variable(candidate))
+            self.assertEqual(stable_unresolved.variable_offset(candidate), 0)
+            self.assertFalse(stable_unresolved.has_variable(candidate))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling GNU tar's `excfile_add` at `0x4173d0` in the public DecBench `O2/tar/tar` emits `<None|const 0> = excfile_tail;` — a definition with no variable on its left. The binding the variable should carry has been handed to a constant instead.

### Root cause

AIL expression indexes are not unique across atom kinds. When a `VirtualVariable` and a `Const` happen to share an index, `VariableMap` keys them the same way, so a lookup for the variable returns the constant's binding. Nothing detects the collision; the wrong answer is simply returned.

### Fix

`VariableMap` separates non-vvar indexes from stable varid defaults, and adds occurrence-specific overrides and tombstones so a colliding occurrence resolves to its own binding or to nothing at all. Native deep-copy, return duplication and dephication propagate occurrence bindings; JSON v2 preserves them, while an ambiguous v1 binding fails closed rather than guessing. Inferred prototypes and value returns stay out of scope.

The one consumer outside this repository is `angr-management`'s `ail_objects.py`, which calls `VariableMap.variable()`. Its signature is unchanged and `None` was already reachable there, so no companion change is needed.

### Testing

`test_variable_map.py` and `test_dephication_rewriting.py` cover collisions, remaps, tombstones and serialization. The before/after decompilation of `excfile_add` is in the comment below.

Validation: https://github.com/angr/angr/pull/6853#issuecomment-5303466406

session: sharpen
