### PR TITLE
Decompiler: Preserve intra-function tail jumps

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -1673,6 +1673,7 @@ class Clinic(Analysis, Serializable):
         """
         Rewrite tail jumps to functions as call statements.
         """
+        function_block_addrs = {block.addr for block in ail_graph}
         for block in list(ail_graph.nodes()):
             if ail_graph.out_degree[block] > 1:
                 continue
@@ -1693,7 +1694,11 @@ class Clinic(Analysis, Serializable):
                 continue
 
             for slot_name, target in slots:
-                if not isinstance(target, ailment.Const) or not self.kb.functions.contains_addr(target.value):
+                if (
+                    not isinstance(target, ailment.Const)
+                    or target.value in function_block_addrs
+                    or not self.kb.functions.contains_addr(target.value)
+                ):
                     continue
 
                 target_func = self.kb.functions.get_by_addr(target.value)

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2055,6 +2055,12 @@ class TestDecompiler(unittest.TestCase):
         assert "setlocale(" in d.codegen.text
         assert "NULL);" in d.codegen.text, "The arguments for setlocale() are missing"
 
+        # fadvise has a conditional tail jump to fdadvise.
+        f = proj.kb.functions["fadvise"]
+        d = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
+        print_decompilation_result(d)
+        assert "return fdadvise(" in d.codegen.text
+
     def test_decompiling_thumb_self_loop_as_loop(self):
         bin_path = os.path.join(test_location, "armel", "Nucleo_read_hyperterminal.elf")
         proj = angr.Project(bin_path, auto_load_libs=False)

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2055,6 +2055,30 @@ class TestDecompiler(unittest.TestCase):
         assert "setlocale(" in d.codegen.text
         assert "NULL);" in d.codegen.text, "The arguments for setlocale() are missing"
 
+    def test_decompiling_thumb_self_loop_as_loop(self):
+        bin_path = os.path.join(test_location, "armel", "Nucleo_read_hyperterminal.elf")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        function_symbol = proj.loader.find_symbol("HardFault_Handler")
+        assert function_symbol is not None
+
+        cfg = proj.analyses.CFGFast(normalize=True, function_starts=[function_symbol.rebased_addr])
+        func = cfg.functions[function_symbol.rebased_addr]
+
+        clinic = proj.analyses.Clinic(func, cfg=cfg.model)
+        assert clinic.graph is not None
+        clinic_entry = next(block for block in clinic.graph if block.addr == func.addr)
+        self.assertTrue(clinic.graph.has_edge(clinic_entry, clinic_entry))
+        self.assertIsInstance(clinic_entry.statements[-1], ailment.Stmt.Jump)
+
+        for structurer in (SAILRStructurer.NAME, PhoenixStructurer.NAME):
+            with self.subTest(structurer=structurer):
+                dec = proj.analyses[Decompiler].prep(fail_fast=True)(
+                    func, cfg=cfg.model, options=[(get_structurer_option(), structurer)]
+                )
+                assert dec.codegen is not None and dec.codegen.text is not None
+                self.assertIn("while (1)", dec.codegen.text)
+                self.assertEqual(dec.codegen.text.count(f"{func.name}("), 1)
+
     @for_all_structuring_algos
     def test_decompiling_du_di_set_alloc(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "du")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

In DecBench `binaries/O2/libopencm3/blink.elf`, `blocking_handler`/`exti0_isr` at `0x800025d` is a Thumb self-loop. The baseline decompiler rewrites it as a recursive tail call.

### Root cause

Clinic converted a direct intra-function jump to an external-function tail call because it did not preserve targets that are blocks in the current function.

### Fix

Direct jumps whose targets belong to the current function remain jumps; unconditional and conditional jumps to external functions keep the existing tail-call conversion.

### Testing

The committed `tests/armel/Nucleo_read_hyperterminal.elf` regression passes under SAILR and Phoenix, and the pinned DecBench reproducer changes from recursion to an infinite loop. Validation: https://github.com/angr/angr/pull/6946#issuecomment-5419156523

session: sharpen
