### PR TITLE
Read stack offsets as signed in LiveDefinitions.get_stack_offset

### DIFF
--- a/angr/knowledge_plugins/key_definitions/live_definitions.py
+++ b/angr/knowledge_plugins/key_definitions/live_definitions.py
@@ -318,6 +318,17 @@ class LiveDefinitions:
         return "stack_base" in addr.variables
 
     @staticmethod
+    def _as_signed_offset(offset: int, bits: int) -> int:
+        """
+        Stack offsets are signed, but the concrete addends inside an address AST are unsigned bitvector values, and
+        simplifiers are free to rewrite `stack_base - 0xc` into `stack_base + 0xfffffff4`. Adding that raw value
+        gives a huge positive offset instead of -0xc, so reinterpret the wrapped-around sum as signed.
+        """
+        mask = (1 << bits) - 1
+        offset &= mask
+        return offset - (1 << bits) if offset > mask >> 1 else offset
+
+    @staticmethod
     def get_stack_offset(addr: claripy.ast.Base, had_stack_base=False) -> int | None:
         if had_stack_base and addr.op == "BVV":
             assert isinstance(addr, claripy.ast.BV)
@@ -332,14 +343,14 @@ class LiveDefinitions:
                     off0 = LiveDefinitions.get_stack_offset(cast(claripy.ast.BV, addr.args[0]), had_stack_base=True)
                     off1 = LiveDefinitions.get_stack_offset(cast(claripy.ast.BV, addr.args[1]), had_stack_base=True)
                     if off0 is not None and off1 is not None:
-                        return off0 + off1
+                        return LiveDefinitions._as_signed_offset(off0 + off1, addr.size())
                 elif len(addr.args) == 1:
                     return 0
             elif addr.op == "__sub__" and len(addr.args) == 2:
                 off0 = LiveDefinitions.get_stack_offset(cast(claripy.ast.BV, addr.args[0]), had_stack_base=True)
                 off1 = LiveDefinitions.get_stack_offset(cast(claripy.ast.BV, addr.args[1]), had_stack_base=True)
                 if off0 is not None and off1 is not None:
-                    return off0 - off1
+                    return LiveDefinitions._as_signed_offset(off0 - off1, addr.size())
         return None
 
     @staticmethod

--- a/tests/knowledge_plugins/key_definitions/test_live_definitions.py
+++ b/tests/knowledge_plugins/key_definitions/test_live_definitions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from unittest import TestCase, main
 
 import archinfo
+import claripy
 
 from angr.knowledge_plugins.key_definitions.atoms import Register, SpOffset
 from angr.knowledge_plugins.key_definitions.live_definitions import LiveDefinitions
@@ -16,6 +17,26 @@ class TestLiveDefinitions(TestCase):
 
         sp_offset = self.arch.registers["sp"][0]
         self.sp_register = Register(sp_offset, self.arch.bytes)
+
+    def test_negative_stack_offset_is_signed_regardless_of_ast_shape(self):
+        # `sp - 0xc` and `sp + 0xfffffff4` are the same address; simplifiers pick either shape freely, and the
+        # offset has to come back as -0xc for both. Reading the addend as unsigned yields 0xfffffff4 instead,
+        # which desynchronizes every stack-offset comparison built on top of get_stack_offset().
+        arch = archinfo.arch_x86.ArchX86()
+        live_definitions = LiveDefinitions(arch)
+        base = live_definitions.stack_address(0)
+
+        assert LiveDefinitions.get_stack_offset(base - 0xC) == -0xC
+        assert LiveDefinitions.get_stack_offset(base + 0xFFFFFFF4) == -0xC
+        assert LiveDefinitions.get_stack_offset(base + claripy.BVV(0xFFFFFFF4, 32)) == -0xC
+
+    def test_positive_stack_offset_is_unchanged(self):
+        arch = archinfo.arch_x86.ArchX86()
+        live_definitions = LiveDefinitions(arch)
+        base = live_definitions.stack_address(0)
+
+        assert LiveDefinitions.get_stack_offset(base) == 0
+        assert LiveDefinitions.get_stack_offset(base + 0xC) == 0xC
 
     def test_get_sp_retrieves_the_value_of_sp_register(self):
         live_definitions = LiveDefinitions(self.arch)


### PR DESCRIPTION
get_stack_offset() walks an address AST and adds up the concrete addends it finds, but a concrete addend is an unsigned bitvector value. Whether a negative offset survives therefore depended on the shape the simplifier chose: `stack_base - 0xc` (a __sub__) came back as -0xc, while the equivalent `stack_base + 0xfffffff4` (an __add__) came back as 4294967284.

Both shapes occur. The clarirs simplifier rewrites `(sum + b) - c` into `sum + (b - c)`, so a stack pointer walked down by successive pushes ends up as an __add__ with a wrapped-around constant, where claripy kept a __sub__.