### PR TITLE
coverage: check out a referenced angr/binaries pull request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,10 +60,13 @@ jobs:
         run: |
           tar -xpf $PWD/env.tzst -C /
           rm env.tzst
+      - id: binaries-ref
+        uses: angr/ci-settings/actions/binaries-ref@master
       - name: Download test binaries
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           repository: angr/binaries
+          ref: ${{ steps.binaries-ref.outputs.ref }}
           path: binaries
       - name: Relocate binaries directory
         run: mv binaries ..


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`coverage.yml` checks out `angr/binaries` with no `ref`, so it always builds against master. A pull request whose new test loads a fixture from an open `angr/binaries` pull request therefore fails here while every container-based job passes, because those resolve the reference through `resolve_refs.py` in the CI image. Four currently-open pull requests are red for exactly this reason and for no other, each failing on its own new test and nothing else.

This resolves the ref with the shared action from angr/ci-settings and passes it to the existing checkout, so the coverage run agrees with the rest of CI about which binaries revision the pull request meant.

`nightly-ci.yml` is deliberately left alone. It runs on a schedule, and its `pull_request` trigger only fires when that workflow file itself changes, so a resolved ref would never be used there.

Blocked on angr/ci-settings#123, which adds the action; this references it at `master`.
