### PR TITLE
CFGFast: Attribute a one-instruction block's default exit to that instruction

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3211,11 +3211,13 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         default_branch_ins_addr = None
         if irsb.instruction_addresses:
             if self.project.arch.branch_delay_slot and len(irsb.instruction_addresses) > 1:
-                # the last instruction is the delay slot of the branch that ends this block
+                # step back over the delay slot to the branch that owns it. This assumes the block ends in a
+                # terminator that has a delay slot, which is not true of all of them -- a syscall has none, so the
+                # step-back names the instruction before it. That is longstanding behaviour and is left alone here.
                 default_branch_ins_addr = irsb.instruction_addresses[-2]
             else:
-                # either this architecture has no delay slots, or the block holds a single instruction and therefore
-                # contains no delay slot (e.g. the block was truncated at a known block boundary, or decoding the
+                # either this architecture has no delay slots, or the block holds a single instruction and so cannot
+                # hold both a branch and its delay slot (the block was truncated at a known boundary, or decoding the
                 # delay slot failed). Either way the last instruction is the source of the default exit.
                 default_branch_ins_addr = irsb.instruction_addresses[-1]
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3210,10 +3210,13 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         # default statement
         default_branch_ins_addr = None
         if irsb.instruction_addresses:
-            if self.project.arch.branch_delay_slot:
-                if len(irsb.instruction_addresses) > 1:
-                    default_branch_ins_addr = irsb.instruction_addresses[-2]
+            if self.project.arch.branch_delay_slot and len(irsb.instruction_addresses) > 1:
+                # the last instruction is the delay slot of the branch that ends this block
+                default_branch_ins_addr = irsb.instruction_addresses[-2]
             else:
+                # either this architecture has no delay slots, or the block holds a single instruction and therefore
+                # contains no delay slot (e.g. the block was truncated at a known block boundary, or decoding the
+                # delay slot failed). Either way the last instruction is the source of the default exit.
                 default_branch_ins_addr = irsb.instruction_addresses[-1]
 
         successors.append((DEFAULT_STATEMENT, default_branch_ins_addr, irsb_next, jumpkind))

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1063,6 +1063,28 @@ class TestCfgfast(unittest.TestCase):
         ):
             assert addr in cfg.kb.functions, f"{name} at {addr:#x} was dropped"
 
+    def test_single_instruction_indirect_jump_on_delay_slot_arch(self):
+        # On a delay-slot architecture the branch that ends a block sits one instruction before the end, so CFGFast
+        # took the block's last instruction to be the delay slot and had no instruction address to attribute the
+        # default exit to when the block held a single instruction. A p-code SPARC word that does not decode lifts
+        # to IllegalInstructionTrap followed by an indirect goto, which is exactly such a block, and the missing
+        # instruction address aborted the entire analysis.
+        proj = angr.load_shellcode(
+            b"\x00" * 4,
+            arch=archinfo.ArchPcode("sparc:BE:32:default"),
+            load_address=0x400000,
+            start_offset=0x400000,
+        )
+        cfg = proj.analyses.CFGFast()
+
+        node = cfg.model.get_any_node(0x400000)
+        assert node is not None
+        assert list(node.instruction_addrs) == [0x400000]
+        # a one-instruction block on a delay-slot architecture cannot hold a real branch and its delay slot, so the
+        # indirect jump is a decoding artifact: it gets no successors and is not queued for resolution
+        assert not list(cfg.graph.successors(node))
+        assert 0x400000 not in cfg.indirect_jumps
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

On a delay-slot architecture the branch that ends a block sits one instruction before the end, so `_scan_irsb` takes `instruction_addresses[-2]` as the source of the default exit — and leaves it `None` when the block holds a single instruction. `_create_jobs` then asserts that the instruction address is not `None` whenever the successor's target is not a compile-time constant, so the whole analysis aborts.

A block of that shape is easy to reach. A p-code SPARC word that does not decode lifts to `IllegalInstructionTrap` followed by an indirect `goto`, with `irsb.next` unset because that is how the p-code engine reports a non-constant target. Any jump, call or linear-scan target that lands on non-code bytes therefore aborts `CFGFast` outright rather than degrading.

`CFGBase._indirect_jump_encountered` already knows what such a block means: when the architecture has delay slots and the node holds fewer than two instructions it returns no jump, with a comment saying decoding failed on the second instruction, and `_create_jobs` then drops the successor. So the intended recovery is that the node exists, gets no successor and registers no indirect jump. The assert fires three lines before that handler can run.

The fix falls back to the block's last instruction, which is what both sibling exit paths in the same function already do — the statement-carrying path uses `last_ins_addr`, and the statement-less path only steps back when there is somewhere to step back to. It also restores the behaviour this code had before #2090 rewrote it in terms of `instruction_addresses` and added a `len > 1` guard whose else-branch silently left `None`; the assert encoding the violated invariant arrived later, in #5764.

Fixes #6763.

Measurements, including what changes on binaries that never hit the assert, are here: https://github.com/angr/angr/pull/6914#issuecomment-5388782213
