### PR TITLE
Recover a CFG from a jar that declares no entry method

### DIFF
--- a/angr/analyses/cfg/cfg_fast_soot.py
+++ b/angr/analyses/cfg/cfg_fast_soot.py
@@ -59,8 +59,10 @@ class CFGFastSoot(CFGFast):
 
         self._function_returns = defaultdict(set)
 
-        entry: SootAddressDescriptor = self.project.entry
-        entry_func = entry.method
+        # A jar without a Main-Class manifest attribute (i.e. a library jar) has no entry method, in which case
+        # the loader leaves Project.entry as the default 0 instead of a SootAddressDescriptor.
+        entry = self.project.entry
+        entry_func = entry.method if isinstance(entry, SootAddressDescriptor) else None
 
         obj = self.project.loader.main_object
 

--- a/tests/analyses/cfg/test_cfgfast_soot.py
+++ b/tests/analyses/cfg/test_cfgfast_soot.py
@@ -34,6 +34,19 @@ class TestCfgfastSoot(unittest.TestCase):
         cfg = p.analyses.CFGFastSoot()
         assert cfg.graph.nodes()
 
+    def test_simple2_without_entry_point(self):
+        # simple2.jar has no Main-Class manifest attribute, so without an explicit entry_point the loader leaves
+        # Project.entry at 0. CFGFastSoot must still analyze every method of every class.
+        binary_path = os.path.join(test_location, "java", "simple2.jar")
+        p = angr.Project(binary_path, auto_load_libs=False)
+        assert p.entry == 0
+        cfg = p.analyses.CFGFastSoot()
+        assert cfg.graph.nodes()
+        function_names = {f.name for f in p.kb.functions.values()}
+        assert "simple2.Class1.main(java.lang.String[])" in function_names
+        # methods that no entry point reaches are analyzed too
+        assert "simple2.Class1.unreachable(int)" in function_names
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`CFGFastSoot._pre_analysis` annotated `Project.entry` as a `SootAddressDescriptor` and read `.method` off it. A jar with no `Main-Class` manifest attribute — any library jar — has no entry method, so `Soot.__init__` never assigns one and `Backend` leaves `_entry` at its default `0`. Reading `.method` off an int raised `AttributeError: 'int' object has no attribute 'method'` before any analysis ran, so a library jar could not be analysed at all.

The handling for a missing entry method already exists three lines below: fall back to the main method, then to the first method of the first class, and otherwise raise `AngrCFGError("There is no method in the Jar file.")`. That branch was written for this case and was merely unreachable, because the attribute access came first. Reading the entry only when it is a descriptor lets it run.

This does not change what gets analysed. `_pre_analysis` already inserts a job for every method of every class, and the entry only decides which is scanned first — `simple2.jar` recovers 51 nodes and 8 functions whether or not an entry point is supplied. Jars that do declare an entry are unaffected.

`SimJavaVM` is left alone: its `ValueError` for a project with no entry is correct, since a library jar genuinely has no entry state, and `entry_state()` still raises it.

The regression uses the existing `binaries/tests/java/simple2.jar`, which has five classes and no `Main-Class`.
