### PR TITLE
CFGFast: two quadratic/futile hot spots in the scanning phase

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/syscall_resolver.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/syscall_resolver.py
@@ -32,9 +32,17 @@ class SyscallResolver(IndirectJumpResolver):
 
     def __init__(self, project):
         super().__init__(project, timeless=True)
+        # Resolving a syscall means asking the OS model to turn a syscall number into a SimProcedure. The base SimOS
+        # cannot do that: SimOS.syscall() unconditionally returns None. So on a project with no OS model -- a firmware
+        # blob or any other bare-metal image -- every resolution attempt is guaranteed to come back empty, and the
+        # symbolic execution below is spent only to reach that conclusion. Decide it once, here.
+        from angr.simos import SimOS  # pylint:disable=import-outside-toplevel
+
+        simos = project.simos
+        self._os_resolves_syscalls = simos is not None and type(simos).syscall is not SimOS.syscall
 
     def filter(self, cfg, addr, func_addr, block, jumpkind):
-        return jumpkind.startswith("Ijk_Sys")
+        return self._os_resolves_syscalls and jumpkind.startswith("Ijk_Sys")
 
     def resolve(  # pylint:disable=unused-argument
         self, cfg, addr: int, func_addr: int, block: Block, jumpkind: str, func_graph_complete: bool = True, **kwargs

--- a/angr/analyses/cfg/indirect_jump_resolvers/syscall_resolver.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/syscall_resolver.py
@@ -10,6 +10,7 @@ from angr.errors import (
     SimError,
     SimOperationError,
 )
+from angr.simos import SimOS
 from angr.state_plugins.inspect import BP, BP_AFTER
 
 from .constant_value_manager import ConstantValueManager
@@ -32,12 +33,6 @@ class SyscallResolver(IndirectJumpResolver):
 
     def __init__(self, project):
         super().__init__(project, timeless=True)
-        # Resolving a syscall means asking the OS model to turn a syscall number into a SimProcedure. The base SimOS
-        # cannot do that: SimOS.syscall() unconditionally returns None. So on a project with no OS model -- a firmware
-        # blob or any other bare-metal image -- every resolution attempt is guaranteed to come back empty, and the
-        # symbolic execution below is spent only to reach that conclusion. Decide it once, here.
-        from angr.simos import SimOS  # pylint:disable=import-outside-toplevel
-
         simos = project.simos
         self._os_resolves_syscalls = simos is not None and type(simos).syscall is not SimOS.syscall
 

--- a/angr/analyses/forward_analysis/forward_analysis.py
+++ b/angr/analyses/forward_analysis/forward_analysis.py
@@ -527,12 +527,23 @@ class ForwardAnalysis[AnalysisState, NodeType, JobType, JobKey, SuccessorType]:
         """
 
         to_remove = []
+        kept: deque[JobInfo[JobType, JobKey]] = deque()
         for job_info in self._job_info_queue:
             if predicate(job_info.job):
                 to_remove.append(job_info)
+            else:
+                kept.append(job_info)
+
+        if not to_remove:
+            return
+
+        # Rebuild the queue in a single pass. Deleting the matches one at a time costs a scan of the whole queue per
+        # match, and each step of that scan runs JobInfo.__eq__, which compares every field of the underlying job. On
+        # an analysis that removes jobs often -- CFGFast on ARM discards a block's jobs whenever a decoding assumption
+        # is invalidated -- that makes one call quadratic in the length of the queue.
+        self._job_info_queue = kept
 
         for job_info in to_remove:
-            self._job_info_queue.remove(job_info)
             key = self._job_key(job_info.job)
             if key in self._job_map:
                 del self._job_map[key]

--- a/angr/analyses/forward_analysis/forward_analysis.py
+++ b/angr/analyses/forward_analysis/forward_analysis.py
@@ -537,10 +537,6 @@ class ForwardAnalysis[AnalysisState, NodeType, JobType, JobKey, SuccessorType]:
         if not to_remove:
             return
 
-        # Rebuild the queue in a single pass. Deleting the matches one at a time costs a scan of the whole queue per
-        # match, and each step of that scan runs JobInfo.__eq__, which compares every field of the underlying job. On
-        # an analysis that removes jobs often -- CFGFast on ARM discards a block's jobs whenever a decoding assumption
-        # is invalidated -- that makes one call quadratic in the length of the queue.
         self._job_info_queue = kept
 
         for job_info in to_remove:

--- a/tests/analyses/cfg/test_syscall_resolver.py
+++ b/tests/analyses/cfg/test_syscall_resolver.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
+
+import os.path
+import unittest
+
+import angr
+from angr.analyses.cfg.indirect_jump_resolvers.syscall_resolver import SyscallResolver
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestSyscallResolver(unittest.TestCase):
+    def test_filter_accepts_syscalls_when_the_os_model_can_resolve_them(self):
+        proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        resolver = SyscallResolver(proj)
+
+        assert resolver.filter(None, 0, 0, None, "Ijk_Sys_syscall") is True
+        assert resolver.filter(None, 0, 0, None, "Ijk_Boring") is False
+
+    def test_filter_rejects_syscalls_on_a_project_with_no_os_model(self):
+        # A firmware blob gets the base SimOS, whose syscall() unconditionally returns None. Resolution can never
+        # succeed, so the resolver must not symbolically execute the block to find that out.
+        proj = angr.Project(
+            os.path.join(test_location, "armel", "chall.bin"),
+            main_opts={"backend": "blob", "arch": "ARMEL", "base_addr": 0},
+            auto_load_libs=False,
+        )
+        assert proj.simos.syscall(proj.factory.blank_state()) is None
+
+        resolver = SyscallResolver(proj)
+        assert resolver.filter(None, 0, 0, None, "Ijk_Sys_syscall") is False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/test_forward_analysis.py
+++ b/tests/analyses/test_forward_analysis.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses"  # pylint:disable=redefined-builtin
+
+import unittest
+
+from angr.analyses.forward_analysis import ForwardAnalysis
+
+
+class _Job:
+    """A minimal job: identity is its key, so JobInfo equality is exercised for real."""
+
+    def __init__(self, key, tag=""):
+        self.key = key
+        self.tag = tag
+
+    def __eq__(self, other):
+        return type(other) is _Job and self.key == other.key and self.tag == other.tag
+
+    def __hash__(self):
+        return hash((self.key, self.tag))
+
+
+class _Queue(ForwardAnalysis):
+    """ForwardAnalysis reduced to its job queue, which is all _remove_job touches."""
+
+    def __init__(self):
+        super().__init__(order_jobs=False, allow_merging=False, allow_widening=False)
+
+    def _job_key(self, job):
+        return job.key
+
+
+class TestForwardAnalysisJobQueue(unittest.TestCase):
+    def _queue(self, jobs):
+        q = _Queue()
+        for job in jobs:
+            q._insert_job(job)
+        return q
+
+    def test_remove_job_removes_exactly_the_matching_jobs(self):
+        jobs = [_Job(i) for i in range(10)]
+        q = self._queue(jobs)
+
+        q._remove_job(lambda j: j.key % 3 == 0)
+
+        assert [j.key for j in q.jobs] == [1, 2, 4, 5, 7, 8]
+        assert sorted(q._job_map) == [1, 2, 4, 5, 7, 8]
+
+    def test_remove_job_preserves_queue_order(self):
+        q = self._queue([_Job(k) for k in (7, 3, 9, 1, 5)])
+
+        q._remove_job(lambda j: j.key == 9)
+
+        assert [j.key for j in q.jobs] == [7, 3, 1, 5]
+
+    def test_remove_job_matching_nothing_leaves_the_queue_alone(self):
+        q = self._queue([_Job(i) for i in range(5)])
+
+        q._remove_job(lambda j: j.key > 100)
+
+        assert [j.key for j in q.jobs] == [0, 1, 2, 3, 4]
+        assert sorted(q._job_map) == [0, 1, 2, 3, 4]
+
+    def test_remove_job_removes_every_equal_job(self):
+        # Jobs that compare equal but are distinct objects must all go: deleting them one at a time by value used
+        # to rely on list.remove() finding "a" match rather than the one selected.
+        q = _Queue()
+        for job in (_Job(1, "a"), _Job(2, "b"), _Job(3, "a"), _Job(4, "b")):
+            q._insert_job(job)
+
+        q._remove_job(lambda j: j.tag == "a")
+
+        assert [j.key for j in q.jobs] == [2, 4]
+        assert sorted(q._job_map) == [2, 4]
+
+    def test_remove_job_can_empty_the_queue(self):
+        q = self._queue([_Job(i) for i in range(4)])
+
+        q._remove_job(lambda j: True)
+
+        assert not list(q.jobs)
+        assert not q._job_map
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Two independent hot spots in CFGFast's scanning phase, each found by profiling
32-bit ARM firmware images that exhaust a 300 s deadline before they ever reach
post-analysis. Both changes are semantics-preserving; both are measured with the
deadline removed so neither number is censored.

The commits are independent and either can be dropped without affecting the other.

## 1. `ForwardAnalysis._remove_job` is quadratic in the job queue

`_remove_job` collected the matching `JobInfo`s and then deleted them one at a
time with `deque.remove()`. Each of those is a scan of the whole queue, and every
step of that scan runs `JobInfo.__eq__`, which compares twelve fields of the
underlying job. One call is quadratic in the queue length.

CFGFast on ARM reaches this constantly. `_cascading_remove_lifted_blocks` calls
`_remove_jobs_by_source_node_addr` once per block it drops whenever a decoding
assumption is invalidated, and on firmware images that happens tens of thousands
of times.

The fix collects the survivors in the same pass and swaps the queue for them.
Removal becomes identity-based, which selects exactly the `JobInfo`s the
predicate matched. Two `JobInfo`s that compare equal have the same key and the
same job, so no predicate can separate them and the outcome is unchanged.

Measured on a 1.5 MB ARMEL Intel-HEX firmware image, both sides given enough
time to finish:

| | before | after |
| --- | ---: | ---: |
| CFGFast wall time | 484.0 s | **77.8 s** |
| functions recovered | 4,061 | 4,061 |
| blocks recovered | 37,415 | 37,415 |
| time inside `_remove_job` | 405.1 s | 0.0 s |

**6.2x**, same recovery. A py-spy profile of the same object at 97 Hz puts
93.3% of the whole run under `_cascading_remove_lifted_blocks`, of which 93.29%
is `_remove_job` and 68.6% is self time in `JobInfo.__eq__`.

The five new unit tests in `tests/analyses/test_forward_analysis.py` pass on
`master` as well as on this branch, which is the point: they pin the behaviour
the rewrite has to preserve, including the case of several jobs that compare
equal.

## 2. `SyscallResolver` symbolically executes work it cannot use

`SyscallResolver.filter` accepts any `Ijk_Sys` jumpkind, and
`_resolve_syscall_to_stub` then builds a blank state, installs a
`ConstantValueManager` breakpoint and symbolically executes the block before
asking `project.simos.syscall()` what the syscall is. On a project with no OS
model -- a firmware blob, an Intel-HEX image, any bare-metal target -- that call
is `SimOS.syscall()`, which is a documented unconditional `return None`. The
resolution cannot succeed, and the symbolic execution is spent only to arrive at
that.

CFGFast on such a target reaches this often, because it linear-sweeps regions
that carry no function-start evidence and random ARM and THUMB data decodes to
`svc` regularly, so the sweep manufactures a steady supply of blocks ending in a
bogus syscall.

The fix decides once, at construction, whether the project's OS model overrides
`syscall()` at all, and lets `filter()` reject everything when it does not.
Projects with a real `SimUserland` are unaffected, and so is any `SimOS`
subclass that overrides `syscall()`.

Measured on a 1.8 MB ARMEL Intel-HEX firmware image, both sides given enough
time to finish, run back to back at the same load:

| | before | after |
| --- | ---: | ---: |
| CFGFast wall time | 389.3 s | **123.4 s** |
| functions recovered | 7,878 | 7,878 |
| blocks recovered | 58,821 | 58,821 |
| function-address set (sha256 prefix) | `2dc5565efc3f87a4` | `2dc5565efc3f87a4` |
| time inside the resolver | 266.0 s | 0.0 s |
| resolution attempts | 5,786 | 0 |
| **resolutions that succeeded** | **0** | 0 |

**3.2x**, byte-identical recovery. Across six such firmware images the resolver
was entered thousands of times and never once returned a stub.

`tests/analyses/cfg/test_syscall_resolver.py::test_filter_rejects_syscalls_on_a_project_with_no_os_model`
fails on `master` and passes here; the companion test asserts the resolver is
still active on a Linux ELF.

## Validation

Run against `origin/master` at `5d32d30d6`. The numbers above were taken at
`0c59b6383`. The follow-up commit `e2a95f1b6` only hoists an import that was
already executed on the same path and deletes two block comments, so it cannot
move any of them; the regressions were re-run on it and are 7 passed, with
pylint, `ruff check` and `ruff format --check` unchanged on both files.

- `tests/analyses/cfg`, `tests/analyses/test_slicing.py`,
  `tests/analyses/test_forward_analysis.py`, `tests/analyses/test_ddg.py`,
  `tests/analyses/test_cdg.py`: 171 passed, 10 skipped, 26 subtests passed,
  4 failed. All four failures reproduce unmodified on `origin/master`
  (`test_cfgfast_soot` needs a `java` binary this host does not have;
  `test_cfg_macho_sections` fails at `master` too).
- `ruff check`, `ruff format --check`: clean on all four changed files.
- `pylint`: 10.00/10 on the changed files.
- `pyright`: 0 errors on the changed files.
- Not run: the complete workspace gate, the native Rust suite and the GUI suite,
  because a long-running analysis job holds this machine's other checkouts.

## Relationship to #6676

#6676 also touches `_cascading_remove_lifted_blocks`, which is what drives the
first hot spot. There is no overlap: its hunk there adds a control-flow-blanket
removal and leaves `self._remove_jobs_by_source_node_addr(existing_node.addr)`
as unchanged context, and it does not touch
`angr/analyses/forward_analysis/forward_analysis.py`,
`angr/analyses/cfg/indirect_jump_resolvers/syscall_resolver.py`, or any other
file this branch changes. The two should merge in either order.

