### PR TITLE
Do not spill a CFG whose addresses cannot be serialized

### DIFF
--- a/angr/knowledge_plugins/cfg/spilling_cfg.py
+++ b/angr/knowledge_plugins/cfg/spilling_cfg.py
@@ -24,7 +24,7 @@ from angr.protos import cfg_pb2
 
 from .block_id import BlockID
 from .cfg_node import CFGENode, CFGNode
-from .spilling_digraph import SpillingDiGraph
+from .spilling_digraph import NO_SPILLING_CACHE_LIMIT, SpillingDiGraph
 from .types import CFG_ADDR_TYPES, CFGENODE_K, CFGNODE_K, SOOTNODE_K, K
 
 if TYPE_CHECKING:
@@ -37,6 +37,12 @@ l = logging.getLogger(name=__name__)
 
 # a global flag to disable SpillingFunctionDict usage; mainly for testing purposes
 USE_SPILLING_CFGNODE_DICT = os.environ.get("USE_SPILLING_CFGNODE_DICT", "True").lower() not in ("0", "false", "no")
+
+# Address types whose CFGs cannot be spilled to LMDB. Block keys are serialized for every address type, but the
+# *values* are not: nodes are stored as cfg_pb2.CFGNode messages whose "ea" field is a uint64, and edge attributes are
+# packed with a struct that stores "ins_addr" as a uint64. Soot addresses are SootAddressDescriptor instances and have
+# no such encoding, so a Soot CFG is kept entirely in memory instead of crashing on the first eviction.
+UNSPILLABLE_ADDR_TYPES: frozenset[str] = frozenset({"soot"})
 
 
 class SpillingCFGNodeDict:
@@ -777,9 +783,9 @@ class SpillingCFG:
         addr_type: CFG_ADDR_TYPES = "int",
     ):
         if USE_SPILLING_CFGNODE_DICT:
-            effective_edge_cache_limit = edge_cache_limit if edge_cache_limit is not None else 2**31 - 1
+            effective_edge_cache_limit = edge_cache_limit if edge_cache_limit is not None else NO_SPILLING_CACHE_LIMIT
         else:
-            effective_edge_cache_limit = 2**31 - 1
+            effective_edge_cache_limit = NO_SPILLING_CACHE_LIMIT
 
         self._addr_type = addr_type
         self._graph: SpillingDiGraph = SpillingDiGraph(
@@ -792,9 +798,9 @@ class SpillingCFG:
         self._rtdb = rtdb
 
         if USE_SPILLING_CFGNODE_DICT:
-            effective_cache_limit = cache_limit if cache_limit is not None else 2**31 - 1
+            effective_cache_limit = cache_limit if cache_limit is not None else NO_SPILLING_CACHE_LIMIT
         else:
-            effective_cache_limit = 2**31 - 1
+            effective_cache_limit = NO_SPILLING_CACHE_LIMIT
 
         self._nodes: SpillingCFGNodeDict = SpillingCFGNodeDict(
             rtdb,
@@ -807,6 +813,7 @@ class SpillingCFG:
         self._out_degree_cache: dict[K, int] = {}
         self._spilling_enabled = cache_limit is not None
         self._edge_spilling_enabled = edge_cache_limit is not None
+        self._disable_spilling_for_addr_type()
 
     @property
     def addr_type(self) -> str:
@@ -820,6 +827,22 @@ class SpillingCFG:
             raise RuntimeError("Cannot change addr_type after nodes have been added")
         self._addr_type = value
         self._graph.addr_type = value
+        self._disable_spilling_for_addr_type()
+
+    def _disable_spilling_for_addr_type(self) -> None:
+        """
+        Turn node and edge spilling off if the current addr_type cannot be serialized.
+
+        See :data:`UNSPILLABLE_ADDR_TYPES`. Called whenever addr_type is established, which is always before the first
+        node is inserted.
+        """
+        if self._addr_type not in UNSPILLABLE_ADDR_TYPES:
+            return
+        if self._spilling_enabled or self._edge_spilling_enabled:
+            l.debug("Disabling CFG spilling: addr_type %s cannot be serialized.", self._addr_type)
+        self.cache_limit = None
+        self._edge_spilling_enabled = False
+        self._graph.disable_edge_spilling()
 
     @property
     def _cfg_model(self) -> CFGModel | None:
@@ -1219,12 +1242,15 @@ class SpillingCFG:
 
     @cache_limit.setter
     def cache_limit(self, value: int | None) -> None:
+        if value is not None and self._addr_type in UNSPILLABLE_ADDR_TYPES:
+            l.warning("Ignoring cache_limit %s: a CFG with addr_type %s cannot be spilled.", value, self._addr_type)
+            value = None
         if value is not None:
             self._nodes.cache_limit = value
             self._spilling_enabled = True
         else:
             # Set to a very large value to effectively disable spilling
-            self._nodes.cache_limit = 2**31 - 1
+            self._nodes.cache_limit = NO_SPILLING_CACHE_LIMIT
             self._spilling_enabled = False
 
     @property
@@ -1304,3 +1330,6 @@ class SpillingCFG:
             jk = edata.get("jumpkind", "")
             if jk == "Ijk_Call" or jk.startswith("Ijk_Sys"):
                 self._call_dst_keys.add(dst_key)
+
+        # a graph pickled before spilling was gated on addr_type may claim spilling is enabled
+        self._disable_spilling_for_addr_type()

--- a/angr/knowledge_plugins/cfg/spilling_digraph.py
+++ b/angr/knowledge_plugins/cfg/spilling_digraph.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
 
 l = logging.getLogger(__name__)
 
+# The cache limit a spilling container gets when spilling is off: high enough that eviction never fires.
+NO_SPILLING_CACHE_LIMIT = 2**31 - 1
+
 
 class DirtyDict[DK, DV](UserDict[DK, DV]):
     """
@@ -571,6 +574,17 @@ class SpillingDiGraph(networkx.DiGraph):
     #
     #  Spilling helpers
     #
+
+    def disable_edge_spilling(self) -> None:
+        """
+        Stop spilling adjacency data and keep every entry in memory.
+
+        Used when the addresses in this graph have no serializable encoding, so that eviction never attempts to
+        write a record it cannot build.
+        """
+        self._edge_cache_limit = NO_SPILLING_CACHE_LIMIT
+        self._adj._cache_limit = NO_SPILLING_CACHE_LIMIT
+        self._pred._cache_limit = NO_SPILLING_CACHE_LIMIT
 
     def load_all_spilled_edges(self) -> None:
         """Load all spilled adjacency entries back into memory."""

--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -768,7 +768,9 @@ class FunctionManager[K: (int, SootMethodDescriptor)](KnowledgeBasePlugin, colle
         self.function_address_types = self._kb._project.arch.function_address_types
         self.address_types = self._kb._project.arch.address_types
 
-        if cache_limit is None and USE_SPILLING_FUNCTION_DICT:
+        if not self.spillable:
+            cache_limit = None
+        elif cache_limit is None and USE_SPILLING_FUNCTION_DICT:
             cache_limit = self.get_default_cache_limit()
 
         # Use SpillingFunctionDict when caching is enabled, otherwise plain FunctionDict
@@ -906,6 +908,17 @@ class FunctionManager[K: (int, SootMethodDescriptor)](KnowledgeBasePlugin, colle
         self._func_from_signature = {}
         self._old_func_name_to_addrs = defaultdict(set)
         self._key_func_addrs = defaultdict(set)
+
+    @property
+    def spillable(self) -> bool:
+        """
+        Whether functions in this manager can be spilled to LMDB.
+
+        FunctionParser serializes a function's address into a protobuf uint64 field, so only functions with integer
+        addresses can be spilled. Soot methods (Java and Android projects) are addressed by SootMethodDescriptor and
+        are therefore kept in memory.
+        """
+        return self.function_address_types == (int,)
 
     def get_default_cache_limit(self, max_limit: int = 5000) -> int | None:
         """
@@ -1619,6 +1632,12 @@ class FunctionManager[K: (int, SootMethodDescriptor)](KnowledgeBasePlugin, colle
         """
         if isinstance(self._function_map, SpillingFunctionDict):
             self._function_map.cache_limit = value
+        elif not self.spillable:
+            l.warning(
+                "Ignoring cache_limit %s: functions addressed by %s cannot be spilled.",
+                value,
+                ", ".join(t.__name__ for t in self.function_address_types),
+            )
         else:
             # Need to convert FunctionDict to SpillingFunctionDict
             old_map = self._function_map

--- a/tests/analyses/cfg/test_cfgfast_soot.py
+++ b/tests/analyses/cfg/test_cfgfast_soot.py
@@ -7,6 +7,7 @@ import os
 import unittest
 
 import angr
+from angr.knowledge_plugins.cfg.spilling_cfg import SpillingCFG, get_block_key
 
 try:
     import pysoot
@@ -33,6 +34,69 @@ class TestCfgfastSoot(unittest.TestCase):
         p = angr.Project(binary_path, main_opts={"entry_point": "simple2.Class1.main"}, auto_load_libs=False)
         cfg = p.analyses.CFGFastSoot()
         assert cfg.graph.nodes()
+
+    def test_soot_cfg_declines_to_spill(self):
+        """A Soot CFG must never spill: CFGNode, edge, and Function values are all serialized with encoders that
+        only understand integer addresses, so evicting one raises TypeError/struct.error instead of writing a
+        record. The spilling layer therefore keeps a Soot CFG entirely in memory."""
+        binary_path = os.path.join(test_location, "java", "simple1.jar")
+        p = angr.Project(binary_path, main_opts={"entry_point": "simple1.Class1.main"}, auto_load_libs=False)
+        cfg = p.analyses.CFGFastSoot()
+
+        graph = cfg.model.graph
+        assert graph.addr_type == "soot"
+
+        # A cache limit small enough to force eviction must be declined rather than crash while serializing.
+        total_nodes = len(graph)
+        assert total_nodes > 2
+        graph.cache_limit = 1
+        graph.db_batch_size = 1
+        assert graph.spilled_count == 0
+        assert len(graph) == total_nodes
+
+        total_functions = len(p.kb.functions)
+        assert total_functions > 1
+        p.kb.functions.cache_limit = 1
+        assert len(p.kb.functions) == total_functions
+
+        assert graph.cache_limit is None
+        assert p.kb.functions.cache_limit is None
+        assert not p.kb.functions.spillable
+
+    def test_soot_graph_survives_a_cache_limit_smaller_than_the_graph(self):
+        """A Soot-typed graph built with a cache limit far below its size must still hold every node and edge, with
+        their attributes intact: the spilling encoders cannot serialize Soot addresses, so nothing may be evicted."""
+        binary_path = os.path.join(test_location, "java", "simple1.jar")
+        p = angr.Project(binary_path, main_opts={"entry_point": "simple1.Class1.main"}, auto_load_libs=False)
+        cfg = p.analyses.CFGFastSoot()
+
+        nodes = list(cfg.model.graph.nodes())
+        edges = [(src, dst, cfg.model.graph.get_edge_data(src, dst)) for src, dst in cfg.model.graph.edges]
+        assert len(nodes) > 4
+        assert len(edges) > 4
+
+        # A limit of 2 with a batch size of 1 means eviction is attempted long before the last node is inserted.
+        graph = SpillingCFG(
+            rtdb=p.kb.rtdb,
+            cache_limit=2,
+            db_batch_size=1,
+            edge_cache_limit=2,
+            edge_db_batch_size=1,
+            addr_type="soot",
+        )
+        for node in nodes:
+            graph.add_node(node)
+        for src, dst, data in edges:
+            graph.add_edge(src, dst, **data)
+
+        assert len(graph) == len(nodes)
+        assert graph.number_of_edges() == len(edges)
+        for node in nodes:
+            assert node in graph
+            assert graph.get_node_by_key(get_block_key(node)).addr == node.addr
+        for src, dst, data in edges:
+            assert graph.has_edge(src, dst)
+            assert graph.get_edge_data(src, dst) == data
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The spilling containers serialize block keys for every address type, but the values they write are angrDb messages: `cfg.proto` declares `CFGNode.ea` as a `uint64`, and the edge attributes go through a `struct` that stores `ins_addr` as a `uint64`. A Soot address is a `SootAddressDescriptor`, which has no such encoding, so the first eviction of a `CFGFastSoot` graph raises `TypeError: 'SootAddressDescriptor' object cannot be interpreted as an integer` at `cfg_node.py:288`, `struct.error` at `spilling_digraph.py:239`, or the `SootMethodDescriptor` equivalent at `function_parser.py:60`, and the analysis dies. Small Soot CFGs never reach the cache limit, so this only shows up on real applications.

`CFGModel` already declines the spilled read path unless `addr_type` is `"int"` (`cfg_model.py:283`); it is only the write path that was ungated. This gates it there too, so a CFG whose addresses have no encoding keeps its nodes and edges in memory, and `FunctionManager` does the same when function addresses are not integers.

This is not a lost capability: spilling was never able to store these graphs. It is also not a format change — the spill store is process-scoped scratch that `RuntimeDb` creates under the temporary directory and removes at exit, so there are no files to invalidate. Making angrDb persist Soot CFGs would mean adding Soot messages to the protobuf schema, which is a separate feature and is left alone; angrDb behaviour is unchanged, and both encoders still refuse a Soot input exactly as before.

Catching the error during eviction and dropping the entry would be worse than the crash: eviction removes the node from the live dict and records its key as spilled before attempting the write, so a swallowed exception leaves a key that resolves to nothing later. That yields a CFG with holes that looks like a successful result.

The regressions are in `tests/analyses/cfg/test_cfgfast_soot.py` and use the existing `binaries/tests/java/simple1.jar`. One forces eviction through the public `cache_limit` setter; the other builds a graph with a cache limit smaller than the graph and asserts every node and edge is still retrievable with the right value. Both fail on master with the real error. Note that such a test needs a live `RuntimeDb` — with `rtdb=None` eviction is a silent no-op and the defect cannot be reproduced.

Related but different: #2028, which is the remaining failure on one of the applications tested here.
