### PR TITLE
docs: default SPHINXOPTS to -j auto in Makefile to speed up Sphinx builds

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
Addresses #6891 by defaulting `SPHINXOPTS` in `docs/Makefile` to `-j auto`. This enables parallel execution during Sphinx documentation builds across all available CPU cores, significantly reducing overall build time and helping avoid Read the Docs build-time limit kills.

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
