### PR TITLE
Decompiler: Remove the whole orphaned chain in LoweredSwitchSimplifier

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, deque
 from typing import TYPE_CHECKING
 
 import networkx
@@ -369,14 +369,19 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         # sometimes they overlap
                         # e.g., 0x402cc7 in mv_-O2
                         continue
-                    # ensure all nodes that are only reachable from onode are also removed
-                    # FIXME: Remove the entire path of nodes instead of only the immediate successors
-                    successors = list(graph_copy.successors(onode))
-                    graph_copy.remove_node(onode)
-                    for succ in successors:
-                        in_edges = [(src, dst) for src, dst in graph_copy.in_edges(succ) if src is not succ]
-                        if not in_edges:
-                            graph_copy.remove_node(succ)
+                    # ensure all nodes that are only reachable from onode are also removed, following the
+                    # chain of them: redundant nodes point at one another, so removing one orphans the next
+                    worklist = deque([onode])
+                    while worklist:
+                        node = worklist.popleft()
+                        if node not in graph_copy:
+                            continue
+                        successors = list(graph_copy.successors(node))
+                        graph_copy.remove_node(node)
+                        for succ in successors:
+                            in_edges = [(src, dst) for src, dst in graph_copy.in_edges(succ) if src is not succ]
+                            if not in_edges:
+                                worklist.append(succ)
                 # apply delayed edges
                 for src, dst in delayed_edges:
                     if src is None:

--- a/tests/analyses/decompiler/test_lowered_switch_simplifier.py
+++ b/tests/analyses/decompiler/test_lowered_switch_simplifier.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
 
+import os
 import unittest
 
 import angr
 from angr.analyses.decompiler.optimization_passes import LoweredSwitchSimplifier
 from angr.analyses.decompiler.presets import DECOMPILATION_PRESETS
+from tests.common import bin_location, load_project_with_scoped_cfg
+
+test_location = os.path.join(bin_location, "tests")
 
 # a character-scanning loop carved out of busybox (compiled at -O0). the comparison chain that
 # LoweredSwitchSimplifier recognizes contains back edges to the head comparison node, which used to cause
@@ -43,6 +47,30 @@ class TestLoweredSwitchSimplifier(unittest.TestCase):
         dec = proj.analyses.Decompiler(func, cfg=cfg.model, optimization_passes=all_optimization_passes)
         assert dec.codegen is not None and dec.codegen.text is not None
         assert "while" in dec.codegen.text
+
+    def test_redundant_comparison_node_removed_by_an_earlier_one(self):
+        # doshn() in file(1) built at -O0 has a comparison chain whose redundant comparison nodes point at one
+        # another, so removing one of them orphans the next one the same loop still has to visit.
+        proj, cfg = load_project_with_scoped_cfg(os.path.join(test_location, "x86_64", "file_gcc17_O0"), 0x423B74)
+
+        dec = proj.analyses.Decompiler(cfg.functions[0x423B74], cfg=cfg)
+
+        assert not dec.errors
+        assert dec.codegen is not None and dec.codegen.text is not None
+        assert "switch (" in dec.codegen.text
+
+    def test_orphaned_chain_is_removed_entirely(self):
+        # the same shape at -O2, where the orphaned chain is long enough that stopping at the immediate
+        # successors leaves nodes unreachable from the function entry and the structurer gives up on them.
+        proj, cfg = load_project_with_scoped_cfg(
+            os.path.join(test_location, "x86_64", "file_gcc13.3.0_O2"), 0x4091D0, window=0x3000
+        )
+
+        dec = proj.analyses.Decompiler(cfg.functions[0x4091D0], cfg=cfg)
+
+        assert not dec.errors
+        assert dec.codegen is not None and dec.codegen.text is not None
+        assert "switch (" in dec.codegen.text
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`LoweredSwitchSimplifier`'s removal loop carried a FIXME saying it should remove the whole orphaned path, not only the immediate successors. That is the bug: redundant comparison nodes point at one another, so removing one orphans the next, the rest of the chain is left unreachable, and the loop later calls `successors()` on a node it already removed. `Analysis._resilience` catches the `NetworkXError`, so the symptom is a silent fallback to the `basic` preset rather than a crash.

Follow the chain with a worklist, which also leaves an already-removed node simply absent when reached. Two narrower repairs measured worse: skipping the node strands the unreachable remainder and decompiles `sub_4091d0` to an empty body, and additionally verifying the graph discards the rewrite more often than it applies it.

Regressions cover `doshn` and `sub_4091d0`, fixtures already in `angr/binaries`.

Validation: https://github.com/angr/angr/pull/6942#issuecomment-5416145542

session: emo-corpus
