### PR TITLE
CFGFast: Fix a KeyError from _remove_redundant_overlapping_blocks on ARM.

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -4928,7 +4928,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
         removed_node_keys = set()
 
-        a_key = None  # a is always the most recent non-removed node
+        a_key = None  # a is always the most recent node that is still in the graph
         is_arm = is_arm_arch(self.project.arch)
 
         for i in range(len(sorted_node_keys)):  # pylint:disable=consider-using-enumerate
@@ -4942,6 +4942,14 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
             if b_key in removed_node_keys:
                 # skip all removed nodes
+                continue
+
+            # the _scan_block() call at the bottom of this loop drops the blocks whose decoding assumptions it
+            # invalidates, anywhere in the graph, so a key from the snapshot above may no longer name a node
+            if not self.graph.has_node_key(b_key):
+                continue
+            if not self.graph.has_node_key(a_key):
+                a_key = b_key
                 continue
 
             a_addr = block_key_to_addr(a_key)

--- a/angr/knowledge_plugins/cfg/spilling_cfg.py
+++ b/angr/knowledge_plugins/cfg/spilling_cfg.py
@@ -954,7 +954,9 @@ class SpillingCFG:
         self._out_degree_cache.pop(block_key, None)
 
     def has_node(self, node: CFGNode) -> bool:
-        block_key = get_block_key(node)
+        return self.has_node_key(get_block_key(node))
+
+    def has_node_key(self, block_key: K) -> bool:
         return block_key in self._graph
 
     def nodes_by_addr(self, addr: int) -> Iterator[CFGNode]:

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1182,6 +1182,15 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_arm_overlapping_blocks_survive_a_rescan_that_drops_blocks(self):
+        # _remove_redundant_overlapping_blocks() walks a snapshot of the graph's node keys, and rescans the leftover
+        # of every block it truncates. That rescan invalidates decoding assumptions and drops the blocks that rest on
+        # them, so a key in the snapshot can stop naming a node of the graph before the walk reaches it.
+        proj = angr.Project(os.path.join(test_location, "armel", "libc.so.6"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast()
+
+        assert len(cfg.kb.functions) > 1000, f"CFGFast recovered only {len(cfg.kb.functions)} functions"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast()` with default options raises `KeyError` on `binaries/tests/armel/libc.so.6`:

```
  File "angr/analyses/cfg/cfg_fast.py", line 2973, in _post_analysis
    self._remove_redundant_overlapping_blocks(function_alignment=4, is_arm=True)
  File "angr/analyses/cfg/cfg_fast.py", line 4996, in _remove_redundant_overlapping_blocks
    a = self.graph.get_node_by_key(a_key)
  File "angr/knowledge_plugins/cfg/spilling_cfg.py", line 840, in get_node_by_key
    raise KeyError(block_key)
KeyError: (4468187, 6)
```

Nothing is recoverable from this: the exception escapes `_post_analysis()`, so the caller gets no CFG at all rather than a degraded one.

### Root cause

`_remove_redundant_overlapping_blocks` walks `sorted_node_keys`, a snapshot taken before the loop, and pairs each key with `a_key`, the most recent key it has kept. The only removals it accounts for are the ones it performs itself:

```python
removed_node_keys = set()
...
if b_key in removed_node_keys:
    # skip all removed nodes
    continue
```

When the walk truncates a block it rescans the leftover, inside the same loop:

```python
dummy_job = CFGJob(new_b_addr, a.function_address, "Ijk_Boring", job_type=CFGJobType.NORMAL)
self._scan_block(dummy_job)
```

On ARM a scan that fails to decode reaches `_cascading_remove_lifted_blocks`, which drops every block resting on the decoding assumption it just invalidated — anywhere in the graph, including keys the walk has already passed and keys it has yet to reach. `removed_node_keys` never hears about those. `0x442ddb` (`4468187`) is such a key, still held in `a_key` when the walk reaches `a = self.graph.get_node_by_key(a_key)` further down the loop body, and that call raises on it.

### Fix

Ask the graph whether a key still names a node, through a `has_node_key` beside `SpillingCFG`'s existing `has_node`, which is rewritten in terms of it:

```python
def has_node(self, node: CFGNode) -> bool:
    return self.has_node_key(get_block_key(node))

def has_node_key(self, block_key: K) -> bool:
    return block_key in self._graph
```

The walk skips a `b_key` that no longer names a node, and where it is `a_key` that has gone it adopts `b_key` as the new `a`, so the pairing resumes from a node that exists. All three call sites of `_cascading_remove_lifted_blocks` are on the ARM decoding paths, so no other architecture reaches either skip. The same run, after:

```
CFGFast() returned
  CFG nodes = 65807
  functions = 8930
```

### Testing

`test_arm_overlapping_blocks_survive_a_rescan_that_drops_blocks` loads `tests/armel/libc.so.6`, runs a default `CFGFast()` and asserts more than 1000 functions come back. It fails on master with the `KeyError` above.

#199 reports this state under its 2016 symptom, and #6241 turned what #4578 left into a `KeyError`. #6764 and #6808 are a separate defect in the first loop of this function; neither fixes the other.

Validation: https://github.com/angr/angr/pull/6902#issuecomment-5379628979

session: sharpen
