### PR TITLE
CFGFast: Do not judge a function by the block past a non-returning call

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -4746,6 +4746,34 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         # if node.addr in self.kb.functions.callgraph:
         #    self.kb.functions.callgraph.remove_node(node.addr)
 
+    def _reached_only_by_call_fallthrough(self, cfg_node: CFGNode) -> bool:
+        """
+        Is this block reachable only as the fall-through of a call to a function we recovered?
+
+        Whatever a compiler leaves after a call it treats as non-returning is not executed: MSVC pads with
+        ``int3``, GCC emits the TOC restore after every PowerPC64 ``bl``, and both are followed by the
+        alignment of the next function. CFGFast recovers that block anyway, because the callee's returning
+        status is usually still unknown when the scan reaches the call site. What is beyond such a block says
+        nothing about whether the function it hangs off was decoded out of data.
+
+        The callee has to be a function with blocks of its own. A stray ``int`` or ``syscall`` in decoded data
+        gets a fall-through edge too, and so does a call whose target is not in the image; a block behind one of
+        those is the tail of a decode rather than the padding after a call.
+        """
+        graph = self.model.graph
+        in_edges = list(graph.in_edges(cfg_node, data=True))
+        if not in_edges:
+            return False
+        for src, _, data in in_edges:
+            if data.get("jumpkind") != "Ijk_FakeRet":
+                return False
+            if not any(
+                edge_data.get("jumpkind") == "Ijk_Call" and self.kb.functions.get_func_block_count(dst.addr)
+                for _, dst, edge_data in graph.out_edges(src, data=True)
+            ):
+                return False
+        return True
+
     def drop_bad_functions(self):
         # remove all functions that are bad, i.e., likely the result of decoding data as code
         # - if a function jumps to data, then it's likely bad
@@ -4790,6 +4818,8 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 cfg_node = self.model.get_any_node(block_addr)
                 if cfg_node is not None and cfg_node.size > 0:
                     out_degree = self.model.graph.out_degree[cfg_node]
+                    if out_degree < 2 and self._reached_only_by_call_fallthrough(cfg_node):
+                        continue
                     # is it jumping to data?
                     if out_degree == 0:
                         # might be size-limited during CFGNode generation; check the location after the end of the block

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,31 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_msvc_function_ending_in_a_noreturning_call_is_kept(self):
+        # each of these five ends in a call MSVC treats as non-returning, and the block CFGFast recovers past
+        # that call is the single int3 MSVC leaves there. drop_bad_functions() used to read the run of int3
+        # padding that follows as the function running into data and delete the whole function; the image's own
+        # exception directory names all five.
+        proj = angr.Project(os.path.join(test_location, "x86_64", "windows", "ipnathlp.dll"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        for addr in (0x180004D20, 0x18001A3EC, 0x18001FDFC, 0x180024064, 0x180024080):
+            assert addr in cfg.kb.functions, f"{addr:#x} was dropped"
+            assert cfg.model.get_any_node(addr) is not None, f"no block covers {addr:#x}"
+        # the one-block int3 the linear scan picked up out of the padding is still not a function
+        assert 0x180004681 not in cfg.kb.functions
+
+    def test_ppc64_function_ending_in_a_noreturning_call_is_kept(self):
+        # rejected(): puts() and then exit(). Its .opd descriptor at 0x10010e20 puts it at 0x100007bc with a
+        # size of 60, so all three blocks below are inside it. GCC emits the TOC restore after the bl to exit()
+        # and pads the rest of the section with zeroes, so the block past that call runs into bytes that do not
+        # decode -- which said nothing about the function, and cost it all three blocks.
+        proj = angr.Project(os.path.join(test_location, "ppc64", "fauxware"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        assert 0x100007BC in cfg.kb.functions
+        assert {0x100007BC, 0x100007DC, 0x100007E8} <= cfg.kb.functions[0x100007BC].block_addrs_set
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`drop_bad_functions()` deletes functions whose last block sits after a call that never comes back. On `binaries/tests/ppc64/fauxware`, `rejected()` — `puts()` then `exit()`, entry `0x100007bc` through the `.opd` descriptor at `0x10010e20` — is removed whole by `CFGFast(normalize=True)`:

```
rejected: .opd descriptor at 0x10010e20, size 60, entry 0x100007bc
kb.functions[0x100007bc]: gone
  0x100007bc: CFG node absent
  0x100007dc: CFG node absent
  0x100007e8: CFG node absent
```

Nothing about the function is wrong. Its blocks go with it, so the call graph loses an edge and every consumer keyed on that address — decompilation, callee resolution, the function's own prototype — has nothing to work from. Five functions in `binaries/tests/x86_64/windows/ipnathlp.dll` that the image's own exception directory names go the same way.

### Root cause

The pass reads what lies past a block with no successors as evidence that the function was decoded out of data:

```python
if out_degree == 0:
    block_end = cfg_node.addr + cfg_node.size
    ...
    if self._seg_list.occupied_by_sort(block_end) == "nodecode":
        full_funcs_to_remove.append(func_addr)
        break
```

The block that trips this is usually the one CFGFast recovers *past a call*. When the callee never returns, that block is whatever the compiler left in a spot that is not executed: the TOC restore GCC emits after every PowerPC64 `bl`, or the `int3` MSVC pads with. It has no successors because nothing follows it but alignment, and the alignment is exactly what the test reads:

```
the block CFGFast recovers past the bl to exit(), and the bytes after it:
    0x100007e8: ld r2, 0x28(r1)
    0x100007ec: 0000000000000001  (nodecode)
```

### Fix

`_reached_only_by_call_fallthrough()` skips a block whose in-edges are all `Ijk_FakeRet` from a site that also has an `Ijk_Call` edge to a function with blocks of its own. The same run then keeps the function:

```
kb.functions[0x100007bc]: sub_100007bc, blocks ['0x100007bc', '0x100007dc', '0x100007e8']
  0x100007bc: CFG node present
  0x100007dc: CFG node present
  0x100007e8: CFG node present
```

The callee has to be a recovered function because a stray `int` or `syscall` in decoded data gets a fall-through edge too. Gating instead on the callee being *known* non-returning does not work here: this pass runs before that analysis settles.

### Testing

`test_ppc64_function_ending_in_a_noreturning_call_is_kept` asserts `0x100007bc` is in `kb.functions` with all three of its blocks, and `test_msvc_function_ending_in_a_noreturning_call_is_kept` asserts the five `ipnathlp.dll` functions survive while the one-block `int3` the linear scan picked out of the padding at `0x180004681` is still not a function. On the baseline the first fails on the missing function and the second on `0x180004d20`; both pass on the head.

Fixes #6859. Validation: https://github.com/angr/angr/pull/6865#issuecomment-5315615905

session: sharpen
