### PR TITLE
CFGFast: Keep a function the binary's own symbol table names

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -4721,6 +4721,12 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                         nodes_to_remove.append(func_addr)
                         continue
 
+            if func_addr in self._function_addresses_from_symbols:
+                # the file's own symbol table names a function here, so this is not something the linear scan
+                # invented out of data. an instruction set the lifter does not implement looks exactly like data
+                # from here, and the tests below cannot tell the two apart.
+                continue
+
             if not (
                 self.kb.functions.is_func_nonreturning(func_addr)
                 or self.kb.functions.is_func_returning_unknown(func_addr)

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1031,6 +1031,22 @@ class TestCfgfast(unittest.TestCase):
 
         assert len(cfg.kb.functions) < 150, f"32 KB of random data produced {len(cfg.kb.functions)} functions"
 
+    def test_function_the_symbol_table_names_is_kept(self):
+        # glibc's EVEX string routines and the AVX-512 PLT resolvers are ordinary code that VEX cannot lift, so
+        # a block in each ends in Ijk_NoDecode and drop_bad_functions() deleted the whole function. The file's
+        # own symbol table gives each of them a name and a size, so the premise of that pass -- that the linear
+        # scan decoded data as code -- does not hold here.
+        proj = angr.Project(os.path.join(test_location, "x86_64", "langdetect_gcc"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        for addr, name in (
+            (0x424CC0, "__stpcpy_evex"),
+            (0x430CE0, "__strlen_evex"),
+            (0x45B480, "__memcmp_evex_movbe"),
+            (0x4686A0, "_dl_runtime_resolve_xsavec"),
+        ):
+            assert addr in cfg.kb.functions, f"{name} at {addr:#x} was dropped"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`drop_bad_functions()` deletes a function whose block ends in bytes the lifter
could not decode. That is sound when the bytes are data and wrong when they are
an instruction set VEX does not implement, and then a function whose recovered
blocks were all correct goes with them.

A function whose entry the binary's own symbol table names was not invented by
the linear scan, so skip it there. Symbols only, not `.eh_frame` or a PE
exception directory, whose hints also name padding.

The regression covers the EVEX string routines and the AVX-512 PLT resolvers in
`x86_64/langdetect_gcc`.

Fixes #6858. Fixes #6832. Validation: https://github.com/angr/angr/pull/6866#issuecomment-5315616053
