### PR TITLE
CFGFast: Delete the function that starts inside an instruction, not another one

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -4830,7 +4830,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             if cfg_node is not None:
                 self.model.remove_node_and_graph_node(cfg_node)
             if self.kb.functions.contains_addr(node_addr):
-                del self.kb.functions[func_addr]
+                del self.kb.functions[node_addr]
 
     def _analyze_all_function_features(self, all_funcs_completed=False):
         """

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,22 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_function_starting_inside_an_instruction_is_the_one_dropped(self):
+        # 0x4249f4 is where the prologue scan landed inside the `mov dword ptr [esp + 0x50], edx` at 0x4249f1,
+        # so drop_bad_functions() collects it. The deletion then ran on the wrong address and took 0x424cc0,
+        # an ordinary `push edi; call ...` entry, with it.
+        path = os.path.join(
+            test_location,
+            "x86_64",
+            "windows",
+            "50e5f670700243535f8ff558831dbbc314b215092f523355aa7a1c26205ece37",
+        )
+        proj = angr.Project(path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        assert 0x4249F4 not in cfg.kb.functions
+        assert 0x424CC0 in cfg.kb.functions
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`drop_bad_functions()` removes the wrong function when the prologue scan lands in the middle of an instruction. On `binaries/tests/x86_64/windows/50e5f670700243535f8ff558831dbbc314b215092f523355aa7a1c26205ece37`, `CFGFast(normalize=True)` on master leaves this behind:

```
0x4249f4 (`push eax; mov eax, dword ptr [esp + 0x50]`)
    in kb.functions, CFG node absent
0x424cc0 (`push edi; call 0x408a60`)
    NOT in kb.functions, CFG node present
```

`0x4249f4` is inside the `mov dword ptr [esp + 0x50], edx` at `0x4249f1`, so the pass is right to want it gone — but it keeps the function record and takes only the blocks, and it deletes `0x424cc0`, an ordinary entry the pass never objected to, whose nodes stay in the graph. Both addresses come out with the function manager and the CFG model disagreeing, in opposite directions.

### Root cause

The loop that removes those functions deletes by the wrong variable:

```python
for node_addr in nodes_to_remove:
    cfg_node = self.model.get_any_node(node_addr)
    if cfg_node is not None:
        self.model.remove_node_and_graph_node(cfg_node)
    if self.kb.functions.contains_addr(node_addr):
        del self.kb.functions[func_addr]
```

`node_addr` is tested and `func_addr` is deleted. `func_addr` is whatever the two loops above left in scope — the last function iterated, or the last one removed for jumping to data — so every iteration aims at the same unrelated address. `FunctionManager.__delitem__` checks membership before deleting, so the second and later iterations are silent no-ops and the mistake never raises.

### Fix

Delete `node_addr`, the address the guard on the line above already tested. The same run then gives:

```
0x4249f4 (`push eax; mov eax, dword ptr [esp + 0x50]`)
    NOT in kb.functions, CFG node absent
0x424cc0 (`push edi; call 0x408a60`)
    in kb.functions, CFG node present
```

### Testing

`test_function_starting_inside_an_instruction_is_the_one_dropped` runs `CFGFast(normalize=True)` on that binary and asserts `0x4249f4 not in cfg.kb.functions` and `0x424cc0 in cfg.kb.functions`. Both assertions fail on the baseline, each for its own half of the swap.

Validation: https://github.com/angr/angr/pull/6867#issuecomment-5316321226

session: sharpen
