### PR TITLE
Decompiler: Distinguish retries from structuring updates

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/cross_jump_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/cross_jump_reverter.py
@@ -7,7 +7,11 @@ from itertools import count
 
 from angr.analyses.decompiler.counters import AILBlockCallCounter
 
-from .optimization_pass import OptimizationPassStage, StructuringOptimizationPass
+from .optimization_pass import (
+    OptimizationPassStage,
+    StructuringOptimizationPass,
+    StructuringOptimizationPassResult,
+)
 
 l = logging.getLogger(__name__)
 
@@ -79,7 +83,7 @@ class CrossJumpReverter(StructuringOptimizationPass):
             to_update[goto_target].append(node)
 
         if not to_update:
-            return False
+            return StructuringOptimizationPassResult.STOP
 
         updates = False
         sorted_targets = sorted(to_update.items(), key=lambda x: x[0].addr)
@@ -104,4 +108,4 @@ class CrossJumpReverter(StructuringOptimizationPass):
             if delete_original:
                 self.out_graph.remove_node(goto_target)
 
-        return updates
+        return StructuringOptimizationPassResult.UPDATED if updates else StructuringOptimizationPassResult.STOP

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -14,7 +14,10 @@ from angr.ailment.statement import Assignment, ConditionalJump, Jump, Label, Ret
 from angr.analyses.decompiler.block_io_finder import BlockIOFinder
 from angr.analyses.decompiler.block_similarity import index_of_similar_stmts, is_similar, longest_ail_subseq
 from angr.analyses.decompiler.counters.boolean_counter import BooleanCounter
-from angr.analyses.decompiler.optimization_passes.optimization_pass import StructuringOptimizationPass
+from angr.analyses.decompiler.optimization_passes.optimization_pass import (
+    StructuringOptimizationPass,
+    StructuringOptimizationPassResult,
+)
 from angr.analyses.decompiler.utils import remove_labels, to_ail_supergraph
 from angr.knowledge_plugins.key_definitions.atoms import MemoryLocation
 from angr.utils.graph import dominates
@@ -84,7 +87,7 @@ class DuplicationReverter(StructuringOptimizationPass):
     # Main Analysis
     #
 
-    def _analyze(self, cache=None) -> bool:
+    def _analyze(self, cache=None) -> StructuringOptimizationPassResult:
         """
         This function is the main analysis function for this deoptimization which implements SAILR's ISD deoptimization.
         There are generally three steps to this deoptimization:
@@ -99,9 +102,8 @@ class DuplicationReverter(StructuringOptimizationPass):
         In these cases, we bail. In stage 3, we reinsert the merged candidate into the original graph. This stage is
         also a little messy because need to correct every jump address.
 
-        Finally, the _analyze function returns True if the analysis was successful and a change was made to the graph.
-        In this case, we return True if this optimization requires another iteration, and False if it does not.
-        It can be True even if no changes were made to the graph.
+        Finally, the _analyze function reports whether analysis should stop, retry another candidate, or retain an
+        updated graph.
         """
         # construct graphs for writing and reading so we can corrupt the write graph
         # but still have a clean copy to read from
@@ -112,7 +114,7 @@ class DuplicationReverter(StructuringOptimizationPass):
         # phase 1: search for candidates to merge based on the ISD-schema
         candidate = self._search_for_deduplication_candidate()
         if candidate is None:
-            return False
+            return StructuringOptimizationPassResult.STOP
 
         # phase 2: construct the middle graph/node that is merged from the duplicate candidate
         try:
@@ -120,16 +122,16 @@ class DuplicationReverter(StructuringOptimizationPass):
         except SAILRSemanticError as e:
             _l.debug("Skipping this candidate because of %s...", e)
             self.candidate_blacklist.add(tuple(candidate))
-            return True
+            return StructuringOptimizationPassResult.RETRY
 
         # phase 3: reinsert the merged candidate into the original graph
         success = self._reinsert_merged_candidate(ail_merge_graph, candidate)
         if not success:
             self.candidate_blacklist.add(tuple(candidate))
-            return True
+            return StructuringOptimizationPassResult.RETRY
 
         self.out_graph = to_ail_supergraph(self.write_graph)
-        return True
+        return StructuringOptimizationPassResult.UPDATED
 
     def _search_for_deduplication_candidate(self) -> tuple[Block, Block] | None:
         candidates = self._find_initial_candidates()

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -19,7 +19,7 @@ from angr.analyses.decompiler.condition_processor import ConditionProcessor
 from angr.analyses.decompiler.counters import ControlFlowStructureCounter
 from angr.analyses.decompiler.goto_manager import Goto, GotoManager
 from angr.analyses.decompiler.structuring import RecursiveStructurer, SAILRStructurer
-from angr.analyses.decompiler.utils import add_labels, is_empty_node, remove_edges_in_ailgraph
+from angr.analyses.decompiler.utils import add_labels, copy_graph, is_empty_node, remove_edges_in_ailgraph
 
 if TYPE_CHECKING:
     from angr.analyses.decompiler.region_identifier import RegionIdentifier, RegionOverlay
@@ -67,6 +67,18 @@ class OptimizationPassStage(Enum):
     BEFORE_REGION_IDENTIFICATION = 9
     DURING_REGION_IDENTIFICATION = 10
     AFTER_STRUCTURING = 11
+
+
+class StructuringOptimizationPassResult(Enum):
+    """The outcome of one structuring optimization attempt.
+
+    STOP and RETRY leave ``out_graph`` unchanged; RETRY consumes an iteration before trying another candidate.
+    UPDATED reports a graph mutation that the base class must verify.
+    """
+
+    STOP = 0
+    RETRY = 1
+    UPDATED = 2
 
 
 class BaseOptimizationPass:
@@ -537,8 +549,24 @@ class StructuringOptimizationPass(OptimizationPass):
         self._initial_structure_counter = None
         self._current_structure_counter = None
 
-    def _analyze(self, cache=None) -> bool:
+    def _analyze(self, cache=None) -> bool | StructuringOptimizationPassResult:
         raise NotImplementedError
+
+    def _requires_structurability_check(self) -> bool:
+        return (
+            self._require_structurable_graph
+            or self._require_gotos
+            or self._prevent_new_gotos
+            or self._must_improve_rel_quality
+        )
+
+    @staticmethod
+    def _normalize_analyze_result(result: object) -> StructuringOptimizationPassResult:
+        if isinstance(result, bool):
+            return StructuringOptimizationPassResult.UPDATED if result else StructuringOptimizationPassResult.STOP
+        if isinstance(result, StructuringOptimizationPassResult):
+            return result
+        raise TypeError(f"Unexpected structuring optimization pass result {result!r}")
 
     def analyze(self):
         try:
@@ -555,12 +583,12 @@ class StructuringOptimizationPass(OptimizationPass):
         if not ret:
             return
 
-        # only initialize self._goto_manager if this optimization requires a structurable graph or gotos
+        # initialize structuring-derived state only when a configured check consumes it
         initial_structurable: bool | None = None
-        if self._require_structurable_graph or self._require_gotos or self._prevent_new_gotos:
+        if self._requires_structurability_check():
             initial_structurable = self._graph_is_structurable(self._graph, initial=True)
 
-        if self._require_structurable_graph and initial_structurable is False:
+        if initial_structurable is False:
             return
 
         if self._require_gotos:
@@ -574,8 +602,8 @@ class StructuringOptimizationPass(OptimizationPass):
         if self._max_opt_iters > 1:
             self._fixed_point_analyze(cache=cache)
         else:
-            updates = self._analyze(cache=cache)
-            if not updates:
+            result = self._normalize_analyze_result(self._analyze(cache=cache))
+            if result is not StructuringOptimizationPassResult.UPDATED:
                 self.out_graph = None
 
         # analysis is complete, no out_graph means it failed somewhere along the way
@@ -587,7 +615,7 @@ class StructuringOptimizationPass(OptimizationPass):
             self.out_graph = add_labels(self.out_graph, self.manager)
 
         if (
-            self._require_structurable_graph
+            self._requires_structurability_check()
             and self._max_opt_iters <= 1
             and not self._graph_is_structurable(self.out_graph, readd_labels=False)
         ):
@@ -628,21 +656,26 @@ class StructuringOptimizationPass(OptimizationPass):
 
             # backup the graph before the optimization
             if self._recover_structure_fails and self.out_graph is not None:
-                self._prev_graph = networkx.DiGraph(self.out_graph)
+                self._prev_graph = copy_graph(self.out_graph)
 
             # run the optimization, output applied to self.out_graph
-            changes = self._analyze(cache=cache)
-            if not changes:
+            result = self._normalize_analyze_result(self._analyze(cache=cache))
+            if result is StructuringOptimizationPassResult.STOP:
                 break
+            if result is StructuringOptimizationPassResult.RETRY:
+                continue
 
-            had_any_changes = True
-            # check if the graph is structurable
-            if not self._graph_is_structurable(self.out_graph, readd_labels=self._readd_labels):
+            # update structuring-derived state and reject invalid graphs when any configured check depends on it
+            if self._requires_structurability_check() and not self._graph_is_structurable(
+                self.out_graph, readd_labels=self._readd_labels
+            ):
                 if self._recover_structure_fails:
                     self.out_graph = self._prev_graph
                 else:
                     self.out_graph = None
-                    break
+                break
+
+            had_any_changes = True
 
         if not had_any_changes:
             self.out_graph = None

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -598,7 +598,7 @@ class StructuringOptimizationPass(OptimizationPass):
                 return
 
         # setup for the very first analysis
-        self.out_graph = networkx.DiGraph(self._graph)
+        self.out_graph = copy_graph(self._graph)
         if self._max_opt_iters > 1:
             self._fixed_point_analyze(cache=cache)
         else:

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -72,8 +72,8 @@ class OptimizationPassStage(Enum):
 class StructuringOptimizationPassResult(Enum):
     """The outcome of one structuring optimization attempt.
 
-    STOP and RETRY leave ``out_graph`` unchanged; RETRY consumes an iteration before trying another candidate.
-    UPDATED reports a graph mutation that the base class must verify.
+    STOP ends the loop and RETRY consumes an iteration before another candidate is tried; neither offers a graph for
+    the base class to verify. UPDATED reports a graph mutation that the base class must verify.
     """
 
     STOP = 0

--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_low.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_low.py
@@ -9,7 +9,7 @@ import networkx
 from angr.ailment import Block
 from angr.ailment.statement import ConditionalJump
 
-from .optimization_pass import StructuringOptimizationPass
+from .optimization_pass import StructuringOptimizationPass, StructuringOptimizationPassResult
 from .return_duplicator_base import ReturnDuplicatorBase
 
 _l = logging.getLogger(name=__name__)
@@ -164,4 +164,6 @@ class ReturnDuplicatorLow(StructuringOptimizationPass, ReturnDuplicatorBase):
         """
         This analysis is run in a loop in analyze() for a maximum of max_opt_iters times.
         """
-        return self._analyze_core(self.out_graph)
+        if self._analyze_core(self.out_graph):
+            return StructuringOptimizationPassResult.UPDATED
+        return StructuringOptimizationPassResult.STOP

--- a/angr/analyses/decompiler/utils.py
+++ b/angr/analyses/decompiler/utils.py
@@ -1011,11 +1011,13 @@ def peephole_optimize_expr(expr: ailment.Expression, expr_opts: list[PeepholeOpt
 
 def copy_graph(graph: networkx.DiGraph[Block]) -> networkx.DiGraph[Block]:
     """
-    Copy AIL Graph.
+    Copy an AIL graph, including its graph, node, and edge attributes. Blocks and their statement lists are copied;
+    attribute values retain NetworkX's shallow-copy semantics.
 
-    :return: A copy of the AIl graph.
+    :return: A copy of the AIL graph.
     """
     graph_copy = networkx.DiGraph()
+    graph_copy.graph.update(graph.graph)
     block_mapping = {}
     # copy all blocks
     for block in graph.nodes():
@@ -1023,7 +1025,7 @@ def copy_graph(graph: networkx.DiGraph[Block]) -> networkx.DiGraph[Block]:
         new_stmts = copy.copy(block.statements)
         new_block.statements = new_stmts
         block_mapping[block] = new_block
-        graph_copy.add_node(new_block)
+        graph_copy.add_node(new_block, **graph.nodes[block])
 
     # copy all edges
     for src, dst, data in graph.edges(data=True):

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3711,11 +3711,15 @@ class TestDecompiler(unittest.TestCase):
         proj.analyses.CompleteCallingConventions(cfg=cfg)
 
         f = proj.kb.functions["main"]
-        d = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
+        d = proj.analyses[Decompiler].prep(fail_fast=True)(
+            f,
+            cfg=cfg.model,
+            options=decompiler_options,
+            preset=DECOMPILATION_PRESETS["full"],
+        )
         print_decompilation_result(d)
 
-        # incorrect region replacement was causing the while loop be duplicated, so we would end up with four while
-        # loops. In the original source, there is only a single while loop.
+        # Incorrect fixed-point output could lose or duplicate this loop. In the original source, there is one loop.
         assert d.codegen.text.count("while (") == 1
 
     @structuring_algo("sailr")

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -3723,6 +3723,29 @@ class TestDecompiler(unittest.TestCase):
         assert d.codegen.text.count("while (") == 1
 
     @structuring_algo("sailr")
+    def test_decompiling_chmod_gcc_O1_rejected_pass_leaves_no_dangling_goto(self, decompiler_options=None):
+        # ReturnDuplicatorLow rewrites Phi statements in place, and the graph it is handed for the first
+        # iteration used to share its blocks with the caller's graph. Clearing out_graph then left those
+        # rewrites behind, and the block they name never reached the output: nine gotos were emitted for
+        # LABEL_0x406f33 with no such label anywhere in the function.
+        bin_path = os.path.join(test_location, "x86_64", "chmod_gcc_-O1")
+        func_addr = 0x406875
+        p, cfg = load_project_with_scoped_cfg(
+            bin_path, func_addr, project_kwargs={"auto_load_libs": False}, include_plt=True
+        )
+
+        f = cfg.functions[func_addr]
+        d = p.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
+        print_decompilation_result(d)
+
+        text = d.codegen.text if d.codegen is not None else None
+        assert text is not None, f"Failed to decompile function {f!r}."
+        defined = set(re.findall(r"^(\w+):", text, re.MULTILINE))
+        targets = set(re.findall(r"goto\s+(\w+);", text))
+        assert targets, "the function should still contain gotos; the fixture no longer covers the defect"
+        assert not targets - defined, f"goto targets with no label definition: {sorted(targets - defined)}"
+
+    @structuring_algo("sailr")
     def test_decompiling_function_with_long_cascading_data_flows(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "netfilter_b64.sys")
         proj = angr.Project(bin_path, auto_load_libs=False)

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -6156,6 +6156,37 @@ class TestDecompiler(unittest.TestCase):
         assert re.search(r"\bv\d+ < 8\b", text), "the CondB SUBB ccall was not rewritten into a byte comparison"
         assert re.search(r"> \(char\)", text), "the CondBE SUBB ccall operands were not narrowed to byte width"
 
+    def test_reverted_structuring_pass_keeps_the_flag_definitions_it_reverted(self, decompiler_options=None):
+        # ReturnDuplicatorLow runs its optimization in a fixed-point loop and rolls the graph back after any
+        # iteration whose output does not structure. On sub_41f6ce all four iterations are rolled back, so the pass
+        # ends holding the graph it started from -- yet it still reported a change, and the decompiler adopted the
+        # AIL-simplified copy it handed back. That copy is missing the flag definitions for the jb at 0x41f736.
+        bin_path = os.path.join(
+            test_location, "i386", "windows", "a71a3c3b922705cb5e2d8aa9c74f5c73c47fb27f10b1327eb2bb054d99a14397"
+        )
+        func_addr = 0x41F6CE
+        proj, _ = load_project_with_scoped_cfg(
+            bin_path,
+            func_addr,
+            window=0x1000,
+            expand_call_tree=False,
+            cfg_kwargs={"force_complete_scan": True},
+        )
+
+        f = proj.kb.functions[func_addr]
+        # guard against the scoped CFG window silently truncating the function under test
+        assert f.size >= 0x82, f"sub_41f6ce was truncated by the scoped CFG: size {f.size:#x}."
+        dec = proj.analyses[Decompiler].prep(fail_fast=True)(f, options=decompiler_options)
+        assert dec.codegen is not None and dec.codegen.text is not None, f"Failed to decompile function {f!r}."
+        print_decompilation_result(dec)
+
+        # "sub al, 0x87" at 0x41f72d and "stc" at 0x41f733 set the flags that "jb 0x41f765" at 0x41f736 reads, and
+        # the jb's CondB ccall is emitted either way. The SUBB ccall that defines those flags must be there too.
+        text = dec.codegen.text
+        assert re.search(r"_ccall\(4, [^;]*135, 0\)", text), (
+            "the SUBB flag definition for the jb at 0x41f736 was dropped"
+        )
+
     def test_widening_conversion_signedness(self, decompiler_options=None):
         # A widening integer conversion carries the signedness of its source operand: a sign-extending Convert
         # (e.g. movswl) implies a signed source, and a zero-extending Convert (e.g. movzwl) implies an unsigned

--- a/tests/analyses/decompiler/test_optimization_passes.py
+++ b/tests/analyses/decompiler/test_optimization_passes.py
@@ -6,6 +6,7 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 
 import logging
 import unittest
+from types import SimpleNamespace
 
 import networkx
 
@@ -16,6 +17,10 @@ from angr.ailment.expression import BinaryOp, Call, Const, Load, Register, Virtu
 from angr.ailment.manager import Manager
 from angr.ailment.statement import Assignment, ConditionalJump, Return, Store, WeakAssignment
 from angr.analyses.decompiler.optimization_passes import DetermineLoadSizes, FlipBooleanCmp
+from angr.analyses.decompiler.optimization_passes.optimization_pass import (
+    StructuringOptimizationPass,
+    StructuringOptimizationPassResult,
+)
 from angr.analyses.decompiler.structurer_nodes import ConditionNode, SequenceNode
 
 log = logging.getLogger(__name__)
@@ -32,6 +37,307 @@ def r(o):
     return Register(0, o, 32)
 
 
+class _FixedPointLifecyclePass(StructuringOptimizationPass):
+    def __init__(  # pylint:disable=super-init-not-called
+        self,
+        results,
+        structurability_results=(),
+        max_opt_iters=5,
+        require_structurable_graph=True,
+        recover_structure_fails=True,
+        require_gotos=False,
+        prevent_new_gotos=False,
+    ):
+        self._graph = networkx.DiGraph()
+        self.out_graph = networkx.DiGraph()
+        self._results = iter(results)
+        self._structurability_results = iter(structurability_results)
+        self._max_opt_iters = max_opt_iters
+        self._require_structurable_graph = require_structurable_graph
+        self._prevent_new_gotos = prevent_new_gotos
+        self._must_improve_rel_quality = False
+        self._simplify_ail = False
+        self._require_gotos = require_gotos
+        self._recover_structure_fails = recover_structure_fails
+        self._readd_labels = False
+        self.analysis_count = 0
+        self.structurability_checks = 0
+
+    def _check(self):
+        return True, None
+
+    def _analyze(self, cache=None):
+        self.analysis_count += 1
+        result = next(self._results)
+        if result is StructuringOptimizationPassResult.UPDATED or result is True:
+            assert self.out_graph is not None
+            self.out_graph.add_node(Block(self.analysis_count, 0))
+        return result
+
+    def _graph_is_structurable(self, graph, readd_labels=False, initial=False):
+        self.structurability_checks += 1
+        structurable = next(self._structurability_results, True)
+        if structurable:
+            self._goto_manager = SimpleNamespace(gotos=set())
+        return structurable
+
+
+class _FixedPointStatementRollbackPass(_FixedPointLifecyclePass):
+    def __init__(self):
+        super().__init__(
+            [StructuringOptimizationPassResult.UPDATED, StructuringOptimizationPassResult.UPDATED],
+            [True, False],
+        )
+
+    def _analyze(self, cache=None):
+        self.analysis_count += 1
+        assert self.out_graph is not None
+        if self.analysis_count == 1:
+            self.out_graph.add_node(Block(1, 0, statements=[Return(0, [])]))
+        else:
+            node = next(iter(self.out_graph))
+            node.statements[0] = Return(1, [])
+        return StructuringOptimizationPassResult.UPDATED
+
+
+class _FixedPointAttributeRollbackPass(_FixedPointLifecyclePass):
+    def __init__(self):
+        super().__init__(
+            [StructuringOptimizationPassResult.UPDATED, StructuringOptimizationPassResult.UPDATED],
+            [True, False],
+        )
+
+    def _analyze(self, cache=None):
+        self.analysis_count += 1
+        assert self.out_graph is not None
+        if self.analysis_count == 1:
+            src = Block(1, 0)
+            dst = Block(2, 0)
+            self.out_graph.graph["status"] = "accepted"
+            self.out_graph.add_node(src, original_nodes=[src])
+            self.out_graph.add_node(dst)
+            self.out_graph.add_edge(src, dst, type="accepted")
+        else:
+            src, dst = sorted(self.out_graph, key=lambda node: node.addr)
+            self.out_graph.graph["status"] = "rejected"
+            self.out_graph.nodes[src]["original_nodes"] = []
+            self.out_graph[src][dst]["type"] = "rejected"
+        return StructuringOptimizationPassResult.UPDATED
+
+
+# pylint:disable=protected-access
+class TestStructuringOptimizationPass(unittest.TestCase):
+    def test_fixed_point_retry_without_graph_update_is_not_output(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [StructuringOptimizationPassResult.RETRY, StructuringOptimizationPassResult.STOP]
+        )
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 2)
+        self.assertEqual(optimization_pass.structurability_checks, 0)
+        self.assertIsNone(optimization_pass.out_graph)
+
+    def test_fixed_point_graph_update_is_output(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [StructuringOptimizationPassResult.UPDATED, StructuringOptimizationPassResult.STOP]
+        )
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 2)
+        self.assertEqual(optimization_pass.structurability_checks, 1)
+        self.assertIsNotNone(optimization_pass.out_graph)
+        assert optimization_pass.out_graph is not None
+        self.assertEqual({node.addr for node in optimization_pass.out_graph}, {1})
+
+    def test_fixed_point_rolled_back_graph_update_is_not_output(self):
+        optimization_pass = _FixedPointLifecyclePass([StructuringOptimizationPassResult.UPDATED], [False])
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 1)
+        self.assertEqual(optimization_pass.structurability_checks, 1)
+        self.assertIsNone(optimization_pass.out_graph)
+
+    def test_fixed_point_failed_graph_update_restores_last_accepted_graph_and_stops(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [
+                StructuringOptimizationPassResult.UPDATED,
+                StructuringOptimizationPassResult.UPDATED,
+                StructuringOptimizationPassResult.UPDATED,
+            ],
+            [True, False],
+        )
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 2)
+        self.assertEqual(optimization_pass.structurability_checks, 2)
+        self.assertIsNotNone(optimization_pass.out_graph)
+        assert optimization_pass.out_graph is not None
+        self.assertEqual({node.addr for node in optimization_pass.out_graph}, {1})
+
+    def test_fixed_point_failed_graph_update_without_recovery_discards_output(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [StructuringOptimizationPassResult.UPDATED],
+            [False],
+            recover_structure_fails=False,
+        )
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 1)
+        self.assertEqual(optimization_pass.structurability_checks, 1)
+        self.assertIsNone(optimization_pass.out_graph)
+
+    def test_fixed_point_update_skips_structurability_when_not_required(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [StructuringOptimizationPassResult.UPDATED, StructuringOptimizationPassResult.STOP],
+            [False],
+            require_structurable_graph=False,
+        )
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 2)
+        self.assertEqual(optimization_pass.structurability_checks, 0)
+        self.assertIsNotNone(optimization_pass.out_graph)
+        assert optimization_pass.out_graph is not None
+        self.assertEqual({node.addr for node in optimization_pass.out_graph}, {1})
+
+    def test_fixed_point_stop_halts(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [StructuringOptimizationPassResult.STOP, StructuringOptimizationPassResult.UPDATED]
+        )
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 1)
+        self.assertEqual(optimization_pass.structurability_checks, 0)
+        self.assertIsNone(optimization_pass.out_graph)
+
+    def test_fixed_point_max_iters_one_retry_is_not_output(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [StructuringOptimizationPassResult.RETRY],
+            max_opt_iters=1,
+            require_structurable_graph=False,
+        )
+
+        optimization_pass._analyze_and_verify()
+
+        self.assertEqual(optimization_pass.analysis_count, 1)
+        self.assertEqual(optimization_pass.structurability_checks, 0)
+        self.assertIsNone(optimization_pass.out_graph)
+
+    def test_fixed_point_retries_are_bounded_by_max_iters(self):
+        optimization_pass = _FixedPointLifecyclePass([StructuringOptimizationPassResult.RETRY] * 4, max_opt_iters=3)
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 3)
+        self.assertEqual(optimization_pass.structurability_checks, 0)
+        self.assertIsNone(optimization_pass.out_graph)
+
+    def test_fixed_point_bool_results_remain_supported(self):
+        optimization_pass = _FixedPointLifecyclePass([True, False], max_opt_iters=2)
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertEqual(optimization_pass.analysis_count, 2)
+        self.assertEqual(optimization_pass.structurability_checks, 1)
+        self.assertIsNotNone(optimization_pass.out_graph)
+        assert optimization_pass.out_graph is not None
+        self.assertEqual({node.addr for node in optimization_pass.out_graph}, {1})
+
+    def test_fixed_point_rejects_invalid_result(self):
+        optimization_pass = _FixedPointLifecyclePass([None])
+
+        with self.assertRaisesRegex(TypeError, "Unexpected structuring optimization pass result None"):
+            optimization_pass._fixed_point_analyze()
+
+    def test_single_iteration_rejects_invalid_result(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [None],
+            max_opt_iters=1,
+            require_structurable_graph=False,
+        )
+
+        with self.assertRaisesRegex(TypeError, "Unexpected structuring optimization pass result None"):
+            optimization_pass._analyze_and_verify()
+
+    def test_initial_structurability_failure_stops_goto_dependent_pass(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [StructuringOptimizationPassResult.UPDATED],
+            [False],
+            require_structurable_graph=False,
+            require_gotos=True,
+        )
+        optimization_pass.out_graph = None
+
+        optimization_pass._analyze_and_verify()
+
+        self.assertEqual(optimization_pass.analysis_count, 0)
+        self.assertEqual(optimization_pass.structurability_checks, 1)
+        self.assertIsNone(optimization_pass.out_graph)
+
+    def test_single_iteration_refreshes_structurability_for_goto_checks(self):
+        optimization_pass = _FixedPointLifecyclePass(
+            [StructuringOptimizationPassResult.UPDATED],
+            [True, False],
+            max_opt_iters=1,
+            require_structurable_graph=False,
+            prevent_new_gotos=True,
+        )
+
+        optimization_pass._analyze_and_verify()
+
+        self.assertEqual(optimization_pass.analysis_count, 1)
+        self.assertEqual(optimization_pass.structurability_checks, 2)
+        self.assertIsNone(optimization_pass.out_graph)
+
+    def test_fixed_point_rollback_restores_block_statements(self):
+        optimization_pass = _FixedPointStatementRollbackPass()
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertIsNotNone(optimization_pass.out_graph)
+        assert optimization_pass.out_graph is not None
+        node = next(iter(optimization_pass.out_graph))
+        self.assertEqual(node.statements[0].idx, 0)
+
+    def test_fixed_point_rollback_restores_graph_attributes(self):
+        optimization_pass = _FixedPointAttributeRollbackPass()
+
+        optimization_pass._fixed_point_analyze()
+
+        self.assertIsNotNone(optimization_pass.out_graph)
+        assert optimization_pass.out_graph is not None
+        src, dst = sorted(optimization_pass.out_graph, key=lambda node: node.addr)
+        self.assertEqual(optimization_pass.out_graph.graph["status"], "accepted")
+        self.assertEqual(optimization_pass.out_graph.nodes[src]["original_nodes"], [src])
+        self.assertEqual(optimization_pass.out_graph[src][dst]["type"], "accepted")
+
+    def test_single_iteration_bool_update_is_output(self):
+        optimization_pass = _FixedPointLifecyclePass([True], max_opt_iters=1)
+
+        optimization_pass._analyze_and_verify()
+
+        self.assertEqual(optimization_pass.analysis_count, 1)
+        self.assertIsNotNone(optimization_pass.out_graph)
+        assert optimization_pass.out_graph is not None
+        self.assertEqual({node.addr for node in optimization_pass.out_graph}, {1})
+
+    def test_single_iteration_bool_no_update_is_not_output(self):
+        optimization_pass = _FixedPointLifecyclePass([False], max_opt_iters=1)
+
+        optimization_pass._analyze_and_verify()
+
+        self.assertEqual(optimization_pass.analysis_count, 1)
+        self.assertIsNone(optimization_pass.out_graph)
+
+
+# pylint:enable=protected-access
 class TestFlipBooleanCmp(unittest.TestCase):
     """
     Test FlipBooleanCmp optimization pass.

--- a/tests/analyses/decompiler/test_optimization_passes.py
+++ b/tests/analyses/decompiler/test_optimization_passes.py
@@ -6,7 +6,6 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 
 import logging
 import unittest
-from types import SimpleNamespace
 
 import networkx
 
@@ -16,6 +15,7 @@ from angr.ailment.constant import UNDETERMINED_SIZE
 from angr.ailment.expression import BinaryOp, Call, Const, Load, Register, VirtualVariable, VirtualVariableCategory
 from angr.ailment.manager import Manager
 from angr.ailment.statement import Assignment, ConditionalJump, Return, Store, WeakAssignment
+from angr.analyses.decompiler.goto_manager import GotoManager
 from angr.analyses.decompiler.optimization_passes import DetermineLoadSizes, FlipBooleanCmp
 from angr.analyses.decompiler.optimization_passes.optimization_pass import (
     StructuringOptimizationPass,
@@ -78,7 +78,7 @@ class _FixedPointLifecyclePass(StructuringOptimizationPass):
         self.structurability_checks += 1
         structurable = next(self._structurability_results, True)
         if structurable:
-            self._goto_manager = SimpleNamespace(gotos=set())
+            self._goto_manager = GotoManager(None)
         return structurable
 
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

The decompiler emits C that jumps to labels it never defines, returns a variable it never assigns, and drops the flag definitions a branch reads. On `master` `b4ad96cd3`, in binaries this repository already tests with:

- `tests/x86_64/chmod_gcc_-O1` at `0x406875` emits nine `goto LABEL_0x406f33;` with **no definition of that label**, and `tests/i386/ls_gcc_7.5_reassembler` at `0x805d6d3` emits three dangling `goto LABEL_0x805de72;` plus `return v50;` where **`v50` is never assigned**.
- `tests/i386/windows/a71a3c3b922705cb5e2d8aa9c74f5c73c47fb27f10b1327eb2bb054d99a14397` at `0x41f6ce` loses the flags for `jb 0x41f765`, whose instructions are `sub al, 0x87` at `0x41f72d` and `stc` at `0x41f733`. Diffing `master` against this branch:

```diff
     unsigned long long v48;  // 4115
+    unsigned int v49;  // 4124
@@
 LABEL_41f72d:
     *((char *)(unsigned int)v48) = ~(*((char *)(unsigned int)v48));
-    goto LABEL_0x41f734;
+    v49 = _ccall(4, (unsigned int)(char)v20, 135, 0);
+    v11 = 0;
+    v13 = 0;
+    v12 = v49 | 1;
+    v14 = 0;
+    goto LABEL_41f734;
```

`v49` is the SUBB against `0x87` and `v12 = v49 | 1` is the `stc`. Their consumer, `_ccall(2, v11, v12, v13, v14)` for that `jb`, is emitted either way, so on the `0x41f72d` path `master` reads flags from unrelated blocks. That `goto` is the first defect too: `master`'s `LABEL_0x41f734` is dangling and this branch resolves it, taking the function from four dangling targets to three.

The same defect reports itself as `Cannot find the virtual variable in Phi expression ...` from `ReturnDuplicatorBase`; #7132 is another producer.

### Root cause

`StructuringOptimizationPass` used one boolean for both retrying and reporting an updated graph, so a retry could be published as output. Both halves of the class copied a graph's topology while sharing its blocks, and `ReturnDuplicatorLow` rewrites a block's statement list in place when it drops a phi predecessor.

`_fixed_point_analyze` saved the graph with `networkx.DiGraph(self.out_graph)`, so a rollback restored the edges and not the phi edit.

`_analyze_and_verify` started every pass with `self.out_graph = networkx.DiGraph(self._graph)`, sharing every `Block` with Clinic's graph, so a pass returning `out_graph = None` to say it did nothing has already left its phi rewrite in Clinic's graph and the rejection undoes nothing.

`_fixed_point_analyze` also set `had_any_changes = True` before checking whether the result structures, so a run whose every iteration rolled back still published `out_graph`, the graph it started from. `_improves_relative_quality()` cannot catch that: `_current_structure_counter` is written only when a structurability probe succeeds, so it is still `None`, and the helper's `None` branch returns `True` and logs `Relative quality check failed due to missing structure counters`. That is the `0x41f6ce` path.

### Fix

Fixed-point passes now return explicit stop, retry and updated outcomes; only an updated graph refreshes structuring state, and `had_any_changes` is set after the structurability probe, not before. Both graph copies now copy the blocks and their statement lists as well as the topology. The structurability probe is gated on one predicate folding in `must_improve_rel_quality`; of the four shipped passes only `LoweredSwitchSimplifier` sets any of those flags to `False`, and it sets all, so none changes behaviour.

The two copies are not interchangeable. Four builds at `master` `b4ad96cd3` on `chmod_gcc_-O1` `0x406875`, each run twice with byte-identical output: `master` emits nine dangling gotos; the `_prev_graph` copy alone clears them; the rest of this branch's production changes alone still emit nine, because rejecting a pass that has already edited the caller's graph moves nothing; this pull request clears them.

An earlier revision said only "one instance" of the fail-open goes. Measured over the same twelve `(object, function)` pairs on both arms: **10 fail open on `master`, 0 on this branch.** All ten are `ReturnDuplicatorLow`, with the initial counter present, the current counter `None`, and output structurally identical to input. On the branch those ten do not reach the gate because `out_graph` is `None` before it -- the fix working -- not because nothing ran; the loop is entered on both arms. The other two did not reproduce: one function reaches the gate on **both** arms with both counters present and returns `True` on its merits, showing the gate still runs; `betaflight_STM32F405.elf` `0x8009ef9` fails its initial probe on both arms and says nothing either way. A hit costs five structuring probes on `master`, two here.

This does not repair `_improves_relative_quality` itself: its `None` branch is byte-identical here and still returns `True`, made unreachable for every shipped configuration rather than correct.

Six of the ten hits are publicly citable: `sub_41f6ce` above, and five objects in `noelo-lab/decbench-dataset` -- `O0/cronie/crontab` `0x406d1d`, `O2-noinline/coreutils/stat` `0x4071b0`, `O2/openssh-portable/ssh` `0x443610` and `0x470310`, `O2/u-boot/u-boot` `0x6085fe68`. The other four are from a corpus that is not ours to publish.

### Testing

`test_reverted_structuring_pass_keeps_the_flag_definitions_it_reverted` decompiles `0x41f6ce` from the tracked binary above with a scoped CFG and asserts the SUBB ccall defining the `jb`'s flags is present. It passes here and fails on `master`, printing the missing-counters warning. It covers the change as a whole, not the `had_any_changes` half alone -- the graph copy on its own also makes it pass. The eighteen lifecycle regressions in `tests/analyses/decompiler/test_optimization_passes.py` cover the stop, retry, update, rollback and single-iteration paths.

`test_decompiling_chmod_gcc_O1_rejected_pass_leaves_no_dangling_goto` fails on the baseline naming `LABEL_0x406f33` and passes here. `test_decompiling_incorrect_duplication_chcon_main` moves to the full preset, where `master` loses the loop it requires (0 `while (`, 3 gotos) and this change recovers it (1, 2).

Refs #4420, which asks for fewer gotos in that chcon test. Not closed here: `chcon.o` `main` has 7 gotos before and after under the old preset. Validation: https://github.com/angr/angr/pull/6904#issuecomment-5380478475

session: sharpen
