### PR TITLE
Decompiler: Render program bytes that are not valid UTF-8

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -1,6 +1,7 @@
 # pylint:disable=missing-class-docstring,too-many-boolean-expressions,unused-argument,no-self-use,protected-access
 from __future__ import annotations
 
+import contextlib
 import logging
 import re
 import struct
@@ -2587,8 +2588,15 @@ class CConstant(CExpression):
         return self._type
 
     @staticmethod
-    def str_to_c_str(_str, prefix: str = "", maxlen: int | None = None) -> str:
+    def str_to_c_str(_str: str | bytes, prefix: str = "", maxlen: int | None = None) -> str:
+        if isinstance(_str, bytes):
+            # bytes that do not decode stay bytes, so that repr() escapes them as \xNN below
+            with contextlib.suppress(UnicodeDecodeError):
+                _str = _str.decode("utf-8")
+
         repr_str = repr(_str)
+        if isinstance(_str, bytes):
+            repr_str = repr_str[1:]  # drop the b prefix
         base_str = repr_str[1:-1]
 
         if maxlen is not None and len(base_str) > maxlen:
@@ -2602,13 +2610,13 @@ class CConstant(CExpression):
     def c_repr_chunks(self, indent=0, asexpr=False):
         def _default_output(v) -> str | None:
             if isinstance(v, MemoryData) and v.sort == MemoryDataSort.String and v.content is not None:
-                return CConstant.str_to_c_str(v.content.decode("utf-8"), maxlen=self.codegen.max_str_len)
+                return CConstant.str_to_c_str(v.content, maxlen=self.codegen.max_str_len)
             if isinstance(v, Function):
                 return get_cpp_function_name(v.demangled_name)
             if isinstance(v, str):
                 return CConstant.str_to_c_str(v, maxlen=self.codegen.max_str_len)
             if isinstance(v, bytes):
-                return CConstant.str_to_c_str(v.replace(b"\x00", b"").decode("utf-8"), maxlen=self.codegen.max_str_len)
+                return CConstant.str_to_c_str(v.replace(b"\x00", b""), maxlen=self.codegen.max_str_len)
             return None
 
         if self.collapsed:
@@ -2640,13 +2648,11 @@ class CConstant(CExpression):
                 if isinstance(self._type, SimTypePointer) and isinstance(self._type.pts_to, SimTypeChar):
                     refval = self.reference_values[self._type]
                     if isinstance(refval, MemoryData):
-                        v = refval.content.decode("utf-8") if refval.content else f"<unknown@{refval.addr:#x}>"
-                    elif isinstance(refval, bytes):
-                        v = refval.decode("latin1")
+                        v = refval.content or f"<unknown@{refval.addr:#x}>"
                     else:
-                        # it must be a string
+                        # it must be raw bytes or a string
                         v = refval
-                        assert isinstance(v, str)
+                        assert isinstance(v, (bytes, str))
                     yield CConstant.str_to_c_str(v, maxlen=self.codegen.max_str_len), self
                     return
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -800,7 +800,18 @@ class TestDecompiler(unittest.TestCase):
         assert code.count(decls) == 1  # it should only appear once
 
     def test_decompiling_strings_c_representation(self):
-        input_expected = [("""Foo"bar""", '"Foo\\"bar"'), ("""Foo'bar""", '"Foo\'bar"')]
+        input_expected = [
+            ("""Foo"bar""", '"Foo\\"bar"'),
+            ("""Foo'bar""", '"Foo\'bar"'),
+            # bytes from the binary are rendered as text when they decode as UTF-8...
+            (b"hello", '"hello"'),
+            (b"caf\xc3\xa9", '"caf\u00e9"'),
+            (b'Foo"bar', '"Foo\\"bar"'),
+            # ...and as \xNN escapes when they do not, instead of raising UnicodeDecodeError
+            (b"unable to open file for read\xcc", '"unable to open file for read\\xcc"'),
+            (b"\xff\xfe\x80", '"\\xff\\xfe\\x80"'),
+            (b'Foo"bar\xcc', '"Foo\\"bar\\xcc"'),
+        ]
 
         for _input, expected in input_expected:
             result = angr.analyses.decompiler.structured_codegen.c.CConstant.str_to_c_str(_input)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CConstant.c_repr_chunks` decodes bytes taken from the analyzed program as strict UTF-8, so a `char *` whose target is not valid UTF-8 raises out of code generation and the function produces no output at all. Decompiling `_vfiprintf_r` at `0x8005815` in the public DecBench object `O2-noinline/libopencm3/adc-dac-printf.elf` (md5 `71699ecd8c605efc0704cafcb8244f7f`) on master:

```
len(d.codegen.text) = 0
len(d.errors) = 2
--- error[0]: UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcc in position 32: unexpected end of data
  File "angr/analyses/decompiler/structured_codegen/c.py", line 2641, in c_repr_chunks
    v = refval.content.decode("utf-8") if refval.content else f"<unknown@{refval.addr:#x}>"
```

`Analysis._resilience` swallows it, so this is a total decompilation failure that reports itself only in `d.errors`, not degraded output.

### Root cause

Three sites in the code generator decode program bytes as text — `c.py:2603` and `c.py:2609` in `_default_output`, and `c.py:2641` in the traceback above. Nothing constrains a `char *` target to be UTF-8; the bytes are whatever is in the binary. The next line already used `decode("latin1")`, which cannot fail, so the safe pattern was present in the same function.

### Fix

`str_to_c_str` takes `str | bytes`, decoding as UTF-8 when that succeeds and otherwise keeping the bytes so `repr` escapes each one as `\xNN`, which is how a C literal spells a byte that is not text. The three call sites pass bytes rather than decoding first, which retires the `latin1` decode as well. The same function now decompiles to 34176 characters and the offending constant renders as

```c
*(&v33) = "                0000000000000000\xcc";
```

Left alone: `maxlen` truncation can still cut a `\xNN` escape in half. That predates this change for `str` inputs and is not what this fixes.

### Testing

`pytest tests/analyses/decompiler/test_decompiler.py -k test_decompiling_strings_c_representation` extends the existing `str_to_c_str` test with six byte inputs that do and do not decode; each of the six produces a different string under the master `str_to_c_str`, which never received `bytes` at all. No binary fixture is added: the byte reaches the renderer through a separate CFGFast defect fixed in #6943, and a fixture-based regression would go vacuous the moment that lands, whereas the rendering contract this pins does not depend on how the bytes got there.

Validation: https://github.com/angr/angr/pull/6940#issuecomment-5415184736

session: sharpen