### PR TITLE
CFGFast: Do not decode an object CLE invented

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1807,7 +1807,10 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         if not self._inside_regions(job.addr):
             obj = self.project.loader.find_object_containing(job.addr)
             if obj is not None and isinstance(obj, self._cle_pseudo_objects):
-                pass
+                # An object CLE invents holds no file content, so the only addresses in it that
+                # stand for anything are the ones something is hooked at. The rest is zero fill.
+                if not self._addr_hooked_or_syscall(job.addr):
+                    raise AngrSkipJobNotice
             else:
                 # it's outside permitted regions. skip.
                 if job.jumpkind == "Ijk_Call":

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,30 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_cfg_does_not_decode_an_object_cle_invented(self):
+        # cle##externs holds no file content, so an address in it that nothing is hooked at is
+        # zero fill: decoding it yields blocks until the object runs out. Packing the objects
+        # together puts it directly above the image, which is where this blob's recovery runs off
+        # the end into it.
+        path = os.path.join(test_location, "armel", "i2c_api.o")
+        proj = angr.Project(
+            path,
+            auto_load_libs=False,
+            main_opts={"backend": "blob", "arch": "ARMEL", "base_addr": 0x1000},
+            rebase_granularity=1,
+        )
+        extern = proj.loader.extern_object
+        assert extern.min_addr == proj.loader.main_object.max_addr + 1
+
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        image = [n for n in cfg.model.nodes() if n.addr <= proj.loader.main_object.max_addr]
+        invented = [
+            n for n in cfg.model.nodes() if extern.min_addr <= n.addr <= extern.max_addr and not proj.is_hooked(n.addr)
+        ]
+        assert image
+        assert not invented, f"{len(invented)} blocks decoded out of {extern}: {invented[:3]}"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

CFGFast decodes the zero fill of the objects CLE invents. Load `binaries/tests/armel/i2c_api.o` as a raw ARMEL blob at `0x1000` with `rebase_granularity=1`, which packs `cle##externs` at `0x379c`, immediately above the image's last byte at `0x379b`. Recovery runs off the end and keeps going:

```text
CFG nodes: 494 total, 328 in the image, 166 in cle##externs at an address nothing is hooked at
  blocks 0x379d to 0xb73b, sizes [98, 198], gaps between consecutive block addresses ['0xc6']
```

Those 166 blocks span the whole extern object at an even `0xc6` stride, and all of them are attached to one image function: `0x3535` has 170 blocks, 166 of which are outside the image. Nothing bounds it but the size of the object.

### Root cause

`_pre_job_handling` lets a job through whenever its address is in one of the objects CLE invents, hooked or not:

```python
if not self._inside_regions(job.addr):
    obj = self.project.loader.find_object_containing(job.addr)
    if obj is not None and isinstance(obj, self._cle_pseudo_objects):
        pass
```

`_cle_pseudo_objects` is `(ExternObject, KernelObject, TLSObject)`. None of them holds file content: an address in one stands for something only when a hook or a syscall is registered there, and every other address is zero fill the loader supplies. The `pass` was written for the hooked case and admits the rest with it. Because the job proceeds, its successors do too, so one call landing in the object seeds a walk across all of it.

### Fix

Skip such a job unless `_addr_hooked_or_syscall` holds for the address, adding no node and no call edge. The blob above then decodes 328 nodes, all inside the image, `0x3535` is 4 blocks, and the function count is 107 either way — the image is untouched.

`_executable_memory_regions` already excludes these objects and no seed reaches them, so `_pre_job_handling` is the only route by which blocks land in one.

### Testing

`test_cfg_does_not_decode_an_object_cle_invented` builds that blob, asserts the extern object begins one byte above the image, and requires no CFG node in it at an unhooked address while the image still recovers nodes. It fails on master with 166 such blocks.

The companion loader change in cle, its pull request 765, stops most of these objects being placed over address 0 to begin with; the two are independently sufficient and neither needs the other, so this was reproduced against cle master rather than against that branch, which relocates the extern object away from the image. It is named in prose rather than as a reference token deliberately: a reference pins this pull request's CI to that branch, which is not the loader the reproduction above was measured against.

Fixes #6834. Validation: https://github.com/angr/angr/pull/6889#issuecomment-5331303704

session: sharpen