### PR TITLE
Serialize Soot addresses

### DIFF
--- a/angr/codenode.py
+++ b/angr/codenode.py
@@ -4,7 +4,7 @@ import logging
 import weakref
 from typing import TYPE_CHECKING
 
-from archinfo.arch_soot import SootMethodDescriptor
+from archinfo.arch_soot import SootAddressDescriptor, SootMethodDescriptor
 
 import angr
 
@@ -14,13 +14,17 @@ if TYPE_CHECKING:
 l = logging.getLogger(name=__name__)
 
 
-def repr_addr[K: (int, SootMethodDescriptor)](addr: K) -> str:
+# A code node's address: a native address, or a Soot method or statement address.
+type NodeAddress = int | SootAddressDescriptor | SootMethodDescriptor
+
+
+def repr_addr(addr: NodeAddress) -> str:
     if isinstance(addr, int):
         return hex(addr)
     return repr(addr)
 
 
-class CodeNode[K: (int, SootMethodDescriptor)]:
+class CodeNode[K: NodeAddress]:
     """
     The base class of nodes in a function graph.
     """
@@ -82,7 +86,7 @@ class CodeNode[K: (int, SootMethodDescriptor)]:
     is_hook = None
 
 
-class BlockNode[K: (int, SootMethodDescriptor)](CodeNode[K]):
+class BlockNode[K: NodeAddress](CodeNode[K]):
     """
     Represents a block of code in a function graph.
     """
@@ -91,7 +95,7 @@ class BlockNode[K: (int, SootMethodDescriptor)](CodeNode[K]):
 
     is_hook = False
 
-    def __init__(self, addr: int, size, bytestr=None, **kwargs):
+    def __init__(self, addr: K, size, bytestr=None, **kwargs):
         super().__init__(addr, size, **kwargs)
         self.bytestr = bytestr
 
@@ -105,14 +109,14 @@ class BlockNode[K: (int, SootMethodDescriptor)](CodeNode[K]):
         self.__init__(*dat[:-1], thumb=dat[-1])
 
 
-class SootBlockNode(BlockNode[SootMethodDescriptor]):
+class SootBlockNode(BlockNode[SootAddressDescriptor]):
     """
     Represents a Soot block of code in a function graph.
     """
 
     __slots__ = ["stmts"]
 
-    def __init__(self, addr: SootMethodDescriptor, size, stmts, **kwargs):
+    def __init__(self, addr: SootAddressDescriptor, size, stmts, **kwargs):
         super().__init__(addr, size, **kwargs)
         self.stmts = stmts
 
@@ -128,7 +132,7 @@ class SootBlockNode(BlockNode[SootMethodDescriptor]):
         self.__init__(*data)
 
 
-class FuncNode[K: (int, SootMethodDescriptor)](CodeNode[K]):
+class FuncNode[K: NodeAddress](CodeNode[K]):
     """
     Represents a function callee in a function graph.
     """
@@ -165,7 +169,7 @@ class FuncNode[K: (int, SootMethodDescriptor)](CodeNode[K]):
         self.__init__(*state)
 
 
-class HookNode[K: (int, SootMethodDescriptor)](CodeNode[K]):
+class HookNode[K: NodeAddress](CodeNode[K]):
     """
     Represents a hook in a function graph.
     """
@@ -209,7 +213,7 @@ class HookNode[K: (int, SootMethodDescriptor)](CodeNode[K]):
         self.__init__(*dat)
 
 
-class SyscallNode[K: (int, SootMethodDescriptor)](HookNode[K]):
+class SyscallNode[K: NodeAddress](HookNode[K]):
     """
     Represents a syscall in a function graph.
     """

--- a/angr/knowledge_plugins/cfg/cfg_model.py
+++ b/angr/knowledge_plugins/cfg/cfg_model.py
@@ -14,6 +14,7 @@ from angr.engines.vex.lifter import VEX_IRSB_MAX_SIZE
 from angr.errors import AngrCFGError
 from angr.protos import cfg_pb2, primitives_pb2
 from angr.serializable import Serializable
+from angr.utils.addr_conv import addr_from_pb, addr_to_pb
 from angr.utils.enums_conv import cfg_jumpkind_from_pb, cfg_jumpkind_to_pb
 
 from .cfg_node import CFGNode
@@ -223,7 +224,7 @@ class CFGModel(Serializable):
             for block_key, msg_bytes, _copied in self.graph.export_serialized_nodes():
                 node_pb = cmsg.nodes.add()
                 node_pb.ParseFromString(msg_bytes)
-                key_to_addr[block_key] = node_pb.ea
+                key_to_addr[block_key] = addr_from_pb(node_pb, "ea")
         else:
             nodes = [n.serialize_to_cmessage() for n in self.graph.nodes()]
             cmsg.nodes.extend(nodes)
@@ -239,14 +240,17 @@ class CFGModel(Serializable):
         edges = []
         for src_ea, dst_ea, data in edge_iter:
             edge = primitives_pb2.Edge()  # type:ignore
-            edge.src_ea = src_ea
-            edge.dst_ea = dst_ea
+            addr_to_pb(edge, "src_ea", src_ea)
+            addr_to_pb(edge, "dst_ea", dst_ea)
             for k, v in data.items():
                 if k == "jumpkind":
                     jk = cfg_jumpkind_to_pb(v)
                     edge.jumpkind = primitives_pb2.Edge.UnknownJumpkind if jk is None else jk  # type:ignore
                 elif k == "ins_addr":
-                    edge.ins_addr = v if v is not None else 0xFFFF_FFFF_FFFF_FFFF
+                    if v is None:
+                        edge.ins_addr = 0xFFFF_FFFF_FFFF_FFFF
+                    else:
+                        addr_to_pb(edge, "ins_addr", v)
                 elif k == "stmt_idx":
                     edge.stmt_idx = v if v is not None else -1
                 else:
@@ -298,11 +302,12 @@ class CFGModel(Serializable):
             # edges
             for edge_pb2 in cmsg.edges:
                 # more than one node at a given address is unsupported, grab the first one
-                src = next(model.graph.nodes_by_addr(edge_pb2.src_ea))
-                dst = next(model.graph.nodes_by_addr(edge_pb2.dst_ea))
+                src = next(model.graph.nodes_by_addr(addr_from_pb(edge_pb2, "src_ea")))
+                dst = next(model.graph.nodes_by_addr(addr_from_pb(edge_pb2, "dst_ea")))
+                ins_addr = addr_from_pb(edge_pb2, "ins_addr")
                 data = {
                     "jumpkind": cfg_jumpkind_from_pb(edge_pb2.jumpkind),
-                    "ins_addr": edge_pb2.ins_addr if edge_pb2.ins_addr != 0xFFFF_FFFF_FFFF_FFFF else None,
+                    "ins_addr": ins_addr if ins_addr != 0xFFFF_FFFF_FFFF_FFFF else None,
                     "stmt_idx": edge_pb2.stmt_idx if edge_pb2.stmt_idx != -1 else None,
                 }
                 model.graph.add_edge(src, dst, **data)

--- a/angr/knowledge_plugins/cfg/cfg_node.py
+++ b/angr/knowledge_plugins/cfg/cfg_node.py
@@ -11,6 +11,7 @@ from angr.codenode import BlockNode, HookNode, SyscallNode
 from angr.engines.successors import SimSuccessors
 from angr.protos import cfg_pb2
 from angr.serializable import Serializable
+from angr.utils.addr_conv import addr_from_pb, addr_to_pb, optional_addr_from_pb
 from angr.utils.ins_addr_list import InsAddrList
 
 from .block_id import BlockID
@@ -285,7 +286,7 @@ class CFGNode(Serializable):
 
     def serialize_to_cmessage(self):
         obj = self._get_cmsg()
-        obj.ea = self.addr
+        addr_to_pb(obj, "ea", self.addr)
         obj.size = self.size
         assert isinstance(self.instruction_addrs, InsAddrList)
         obj.ins_base_addr = self.instruction_addrs.base_addr
@@ -293,14 +294,15 @@ class CFGNode(Serializable):
         if self.block_id is not None:
             if type(self.block_id) is int:
                 obj.block_id.append(self.block_id)  # pylint:disable=no-member
-            else:
+            elif self.block_id != self.addr:
+                # for a Soot node the block ID is the address itself (see CFGFastSoot._generate_cfgnode)
                 raise NotImplementedError("Non-integer block_id serialization is not supported for CFGNode")
         if self.simprocedure_name is not None:
             obj.simprocedure_name = self.simprocedure_name
         if self.no_ret is not None:
             obj.no_ret = self.no_ret
         if self.function_address is not None:
-            obj.function_address = self.function_address
+            addr_to_pb(obj, "function_address", self.function_address)
         obj.thumb = self.thumb
         if self.byte_string is not None:
             obj.byte_string = self.byte_string
@@ -311,18 +313,19 @@ class CFGNode(Serializable):
 
     @classmethod
     def parse_from_cmessage(cls, cmsg, cfg=None):  # pylint:disable=arguments-differ
-        block_id = None if len(cmsg.block_id) == 0 else cmsg.block_id[0]
+        addr = addr_from_pb(cmsg, "ea")
+        block_id = cmsg.block_id[0] if cmsg.block_id else (addr if isinstance(addr, SootAddressDescriptor) else None)
         instruction_addrs = InsAddrList(cmsg.ins_base_addr, cmsg.ins_sizes)
 
         node = cls(
-            cmsg.ea,
+            addr,
             cmsg.size,
             cfg=cfg,
             block_id=block_id,
             instruction_addrs=instruction_addrs,
             simprocedure_name=cmsg.simprocedure_name if cmsg.HasField("simprocedure_name") else None,
             no_ret=cmsg.no_ret if cmsg.HasField("no_ret") else None,
-            function_address=cmsg.function_address if cmsg.HasField("function_address") else None,
+            function_address=optional_addr_from_pb(cmsg, "function_address"),
             thumb=cmsg.thumb,
             byte_string=cmsg.byte_string if cmsg.HasField("byte_string") else None,
             is_syscall=cmsg.is_syscall,

--- a/angr/knowledge_plugins/cfg/spilling_digraph.py
+++ b/angr/knowledge_plugins/cfg/spilling_digraph.py
@@ -35,6 +35,21 @@ if TYPE_CHECKING:
 l = logging.getLogger(__name__)
 
 
+def _soot_addr_to_dict(addr: SootAddressDescriptor) -> dict:
+    return {
+        "class_name": addr.method.class_name,
+        "name": addr.method.name,
+        "params": addr.method.params,
+        "block_idx": addr.block_idx,
+        "stmt_idx": addr.stmt_idx,
+    }
+
+
+def _soot_addr_from_dict(d: dict) -> SootAddressDescriptor:
+    method = SootMethodDescriptor(d["class_name"], d["name"], tuple(d["params"]))
+    return SootAddressDescriptor(method, d["block_idx"], d["stmt_idx"])
+
+
 class DirtyDict[DK, DV](UserDict[DK, DV]):
     """
     A simple dict subclass that tracks whether it has been modified since creation or last reset.
@@ -252,6 +267,30 @@ class SpillingAdjDict(MutableMapping):
             "stmt_idx": stmt_idx if stmt_idx != -1 else None,
         }
 
+    @staticmethod
+    def _serialize_soot_edge_data(edge_data: dict) -> bytes:
+        """Serialize an edge attribute dict whose ins_addr is a Soot address."""
+        jk = cfg_jumpkind_to_pb(edge_data.get("jumpkind"))
+        ins_addr = edge_data.get("ins_addr")
+        return json_encode(
+            {
+                "jumpkind": primitives_pb2.Edge.UnknownJumpkind if jk is None else jk,
+                "ins_addr": None if ins_addr is None else _soot_addr_to_dict(ins_addr),
+                "stmt_idx": edge_data.get("stmt_idx"),
+            }
+        )
+
+    @staticmethod
+    def _deserialize_soot_edge_data(data: bytes) -> dict:
+        """Deserialize an edge attribute dict whose ins_addr is a Soot address."""
+        d = json_decode(data)
+        ins_addr = d["ins_addr"]
+        return {
+            "jumpkind": cfg_jumpkind_from_pb(d["jumpkind"]),
+            "ins_addr": None if ins_addr is None else _soot_addr_from_dict(ins_addr),
+            "stmt_idx": d["stmt_idx"],
+        }
+
     def _serialize_inner_dict(self, inner_dict: DirtyDict[K, dict]) -> bytes:
         """Serialize an inner adjacency dict to bytes.
 
@@ -266,6 +305,7 @@ class SpillingAdjDict(MutableMapping):
         """
         buf = bytearray()
         buf.extend(struct.pack("<I", len(inner_dict)))
+        serialize_edge_data = self._serialize_soot_edge_data if self.addr_type == "soot" else self._serialize_edge_data
         for dst_key, edge_data in inner_dict.items():
             match self.addr_type:
                 case "int":
@@ -290,19 +330,12 @@ class SpillingAdjDict(MutableMapping):
                 case "soot":
                     # dst_key: SOOTNODE_K
                     assert isinstance(dst_key, SootAddressDescriptor)
-                    d = {
-                        "class_name": dst_key.method.class_name,
-                        "name": dst_key.method.name,
-                        "params": dst_key.method.params,
-                        "block_idx": dst_key.block_idx,
-                        "stmt_idx": dst_key.stmt_idx,
-                    }
-                    key_bytes = json_encode(d)
+                    key_bytes = json_encode(_soot_addr_to_dict(dst_key))
 
                 case _:
                     raise TypeError(f"Unsupported addr_type {self.addr_type}")
 
-            proto_bytes = SpillingAdjDict._serialize_edge_data(edge_data)
+            proto_bytes = serialize_edge_data(edge_data)
             buf.extend(struct.pack("<H", len(key_bytes)))
             buf.extend(key_bytes)
             buf.extend(struct.pack("<I", len(proto_bytes)))
@@ -317,6 +350,9 @@ class SpillingAdjDict(MutableMapping):
         offset += 4
 
         inner_dict: DirtyDict[K, dict] = DirtyDict()
+        deserialize_edge_data = (
+            self._deserialize_soot_edge_data if self.addr_type == "soot" else self._deserialize_edge_data
+        )
         for _ in range(num_entries):
             key_len = struct.unpack_from("<H", data, offset)[0]
             offset += 2
@@ -346,9 +382,7 @@ class SpillingAdjDict(MutableMapping):
                     dst_key = (block_id_obj, size, looping_times)
 
                 case "soot":
-                    d = json_decode(key_bytes)
-                    method = SootMethodDescriptor(d["class_name"], d["name"], d["params"])
-                    dst_key = SootAddressDescriptor(method, d["block_idx"], d["stmt_idx"])
+                    dst_key = _soot_addr_from_dict(json_decode(key_bytes))
 
                 case _:
                     raise TypeError(f"Unsupported addr_type {self.addr_type}")
@@ -358,7 +392,7 @@ class SpillingAdjDict(MutableMapping):
             proto_bytes = data[offset : offset + proto_len]
             offset += proto_len
 
-            edge_data = SpillingAdjDict._deserialize_edge_data(proto_bytes)
+            edge_data = deserialize_edge_data(proto_bytes)
             inner_dict[dst_key] = edge_data
         inner_dict.dirty = False
 

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -818,14 +818,14 @@ class Function(Serializable):
 
     def __str__(self):
         return (
-            f"Function {self.name} [{self.addr:#x}]\n"
+            f"Function {self.name} [{hex(self.addr) if isinstance(self.addr, int) else self.addr}]\n"
             f"  Syscall: {self.is_syscall}\n"
             f"  SP difference: {self.sp_delta}\n"
             f"  Has return: {self.has_return}\n"
             f"  Returning: {'Unknown' if self.returning is None else self.returning}\n"
             f"  Alignment: {self.is_alignment}\n"
             f"  Arguments: reg: {self._argument_registers}, stack: {self._argument_stack_variables}\n"
-            f"  Blocks: [{', '.join(f'{i:#x}' for i in self.block_addrs)}]\n"
+            f"  Blocks: [{', '.join(hex(i) if isinstance(i, int) else str(i) for i in self.block_addrs)}]\n"
             f"  Cyclomatic Complexity: {self.cyclomatic_complexity}\n"
             f"  Calling convention: {self.calling_convention}"
         )

--- a/angr/knowledge_plugins/functions/function_parser.py
+++ b/angr/knowledge_plugins/functions/function_parser.py
@@ -7,9 +7,16 @@ from collections import defaultdict
 
 import angr
 from angr.calling_conventions import CC_NAMES, SimCC, SimCCUsercall
-from angr.codenode import BlockNode, FuncNode, HookNode
+from angr.codenode import BlockNode, FuncNode, HookNode, SootBlockNode
 from angr.protos import function_pb2, primitives_pb2
 from angr.sim_type import SimType, SimTypeFunction
+from angr.utils.addr_conv import (
+    addr_from_pb,
+    addr_to_pb,
+    optional_addr_from_pb,
+    soot_addr_from_pb,
+    soot_addr_to_pb,
+)
 from angr.utils.enums_conv import (
     _EDGETYPE_MISSING,
     _PB_TO_FUNCTION_EDGETYPES,
@@ -57,7 +64,7 @@ class FunctionParser:
         :return :
         """
         obj = angr.knowledge_plugins.Function._get_cmsg()
-        obj.ea = function.addr
+        addr_to_pb(obj, "ea", function.addr)
         obj.is_entrypoint = False  # TODO: Set this up accordingly
         obj.name = function.name
         obj.is_default_name = function.is_default_name
@@ -89,7 +96,7 @@ class FunctionParser:
         for endpoint_type, endpoint_nodes in function.endpoints_with_type.items():
             for node in endpoint_nodes:
                 ep = primitives_pb2.Endpoint()
-                ep.ea = node.addr
+                addr_to_pb(ep, "ea", node.addr)
                 ep.size = node.size
                 match endpoint_type:
                     case "call":
@@ -117,9 +124,10 @@ class FunctionParser:
         blocks_list = []
         for b in function.code_nodes.values():
             block = primitives_pb2.Block()
-            block.ea = b.addr
+            addr_to_pb(block, "ea", b.addr)
             block.size = b.size
-            if isinstance(b, BlockNode):
+            # a Soot block is a list of statements and carries no bytes
+            if isinstance(b, BlockNode) and not isinstance(b, SootBlockNode):
                 assert b.bytestr is not None, (
                     f"Block bytes cannot be None when serializing a function. Is this function meta-only ({function.meta_only})?"
                 )
@@ -139,7 +147,7 @@ class FunctionParser:
                 external_func_addrs.add(node.addr)
             elif node.addr not in block_addrs_set and isinstance(node, BlockNode):
                 block = primitives_pb2.Block()
-                block.ea = node.addr
+                addr_to_pb(block, "ea", node.addr)
                 block.size = node.size
                 block.bytes = node.bytestr or b""
                 external_blocks.append(block)
@@ -147,8 +155,8 @@ class FunctionParser:
         TRANSITION_JK = func_edge_type_to_pb("transition")  # default edge type
         for src, dst, data in function.transition_graph.edges(data=True):
             edge = primitives_pb2.Edge()
-            edge.src_ea = src.addr
-            edge.dst_ea = dst.addr
+            addr_to_pb(edge, "src_ea", src.addr)
+            addr_to_pb(edge, "dst_ea", dst.addr)
             edge.jumpkind = TRANSITION_JK
             edge.confirmed = 2  # default value
             for key, value in data.items():
@@ -156,7 +164,7 @@ class FunctionParser:
                     edge.jumpkind = func_edge_type_to_pb(value)
                 elif key == "ins_addr":
                     if value is not None:
-                        edge.ins_addr = value
+                        addr_to_pb(edge, "ins_addr", value)
                 elif key == "stmt_idx":
                     if value is not None:
                         edge.stmt_idx = value
@@ -169,16 +177,20 @@ class FunctionParser:
             edges.append(edge)
         obj.graph.edges.extend(edges)  # pylint:disable=no-member
         # referenced functions
-        obj.external_functions.extend(external_func_addrs)  # pylint:disable=no-member
+        for func_addr in external_func_addrs:
+            if isinstance(func_addr, int):
+                obj.external_functions.append(func_addr)  # pylint:disable=no-member
+            else:
+                soot_addr_to_pb(func_addr, obj.soot_external_functions.add())  # pylint:disable=no-member
         obj.external_blocks.extend(external_blocks)  # pylint:disable=no-member
 
         for call_site_addr, (call_target_addr, retn_addr) in function._call_sites.items():
             call_site = function_pb2.CallSite()
-            call_site.ea = call_site_addr
+            addr_to_pb(call_site, "ea", call_site_addr)
             if call_target_addr is not None:
-                call_site.target_ea = call_target_addr
+                addr_to_pb(call_site, "target_ea", call_target_addr)
             if retn_addr is not None:
-                call_site.return_ea = retn_addr
+                addr_to_pb(call_site, "return_ea", retn_addr)
             obj.call_sites.append(call_site)  # pylint:disable=no-member
 
         return obj
@@ -212,7 +224,7 @@ class FunctionParser:
 
         obj = angr.knowledge_plugins.functions.Function(
             function_manager,
-            cmsg.ea,
+            addr_from_pb(cmsg, "ea"),
             name=cmsg.name,
             is_plt=cmsg.is_plt,
             syscall=cmsg.is_syscall,
@@ -243,7 +255,7 @@ class FunctionParser:
             raise ValueError(f"Cannot convert SignatureSource enum {cmsg.matched_from} to Function.from_signature.")
 
         if meta_only:
-            startpoint_addr = cmsg.ea
+            startpoint_addr = obj.addr
             obj.startpoint = (
                 HookNode(startpoint_addr, 0, project.hooked_by(startpoint_addr))
                 if project and project.is_hooked(startpoint_addr)
@@ -252,11 +264,11 @@ class FunctionParser:
 
             block_addrs_set = set()
             for b in cmsg.blocks:
-                block_addrs_set.add(b.ea)
+                block_addrs_set.add(addr_from_pb(b, "ea"))
             obj._local_block_addrs = block_addrs_set
 
             for endpoint in cmsg.endpoints:
-                block = BlockNode(endpoint.ea, endpoint.size, bytestr=None)
+                block = BlockNode(addr_from_pb(endpoint, "ea"), endpoint.size, bytestr=None)
                 match endpoint.type:
                     case primitives_pb2.EndpointType.CALL:
                         obj._callout_sites.add(block)
@@ -276,15 +288,16 @@ class FunctionParser:
         blocks = {}
         external_blocks = {}
         for b in cmsg.blocks:
-            block = BlockNode(b.ea, b.size, bytestr=b.bytes)
+            block = BlockNode(addr_from_pb(b, "ea"), b.size, bytestr=b.bytes)
             blocks[block.addr] = block
 
         for b in cmsg.external_blocks:
-            block = BlockNode(b.ea, b.size, bytestr=b.bytes)
+            block = BlockNode(addr_from_pb(b, "ea"), b.size, bytestr=b.bytes)
             external_blocks[block.addr] = block
 
         # addresses of referenced functions that are not inside the current function
         external_func_addrs = set(cmsg.external_functions)
+        external_func_addrs.update(soot_addr_from_pb(pb) for pb in cmsg.soot_external_functions)
 
         # edges
         edges = {}
@@ -293,11 +306,12 @@ class FunctionParser:
         # func_edge_type_from_pb only to log the error for an unrecognized value
         edge_type_of = _PB_TO_FUNCTION_EDGETYPES.get
         for edge_cmsg in cmsg.graph.edges:
-            if edge_cmsg.src_ea in blocks:
-                src = blocks[edge_cmsg.src_ea]
-            else:
+            edge_src_ea = addr_from_pb(edge_cmsg, "src_ea")
+            edge_dst_ea = addr_from_pb(edge_cmsg, "dst_ea")
+            src = blocks.get(edge_src_ea)
+            if src is None:
                 src = FunctionParser._get_hook_or_func_node(
-                    edge_cmsg.src_ea,
+                    edge_src_ea,
                     external_blocks,
                     external_func_addrs,
                     project,
@@ -309,13 +323,12 @@ class FunctionParser:
             assert edge_type is not None
 
             if edge_type == "call":
-                dst = FuncNode(edge_cmsg.dst_ea)
+                dst = FuncNode(edge_dst_ea)
             else:
-                if edge_cmsg.dst_ea in blocks:
-                    dst = blocks[edge_cmsg.dst_ea]
-                else:
+                dst = blocks.get(edge_dst_ea)
+                if dst is None:
                     dst = FunctionParser._get_hook_or_func_node(
-                        edge_cmsg.dst_ea,
+                        edge_dst_ea,
                         external_blocks,
                         external_func_addrs,
                         project,
@@ -323,7 +336,7 @@ class FunctionParser:
 
             data = {
                 "outside": edge_cmsg.is_outside,
-                "ins_addr": edge_cmsg.ins_addr,
+                "ins_addr": addr_from_pb(edge_cmsg, "ins_addr"),
                 "stmt_idx": edge_cmsg.stmt_idx,
             }
             if edge_cmsg.confirmed == 0:
@@ -331,9 +344,9 @@ class FunctionParser:
             elif edge_cmsg.confirmed == 1:
                 data["confirmed"] = True
             if edge_type == "fake_return":
-                fake_return_edges[edge_cmsg.src_ea].append((src, dst, data))
+                fake_return_edges[edge_src_ea].append((src, dst, data))
             else:
-                edges[(edge_cmsg.src_ea, edge_cmsg.dst_ea, edge_type)] = (src, dst, data)
+                edges[(edge_src_ea, edge_dst_ea, edge_type)] = (src, dst, data)
 
         added_nodes = set()
         for k, v in edges.items():
@@ -401,9 +414,10 @@ class FunctionParser:
                 pass
 
         for endpoint in cmsg.endpoints:
-            if endpoint.ea not in blocks:
+            endpoint_ea = addr_from_pb(endpoint, "ea")
+            if endpoint_ea not in blocks:
                 continue
-            block = blocks[endpoint.ea]
+            block = blocks[endpoint_ea]
             match endpoint.type:
                 case primitives_pb2.EndpointType.CALL:
                     obj._callout_sites.add(block)
@@ -423,9 +437,9 @@ class FunctionParser:
         obj.update_func_block_count()
 
         for call_site_cmsg in cmsg.call_sites:
-            obj._call_sites[call_site_cmsg.ea] = (
-                call_site_cmsg.target_ea if call_site_cmsg.HasField("target_ea") else None,
-                call_site_cmsg.return_ea if call_site_cmsg.HasField("return_ea") else None,
+            obj._call_sites[addr_from_pb(call_site_cmsg, "ea")] = (
+                optional_addr_from_pb(call_site_cmsg, "target_ea"),
+                optional_addr_from_pb(call_site_cmsg, "return_ea"),
             )
 
         obj._dirty = False

--- a/angr/knowledge_plugins/functions/function_parser.py
+++ b/angr/knowledge_plugins/functions/function_parser.py
@@ -224,7 +224,7 @@ class FunctionParser:
 
         obj = angr.knowledge_plugins.functions.Function(
             function_manager,
-            addr_from_pb(cmsg, "ea"),
+            addr_from_pb(cmsg, "ea"),  # type:ignore
             name=cmsg.name,
             is_plt=cmsg.is_plt,
             syscall=cmsg.is_syscall,

--- a/angr/knowledge_plugins/functions/soot_function.py
+++ b/angr/knowledge_plugins/functions/soot_function.py
@@ -8,7 +8,7 @@ import networkx
 
 from angr.codenode import BlockNode
 
-from .function import Function, FunctionInfo
+from .function import Function, FunctionInfo, PrototypeSource
 
 
 class SootFunction(Function):
@@ -68,8 +68,11 @@ class SootFunction(Function):
             binary_name = os.path.basename(self.binary.binary)
 
         self._name = addr.__repr__()
+        self.is_default_name = True
         self.binary_name = binary_name
 
+        # Register offsets of those arguments passed in registers
+        self._argument_registers = []
         # Stack offsets of those arguments passed in stack variables
         self._argument_stack_variables = []
 
@@ -84,11 +87,13 @@ class SootFunction(Function):
 
         # Function prototype
         self._prototype = None
+        self._prototype_libname = None
+        self._prototype_source = PrototypeSource.NONE
 
         # Whether this function returns or not. `None` means it's not determined yet
         self._returning = None
 
-        self._is_alignment = None
+        self._is_alignment = False
 
         # Determine returning status for SimProcedures and Syscalls
         hooker = None
@@ -106,7 +111,11 @@ class SootFunction(Function):
         self._local_block_addrs = set()  # a set of addresses of all blocks inside the function
 
         self._info = FunctionInfo(self)
+        self._cyclomatic_complexity = None
+        self.ran_cca = False  # this is set by CompleteCallingConventions to avoid reprocessing failed functions
         self._dirty = False
+        self.meta_only = False
+        self.evicted = False
         self.tags = ()  # store function tags. can be set manually by performing CodeTagging analysis.
 
     def normalize(self):

--- a/angr/protos/cfg.proto
+++ b/angr/protos/cfg.proto
@@ -38,6 +38,8 @@ message CFGNode {
     bool            is_syscall = 12; // Whether this is a syscall node
     uint64          ins_base_addr = 13; // Base address for compact instruction address storage
     bytes           ins_sizes = 14; // Instruction sizes as bytestring (one byte per instruction)
+    optional SootAddress soot_ea = 15; // Address of the node when it is a Java address; ea is unset
+    optional SootAddress soot_function_address = 16; // Function of the node when it is a Java method
 }
 
 message CFGENode {

--- a/angr/protos/function.proto
+++ b/angr/protos/function.proto
@@ -9,6 +9,9 @@ message CallSite {
     uint64          ea = 1; // Address of the basic block that ends in a call
     optional uint64 target_ea = 2; // Address of the call target; unset if the target is unknown
     optional uint64 return_ea = 3; // Address the call returns to; unset if the call does not return
+    optional SootAddress soot_ea = 4; // Address of the block when it is a Java address; ea is unset
+    optional SootAddress soot_target_ea = 5; // Call target when it is a Java method
+    optional SootAddress soot_return_ea = 6; // Return address when it is a Java address
 }
 
 message Function {
@@ -42,4 +45,6 @@ message Function {
     repeated string previous_names = 27; // Previous names of this function
     uint32          prototype_source = 28; // did we guess this prototype?
     repeated CallSite call_sites = 29; // Call sites within this function
+    optional SootAddress soot_ea = 30; // Address of the function when it is a Java method; ea is unset
+    repeated SootAddress soot_external_functions = 31; // Java methods among the referenced functions
 }

--- a/angr/protos/primitives.proto
+++ b/angr/protos/primitives.proto
@@ -52,12 +52,24 @@ message Instruction {
     bool            local_noreturn = 4;
 }
 
+// A Java address, as archinfo represents one. The class name, method name and parameter types identify the
+// method; block_idx and stmt_idx locate a statement inside it. An address with no block_idx is a whole
+// method (a SootMethodDescriptor); one with a block_idx is a statement (a SootAddressDescriptor).
+message SootAddress {
+    string          class_name = 1;
+    string          method_name = 2;
+    repeated string params = 3;
+    optional int32  block_idx = 4;
+    optional int32  stmt_idx = 5;
+}
+
 // Derived from McSema's CFG.proto
 message Block {
     uint64  ea = 1; // Effective address of the block
     Instruction instructions = 2;   // Instructions in this block
     uint32  size = 4; // Size of the block
     bytes   bytes = 5; // Bytes of this block
+    optional SootAddress soot_ea = 6; // Address of the block when it is a Java address; ea is unset
 }
 
 // Derived from McSema's CFG.proto
@@ -135,6 +147,9 @@ message Edge {
     int64               stmt_idx = 6; // ID of the source statement
     uint32              confirmed = 7; // whether this is a confirmed return edge; 0 = unconfirmed, 1 = confirmed,
                                        // 2 (or other values) = n/a (not a return edge)
+    optional SootAddress soot_src_ea = 8; // Source address when it is a Java address; src_ea is unset
+    optional SootAddress soot_dst_ea = 9; // Destination address when it is a Java address; dst_ea is unset
+    optional SootAddress soot_ins_addr = 10; // Source instruction when it is a Java address; ins_addr is unset
 }
 
 message BlockGraph {
@@ -152,4 +167,5 @@ message Endpoint {
     EndpointType type = 1; // Type of the endpoint
     uint64       ea = 2; // Address of the endpoint
     uint32       size = 3; // Size of the endpoint - so that we do not have to load blocks
+    optional SootAddress soot_ea = 4; // Address of the endpoint when it is a Java address; ea is unset
 }

--- a/angr/utils/addr_conv.py
+++ b/angr/utils/addr_conv.py
@@ -4,6 +4,9 @@ from archinfo.arch_soot import SootAddressDescriptor, SootMethodDescriptor
 
 from angr.protos.primitives_pb2 import SootAddress
 
+# An address as the angrDb messages carry it: a native address, or a Soot method or statement address.
+type Address = int | SootAddressDescriptor | SootMethodDescriptor
+
 
 def soot_addr_to_pb(addr: SootAddressDescriptor | SootMethodDescriptor, pb: SootAddress) -> None:
     """
@@ -40,7 +43,7 @@ def addr_to_pb(cmsg, field: str, addr) -> None:
         soot_addr_to_pb(addr, getattr(cmsg, "soot_" + field))
 
 
-def addr_from_pb(cmsg, field: str):
+def addr_from_pb(cmsg, field: str) -> Address:
     """
     Read back an address stored by :func:`addr_to_pb`.
     """
@@ -50,7 +53,7 @@ def addr_from_pb(cmsg, field: str):
     return getattr(cmsg, field)
 
 
-def optional_addr_from_pb(cmsg, field: str):
+def optional_addr_from_pb(cmsg, field: str) -> Address | None:
     """
     Read back an address stored by :func:`addr_to_pb` in an optional field, or None when it was never stored.
     """

--- a/angr/utils/addr_conv.py
+++ b/angr/utils/addr_conv.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from archinfo.arch_soot import SootAddressDescriptor, SootMethodDescriptor
+
+from angr.protos.primitives_pb2 import SootAddress
+
+
+def soot_addr_to_pb(addr: SootAddressDescriptor | SootMethodDescriptor, pb: SootAddress) -> None:
+    """
+    Fill a SootAddress message from a Soot method or statement address.
+    """
+    method = addr.method if isinstance(addr, SootAddressDescriptor) else addr
+    pb.class_name = method.class_name
+    pb.method_name = method.name
+    pb.params.extend(method.params)
+    if isinstance(addr, SootAddressDescriptor):
+        pb.block_idx = addr.block_idx
+        if addr.stmt_idx is not None:
+            pb.stmt_idx = addr.stmt_idx
+
+
+def soot_addr_from_pb(pb: SootAddress) -> SootAddressDescriptor | SootMethodDescriptor:
+    """
+    Build a Soot method or statement address from a SootAddress message.
+    """
+    method = SootMethodDescriptor(pb.class_name, pb.method_name, tuple(pb.params))
+    if not pb.HasField("block_idx"):
+        return method
+    return SootAddressDescriptor(method, pb.block_idx, pb.stmt_idx if pb.HasField("stmt_idx") else None)
+
+
+def addr_to_pb(cmsg, field: str, addr) -> None:
+    """
+    Store an address in ``cmsg``, using the uint64 field ``field`` for an integer address and the SootAddress
+    field ``soot_<field>`` for a Soot one.
+    """
+    if isinstance(addr, int):
+        setattr(cmsg, field, addr)
+    else:
+        soot_addr_to_pb(addr, getattr(cmsg, "soot_" + field))
+
+
+def addr_from_pb(cmsg, field: str):
+    """
+    Read back an address stored by :func:`addr_to_pb`.
+    """
+    soot_field = "soot_" + field
+    if cmsg.HasField(soot_field):
+        return soot_addr_from_pb(getattr(cmsg, soot_field))
+    return getattr(cmsg, field)
+
+
+def optional_addr_from_pb(cmsg, field: str):
+    """
+    Read back an address stored by :func:`addr_to_pb` in an optional field, or None when it was never stored.
+    """
+    soot_field = "soot_" + field
+    if cmsg.HasField(soot_field):
+        return soot_addr_from_pb(getattr(cmsg, soot_field))
+    return getattr(cmsg, field) if cmsg.HasField(field) else None

--- a/tests/analyses/cfg/test_cfgfast_soot.py
+++ b/tests/analyses/cfg/test_cfgfast_soot.py
@@ -154,6 +154,22 @@ class TestCfgfastSoot(unittest.TestCase):
         names = {f.name for f in cfg.kb.functions.values()}
         assert any("greet" in name for name in names), names
 
+    def test_str_of_a_soot_function(self):
+        # Function.__str__ formats the address with ":#x" and every block address the same way. A Soot
+        # function's address is a SootMethodDescriptor and its blocks are SootAddressDescriptors, so both
+        # raised TypeError. __repr__ already guarded this; __str__ did not.
+        binary_path = os.path.join(test_location, "java", "simple1.jar")
+        p = angr.Project(binary_path, main_opts={"entry_point": "simple1.Class1.main"}, auto_load_libs=False)
+        cfg = p.analyses.CFGFastSoot()
+
+        functions = list(cfg.kb.functions.values())
+        assert functions
+
+        for function in functions:
+            rendered = str(function)
+            assert function.name in rendered
+            assert str(function.addr) in rendered
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/analyses/cfg/test_cfgfast_soot.py
+++ b/tests/analyses/cfg/test_cfgfast_soot.py
@@ -6,7 +6,12 @@ __package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-bu
 import os
 import unittest
 
+from archinfo.arch_soot import SootAddressDescriptor, SootMethodDescriptor
+
 import angr
+from angr.knowledge_plugins.cfg import CFGModel
+from angr.knowledge_plugins.cfg.spilling_cfg import SpillingCFG, get_block_key
+from angr.knowledge_plugins.functions import Function
 
 try:
     import pysoot
@@ -33,6 +38,95 @@ class TestCfgfastSoot(unittest.TestCase):
         p = angr.Project(binary_path, main_opts={"entry_point": "simple2.Class1.main"}, auto_load_libs=False)
         cfg = p.analyses.CFGFastSoot()
         assert cfg.graph.nodes()
+
+    @staticmethod
+    def _simple1_cfg():
+        binary_path = os.path.join(test_location, "java", "simple1.jar")
+        p = angr.Project(binary_path, main_opts={"entry_point": "simple1.Class1.main"}, auto_load_libs=False)
+        return p, p.analyses.CFGFastSoot()
+
+    def test_soot_cfg_model_round_trips_through_a_cmessage(self):
+        _, cfg = self._simple1_cfg()
+        assert cfg.model.addr_type == "soot"
+
+        model = CFGModel.parse_from_cmessage(cfg.model.serialize_to_cmessage())
+
+        def nodes_of(m):
+            return sorted((n.addr, n.size, n.function_address) for n in m.graph.nodes())
+
+        def edges_of(m):
+            return sorted(
+                (src.addr, dst.addr, data.get("jumpkind"), data.get("ins_addr"), data.get("stmt_idx"))
+                for src, dst, data in m.graph.edges(data=True)
+            )
+
+        assert nodes_of(model) == nodes_of(cfg.model)
+        assert edges_of(model) == edges_of(cfg.model)
+        for node in model.graph.nodes():
+            assert isinstance(node.addr, SootAddressDescriptor)
+            assert isinstance(node.function_address, SootMethodDescriptor)
+
+    def test_soot_function_round_trips_through_a_cmessage(self):
+        p, _ = self._simple1_cfg()
+        assert p.kb.functions
+
+        for func in list(p.kb.functions.values()):
+            parsed = Function.parse_from_cmessage(
+                func.serialize_to_cmessage(), function_manager=p.kb.functions, project=p
+            )
+            assert parsed.addr == func.addr
+            assert isinstance(parsed.addr, SootMethodDescriptor)
+            assert {n.addr for n in parsed.transition_graph} == {n.addr for n in func.transition_graph}
+            assert sorted(parsed.get_call_sites()) == sorted(func.get_call_sites())
+            for call_site in func.get_call_sites():
+                assert parsed.get_call_target(call_site) == func.get_call_target(call_site)
+                assert parsed.get_call_return(call_site) == func.get_call_return(call_site)
+
+    def test_soot_cfg_survives_node_and_edge_eviction(self):
+        p, cfg = self._simple1_cfg()
+        nodes = list(cfg.model.graph.nodes())
+        edges = [(src, dst, cfg.model.graph.get_edge_data(src, dst)) for src, dst in cfg.model.graph.edges]
+        assert len(nodes) > 4
+        assert len(edges) > 4
+
+        # a limit of 2 with a batch size of 1 evicts long before the last node is inserted
+        graph = SpillingCFG(
+            rtdb=p.kb.rtdb,
+            cache_limit=2,
+            db_batch_size=1,
+            edge_cache_limit=2,
+            edge_db_batch_size=1,
+            addr_type="soot",
+        )
+        for node in nodes:
+            graph.add_node(node)
+        for src, dst, data in edges:
+            graph.add_edge(src, dst, **data)
+
+        assert graph.spilled_count > 0
+        assert len(graph) == len(nodes)
+        assert graph.number_of_edges() == len(edges)
+        for node in nodes:
+            reloaded = graph.get_node_by_key(get_block_key(node))
+            assert reloaded.addr == node.addr
+            assert reloaded.size == node.size
+            assert reloaded.function_address == node.function_address
+        for src, dst, data in edges:
+            assert graph.get_edge_data(src, dst) == data
+
+    def test_soot_functions_survive_eviction(self):
+        p, _ = self._simple1_cfg()
+        before = {addr: {n.addr for n in func.transition_graph} for addr, func in p.kb.functions.items()}
+        assert len(before) > 1
+
+        p.kb.functions.cache_limit = 1
+        assert p.kb.functions.cached_function_count <= 1
+
+        for addr, node_addrs in before.items():
+            func = p.kb.functions[addr]
+            assert func.addr == addr
+            assert isinstance(func.addr, SootMethodDescriptor)
+            assert {n.addr for n in func.transition_graph} == node_addrs
 
     def test_simple2_without_entry_point(self):
         # simple2.jar has no Main-Class manifest attribute, so without an explicit entry_point the loader leaves


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

angrDb cannot serialize a Soot CFG. On `binaries/tests/java/simple1.jar` with entry point `simple1.Class1.main`, a recovered `CFGFastSoot` model of 9 nodes and 4 functions fails at every serialization entry point:

```
TypeError: 'SootAddressDescriptor' object cannot be interpreted as an integer
  angr/knowledge_plugins/cfg/spilling_cfg.py, in export_serialized_nodes
TypeError: 'SootMethodDescriptor' object cannot be interpreted as an integer
  angr/knowledge_plugins/functions/function_parser.py:60, in serialize -> obj.ea = function.addr
TypeError: unsupported format string passed to SootMethodDescriptor.__format__
  angr/knowledge_plugins/functions/function.py:821, in __str__
```

So no Soot project can be saved, and none can be analysed under a memory limit either: the spilling containers reuse the same encoders, so eviction raises rather than spilling.

### Root cause

`CFGNode.ea`, `Function.ea`, `CallSite.ea`, `Edge.src_ea` and `Endpoint.ea` are all declared `uint64` in `angr/protos/`, and there is no message in that directory that can hold a Java address at all. A Soot address is not an integer — `SootMethodDescriptor` is a class name, a method name and its parameter types; `SootAddressDescriptor` adds a block index and a statement index — so the assignment `obj.ea = function.addr` raises before any encoding happens.

### Fix

Add a `SootAddress` message to `primitives.proto` and an optional `soot_` counterpart beside each `uint64` address field it has to reach: `CFGNode.soot_ea` and `soot_function_address`, `Function.soot_ea`, `CallSite.soot_ea`/`soot_target_ea`/`soot_return_ea`, `Edge.soot_src_ea`/`soot_dst_ea`/`soot_ins_addr`, `Block.soot_ea`, `Endpoint.soot_ea`. `angr/utils/addr_conv.py` converts in both directions, and the field is written only when the address is a `SootAddressDescriptor` or `SootMethodDescriptor`, so the native path is untouched: serializing a `CFGFast` model of `binaries/tests/x86_64/fauxware` gives the same 7927-byte message, sha256 `b3f8a5ec3ff6a043c8e6b30b9365a10652707d7445420b3dcc20d8a1cfc6061a`, and the same digest over its 40 `Function` messages, on the baseline and on this head.

Three smaller things in the same seam were needed to reach it: `CFGNode` no longer refuses a `block_id` equal to the address, the spilling edge encoder sends Soot edge data through the JSON form its Soot keys already used, and `SootFunction.__init__` gained the attributes the serializer reads. `Function.__str__` now formats a Soot address rather than raising.

### Testing

`tests/analyses/cfg/test_cfgfast_soot.py` gains five tests, all skipped unless pysoot is importable: two round-trip the `simple1.jar` CFG model and each of its functions through a real cmessage and assert node addresses, edge data, call sites and call targets come back equal; two drive the real spill path with `cache_limit=2` and `db_batch_size=1` so eviction happens before the last node is inserted, and assert every node and edge reloads; one pins `str()` of a Soot function. All five fail on the baseline with the `TypeError`s above; all five pass on this head.

Replaces #6918. Validation: https://github.com/angr/angr/pull/6930#issuecomment-5420032571

session: sharpen
