### PR TITLE
Decompiler: Preserve Phoenix switch entry identities

### DIFF
--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -20,6 +20,7 @@ from angr.analyses.decompiler.sequence_walker import SequenceWalker
 from angr.analyses.decompiler.structurer_nodes import (
     BaseNode,
     BreakNode,
+    CodeNode,
     ConditionalBreakNode,
     ConditionNode,
     ContinueNode,
@@ -89,6 +90,7 @@ class PhoenixStructurer(StructurerBase):
 
     NAME = "phoenix"
     SUPPORTS_OVERLAYS = True
+    _SWITCH_ENTRY_IDX_UNKNOWN = object()
 
     def __init__(
         self,
@@ -161,6 +163,82 @@ class PhoenixStructurer(StructurerBase):
             assert len([nn for nn in g if g.in_degree[nn] == 0]) <= 1, (
                 f"{msg}: More than one graph entrance. Please report this."
             )
+
+    @classmethod
+    def _switch_entry_idx(cls, node):
+        """Recover the index of a structured node's entry block."""
+
+        if isinstance(node, (Block, MultiNode)):
+            return node.idx
+        if isinstance(node, CodeNode):
+            return cls._switch_entry_idx(node.node)
+        if isinstance(node, SequenceNode) and node.nodes and node.nodes[0].addr == node.addr:
+            return cls._switch_entry_idx(node.nodes[0])
+        if isinstance(node, IncompleteSwitchCaseNode) and node.head is not None and node.head.addr == node.addr:
+            return cls._switch_entry_idx(node.head)
+        return cls._SWITCH_ENTRY_IDX_UNKNOWN
+
+    @classmethod
+    def _switch_resolve_entry_nodes(
+        cls, nodes, expected_entries: set[tuple[int, int | None]]
+    ) -> dict[tuple[int, int | None], Any] | None:
+        """Resolve switch metadata identities against direct successor nodes as a group."""
+
+        candidates_by_addr = defaultdict(list)
+        for candidate in nodes:
+            candidates_by_addr[candidate.addr].append(candidate)
+
+        expected_indices_by_addr = defaultdict(set)
+        for entry_addr, entry_idx in expected_entries:
+            expected_indices_by_addr[entry_addr].add(entry_idx)
+
+        resolved: dict[tuple[int, int | None], Any] = {}
+        for entry_addr, expected_indices in expected_indices_by_addr.items():
+            candidates = candidates_by_addr.get(entry_addr, [])
+            if not candidates:
+                for entry_idx in expected_indices:
+                    resolved[entry_addr, entry_idx] = None
+                continue
+
+            if len(expected_indices) == 1 and len(candidates) == 1:
+                resolved[entry_addr, next(iter(expected_indices))] = candidates[0]
+                continue
+
+            candidates_by_idx = {}
+            for candidate in candidates:
+                candidate_idx = cls._switch_entry_idx(candidate)
+                if candidate_idx is cls._SWITCH_ENTRY_IDX_UNKNOWN or candidate_idx in candidates_by_idx:
+                    return None
+                candidates_by_idx[candidate_idx] = candidate
+
+            remaining_indices = set(expected_indices)
+            for entry_idx in expected_indices:
+                exact_match = candidates_by_idx.pop(entry_idx, None)
+                if exact_match is not None:
+                    resolved[entry_addr, entry_idx] = exact_match
+                    remaining_indices.remove(entry_idx)
+
+            if not candidates_by_idx:
+                for entry_idx in remaining_indices:
+                    resolved[entry_addr, entry_idx] = None
+            else:
+                return None
+
+        return resolved
+
+    @classmethod
+    def _switch_entries_match(cls, left, right) -> bool:
+        if left is right:
+            return True
+        if left.addr != right.addr:
+            return False
+        left_idx = cls._switch_entry_idx(left)
+        right_idx = cls._switch_entry_idx(right)
+        return (
+            left_idx is not cls._SWITCH_ENTRY_IDX_UNKNOWN
+            and right_idx is not cls._SWITCH_ENTRY_IDX_UNKNOWN
+            and left_idx == right_idx
+        )
 
     def _analyze(self):
         # iterate until there is only one node in the region
@@ -1305,37 +1383,50 @@ class PhoenixStructurer(StructurerBase):
         if not isinstance(last_stmt, IncompleteSwitchCaseHeadStatement):
             return False
 
+        # make a fake jumptable
+        node_default_addr = None
+        node_default_idx = None
+        case_entries: dict[int, tuple[int, int | None]] = {}
+        for _, case_value, case_target_addr, case_target_idx, _ in last_stmt.case_addrs:
+            if isinstance(case_value, str):
+                if case_value == "default":
+                    node_default_addr = case_target_addr
+                    node_default_idx = case_target_idx
+                    continue
+                raise ValueError(f"Unsupported 'case_value' {case_value}")
+            case_entries[case_value] = (case_target_addr, case_target_idx)
+
         # sanity check: all case nodes must have at most one common successor at this point
-        # note that we are ignoring AIL blocks with block ID != None
-        nodes = {(nn.addr, nn.idx if isinstance(nn, Block) else None): nn for nn in graph_raw.successors(node)}
+        expected_entries = set(case_entries.values())
+        default_entry = None
+        if node_default_addr is not None:
+            default_entry = node_default_addr, node_default_idx
+            expected_entries.add(default_entry)
+        entry_nodes = self._switch_resolve_entry_nodes(graph_raw.successors(node), expected_entries)
+        if entry_nodes is None:
+            return False
+
         successors: set[int] = set()
         case_nodes: set[int] = set()
         for _, _, case_target_addr, case_target_idx, _ in last_stmt.case_addrs:
             case_nodes.add(case_target_addr)
-            case_node = nodes.get((case_target_addr, case_target_idx))
+            case_node = entry_nodes[case_target_addr, case_target_idx]
             if case_node is None:
                 continue
             successors.update(nn.addr for nn in graph_raw.successors(case_node))
         if len(successors.difference(case_nodes)) > 1:
             return False
 
-        # make a fake jumptable
-        node_default_addr = None
-        case_entries: dict[int, int | tuple[int, int | None]] = {}
-        for _, case_value, case_target_addr, case_target_idx, _ in last_stmt.case_addrs:
-            if isinstance(case_value, str):
-                if case_value == "default":
-                    node_default_addr = case_target_addr
-                    continue
-                raise ValueError(f"Unsupported 'case_value' {case_value}")
-            case_entries[case_value] = (case_target_addr, case_target_idx)
-
+        selected_entry_to_case = {}
         cases, node_default, to_remove = self._switch_build_cases(
             case_entries,
             node,
             node,
             node_default_addr,
             graph_raw,
+            entry_nodes=entry_nodes,
+            default_entry=default_entry,
+            selected_entry_to_case=selected_entry_to_case,
         )
         fake_node_default = False
         if node_default_addr is not None and node_default is None:
@@ -1344,7 +1435,7 @@ class PhoenixStructurer(StructurerBase):
             jmp_to_default_node = Jump(
                 self.ail_manager.next_atom(),
                 Const(self.ail_manager.next_atom(), node_default_addr, self.project.arch.bits),
-                None,
+                target_idx=node_default_idx,
                 ins_addr=SWITCH_MISSING_DEFAULT_NODE_ADDR,
             )
             node_default = Block(SWITCH_MISSING_DEFAULT_NODE_ADDR, 0, statements=[jmp_to_default_node])
@@ -1363,6 +1454,7 @@ class PhoenixStructurer(StructurerBase):
             graph_raw,
             full_graph_raw,
             bail_on_nonhead_outedges=True,
+            selected_entry_to_case=selected_entry_to_case,
         )
         if not r:
             if fake_node_default:
@@ -1376,7 +1468,7 @@ class PhoenixStructurer(StructurerBase):
         if node_default is not None and self._region.graph.out_degree[node] > 1:
             other_out_nodes = list(self._region.graph.successors(node))
             for o in other_out_nodes:
-                if o.addr == node_default.addr and o is not node_default:
+                if o is not node_default and self._switch_entries_match(o, node_default):
                     self._region.remove_node(o, absorbed_into=node_default, absorb_out_edges=True)
 
         switch_end_addr = self._switch_find_switch_end_addr(cases, node_default, {nn.addr for nn in self._region.graph})
@@ -1974,49 +2066,59 @@ class PhoenixStructurer(StructurerBase):
         node_a: BaseNode,
         node_b_addr: int | None,
         graph_raw: networkx.DiGraph,
+        *,
+        entry_nodes: dict[tuple[int, int | None], Any] | None = None,
+        default_entry: tuple[int, int | None] | None = None,
+        selected_entry_to_case: dict[int, SequenceNode] | None = None,
     ) -> tuple[OrderedDict, Any, set[Any]]:
         cases: OrderedDict[int | tuple[int, ...], SequenceNode] = OrderedDict()
         to_remove = set()
 
         graph = graph_raw.filtered()
+        default_node_candidates = []
+        node_a_successors = []
+        node_b_in_node_a_successors = False
 
-        default_node_candidates = (
-            [nn for nn in graph.nodes if nn.addr == node_b_addr] if node_b_addr is not None else []
-        )
-        node_default = (
-            self._switch_find_default_node(graph, head_node, node_b_addr) if node_b_addr is not None else None
-        )
+        if entry_nodes is None:
+            default_node_candidates = (
+                [nn for nn in graph.nodes if nn.addr == node_b_addr] if node_b_addr is not None else []
+            )
+            node_default = (
+                self._switch_find_default_node(graph, head_node, node_b_addr) if node_b_addr is not None else None
+            )
+        else:
+            node_default = entry_nodes[default_entry] if default_entry is not None else None
         if node_default is not None and not isinstance(node_default, SequenceNode):
             # make the default node a SequenceNode so that we can insert Break and Continue nodes into it later
             new_node = SequenceNode(node_default.addr, nodes=[node_default])
             self.replace_nodes_both(node_default, new_node)
             node_default = new_node
+        if entry_nodes is not None and node_default is not None and selected_entry_to_case is not None:
+            selected_entry_to_case[id(node_default)] = node_default
 
         converted_nodes: dict[tuple[int, int | None], Any] = {}
         entry_addr_to_ids: defaultdict[tuple[int, int | None], set[int]] = defaultdict(set)
 
-        # the default node might get duplicated (e.g., by EagerReturns). we detect if a duplicate of the default node
-        # (node b) is a successor node of node a. we only skip those entries going to the default node if no duplicate
-        # of default node exists in node a's successors.
-        node_a_successors = list(graph.successors(node_a))
-        if len(default_node_candidates) > 1:
-            node_b_in_node_a_successors = any(nn for nn in node_a_successors if nn in default_node_candidates)
-        else:
-            # the default node is not duplicated
-            node_b_in_node_a_successors = False
+        if entry_nodes is None:
+            # the default node might get duplicated (e.g., by EagerReturns). we detect if a duplicate of the default
+            # node (node b) is a successor node of node a. we only skip those entries going to the default node if no
+            # duplicate of default node exists in node a's successors.
+            node_a_successors = list(graph.successors(node_a))
+            if len(default_node_candidates) > 1:
+                node_b_in_node_a_successors = any(nn for nn in node_a_successors if nn in default_node_candidates)
 
-        for case_idx, entry_addr in case_and_entryaddrs.items():
-            if isinstance(entry_addr, tuple):
-                entry_addr, entry_idx = entry_addr
-            else:
-                entry_idx = None
+        for case_idx, entry_addr_and_idx in case_and_entryaddrs.items():
+            entry_key = entry_addr_and_idx if isinstance(entry_addr_and_idx, tuple) else (entry_addr_and_idx, None)
+            entry_addr, entry_idx = entry_key
 
-            if not node_b_in_node_a_successors and entry_addr == node_b_addr:
+            if entry_nodes is not None and entry_key == default_entry:
+                continue
+            if entry_nodes is None and not node_b_in_node_a_successors and entry_addr == node_b_addr:
                 # jump to default or end of the switch-case structure - ignore this case
                 continue
 
-            entry_addr_to_ids[(entry_addr, entry_idx)].add(case_idx)
-            if (entry_addr, entry_idx) in converted_nodes:
+            entry_addr_to_ids[entry_key].add(case_idx)
+            if entry_key in converted_nodes:
                 continue
 
             if entry_addr in {self._region.head.addr, head_node.addr}:
@@ -2024,6 +2126,8 @@ class PhoenixStructurer(StructurerBase):
                 # lead to the removal of the region head node or the switch head node). replace this entry with a
                 # goto statement later.
                 entry_node = None
+            elif entry_nodes is not None:
+                entry_node = entry_nodes[entry_key]
             else:
                 entry_node = next(
                     iter(
@@ -2050,7 +2154,7 @@ class PhoenixStructurer(StructurerBase):
                     ],
                 )
                 case_node = SequenceNode(0, nodes=[case_inner_node])
-                converted_nodes[(entry_addr, entry_idx)] = case_node
+                converted_nodes[entry_key] = case_node
                 continue
 
             if isinstance(entry_node, SequenceNode):
@@ -2059,7 +2163,9 @@ class PhoenixStructurer(StructurerBase):
                 case_node = SequenceNode(entry_node.addr, nodes=[entry_node])
             to_remove.add(entry_node)
 
-            converted_nodes[(entry_addr, entry_idx)] = case_node
+            converted_nodes[entry_key] = case_node
+            if entry_nodes is not None and selected_entry_to_case is not None:
+                selected_entry_to_case[id(entry_node)] = case_node
 
         for entry_addr_and_idx, converted_node in converted_nodes.items():
             assert entry_addr_and_idx in entry_addr_to_ids
@@ -2087,8 +2193,11 @@ class PhoenixStructurer(StructurerBase):
         full_graph: networkx.DiGraph,
         node_a=None,
         bail_on_nonhead_outedges: bool = False,
+        selected_entry_to_case: dict[int, SequenceNode] | None = None,
     ) -> bool:
         scnode = SwitchCaseNode(cmp_expr, cases, node_default, addr=addr)
+        if selected_entry_to_case is not None:
+            to_remove = set(to_remove)
 
         # insert the switch-case node to the graph
         other_nodes_inedges = []
@@ -2163,9 +2272,15 @@ class PhoenixStructurer(StructurerBase):
                 [edge for edge in out_edges if edge[1] is not head], key=lambda edge: (edge[0].addr, edge[1].addr)
             )
 
-            # for all out edges going to head, we ensure there is a goto at the end of each corresponding case node
+            resolved_out_edges_to_head: list[tuple[Any, SequenceNode]] = []
             for out_src, out_dst in out_edges_to_head:
                 assert out_dst is head
+                if selected_entry_to_case is not None:
+                    selected_case_node = selected_entry_to_case.get(id(out_src))
+                    if selected_case_node is None:
+                        return False
+                    resolved_out_edges_to_head.append((out_src, selected_case_node))
+                    continue
                 all_case_nodes = list(cases.values())
                 if node_default is not None:
                     all_case_nodes.append(node_default)
@@ -2227,6 +2342,21 @@ class PhoenixStructurer(StructurerBase):
                         scnode.addr,
                         out_dst_succ_fullgraph.addr,
                     )
+
+            for out_src, case_node in resolved_out_edges_to_head:
+                try:
+                    case_node_last_stmt = self.cond_proc.get_last_statement(case_node)
+                except EmptyBlockNotice:
+                    case_node_last_stmt = None
+                if not isinstance(case_node_last_stmt, Jump):
+                    jump_stmt = Jump(
+                        self.ail_manager.next_atom(),
+                        Const(self.ail_manager.next_atom(), head.addr, self.project.arch.bits),
+                        None,
+                        ins_addr=out_src.addr,
+                    )
+                    jump_node = Block(out_src.addr, 0, statements=[jump_stmt])
+                    case_node.nodes.append(jump_node)
 
             if out_dst_succ is not None:
                 self._region.add_edge(scnode, out_dst_succ)

--- a/angr/analyses/decompiler/structuring/phoenix.py
+++ b/angr/analyses/decompiler/structuring/phoenix.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections import OrderedDict, defaultdict
+from collections.abc import Mapping
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
@@ -2061,7 +2062,9 @@ class PhoenixStructurer(StructurerBase):
 
     def _switch_build_cases(
         self,
-        case_and_entryaddrs: dict[int, int | tuple[int, int | None]],
+        # Read-only: a Mapping so a caller that knows every value is a (addr, idx) pair can pass its
+        # narrower dict. dict is invariant in its value type, Mapping is covariant.
+        case_and_entryaddrs: Mapping[int, int | tuple[int, int | None]],
         head_node,
         node_a: BaseNode,
         node_b_addr: int | None,

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -10,6 +10,7 @@ import re
 import time
 import unittest
 from functools import wraps
+from unittest import mock
 
 import networkx
 
@@ -466,11 +467,23 @@ class TestDecompiler(unittest.TestCase):
         p.analyses[CompleteCallingConventionsAnalysis].prep()(recover_variables=False, analyze_callsites=True)
 
         f = cfg.functions["process_file"]
-        dec = p.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
+        aliased_entries = []
+        original_make_switch_cases_core = PhoenixStructurer._make_switch_cases_core  # pylint:disable=protected-access
+
+        def audit_switch_entries(structurer, *args, **kwargs):
+            head, cases, default = args[0], args[2], args[4]
+            for case_value, case_node in cases.items():
+                if default is case_node:
+                    aliased_entries.append((head.addr, case_value, case_node.addr))
+            return original_make_switch_cases_core(structurer, *args, **kwargs)
+
+        with mock.patch.object(PhoenixStructurer, "_make_switch_cases_core", audit_switch_entries):
+            dec = p.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
         assert dec.codegen is not None, f"Failed to decompile function {f!r}."
         print_decompilation_result(dec)
         code = dec.codegen.text
         assert code is not None
+        self.assertFalse(aliased_entries, f"case/default metadata selected the same live node: {aliased_entries!r}")
         # the reconstructed switch and its case bodies survive: without the fix, structuring drops the outer switch
         # entirely, leaving only a small fragment (~1.4k chars) that is missing these cases and their bodies.
         assert "switch (" in code
@@ -481,6 +494,14 @@ class TestDecompiler(unittest.TestCase):
         assert "print_size(" in code
         # no unstructured switch head statement leaked into the output
         assert "IncompleteSwitchCaseHeadStatement" not in code
+        self.assertRegex(
+            code,
+            re.compile(
+                r"case 7:.*?case 1:\s+[A-Za-z_]\w* = 1;\s+return 1;\s+"
+                r"default:\s+[A-Za-z_]\w* = 1;\s+break;",
+                re.DOTALL,
+            ),
+        )
 
     @for_all_structuring_algos
     def test_decompiling_true_x86_64_0(self, decompiler_options=None):

--- a/tests/analyses/decompiler/test_phoenix_switch_entry_identity.py
+++ b/tests/analyses/decompiler/test_phoenix_switch_entry_identity.py
@@ -39,7 +39,7 @@ def _const(idx: int, value: int) -> Const:
 
 def _build_lowered_switch_graph():
     project = angr.load_shellcode(b"\x90", "AMD64", load_address=0x4000)
-    manager = Manager(arch=project.arch)
+    manager = Manager()
     switch_variable = VirtualVariable(0, 1, 64, VirtualVariableCategory.REGISTER, oident=0)
     assignment_variable = VirtualVariable(1, 2, 64, VirtualVariableCategory.REGISTER, oident=8)
 

--- a/tests/analyses/decompiler/test_phoenix_switch_entry_identity.py
+++ b/tests/analyses/decompiler/test_phoenix_switch_entry_identity.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import unittest
+from collections import defaultdict
+from types import SimpleNamespace
+from typing import Any, cast
+
+import networkx
+
+import angr
+from angr.ailment import Block, Manager
+from angr.ailment.expression import BinaryOp, Const, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import Assignment, ConditionalJump, Jump, Return
+from angr.analyses.decompiler.condition_processor import ConditionProcessor
+from angr.analyses.decompiler.optimization_passes import LoweredSwitchSimplifier
+from angr.analyses.decompiler.region_overlay import OverlayManager
+from angr.analyses.decompiler.structurer_nodes import (
+    CodeNode,
+    IncompleteSwitchCaseHeadStatement,
+    IncompleteSwitchCaseNode,
+    SequenceNode,
+    SwitchCaseNode,
+)
+from angr.analyses.decompiler.structuring import PhoenixStructurer, SAILRStructurer
+
+
+class _FilteredDiGraph(networkx.DiGraph):
+    def filtered(self):
+        return self
+
+
+def _const(idx: int, value: int) -> Const:
+    return Const(idx, value, 64)
+
+
+def _build_lowered_switch_graph():
+    project = angr.load_shellcode(b"\x90", "AMD64", load_address=0x4000)
+    manager = Manager(arch=project.arch)
+    switch_variable = VirtualVariable(0, 1, 64, VirtualVariableCategory.REGISTER, oident=0)
+    assignment_variable = VirtualVariable(1, 2, 64, VirtualVariableCategory.REGISTER, oident=8)
+
+    def comparison(idx: int, value: int) -> BinaryOp:
+        return BinaryOp(idx, "CmpEQ", [switch_variable, _const(idx + 1, value)], False)
+
+    head = Block(
+        0x4000,
+        1,
+        statements=[
+            ConditionalJump(
+                10,
+                comparison(11, 1),
+                _const(12, 0x5000),
+                _const(13, 0x4010),
+                true_target_idx=None,
+                false_target_idx=None,
+                ins_addr=0x4000,
+            )
+        ],
+    )
+    final_comparison = Block(
+        0x4010,
+        1,
+        statements=[
+            Assignment(20, assignment_variable, _const(21, 5)),
+            ConditionalJump(
+                22,
+                comparison(23, 20),
+                _const(24, 0x6000),
+                _const(25, 0x7000),
+                true_target_idx=None,
+                false_target_idx=None,
+                ins_addr=0x4010,
+            ),
+        ],
+    )
+    case_1 = Block(0x5000, 1, statements=[Return(30, [])])
+    case_20 = Block(0x6000, 1, statements=[Return(31, [])])
+    default = Block(0x7000, 1, statements=[Return(32, [])])
+    graph = networkx.DiGraph(
+        [
+            (head, case_1),
+            (head, final_comparison),
+            (final_comparison, case_20),
+            (final_comparison, default),
+        ]
+    )
+
+    blocks_by_addr = defaultdict(set)
+    blocks_by_addr_and_idx = {}
+    for node in graph:
+        blocks_by_addr[node.addr].add(node)
+        blocks_by_addr_and_idx[node.addr, node.idx] = node
+
+    function = SimpleNamespace(addr=head.addr, project=project, name="synthetic_lowered_switch")
+    simplified = LoweredSwitchSimplifier(
+        function,
+        manager,
+        graph=graph,
+        blocks_by_addr=blocks_by_addr,
+        blocks_by_addr_and_idx=blocks_by_addr_and_idx,
+        region_identifier=SimpleNamespace(regions_by_block_addrs=[]),
+    )
+    assert simplified.out_graph is not None
+    return simplified.out_graph, manager, project
+
+
+def _find_switch_case_node(node):
+    if isinstance(node, SwitchCaseNode):
+        return node
+    if isinstance(node, SequenceNode):
+        for child in node.nodes:
+            switch = _find_switch_case_node(child)
+            if switch is not None:
+                return switch
+    return None
+
+
+class TestPhoenixSwitchEntryIdentity(unittest.TestCase):
+    def test_switch_entry_identity_helpers(self):
+        entry_addr = 0x5000
+        left = CodeNode(Block(entry_addr, 0, idx=1), None)
+        right = IncompleteSwitchCaseNode(entry_addr, Block(entry_addr, 0, idx=1), [])
+        different = IncompleteSwitchCaseNode(entry_addr, Block(entry_addr, 0, idx=2), [])
+
+        self.assertEqual(PhoenixStructurer._switch_entry_idx(left), 1)
+        self.assertEqual(PhoenixStructurer._switch_entry_idx(right), 1)
+        self.assertTrue(PhoenixStructurer._switch_entries_match(left, right))
+        self.assertFalse(PhoenixStructurer._switch_entries_match(left, different))
+
+    def test_switch_entry_resolution_with_missing_and_mismatched_identities(self):
+        entry_addr = 0x5000
+        expected_entries: set[tuple[int, int | None]] = {(entry_addr, 1), (entry_addr, 2)}
+        matching = Block(entry_addr, 0, idx=1)
+
+        resolved = PhoenixStructurer._switch_resolve_entry_nodes([matching], expected_entries)
+        self.assertEqual(resolved, {(entry_addr, 1): matching, (entry_addr, 2): None})
+
+        mismatched = Block(entry_addr, 0, idx=3)
+        for candidates in ([matching, mismatched], [mismatched, matching]):
+            with self.subTest(candidate_indices=[candidate.idx for candidate in candidates]):
+                self.assertIsNone(PhoenixStructurer._switch_resolve_entry_nodes(candidates, expected_entries))
+
+    def test_lowered_switch_identity_survives_recursive_structuring(self):
+        for structurer_cls in (PhoenixStructurer, SAILRStructurer):
+            for reverse_successors in (False, True):
+                with self.subTest(structurer=structurer_cls.NAME, reverse_successors=reverse_successors):
+                    lowered_graph, manager, project = _build_lowered_switch_graph()
+                    head = next(node for node in lowered_graph if node.addr == 0x4000)
+                    switch_stmt = head.statements[-1]
+                    self.assertIsInstance(switch_stmt, IncompleteSwitchCaseHeadStatement)
+                    entries = {
+                        (target_addr, target_idx): value
+                        for _, value, target_addr, target_idx, _ in switch_stmt.case_addrs
+                    }
+                    self.assertEqual(entries[0x4010, None], 20)
+                    self.assertEqual(entries[0x4010, 1002], "default")
+
+                    case_entry = next(
+                        node for node in lowered_graph.successors(head) if (node.addr, node.idx) == (0x4010, None)
+                    )
+                    default_entry = next(
+                        node for node in lowered_graph.successors(head) if (node.addr, node.idx) == (0x4010, 1002)
+                    )
+                    lowered_graph.remove_edge(head, case_entry)
+                    lowered_graph.remove_edge(head, default_entry)
+                    same_address_successors = [case_entry, default_entry]
+                    if reverse_successors:
+                        same_address_successors.reverse()
+                    for successor in same_address_successors:
+                        lowered_graph.add_edge(head, successor)
+
+                    project.analyses.CFGFast(normalize=True)
+                    region_identifier = project.analyses.RegionIdentifier(
+                        None,
+                        graph=lowered_graph,
+                        ail_manager=manager,
+                        update_graph=False,
+                    )
+                    structured = project.analyses.RecursiveStructurer(
+                        region_identifier.region,
+                        cond_proc=region_identifier.cond_proc,
+                        func=None,
+                        structurer_cls=structurer_cls,
+                        ail_manager=manager,
+                    )
+
+                    self.assertFalse(structured.result_incomplete)
+                    switch = _find_switch_case_node(structured.result)
+                    self.assertIsNotNone(switch)
+                    if switch is None:
+                        self.fail("RecursiveStructurer did not produce a switch-case node")
+                    self.assertEqual(switch.cases[20].nodes[-1].addr, 0x6000)
+                    self.assertEqual(switch.default_node.nodes[-1].addr, 0x7000)
+
+    def test_ambiguous_structured_entry_bails_without_mutation(self):
+        comparison = Block(0x3000, 0)
+        switch_stmt = IncompleteSwitchCaseHeadStatement(
+            0,
+            Const(0, 0, 32),
+            [
+                (comparison, 20, 0x5000, None, 0),
+                (comparison, "default", 0x5000, 1002, 0),
+            ],
+            ins_addr=0x4000,
+        )
+        head = Block(0x4000, 0, statements=cast(list[Any], [switch_stmt]))
+        unknown_entry = SequenceNode(0x5000, [])
+        graph = _FilteredDiGraph([(head, unknown_entry)])
+        nodes_before = set(graph)
+        edges_before = set(graph.edges)
+        statements_before = list(head.statements)
+
+        structurer = object.__new__(PhoenixStructurer)
+        structurer._region = cast(Any, SimpleNamespace(head=head))
+        structurer.cond_proc = ConditionProcessor
+
+        def fail_on_mutation(*_args, **_kwargs):
+            self.fail("switch matching mutated state before resolving an ambiguous entry")
+
+        structurer._switch_build_cases = fail_on_mutation
+        self.assertFalse(structurer._match_acyclic_switch_cases_incomplete_switch_head(head, graph, graph))
+        self.assertEqual(set(graph), nodes_before)
+        self.assertEqual(set(graph.edges), edges_before)
+        self.assertEqual(head.statements, statements_before)
+        self.assertEqual(unknown_entry.nodes, [])
+
+    def test_loop_back_gotos_use_selected_entry_objects(self):
+        for reverse_successors in (False, True):
+            with self.subTest(reverse_successors=reverse_successors):
+                head = SequenceNode(0x4000, [Block(0x4000, 0, idx=None)])
+                case = Block(0x5000, 0, idx=None)
+                default = Block(0x5000, 0, idx=1002)
+                successors = [case, default]
+                if reverse_successors:
+                    successors.reverse()
+
+                graph = networkx.DiGraph()
+                graph.add_edges_from((head, successor) for successor in successors)
+                graph.add_edges_from(((case, head), (default, head)))
+                region = OverlayManager(graph).root
+                region.head = head
+
+                structurer = cast(Any, object.__new__(PhoenixStructurer))
+                structurer._region = region
+                structurer.cond_proc = ConditionProcessor
+                structurer.project = SimpleNamespace(arch=SimpleNamespace(bits=64))
+                structurer.ail_manager = Manager()
+                structurer._graph_helper = SimpleNamespace(
+                    add_node_successor=lambda *_: None,
+                    replace_node=lambda *_: None,
+                )
+                structurer.dowhile_known_tail_nodes = set()
+
+                expected_entries = {(case.addr, case.idx), (default.addr, default.idx)}
+                entry_nodes = structurer._switch_resolve_entry_nodes(region.graph.successors(head), expected_entries)
+                self.assertIsNotNone(entry_nodes)
+                if entry_nodes is None:
+                    self.fail("switch entry resolution unexpectedly failed")
+
+                selected_entry_to_case = {}
+                # pylint: disable-next=assignment-from-no-return
+                cases, selected_default, to_remove = structurer._switch_build_cases(
+                    {20: (case.addr, case.idx)},
+                    head,
+                    head,
+                    default.addr,
+                    region.graph,
+                    entry_nodes=entry_nodes,
+                    default_entry=(default.addr, default.idx),
+                    selected_entry_to_case=selected_entry_to_case,
+                )
+                self.assertIsInstance(selected_default, SequenceNode)
+
+                self.assertTrue(
+                    structurer._make_switch_cases_core(
+                        head,
+                        None,
+                        cases,
+                        default.addr,
+                        selected_default,
+                        head.addr,
+                        to_remove,
+                        region.graph,
+                        region.graph_with_successors,
+                        selected_entry_to_case=selected_entry_to_case,
+                    )
+                )
+                self.assertIsInstance(cases[20].nodes[-1].statements[-1], Jump)
+                self.assertIsInstance(selected_default.nodes[-1].statements[-1], Jump)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_phoenix_switch_entry_identity.py
+++ b/tests/analyses/decompiler/test_phoenix_switch_entry_identity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
 
+import os
 import unittest
 from collections import defaultdict
 from types import SimpleNamespace
@@ -26,6 +27,9 @@ from angr.analyses.decompiler.structurer_nodes import (
     SwitchCaseNode,
 )
 from angr.analyses.decompiler.structuring import PhoenixStructurer, SAILRStructurer
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
 
 
 class _FilteredDiGraph(networkx.DiGraph):
@@ -38,7 +42,7 @@ def _const(idx: int, value: int) -> Const:
 
 
 def _build_lowered_switch_graph():
-    project = angr.load_shellcode(b"\x90", "AMD64", load_address=0x4000)
+    project = angr.Project(os.path.join(test_location, "x86_64", "switch_default_abort.o"), auto_load_libs=False)
     manager = Manager()
     switch_variable = VirtualVariable(0, 1, 64, VirtualVariableCategory.REGISTER, oident=0)
     assignment_variable = VirtualVariable(1, 2, 64, VirtualVariableCategory.REGISTER, oident=8)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Phoenix can swap a lowered switch case and its default in `process_file` from `tests/x86_64/decompiler/du.o`. On the baseline, both entries select the same live node at `0x400902`.

### Root cause

Copied case bodies can share an address while retaining different AIL block indices. The incomplete-switch matcher discarded that index identity and resolved entries according to graph order.

### Fix

Entry identity now survives structured wrappers, colliding entries are resolved as a group before mutation, and the selected live objects are retained through case wrapping and loop-back repair.

### Testing

The real-fixture regression checks that case and default select distinct live nodes; neighboring tests cover both successor orders, ambiguity bailout, and loop-back repair. Validation: https://github.com/angr/angr/pull/6905#issuecomment-5380990645

session: sharpen
