### PR TITLE
CFGFast: Use a Mach-O function-start table for what it does not otherwise find

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -64,6 +64,13 @@ if TYPE_CHECKING:
 l = logging.getLogger(name=__name__)
 
 
+# The CLE function hint sources CFGBase takes as function starts on their own. It is an allowlist
+# rather than "every source but .eh_frame" so that a source CLE adds later is left alone until angr
+# has decided what its entries mean: a linker's function-start table records the data atoms a
+# producer placed among its functions, and seeding those puts function heads on data.
+DEFINITE_FUNCTION_HINT_SOURCES = frozenset({FunctionHintSource.EXPORT_TABLE, FunctionHintSource.EXTERNAL_EH_FRAME})
+
+
 class CFGBase(Analysis):
     """
     The base class for control flow graphs.
@@ -237,6 +244,7 @@ class CFGBase(Analysis):
         self._function_addresses_from_symbols = self._load_func_addrs_from_symbols()
         self._function_addresses_from_eh_frame = self._load_func_addrs_from_eh_frame()
         self._function_addr_and_names_from_hints = self._load_func_addr_and_names_from_hints()
+        self._function_addresses_from_function_starts = self._load_func_addrs_from_function_starts()
 
         # Cache if an object has executable sections or not
         self._object_to_executable_sections = {}
@@ -1103,9 +1111,30 @@ class CFGBase(Analysis):
 
         addrs_and_names = set()
         for function_hint in self._binary.function_hints:
-            if function_hint.source != FunctionHintSource.EH_FRAME:
+            if function_hint.source in DEFINITE_FUNCTION_HINT_SOURCES:
                 addrs_and_names.add((function_hint.addr, function_hint.name))
         return addrs_and_names
+
+    def _load_func_addrs_from_function_starts(self) -> set[int]:
+        """
+        Get the addresses that a linker's function-start table records.
+
+        Mach-O's LC_FUNCTION_STARTS names every atom ld64 placed in an executable section. That
+        includes the data atoms a producer emits among its functions - a Haskell closure's info
+        table, a Swift offset table - so these addresses are candidates and not function starts.
+        Mach-O is the only backend that records this table, and asking any other one for it would
+        make every format depend on a Mach-O load command.
+
+        :return:    A set of addresses that may be functions.
+        """
+
+        if not isinstance(self._binary, MachO):
+            return set()
+        return {
+            function_hint.addr
+            for function_hint in self._binary.function_hints
+            if function_hint.source == FunctionHintSource.FUNCTION_STARTS
+        }
 
     #
     # Analyze function features

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -88,6 +88,22 @@ VEX_IRSB_MAX_SIZE = 400
 # the minimum interval (in seconds) between two consecutive progress notifications
 PROGRESS_NOTIFY_INTERVAL = 0.05
 
+# Instructions after which control does not fall through, used to tell the code a linker's
+# function-start table records from the data atoms it records beside it. Keyed by architecture: one
+# whose terminators are not listed here gets no function-start hints, rather than a decision made
+# with another architecture's set. Privileged and far-transfer instructions are deliberately absent,
+# because no compiler emits them into a user-space function, so finding one is evidence that the
+# bytes are a table and not evidence of the end of a function.
+FALLTHROUGH_TERMINATORS = {
+    "X86": frozenset({"ret", "jmp", "ud2"}),
+    "AMD64": frozenset({"ret", "jmp", "ud2"}),
+    "AARCH64": frozenset({"ret", "retaa", "retab", "b", "br", "braa", "brab", "braaz", "brabz", "brk"}),
+}
+
+# What capstone emits where it has no instruction for the bytes. On a variable-width instruction set
+# it stops; on a fixed-width one it does not, and every undecodable AArch64 word comes back as udf.
+UNDEFINED_MNEMONICS = frozenset({"udf", "invalid", "undefined", ".byte"})
+
 
 l = logging.getLogger(name=__name__)
 
@@ -467,6 +483,7 @@ class CFGJobType(Enum):
     IFUNC_HINTS = 3
     DATAREF_HINTS = 4
     EH_FRAME_HINTS = 5
+    FUNCTION_START_HINTS = 6
 
 
 class CFGJob:
@@ -903,6 +920,8 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         self._write_addr_to_run = defaultdict(list)
 
         self._remaining_eh_frame_addrs: list[int] | None = None
+        self._remaining_function_start_addrs: list[int] | None = None
+        self._function_start_extents: dict[int, int] = {}
         self._remaining_function_prologue_addrs: list[int] | None = None
         self._used_function_prologue_addrs: set[int] = set()
         self._ptr_hints: SortedDict | None = None
@@ -1780,6 +1799,9 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         if self._use_eh_frame:
             self._remaining_eh_frame_addrs = sorted(self._function_addresses_from_eh_frame, reverse=True)
 
+        self._function_start_extents = self._measure_function_start_extents()
+        self._remaining_function_start_addrs = sorted(self._function_start_extents, reverse=True)
+
         if self._use_function_prologues:
             func_addrs_from_prologs = self._func_addrs_from_prologues()
             if self._ptr_hints:
@@ -2402,6 +2424,19 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 self._register_analysis_job(eh_addr, job)
                 return
 
+        if self._remaining_function_start_addrs:
+            while self._remaining_function_start_addrs:
+                start_addr = self._remaining_function_start_addrs.pop()
+                if self._seg_list.is_occupied(start_addr):
+                    continue
+                if not self._function_start_holds_code(start_addr):
+                    continue
+
+                job = CFGJob(start_addr, start_addr, "Ijk_Boring", job_type=CFGJobType.FUNCTION_START_HINTS)
+                self._insert_job(job)
+                self._register_analysis_job(start_addr, job)
+                return
+
         if self._use_function_prologues and self._remaining_function_prologue_addrs:
             while self._remaining_function_prologue_addrs:
                 prolog_addr = self._remaining_function_prologue_addrs.pop()
@@ -2970,6 +3005,71 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 md.content = new_content
 
     # Methods to get start points for scanning
+
+    def _measure_function_start_extents(self) -> dict[int, int]:
+        """
+        How far each address a linker's function-start table records reaches before the next one.
+
+        The distance to the next recorded address is not a function size: the table records atoms,
+        and one function can hold several. It is how many bytes there are to read when asking whether
+        anything ever entered the address as code, where reading too far costs an answer and can
+        never place a boundary. Addresses outside an executable section are dropped, along with every
+        address on an architecture whose terminators are not established.
+
+        :return: A map from address to the number of bytes to decode there.
+        """
+
+        if not self._function_addresses_from_function_starts:
+            return {}
+        if self.project.arch.name not in FALLTHROUGH_TERMINATORS or not self.project.arch.capstone_support:
+            return {}
+
+        ordered = sorted(self._function_addresses_from_function_starts)
+        extents = {}
+        for index, addr in enumerate(ordered):
+            if not self._inside_regions(addr):
+                continue
+            section = self.project.loader.find_section_containing(addr)
+            if section is None or not section.is_executable or section.only_contains_uninitialized_data:
+                continue
+            end = section.vaddr + section.memsize
+            if index + 1 < len(ordered) and ordered[index + 1] < end:
+                end = ordered[index + 1]
+            if end > addr:
+                extents[addr] = end - addr
+        return extents
+
+    def _function_start_holds_code(self, addr: int) -> bool:
+        """
+        Whether the bytes a linker recorded a function start at are a range something enters as code.
+
+        The decode runs forward from the address and stops where a real decoder would: at a byte
+        capstone refuses, at a word it names undefined, and at an instruction encoded entirely in
+        zero bytes, which is what a table is padded and filled with. The range is code if the decode
+        reaches an instruction after which control does not fall through, or consumes the whole
+        extent without one of those stops. Neither half is sufficient alone: a Haskell info table
+        decodes as x86 arithmetic to the end of a range it fits exactly, and an AArch64 function that
+        ends in a call which does not return reaches no terminator.
+        """
+
+        extent = self._function_start_extents.get(addr)
+        if not extent:
+            return False
+        try:
+            data = self.project.loader.memory.load(addr, extent)
+        except KeyError:
+            return False
+
+        terminators = FALLTHROUGH_TERMINATORS[self.project.arch.name]
+        consumed = 0
+        for insn_addr, size, mnemonic, _operands in self.project.arch.capstone.disasm_lite(data, addr):
+            offset = insn_addr - addr
+            if size <= 0 or mnemonic in UNDEFINED_MNEMONICS or not any(data[offset : offset + size]):
+                return False
+            if mnemonic in terminators:
+                return True
+            consumed = offset + size
+        return consumed == len(data)
 
     def _func_addrs_from_prologues(self):
         """

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -11,6 +11,7 @@ import random
 import unittest
 
 import archinfo
+from cle.backends.backend import FunctionHintSource
 
 import angr
 from angr.analyses.cfg.indirect_jump_resolvers import mips_elf_fast
@@ -967,6 +968,28 @@ class TestCfgfast(unittest.TestCase):
         assert "_main" in func_names
         assert "_accepted" in func_names
         assert "_authenticate" in func_names
+
+    def test_macho_function_starts_seed_functions(self):
+        # LC_FUNCTION_STARTS records the address of every atom ld64 placed in an executable section.
+        # With every other source of starting points turned off, the table is all CFGFast has.
+        path = os.path.join(test_location, "aarch64", "dyld_ios15.macho")
+        proj = angr.Project(path, auto_load_libs=False)
+        recorded = {
+            hint.addr
+            for hint in proj.loader.main_object.function_hints
+            if hint.source == FunctionHintSource.FUNCTION_STARTS
+        }
+        assert len(recorded) == 36
+
+        cfg = proj.analyses.CFGFast(
+            symbols=False,
+            start_at_entry=False,
+            function_prologues=False,
+            force_smart_scan=False,
+            force_complete_scan=False,
+            data_references=False,
+        )
+        assert recorded <= set(cfg.kb.functions)
 
     def test_syscalls_resolved_with_constant_propagation(self):
         for arch in ["x86", "x86_64"]:


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`LC_FUNCTION_STARTS` is the only record of where a stripped Mach-O image's functions begin, and CFGFast had no use for one. Fed in unfiltered it is worse than nothing: ld64 writes an entry for every atom it placed in an executable section, so a Haskell closure's info table and a Swift offset table are recorded beside the functions, and seeding those puts function heads on data.

On `binaries/tests/armhf/FileProtection-05.armv7.macho` the table has 73 entries, every one of them a named function in `__text`, and every one becomes a starting point. `0xa20d` is `arclite_uninitialized_function`, four bytes holding a `trap` and the `nop` that pads it out, ahead of `cxxConstruct` at `0xa211`:

```
0xa20d:  trap ; nop
0xa211:  push {r4, r7, lr} ; add r7, sp, #4 ; mov r4, r0 ; cmp r4, #0 ...
```

CFGFast recovers functions at `0xa20d`, `0xa20f` and `0xa211` where the image has two. `0xa20d` and `0xa211` are table entries; `0xa20f` is that `nop`, which the table does not record.

### Root cause

`CFGBase._load_func_addr_and_names_from_hints` denies one hint source and admits every other:

```python
if function_hint.source != FunctionHintSource.EH_FRAME:
    addrs_and_names.add((function_hint.addr, function_hint.name))
```

so a source CLE adds later is trusted the day it appears, on every architecture and with no check on what is at the address. `_pre_analysis` then puts those addresses into `starting_points` beside the symbol table, before the scan runs. A table entry therefore does not merely supply an address nothing else found — it fixes a function boundary ahead of everything the scan would have concluded, which is how the entry at `0xa20d` produces a second function at `0xa20f`, on the `nop` in its own last two bytes.

### Fix

`DEFINITE_FUNCTION_HINT_SOURCES` is an allowlist, `{EXPORT_TABLE, EXTERNAL_EH_FRAME}`, rather than "every source but `.eh_frame`". `FUNCTION_STARTS` addresses take a new job type consumed after the worklist drains, like the `.eh_frame` ones, and only where the address is not already occupied and the bytes there decode as code: forward from the address to the next recorded one, stopping at a byte capstone refuses, a word it names undefined, or an instruction encoded entirely in zeroes, and accepted on reaching an instruction after which control does not fall through or on consuming the whole extent. Only the Mach-O backend is asked for a table.

An architecture whose fall-through terminators are not established gets no hints at all, which is why the ARMEL image above ends with 234 functions rather than 238: `0x9b71`, `0xa20d` and `0xa2e5` are real Thumb code that nothing else there reaches, and giving them up is the price of not trusting an unvalidated table on an architecture angr does not model. The fourth address dropped, `0xa20f`, is the `nop` inside `0xa20d` and was never a function. On `binaries/tests/aarch64/dyld_ios15.macho` nothing moves — all 36 recorded addresses are functions before and after, 92 functions either way.

### Testing

`test_macho_function_starts_seed_functions` loads `dyld_ios15.macho`, asserts CLE records 36 `FUNCTION_STARTS` hints, and runs `CFGFast` with symbols, entry point, prologues, smart scan, complete scan and data references all off, so the table is the only source of starting points; all 36 addresses must be functions.

**Merge order, corrected 2026-09-06.** This used to say angr/cle#754 has to land first. It will not land: it was closed unmerged on 2026-09-05. The loader half is already on cle master — it went in on 2026-09-04 as `0e77ade3` through angr/cle#810 — so the dependency this branch was waiting on is in, and the blocker recorded here and in the validation comment is gone.

Two things came with it. cle#810 named the hint source `FunctionHintSource.MACHO_FUNCTION_STARTS`; cle#754 called it `FunctionHintSource.FUNCTION_STARTS`, and that is the name this branch still reads in `angr/analyses/cfg/cfg_base.py` and `tests/analyses/cfg/test_cfgfast.py`. So the branch as published does not run against cle master: `cfg_base.py:1136` raises `AttributeError` on a `CFGFast` over a Mach-O image that carries hints, and three tests in `tests/analyses/cfg/test_cfgfast.py` fail rather than the one the `Test Results` check reports. And because angr master's `_load_func_addr_and_names_from_hints` still admits every source but `EH_FRAME`, master now seeds every `LC_FUNCTION_STARTS` entry with no check at all — which means `test_macho_function_starts_seed_functions` passes on unmodified angr master against cle master once the name is corrected. Measured on angr master `87411a719` with only this branch's test file dropped in: `1 passed`. The test no longer shows that the change does anything.

**What the filter costs, measured 2026-09-06.** angr master `87411a719` with cle master `0e77ade3`, against this branch with the enum name corrected on the same cle; one default `CFGFast()` per object, over every Mach-O fixture in `angr/binaries` at `003e82a2b` — 27 by magic number, 25 of which load, only 9 named `*.macho`. Eleven fixtures move, and on every one of them the branch finds fewer functions than master: across them it gives up 211 function starts and gains 6, and 163 of the 211 carry a symbol at exactly that address. One of the 211 is demonstrably spurious, the `0xa20f` `nop` above. The largest single case is `OneSignalInAppMessages`, 42 given up and 2 gained; on `OneSignalCore` it is 31 given up, none gained, all 31 named.

The byte check is not what drops them. On `armhf/FileProtection-05.arm64.macho` the address given up is `0x10000584c`, `__ZL32__arclite_objc_allocateClassPairP10objc_classPKcm`, and `_function_start_holds_code` returns `True` for it. It is lost because the hints are consumed after the worklist drains, by which point `_seg_list.is_occupied` covers the address: this branch's own CFG holds it as a plain block inside `__ZL28__arclite_objc_readClassPair...` at `0x100005528`.

Validation: https://github.com/angr/angr/pull/6861#issuecomment-5312837743

session: sharpen
