### PR TITLE
Decompiler: Track ARM registers that save and restore the stack pointer

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypeGuard
 
 import capstone
 import networkx
+from archinfo.arch_arm import is_arm_arch
 
 from angr import ailment
 from angr.ailment import AILBlockRewriter, Assignment, Block, Statement
@@ -25,7 +26,7 @@ from angr.analyses.decompiler.optimization_pass_registry import name_to_pass, pa
 from angr.analyses.s_liveness import SLivenessAnalysis
 from angr.analyses.s_reaching_definitions import SReachingDefinitions
 from angr.analyses.s_reaching_definitions.s_rda_model import SRDAModel
-from angr.analyses.stack_pointer_tracker import OffsetVal, Register
+from angr.analyses.stack_pointer_tracker import TOP, OffsetVal, Register
 from angr.analyses.typehoon import Typehoon
 from angr.analyses.typehoon.simple_solver import SimpleSolver
 from angr.calling_conventions import (
@@ -39,7 +40,7 @@ from angr.calling_conventions import (
 )
 from angr.code_location import ExternalCodeLocation
 from angr.codenode import BlockNode, FuncNode
-from angr.errors import AngrDecompilationComplexityError, AngrDecompilationError
+from angr.errors import AngrDecompilationComplexityError, AngrDecompilationError, SimTranslationError
 from angr.knowledge_base import KnowledgeBase
 from angr.knowledge_plugins.cfg.memory_data import MemoryDataSort
 from angr.knowledge_plugins.functions import Function
@@ -1458,7 +1459,7 @@ class Clinic(Analysis, Serializable):
             return self._cross_insn_opt_for_large_blocks and block_size >= self._cross_insn_opt_min_block_size
 
         regs = {self.project.arch.sp_offset}
-        initial_reg_values = {
+        initial_reg_values: dict[int | None, OffsetVal | None] = {
             self.project.arch.sp_offset: OffsetVal(
                 Register(self.project.arch.sp_offset, self.project.arch.bits), self._sp_shift
             )
@@ -1470,7 +1471,14 @@ class Clinic(Analysis, Serializable):
             )
 
         regs |= self._find_regs_compared_against_sp(self._func_graph)
-        regs |= self._find_regs_saving_sp(self._func_graph)
+        if is_arm_arch(self.project.arch):
+            # StackPointerTracker normalizes a copy of an unnormalized function before traversing it. Do not prove
+            # saved-SP provenance against a different graph in that case.
+            saved_sp_regs = self._find_regs_saving_sp(self.function.graph) if self.function.normalized else set()
+            initial_reg_values.update(dict.fromkeys(saved_sp_regs, TOP))
+        else:
+            saved_sp_regs = self._find_regs_saving_sp(self._func_graph)
+        regs |= saved_sp_regs
 
         spt = self.project.analyses.StackPointerTracker(
             self.function,
@@ -4066,7 +4074,192 @@ class Clinic(Analysis, Serializable):
         # Unless that register is tracked, the tracker cannot resolve sp after the restore and reports
         # the whole function as inconsistent, leaking raw sp virtual variables into the output. Track
         # any register that both receives a copy of sp and is later used to restore it.
-        # TODO: Implement this function for architectures beyond amd64
+        if is_arm_arch(self.project.arch):
+            if not self.project.arch.capstone_support:
+                return set()
+
+            entry_nodes = [
+                node for node in func_graph if (node.addr, getattr(node, "idx", None)) == self.entry_node_addr
+            ]
+            if len(entry_nodes) != 1:
+                return set()
+
+            entry_node = entry_nodes[0]
+            if func_graph.in_degree(entry_node) != 0:
+                return set()
+
+            reachable_nodes = networkx.descendants(func_graph, entry_node) | {entry_node}
+            if len(reachable_nodes) != func_graph.number_of_nodes():
+                return set()
+
+            endpoint_nodes = {node for node in reachable_nodes if func_graph.out_degree(node) == 0}
+            if not endpoint_nodes:
+                return set()
+            nodes_reaching_endpoints = endpoint_nodes.copy()
+            endpoint_worklist = list(endpoint_nodes)
+            while endpoint_worklist:
+                node = endpoint_worklist.pop()
+                for predecessor in func_graph.predecessors(node):
+                    if predecessor not in nodes_reaching_endpoints:
+                        nodes_reaching_endpoints.add(predecessor)
+                        endpoint_worklist.append(predecessor)
+            if nodes_reaching_endpoints != reachable_nodes:
+                return set()
+
+            copies_by_node = defaultdict(list)
+            writes_by_node = defaultdict(list)
+            affine_adjustments_by_node = defaultdict(set)
+            for node in reachable_nodes:
+                if not isinstance(node, BlockNode):
+                    return set()
+
+                try:
+                    block = self.project.factory.block(
+                        node.addr, size=node.size, thumb=node.thumb, cross_insn_opt=False
+                    )
+                    capstone_block = block.capstone
+                except (AttributeError, capstone.CsError, SimTranslationError):
+                    return set()
+                if node.size and (
+                    not capstone_block.insns or sum(insn.size for insn in capstone_block.insns) != node.size
+                ):
+                    return set()
+                # Per-block Thumb decoding cannot reconstruct IT state inherited from a predecessor.
+                if any(insn.id == capstone.arm.ARM_INS_IT for insn in capstone_block.insns):
+                    return set()
+
+                try:
+                    vex_block = block.vex
+                except (AttributeError, SimTranslationError):
+                    return set()
+                capstone_insn_addrs = tuple(insn.address for insn in capstone_block.insns)
+                if (
+                    vex_block.instructions != len(capstone_block.insns)
+                    or tuple(vex_block.instruction_addresses) != capstone_insn_addrs
+                    or vex_block.size != node.size
+                    or vex_block.jumpkind == "Ijk_NoDecode"
+                ):
+                    return set()
+
+                for insn_idx, insn in enumerate(capstone_block.insns):
+                    try:
+                        read_regs, written_regs = insn.regs_access()
+                    except (AttributeError, capstone.CsError):
+                        return set()
+                    read_regs = set(read_regs)
+                    written_regs = set(written_regs)
+                    writes_by_node[node].append((insn_idx, written_regs))
+
+                    if insn.cc != capstone.arm.ARM_CC_AL:
+                        continue
+                    operands = insn.operands
+
+                    # ARM epilogues may adjust a frame pointer immediately before copying it back into sp. Only admit
+                    # the exact two-operand ADDS-immediate form used by the real supported epilogue.
+                    # Restricting their placement to endpoint blocks is handled by the candidate proof below.
+                    if (
+                        insn.id == capstone.arm.ARM_INS_ADD
+                        and insn.update_flags
+                        and not insn.writeback
+                        and len(operands) == 2
+                    ):
+                        adjusted_reg = None
+                        if operands[0].type == capstone.arm.ARM_OP_REG and operands[1].type == capstone.arm.ARM_OP_IMM:
+                            adjusted_reg = operands[0].reg
+
+                        if (
+                            adjusted_reg is not None
+                            and adjusted_reg in read_regs
+                            and adjusted_reg in written_regs
+                            and all(
+                                operand.shift.type == capstone.arm.ARM_SFT_INVALID
+                                for operand in operands
+                                if operand.type == capstone.arm.ARM_OP_REG
+                            )
+                        ):
+                            affine_adjustments_by_node[node].add((insn_idx, adjusted_reg))
+
+                    if insn.id == capstone.arm.ARM_INS_MOV and len(operands) == 2:
+                        dst, src = operands
+                    elif (
+                        insn.id == capstone.arm.ARM_INS_ADD
+                        and len(operands) == 3
+                        and operands[2].type == capstone.arm.ARM_OP_IMM
+                        and operands[2].imm == 0
+                    ):
+                        dst, src, _ = operands
+                    else:
+                        continue
+
+                    if dst.type != capstone.arm.ARM_OP_REG or src.type != capstone.arm.ARM_OP_REG:
+                        continue
+                    if any(operand.shift.type != capstone.arm.ARM_SFT_INVALID for operand in (dst, src)):
+                        continue
+                    if dst.reg not in written_regs:
+                        continue
+                    copies_by_node[node].append((insn_idx, dst.reg, src.reg))
+
+            candidate_regs = {
+                capstone.arm.ARM_REG_R4: "r4",
+                capstone.arm.ARM_REG_R5: "r5",
+                capstone.arm.ARM_REG_R6: "r6",
+                capstone.arm.ARM_REG_R7: "r7",
+                capstone.arm.ARM_REG_R8: "r8",
+                capstone.arm.ARM_REG_R9: "r9",
+                capstone.arm.ARM_REG_R10: "r10",
+                capstone.arm.ARM_REG_R11: "r11",
+            }
+            sp_reg = capstone.arm.ARM_REG_SP
+            saves_by_reg = defaultdict(list)
+            restores_by_reg_and_node = defaultdict(lambda: defaultdict(list))
+            for node, copies in copies_by_node.items():
+                for insn_idx, dst_reg, src_reg in copies:
+                    if src_reg == sp_reg:
+                        saves_by_reg[dst_reg].append((node, insn_idx))
+                    if dst_reg == sp_reg:
+                        restores_by_reg_and_node[src_reg][node].append(insn_idx)
+
+            saved_sp_regs = set()
+            for candidate_reg, reg_name in candidate_regs.items():
+                saves = saves_by_reg[candidate_reg]
+                if len(saves) != 1 or saves[0][0] is not entry_node:
+                    continue
+
+                restores_by_node = restores_by_reg_and_node[candidate_reg]
+                if set(restores_by_node) != endpoint_nodes or any(
+                    len(insn_indices) != 1 for insn_indices in restores_by_node.values()
+                ):
+                    continue
+
+                save_idx = saves[0][1]
+                restore_by_endpoint = {node: insn_indices[0] for node, insn_indices in restores_by_node.items()}
+                if entry_node in endpoint_nodes and save_idx >= restore_by_endpoint[entry_node]:
+                    continue
+
+                clobbered = False
+                for node, writes in writes_by_node.items():
+                    for insn_idx, written_regs in writes:
+                        if candidate_reg not in written_regs:
+                            continue
+                        if node is entry_node and insn_idx <= save_idx:
+                            continue
+                        if node in endpoint_nodes and insn_idx >= restore_by_endpoint[node]:
+                            continue
+                        if node in endpoint_nodes and (insn_idx, candidate_reg) in affine_adjustments_by_node[node]:
+                            continue
+                        clobbered = True
+                        break
+                    if clobbered:
+                        break
+                if clobbered:
+                    continue
+
+                if reg_name in self.project.arch.registers:
+                    saved_sp_regs.add(self.project.arch.registers[reg_name][0])
+
+            return saved_sp_regs
+
+        # TODO: Implement this function for architectures beyond amd64 and ARM
         if self.project.arch.name != "AMD64":
             return set()
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -1240,6 +1240,46 @@ class TestDecompiler(unittest.TestCase):
         assert '"Username: "' in code
         assert '"Password: "' in code
 
+    def test_arm_thumb_stack_pointer_saved_in_r7(self):
+        bin_path = os.path.join(test_location, "armhf", "fauxware")
+        p = angr.Project(bin_path, auto_load_libs=False)
+
+        cfg = p.analyses[CFGFast].prep()(normalize=True)
+        r7_offset = p.arch.registers["r7"][0]
+        sp_offset = p.arch.sp_offset
+        assert r7_offset == 36
+
+        authenticate = cfg.functions[0x104C9]
+        dec = p.analyses[Decompiler].prep(fail_fast=True)(authenticate, cfg=cfg.model)
+        assert dec.clinic is not None
+        spt = dec.clinic._spt  # pylint: disable=protected-access
+        assert spt is not None
+        assert r7_offset in spt.reg_offsets
+        assert not spt.inconsistent_for(sp_offset)
+        assert authenticate.endpoints
+        assert all(spt.offset_after_block(endpoint.addr, sp_offset) == 0 for endpoint in authenticate.endpoints)
+        assert dec.clinic.graph is not None
+        self.assertFalse(
+            any(
+                isinstance(stmt, ailment.Stmt.Assignment)
+                and isinstance(stmt.dst, ailment.Expr.VirtualVariable)
+                and stmt.dst.was_stack
+                and isinstance(stmt.src, ailment.Expr.VirtualVariable)
+                and stmt.src.was_reg
+                and stmt.src.reg_offset == r7_offset
+                for block in dec.clinic.graph
+                for stmt in block.statements
+            ),
+            "saved r7 leaked into final AIL as a register-save spill",
+        )
+
+        accepted = cfg.functions[0x1052D]
+        dec = p.analyses[Decompiler].prep(fail_fast=True)(accepted, cfg=cfg.model)
+        assert dec.clinic is not None
+        spt = dec.clinic._spt  # pylint: disable=protected-access
+        assert spt is not None
+        assert r7_offset not in spt.reg_offsets
+
     @for_all_structuring_algos
     def test_stack_canary_removal_x8664_extra_exits(self, decompiler_options=None):
         # Test stack canary removal on functions with extra exit

--- a/tests/analyses/test_clinic.py
+++ b/tests/analyses/test_clinic.py
@@ -5,9 +5,19 @@ __package__ = __package__ or "tests.analyses"  # pylint:disable=redefined-builti
 
 import os
 import unittest
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest import mock
+
+import capstone
+import networkx
+from archinfo import ArchARMEL, ArchPcode
 
 import angr
 import angr.analyses.decompiler
+from angr.analyses.decompiler.clinic import Clinic
+from angr.analyses.stack_pointer_tracker import TOP, OffsetVal
+from angr.codenode import BlockNode
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
@@ -16,6 +26,142 @@ test_location = os.path.join(bin_location, "tests")
 # pylint: disable=missing-class-docstring
 # pylint: disable=no-self-use
 class TestClinic(unittest.TestCase):
+    @staticmethod
+    def _arm_reg_operand(reg, *, shift=capstone.arm.ARM_SFT_INVALID):
+        return SimpleNamespace(
+            type=capstone.arm.ARM_OP_REG,
+            reg=reg,
+            shift=SimpleNamespace(type=shift),
+        )
+
+    @staticmethod
+    def _arm_imm_operand(value):
+        return SimpleNamespace(type=capstone.arm.ARM_OP_IMM, imm=value)
+
+    @classmethod
+    def _arm_insn(
+        cls,
+        insn_id,
+        operands,
+        writes,
+        *,
+        reads=(),
+        cc=capstone.arm.ARM_CC_AL,
+        size=2,
+        update_flags=False,
+        writeback=False,
+    ):
+        reads = tuple(reads)
+        writes = tuple(writes)
+        return SimpleNamespace(
+            id=insn_id,
+            cc=cc,
+            operands=operands,
+            size=size,
+            update_flags=update_flags,
+            writeback=writeback,
+            regs_access=lambda: (reads, writes),
+        )
+
+    @classmethod
+    def _arm_copy(cls, dst, src, *, cc=capstone.arm.ARM_CC_AL):
+        return cls._arm_insn(
+            capstone.arm.ARM_INS_MOV,
+            [cls._arm_reg_operand(dst), cls._arm_reg_operand(src)],
+            [dst],
+            reads=[src],
+            cc=cc,
+        )
+
+    @classmethod
+    def _arm_affine_copy(cls, dst, src, *, cc=capstone.arm.ARM_CC_AL):
+        return cls._arm_insn(
+            capstone.arm.ARM_INS_ADD,
+            [cls._arm_reg_operand(dst), cls._arm_reg_operand(src), cls._arm_imm_operand(0)],
+            [dst],
+            reads=[src],
+            cc=cc,
+        )
+
+    @classmethod
+    def _arm_adjust(
+        cls,
+        dst,
+        value,
+        *,
+        src=None,
+        insn_id=capstone.arm.ARM_INS_ADD,
+        cc=capstone.arm.ARM_CC_AL,
+        shift=capstone.arm.ARM_SFT_INVALID,
+        writes=None,
+        update_flags=True,
+        writeback=False,
+    ):
+        if src is None:
+            operands = [cls._arm_reg_operand(dst, shift=shift), cls._arm_imm_operand(value)]
+            reads = [dst]
+        else:
+            operands = [
+                cls._arm_reg_operand(dst),
+                cls._arm_reg_operand(src, shift=shift),
+                cls._arm_imm_operand(value),
+            ]
+            reads = [src]
+        return cls._arm_insn(
+            insn_id,
+            operands,
+            [dst] if writes is None else writes,
+            reads=reads,
+            cc=cc,
+            update_flags=update_flags,
+            writeback=writeback,
+        )
+
+    @staticmethod
+    def _arm_block(
+        node,
+        instructions,
+        *,
+        vex_instruction_count=None,
+        vex_instruction_addresses=None,
+        vex_size=None,
+        vex_jumpkind="Ijk_Boring",
+    ):
+        for offset, insn in enumerate(instructions):
+            insn.address = node.addr + offset * insn.size
+        instruction_count = len(instructions) if vex_instruction_count is None else vex_instruction_count
+        vex = SimpleNamespace(
+            instructions=instruction_count,
+            instruction_addresses=(
+                tuple(insn.address for insn in instructions)
+                if vex_instruction_addresses is None
+                else vex_instruction_addresses
+            ),
+            size=node.size if vex_size is None else vex_size,
+            jumpkind=vex_jumpkind,
+        )
+        return SimpleNamespace(capstone=SimpleNamespace(insns=instructions), vex=vex)
+
+    @staticmethod
+    def _arm_clinic(graph, blocks):
+        arch = ArchARMEL()
+        factory = SimpleNamespace(block=mock.Mock(side_effect=lambda addr, **_: blocks[addr]))
+        clinic = object.__new__(Clinic)
+        clinic.project = cast(angr.Project, SimpleNamespace(arch=arch, factory=factory))
+        entry = next(node for node in graph if graph.in_degree(node) == 0)
+        clinic.entry_node_addr = (entry.addr, None)
+        return clinic
+
+    @classmethod
+    def _single_block_saved_sp(cls, middle=(), post_restore=(), *, save=None, restore=None):
+        save = save or cls._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP)
+        restore = restore or cls._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7)
+        instructions = [save, *middle, restore, *post_restore]
+        node = BlockNode(0x1001, sum(insn.size for insn in instructions), thumb=True)
+        graph = networkx.DiGraph()
+        graph.add_node(node)
+        return graph, {node.addr: cls._arm_block(node, instructions)}
+
     def test_smoketest(self):
         binary_path = os.path.join(test_location, "x86_64", "all")
         proj = angr.Project(binary_path, auto_load_libs=False, load_debug_info=True)
@@ -24,6 +170,446 @@ class TestClinic(unittest.TestCase):
         main_func = cfg.kb.functions["main"]
 
         proj.analyses.Clinic(main_func)
+
+    def test_arm_saved_sp_without_capstone_fails_closed(self):
+        arch = object.__new__(ArchPcode)
+        arch.name = "ARM:LE:32:Cortex"
+        assert not arch.capstone_support
+
+        block = BlockNode(0x1001, 2, thumb=True)
+        graph = networkx.DiGraph()
+        graph.add_node(block)
+
+        factory = SimpleNamespace(block=mock.Mock(side_effect=AssertionError("Capstone must not be used")))
+        clinic = object.__new__(Clinic)
+        clinic.project = cast(angr.Project, SimpleNamespace(arch=arch, factory=factory))
+        clinic.entry_node_addr = (block.addr, None)
+
+        assert clinic._find_regs_saving_sp(graph) == set()  # pylint: disable=protected-access
+        factory.block.assert_not_called()
+
+    def test_arm_saved_sp_in_it_block_fails_closed(self):
+        arch = ArchARMEL()
+
+        instructions = [
+            self._arm_insn(capstone.arm.ARM_INS_IT, [], []),
+            self._arm_affine_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP),
+            self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7),
+        ]
+
+        block = BlockNode(0x1001, 6, thumb=True)
+        graph = networkx.DiGraph()
+        graph.add_node(block)
+        factory = SimpleNamespace(
+            block=mock.Mock(return_value=SimpleNamespace(capstone=SimpleNamespace(insns=instructions)))
+        )
+        clinic = object.__new__(Clinic)
+        clinic.project = cast(angr.Project, SimpleNamespace(arch=arch, factory=factory))
+        clinic.entry_node_addr = (block.addr, None)
+
+        assert clinic._find_regs_saving_sp(graph) == set()  # pylint: disable=protected-access
+        factory.block.assert_called_once_with(block.addr, size=block.size, thumb=True, cross_insn_opt=False)
+
+    def test_arm_saved_sp_conditional_save_fails_closed(self):
+        save = self._arm_affine_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP, cc=capstone.arm.ARM_CC_EQ)
+        graph, blocks = self._single_block_saved_sp(save=save)
+        clinic = self._arm_clinic(graph, blocks)
+
+        self.assertEqual(clinic._find_regs_saving_sp(graph), set())  # pylint: disable=protected-access
+
+    def test_arm_saved_sp_invalid_condition_fails_closed(self):
+        save = self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP, cc=capstone.arm.ARM_CC_INVALID)
+        graph, blocks = self._single_block_saved_sp(save=save)
+        clinic = self._arm_clinic(graph, blocks)
+
+        self.assertEqual(clinic._find_regs_saving_sp(graph), set())  # pylint: disable=protected-access
+
+    def test_arm_saved_sp_clobbers_fail_closed(self):
+        clobbers = {
+            "explicit": self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_R11),
+            "load": self._arm_insn(
+                capstone.arm.ARM_INS_LDR,
+                [self._arm_reg_operand(capstone.arm.ARM_REG_R7), self._arm_reg_operand(capstone.arm.ARM_REG_R0)],
+                [capstone.arm.ARM_REG_R7],
+                reads=[capstone.arm.ARM_REG_R0],
+            ),
+            "implicit": self._arm_insn(
+                capstone.arm.ARM_INS_POP,
+                [self._arm_reg_operand(capstone.arm.ARM_REG_R7)],
+                [capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP],
+                reads=[capstone.arm.ARM_REG_SP],
+            ),
+            "writeback": self._arm_insn(
+                capstone.arm.ARM_INS_LDR,
+                [self._arm_reg_operand(capstone.arm.ARM_REG_R0), self._arm_reg_operand(capstone.arm.ARM_REG_R7)],
+                [capstone.arm.ARM_REG_R0, capstone.arm.ARM_REG_R7],
+                reads=[capstone.arm.ARM_REG_R7],
+            ),
+        }
+
+        for clobber_kind, clobber in clobbers.items():
+            with self.subTest(clobber_kind=clobber_kind):
+                graph, blocks = self._single_block_saved_sp(middle=[clobber])
+                clinic = self._arm_clinic(graph, blocks)
+                self.assertEqual(
+                    clinic._find_regs_saving_sp(graph),  # pylint: disable=protected-access
+                    set(),
+                )
+
+    def test_arm_saved_sp_branched_clobber_fails_closed(self):
+        entry_insns = [self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP)]
+        clobber_insns = [self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_R11)]
+        restore_insns = [self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7)]
+        entry = BlockNode(0x1001, 2, thumb=True)
+        clobber = BlockNode(0x1101, 2, thumb=True)
+        left_endpoint = BlockNode(0x1201, 2, thumb=True)
+        right_endpoint = BlockNode(0x1301, 2, thumb=True)
+        graph = networkx.DiGraph([(entry, clobber), (clobber, left_endpoint), (entry, right_endpoint)])
+        blocks = {
+            entry.addr: self._arm_block(entry, entry_insns),
+            clobber.addr: self._arm_block(clobber, clobber_insns),
+            left_endpoint.addr: self._arm_block(left_endpoint, restore_insns),
+            right_endpoint.addr: self._arm_block(
+                right_endpoint, [self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7)]
+            ),
+        }
+        clinic = self._arm_clinic(graph, blocks)
+
+        self.assertEqual(clinic._find_regs_saving_sp(graph), set())  # pylint: disable=protected-access
+
+    def test_arm_saved_sp_restore_topology_fails_closed(self):
+        def save():
+            return self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP)
+
+        def restore():
+            return self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7)
+
+        entry = BlockNode(0x1001, 2, thumb=True)
+        left_endpoint = BlockNode(0x1101, 2, thumb=True)
+        right_endpoint = BlockNode(0x1201, 2, thumb=True)
+        missing_graph = networkx.DiGraph([(entry, left_endpoint), (entry, right_endpoint)])
+        missing_blocks = {
+            entry.addr: self._arm_block(entry, [save()]),
+            left_endpoint.addr: self._arm_block(left_endpoint, [restore()]),
+            right_endpoint.addr: self._arm_block(right_endpoint, [self._arm_insn(capstone.arm.ARM_INS_NOP, [], [])]),
+        }
+
+        duplicate_node = BlockNode(0x2001, 6, thumb=True)
+        duplicate_graph = networkx.DiGraph()
+        duplicate_graph.add_node(duplicate_node)
+        duplicate_blocks = {duplicate_node.addr: self._arm_block(duplicate_node, [save(), restore(), restore()])}
+
+        non_endpoint_entry = BlockNode(0x3001, 2, thumb=True)
+        non_endpoint_restore = BlockNode(0x3101, 2, thumb=True)
+        non_endpoint_endpoint = BlockNode(0x3201, 2, thumb=True)
+        non_endpoint_graph = networkx.DiGraph(
+            [(non_endpoint_entry, non_endpoint_restore), (non_endpoint_restore, non_endpoint_endpoint)]
+        )
+        non_endpoint_blocks = {
+            non_endpoint_entry.addr: self._arm_block(non_endpoint_entry, [save()]),
+            non_endpoint_restore.addr: self._arm_block(non_endpoint_restore, [restore()]),
+            non_endpoint_endpoint.addr: self._arm_block(non_endpoint_endpoint, [restore()]),
+        }
+
+        reversed_node = BlockNode(0x4001, 4, thumb=True)
+        reversed_graph = networkx.DiGraph()
+        reversed_graph.add_node(reversed_node)
+        reversed_blocks = {reversed_node.addr: self._arm_block(reversed_node, [restore(), save()])}
+
+        cases = {
+            "missing_endpoint_restore": (missing_graph, missing_blocks),
+            "duplicate_endpoint_restore": (duplicate_graph, duplicate_blocks),
+            "non_endpoint_restore": (non_endpoint_graph, non_endpoint_blocks),
+            "restore_before_save": (reversed_graph, reversed_blocks),
+        }
+        for topology_kind, (graph, blocks) in cases.items():
+            with self.subTest(topology_kind=topology_kind):
+                clinic = self._arm_clinic(graph, blocks)
+                self.assertEqual(
+                    clinic._find_regs_saving_sp(graph),  # pylint: disable=protected-access
+                    set(),
+                )
+
+    def test_arm_saved_sp_real_endpoint_affine_adjustment_is_allowed(self):
+        adjustment = self._arm_adjust(capstone.arm.ARM_REG_R7, 24)
+        graph, blocks = self._single_block_saved_sp(middle=[adjustment])
+        clinic = self._arm_clinic(graph, blocks)
+        r7_offset = clinic.project.arch.registers["r7"][0]
+
+        self.assertEqual(
+            clinic._find_regs_saving_sp(graph),  # pylint: disable=protected-access
+            {r7_offset},
+        )
+
+    def test_arm_saved_sp_endpoint_affine_adjustments_fail_closed(self):
+        adjustments = {
+            "conditional": self._arm_adjust(capstone.arm.ARM_REG_R7, 24, cc=capstone.arm.ARM_CC_EQ),
+            "other_source": self._arm_adjust(capstone.arm.ARM_REG_R7, 24, src=capstone.arm.ARM_REG_R6),
+            "three_operand_add": self._arm_adjust(capstone.arm.ARM_REG_R7, 24, src=capstone.arm.ARM_REG_R7),
+            "two_operand_sub": self._arm_adjust(capstone.arm.ARM_REG_R7, 24, insn_id=capstone.arm.ARM_INS_SUB),
+            "three_operand_sub": self._arm_adjust(
+                capstone.arm.ARM_REG_R7,
+                24,
+                src=capstone.arm.ARM_REG_R7,
+                insn_id=capstone.arm.ARM_INS_SUB,
+            ),
+            "register_rhs": self._arm_insn(
+                capstone.arm.ARM_INS_ADD,
+                [
+                    self._arm_reg_operand(capstone.arm.ARM_REG_R7),
+                    self._arm_reg_operand(capstone.arm.ARM_REG_R7),
+                    self._arm_reg_operand(capstone.arm.ARM_REG_R0),
+                ],
+                [capstone.arm.ARM_REG_R7],
+                reads=[capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_R0],
+                update_flags=True,
+            ),
+            "shifted_source": self._arm_adjust(
+                capstone.arm.ARM_REG_R7,
+                24,
+                src=capstone.arm.ARM_REG_R7,
+                shift=capstone.arm.ARM_SFT_LSL,
+            ),
+            "implicit_write": self._arm_adjust(
+                capstone.arm.ARM_REG_R0,
+                24,
+                writes=[capstone.arm.ARM_REG_R0, capstone.arm.ARM_REG_R7],
+            ),
+            "writeback": self._arm_adjust(capstone.arm.ARM_REG_R7, 24, writeback=True),
+            "no_flags_update": self._arm_adjust(capstone.arm.ARM_REG_R7, 24, update_flags=False),
+            "unknown_alias": self._arm_adjust(capstone.arm.ARM_REG_R7, 24, insn_id=capstone.arm.ARM_INS_ADC),
+        }
+
+        for adjustment_kind, adjustment in adjustments.items():
+            with self.subTest(adjustment_kind=adjustment_kind):
+                graph, blocks = self._single_block_saved_sp(middle=[adjustment])
+                clinic = self._arm_clinic(graph, blocks)
+                self.assertEqual(
+                    clinic._find_regs_saving_sp(graph),  # pylint: disable=protected-access
+                    set(),
+                )
+
+    def test_arm_saved_sp_non_endpoint_affine_adjustments_fail_closed(self):
+        for adjusted_paths in ("one", "all"):
+            with self.subTest(adjusted_paths=adjusted_paths):
+                entry = BlockNode(0x1001, 2, thumb=True)
+                left = BlockNode(0x1101, 2, thumb=True)
+                right = BlockNode(0x1201, 2, thumb=True)
+                left_endpoint = BlockNode(0x1301, 2, thumb=True)
+                right_endpoint = BlockNode(0x1401, 2, thumb=True)
+                graph = networkx.DiGraph(
+                    [
+                        (entry, left),
+                        (entry, right),
+                        (left, left_endpoint),
+                        (right, right_endpoint),
+                    ]
+                )
+                blocks = {
+                    entry.addr: self._arm_block(
+                        entry, [self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP)]
+                    ),
+                    left.addr: self._arm_block(left, [self._arm_adjust(capstone.arm.ARM_REG_R7, 24)]),
+                    right.addr: self._arm_block(
+                        right,
+                        [
+                            self._arm_adjust(capstone.arm.ARM_REG_R7, 24)
+                            if adjusted_paths == "all"
+                            else self._arm_insn(capstone.arm.ARM_INS_NOP, [], [])
+                        ],
+                    ),
+                    left_endpoint.addr: self._arm_block(
+                        left_endpoint,
+                        [self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7)],
+                    ),
+                    right_endpoint.addr: self._arm_block(
+                        right_endpoint,
+                        [self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7)],
+                    ),
+                }
+                clinic = self._arm_clinic(graph, blocks)
+
+                self.assertEqual(
+                    clinic._find_regs_saving_sp(graph),  # pylint: disable=protected-access
+                    set(),
+                )
+
+    def test_arm_saved_sp_loop_affine_adjustment_fails_closed(self):
+        entry = BlockNode(0x1001, 2, thumb=True)
+        loop = BlockNode(0x1101, 2, thumb=True)
+        endpoint = BlockNode(0x1201, 2, thumb=True)
+        graph = networkx.DiGraph([(entry, loop), (loop, loop), (loop, endpoint)])
+        blocks = {
+            entry.addr: self._arm_block(entry, [self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP)]),
+            loop.addr: self._arm_block(loop, [self._arm_adjust(capstone.arm.ARM_REG_R7, 24)]),
+            endpoint.addr: self._arm_block(
+                endpoint, [self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7)]
+            ),
+        }
+        clinic = self._arm_clinic(graph, blocks)
+
+        self.assertEqual(clinic._find_regs_saving_sp(graph), set())  # pylint: disable=protected-access
+
+    def test_arm_saved_sp_multiple_endpoint_affine_adjustments_are_allowed(self):
+        entry = BlockNode(0x1001, 2, thumb=True)
+        left_endpoint = BlockNode(0x1101, 4, thumb=True)
+        right_endpoint = BlockNode(0x1201, 4, thumb=True)
+        graph = networkx.DiGraph([(entry, left_endpoint), (entry, right_endpoint)])
+        blocks = {
+            entry.addr: self._arm_block(entry, [self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP)]),
+            left_endpoint.addr: self._arm_block(
+                left_endpoint,
+                [
+                    self._arm_adjust(capstone.arm.ARM_REG_R7, 24),
+                    self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7),
+                ],
+            ),
+            right_endpoint.addr: self._arm_block(
+                right_endpoint,
+                [
+                    self._arm_adjust(
+                        capstone.arm.ARM_REG_R7,
+                        24,
+                    ),
+                    self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7),
+                ],
+            ),
+        }
+        clinic = self._arm_clinic(graph, blocks)
+        r7_offset = clinic.project.arch.registers["r7"][0]
+
+        self.assertEqual(
+            clinic._find_regs_saving_sp(graph),  # pylint: disable=protected-access
+            {r7_offset},
+        )
+
+    def test_arm_saved_sp_write_after_restore_is_allowed(self):
+        pop_r7 = self._arm_insn(
+            capstone.arm.ARM_INS_POP,
+            [self._arm_reg_operand(capstone.arm.ARM_REG_R7)],
+            [capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP],
+            reads=[capstone.arm.ARM_REG_SP],
+        )
+        graph, blocks = self._single_block_saved_sp(post_restore=[pop_r7])
+        clinic = self._arm_clinic(graph, blocks)
+        r7_offset = clinic.project.arch.registers["r7"][0]
+
+        self.assertEqual(clinic._find_regs_saving_sp(graph), {r7_offset})  # pylint: disable=protected-access
+
+    def test_arm_saved_sp_unknown_register_access_fails_closed(self):
+        unknown = self._arm_insn(capstone.arm.ARM_INS_NOP, [], [])
+
+        def unavailable_access():
+            raise capstone.CsError(capstone.CS_ERR_DETAIL)
+
+        unknown.regs_access = unavailable_access
+        graph, blocks = self._single_block_saved_sp(middle=[unknown])
+        clinic = self._arm_clinic(graph, blocks)
+
+        self.assertEqual(clinic._find_regs_saving_sp(graph), set())  # pylint: disable=protected-access
+
+    def test_arm_saved_sp_vex_mismatches_fail_closed(self):
+        for mismatch_kind in ("instruction_count", "instruction_addresses", "size", "no_decode"):
+            with self.subTest(mismatch_kind=mismatch_kind):
+                graph, blocks = self._single_block_saved_sp()
+                node = next(iter(graph))
+                instructions = blocks[node.addr].capstone.insns
+                block_options: dict[str, Any] = {}
+                if mismatch_kind == "instruction_count":
+                    block_options["vex_instruction_count"] = len(instructions) - 1
+                elif mismatch_kind == "instruction_addresses":
+                    addresses = tuple(insn.address for insn in instructions)
+                    block_options["vex_instruction_addresses"] = (addresses[0] + 2, *addresses[1:])
+                elif mismatch_kind == "size":
+                    block_options["vex_size"] = node.size - 2
+                else:
+                    block_options["vex_jumpkind"] = "Ijk_NoDecode"
+                blocks[node.addr] = self._arm_block(node, instructions, **block_options)
+                clinic = self._arm_clinic(graph, blocks)
+
+                self.assertEqual(
+                    clinic._find_regs_saving_sp(graph),  # pylint: disable=protected-access
+                    set(),
+                )
+
+    def test_arm_saved_sp_candidate_initial_value_is_top(self):
+        save = self._arm_copy(capstone.arm.ARM_REG_R11, capstone.arm.ARM_REG_SP)
+        restore = self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R11)
+        graph, blocks = self._single_block_saved_sp(save=save, restore=restore)
+        clinic = self._arm_clinic(graph, blocks)
+        cast(Any, clinic).function = SimpleNamespace(graph=graph, normalized=True)
+        clinic._func_graph = graph  # pylint: disable=protected-access
+        clinic._sp_shift = 0  # pylint: disable=protected-access
+        clinic._fail_fast = False  # pylint: disable=protected-access
+        clinic._sp_tracker_track_memory = False  # pylint: disable=protected-access
+        stack_pointer_tracker = SimpleNamespace(inconsistent_for=mock.Mock(return_value=False))
+        stack_pointer_tracker_analysis = mock.Mock(return_value=stack_pointer_tracker)
+        cast(Any, clinic.project).analyses = SimpleNamespace(StackPointerTracker=stack_pointer_tracker_analysis)
+
+        self.assertIs(clinic._track_stack_pointers(), stack_pointer_tracker)  # pylint: disable=protected-access
+
+        _, tracked_regs = stack_pointer_tracker_analysis.call_args.args
+        initial_reg_values = stack_pointer_tracker_analysis.call_args.kwargs["initial_reg_values"]
+        r11_offset = clinic.project.arch.registers["r11"][0]
+        self.assertEqual(r11_offset, clinic.project.arch.bp_offset)
+        self.assertIn(r11_offset, tracked_regs)
+        self.assertIs(initial_reg_values[r11_offset], TOP)
+        self.assertIsInstance(initial_reg_values[clinic.project.arch.sp_offset], OffsetVal)
+
+    def test_arm_saved_sp_unnormalized_function_fails_closed(self):
+        graph, blocks = self._single_block_saved_sp()
+        clinic = self._arm_clinic(graph, blocks)
+        cast(Any, clinic).function = SimpleNamespace(graph=graph, normalized=False)
+        clinic._func_graph = graph  # pylint: disable=protected-access
+        clinic._sp_shift = 0  # pylint: disable=protected-access
+        clinic._fail_fast = False  # pylint: disable=protected-access
+        clinic._sp_tracker_track_memory = False  # pylint: disable=protected-access
+        stack_pointer_tracker = SimpleNamespace(inconsistent_for=mock.Mock(return_value=False))
+        stack_pointer_tracker_analysis = mock.Mock(return_value=stack_pointer_tracker)
+        cast(Any, clinic.project).analyses = SimpleNamespace(StackPointerTracker=stack_pointer_tracker_analysis)
+
+        self.assertIs(clinic._track_stack_pointers(), stack_pointer_tracker)  # pylint: disable=protected-access
+
+        _, tracked_regs = stack_pointer_tracker_analysis.call_args.args
+        initial_reg_values = stack_pointer_tracker_analysis.call_args.kwargs["initial_reg_values"]
+        r7_offset = clinic.project.arch.registers["r7"][0]
+        self.assertNotIn(r7_offset, tracked_regs)
+        self.assertNotIn(r7_offset, initial_reg_values)
+
+    def test_arm_saved_sp_exception_clobber_uses_full_function_graph(self):
+        entry_insns = [self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_SP)]
+        clobber_insns = [self._arm_copy(capstone.arm.ARM_REG_R7, capstone.arm.ARM_REG_R11)]
+        restore_insns = [self._arm_copy(capstone.arm.ARM_REG_SP, capstone.arm.ARM_REG_R7)]
+        entry = BlockNode(0x1001, 2, thumb=True)
+        handler = BlockNode(0x1101, 2, thumb=True)
+        endpoint = BlockNode(0x1201, 2, thumb=True)
+        full_graph = networkx.DiGraph()
+        full_graph.add_edge(entry, endpoint)
+        full_graph.add_edge(entry, handler, type="exception")
+        full_graph.add_edge(handler, endpoint)
+        filtered_graph = networkx.DiGraph([(entry, endpoint)])
+        blocks = {
+            entry.addr: self._arm_block(entry, entry_insns),
+            handler.addr: self._arm_block(handler, clobber_insns),
+            endpoint.addr: self._arm_block(endpoint, restore_insns),
+        }
+        clinic = self._arm_clinic(full_graph, blocks)
+        cast(Any, clinic).function = SimpleNamespace(graph=full_graph, normalized=True)
+        clinic._func_graph = filtered_graph  # pylint: disable=protected-access
+        clinic._sp_shift = 0  # pylint: disable=protected-access
+        clinic._fail_fast = False  # pylint: disable=protected-access
+        clinic._sp_tracker_track_memory = False  # pylint: disable=protected-access
+        stack_pointer_tracker = SimpleNamespace(inconsistent_for=mock.Mock(return_value=False))
+        stack_pointer_tracker_analysis = mock.Mock(return_value=stack_pointer_tracker)
+        cast(Any, clinic.project).analyses = SimpleNamespace(StackPointerTracker=stack_pointer_tracker_analysis)
+
+        self.assertIs(clinic._track_stack_pointers(), stack_pointer_tracker)  # pylint: disable=protected-access
+
+        _, tracked_regs = stack_pointer_tracker_analysis.call_args.args
+        initial_reg_values = stack_pointer_tracker_analysis.call_args.kwargs["initial_reg_values"]
+        r7_offset = clinic.project.arch.registers["r7"][0]
+        self.assertNotIn(r7_offset, tracked_regs)
+        self.assertNotIn(r7_offset, initial_reg_values)
 
 
 if __name__ == "__main__":

--- a/tests/analyses/test_stack_pointer_tracker.py
+++ b/tests/analyses/test_stack_pointer_tracker.py
@@ -9,6 +9,7 @@ import os
 import unittest
 
 import angr
+from angr.analyses.stack_pointer_tracker import OffsetVal, Register
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
@@ -59,6 +60,25 @@ class TestStackPointerTracker(unittest.TestCase):
         sp_result, bp_result = run_tracker(track_mem=False, use_bp=True)
         assert sp_result == 8
         assert bp_result is None
+
+    def test_stack_pointer_tracker_explicit_initial_bp_copied_from_sp(self):
+        p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        p.analyses.CFGFast()
+        main = p.kb.functions["main"]
+        sp = p.arch.sp_offset
+        bp = p.arch.bp_offset
+        initial_reg_values = {
+            sp: OffsetVal(Register(sp, p.arch.bits), 0x20),
+            bp: OffsetVal(Register(bp, p.arch.bits), 0x40),
+        }
+
+        sptracker = p.analyses.StackPointerTracker(
+            main, {sp, bp}, track_memory=True, initial_reg_values=initial_reg_values
+        )
+
+        self.assertEqual(sptracker.offset_after(0x40071D, sp), 0x18)
+        self.assertEqual(sptracker.offset_after(0x40071D, bp), 0x40)
+        self.assertEqual(sptracker.offset_after(0x40071E, bp), 0x18)
 
     def test_stack_pointer_tracker_just_sp(self):
         sp_result = run_tracker(track_mem=False, use_bp=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

On `tests/armhf/fauxware`, `authenticate` at `0x104c9` saves `sp` in `r7` and restores it in the epilogue. The baseline leaves the endpoint stack pointer inconsistent and leaks one raw-`r7` stack assignment into final AIL.

### Root cause

`StackPointerTracker` carries stack-pointer provenance through `sp` and `bp`, but Clinic did not recognize an unambiguous callee-saved register as a saved stack pointer.

### Fix

Clinic accepts a saved-SP register only when normalized VEX topology and Capstone decoding prove one save, one restore, and a clobber-free path. Ambiguous paths remain `TOP`.

### Testing

The real-fixture regression checks consistent endpoint SP values and zero final-AIL stack assignments sourced from raw `r7`. Validation: https://github.com/angr/angr/pull/6900#issuecomment-5360192757

session: sharpen
