### PR TITLE
JumpTableResolver: Recognize Mach-O zero fill and refuse a table read out of it

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -787,7 +787,7 @@ class JumpTableResolver(IndirectJumpResolver):
 
         self.resolve_calls = resolve_calls
 
-        self._bss_regions = None
+        self._bss_regions: list[tuple[int, int]] = []
         # the maximum number of resolved targets. Will be initialized from CFG.
         self._max_targets = 0
 
@@ -1892,6 +1892,16 @@ class JumpTableResolver(IndirectJumpResolver):
         ):
             l.debug(
                 "Jump table %#x might have jump targets outside mapped memory regions. "
+                "Continue to resolve it from the next data source.",
+                addr,
+            )
+            return None
+
+        if any(start <= min_jumptable_addr < start + size for start, size in self._bss_regions):
+            # The bytes there are the loader's zero fill rather than the program's data, so whatever
+            # this reads is an artifact of how the object was loaded.
+            l.debug(
+                "Jump table %#x is read out of memory that is only zero-filled. "
                 "Continue to resolve it from the next data source.",
                 addr,
             )

--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -2196,12 +2196,32 @@ class JumpTableResolver(IndirectJumpResolver):
     def _find_bss_region(self):
         self._bss_regions = []
 
-        # TODO: support other sections other than '.bss'.
-        # TODO: this is very hackish. fix it after the chaos.
-        for section in self.project.loader.main_object.sections:
-            if section.name == ".bss":
-                self._bss_regions.append((section.vaddr, section.memsize))
-                break
+        main_object = self.project.loader.main_object
+        tls_start, tls_end = self._tls_block(main_object)
+        for section in main_object.sections:
+            if not section.memsize:
+                continue
+            try:
+                zero_filled = section.only_contains_uninitialized_data
+            except NotImplementedError:
+                # A backend that builds sections without modelling their content cannot say.
+                continue
+            if not zero_filled:
+                continue
+            if tls_start <= section.vaddr < tls_end:
+                # A thread-local zero-fill section describes the initial image of a thread's
+                # thread-local block rather than memory at its own address. An ELF .tbss is laid over
+                # the addresses the linker gave to whatever follows the thread-local template, so
+                # what a read there returns is that section's data and is not uninitialized.
+                continue
+            self._bss_regions.append((section.vaddr, section.memsize))
+
+    @staticmethod
+    def _tls_block(obj) -> tuple[int, int]:
+        if not obj.tls_used or obj.tls_data_start is None:
+            return 0, 0
+        start = obj.mapped_base + obj.tls_data_start
+        return start, start + (obj.tls_block_size or 0)
 
     def _init_registers_on_demand(self, state):
         # for uninitialized read using a register as the source address, we replace them in memory on demand

--- a/tests/analyses/cfg/test_jumptables.py
+++ b/tests/analyses/cfg/test_jumptables.py
@@ -3265,6 +3265,45 @@ class TestJumpTableResolver(unittest.TestCase):
         # initialized; only .bss and __libc_freeres_ptrs are uninitialized memory.
         assert self._bss_regions("i386", "bronze_ropchain") == [(0x80DB320, 0xCDC), (0x80DBFFC, 0x14)]
 
+    def test_jump_table_base_in_bss_is_rejected(self):
+        path = os.path.join(test_location, "x86_64", "fpijr_callback_array")
+        proj = angr.Project(path, auto_load_libs=False)
+
+        # .bss is matched by name, so the region set here is the same one the resolver always had.
+        assert JumpTableResolver(proj)._bss_regions == [(0x404020, 0x60)]  # pylint:disable=protected-access
+
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=False, resolve_indirect_jumps=True)
+
+        # The dispatch at 0x4011d0 indexes a callback array the program fills in at run time. Its base
+        # is a concrete .bss address, so the entries come from the loader's zero fill rather than from
+        # the file, and every one of them is 0.
+        assert 0x4011D0 not in cfg.model.jump_tables
+
+    def test_jump_table_base_in_zero_fill_is_rejected(self):
+        path = os.path.join(test_location, "aarch64", "lynx-2.9.0dev.10_ios_arm64.macho")
+        proj = angr.Project(path, auto_load_libs=False, use_sim_procedures=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=False, resolve_indirect_jumps=True)
+
+        # 0x10001e8fc dispatches through x28. With the zero-fill regions hooked, the resolver's
+        # slice takes the stale adrp/add at 0x10001e788 for the base rather than the adr at
+        # 0x10001e800 that reaches the dispatch, so the base lands in __DATA,__common.
+        assert 0x10001E8FC not in cfg.model.jump_tables
+
+        # A second dispatch reads a real table out of __TEXT,__const and must still resolve, so
+        # that the assertion above cannot pass by the resolver never resolving anything here.
+        jt = cfg.model.jump_tables[0x10009D01C]
+        assert len(jt.jumptables) == 1
+        assert jt.jumptables[0].addr == 0x1001069D3
+        assert jt.jumptables[0].entry_size == 1
+        assert sorted(jt.jumptables[0].entries) == [
+            0x10009D034,
+            0x10009D058,
+            0x10009D074,
+            0x10009D080,
+            0x10009D0D8,
+            0x10009D0E4,
+        ]
+
 
 class TestJumpTableResolverCallTables(unittest.TestCase):
     """

--- a/tests/analyses/cfg/test_jumptables.py
+++ b/tests/analyses/cfg/test_jumptables.py
@@ -3246,6 +3246,25 @@ class TestJumpTableResolver(unittest.TestCase):
         assert jt0.jumptables[0].entries_guessed is True
         assert jt0.jumptables[0].entries == [0x4154DA, 0x4154F0, 0x4154F0, 0x4154F0, 0x4154F0]
 
+    @staticmethod
+    def _bss_regions(*path):
+        proj = angr.Project(os.path.join(test_location, *path), auto_load_libs=False)
+        return JumpTableResolver(proj)._bss_regions  # pylint:disable=protected-access
+
+    def test_bss_regions_on_macho(self):
+        # A Mach-O zero-fill section is called __bss, so matching the name ".bss" found nothing and
+        # reads from it came back as the zeroes CLE pads the segment with.
+        assert self._bss_regions("aarch64", "dyld_ios15.macho") == [(0x10000C1B0, 0x100)]
+
+    def test_bss_regions_cover_every_zero_fill_section(self):
+        # .sbss as well as .bss
+        assert self._bss_regions("mipsel", "jumptable_0") == [(0x100004A8, 0x6C), (0x10000520, 0xE8)]
+
+    def test_bss_regions_exclude_thread_local_zero_fill(self):
+        # .tbss is laid over the addresses of .init_array, .fini_array and .data.rel.ro, which are
+        # initialized; only .bss and __libc_freeres_ptrs are uninitialized memory.
+        assert self._bss_regions("i386", "bronze_ropchain") == [(0x80DB320, 0xCDC), (0x80DBFFC, 0x14)]
+
 
 class TestJumpTableResolverCallTables(unittest.TestCase):
     """


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`JumpTableResolver` looked for uninitialized memory by matching the section name `.bss`. No Mach-O section is called that — the zero-fill sections are `__bss` and `__common` — so `_bss_regions` is empty on the whole format, `BSSHook` is never installed, and every read the resolver makes there returns the zeroes CLE pads the segment with as though they were the program's data.

On `binaries/tests/aarch64/lynx-2.9.0dev.10_ios_arm64.macho` that costs a real jump table. `CFGFast` resolves 38 dispatches, and the switch at `0x10009d01c`, whose table lives at `0x1001069d3` in `__TEXT,__const`, is not one of them:

```text
dispatch 0x10009d01c: no jump table resolved
```

The name test does match on an ELF, and the guard is still needed there. `binaries/tests/x86_64/fpijr_callback_array` dispatches through a callback array the program fills in at run time, and master reads it as a jump table:

```text
0x4011d0: base 0x404048 entries ['0x0', '0x0', '0x0', '0x0']
```

#6856 traces the same read on an `MH_DYLIB`, which CLE links at base 0, to a table base of zero that addresses the Mach header, which the resolver then reads as an array of function pointers.

### Root cause

```python
# TODO: support other sections other than '.bss'.
for section in self.project.loader.main_object.sections:
    if section.name == ".bss":
        self._bss_regions.append((section.vaddr, section.memsize))
        break
```

A name test cannot answer this for a format that does not use the name, and the `break` keeps only the first region even where it can. Installing the hook is not sufficient on its own, though: with `_bss_regions` populated and no further guard, 40 dispatches resolve, and the extra one is `0x10001e8fc` taking a 9-entry table at base `0x10014e03c` in `__common` whose entries are nine copies of `0x10001e90c` — zero fill read through an unconstrained hook rather than through concrete zeroes, which is a different wrong answer to the same question. The hook cannot reach the ELF case at all: the base there is concrete, so the entries are loaded straight out of the loader's memory rather than through the state the hook instruments.

### Fix

Ask the section through `only_contains_uninitialized_data` instead of its name, and keep every region rather than the first. Thread-local zero fill is left out: an ELF `.tbss` is laid over the addresses of whatever follows the thread-local template, so a read there returns that section's data and is not uninitialized. A table whose base falls in one of the regions is refused, and the resolver goes on to the next data source.

`0x10009d01c` then resolves to `0x1001069d3` with entries `0x10009d034`, `0x10009d058`, `0x10009d074`, `0x10009d080`, `0x10009d0d8` and `0x10009d0e4`; `0x10001e8fc` resolves nothing. 39 dispatches resolve, and every table master already had is unchanged.

### Testing

Five tests. `test_bss_regions_on_macho` pins the region list for `aarch64/dyld_ios15.macho`; `test_bss_regions_cover_every_zero_fill_section` pins both regions of `mipsel/jumptable_0`, which master's `break` truncated to `0x10000520` alone; `test_bss_regions_exclude_thread_local_zero_fill` pins `i386/bronze_ropchain`, whose `.tbss` overlays initialized data.

`test_jump_table_base_in_bss_is_rejected` is the one that fails on master at the refusal itself: no table at `0x4011d0` in `x86_64/fpijr_callback_array`. Reverting the refusal alone brings that table back, and the region list is identical either way, so nothing but the refusal accounts for it.

`test_jump_table_base_in_zero_fill_is_rejected` asserts no table at `0x10001e8fc` and the six entries above at `0x10009d01c`. Its first assertion holds on master as well, for an unrelated reason, so it guards the refusal against the section change rather than against master. It needs the fixture in angr/binaries#182 and a CLE that answers the zero-fill predicate for Mach-O sections, which master does.

Fixes #6856. Validation: https://github.com/angr/angr/pull/6880#issuecomment-5327613221

sync: angr/binaries#182

session: sharpen