### PR TITLE
CFGFast: Do not delete a block another function still owns

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -4814,9 +4814,13 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 # TODO: Handle Ijk_Privileged in user-space binaries
                 # TODO: Include conditional jumps that jump to data
 
+        shared_block_addrs = self._blocks_owned_by_other_functions(full_funcs_to_remove)
+
         for func_addr in full_funcs_to_remove:
             func = self.kb.functions.get_by_addr(func_addr, meta_only=True)
             for block_addr in list(func.block_addrs_set):
+                if block_addr in shared_block_addrs:
+                    continue
                 cfg_node = self.model.get_any_node(block_addr)
                 if cfg_node is not None:
                     # mark all blocks as data
@@ -4831,6 +4835,35 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 self.model.remove_node_and_graph_node(cfg_node)
             if self.kb.functions.contains_addr(node_addr):
                 del self.kb.functions[func_addr]
+
+    def _blocks_owned_by_other_functions(self, func_addrs_to_remove: list[int]) -> set[int]:
+        """
+        Collect the blocks of the given functions that a function outside that set also owns.
+
+        :param func_addrs_to_remove: Addresses of the functions that are about to be removed.
+        :return:                     Addresses of those blocks that a function outside the set also owns.
+        """
+
+        if not func_addrs_to_remove:
+            return set()
+
+        removed_func_addrs = set(func_addrs_to_remove)
+        unclaimed_block_addrs: set[int] = set()
+        for func_addr in removed_func_addrs:
+            unclaimed_block_addrs |= self.kb.functions.get_by_addr(func_addr, meta_only=True).block_addrs_set
+
+        shared_block_addrs: set[int] = set()
+        for func_addr in self.kb.functions:
+            if func_addr in removed_func_addrs:
+                continue
+            func = self.kb.functions.get_by_addr(func_addr, meta_only=True)
+            shared = unclaimed_block_addrs & func.block_addrs_set
+            if shared:
+                shared_block_addrs |= shared
+                unclaimed_block_addrs -= shared
+                if not unclaimed_block_addrs:
+                    break
+        return shared_block_addrs
 
     def _analyze_all_function_features(self, all_funcs_completed=False):
         """

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,21 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_dropping_a_bad_function_keeps_the_blocks_another_function_owns(self):
+        # drop_bad_functions() drops 0x46cd99: it does not return, it has three blocks, and the last of them
+        # has no successors and is followed by alignment padding. That last block is 0x46cdb0, the fall-through
+        # of the call at 0x46cdab, and it is also the entire body of core::slice::iter::Iter::size_hint, which
+        # the binary's own symbol table names. Removing the dropped function's CFG nodes took the named
+        # function with it.
+        proj = angr.Project(os.path.join(test_location, "x86_64", "decompiler", "fmt_rust"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast()
+
+        assert 0x46CD99 not in cfg.kb.functions
+        assert cfg.model.get_any_node(0x46CD99) is None
+        assert 0x46CDB0 in cfg.kb.functions
+        assert cfg.kb.functions.get_by_addr(0x46CDB0).block_addrs_set == {0x46CDB0}
+        assert cfg.model.get_any_node(0x46CDB0) is not None
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`drop_bad_functions()` removes a function by deleting the CFG node of every block in its
block set, without checking whether a function it keeps owns the same block. On
`binaries/tests/x86_64/decompiler/fmt_rust` that also deletes
`core::slice::iter::Iter::size_hint` at `0x46cdb0`, which the binary's own symbol table
names:

```
0x46cd99  CFG node : None
0x46cd99  function : (not in kb.functions)
0x46cdb0  CFG node : None
0x46cdb0  function : (not in kb.functions)
functions owning 0x46cdb0 as a block: []
```

`0x46cd99` is the function being dropped, and dropping it is correct. `0x46cdb0` is its
last block, and it is also the entire body of `size_hint`. What goes with it is not just
the function entry: the CFG node leaves the model and the range is re-marked as data, so
callers, cross references and decompilation all see nothing at that address.

### Root cause

Immediately before the removal loop runs, both functions exist and share the block:

```
0x46cd99 sub_46cd99 blocks=['0x46cd99', '0x46cda8', '0x46cdb0'] returning=False from_symbol=False
0x46cdb0 _ZN91_$LT$core..slice..iter..Iter$LT$T$GT$$u20$as$u20$core..iter..traits..iterator..Iterator$GT$9size_hint17h0d2f53ad5a172c5dE blocks=['0x46cdb0'] returning=True from_symbol=True
```

The loop walks the dropped function's block set and consults nothing else:

```python
for func_addr in full_funcs_to_remove:
    func = self.kb.functions.get_by_addr(func_addr, meta_only=True)
    for block_addr in list(func.block_addrs_set):
        cfg_node = self.model.get_any_node(block_addr)
        if cfg_node is not None:
            self._seg_list.occupy(cfg_node.addr, cfg_node.size, "unknown")
            self.model.remove_node_and_graph_node(cfg_node)
    del self.kb.functions[func_addr]
```

A block address has one CFG node however many functions claim it, so removing the node
removes it for all of them. The selection loop above does refuse to drop a function the
symbol table names — `if func_addr in self._function_addresses_from_symbols: continue` —
but that guard only decides which function is dropped. It does not keep a named
function's blocks out of a different function's removal.

### Fix

Collect the blocks a surviving function still owns before the loop starts, in a new
`_blocks_owned_by_other_functions()`, and skip them:

```python
shared_block_addrs = self._blocks_owned_by_other_functions(full_funcs_to_remove)

for func_addr in full_funcs_to_remove:
    func = self.kb.functions.get_by_addr(func_addr, meta_only=True)
    for block_addr in list(func.block_addrs_set):
        if block_addr in shared_block_addrs:
            continue
```

`CFGNode.function_address` cannot stand in for that set: on most of the blocks that need
sparing it names the function being dropped. Same reproducer, after:

```
0x46cd99  CFG node : None
0x46cd99  function : (not in kb.functions)
0x46cdb0  CFG node : <CFGNode _ZN91_$LT$core..slice..iter..Iter$LT$T$GT$$u20$as$u20$core..iter..traits..iterator..Iterator$GT$9size_hint17h0d2f53ad5a172c5dE [39]>
0x46cdb0  function : _ZN91_$LT$core..slice..iter..Iter$LT$T$GT$$u20$as$u20$core..iter..traits..iterator..Iterator$GT$9size_hint17h0d2f53ad5a172c5dE  blocks=['0x46cdb0']
functions owning 0x46cdb0 as a block: ['0x46cdb0']
```

The bad function still goes; only the block another function owns survives it.

### Testing

`test_dropping_a_bad_function_keeps_the_blocks_another_function_owns` loads `fmt_rust`
and asserts that `0x46cd99` is gone from both `kb.functions` and the CFG model while
`0x46cdb0` stays in both with its single-block body intact. It fails on master, where
`0x46cdb0` is absent from both. Independent of #6865 and #6867 in the same routine.

Validation: https://github.com/angr/angr/pull/6901#issuecomment-5367606408

session: sharpen