### PR TITLE
CFGFast: Correct the comment describing the smart scan's nodecode skip

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1595,8 +1595,18 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         return self._seg_list.sort_ratio_backwards(cutoff_addr - 1, window_size, "nodecode")
 
     def _next_code_addr_smart(self) -> int | None:
-        # in the smart scanning mode, if there are more than N consecutive no-decode cases, we skip an entire window of
-        # bytes.
+        # In the smart scanning mode, a stretch of bytes that is largely undecodable is skipped past rather than
+        # scanned. The test is a ratio and not a run: _nodecode_bytes_ratio is the fraction of the last
+        # nodecode_window_size *occupied* bytes at or before the scan position that belong to "nodecode" segments, and
+        # the walk behind that position steps over gaps and over segments of every other sort. The undecodable bytes
+        # therefore do not have to be adjacent - a window in which decoded code and small undecodable runs alternate
+        # can reach nodecode_threshold while no run in it is longer than a few dozen bytes. Once it does, every address
+        # below self._next_addr + nodecode_step is occupied as "skip" and is never scanned again.
+        #
+        # That makes nodecode_threshold a precision/recall knob rather than a safety net: lowering it costs coverage
+        # of code that neighbours data, and raising it costs decoding data as code on packed images. Addresses named
+        # by a symbol, an unwind record, or a function hint are seeded before the scan runs and are unaffected either
+        # way.
         nodecode_bytes_ratio = (
             0.0 if self._next_addr is None else self._nodecode_bytes_ratio(self._next_addr, self._nodecode_window_size)
         )


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The comment above `CFGFast._next_code_addr_smart` says the smart scan skips a
window "if there are more than N consecutive no-decode cases". The code does not
test that. `_nodecode_bytes_ratio` calls
`SegmentList.sort_ratio_backwards(addr - 1, nodecode_window_size, "nodecode")`,
which is the fraction of the last `nodecode_window_size` *occupied* bytes that
belong to `nodecode` segments; the backward walk steps over gaps and over
segments of every other sort, so the undecodable bytes need not be adjacent to
each other at all.

The difference is not academic. On an x86-64 Mach-O dylib built by GHC, where
every closure's 16-40 byte info table is its own atom immediately before its
entry code, the skip fires nine times and refuses 147,587 bytes — 31.8% of
`__text`. At every one of the nine the trailing window is 43-66% *recovered
code*, and the longest run of consecutive undecodable bytes at any of the nine
decision points is **39 bytes**. Read literally, the comment says none of those
skips should have happened.

This changes the comment only. The heuristic is untouched, deliberately:
raising `nodecode_threshold` so those nine stop firing also makes
`tests/x86_64/windows/pitou.sys` decode packed data as code, and it introduces
new timeouts elsewhere. angr#6862 has that measurement in both directions and
the reasons not to retune the knob; this pull request is only the part of it
that is a plainly wrong statement in the source.

The replacement says what the ratio is taken over, that the bytes need not be
adjacent, that the refused addresses are occupied as `skip` and never revisited,
and that addresses named by a symbol, an unwind record or a function hint are
seeded before the scan and so are unaffected either way — which is the thing a
reader most needs in order to judge whether the knob applies to their case.

Refs #6862.
