### PR TITLE
Ssailification: Drop a stack phi whose sources do not match its destination

### DIFF
--- a/angr/analyses/decompiler/ssailification/rewriting.py
+++ b/angr/analyses/decompiler/ssailification/rewriting.py
@@ -214,6 +214,16 @@ class RewritingAnalysis:
 
         return False, None
 
+    @staticmethod
+    def _is_perfect_match(vvar: VirtualVariable, dst: VirtualVariable) -> bool:
+        """
+        Whether vvar defines exactly the storage that dst denotes. Definitions are recorded under every byte they
+        cover, so a lookup by dst's offset can return a definition that merely overlaps it.
+        """
+        if dst.was_reg:
+            return vvar.reg_offset == dst.reg_offset and vvar.size == dst.size
+        return vvar.stack_offset == dst.stack_offset and vvar.size == dst.size
+
     def _stack_predicate(self, node_: Block, *, stack_offset: int) -> tuple[bool, Any]:
         out_state: RewritingState = (
             self.head_controlled_loop_outstates[(node_.addr, node_.idx)]
@@ -252,6 +262,7 @@ class RewritingAnalysis:
                 # a combo-register argument spans multiple (usually non-contiguous) registers; the function body
                 # reads the constituent registers individually, so we expose each constituent register vvar in the
                 # initial state and keep the link back to the combo argument
+                assert arg_vvar.reg_vvars is not None
                 for reg_vvar in arg_vvar.reg_vvars:
                     combo_reg_vvar_to_arg[reg_vvar.varid] = arg_vvar
                     for suboffset in range(reg_vvar.reg_offset, reg_vvar.reg_offset + reg_vvar.size):
@@ -361,6 +372,7 @@ class RewritingAnalysis:
                 for suboff in range(stack_offset, stack_offset + func_arg.size):
                     state.stackvars[suboff] = func_arg
             elif func_arg.parameter_category == VirtualVariableCategory.COMBO_REGISTER:
+                assert func_arg.reg_vvars is not None
                 for reg_vvar in func_arg.reg_vvars:
                     for suboff in range(reg_vvar.reg_offset, reg_vvar.reg_offset + reg_vvar.size):
                         state.registers[suboff] = reg_vvar
@@ -426,46 +438,27 @@ class RewritingAnalysis:
                     assert isinstance(stmt.dst, VirtualVariable)
                     assert isinstance(stmt.src, Phi)
 
-                    src_and_vvars = []
                     if stmt.dst.was_reg:
-                        perfect_matches = []
-                        for pred in self._graph.predecessors(original_node):
-                            vvar = self._follow_one_path_backward(
-                                self._graph,
-                                pred,
-                                partial(self._reg_predicate, reg_offset=stmt.dst.reg_offset),
-                            )
-                            src_and_vvars.append(((pred.addr, pred.idx), vvar))
-                            perfect_matches.append(
-                                (vvar.reg_offset == stmt.dst.reg_offset and vvar.size == stmt.dst.size)
-                                if vvar is not None
-                                else True
-                            )
-                        if all(perfect_matches):
-                            phi_var = Phi(stmt.src.idx, stmt.src.bits, src_and_vvars=src_and_vvars)
-                            phi_stmt = Assignment(stmt.idx, stmt.dst, phi_var, **stmt.tags)
-                            phi_stmts.append(phi_stmt)
-                        else:
-                            # different sizes of vvars found; this means the variable is unused from this point on
-                            continue
-
+                        predicate = partial(self._reg_predicate, reg_offset=stmt.dst.reg_offset)
                     elif stmt.dst.was_stack:
-                        for pred in self._graph.predecessors(original_node):
-                            vvar = self._follow_one_path_backward(
-                                self._graph,
-                                pred,
-                                partial(
-                                    self._stack_predicate,
-                                    stack_offset=stmt.dst.stack_offset,
-                                ),
-                            )
-                            src_and_vvars.append(((pred.addr, pred.idx), vvar))
-
-                        phi_var = Phi(stmt.src.idx, stmt.src.bits, src_and_vvars=src_and_vvars)
-                        phi_stmt = Assignment(stmt.idx, stmt.dst, phi_var, **stmt.tags)
-                        phi_stmts.append(phi_stmt)
+                        predicate = partial(self._stack_predicate, stack_offset=stmt.dst.stack_offset)
                     else:
                         raise NotImplementedError
+
+                    src_and_vvars = []
+                    perfect_matches = []
+                    for pred in self._graph.predecessors(original_node):
+                        vvar = self._follow_one_path_backward(self._graph, pred, predicate)
+                        src_and_vvars.append(((pred.addr, pred.idx), vvar))
+                        perfect_matches.append(vvar is None or self._is_perfect_match(vvar, stmt.dst))
+
+                    if not all(perfect_matches):
+                        # different sizes of vvars found; this means the variable is unused from this point on
+                        continue
+
+                    phi_var = Phi(stmt.src.idx, stmt.src.bits, src_and_vvars=src_and_vvars)
+                    phi_stmt = Assignment(stmt.idx, stmt.dst, phi_var, **stmt.tags)
+                    phi_stmts.append(phi_stmt)
 
                 node = node.copy(statements=phi_stmts + phi_extraction_stmts + other_stmts)
                 self.out_blocks[node_key] = node

--- a/tests/analyses/decompiler/test_partial_stack_writes.py
+++ b/tests/analyses/decompiler/test_partial_stack_writes.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,no-member
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from angr.ailment.expression import Phi, VirtualVariable
+from angr.ailment.statement import Assignment
+from angr.analyses import Decompiler
+from tests.common import bin_location, print_decompilation_result
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestPartialStackWrites(unittest.TestCase):
+    """
+    Ssailification records every definition under each byte it covers, so looking a stack slot up by its offset can
+    return a definition that merely overlaps it. The phi back-patch in RewritingAnalysis._post_analysis therefore
+    drops a phi whose sources do not denote exactly the destination's storage; a stack slot written at one width in
+    one predecessor and at another width in another predecessor is not one variable, and wiring the narrower
+    definition in produces a phi whose sources disagree in width with its destination.
+    """
+
+    def test_stack_phi_sources_match_destination(self):
+        bin_path = os.path.join(test_location, "x86_64", "test_arrays")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        func = cfg.functions[0x40059D]
+        dec = proj.analyses[Decompiler].prep(fail_fast=True)(func, cfg=cfg.model)
+        assert dec.codegen is not None and dec.codegen.text is not None
+        assert dec.clinic is not None and dec.clinic.graph is not None
+        print_decompilation_result(dec)
+
+        stack_phis = 0
+        for block in dec.clinic.graph:
+            for stmt in block.statements:
+                if not (
+                    isinstance(stmt, Assignment) and isinstance(stmt.dst, VirtualVariable) and isinstance(stmt.src, Phi)
+                ):
+                    continue
+                if stmt.dst.was_stack:
+                    stack_phis += 1
+                for _, src in stmt.src.src_and_vvars:
+                    assert src is None or src.bits == stmt.dst.bits, (
+                        f"phi for vvar {stmt.dst.varid} ({stmt.dst.bits} bits) has a {src.bits}-bit source"
+                    )
+
+        # the function must still produce stack phis, or the assertion above proves nothing
+        assert stack_phis > 0
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`sub_100019b0` at `0x100019b0` in `binaries/tests/x86_64/windows/10c073e1a9a94b1589e7d39acb11c3273ce8c9b66cb5379277a78394e91368fd` produces no decompilation at all. Variable recovery subtracts an 8-bit value from a 16-bit one and claripy refuses:

```
  File "angr/analyses/variable_recovery/engine_ail.py", line 812, in _handle_binop_Sub
    compute = r0.data - r1.data
claripy.errors.ClaripyOperationError: args' length must all be equal
```

The whole function is lost, not one expression: the decompiler's resilience wrapper retries with the basic preset and fails identically, so the output is empty. The malformed phi behind it is not rare -- 439 of them across 78 functions in 30 `angr/binaries` fixtures on the merge base.

### Root cause

Ssailification's phi back-patch already drops a phi whose sources do not denote exactly the destination's storage, but the test existed only on the register branch. The stack branch appended every source it found, unconditionally:

```python
elif stmt.dst.was_stack:
    for pred in self._graph.predecessors(original_node):
        vvar = self._follow_one_path_backward(
            self._graph, pred, partial(self._stack_predicate, stack_offset=stmt.dst.stack_offset)
        )
        src_and_vvars.append(((pred.addr, pred.idx), vvar))
```

Definitions are recorded under every byte they cover and `_stack_predicate` matches on the offset alone, so a lookup by the destination's offset can return a definition that merely overlaps it. On `binaries/tests/x86_64/test_arrays`, `main` at `0x40059d`, that produces exactly one such phi, verbatim from `repr()`:

```
vvar_78{s-56|2b} = Phi([((4195846, None), vvar_80{s-56|1b}), ((4195858, None), vvar_78{s-56|2b})])
```

A 16-bit destination with source widths `[8, 16]`. It is minted at SSA level 1 and survives into `clinic.graph` unchanged, and variable recovery then reads a value wider than the vvar it asked for.

### Fix

`_is_perfect_match` states the test once, for both categories, and the two branches now differ only in which predicate they pass to one shared loop -- so a phi whose sources disagree with its destination is dropped on the stack just as it already was on registers, and the two cases cannot drift apart again. On the PE fixture the function goes from no output to 4385 characters over 166 lines. On `test_arrays` `main` the stack phis go 4 to 3, none width-inconsistent, and the emitted C is byte-identical between the arms at 568 characters, sha256 `735a7cb56d0d4692ca301c975713ffdd233a92687ddeab4ae77bb3520148f067`. Not done here: guarding the claripy call in `engine_ail.py`, which would hide the malformed value rather than stop producing it. Where a slot-unifying phi is now correctly dropped, two corpus functions lose output quality; both are named in the validation comment.

### Testing

`pytest tests/analyses/decompiler/test_partial_stack_writes.py` fails on the merge base with `AssertionError: phi for vvar 78 (16 bits) has a 8-bit source` and passes on this head. It asserts the phi invariant rather than the exception, and also asserts that the function still produces stack phis, so it cannot pass by producing none. A paired A/B over the 30 fixtures carrying such phis reports 439 width-inconsistent stack phis on the baseline and 0 on head, with 78 of 78 functions still decompiling and 0 new errors; the counts, the control group and the seven output deltas are in the validation comment.

Validation: https://github.com/angr/angr/pull/6947#issuecomment-5419195934

session: sharpen