### PR TITLE
Decompiler: stop rewriting outer-switch gotos inside nested loops

### DIFF
--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -234,7 +234,7 @@ class StructurerBase(Analysis):
             # of course, this only works if all nodes either end with a return or a goto that goes to the end of the
             # outer switch-case. we detect it first.
             # TODO: Implement the above logic
-            return walker._handle_Loop(node, parent=parent, index=index, label=label)
+            return None
 
         def _handle_SwitchCase(node: SwitchCaseNode, parent=None, index=0, label=None):
             # if a node inside this switch-case has a goto that goes to the end of the outer switch-case, we will

--- a/tests/analyses/decompiler/test_switch_goto_in_nested_loop.py
+++ b/tests/analyses/decompiler/test_switch_goto_in_nested_loop.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,no-member
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from angr.analyses import CFGFast, CompleteCallingConventionsAnalysis, Decompiler
+from tests.common import bin_location, print_decompilation_result
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestSwitchGotoInNestedLoop(unittest.TestCase):
+    def test_goto_leaving_a_switch_from_inside_a_loop_stays_a_goto(self):
+        # sub_41264c holds a switch whose case arm is a loop, and that loop jumps to the end of the switch at
+        # 0x412704. Rewriting the jump into a break would leave the loop only, so the assignments that follow
+        # the loop inside the arm would run and overwrite the values the jump carries out of the switch.
+        bin_path = os.path.join(test_location, "armel", "ld-linux.so.3")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses[CFGFast].prep()(normalize=True, data_references=True)
+        proj.analyses[CompleteCallingConventionsAnalysis].prep()(
+            cfg=cfg.model, recover_variables=True, analyze_callsites=True
+        )
+
+        f = cfg.functions[0x41264C]
+        dec = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model)
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+
+        code = dec.codegen.text
+        assert code.count("goto LABEL_412704;") == 1
+        assert code.count("LABEL_412704:") == 1
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`_switch_handle_gotos()` rewrites a goto that leaves the enclosing switch into a `break`. Where that goto sits inside a loop nested in a case arm, the `break` binds to the loop instead. Decompiling `sub_41264c` at `0x41264c` in `binaries/tests/armel/ld-linux.so.3` on master emits:

```c
                        else
                        {
                            v10 = v9 + 1;
                            v5 = v9;
                            break;
                        }
                    }
                    v5 = 1;
                    goto LABEL_412700;
...
LABEL_412700:
            v10 = 2;
            break;
        }
        ptr = ::0x400788::malloc(v10);
```

Control leaves the loop but stays in the switch, so `v5 = 1` and `v10 = 2` then run and overwrite both values the jump carried out, and `malloc` receives 2. Nothing raises and nothing is logged, so this shape is invisible to any sweep that watches for exceptions.

### Root cause

The nested walker `_rewrite_conditional_jumps_to_breaks` installs replaces the handlers for constructs a break must not be pushed into, but `_handle_Loop` delegated back to the outer walker and descended anyway:

```python
# of course, this only works if all nodes either end with a return or a goto that goes to the end of the
# outer switch-case. we detect it first.
# TODO: Implement the above logic
return walker._handle_Loop(node, parent=parent, index=index, label=label)
```

The comment states the precondition that would make the rewrite valid inside a loop, and the analysis that would check it is still the TODO above the line.

### Fix

`_handle_Loop` returns `None`, so the rewrite stops at a nested loop, matching the `_dummy` handlers already installed beside it. The same site now emits:

```c
                            v10 = v9 + 1;
                            v5 = v9;
                            goto LABEL_412704;
...
LABEL_412704:
        ptr = ::0x400788::malloc(v10);
```

Not done here: the TODO analysis that would hoist a break out to the arm. Until it exists a goto is the conservative emission, and it costs output quality where the loop already sat at the tail of the last arm — there break and goto were equivalent, and such an arm now emits a goto.

### Testing

`tests/analyses/decompiler/test_switch_goto_in_nested_loop.py` decompiles that function and asserts `goto LABEL_412704;` and its label each appear once; on master both counts are 0. Decompiling every function with a cyclic CFG in 26 ARM and x86 ELF fixtures under `binaries/tests` inserts 905 breaks through this path, 29 of them inside a nested loop, and changes output in 7 functions: 5 were bound to the wrong construct, and 1 is the equivalent-goto case above.

Related to #6737, which also covers the nested-switch half.

Validation: https://github.com/angr/angr/pull/6938#issuecomment-5413760627

session: sharpen