### PR TITLE
docs: Collapse the global toctree furo renders into every page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -264,5 +264,39 @@ def _patch_directive_header_for_reexports() -> None:
 _patch_directive_header_for_reexports()
 
 
+# -- Global navigation sidebar ----------------------------------------------
+# ``index.rst`` declares ``:maxdepth: 2``, but furo asks for the global toctree
+# with an explicit ``maxdepth=-1``, and Sphinx lets an explicit argument
+# override the option written in the directive. The full recursive API tree is
+# therefore expanded into the sidebar of every one of the roughly 1,250 pages,
+# which accounts for most of the build's wall clock and pushes Read the Docs
+# past its build timeout on slower builders.
+#
+# Wrapping the context callable puts that choice back in this file. ``collapse``
+# is the part that saves the time: bounding the depth alone still resolves and
+# deep-copies the whole tree before pruning it, whereas collapsing stops sibling
+# packages from being expanded at all. The depth is left unbounded on purpose,
+# so the branch the reader is in is still shown in full. Page bodies, the search
+# index and the object inventory are unaffected; only the sidebar changes.
+#
+# The priority has to be below furo's, which connects at the default of 500, so
+# that the wrapper is installed before the theme reads it.
+
+
+def limit_global_toctree(_app, _pagename, _templatename, context, _doctree):
+    """Collapse the global toctree that the theme renders into the sidebar."""
+    original = context.get("toctree")
+    if original is None:
+        return
+
+    def bounded(**kwargs):
+        kwargs["maxdepth"] = -1
+        kwargs["collapse"] = True
+        return original(**kwargs)
+
+    context["toctree"] = bounded
+
+
 def setup(app):
     app.connect("autodoc-skip-member", skip_inherited_undocumented)
+    app.connect("html-page-context", limit_global_toctree, priority=400)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -283,15 +283,27 @@ _patch_directive_header_for_reexports()
 # that the wrapper is installed before the theme reads it.
 
 
-def limit_global_toctree(_app, _pagename, _templatename, context, _doctree):
-    """Collapse the global toctree that the theme renders into the sidebar."""
+def limit_global_toctree(_app, pagename, _templatename, context, _doctree):
+    """Bound the global toctree that the theme renders into the sidebar.
+
+    Rendering the fully expanded tree into all 1245 pages dominates the build.
+    The 1192 pages under api/ are the reason, so they keep a collapsed tree,
+    which still expands the branch the reader is in. The 53 narrative pages are
+    cheap enough to show every section's children.
+    """
     original = context.get("toctree")
     if original is None:
         return
 
+    is_api = pagename == "api" or pagename.startswith("api/")
+
     def bounded(**kwargs):
-        kwargs["maxdepth"] = -1
-        kwargs["collapse"] = True
+        if is_api:
+            kwargs["maxdepth"] = -1
+            kwargs["collapse"] = True
+        else:
+            kwargs["maxdepth"] = 2
+            kwargs["collapse"] = False
         return original(**kwargs)
 
     context["toctree"] = bounded


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The documentation build on Read the Docs sits close enough to the 2400 s build
limit that it fails intermittently. Of the 400 most recent builds of this
project 287 ran to completion and 24 of those failed, 22 of them by running into
the limit at around 2408 s; `latest`, which is master, is among them. The split
is entirely down to how fast a builder we get: every build whose `uv sync` step
took over 500 s hit the limit, and every build that synced in 500 s or less
finished.

Nearly all of the wall clock goes into the sidebar rather than the pages.
`docs/index.rst` declares `:maxdepth: 2` for its toctree, but furo asks Sphinx
for the global toctree with an explicit `maxdepth=-1` and `collapse=False`, and
`maxdepth = maxdepth or toctree.get('maxdepth', -1)` in Sphinx's toctree adapter
means the theme's explicit argument beats the option written in the directive.
So the unbounded sidebar is a theme default overriding what this documentation
asked for, not a preference anyone here expressed. The effect is that a
1242-entry navigation tree covering the whole API is resolved and rendered into
every one of the roughly 1250 pages: a profile of a full build puts 707 s of
919 s inside furo's `_compute_navigation_tree`, whose hot leaf is a deepcopy of
the toctree once per page, and a typical API page is 240 KB of HTML of which
226 KB is sidebar.

This adds an `html-page-context` handler that runs ahead of the theme's own and
wraps the `toctree` callable the theme calls, so the global tree is requested
with `collapse=True`. Collapsing is the part that saves the time; bounding the
depth alone does not, because Sphinx resolves and copies the whole tree before
it prunes anything. The depth stays unbounded, so the branch the reader is in is
still shown in full and only sibling packages stop being expanded. Page bodies,
the search index and the object inventory come out byte-identical to a build
without this, and the warning and error counts are unchanged; only the sidebar
differs. Measurements, and what could and could not be checked locally, are in
[this comment](https://github.com/angr/angr/pull/6906#issuecomment-5383567270).
