### PR TITLE
Suppress pthread static-exit register fill warnings

### DIFF
--- a/angr/procedures/posix/pthread.py
+++ b/angr/procedures/posix/pthread.py
@@ -22,7 +22,12 @@ class pthread_create(angr.SimProcedure):
 
     def static_exits(self, blocks, **kwargs):
         # Execute those blocks with a blank state, and then dump the arguments
-        blank_state = angr.SimState(project=self.project, mode="fastpath", cle_memory_backer=self.project.loader.memory)
+        blank_state = angr.SimState(
+            project=self.project,
+            mode="fastpath",
+            cle_memory_backer=self.project.loader.memory,
+            add_options={angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS},
+        )
 
         # Execute each block
         state = blank_state

--- a/tests/procedures/posix/test_pthread.py
+++ b/tests/procedures/posix/test_pthread.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch, sentinel
+
+import angr
+from angr.procedures.posix.pthread import pthread_create
+
+
+class TestPthreadCreate(unittest.TestCase):
+    """Test static pthread procedure behavior."""
+
+    def test_static_exits_symbol_fills_unspecified_registers(self):
+        state = MagicMock()
+        state.memory.load.return_value = sentinel.return_address
+        cc = MagicMock()
+        cc.get_args.return_value = (sentinel.thread, sentinel.attr, sentinel.start_routine)
+        project = MagicMock()
+        project.loader.memory = sentinel.loader_memory
+        procedure = cast(
+            pthread_create,
+            SimpleNamespace(project=project, cc=cc, prototype=sentinel.prototype, arch=SimpleNamespace(bytes=8)),
+        )
+
+        with patch.object(angr, "SimState", return_value=state) as sim_state:
+            exits = pthread_create.static_exits(procedure, [])
+
+        sim_state.assert_called_once_with(
+            project=project,
+            mode="fastpath",
+            cle_memory_backer=sentinel.loader_memory,
+            add_options={angr.options.SYMBOL_FILL_UNCONSTRAINED_REGISTERS},
+        )
+        self.assertEqual(
+            exits,
+            [
+                {"address": sentinel.start_routine, "jumpkind": "Ijk_Call", "namehint": "thread_entry"},
+                {"address": sentinel.return_address, "jumpkind": "Ijk_Ret", "namehint": None},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

This change has no verified real trigger. Its regression in `tests/procedures/posix/test_pthread.py` fabricates the `pthread_create.static_exits()` state with `MagicMock`; no compiler-produced pthread fixture, thread-start function, or address is attached, and no maintainer has confirmed that the defensive change is wanted.

### Root cause

The public path that produces the warnings was never identified, so the premise that normal pthread analysis reaches this state remains unverified.

### Fix

This pull request is withdrawn instead of preserving a guard for an unproduced state.

### Testing

The prior focused test and hosted checks establish only that the synthetic state is handled; they do not supply the missing real-path evidence. Validation: https://github.com/angr/angr/pull/6935#issuecomment-5434738008

session: decbench
