### PR TITLE
CFGBase: Track the functions with no jobs left instead of rescanning

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -222,6 +222,9 @@ class CFGBase(Analysis):
         # a dict of mapping between function addresses and sets of jobs (include both future jobs and pending jobs)
         # a set is used to speed up the job removal procedure
         self._jobs_to_analyze_per_function = defaultdict(set)
+        # the subset of keys of _jobs_to_analyze_per_function whose job set is empty, maintained by
+        # _register_analysis_job() and _deregister_analysis_job()
+        self._functions_without_jobs = set()
         # addresses of functions that have been completely recovered (i.e. all of its blocks are identified) so far
         self._completed_functions = set()
 
@@ -353,6 +356,7 @@ class CFGBase(Analysis):
         """
 
         self._jobs_to_analyze_per_function = defaultdict(set)
+        self._functions_without_jobs = set()
         self._completed_functions = set()
 
     def _function_completed(self, func_addr: int):
@@ -1578,6 +1582,7 @@ class CFGBase(Analysis):
         """
 
         self._jobs_to_analyze_per_function[func_addr].add(job)
+        self._functions_without_jobs.discard(func_addr)
 
     def _deregister_analysis_job(self, func_addr, job):
         """
@@ -1588,25 +1593,23 @@ class CFGBase(Analysis):
         :return:              None
         """
 
-        self._jobs_to_analyze_per_function[func_addr].discard(job)
+        jobs = self._jobs_to_analyze_per_function[func_addr]
+        jobs.discard(job)
+        if not jobs:
+            self._functions_without_jobs.add(func_addr)
 
     def _get_finished_functions(self):
         """
         Obtain all functions of which we have finished analyzing. As _jobs_to_analyze_per_function is a defaultdict(),
         if a function address shows up in it with an empty job list, we consider we have exhausted all jobs of this
         function (both current jobs and pending jobs), thus the analysis of this function is done.
+        _functions_without_jobs holds exactly those addresses.
 
         :return: a list of function addresses of that we have finished analysis.
         :rtype:  list
         """
 
-        finished_func_addrs = []
-        for func_addr, all_jobs in self._jobs_to_analyze_per_function.items():
-            if not all_jobs:
-                # great! we have finished analyzing this function!
-                finished_func_addrs.append(func_addr)
-
-        return finished_func_addrs
+        return list(self._functions_without_jobs)
 
     def _cleanup_analysis_jobs(self, finished_func_addrs=None):
         """
@@ -1624,6 +1627,9 @@ class CFGBase(Analysis):
         for func_addr in finished_func_addrs:
             if func_addr in self._jobs_to_analyze_per_function:
                 del self._jobs_to_analyze_per_function[func_addr]
+        # rebuilt, not discarded in place, so that the set does not keep a hash table sized to its
+        # high-water mark for the rest of the analysis
+        self._functions_without_jobs = self._functions_without_jobs.difference(finished_func_addrs)
 
     def _make_completed_functions(self):
         """

--- a/tests/analyses/cfg/test_cfg_job_tracking.py
+++ b/tests/analyses/cfg/test_cfg_job_tracking.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from angr.analyses.cfg.cfg_base import CFGBase
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+def _rescan(cfg):
+    """Every function tracked by the analysis whose job set is empty."""
+    return {func_addr for func_addr, jobs in cfg._jobs_to_analyze_per_function.items() if not jobs}
+
+
+class TestCFGJobTracking(unittest.TestCase):
+    """CFGBase reports the functions with no jobs left without rescanning every function."""
+
+    def _recover_and_compare(self, path):
+        """Run CFGFast, comparing what _get_finished_functions returns against a rescan on every call."""
+        proj = angr.Project(path, auto_load_libs=False)
+        original = CFGBase._get_finished_functions
+        observed = {"calls": 0, "returned": 0}
+
+        def compared(self):
+            reported = set(original(self))
+            rescanned = _rescan(self)
+            assert reported == rescanned, (
+                f"reported but not found by a rescan: {sorted(reported - rescanned)}; "
+                f"found by a rescan but not reported: {sorted(rescanned - reported)}"
+            )
+            observed["calls"] += 1
+            observed["returned"] += len(reported)
+            return list(reported)
+
+        CFGBase._get_finished_functions = compared
+        try:
+            proj.analyses.CFGFast()
+        finally:
+            CFGBase._get_finished_functions = original
+        return observed
+
+    def test_finished_functions_match_a_rescan_x86_64(self):
+        observed = self._recover_and_compare(os.path.join(test_location, "x86_64", "fauxware"))
+        assert observed["calls"] > 0
+        assert observed["returned"] > 0
+
+    def test_finished_functions_match_a_rescan_armel(self):
+        observed = self._recover_and_compare(os.path.join(test_location, "armel", "fauxware"))
+        assert observed["calls"] > 0
+        assert observed["returned"] > 0
+
+    def _empty_cfg(self):
+        proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast()
+        cfg._jobs_to_analyze_per_function.clear()
+        cfg._functions_without_jobs.clear()
+        return cfg
+
+    def test_registering_a_job_unmarks_a_finished_function(self):
+        cfg = self._empty_cfg()
+        job = object()
+
+        cfg._register_analysis_job(0x400000, job)
+        assert cfg._get_finished_functions() == []
+        assert _rescan(cfg) == set()
+
+        cfg._deregister_analysis_job(0x400000, job)
+        assert cfg._get_finished_functions() == [0x400000]
+        assert _rescan(cfg) == {0x400000}
+
+        cfg._register_analysis_job(0x400000, object())
+        assert cfg._get_finished_functions() == []
+        assert _rescan(cfg) == set()
+
+    def test_deregistering_an_unknown_job_marks_the_function_finished(self):
+        # _jobs_to_analyze_per_function is a defaultdict, so deregistering a job that was never
+        # registered leaves an empty entry behind, and an empty entry counts as finished.
+        cfg = self._empty_cfg()
+
+        cfg._deregister_analysis_job(0x400000, object())
+        assert cfg._get_finished_functions() == [0x400000]
+        assert _rescan(cfg) == {0x400000}
+
+    def test_cleanup_drops_the_function_from_both_records(self):
+        cfg = self._empty_cfg()
+        job = object()
+        cfg._register_analysis_job(0x400000, job)
+        cfg._deregister_analysis_job(0x400000, job)
+
+        cfg._cleanup_analysis_jobs(finished_func_addrs=[0x400000])
+
+        assert cfg._get_finished_functions() == []
+        assert _rescan(cfg) == set()
+        assert 0x400000 not in cfg._jobs_to_analyze_per_function
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGBase._get_finished_functions()` answers "which functions have no jobs left" by walking every entry of `_jobs_to_analyze_per_function`, and `CFGFast._job_queue_empty()` reaches it through `_make_completed_functions()` on every job-queue drain. Its cost is the number of functions still in flight, not the number that just finished.

On `binaries/tests/riscv/asterisk-libasteriskpj.so.2` the pass runs 2,348 times and walks 136,934 dict entries to report 8,426 addresses -- sixteen entries visited per address reported, 2,403 of them in its widest single call:

```
_get_finished_functions calls       = 2348
function addresses returned (total) = 8426
entries VISITED by the lookup, summed over calls = 136934
entries VISITED by the lookup, widest single call = 2403
```

That ratio grows with the number of partially analyzed functions, so the scan is negligible on a small binary and dominant on a large one: on a stripped ARM firmware image it is 21.4-21.8% of a 300 s run, measured in the validation record.

### Root cause

The set is mutated in exactly two places -- `_register_analysis_job()` adds a job to a function and `_deregister_analysis_job()` removes one -- and the lookup re-derives it from scratch on every call instead of being told:

```python
finished_func_addrs = []
for func_addr, all_jobs in self._jobs_to_analyze_per_function.items():
    if not all_jobs:
        finished_func_addrs.append(func_addr)
return finished_func_addrs
```

Nothing else touches those job sets, so every walk re-answers a question the two mutators already knew the answer to, over a dict whose size is the analysis's working set rather than its result.

### Fix

Maintain `_functions_without_jobs` in the two mutators -- `discard` on register, `add` when a deregister empties a function's set -- and make the lookup `list(self._functions_without_jobs)`. `_cleanup_analysis_jobs()` drops the finished addresses from both records, rebuilding the set with `difference()` rather than discarding in place so it does not retain a hash table sized to the run's high-water mark, and `_initialize_cfg()` resets it alongside `_jobs_to_analyze_per_function`.

The lookup then visits only what it returns, on the same binary and with the recovery unchanged -- same 3,233 functions, same 65,484 CFG nodes, same function-address sha256 on both sides:

```
entries VISITED by the lookup, summed over calls = 8426
entries VISITED by the lookup, widest single call = 1661
_get_finished_functions      2348 calls  tottime=  0.0013 s
```

The old scan is deliberately not kept in production as a cross-check. The tests make that comparison instead, so the shipped path has one implementation of the answer rather than two that can drift.

### Testing

`tests/analyses/cfg/test_cfg_job_tracking.py` drives real `CFGFast` recoveries of `binaries/tests/x86_64/fauxware` and `binaries/tests/armel/fauxware` with `_get_finished_functions` wrapped, asserting on every call that what it returns equals a fresh rescan of `_jobs_to_analyze_per_function` -- the equivalence this change rests on, checked continuously rather than once at the end. Three further tests pin the bookkeeping directly: registering a job unmarks a finished function, deregistering a job that was never registered marks one finished (the `defaultdict` behaviour the old scan had), and cleanup drops the address from both records. On the merge base the two recovery tests pass unchanged and the three bookkeeping tests fail with `AttributeError`, since `_functions_without_jobs` does not exist there.

Validation: https://github.com/angr/angr/pull/6910#issuecomment-5387450143

session: sharpen