### PR TITLE
Decompiler: rebind breaks and continues that no longer reach their target

### DIFF
--- a/angr/analyses/decompiler/region_simplifiers/break_rebinder.py
+++ b/angr/analyses/decompiler/region_simplifiers/break_rebinder.py
@@ -1,0 +1,185 @@
+# pylint:disable=unused-argument
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from angr import ailment
+from angr.analyses.decompiler.sequence_walker import SequenceWalker
+from angr.analyses.decompiler.structurer_nodes import (
+    BreakNode,
+    CascadingConditionNode,
+    CodeNode,
+    ConditionalBreakNode,
+    ConditionNode,
+    ContinueNode,
+    LoopNode,
+    MultiNode,
+    SequenceNode,
+    SwitchCaseNode,
+)
+from angr.analyses.decompiler.utils import first_nonlabel_statement, sequence_to_blocks
+
+if TYPE_CHECKING:
+    from angr.ailment import Manager
+
+
+def _label_addrs(block: ailment.Block) -> set[int]:
+    """
+    Addresses a jump into block may name: its own address and those of its leading labels.
+    """
+    addrs = {block.addr}
+    for stmt in block.statements:
+        if not isinstance(stmt, ailment.Stmt.Label):
+            break
+        if "ins_addr" in stmt.tags:
+            addrs.add(stmt.tags["ins_addr"])
+    return addrs
+
+
+def _entry_addrs(node) -> set[int] | None:
+    """
+    Addresses that may name where control arrives when it enters node, or None if node is unknown.
+    """
+    if node is None:
+        return None
+    addrs = {node.addr} if isinstance(node.addr, int) else set()
+    if isinstance(node, LoopNode):
+        if node.continue_addr is not None:
+            addrs.add(node.continue_addr)
+        if node.iterator is not None and "ins_addr" in node.iterator.tags:
+            addrs.add(node.iterator.tags["ins_addr"])
+    blocks = sequence_to_blocks(node)
+    if blocks:
+        addrs |= _label_addrs(blocks[0])
+        # a goto-only block keeps the address it was split from, not the address it sends control to
+        stmt = first_nonlabel_statement(blocks[0])
+        if isinstance(stmt, ailment.Stmt.Jump) and isinstance(stmt.target, ailment.Expr.Const):
+            addrs.add(stmt.target.value)
+    return addrs
+
+
+class BreakRebinder(SequenceWalker):
+    """
+    Rewrite Break and Continue nodes that no longer reach their targets into gotos.
+
+    Structuring records in every Break and Continue node the address it must reach. A later phase can enclose such a
+    node in a loop or a switch-case that did not exist when it was created, and in C it binds to that construct
+    instead. A node whose target is not where its binding construct sends control becomes a goto to the target.
+    """
+
+    def __init__(self, node, manager: Manager, bits: int):
+        handlers = {
+            SequenceNode: self._handle_sequencenode,
+            CodeNode: self._handle_codenode,
+            MultiNode: self._handle_multinode,
+            LoopNode: self._handle_loopnode,
+            SwitchCaseNode: self._handle_switchcasenode,
+            ConditionNode: self._handle_conditionnode,
+            CascadingConditionNode: self._handle_cascadingconditionnode,
+            BreakNode: self._handle_breaknode,
+            ConditionalBreakNode: self._handle_conditionalbreaknode,
+            ContinueNode: self._handle_continuenode,
+        }
+
+        super().__init__(handlers)
+        self.manager = manager
+        self.bits = bits
+        self.blocks = sequence_to_blocks(node)
+
+        self.walk(node)
+
+    #
+    # Handlers
+    #
+
+    def _handle_sequencenode(self, node, successor=None, **kwargs):
+        for idx, (child, child_successor) in enumerate(zip(node.nodes, [*node.nodes[1:], successor])):
+            new_node = self._handle(child, successor=child_successor, **kwargs)
+            if new_node is not None:
+                node.nodes[idx] = new_node
+
+    def _handle_multinode(self, node, **kwargs):
+        self._handle_sequencenode(node, **kwargs)
+
+    def _handle_codenode(self, node, **kwargs):
+        new_node = self._handle(node.node, **kwargs)
+        if new_node is not None:
+            node.node = new_node
+
+    def _handle_conditionnode(self, node, **kwargs):
+        if node.true_node is not None:
+            new_node = self._handle(node.true_node, **kwargs)
+            if new_node is not None:
+                node.true_node = new_node
+        if node.false_node is not None:
+            new_node = self._handle(node.false_node, **kwargs)
+            if new_node is not None:
+                node.false_node = new_node
+
+    def _handle_cascadingconditionnode(self, node: CascadingConditionNode, **kwargs):
+        for idx, (cond, child) in enumerate(node.condition_and_nodes):
+            new_node = self._handle(child, **kwargs)
+            if new_node is not None:
+                node.condition_and_nodes[idx] = cond, new_node
+        if node.else_node is not None:
+            new_node = self._handle(node.else_node, **kwargs)
+            if new_node is not None:
+                node.else_node = new_node
+
+    def _handle_loopnode(self, node: LoopNode, successor=None, **kwargs):
+        self._handle(
+            node.sequence_node,
+            successor=node,  # the end of a loop always jumps to the beginning of its body
+            break_target=_entry_addrs(successor),
+            continue_target=_entry_addrs(node),
+        )
+
+    def _handle_switchcasenode(self, node: SwitchCaseNode, successor=None, continue_target=None, **kwargs):
+        break_target = _entry_addrs(successor)
+        for case_idx in node.cases:
+            new_node = self._handle(node.cases[case_idx], break_target=break_target, continue_target=continue_target)
+            if new_node is not None:
+                node.cases[case_idx] = new_node
+        if node.default_node is not None:
+            new_node = self._handle(node.default_node, break_target=break_target, continue_target=continue_target)
+            if new_node is not None:
+                node.default_node = new_node
+
+    def _handle_breaknode(self, node: BreakNode, break_target=None, **kwargs):
+        return self._rewrite_to_goto(node, break_target)
+
+    def _handle_continuenode(self, node: ContinueNode, continue_target=None, **kwargs):
+        return self._rewrite_to_goto(node, continue_target)
+
+    def _handle_conditionalbreaknode(self, node: ConditionalBreakNode, break_target=None, **kwargs):
+        goto = self._rewrite_to_goto(node, break_target)
+        return None if goto is None else ConditionNode(node.addr, None, node.condition, goto)
+
+    #
+    # Utils
+    #
+
+    def _rewrite_to_goto(self, node: BreakNode | ContinueNode, target_addrs: set[int] | None) -> ailment.Block | None:
+        if not isinstance(node.target, int) or not isinstance(node.addr, int):
+            return None
+        if target_addrs is None or node.target in target_addrs:
+            return None
+        target_block = next((block for block in self.blocks if node.target in _label_addrs(block)), None)
+        if target_block is None:
+            return None
+        label = self._ensure_label(target_block, node.target)
+        jump = ailment.Stmt.Jump(
+            self.manager.next_atom(),
+            ailment.Expr.Const(self.manager.next_atom(), node.target, self.bits),
+            target_idx=label.tags.get("block_idx"),
+            ins_addr=node.addr,
+        )
+        return ailment.Block(node.addr, 0, statements=[jump], idx=None)
+
+    def _ensure_label(self, block: ailment.Block, target: int) -> ailment.Stmt.Label:
+        for stmt in block.statements:
+            if isinstance(stmt, ailment.Stmt.Label) and stmt.tags.get("ins_addr") == target:
+                return stmt
+        label = ailment.Stmt.Label(self.manager.next_atom(), f"LABEL_{target:x}", ins_addr=target, block_idx=block.idx)
+        block.statements = [label, *block.statements]
+        return label

--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -13,6 +13,7 @@ from angr.analyses.decompiler.semantic_naming.region_loop_counter_naming import 
 from angr.analyses.decompiler.structurer_nodes import LoopNode
 from angr.analyses.decompiler.variable_map import variable_map_of
 
+from .break_rebinder import BreakRebinder
 from .cascading_cond_transformer import CascadingConditionTransformer
 from .cascading_ifs import CascadingIfsRemover
 from .expr_folding import (
@@ -110,6 +111,8 @@ class RegionSimplifier(Analysis):
         r = self._remove_empty_nodes(r)
         # Find nested if-else constructs and convert them into CascadingIfs
         r = self._transform_to_cascading_ifs(r)
+        # Turn break and continue statements that the final structure no longer binds to their targets into gotos
+        r = self._rebind_breaks(r)
 
         self.result = r
 
@@ -260,6 +263,10 @@ class RegionSimplifier(Analysis):
 
     def _simplify_loops(self, region):
         LoopSimplifier(region, self.kb.functions)
+        return region
+
+    def _rebind_breaks(self, region):
+        BreakRebinder(region, self.ail_manager, self.project.arch.bits)
         return region
 
     def _apply_region_loop_counter_naming(self, region) -> None:

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2512,14 +2512,37 @@ class TestDecompiler(unittest.TestCase):
     def test_decompiling_printenv_main(self, decompiler_options=None):
         # when a subgraph inside a loop cannot be structured, instead of entering last-resort refinement, we should
         # return the subgraph and let structuring resume with the knowledge of the loop.
-        # otherwise, in this function, we will see a goto while in reality we do not need any gotos.
+        # the only gotos this function needs are the three that leave the switch at 0x400962: that switch is the
+        # entire body of the loop at 0x400947, so a break there binds to the loop instead and the loop re-tests its
+        # condition with the cursor unadvanced, which never terminates.
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "printenv.o")
         proj = angr.Project(bin_path, auto_load_libs=False)
         cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
         f = proj.kb.functions["main"]
         d = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
         print_decompilation_result(d)
-        assert "goto " not in d.codegen.text
+        assert d.codegen is not None and d.codegen.text is not None
+        assert d.codegen.text.count("goto ") == 3
+
+    @structuring_algo("sailr")
+    def test_decompiling_printenv_main_switch_break_inside_a_loop(self, decompiler_options=None):
+        # structuring mints the breaks that leave the switch at 0x400962 before wrapping that switch in the loop at
+        # 0x400947, and never revisits them. Each one must reach the end of the switch at 0x40098f.
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "printenv.o")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        f = proj.kb.functions["main"]
+        d = proj.analyses[Decompiler].prep(fail_fast=True)(f, cfg=cfg.model, options=decompiler_options)
+        print_decompilation_result(d)
+        assert d.codegen is not None and d.codegen.text is not None
+        text = d.codegen.text
+
+        assert text.count("goto LABEL_40098f;") == 3
+        assert set(re.findall(r"goto (\w+);", text)) <= set(re.findall(r"^(\w+):$", text, re.MULTILINE))
+        # the two breaks and the continue that do bind to their own construct are left alone, as is the break that
+        # leaves the switch at 0x40082d for the loop head at 0x400810
+        assert text.count("break;") == 3
+        assert text.count("continue;") == 1
 
     @structuring_algo("sailr")
     def test_decompiling_ls_ubuntu2204_sub_414cb0(self, decompiler_options=None):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

In `binaries/tests/x86_64/decompiler/printenv.o`, `main` decompiles to a loop that cannot terminate. The switch the structurer builds at `0x400962` is the entire body of the loop at `0x400947`, and the three breaks that leave that switch are emitted as plain `break;`:

```c
                                    break;      // meant to reach 0x40098f
```

In C they bind to the switch, so control falls to the bottom of the loop body and re-tests `v16->padding_0` with `v16` unadvanced. Only the `default` arm advances the cursor, so nothing on those three paths writes what the condition reads. The machine code leaves the loop at `0x40098f`; the emitted C does not leave it at all. Read off the finished structured tree, all three `BreakNode`s under that switch record `target=0x40098f` while binding to `('switch', 0x400962)`, and the natural loop body of `0x400947` computed from the CFG dominators is `{0x400940, 0x400944, 0x400947, 0x40094f, 0x40095c, 0x400964}` -- `0x40098f` is outside it.

### Root cause

Structuring records in every `Break` and `Continue` node the address it must reach, and never revalidates that address when a later phase encloses the node in a loop or switch built afterwards. The C backend then discards the address entirely and lets the statement bind to whatever lexically encloses it, so a binding that was correct when the node was minted becomes silently wrong.

### Fix

`break_rebinder.py` re-derives each binding from the finished region tree, compares it against the address the node records, and rewrites the ones that no longer reach their target into a `goto` at a label it inserts. It runs last in `RegionSimplifier`, after `_simplify_switch_expressions`, `_simplify_switch_clusters` and `_simplify_loops`, because only then does every loop and switch it must reason about exist. On the reproducer the entire textual difference is four lines -- three `break;` becoming `goto LABEL_40098f;` and one inserted `LABEL_40098f:` -- so `goto`/`break;`/`continue;` go from 0/6/1 to 3/3/1 over 119 and 120 lines. Not done here: re-running `_simplify_gotos` afterwards, which would remove 28 of the 29 self-adjacent gotos this introduces corpus-wide but also changes 19 functions this pass never touches; that is its own change and is measured in the validation comment.

### Testing

`test_decompiling_printenv_main` asserted this function needed no gotos, which pinned the broken output; it now asserts `d.codegen.text.count("goto ") == 3`. A new `test_decompiling_printenv_main_switch_break_inside_a_loop` asserts the three are `goto LABEL_40098f;`, that every goto target has a label, and that the two breaks and the continue which do bind correctly are left alone. Both fail on the merge base and pass on this head; `tests/analyses/decompiler/` is 701 passed and 6 skipped with the change against 699 passed, 6 skipped and 2 failed without it, and no other test differs in either direction. Corpus blast radius over 97 decbench binaries and 23,534 functions, with the nondeterminism floor measured on the same binaries, is in the validation comment.

Validation: https://github.com/angr/angr/pull/6952#issuecomment-5421906391

session: sharpen