### PR TITLE
CFGFast: Stop reporting a null terminator the string scan never saw

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1132,11 +1132,13 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             else:
                 inside_region = addr < region_end
             if not inside_region:
+                is_sz = False
                 break
 
             # l.debug("Searching address %x", addr)
             val = self._load_a_byte_as_int(addr)
             if val is None:
+                is_sz = False
                 break
             if val == 0:
                 break
@@ -1178,14 +1180,17 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             else:
                 inside_region = addr < region_end
             if not inside_region:
+                is_sz = False
                 break
 
             # l.debug("Searching address %x", addr)
             val0 = self._load_a_byte_as_int(addr)
             if val0 is None:
+                is_sz = False
                 break
             val1 = self._load_a_byte_as_int(addr + 1)
             if val1 is None:
+                is_sz = False
                 break
             if val0 == 0 and val1 == 0:
                 break

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -16,6 +16,7 @@ import angr
 from angr.analyses.cfg.indirect_jump_resolvers import mips_elf_fast
 from angr.codenode import FuncNode
 from angr.knowledge_plugins.cfg import CFGModel, CFGNode
+from angr.knowledge_plugins.cfg.memory_data import MemoryDataSort
 from tests.common import bin_location, broken
 
 l = logging.getLogger("angr.tests.test_cfgfast")
@@ -111,6 +112,18 @@ class TestCfgfast(unittest.TestCase):
         function_features = {}
 
         self.cfg_fast_functions_check("x86_64", "cfg_0_pe", functions, function_features)
+
+    def test_printable_string_that_reaches_the_end_of_a_region(self):
+        # The last 32 bytes of .text are newlib's blanks[16] + zeroes[16]; .text ends at
+        # 0x8007484, where .ARM.exidx begins, so this string is not null-terminated.
+        path = os.path.join(test_location, "armel", "libopencm3_adc-dac-printf.elf")
+        proj = angr.Project(path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+
+        data = cfg.model.memory_data[0x8007464]
+        assert data.sort == MemoryDataSort.String
+        assert data.size == 32
+        assert data.content == b" " * 16 + b"0" * 16
 
     def test_arm_function_merge(self):
         # function 0x7bb88 is created due to a data hint in another block. this function should be merged with the


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast._scan_for_printable_strings` has four loop exits but only one of them means it met a terminating null. Leaving the scanned region and failing to load a byte both left `is_sz` true, so the scan returned `len(sz) + 1` for a null it never saw, and `MemoryData.fill_content` then read that byte through the loader, which is not limited to the region. On `binaries/tests/armel/libopencm3_adc-dac-printf.elf`, where `.text` ends at `0x8007484` immediately before `.ARM.exidx`:

```
_inside_regions_and_region_end(0x8007464) = (True, 0x8007484)
_scan_for_printable_strings(0x8007464)    = 33
MemoryData         : addr=0x8007464 size=33 sort=string
MemoryData.content : b'                0000000000000000\xcc'
```

`0xcc` is the first byte of `.ARM.exidx`, which is left split into a 1-byte and a 7-byte object instead of one 8-byte object. Downstream the phantom byte is not valid UTF-8, so the code generator raises on it and `_vfiprintf_r` in the same image decompiles to nothing.

### Root cause

Both non-null exits fall out of the loop with the flag the caller reads still set:

```python
if not inside_region:
    break
val = self._load_a_byte_as_int(addr)
if val is None:
    break
if val == 0:
    break
```

Only the third saw a null. The return then adds a byte for it in every case, and the length reaches the loader rather than the region, so the string is not merely mis-sized — it acquires content from the next section.

### Fix

`is_sz = False` at the two exits that did not observe a null, so such a run is judged as not null-terminated and measured against `min_length_non_nullterminated`. The same string then comes back at 32 bytes stopping exactly at the region boundary, and `.ARM.exidx` becomes one 8-byte object. `_scan_for_printable_widestrings` has the same mistake at three exits and is fixed with it, because it is the same rule in the same class of function, not because a second symptom turned up.

### Testing

`pytest tests/analyses/cfg/test_cfgfast.py -k printable_string` fails on master with `assert 33 == 32` and passes here. Instrumenting both scan methods over 314 binaries produced 7116 string classifications, of which 4 change length and none is lost. The wide-string half has no observed instance and therefore no regression test.

The fixture the regression loads is added in the paired binaries pull request linked below, not in this repository.

Validation: https://github.com/angr/angr/pull/6943#issuecomment-5416427845

sync: angr/binaries#194

session: sharpen