### PR TITLE
Pcode: Fix partial reads of a unique written wide

### DIFF
--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -323,9 +323,7 @@ class PCodeIRSBConverter(Converter):
                 # little-endian machine the high half sits at the higher address, on a big-endian one at
                 # the lower. Computing this the big-endian way on a little-endian target silently
                 # returns the low half for both halves of a widening multiply.
-                arch = self._manager.arch
-                assert arch is not None
-                if arch.memory_endness == archinfo.Endness.LE:
+                if self._irsb.arch.memory_endness == archinfo.Endness.LE:
                     right_shift_amount = varnode.offset - unique_offset
                 else:
                     right_shift_amount = (unique_offset + ori_tmp_size) - (varnode.offset + varnode.size)

--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import archinfo
 import pypcode
 from pypcode import OpCode, PcodeOp, Varnode
 
@@ -314,10 +315,20 @@ class PCodeIRSBConverter(Converter):
                         break
                 assert unique_offset is not None, "Cannot find the source unique variable"
                 # TODO: Check size
-                _, ori_tmp_size = self._unique_tracker[unique_offset]
-                t = Tmp(self._manager.next_atom(), unique_offset, ori_tmp_size * 8)
-                # FIXME: Asserting BE
-                right_shift_amount = varnode.offset + varnode.size - (unique_offset + ori_tmp_size)
+                ori_tmp_idx, ori_tmp_size = self._unique_tracker[unique_offset]
+                # Index the parent by its remapped index, not by its unique-space address: the defining
+                # write went through _remap_temp, so a Tmp built from the raw offset names nothing.
+                t = Tmp(self._manager.next_atom(), ori_tmp_idx, ori_tmp_size * 8)
+                # Which end of the parent the sub-range names depends on the byte order: on a
+                # little-endian machine the high half sits at the higher address, on a big-endian one at
+                # the lower. Computing this the big-endian way on a little-endian target silently
+                # returns the low half for both halves of a widening multiply.
+                arch = self._manager.arch
+                assert arch is not None
+                if arch.memory_endness == archinfo.Endness.LE:
+                    right_shift_amount = varnode.offset - unique_offset
+                else:
+                    right_shift_amount = (unique_offset + ori_tmp_size) - (varnode.offset + varnode.size)
                 if right_shift_amount != 0:
                     t = BinaryOp(
                         self._manager.next_atom(),

--- a/tests/ailment/test_converter_pcode.py
+++ b/tests/ailment/test_converter_pcode.py
@@ -50,7 +50,7 @@ class TestPcodeConverter(unittest.TestCase):
         arch = archinfo.ArchPcode("SuperH4:LE:32:default")
         project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
 
-        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager(arch=arch))
+        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager())
 
         defined, used = _tmp_indices(block)
         assert used, "the block should read at least one tmp"
@@ -66,7 +66,7 @@ class TestPcodeConverter(unittest.TestCase):
         arch = archinfo.ArchPcode("SuperH4:LE:32:default")
         project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
 
-        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager(arch=arch))
+        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager())
 
         halves = [str(stmt.src) for stmt in block.statements if isinstance(stmt, Assignment)]
         shifted = [h for h in halves if "Shr" in h]

--- a/tests/ailment/test_converter_pcode.py
+++ b/tests/ailment/test_converter_pcode.py
@@ -1,0 +1,77 @@
+# pylint: disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.ailment"  # pylint:disable=redefined-builtin
+
+import unittest
+
+import archinfo
+
+import angr
+from angr import ailment
+from angr.ailment.expression import Tmp
+from angr.ailment.statement import Assignment
+
+
+def _tmp_indices(block):
+    """Return the tmp indices this block defines and the ones it reads, nested reads included."""
+    defined, used = set(), set()
+
+    def collect(expr):
+        if isinstance(expr, Tmp):
+            used.add(expr.tmp_idx)
+        for operand in getattr(expr, "operands", None) or ():
+            collect(operand)
+        for arg in getattr(expr, "args", None) or ():
+            collect(arg)
+        inner = getattr(expr, "operand", None)
+        if inner is not None:
+            collect(inner)
+
+    for stmt in block.statements:
+        dst = getattr(stmt, "dst", None)
+        if isinstance(dst, Tmp):
+            defined.add(dst.tmp_idx)
+        if isinstance(stmt, Assignment):
+            collect(stmt.src)
+    return defined, used
+
+
+class TestPcodeConverter(unittest.TestCase):
+    def test_partial_read_of_a_wide_unique_names_the_defining_tmp(self):
+        """
+        A SLEIGH multiply writes one wide value into unique space and the following instruction reads
+        half of it. The converter remaps unique-space addresses to tmp indices, and the partial read
+        used to name the parent by its unique-space address instead of its remapped index, producing a
+        tmp that no statement defines. Nothing rejects that until the decompiler indexes it.
+        """
+        # dmulu.l r1,r2 ; sts mach,r3 ; sts macl,r4 ; rts ; nop
+        code = bytes.fromhex("15320a031a040b000900")
+        arch = archinfo.ArchPcode("SuperH4:LE:32:default")
+        project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
+
+        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager(arch=arch))
+
+        defined, used = _tmp_indices(block)
+        assert used, "the block should read at least one tmp"
+        assert not (used - defined), f"tmp read without a definition: {sorted(used - defined)}"
+
+    def test_the_two_halves_of_a_widening_multiply_differ(self):
+        """
+        The high half of a little-endian wide unique lives at the higher address, so extracting it needs
+        a shift. Computing that offset the big-endian way returns the low half for both halves, which
+        decompiles to two identical assignments instead of MACH and MACL.
+        """
+        code = bytes.fromhex("15320a031a040b000900")
+        arch = archinfo.ArchPcode("SuperH4:LE:32:default")
+        project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
+
+        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager(arch=arch))
+
+        halves = [str(stmt.src) for stmt in block.statements if isinstance(stmt, Assignment)]
+        shifted = [h for h in halves if "Shr" in h]
+        assert shifted, f"neither half of the product is shifted: {halves}"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ailment/test_converter_pcode.py
+++ b/tests/ailment/test_converter_pcode.py
@@ -3,14 +3,36 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.ailment"  # pylint:disable=redefined-builtin
 
+import os
 import unittest
-
-import archinfo
 
 import angr
 from angr import ailment
 from angr.ailment.expression import Tmp
 from angr.ailment.statement import Assignment
+
+# 420e5c  dmulu.l r4, r5   -- SLEIGH writes the 64-bit product to one wide unique and reads a
+# 420e5e  sts     MACL, r1     32-bit half of it back for each of MACL and MACH, all under the
+# 420e60  sts     MACH, r2     first instruction. The two sts are register moves.
+# Derived the way tests/common.py derives bin_location. Importing it from here instead would be
+# the first `import tests` of a --collect-only run -- tests/ailment sorts before tests/analyses and
+# has no __init__.py, so pytest has only tests/ailment on sys.path at that point, and the "tests"
+# that binds is not this one. That poisons every later tests.* import: 337 collection errors.
+_binaries = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "binaries")
+TEST_BINARY = os.path.join(_binaries, "tests", "sh4", "test-instr_sh4")
+BLOCK_ADDR = 0x420E5C
+# The instruction bound is load-bearing. The natural block here is 8 instructions and contains two
+# shifts of its own, so without it test_the_two_halves_of_a_widening_multiply_differ finds a Shr and
+# passes on the unfixed converter. Three is a readable window; one would do.
+BLOCK_INSNS = 3
+
+
+def _convert():
+    """Convert the three-instruction block above to AIL. SuperH has no VEX lifter, so this goes
+    through pypcode and the p-code converter."""
+    project = angr.Project(TEST_BINARY, auto_load_libs=False)
+    block = project.factory.block(BLOCK_ADDR, num_inst=BLOCK_INSNS)
+    return ailment.IRSBConverter.convert(block.vex, ailment.Manager())
 
 
 def _tmp_indices(block):
@@ -45,12 +67,7 @@ class TestPcodeConverter(unittest.TestCase):
         used to name the parent by its unique-space address instead of its remapped index, producing a
         tmp that no statement defines. Nothing rejects that until the decompiler indexes it.
         """
-        # dmulu.l r1,r2 ; sts mach,r3 ; sts macl,r4 ; rts ; nop
-        code = bytes.fromhex("15320a031a040b000900")
-        arch = archinfo.ArchPcode("SuperH4:LE:32:default")
-        project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
-
-        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager())
+        block = _convert()
 
         defined, used = _tmp_indices(block)
         assert used, "the block should read at least one tmp"
@@ -62,11 +79,7 @@ class TestPcodeConverter(unittest.TestCase):
         a shift. Computing that offset the big-endian way returns the low half for both halves, which
         decompiles to two identical assignments instead of MACH and MACL.
         """
-        code = bytes.fromhex("15320a031a040b000900")
-        arch = archinfo.ArchPcode("SuperH4:LE:32:default")
-        project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
-
-        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager())
+        block = _convert()
 
         halves = [str(stmt.src) for stmt in block.statements if isinstance(stmt, Assignment)]
         shifted = [h for h in halves if "Shr" in h]


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Five SuperH instructions do not decompile: `dmulu.l r1,r2 ; sts mach,r3 ; sts macl,r4 ; rts ; nop`, which is `bytes.fromhex("15320a031a040b000900")` on `archinfo.ArchPcode("SuperH4:LE:32:default")` loaded at `0x1000`. `dmulu.l` writes one 64-bit unique and each `sts` reads 32 bits of it, so the AIL block reads a tmp that no statement defines:

```
  3: reg2052<32> = t2
  4: reg2048<32> = Conv(64->32, t56064)
```

Nothing rejects that until `SPropagator` indexes `tmp_deflocs`:

```
  File "angr/analyses/s_propagator.py", line 498, in _analyze
    tmp_def_stmtidx = tmp_deflocs[block_loc][tmp_atom]
KeyError: <Tmp 56064>
```

The function is lost rather than degraded — `Decompiler` leaves `codegen` at `None`.

**On a p-code architecture the loss is not confined to decompilation: it takes the
object's whole CFG.** `CFGFast._function_completed` runs `Clinic` from inside CFG
recovery when the architecture name contains a `:` and data references are being
collected — which `CFGFast` does by default — for any non-PLT function of 9 to 11
blocks. Nothing on that path catches what it raises, so one such function ends the
whole analysis. On
[`angr/binaries` `tests/hppa/test-instr_hppa`](https://github.com/angr/binaries/blob/master/tests/hppa/test-instr_hppa)
loaded with `arch=archinfo.ArchPcode("pa-risc:BE:32:default")`, a single
`CFGFast(normalize=True, data_references=True)` raises `KeyError: <Tmp 251392>` and
returns no graph at all; the same object with `data_references=False`, which never
reaches `Clinic`, recovers 2,532 functions over 29,609 nodes.

A widening multiply is the ordinary shape for this, so any SLEIGH architecture whose
analysis goes through the p-code converter can reach it. A decompilation sweep read on
2026-09-10 records that whole-object failure on **74 objects**, across sparc:BE:64,
sparc:BE:32, pa-risc:BE:32 and 68000:BE:32. No VEX architecture loses an object this
way: the VEX failures at the same line are `Ist_LLSC` reads, a separate defect with
its own open change in `angr/angr#6679`.

### Root cause

`angr/ailment/converter_pcode.py` names the parent temporary by its unique-space address instead of by the index `_remap_temp` gave the defining write:

```python
_, ori_tmp_size = self._unique_tracker[unique_offset]
t = Tmp(self._manager.next_atom(), unique_offset, ori_tmp_size * 8)
```

`56064` in the `KeyError` above is that raw offset. Separately, the shift selecting which end of the parent the sub-range names was computed the big-endian way, under an existing `# FIXME: Asserting BE`:

```python
right_shift_amount = varnode.offset + varnode.size - (unique_offset + ori_tmp_size)
```

On a little-endian target the high half sits at the higher address, so that expression is zero and both `sts` read the low 32 bits. Repairing the naming alone would replace the crash with two identical assignments, which is why both are fixed together.

### Fix

Index the parent by `ori_tmp_idx`, and pick the shift from `self._irsb.arch.memory_endness`. Statement 4 becomes the high half, and the block decompiles:

```
  4: reg2048<32> = Conv(64->32, (t2 Shr 32<8>))
```

### Testing

`tests/ailment/test_converter_pcode.py` adds 2 tests. They convert `dmulu.l r4,r5 ; sts MACL,r1 ; sts MACH,r2` at `0x420e5c` in [`angr/binaries` `tests/sh4/test-instr_sh4`](https://github.com/angr/binaries/blob/master/tests/sh4/test-instr_sh4) — a tracked object rather than assembled bytes — so no fixture is added. On the baseline the first fails with `tmp read without a definition: [56064]` and the second with `neither half of the product is shifted`; both pass on this head.

Validation: https://github.com/angr/angr/pull/6934#issuecomment-5407567667

session: sharpen

