### PR TITLE
Serialize the AIL switch-case head marker instead of losing the cache

### DIFF
--- a/angr/protos/ail_types.proto
+++ b/angr/protos/ail_types.proto
@@ -41,6 +41,46 @@ message AilGraph {
     repeated uint32 block_refs = 3;  // indices into the shared pool, in node-insertion order
     // The modal edge-data value (excluding the per-edge ins_addr); edges with has_default_data reference it.
     optional AilEdgeData default_edge_data = 4;
+    // Statements that ailment.Block.to_bytes() cannot carry, removed from their block's payload and stored here.
+    repeated AilNodeExtras node_extras = 5;
+}
+
+//
+// Python-side AIL statements
+//
+// The AIL statement hierarchy is implemented in Rust and ailment.Block.to_bytes() accepts only Rust statements.
+// IncompleteSwitchCaseHeadStatement (angr.analyses.decompiler.structurer_nodes) is the one statement still written
+// in Python. LoweredSwitchSimplifier writes it into a block and RegionIdentifier, the structurers and both code
+// generators all read it back from there, so it is a normal inhabitant of Clinic's graphs and is encoded here.
+//
+
+message IncompleteSwitchCaseEntry {
+    optional bytes cmp_block = 1;  // ailment.Block.to_bytes() of the comparison node; unset when there is none
+    oneof case {
+        int64 value = 2;
+        string label = 3;  // "default"
+    }
+    int64 target_addr = 4;
+    optional int64 target_idx = 5;
+    optional int64 next_addr = 6;
+}
+
+message IncompleteSwitchCaseHead {
+    optional int64 idx = 1;
+    bytes switch_variable = 2;  // Expression.to_bytes()
+    repeated IncompleteSwitchCaseEntry entries = 3;
+    bool peephole_optimized = 4;
+    optional uint64 ins_addr = 5;
+}
+
+message AilPyStatement {
+    uint32 stmt_index = 1;  // position within the block's statement list
+    IncompleteSwitchCaseHead switch_head = 2;
+}
+
+message AilNodeExtras {
+    uint32 node_index = 1;  // index into AilGraph.blocks / AilGraph.block_refs
+    repeated AilPyStatement statements = 2;
 }
 
 //

--- a/angr/utils/ail_serialization.py
+++ b/angr/utils/ail_serialization.py
@@ -17,8 +17,9 @@ import networkx
 
 from angr import sim_variable
 from angr.analyses.decompiler.optimization_passes.static_vvar_rewriter import FixedBuffer, FixedBufferPtr
+from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
 from angr.protos import ail_types_pb2
-from angr.rustylib.ailment import Block, Expression
+from angr.rustylib.ailment import Block, Expression, Statement
 
 if TYPE_CHECKING:
     from angr.sim_variable import SimVariable
@@ -98,21 +99,103 @@ def _parse_edge_data(msg: ail_types_pb2.AilEdgeData) -> dict[str, Any]:
     return data
 
 
-class BlockPool:
-    """A shared pool of ``Block.to_bytes()`` payloads for deduplicating byte-identical blocks across graphs."""
+def _pack_switch_head(stmt: IncompleteSwitchCaseHeadStatement, msg: ail_types_pb2.IncompleteSwitchCaseHead) -> None:
+    if stmt.idx is not None:
+        msg.idx = stmt.idx
+    msg.switch_variable = stmt.switch_variable.to_bytes()
+    msg.peephole_optimized = bool(stmt.peephole_optimized)
+    ins_addr = (stmt.tags or {}).get("ins_addr")
+    if ins_addr is not None:
+        msg.ins_addr = ins_addr
+    for cmp_block, case_value, target_addr, target_idx, next_addr in stmt.case_addrs:
+        entry = msg.entries.add()
+        if cmp_block is not None:
+            entry.cmp_block = cmp_block.to_bytes()
+        if isinstance(case_value, str):
+            entry.label = case_value
+        else:
+            entry.value = case_value
+        entry.target_addr = target_addr
+        if target_idx is not None:
+            entry.target_idx = target_idx
+        if next_addr is not None:
+            entry.next_addr = next_addr
 
-    __slots__ = ("_index_by_payload", "payloads")
+
+def _parse_switch_head(msg: ail_types_pb2.IncompleteSwitchCaseHead) -> IncompleteSwitchCaseHeadStatement:
+    case_addrs = []
+    for entry in msg.entries:
+        cmp_block = Block.from_bytes(entry.cmp_block) if entry.HasField("cmp_block") else None
+        case_value = entry.label if entry.WhichOneof("case") == "label" else entry.value
+        case_addrs.append(
+            (
+                cmp_block,
+                case_value,
+                entry.target_addr,
+                entry.target_idx if entry.HasField("target_idx") else None,
+                entry.next_addr if entry.HasField("next_addr") else None,
+            )
+        )
+    tags = {"ins_addr": msg.ins_addr} if msg.HasField("ins_addr") else {}
+    return IncompleteSwitchCaseHeadStatement(
+        msg.idx if msg.HasField("idx") else None,
+        Expression.from_bytes(msg.switch_variable),
+        case_addrs,
+        peephole_optimized=msg.peephole_optimized,
+        **tags,
+    )
+
+
+def _encode_block(block) -> tuple[bytes, list[ail_types_pb2.AilPyStatement]]:
+    """Split a block into a Rust-serializable payload plus the Python statements removed from it.
+
+    ``Block.to_bytes()`` accepts only Rust statements. The decompiler's graphs also carry
+    ``IncompleteSwitchCaseHeadStatement``, which is still written in Python; it is encoded separately and put back
+    at the same index by :func:`_decode_block_extras`.
+    """
+    statements = block.statements
+    py_indices = {i for i, stmt in enumerate(statements) if not isinstance(stmt, Statement)}
+    if not py_indices:
+        return block.to_bytes(), []
+
+    extras = []
+    for i in sorted(py_indices):
+        stmt = statements[i]
+        if not isinstance(stmt, IncompleteSwitchCaseHeadStatement):
+            raise TypeError(f"Unsupported non-AIL statement {type(stmt).__name__} in block {block.addr:#x}")
+        entry = ail_types_pb2.AilPyStatement()
+        entry.stmt_index = i
+        _pack_switch_head(stmt, entry.switch_head)
+        extras.append(entry)
+    rust_only = block.copy(statements=[s for i, s in enumerate(statements) if i not in py_indices])
+    return rust_only.to_bytes(), extras
+
+
+def _decode_block_extras(block, entries) -> None:
+    """Inverse of the split in :func:`_encode_block`; ``entries`` are in ascending ``stmt_index`` order."""
+    for entry in entries:
+        block.statements.insert(entry.stmt_index, _parse_switch_head(entry.switch_head))
+
+
+class BlockPool:
+    """A shared pool of ``Block.to_bytes()`` payloads for deduplicating identical blocks across graphs."""
+
+    __slots__ = ("_index_by_key", "payloads")
 
     def __init__(self) -> None:
         self.payloads: list[bytes] = []
-        self._index_by_payload: dict[bytes, int] = {}
+        self._index_by_key: dict[bytes, int] = {}
 
-    def add(self, block) -> int:
-        payload = block.to_bytes()
-        idx = self._index_by_payload.get(payload)
+    def add(self, payload: bytes, extras: list[ail_types_pb2.AilPyStatement] | None = None) -> int:
+        # Two blocks whose Rust statements are identical can still differ in the Python statements taken out of the
+        # payload, so those are part of the identity the pool deduplicates on.
+        key = payload
+        if extras:
+            key = b"\0".join([payload, *(e.SerializeToString(deterministic=True) for e in extras)])
+        idx = self._index_by_key.get(key)
         if idx is None:
             idx = len(self.payloads)
-            self._index_by_payload[payload] = idx
+            self._index_by_key[key] = idx
             self.payloads.append(payload)
         return idx
 
@@ -132,10 +215,15 @@ def pack_graph(graph: networkx.DiGraph, pool: BlockPool | None = None) -> ail_ty
         if not isinstance(node, Block):
             raise TypeError(f"Unsupported AIL graph node type {type(node).__name__}; only ailment.Block is allowed")
         node_to_idx[node] = i
+        payload, extras = _encode_block(node)
         if pool is None:
-            msg.blocks.append(node.to_bytes())
+            msg.blocks.append(payload)
         else:
-            msg.block_refs.append(pool.add(node))
+            msg.block_refs.append(pool.add(payload, extras))
+        if extras:
+            node_extras = msg.node_extras.add()
+            node_extras.node_index = i
+            node_extras.statements.extend(extras)
 
     # Pick the modal non-ins_addr edge-data value as the default so common edge attributes are stored once.
     edge_list = list(graph.edges(data=True))
@@ -170,6 +258,8 @@ def parse_graph(msg: ail_types_pb2.AilGraph, pool_payloads=None) -> networkx.DiG
         blocks = [Block.from_bytes(pool_payloads[i]) for i in msg.block_refs]
     else:
         blocks = [Block.from_bytes(b) for b in msg.blocks]
+    for node_extras in msg.node_extras:
+        _decode_block_extras(blocks[node_extras.node_index], node_extras.statements)
     graph.add_nodes_from(blocks)
     default_data = _parse_edge_data(msg.default_edge_data) if msg.HasField("default_edge_data") else {}
     for edge in msg.edges:

--- a/tests/serialization/test_decompilation_cache_serialization.py
+++ b/tests/serialization/test_decompilation_cache_serialization.py
@@ -28,6 +28,7 @@ from angr.analyses.decompiler.optimization_passes.expr_op_swapper import OpDescr
 from angr.analyses.decompiler.optimization_passes.static_vvar_rewriter import FixedBuffer, FixedBufferPtr
 from angr.analyses.decompiler.peephole_optimizations import EXPR_OPTS
 from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
+from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
 from angr.analyses.decompiler.structured_codegen.c import CConstruct
 from angr.analyses.decompiler.structured_codegen.c_serialize import (
     _DISPLAY_OPTION_ATTRS,
@@ -39,6 +40,7 @@ from angr.knowledge_plugins.structured_code import SpillingDecompilationDict
 from angr.protos import codegen_pb2
 from angr.sim_variable import SimRegisterVariable, SimStackVariable
 from angr.utils.ail_serialization import (
+    BlockPool,
     pack_arg_vvars,
     pack_graph,
     pack_ite_exprs,
@@ -139,6 +141,71 @@ class TestAilSerializationHelpers(unittest.TestCase):
         assert back[b0][b1] == {"type": "fake_return", "outside": False, "confirmed": True}
         assert back[b0][b2] == {"type": "transition", "stmt_idx": -2}
         assert back[b1][b2] == {}
+
+    def _switch_head_block(self, idx=7):
+        """A block terminated by the one AIL statement that is still written in Python, as LoweredSwitchSimplifier
+        leaves it: the marker replaces the head block's last statement."""
+        cmp_block = AilBlock(0x2000, 4, statements=[Return(9, [], ins_addr=0x2000)])
+        head = IncompleteSwitchCaseHeadStatement(
+            idx,
+            Const(11, 0x40, 32),
+            [
+                (cmp_block, 1, 0x1100, None, 0x1200),
+                (cmp_block, "default", 0x1300, 4, None),
+            ],
+            ins_addr=0x1000,
+        )
+        return AilBlock(0x1000, 4, statements=[Assignment(0, AilTmp(1, 2, 64), Const(2, 1, 64), ins_addr=0x1000), head])
+
+    def test_graph_roundtrip_with_incomplete_switch_case_head(self):
+        # Block.to_bytes() carries only Rust statements, so the marker is encoded beside the block payload and put
+        # back at its original index on parse.
+        blk = self._switch_head_block()
+        _, b1, _ = self._blocks()
+        g = networkx.DiGraph()
+        g.add_edge(blk, b1, type="transition")
+
+        back = parse_graph(pack_graph(g))
+        restored = next(n for n in back.nodes if n.addr == 0x1000)
+        assert len(restored.statements) == 2
+        head = restored.statements[1]
+        assert isinstance(head, IncompleteSwitchCaseHeadStatement)
+        assert head.idx == 7
+        assert head.tags["ins_addr"] == 0x1000
+        assert head.switch_variable == Const(11, 0x40, 32)
+        assert [(v, ta, ti, na) for _, v, ta, ti, na in head.case_addrs] == [
+            (1, 0x1100, None, 0x1200),
+            ("default", 0x1300, 4, None),
+        ]
+        assert [c.addr for c, *_ in head.case_addrs] == [0x2000, 0x2000]
+
+    def test_block_pool_separates_blocks_differing_only_in_python_statements(self):
+        # The pool deduplicates on the payload, and the marker is not in the payload; two blocks whose Rust
+        # statements are identical must not collapse into one entry.
+        pool = BlockPool()
+        g0 = networkx.DiGraph()
+        g0.add_node(self._switch_head_block(idx=7))
+        g1 = networkx.DiGraph()
+        g1.add_node(self._switch_head_block(idx=8))
+        m0 = pack_graph(g0, pool=pool)
+        m1 = pack_graph(g1, pool=pool)
+        assert m0.block_refs[0] != m1.block_refs[0]
+
+        back0 = parse_graph(m0, pool_payloads=pool.payloads)
+        back1 = parse_graph(m1, pool_payloads=pool.payloads)
+        assert next(iter(back0.nodes)).statements[1].idx == 7
+        assert next(iter(back1.nodes)).statements[1].idx == 8
+
+    def test_graph_rejects_unknown_python_statement(self):
+        # The encoder knows one Python-side statement. Anything else must still raise rather than be dropped.
+        class _Bogus:
+            pass
+
+        blk = AilBlock(0x1000, 4, statements=[_Bogus()])
+        g = networkx.DiGraph()
+        g.add_node(blk)
+        with self.assertRaises(TypeError):
+            pack_graph(g)
 
     def test_graph_rejects_unknown_edge_attr(self):
         b0, b1, _ = self._blocks()

--- a/tests/serialization/test_decompilation_cache_serialization.py
+++ b/tests/serialization/test_decompilation_cache_serialization.py
@@ -28,7 +28,6 @@ from angr.analyses.decompiler.optimization_passes.expr_op_swapper import OpDescr
 from angr.analyses.decompiler.optimization_passes.static_vvar_rewriter import FixedBuffer, FixedBufferPtr
 from angr.analyses.decompiler.peephole_optimizations import EXPR_OPTS
 from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
-from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
 from angr.analyses.decompiler.structured_codegen.c import CConstruct
 from angr.analyses.decompiler.structured_codegen.c_serialize import (
     _DISPLAY_OPTION_ATTRS,
@@ -36,6 +35,7 @@ from angr.analyses.decompiler.structured_codegen.c_serialize import (
     _parse_tags,
     _sanitize_tags,
 )
+from angr.analyses.decompiler.structurer_nodes import IncompleteSwitchCaseHeadStatement
 from angr.knowledge_plugins.structured_code import SpillingDecompilationDict
 from angr.protos import codegen_pb2
 from angr.sim_variable import SimRegisterVariable, SimStackVariable
@@ -415,6 +415,40 @@ class TestDecompilationCacheEndToEnd(unittest.TestCase):
         # parameters preserves the 15 keys
         assert set(back.parameters.keys()) == set(cache.parameters.keys())
         assert len(back.parameters) == 15
+
+    def test_cache_with_incomplete_switch_case_head_roundtrips(self):
+        # dirname's main has a lowered switch that LoweredSwitchSimplifier reverts, so cc_graph -- the snapshot taken
+        # before structuring -- keeps the Python-side marker statement it leaves behind.
+        proj = angr.Project(os.path.join(test_location, "x86_64", "decompiler", "dirname"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        proj.analyses.CompleteCallingConventions(cfg=cfg.model, recover_variables=True, analyze_callsites=True)
+        func = proj.kb.functions.function(name="main")
+        dec = proj.analyses.Decompiler(func, cfg=cfg.model)
+
+        def heads(graph):
+            return [
+                stmt
+                for block in graph.nodes
+                for stmt in block.statements
+                if isinstance(stmt, IncompleteSwitchCaseHeadStatement)
+            ]
+
+        original = heads(dec.clinic.cc_graph)
+        assert original, "cc_graph carries no switch-case head; this test would pass without exercising anything"
+
+        back = DecompilationCache.parse(dec.cache.serialize(), project=proj, kb=proj.kb, function=func, cfg=cfg.model)
+        restored = heads(back.clinic.cc_graph)
+        assert len(restored) == len(original)
+        for before, after in zip(original, restored):
+            assert after.idx == before.idx
+            assert after.tags == before.tags
+            assert after.switch_variable == before.switch_variable
+            assert after.peephole_optimized == before.peephole_optimized
+            assert [(v, ta, ti, na) for _, v, ta, ti, na in after.case_addrs] == [
+                (v, ta, ti, na) for _, v, ta, ti, na in before.case_addrs
+            ]
+        assert back.clinic.cc_graph.number_of_nodes() == dec.clinic.cc_graph.number_of_nodes()
+        assert back.clinic.cc_graph.number_of_edges() == dec.clinic.cc_graph.number_of_edges()
 
     def test_cache_hit_on_deserialized_cache(self):
         cache = self.decompiler.cache


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Serializing a decompilation cache raises, and the cache is discarded for that function. On `binaries/tests/x86_64/decompiler/dirname`, `main` at `0x402a7d` decompiles cleanly -- 1622 characters of C containing a real `switch` -- and then `dec.cache.serialize()` dies:

```
  File "angr/utils/ail_serialization.py", line 111, in add
    payload = block.to_bytes()
TypeError: Block.to_bytes: statements must all be AIL Statements, got IncompleteSwitchCaseHeadStatement
```

The effect is the opposite of what the error suggests: the cache is lost for the functions where switch recovery *worked*, because those are the ones still holding the marker. Enumerated over two populations, 55 of 2740 functions lose their cache this way, and all 55 raised at that one site naming that one class.

### Root cause

`Block.to_bytes` is implemented in Rust and accepts only Rust statements. `IncompleteSwitchCaseHeadStatement` is the one AIL statement still written in Python, and `BlockPool.add` hands the whole block to that method:

```python
def add(self, block) -> int:
    payload = block.to_bytes()
```

The marker is a normal inhabitant of the graphs `Clinic` serializes: `LoweredSwitchSimplifier` writes it into a lowered switch head, and `cc_graph` is deliberately the snapshot taken before structuring consumes it. `RegionIdentifier`, `structurer_base`, Phoenix and both code generators all accommodate it there. `ail_serialization.py` is the only component that assumed otherwise, and the newest.

### Fix

`_encode_block` lifts the Python statements out of the block, encodes the rest through `Block.to_bytes` unchanged, and stores each one with its statement index in a new optional `AilGraph.node_extras` field; `_decode_block_extras` puts them back at the same index. Any *other* non-Rust statement still raises, so the contract is narrowed to this one class rather than dropped. On the reproducer the cache now serializes to 23293 bytes and parses back with the marker equal field by field -- `idx`, `tags`, `switch_variable`, `peephole_optimized` and all four `case_addrs` entries -- with `cc_graph` unchanged at 27 nodes and 29 edges. Deliberately not done: porting the statement to Rust, which `angr/ailment/tagged_object.py` anticipates; when that lands this schema entry becomes dead and nothing here obstructs it.

### Testing

`pytest tests/serialization/test_decompilation_cache_serialization.py -k "incomplete_switch or python_statement"` -- three of the four fail on the merge base with that exact `TypeError` and pass on this head, and the fourth asserts the preserved rejection of any other Python statement and passes on both. One of the three drives a real decompilation of `dirname` `main` rather than a hand-built block, so the fixture is a compiler-produced binary already in the tests repository. `pytest tests/serialization/` is 79 passed, 2 xfailed.

Validation: https://github.com/angr/angr/pull/6944#issuecomment-5416904188

session: sharpen