### PR TITLE
Bound the memory kb.decompilations holds when decompiling many functions

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -4201,7 +4201,7 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
         self,
         expr: Expr.Const,
         type_=None,
-        reference_values: dict[SimType | str, str | bytes | int | float | Function | CExpression] | None = None,
+        reference_values: dict[SimType, str | bytes | int | float | Function | CExpression] | None = None,
         variable=None,
         likely_signed=True,
         **kwargs,
@@ -4304,16 +4304,14 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
             elif function_pointer:
                 self._function_pointers.add(expr_reference_variable)
 
-        var_access = None
         if variable is not None and not reference_values:
+            # _variable() records the variable as in use, which CFunction reads to emit declarations and
+            # CFunctionCall reads to disambiguate call target names
             cvar = self._variable(variable, None)
             offset = self._variable_map.reference_variable_offset(expr)
             var_access = self._access_constant_offset_reference(self._get_variable_reference(cvar), offset, None)
-
-        if var_access is not None:
             if expr.value >= self.min_data_addr:
                 return var_access
-            reference_values["offset"] = var_access
         return CConstant(expr.value, type_, reference_values=reference_values, tags=expr.tags, codegen=self)
 
     def _handle_Expr_UnaryOp(self, expr, type_: SimType | None = None, **kwargs):

--- a/angr/knowledge_plugins/structured_code.py
+++ b/angr/knowledge_plugins/structured_code.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 import lmdb
 
 import angr
+from angr.serializable import Serializable
 
 from .plugin import KnowledgeBasePlugin
 
@@ -37,9 +38,9 @@ class SpillingDecompilationDict(collections.abc.MutableMapping):
     plugin.
 
     Evicted entries are always serialized and written out (caches are mutated in place, so there is no clean/dirty
-    distinction). Entries that cannot be serialized (e.g. DummyStructuredCodeGenerator or rust-flavor caches) are
-    parked in an unbounded in-memory dict. Spilled entries are deserialized on access with the owning knowledge
-    base's project/function attached.
+    distinction). Entries whose code generator implements no serialization at all (DummyStructuredCodeGenerator,
+    rust-flavor caches) have nowhere to spill to and are parked in an in-memory dict. Spilled entries are
+    deserialized on access with the owning knowledge base's project/function attached.
     """
 
     def __init__(self, kb: KnowledgeBase, cache_limit: int = DECOMPILATION_CACHE_LIMIT):
@@ -129,12 +130,14 @@ class SpillingDecompilationDict(collections.abc.MutableMapping):
                 if not self._warned_unspillable:
                     self._warned_unspillable = True
                     l.warning(
-                        "Decompilation cache %r cannot be serialized and will be kept in memory. Further "
-                        "occurrences will not be logged.",
+                        "Decompilation cache %r cannot be serialized. Further occurrences will not be logged.",
                         key,
                         exc_info=True,
                     )
-                self._unspillable[key] = cache
+                # Only a code generator with no serialization of its own has nowhere else to live; anything
+                # else that fails here is a bug, and its entry is dropped like any other cache miss.
+                if cache.codegen is not None and not isinstance(cache.codegen, Serializable):
+                    self._unspillable[key] = cache
                 continue
             self._save_to_lmdb(key, blob)
             self._spilled.add(key)

--- a/tests/serialization/test_decompilation_cache_serialization.py
+++ b/tests/serialization/test_decompilation_cache_serialization.py
@@ -28,6 +28,7 @@ from angr.analyses.decompiler.optimization_passes.expr_op_swapper import OpDescr
 from angr.analyses.decompiler.optimization_passes.static_vvar_rewriter import FixedBuffer, FixedBufferPtr
 from angr.analyses.decompiler.peephole_optimizations import EXPR_OPTS
 from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
+from angr.analyses.decompiler.structured_codegen.base import BaseStructuredCodeGenerator
 from angr.analyses.decompiler.structured_codegen.c import CConstant, CConstruct
 from angr.analyses.decompiler.structured_codegen.c_serialize import (
     _DISPLAY_OPTION_ATTRS,
@@ -37,6 +38,7 @@ from angr.analyses.decompiler.structured_codegen.c_serialize import (
 )
 from angr.knowledge_plugins.structured_code import SpillingDecompilationDict
 from angr.protos import codegen_pb2
+from angr.serializable import Serializable
 from angr.sim_type import SimType
 from angr.sim_variable import SimRegisterVariable, SimStackVariable
 from angr.utils.ail_serialization import (
@@ -422,6 +424,16 @@ class TestDecompilationCacheEndToEnd(unittest.TestCase):
         assert d2.codegen.text == d1.codegen.text
 
 
+class FailingCodeGenerator(BaseStructuredCodeGenerator, Serializable):
+    """A code generator that advertises serialization support and then raises, as a buggy serializer would."""
+
+    def __init__(self):
+        super().__init__("pseudocode")
+
+    def serialize_to_cmessage(self):
+        raise ValueError("synthetic serialization failure")
+
+
 class TestSpillingDecompilationDict(unittest.TestCase):
     """Tests for the LRU + RtDb-spilling backing store of StructuredCodeManager."""
 
@@ -486,6 +498,23 @@ class TestSpillingDecompilationDict(unittest.TestCase):
         assert dummy_key in d._unspillable
         assert d[dummy_key] is dummy_cache
         assert len(d) == 2
+
+    def test_failing_serializer_does_not_retain_the_cache(self):
+        d = SpillingDecompilationDict(self.proj.kb, cache_limit=1)
+        broken_key = (0xDEAD, "pseudocode")
+        broken_cache = DecompilationCache(0xDEAD)
+        broken_cache.codegen = FailingCodeGenerator()
+        d[broken_key] = broken_cache
+
+        # this code generator claims to support serialization, so a failure is a bug rather than a flavor that has
+        # nowhere to spill to: the entry is dropped instead of being held in memory for the rest of the session
+        main_key = (self.main_func.addr, "pseudocode")
+        d[main_key] = self.main_dec.cache
+        assert not d._unspillable
+        assert broken_key not in d
+        assert len(d) == 1
+        with self.assertRaises(KeyError):
+            _ = d[broken_key]
 
     def test_delete_and_discard(self):
         d = SpillingDecompilationDict(self.proj.kb, cache_limit=1)

--- a/tests/serialization/test_decompilation_cache_serialization.py
+++ b/tests/serialization/test_decompilation_cache_serialization.py
@@ -28,7 +28,7 @@ from angr.analyses.decompiler.optimization_passes.expr_op_swapper import OpDescr
 from angr.analyses.decompiler.optimization_passes.static_vvar_rewriter import FixedBuffer, FixedBufferPtr
 from angr.analyses.decompiler.peephole_optimizations import EXPR_OPTS
 from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
-from angr.analyses.decompiler.structured_codegen.c import CConstruct
+from angr.analyses.decompiler.structured_codegen.c import CConstant, CConstruct
 from angr.analyses.decompiler.structured_codegen.c_serialize import (
     _DISPLAY_OPTION_ATTRS,
     _DISPLAY_OPTION_FIELD_FIRST,
@@ -37,6 +37,7 @@ from angr.analyses.decompiler.structured_codegen.c_serialize import (
 )
 from angr.knowledge_plugins.structured_code import SpillingDecompilationDict
 from angr.protos import codegen_pb2
+from angr.sim_type import SimType
 from angr.sim_variable import SimRegisterVariable, SimStackVariable
 from angr.utils.ail_serialization import (
     pack_arg_vvars,
@@ -348,6 +349,33 @@ class TestDecompilationCacheEndToEnd(unittest.TestCase):
         # parameters preserves the 15 keys
         assert set(back.parameters.keys()) == set(cache.parameters.keys())
         assert len(back.parameters) == 15
+
+    def test_constant_below_min_data_addr_keeps_reference_values_typed(self):
+        # A Const that resolves to a global variable renders as a reference to that variable, unless its value is
+        # below min_data_addr, in which case it renders as the constant. __do_global_dtors_aux references a global
+        # at 0x600e38, so raising min_data_addr above it puts it on the second branch. min_data_addr became a
+        # codegen parameter in #5199, which is also where that branch came from.
+        func = self.proj.kb.functions.function(name="__do_global_dtors_aux")
+        dec = self.proj.analyses.Decompiler(func, cfg=self.cfg.model, generate_code=True)
+        codegen = self.proj.analyses.CStructuredCodeGenerator(
+            func,
+            dec.seq_node,
+            cfg=self.cfg.model,
+            ail_graph=dec.clinic.graph,
+            func_args=dec.clinic.arg_list,
+            variable_map=dec.clinic.variable_map,
+            externs=dec.clinic.externs,
+            min_data_addr=1 << 62,
+        )
+
+        constants = [elem.obj for _, elem in codegen.map_pos_to_node.items() if isinstance(elem.obj, CConstant)]
+        assert constants
+        for const in constants:
+            for key in const.reference_values or {}:
+                assert isinstance(key, SimType)
+
+        # reference_values is keyed by SimType, and the serializer interns every key as one
+        assert codegen.serialize()
 
     def test_cache_hit_on_deserialized_cache(self):
         cache = self.decompiler.cache


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling every function of a binary in one process grows memory without bound, so `angr decompile` runs out of memory on a large binary. On an `-O2 -fno-inline` build of iproute2's `ip`, 900 functions in one process reach 2078 MB RSS and 438 decompilation caches sit in `SpillingDecompilationDict._unspillable`, which is never emptied. The mechanism reproduces on `__do_global_dtors_aux` at `0x4005d0` in `binaries/tests/x86_64/fauxware` with `min_data_addr` raised above the binary's addresses:

```
key type histogram : {'SimTypeLongLong': 4, 'str': 1}
'offset' str key   : PRESENT
cache.serialize()  : RAISED AttributeError: 'str' object has no attribute 'to_json'
  raised at        : angr/analyses/decompiler/structured_codegen/c_serialize.py:186 in intern_type
_unspillable size  : 1
```

`binaries/tests/i386/windows/9888704382abfb694984c1c7a7707a45b4ebc406fc98d35622461077553aa797`, already tracked in `angr/binaries`, reaches the same failure at default settings with no `min_data_addr` change. Decompiling 652 of the 766 functions `CFGFast` recovers there — everything but PLT stubs, alignment padding and simprocedures — in one process leaves **336 caches parked in `_unspillable`**, 188 spilled successfully and 128 still resident in the cache, and every one of the 336 fails on this same `AttributeError` at `c_serialize.py:186`.

### Root cause

`_handle_Expr_Const` writes an `"offset"` string key into `CConstant.reference_values`, a mapping keyed by `SimType` everywhere else, and `intern_type` calls `t.to_json()` on every key. That one write makes the cache unserializable. `_evict_lru` then catches any serialization failure and parks the cache in `_unspillable` rather than dropping it, so each failing cache is retained for the life of the process and eviction stops bounding anything.

### Fix

Two commits, because neither alone fixes the symptom. The key is safe to drop: `git log -S` finds it at one site, the write itself, and nothing reads it back. The `_variable()` call that produced the value is kept, because its side effect of recording the variable as in use is what `CFunction` reads to emit declarations. Eviction now parks only caches whose code generator implements no serialization at all — `DummyStructuredCodeGenerator` and rust-flavor caches — and drops the rest, since a cache miss just re-runs the Decompiler. The same reproducer then gives:

```
key type histogram : {'SimTypeLongLong': 4}
'offset' str key   : ABSENT
cache.serialize()  : OK, 3016 bytes
_unspillable size  : 0
```

and `ip` finishes those 900 functions at 1045 MB with `_unspillable` empty. Not addressed: `_unspillable` is still unbounded for the caches it legitimately holds, and instrumenting the `except` surfaced an unrelated `ail_serialization` failure that is its own defect.

### Testing

Two regressions in `tests/serialization/test_decompilation_cache_serialization.py`, one per commit. On master the first fails with `assert False = isinstance('offset', SimType)` and the second with `assert not {(57005, 'pseudocode'): <DecompilationCache ...>}`; both pass on this branch. Decompiling 1250 functions across five binaries on both revisions produces byte-identical text in all 1250, reaching the changed branch 444 times.

Validation: https://github.com/angr/angr/pull/6941#issuecomment-5415879239

session: sharpen
