### PR TITLE
CFGFast: Correct a returning status that no return site supports

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -7,7 +7,7 @@ import math
 import re
 import string
 import time
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, deque
 from collections.abc import Iterator
 from enum import Enum, unique
 from typing import TYPE_CHECKING, Any
@@ -31,6 +31,7 @@ from angr.codenode import FuncNode, HookNode
 from angr.errors import (
     AngrCFGError,
     AngrSkipJobNotice,
+    AngrUnsupportedSyscallError,
     SimEngineError,
     SimIRSBNoDecodeError,
     SimMemoryError,
@@ -48,6 +49,8 @@ from angr.knowledge_plugins.cfg import (
 from angr.knowledge_plugins.cfg.spilling_cfg import block_key_to_addr, block_key_to_size, get_block_key
 from angr.knowledge_plugins.xrefs import XRef, XRefType
 from angr.misc.ux import once
+from angr.procedures.stubs.PathTerminator import PathTerminator
+from angr.procedures.stubs.UnresolvableJumpTarget import UnresolvableJumpTarget
 from angr.rustylib import SegmentList
 from angr.simos import SimWindows
 from angr.utils.constants import DEFAULT_STATEMENT
@@ -82,6 +85,7 @@ if TYPE_CHECKING:
     from angr.engines.pcode.lifter import IRSB as PcodeIRSB
     from angr.knowledge_plugins.cfg.spilling_cfg import SpillingCFG
     from angr.knowledge_plugins.cfg.types import CFGNODE_K
+    from angr.knowledge_plugins.functions.function import Function
 
 
 VEX_IRSB_MAX_SIZE = 400
@@ -2698,6 +2702,8 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         # before the returning fixpoint runs over it.
         self._apply_go_noreturn_funcs()
 
+        # ahead of the loop below, which reads nonreturning_func_addrs() to strip the fall-through edges
+        self._revise_returning_of_functions_that_cannot_return()
         self._analyze_all_function_features(all_funcs_completed=True)
 
         # Scan all functions, and make sure all fake ret edges are either confirmed or removed
@@ -4970,6 +4976,99 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                             self._updated_nonreturning_functions.add(fr.caller_func_addr)
 
                     del self._function_returns[nonreturning_function_addr]
+
+    def _revise_returning_of_functions_that_cannot_return(self):
+        """
+        Correct a returning status that the rebuilt functions no longer support.
+
+        Function.returning is only ever set while the CFG is recovered and never revised, and
+        make_functions() copies a recorded True onto the rebuilt function. That True can come from
+        a block the rebuild has just taken away: the fall-through of a call to a function that does
+        not return carries its blocks, and any ret among them, into another function. What is left
+        owns no return site at all and still claims to return, and _analyze_function_features()
+        skips it from then on because its status is no longer unknown.
+
+        Decide the correction from the procedures that declare NO_RET, not from the returning
+        status of the callee. That status is False both for a callee that cannot come back and for
+        one whose exit was never recovered -- an ARM function that tail-jumps into the unmapped
+        kuser helper page, say -- and a function angr failed to find the exit of is not evidence
+        that its callers do not return.
+        """
+
+        functions = self.functions
+        cannot_return: set[int] = {
+            func_addr for func_addr in functions.function_addrs_set if self._declares_no_ret(func_addr)
+        }
+        worklist: deque[int] = deque(cannot_return)
+
+        while worklist:
+            callee_addr = worklist.popleft()
+            if callee_addr not in functions.callgraph:
+                continue
+            for caller_addr in functions.callgraph.predecessors(callee_addr):
+                if caller_addr in cannot_return or not functions.contains_addr(caller_addr):
+                    continue
+                # most callers of a function that never returns keep a ret of their own; settle those from the
+                # metadata rather than deserializing the whole function and evicting a live one to make room
+                meta = functions.get_by_addr(caller_addr, meta_only=True)
+                if meta.is_simprocedure or meta.has_return or not meta.block_addrs_set:
+                    continue
+                caller = functions.get_by_addr(caller_addr)
+                if not self._all_ways_out_cannot_return(caller, cannot_return):
+                    continue
+                cannot_return.add(caller_addr)
+                worklist.append(caller_addr)
+                if caller.returning is True:
+                    caller.returning = False
+
+    def _declares_no_ret(self, func_addr: int) -> bool:
+        """
+        Does a procedure that stands in for ``func_addr`` declare that it never returns?
+
+        UnresolvableJumpTarget and PathTerminator carry NO_RET to stop exploration and say that
+        angr does not know where control went, not that it cannot come back;
+        _determine_function_returning() leaves UnresolvableJumpTarget out for the same reason.
+        """
+
+        if self.project.is_hooked(func_addr):
+            procedure = self.project.hooked_by(func_addr)
+        else:
+            try:
+                procedure = self.project.simos.syscall_from_addr(func_addr, allow_unsupported=False)
+            except AngrUnsupportedSyscallError:
+                procedure = None
+        if procedure is None or not procedure.NO_RET:
+            return False
+        return not isinstance(procedure, (UnresolvableJumpTarget, PathTerminator))
+
+    def _all_ways_out_cannot_return(self, func: Function, cannot_return: set[int]) -> bool:
+        """
+        Does every way out of ``func`` hand control to a function in ``cannot_return``?
+
+        Read the ways out of the transition graph rather than from Function.endpoints, which does
+        not hold the calls yet: mark_nonreturning_calls_endpoints() adds those only once every
+        returning status is settled, which is what this is deciding. A call is a way out exactly
+        when the rebuild left it without a fall-through, which is how make_functions() records a
+        callee that does not come back; a fall-through the rebuild put in another function is a
+        way out as well, since what happens after it is that function's business.
+        """
+
+        graph = func.transition_graph
+        edges = list(graph.edges(data=True))
+        with_fallthrough = {src for src, _, data in edges if data.get("type") == "fake_return"}
+        ways_out = []
+        for src, dst, data in edges:
+            type_ = data.get("type")
+            if type_ in ("call", "syscall"):
+                if src not in with_fallthrough:
+                    ways_out.append(dst.addr)
+            elif data.get("outside") and type_ in ("transition", "fake_return"):
+                # a tail jump, or a call whose fall-through the rebuild put in another function
+                ways_out.append(dst.addr)
+        if not ways_out:
+            # nothing leaves the function, so angr never found its exit. That is not evidence.
+            return False
+        return all(addr in cannot_return for addr in ways_out)
 
     def _pop_pending_job(self, returning=True) -> CFGJob | None:
         while self._pending_jobs:

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,42 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_function_whose_only_exit_is_a_noreturn_call_does_not_return(self):
+        # pthread_exit and __pthread_unwind_next are each one block ending in a call to
+        # __pthread_unwind, whose own only way out reaches a SimProcedure that declares NO_RET.
+        # Neither has a ret. While the CFG is recovered the call sites are walked past before the
+        # callee is settled, so both pick up the blocks that follow and are recorded as returning;
+        # make_functions() takes those blocks away again but keeps the recorded status.
+        proj = angr.Project(os.path.join(test_location, "i386", "libpthread.so.0"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        for addr in (0x408020, 0x40D800):
+            func = cfg.kb.functions[addr]
+            assert not func.ret_sites
+            assert func.returning is False, f"{func.name} should not return"
+
+        # correcting the status must not move a block or invent a function. 0x40c3c6 is one byte
+        # of hlt behind __pthread_once's call to __pthread_unwind_next, inside __pthread_once's
+        # .eh_frame range 0x40c2e0..0x40c3c7, and it stays where both ground truths put it.
+        once = cfg.kb.functions[0x40C2E0]
+        assert 0x40C3C6 in once.block_addrs_set
+        assert 0x40C3C6 not in cfg.kb.functions
+        assert max(block.addr + block.size for block in once.blocks) - once.addr == 0xE7
+
+    def test_callee_whose_exit_was_never_recovered_does_not_make_its_callers_nonreturning(self):
+        # __aeabi_read_tp jumps into the ARM kuser helper page at 0xffff0fe0, which the kernel
+        # provides and CLE never maps, so angr recovers no exit for it and reads it, and
+        # __errno_location and strtol and vfprintf above it, as non-returning. That is a failure
+        # to recover rather than evidence about the callee, and it must not reach the callers:
+        # printf, fprintf and atoi all return, and each one's only recovered way out is a call to
+        # a function in that chain.
+        proj = angr.Project(os.path.join(test_location, "armel", "libc.so.6"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        for addr in (0x4469C0, 0x446990, 0x42EC3C):
+            func = cfg.kb.functions[addr]
+            assert func.returning is True, f"{func.name} should still return"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Function.returning` is decided while the CFG is recovered and never revised, so a function can be left claiming to return with no `ret` anywhere in it. On `binaries/tests/i386/libpthread.so.0`, `pthread_exit` at `0x408020` and `__pthread_unwind_next` at `0x40d800` are each one block ending in a call to `__pthread_unwind` at `0x40d7a0`:

```
pthread_exit at 0x408020
  returning              = True
  ret_sites              = []
  in nonreturning_func_addrs() = False
  edges out of its transition graph:
    0x408020 -> 0x40d7a0  type=call
```

Nothing re-derives that afterwards, so every consumer that asks whether the call comes back — `nonreturning_func_addrs()`, and the fall-through edges settled from it, among them — is told yes.

### Root cause

While the CFG is recovered, the call site is walked past before the callee is settled, so the function picks up the blocks that follow the call and a `ret` among them records it as returning. `make_functions()` then rebuilds it without those blocks, the callee being known not to return by that point, but copies the recorded status onto the rebuilt function. `_analyze_function_features()` only ever decides a status that is still unknown, so it does not revisit one that is now wrong.

### Fix

Correct the status after the rebuild, in `_revise_returning_of_functions_that_cannot_return()`, run between `make_functions()` and the `_analyze_all_function_features()` call that precedes the fall-through loop. It seeds a worklist with the functions whose stand-in procedure declares `NO_RET` and walks the callgraph backwards, flipping a caller to `False` only where it owns no return site and every recovered way out reaches something already in that set.

The seed is a `NO_RET` declaration, not the callee's `returning`:

```python
if procedure is None or not procedure.NO_RET:
    return False
return not isinstance(procedure, (UnresolvableJumpTarget, PathTerminator))
```

`returning is False` is equally what a function angr failed to find the exit of looks like, and that is not evidence about its callers. Same reproducer, after:

```
pthread_exit at 0x408020
  returning              = False
  ret_sites              = []
  in nonreturning_func_addrs() = True
```

An already-confirmed fall-through edge stays where it is — `0x40c3bd` in `__pthread_once` keeps its edge to `0x40c3c6` on both sides — because the loop that strips fall-throughs skips a `confirmed` edge. This corrects the status, not the edges already settled from it.

### Testing

`test_function_whose_only_exit_is_a_noreturn_call_does_not_return` asserts that `0x408020` and `0x40d800` own no return site and report `returning is False`; both report `True` on master. It also pins `0x40c3c6`, one byte of `hlt` behind `__pthread_once`'s call, inside `__pthread_once` at `0x40c2e0` rather than as a function of its own, and pins that function's extent at `0xe7` bytes, so the correction moves no block and invents none.

`test_callee_whose_exit_was_never_recovered_does_not_make_its_callers_nonreturning` pins `printf`, `fprintf` and `atoi` on `armel/libc.so.6` as returning. There `strtol` at `0x4319b4` and `__errno_location` at `0x415b20` come back with `returning is False` and no `ret`, angr having recovered no exit for either, and `atoi` at `0x42ec3c` is a single call to `strtol`. Seeding from callee `returning` status instead would flip 155 further functions on that binary, `atoi` among them.

Reported as #2070. Validation: https://github.com/angr/angr/pull/6903#issuecomment-5380289122

session: sharpen
