### PR TITLE
SimState: Cover the registration order and single initialization of state plugins

### DIFF
--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -439,19 +439,11 @@ class SimState[IPTypeConc, IPTypeSym](PluginHub[SimStatePlugin]):
         return super().has_plugin(name)
 
     def register_plugin(self, name, plugin, inhibit_init=False):  # pylint: disable=arguments-differ
-        # l.debug("Adding plugin %s of type %s", name, plugin.__class__.__name__)
-        self._set_plugin_state(plugin, inhibit_init=inhibit_init)
-        return super().register_plugin(name, plugin)
-
-    def _init_plugin(self, plugin_cls: type[SimStatePlugin]) -> SimStatePlugin:
-        plugin = plugin_cls()
-        self._set_plugin_state(plugin)
-        return plugin
-
-    def _set_plugin_state(self, plugin: SimStatePlugin, inhibit_init: bool = False):
+        super().register_plugin(name, plugin)
         plugin.set_state(self)
         if not inhibit_init:
             plugin.init_state()
+        return plugin
 
     #
     # Java support

--- a/tests/state_plugins/test_plugin_registration.py
+++ b/tests/state_plugins/test_plugin_registration.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 __package__ = __package__ or "tests.state_plugins"  # pylint:disable=redefined-builtin

--- a/tests/state_plugins/test_plugin_registration.py
+++ b/tests/state_plugins/test_plugin_registration.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+__package__ = __package__ or "tests.state_plugins"  # pylint:disable=redefined-builtin
+
+import collections
+import unittest
+
+import archinfo
+
+import angr
+from angr import sim_options as o
+from angr.state_plugins.plugin import SimStatePlugin
+
+
+class TestPluginRegistration(unittest.TestCase):
+    """
+    Tests for the order in which SimState registers and initializes a preset plugin.
+    """
+
+    def test_a_preset_plugin_is_initialized_once(self):
+        # register_plugin() used to initialize the plugin and _init_plugin() used to initialize it again, so
+        # every plugin the preset supplied ran init_state() twice.
+        project = angr.load_shellcode(b"\x90\x90\xc3", arch="amd64")
+        state = project.factory.blank_state()
+
+        counts: collections.Counter = collections.Counter()
+        original = SimStatePlugin.init_state
+
+        def counting(self):
+            counts[id(self)] += 1
+            return original(self)
+
+        SimStatePlugin.init_state = counting
+        try:
+            fresh = project.factory.blank_state()
+            fresh.history  # noqa: B018  pylint:disable=pointless-statement
+            fresh.solver  # noqa: B018  pylint:disable=pointless-statement
+        finally:
+            SimStatePlugin.init_state = original
+
+        assert counts, "no plugin was initialized"
+        assert set(counts.values()) == {1}, dict(counts)
+        assert state is not fresh
+
+    def test_a_plugin_may_look_itself_up_while_initializing(self):
+        # SimStateHistory.init_state() reads the program counter. On an architecture whose PC register is
+        # unset, that read fills the register symbolically, which records an event on the history plugin that
+        # is still being constructed. Registering only after init_state() returned made that lookup miss and
+        # build a second plugin, without end.
+        arch = archinfo.ArchPcode("dsPIC33F:LE:24:default")
+        project = angr.load_shellcode(b"\x00" * 6, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
+        state = project.factory.blank_state(
+            mode="fastpath",
+            add_options={o.SYMBOL_FILL_UNCONSTRAINED_MEMORY, o.SYMBOL_FILL_UNCONSTRAINED_REGISTERS},
+        )
+
+        state.registers.load("pc")
+
+        assert state.history is not None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`SimState.register_plugin` initialized a plugin before publishing it into the hub, and `_init_plugin` initialized it a second time. Every preset plugin of a plain `blank_state()` on amd64 therefore ran `init_state()` twice, and a plugin whose `init_state()` reaches back through the hub for itself never terminated. `SimStateHistory.init_state()` reads the program counter; on `dsPIC33F:LE:24:default`, whose PC register is unset, that read fills the register symbolically, which records an event on the history plugin still under construction:

```
state.registers.load('pc') raised RecursionError: maximum recursion depth exceeded
    SimStateHistory          instances=52    init_state() calls per instance=[1]
```

52 history plugins were built for one state before the recursion limit stopped it. Nothing on that architecture can construct a state, so lifting, simulation and CFG recovery are all unreachable for the 24-bit PIC and dsPIC SLEIGH languages.

### Root cause

The order in `angr/sim_state.py`: the plugin was initialized first and registered afterwards, so a lookup made from inside `init_state()` missed and built another plugin.

```python
def register_plugin(self, name, plugin, inhibit_init=False):
    self._set_plugin_state(plugin, inhibit_init=inhibit_init)
    return super().register_plugin(name, plugin)

def _init_plugin(self, plugin_cls: type[SimStatePlugin]) -> SimStatePlugin:
    plugin = plugin_cls()
    self._set_plugin_state(plugin)      # and again, via register_plugin, below
    return plugin
```

`_init_plugin` is the hub's constructor hook, and `PluginHub.get_plugin` registers whatever it returns, so `_set_plugin_state` ran once here and once there.

### Fix

Register first, then set the state and initialize once:

```python
def register_plugin(self, name, plugin, inhibit_init=False):
    super().register_plugin(name, plugin)
    plugin.set_state(self)
    if not inhibit_init:
        plugin.init_state()
    return plugin
```

This branch opened with that change. #6995 has since landed the identical hunk on master — `git diff origin/master <head> -- angr/sim_state.py` is empty — so what this branch still adds is only the two regressions that hold the invariant.

### Testing

`tests/state_plugins/test_plugin_registration.py`. `test_a_preset_plugin_is_initialized_once` counts `init_state()` per plugin instance on an amd64 `blank_state()` and asserts every count is 1. `test_a_plugin_may_look_itself_up_while_initializing` builds a `dsPIC33F:LE:24:default` state and reads `pc`. With #6995's hunk reverted both fail — `RecursionError: maximum recursion depth exceeded` and `assert {1, 2} == {1}` — and both pass at this head.

Validation: https://github.com/angr/angr/pull/6933#issuecomment-5406213411

session: mega-corpus
