### PR TITLE
CFGFast: Skip a whole undecodable RISC-V instruction, not one byte

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -16,7 +16,7 @@ import capstone
 import cle
 import networkx
 import pyvex
-from archinfo import Endness
+from archinfo import ArchRISCV64, Endness
 from archinfo.arch_arm import get_real_address_if_arm, is_arm_arch
 from archinfo.arch_soot import SootAddressDescriptor
 from cle.address_translator import AT
@@ -5914,7 +5914,14 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
                 # the default case
                 valid_ins = False
-                nodecode_size = 1
+                if isinstance(self.project.arch, ArchRISCV64):
+                    # RISC-V stores the length of an instruction in the instruction itself: the lowest two bits of
+                    # the first halfword are 0b11 for a 32-bit instruction and anything else for a 16-bit
+                    # compressed one. Longer encodings are reserved and unallocated.
+                    first_byte = self.project.loader.memory.load(real_addr + irsb_size, 1)[0]
+                    nodecode_size = 4 if first_byte & 0b11 == 0b11 else 2
+                else:
+                    nodecode_size = 1
 
                 # special handling for ud, ud1, and ud2 on x86 and x86-64
                 if self.project.arch.name == "AMD64" and irsb_string[-2:] == b"\x0f\x0b":

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,16 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_riscv_scanning_resumes_after_an_undecodable_instruction(self):
+        # VEX cannot lift the feq.s at 0x402390. The scan must resume after all four of its bytes; resuming at the
+        # next halfword instead recovers 0x402392, two bytes into that instruction, as an instruction of its own.
+        proj = angr.Project(os.path.join(test_location, "riscv", "autotalent-autotalent.so"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast()
+        ins_addrs = {ins_addr for node in cfg.model.nodes() for ins_addr in node.instruction_addrs}
+
+        assert 0x402392 not in ins_addrs, "0x402392 is two bytes into the instruction at 0x402390"
+        assert 0x402394 in ins_addrs, "the scan did not resume at 0x402394"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

When VEX cannot decode an instruction, `CFGFast` marks a single byte as `nodecode` and
leaves the rest of the instruction unoccupied, so the linear scan resumes inside it. On
`binaries/tests/riscv/autotalent-autotalent.so` the bytes at `0x402390` are
`d3 a5 d8 a1` — `feq.s a1, fa7, ft9` — which lifts to `Ijk_NoDecode`. That address is
inside `runAutotalent` (`0x401a68`, 8680 bytes), and master resumes two bytes into the
instruction and recovers its tail as code:

```
  block 0x402392 size=4 function=0x402392 instructions=['0x402392', '0x402394']
0x402392 recovered as an instruction: True
```

`0x402392` is the upper halfword of `feq.s`, `d8 a1`, whose low two bits are `0b00`, so
it decodes as a 16-bit compressed instruction that is not there. The scan then heads a
function at that address and attributes the real code after it to that function.

### Root cause

The undecodable case occupies one byte and nothing else:

```python
# the default case
valid_ins = False
nodecode_size = 1
```

`_next_code_addr` rounds the next start address up to the architecture's instruction
alignment:

```python
start_addr = start_addr - start_addr % instr_alignment + instr_alignment
```

`ArchRISCV64.instruction_alignment` is 2. With `0x402390` alone occupied, that lands on
`0x402392`. On a fixed-width architecture the alignment equals the instruction width, so
the round-up reaches the next instruction anyway; on RISC-V with the compressed
extension it is half of a 32-bit one.

### Fix

RISC-V records an instruction's length in the instruction itself — the low two bits of
the first halfword are `0b11` for a 32-bit instruction and anything else for a 16-bit
compressed one — and those bytes have already been read when the lift fails, so the skip
length needs no decoding:

```python
if isinstance(self.project.arch, ArchRISCV64):
    first_byte = self.project.loader.memory.load(real_addr + irsb_size, 1)[0]
    nodecode_size = 4 if first_byte & 0b11 == 0b11 else 2
else:
    nodecode_size = 1
```

At `0x402390` the first byte is `0xd3`, so the skip is 4 and the scan resumes at
`0x402394`:

```
  block 0x402394 size=2 function=0x402394 instructions=['0x402394']
0x402392 recovered as an instruction: False
```

`valid_ins` stays `False`: only the distance to the next instruction changes, not the
verdict on the undecodable one. x86 keeps `nodecode_size = 1`, since its length genuinely
cannot be recovered without decoding, and fixed-width architectures already resume
correctly. The function head the scan plants at the resume point is not removed here; it
now sits on a real instruction boundary instead of two bytes inside `feq.s`.

### Testing

`test_riscv_scanning_resumes_after_an_undecodable_instruction` loads that fixture,
collects every instruction address in the CFG, and asserts that `0x402392` is absent and
`0x402394` present. It fails on master, which recovers both.

Fixes #6928. Validation: https://github.com/angr/angr/pull/6929#issuecomment-5400840500

session: sharpen