### PR TITLE
SootClassHierarchy: Answer the subclass question for an interface

### DIFF
--- a/angr/analyses/soot_class_hierarchy.py
+++ b/angr/analyses/soot_class_hierarchy.py
@@ -85,11 +85,21 @@ class SootClassHierarchy(Analysis):
         return False
 
     def is_subclass_including(self, cls_child, cls_parent):
+        # An interface has no chain of super classes to walk, so the only class it stands in this
+        # relation to is itself. Asking is a legitimate question; get_super_classes_including cannot
+        # answer it and raises, so answer it here rather than let a predicate throw.
+        if "INTERFACE" in cls_child.attrs:
+            return cls_parent is cls_child
+
         parent_classes = self.get_super_classes_including(cls_child)
 
         return cls_parent in parent_classes
 
     def is_subclass(self, cls_child, cls_parent):
+        # See above. An interface extends interfaces, never a class, so it is a subclass of none.
+        if "INTERFACE" in cls_child.attrs:
+            return False
+
         parent_classes = self.get_super_classes(cls_child)
 
         return cls_parent in parent_classes

--- a/tests/analyses/cfg/test_cfgfast_soot.py
+++ b/tests/analyses/cfg/test_cfgfast_soot.py
@@ -47,6 +47,19 @@ class TestCfgfastSoot(unittest.TestCase):
         # methods that no entry point reaches are analyzed too
         assert "simple2.Class1.unreachable(int)" in function_names
 
+    def test_invokespecial_on_an_interface(self):
+        # Impl.greet() calls Greeter.super.greet(), so the invoke's declaring class is an interface.
+        # Resolving it asks SootClassHierarchy whether that interface is a subclass of Impl;
+        # get_super_classes has no chain to walk for an interface and raises, which aborted the CFG.
+        binary_path = os.path.join(test_location, "java", "interface_default.jar")
+        p = angr.Project(binary_path, main_opts={"entry_point": "iface.Impl.main"}, auto_load_libs=False)
+
+        cfg = p.analyses.CFGFastSoot()
+
+        assert cfg.graph.nodes()
+        names = {f.name for f in cfg.kb.functions.values()}
+        assert any("greet" in name for name in names), names
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`SootClassHierarchy.get_super_classes` walks `super_class`, so it has nothing to
walk for an interface and raises `SootClassHierarchyError("This is an Interface")`.
`is_subclass` and `is_subclass_including` call it directly, so asking whether an
interface is a subclass raises instead of answering.

`resolve_special_dispatch` asks exactly that whenever an `invokespecial` names an
interface method — a `default` method called as `Iface.super.m()`. Nothing in angr
catches `SootClassHierarchyError`, so one such call aborts the entire CFG.

An interface extends interfaces and never a class, so it is a subclass of none,
and the only class it stands in the *including* relation to is itself. The
predicates now answer that. `get_super_classes` keeps its contract, since a caller
that genuinely wants a superclass chain still has no meaningful answer for an
interface.

That also matches the JVM's own rule: `invokespecial` on an interface method
invokes that method directly rather than dispatching virtually, which is what
`resolve_special_dispatch` now does when the predicate answers false.

Fixture is in angr/binaries#197

Found by re-running the Java bucket of a corpus sweep with a JDK actually present.
