### PR TITLE
Decompiler: Lower guarded loads to conditional expressions

### DIFF
--- a/native/angr/src/ailment/convert_vex.rs
+++ b/native/angr/src/ailment/convert_vex.rs
@@ -941,13 +941,13 @@ impl<'py, 'r, R: IrReader> Conv<'py, 'r, R> {
             } => {
                 let (load_bits, convert_bits, signed) = loadg_sizes(&cvt)?;
                 let dst_var = self.make_tmp(dst as i64, dst_bits)?;
-                // Python arg eval order: Load(next_atom(), convert(addr), ...,
-                // guard=convert(guard), alt=convert(alt)).
+                // Preserve the historical LoadG operand conversion order: address, guard, then alternative.
                 let lidx = self.next_atom();
                 let a = self.convert_expr(&addr)?;
                 let g = self.convert_expr(&guard)?;
                 let al = self.convert_expr(&alt)?;
-                // Load has NO tags in the Python converter for LoadG.
+                // LoadG is represented as an ITE over an unconditional load. The load, optional conversion, and ITE
+                // are synthesized expressions and therefore have no source tags.
                 let size = (load_bits / 8) as i32;
                 let load = AilExpression {
                     header: ExprHeader::new(
@@ -959,12 +959,11 @@ impl<'py, 'r, R: IrReader> Conv<'py, 'r, R> {
                     inner: ExprInner::Load {
                         addr: Arc::new(a),
                         endness: end,
-                        guard: Some(Arc::new(g)),
-                        alt: Some(Arc::new(al)),
+                        guard: None,
+                        alt: None,
                     },
                 };
-                let src = if convert_bits != load_bits {
-                    // ... and neither has this Convert.
+                let iftrue = if convert_bits != load_bits {
                     let cidx = self.next_atom();
                     new_convert(
                         cidx,
@@ -979,6 +978,17 @@ impl<'py, 'r, R: IrReader> Conv<'py, 'r, R> {
                     )
                 } else {
                     load
+                };
+                let iidx = self.next_atom();
+                let depth = g.header.depth.max(al.header.depth).max(iftrue.header.depth) + 1;
+                let bits = iftrue.header.bits;
+                let src = AilExpression {
+                    header: ExprHeader::new(iidx, depth, bits, Tags::default()),
+                    inner: ExprInner::ITE {
+                        cond: Arc::new(g),
+                        iffalse: Arc::new(al),
+                        iftrue: Arc::new(iftrue),
+                    },
                 };
                 let idx = self.next_atom();
                 out.push(new_stmt(

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -83,6 +83,174 @@ class TestIrsb(unittest.TestCase):
         assert from_py.statements  # non-empty
 
 
+class TestLoadGConversion(unittest.TestCase):
+    _CASES = (
+        ("ILGop_Ident32", "Ity_I32", 32, 32, False, 0xA5C3E17B),
+        ("ILGop_Ident64", "Ity_I64", 64, 64, False, 0x123456789ABCDEF0),
+        ("ILGop_IdentV128", "Ity_V128", 128, 128, False, 0),
+        ("ILGop_8Uto32", "Ity_I32", 8, 32, False, 0xA5C3E17B),
+        ("ILGop_8Sto32", "Ity_I32", 8, 32, True, 0xA5C3E17B),
+        ("ILGop_16Uto32", "Ity_I32", 16, 32, False, 0xA5C3E17B),
+        ("ILGop_16Sto32", "Ity_I32", 16, 32, True, 0xA5C3E17B),
+    )
+
+    @staticmethod
+    def _const(value, bits):
+        const_cls = pyvex.const.V128 if bits == 128 else getattr(pyvex.const, f"U{bits}")
+        return pyvex.IRExpr.Const(const_cls(value))
+
+    @classmethod
+    def _loadg_block(cls, cvt, dst_type, output_bits, alt_value, endness):
+        arch = archinfo.ArchAMD64()
+        tyenv = pyvex.IRTypeEnv(arch)
+        dst = tyenv.add(dst_type)
+        block_addr = 0x400000
+        return pyvex.IRSB.empty_block(
+            arch,
+            block_addr,
+            statements=[
+                pyvex.IRStmt.IMark(block_addr, 1, 0),
+                pyvex.IRStmt.LoadG(
+                    endness,
+                    cvt,
+                    dst,
+                    cls._const(0x401000, 64),
+                    cls._const(alt_value, output_bits),
+                    cls._const(1, 1),
+                ),
+            ],
+            nxt=cls._const(block_addr + 1, 64),
+            tyenv=tyenv,
+            jumpkind="Ijk_Boring",
+            direct_next=True,
+            size=1,
+        )
+
+    def test_loadg_conversion_matrix(self):
+        for cvt, dst_type, load_bits, output_bits, signed, alt_value in self._CASES:
+            for endness in ("Iend_LE", "Iend_BE"):
+                with self.subTest(cvt=cvt, endness=endness):
+                    irsb = self._loadg_block(cvt, dst_type, output_bits, alt_value, endness)
+                    converted = VEXIRSBConverter.convert(irsb, ailment.Manager(arch=irsb.arch))
+                    assignment = converted.statements[0]
+
+                    assert isinstance(assignment, ailment.Stmt.Assignment)
+                    assert isinstance(assignment.dst, ailment.Expr.Tmp)
+                    assert assignment.dst.bits == output_bits
+                    assert isinstance(assignment.src, ailment.Expr.ITE)
+
+                    ite = assignment.src
+                    assert isinstance(ite.cond, ailment.Expr.Const)
+                    assert ite.cond.value == 1 and ite.cond.bits == 1
+                    assert isinstance(ite.iffalse, ailment.Expr.Const)
+                    assert ite.iffalse.value == alt_value
+                    assert ite.iffalse.bits == output_bits
+
+                    true_expr = ite.iftrue
+                    if load_bits == output_bits:
+                        assert isinstance(true_expr, ailment.Expr.Load)
+                        load = true_expr
+                    else:
+                        assert isinstance(true_expr, ailment.Expr.Convert)
+                        assert true_expr.from_bits == load_bits
+                        assert true_expr.to_bits == output_bits
+                        assert true_expr.is_signed is signed
+                        assert isinstance(true_expr.operand, ailment.Expr.Load)
+                        load = true_expr.operand
+
+                    assert load.guard is None and load.alt is None
+                    assert isinstance(load.addr, ailment.Expr.Const)
+                    assert load.addr.value == 0x401000 and load.addr.bits == 64
+                    assert load.size == load_bits // 8
+                    assert load.bits == load_bits
+                    assert load.endness == endness
+                    assert ite.bits == output_bits
+                    assert ite.depth == max(ite.cond.depth, ite.iffalse.depth, ite.iftrue.depth) + 1
+
+                    # The destination, load, and VEX operands keep the historical allocation order. The canonical
+                    # ITE adds one synthesized atom immediately before the Assignment.
+                    assert load.idx == assignment.dst.idx + 1
+                    assert load.addr.idx == load.idx + 1
+                    assert ite.cond.idx == load.addr.idx + 1
+                    assert ite.iffalse.idx == ite.cond.idx + 1
+                    if isinstance(true_expr, ailment.Expr.Convert):
+                        assert true_expr.idx == ite.iffalse.idx + 1
+                        assert ite.idx == true_expr.idx + 1
+                    else:
+                        assert ite.idx == ite.iffalse.idx + 1
+                    assert assignment.idx == ite.idx + 1
+
+                    source_tags = {"ins_addr": 0x400000, "vex_block_addr": 0x400000, "vex_stmt_idx": 1}
+                    assert dict(assignment.tags) == source_tags
+                    assert dict(assignment.dst.tags) == source_tags
+                    assert dict(load.addr.tags) == source_tags
+                    assert dict(ite.cond.tags) == source_tags
+                    assert dict(ite.iffalse.tags) == source_tags
+                    assert not dict(load.tags)
+                    assert not dict(ite.tags)
+                    if isinstance(true_expr, ailment.Expr.Convert):
+                        assert not dict(true_expr.tags)
+
+                    assert pickle.loads(pickle.dumps(converted)) == converted
+
+    def test_real_thumb_loadg_matches_direct_lift(self):
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "binaries",
+            "tests",
+            "armel",
+            "decompiler",
+            "loadg_ite_thumb.elf",
+        )
+        project = angr.Project(path, auto_load_libs=False)
+        symbol = project.loader.main_object.get_symbol("loadg_ite_mask")
+        assert symbol is not None
+
+        block = project.factory.block(symbol.rebased_addr, size=symbol.size, opt_level=1)
+        loadgs = [stmt for stmt in block.vex.statements if isinstance(stmt, pyvex.IRStmt.LoadG)]
+        assert len(loadgs) == 2
+        assert all(stmt.cvt == "ILGop_Ident32" for stmt in loadgs)
+
+        from_python = VEXIRSBConverter.convert(block.vex, ailment.Manager(arch=project.arch))
+        from_lift = VEXIRSBConverter.convert_from_lift(
+            project.arch,
+            symbol.rebased_addr,
+            block.bytes,
+            ailment.Manager(arch=project.arch),
+            opt_level=1,
+            bytes_offset=1,
+        )
+        assert from_python == from_lift
+
+        assignments = {
+            stmt.dst.tmp_idx: stmt
+            for stmt in from_python.statements
+            if isinstance(stmt, ailment.Stmt.Assignment) and isinstance(stmt.dst, ailment.Expr.Tmp)
+        }
+        for vex_stmt in loadgs:
+            src = assignments[vex_stmt.dst].src
+            assert isinstance(src, ailment.Expr.ITE)
+            assert isinstance(src.cond, ailment.Expr.Tmp) and src.cond.tmp_idx == vex_stmt.guard.tmp
+            assert isinstance(src.iffalse, ailment.Expr.Tmp) and src.iffalse.tmp_idx == vex_stmt.alt.tmp
+            assert isinstance(src.iftrue, ailment.Expr.Load)
+            assert src.iftrue.guard is None and src.iftrue.alt is None
+
+        first_load = assignments[loadgs[0].dst].src.iftrue
+        second_load = assignments[loadgs[1].dst].src.iftrue
+        assert isinstance(first_load.addr, ailment.Expr.Tmp)
+        assert isinstance(second_load.addr, ailment.Expr.Tmp)
+        second_addr = assignments[second_load.addr.tmp_idx].src
+        assert isinstance(second_addr, ailment.Expr.BinaryOp) and second_addr.op == "Add"
+        assert isinstance(second_addr.operands[0], ailment.Expr.Tmp)
+        assert second_addr.operands[0].tmp_idx == first_load.addr.tmp_idx
+        assert isinstance(second_addr.operands[1], ailment.Expr.Const)
+        assert second_addr.operands[1].value == 4
+        assert pickle.loads(pickle.dumps(from_python)) == from_python
+
+
 class TestNonConstRoundingMode(unittest.TestCase):
     """VEX sometimes carries the rounding mode in a tmp (e.g. ARM ``vcvtr``
     reads it from FPSCR); the converter must pass it through as an AIL

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -131,7 +131,7 @@ class TestLoadGConversion(unittest.TestCase):
             for endness in ("Iend_LE", "Iend_BE"):
                 with self.subTest(cvt=cvt, endness=endness):
                     irsb = self._loadg_block(cvt, dst_type, output_bits, alt_value, endness)
-                    converted = VEXIRSBConverter.convert(irsb, ailment.Manager(arch=irsb.arch))
+                    converted = VEXIRSBConverter.convert(irsb, ailment.Manager())
                     assignment = converted.statements[0]
 
                     assert isinstance(assignment, ailment.Stmt.Assignment)
@@ -214,12 +214,12 @@ class TestLoadGConversion(unittest.TestCase):
         assert len(loadgs) == 2
         assert all(stmt.cvt == "ILGop_Ident32" for stmt in loadgs)
 
-        from_python = VEXIRSBConverter.convert(block.vex, ailment.Manager(arch=project.arch))
+        from_python = VEXIRSBConverter.convert(block.vex, ailment.Manager())
         from_lift = VEXIRSBConverter.convert_from_lift(
             project.arch,
             symbol.rebased_addr,
             block.bytes,
-            ailment.Manager(arch=project.arch),
+            ailment.Manager(),
             opt_level=1,
             bytes_offset=1,
         )

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -231,6 +231,8 @@ class TestLoadGConversion(unittest.TestCase):
             if isinstance(stmt, ailment.Stmt.Assignment) and isinstance(stmt.dst, ailment.Expr.Tmp)
         }
         for vex_stmt in loadgs:
+            assert isinstance(vex_stmt.guard, pyvex.IRExpr.RdTmp)
+            assert isinstance(vex_stmt.alt, pyvex.IRExpr.RdTmp)
             src = assignments[vex_stmt.dst].src
             assert isinstance(src, ailment.Expr.ITE)
             assert isinstance(src.cond, ailment.Expr.Tmp) and src.cond.tmp_idx == vex_stmt.guard.tmp
@@ -238,8 +240,11 @@ class TestLoadGConversion(unittest.TestCase):
             assert isinstance(src.iftrue, ailment.Expr.Load)
             assert src.iftrue.guard is None and src.iftrue.alt is None
 
-        first_load = assignments[loadgs[0].dst].src.iftrue
-        second_load = assignments[loadgs[1].dst].src.iftrue
+        first_src = assignments[loadgs[0].dst].src
+        second_src = assignments[loadgs[1].dst].src
+        assert isinstance(first_src, ailment.Expr.ITE) and isinstance(second_src, ailment.Expr.ITE)
+        first_load, second_load = first_src.iftrue, second_src.iftrue
+        assert isinstance(first_load, ailment.Expr.Load) and isinstance(second_load, ailment.Expr.Load)
         assert isinstance(first_load.addr, ailment.Expr.Tmp)
         assert isinstance(second_load.addr, ailment.Expr.Tmp)
         second_addr = assignments[second_load.addr.tmp_idx].src

--- a/tests/analyses/decompiler/test_loadg.py
+++ b/tests/analyses/decompiler/test_loadg.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-member
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+from typing import Any, cast
+
+import pyvex
+
+import angr
+from angr import ailment
+from angr.analyses.decompiler.decompilation_options import get_structurer_option
+from tests.common import bin_location, print_decompilation_result
+
+
+class TestLoadG(unittest.TestCase):
+    def test_thumb_complementary_loads(self):
+        path = os.path.join(bin_location, "tests", "armel", "decompiler", "loadg_ite_thumb.elf")
+        project = angr.Project(path, auto_load_libs=False)
+        symbol = project.loader.main_object.get_symbol("loadg_ite_mask")
+        assert symbol is not None
+        assert symbol.rebased_addr == project.entry == 0x110B5
+        assert symbol.size == 16
+
+        block = project.factory.block(symbol.rebased_addr, size=symbol.size, opt_level=1)
+        loadgs = [stmt for stmt in block.vex.statements if isinstance(stmt, pyvex.IRStmt.LoadG)]
+        assert len(loadgs) == 2
+        assert all(stmt.cvt == "ILGop_Ident32" and stmt.end == "Iend_LE" for stmt in loadgs)
+        assert isinstance(loadgs[0].addr, pyvex.IRExpr.RdTmp)
+        assert isinstance(loadgs[1].addr, pyvex.IRExpr.RdTmp)
+        vex_defs = {stmt.tmp: stmt.data for stmt in block.vex.statements if isinstance(stmt, pyvex.IRStmt.WrTmp)}
+        second_vex_addr = vex_defs[loadgs[1].addr.tmp]
+        assert isinstance(second_vex_addr, pyvex.IRExpr.Binop)
+        assert second_vex_addr.op == "Iop_Add32"
+        assert second_vex_addr.args[0].tmp == loadgs[0].addr.tmp
+        assert isinstance(second_vex_addr.args[1], pyvex.IRExpr.Const)
+        assert second_vex_addr.args[1].con.value == 4
+
+        converted = ailment.IRSBConverter.convert(block.vex, ailment.Manager(arch=project.arch))
+        assignments = {
+            stmt.dst.tmp_idx: stmt
+            for stmt in converted.statements
+            if isinstance(stmt, ailment.Stmt.Assignment) and isinstance(stmt.dst, ailment.Expr.Tmp)
+        }
+        ites: list[Any] = [cast(Any, assignments[stmt.dst].src) for stmt in loadgs]
+        assert all(isinstance(expr, ailment.Expr.ITE) for expr in ites)
+        assert all(isinstance(expr.iftrue, ailment.Expr.Load) for expr in ites)
+        assert all(expr.iftrue.guard is None and expr.iftrue.alt is None for expr in ites)
+        assert isinstance(ites[0].iftrue.addr, ailment.Expr.Tmp)
+        assert isinstance(ites[1].iftrue.addr, ailment.Expr.Tmp)
+        second_ail_addr = assignments[ites[1].iftrue.addr.tmp_idx].src
+        assert isinstance(second_ail_addr, ailment.Expr.BinaryOp)
+        assert second_ail_addr.op == "Add"
+        assert isinstance(second_ail_addr.operands[0], ailment.Expr.Tmp)
+        assert second_ail_addr.operands[0].tmp_idx == ites[0].iftrue.addr.tmp_idx
+        assert isinstance(second_ail_addr.operands[1], ailment.Expr.Const)
+        assert second_ail_addr.operands[1].value == 4
+
+        cfg = project.analyses.CFGFast(normalize=True)
+        function = cfg.functions[symbol.rebased_addr]
+        assert function is not None
+        structurer_option = get_structurer_option()
+        assert structurer_option is not None
+        for structurer in ("SAILR", "Phoenix"):
+            with self.subTest(structurer=structurer):
+                dec = project.analyses.Decompiler(
+                    function,
+                    cfg=cfg.model,
+                    options=[(structurer_option, structurer)],
+                )
+                assert dec.codegen is not None and dec.codegen.text is not None
+                print_decompilation_result(dec)
+
+                body = dec.codegen.text[dec.codegen.text.index("{", dec.codegen.text.index("loadg_ite_mask")) + 1 :]
+                assert "a1" in body  # the selector still controls which load reaches the mask
+                assert body.count("a0") >= 2  # both base and base+4 loads survive
+                assert "field_4" in body or "[1]" in body or "+ 4" in body
+                assert "field_0" in body or "*a0" in body or "*(a0)" in body or "[0]" in body
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_loadg.py
+++ b/tests/analyses/decompiler/test_loadg.py
@@ -39,7 +39,7 @@ class TestLoadG(unittest.TestCase):
         assert isinstance(second_vex_addr.args[1], pyvex.IRExpr.Const)
         assert second_vex_addr.args[1].con.value == 4
 
-        converted = ailment.IRSBConverter.convert(block.vex, ailment.Manager(arch=project.arch))
+        converted = ailment.IRSBConverter.convert(block.vex, ailment.Manager())
         assignments = {
             stmt.dst.tmp_idx: stmt
             for stmt in converted.statements


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A Thumb guarded load in `binaries/tests/armel/decompiler/loadg_ite_thumb.elf`, function `loadg_ite_mask` at `0x110b5`, decompiles as though the load were unconditional: the alternative value the guard selects when the load does not happen is missing from the output entirely.

### Root cause

VEX lowers a guarded load to `LoadG`, and AIL carried it as an opaque operation holding its guard and alternative in fields nothing downstream read. Every walker, simplifier and code generator therefore saw a plain load, and the alternative was dropped before codegen ever ran.

### Fix

`LoadG` lowers to an ordinary AIL `ITE` over an unconditional load, so the existing machinery handles it without knowing anything new. The widening conversion applies to the memory-load arm alone rather than to both arms, which is what made the converted value wrong when the two differed in width.

The Rust side builds `ExprInner::ITE` with named fields, so it is unaffected by #6926's reordering of the AIL `ITE` constructor arguments.

### Testing

`tests/ailment/test_irsb.py` covers the conversion matrix and `tests/analyses/decompiler/test_loadg.py` decompiles the real Thumb fixture under both the SAILR and Phoenix presets. The before/after output is in the comment below.

Validation: https://github.com/angr/angr/pull/6854#issuecomment-5305254387

sync: angr/binaries#181

session: sharpen
