### PR TITLE
CFG: Scan only the Mach-O sections that state they hold instructions

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -854,11 +854,13 @@ class CFGBase(Analysis):
                     # Get all executable segments
                     for seg in b.segments:
                         if seg.is_executable:
-                            # Take all sections from this segment (MachO style)
+                            # The whole of __TEXT is r-x, so this segment covers its constant pools and string
+                            # literals as well as its code.
                             for section in seg.sections:
-                                max_mapped_addr = section.min_addr + min(section.memsize, section.filesize)
-                                tpl = (section.min_addr, max_mapped_addr)
-                                memory_regions.append(tpl)
+                                if section.is_executable:
+                                    max_mapped_addr = section.min_addr + min(section.memsize, section.filesize)
+                                    tpl = (section.min_addr, max_mapped_addr)
+                                    memory_regions.append(tpl)
 
             elif isinstance(b, (Hex, SRec)):
                 if b.regions:

--- a/tests/analyses/cfg/test_cfg_macho_sections.py
+++ b/tests/analyses/cfg/test_cfg_macho_sections.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# pylint: disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+from archinfo.arch_arm import get_real_address_if_arm
+
+import angr
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+def sections_holding_blocks(project, cfg):
+    """The names of the sections the blocks CFGFast produced begin in."""
+    names = set()
+    for node in cfg.model.nodes():
+        if node.is_simprocedure or not node.size:
+            continue
+        addr = get_real_address_if_arm(project.arch, node.addr)
+        section = project.loader.main_object.find_section_containing(addr)
+        if section is not None:
+            names.add(section.name)
+    return names
+
+
+class TestCfgMachOSections(unittest.TestCase):
+    def test_cstring_and_unwind_info_are_not_scanned(self):
+        bin_path = os.path.join(test_location, "x86_64", "fauxware.macho")
+        project = angr.Project(bin_path, auto_load_libs=False)
+        cfg = project.analyses.CFGFast()
+
+        text = project.loader.main_object.sections_map["__TEXT,__text"]
+        assert (text.vaddr, text.vaddr + text.memsize) in cfg.regions
+        for name in ("__TEXT,__cstring", "__TEXT,__unwind_info"):
+            section = project.loader.main_object.sections_map[name]
+            assert (section.vaddr, section.vaddr + section.memsize) not in cfg.regions
+
+        assert cfg.kb.functions.get_by_addr(project.entry) is not None
+        assert sections_holding_blocks(project, cfg) == {"__text", "__stubs", "__stub_helper"}
+
+    def test_objc_string_sections_are_not_scanned(self):
+        # This image places the Objective-C name tables directly after __stub_helper, so a decode that runs off
+        # the end of the stubs marches through them.
+        bin_path = os.path.join(test_location, "armhf", "FileProtection-05.armv7.macho")
+        project = angr.Project(bin_path, auto_load_libs=False)
+        cfg = project.analyses.CFGFast()
+
+        assert len(cfg.kb.functions) > 200
+        assert sections_holding_blocks(project, cfg) == {"__text", "__stub_helper", "__symbolstub1"}
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`CFGBase._executable_memory_regions` took every section of an executable Mach-O
segment without asking anything about the section, so the regions to analyze
covered the constant pools, string literals, unwind tables and Objective-C and
Swift metadata that share `__TEXT`'s `r-x` mapping with the code. CFGFast then
seeded function starts inside them and decoded string literals as instructions.

It now keeps the sections that report themselves executable, as the ELF, PE and
XBE branches beside it already do. That needs the cle change below: without it
every section of an `r-x` segment still reports as executable and this filter
does nothing.

Covered by tests over `tests/x86_64/fauxware.macho` and
`tests/armhf/FileProtection-05.armv7.macho`, whose Objective-C name tables
follow `__stub_helper` directly.

Fixes #6860.

sync: angr/cle#762
Validation: https://github.com/angr/angr/pull/6869#issuecomment-5316927899