### PR TITLE
Preserve loop-header variables during expression folding

### DIFF
--- a/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/region_simplifier.py
@@ -122,14 +122,18 @@ class RegionSimplifier(Analysis):
         for sub_region in [*loop_nodes, region]:
             # fold one-use expressions in each sub-region
             if isinstance(sub_region, LoopNode):
-                self._fold_oneuse_expressions_in_region(sub_region.sequence_node)
+                loop_header_counter = ExpressionCounter(sub_region)
+                self._fold_oneuse_expressions_in_region(
+                    sub_region.sequence_node, excluded_varids=set(loop_header_counter.outerscope_uses)
+                )
             else:
                 self._fold_oneuse_expressions_in_region(sub_region)
         return region
 
-    def _fold_oneuse_expressions_in_region(self, region):
+    def _fold_oneuse_expressions_in_region(self, region, excluded_varids: set[int] | None = None):
         # pylint:disable=unreachable
         expr_counter = ExpressionCounter(region)
+        excluded_varids = excluded_varids or set()
 
         variable_assignments = {}
         variable_uses = {}
@@ -143,7 +147,8 @@ class RegionSimplifier(Analysis):
         for var, outerscope_uses in expr_counter.outerscope_uses.items():
             all_uses = expr_counter.all_uses[var]
             if (
-                len(outerscope_uses) == 1
+                var not in excluded_varids
+                and len(outerscope_uses) == 1
                 and len(all_uses) == 1
                 and var in expr_counter.assignments
                 and len(expr_counter.assignments[var]) == 1

--- a/tests/analyses/decompiler/test_expression_overfolding.py
+++ b/tests/analyses/decompiler/test_expression_overfolding.py
@@ -26,10 +26,9 @@ l = logging.getLogger(__name__)
 
 class TestExpressionOverfolding(unittest.TestCase):
     def test_loop_body_assignment_used_by_loop_header_is_not_folded(self):
-        project = angr.Project(os.path.join(test_location, "armel", "decompiler", "blink_main_countdown.elf"))
         for header_kind in ("condition", "iterator"):
             with self.subTest(header_kind=header_kind):
-                manager = Manager(arch=project.arch)
+                manager = Manager()
                 carrier = VirtualVariable(manager.next_atom(), 81, 32, VirtualVariableCategory.REGISTER, oident=20)
                 header_var = VirtualVariable(manager.next_atom(), 19, 32, VirtualVariableCategory.REGISTER, oident=20)
                 header_use_result = VirtualVariable(

--- a/tests/analyses/decompiler/test_expression_overfolding.py
+++ b/tests/analyses/decompiler/test_expression_overfolding.py
@@ -6,9 +6,17 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 
 import logging
 import os
+import re
 import unittest
 
 import angr
+from angr.ailment import Manager
+from angr.ailment.block import Block
+from angr.ailment.expression import BinaryOp, Const, VirtualVariable, VirtualVariableCategory
+from angr.ailment.statement import Assignment
+from angr.analyses.decompiler.decompilation_options import get_structurer_option
+from angr.analyses.decompiler.region_simplifiers.region_simplifier import RegionSimplifier
+from angr.analyses.decompiler.structurer_nodes import LoopNode, SequenceNode
 from tests.common import WORKER, bin_location, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -17,6 +25,102 @@ l = logging.getLogger(__name__)
 
 
 class TestExpressionOverfolding(unittest.TestCase):
+    def test_loop_body_assignment_used_by_loop_header_is_not_folded(self):
+        project = angr.Project(os.path.join(test_location, "armel", "decompiler", "blink_main_countdown.elf"))
+        for header_kind in ("condition", "iterator"):
+            with self.subTest(header_kind=header_kind):
+                manager = Manager(arch=project.arch)
+                carrier = VirtualVariable(manager.next_atom(), 81, 32, VirtualVariableCategory.REGISTER, oident=20)
+                header_var = VirtualVariable(manager.next_atom(), 19, 32, VirtualVariableCategory.REGISTER, oident=20)
+                header_use_result = VirtualVariable(
+                    manager.next_atom(), 68, 32, VirtualVariableCategory.REGISTER, oident=20
+                )
+                temporary = VirtualVariable(manager.next_atom(), 20, 32, VirtualVariableCategory.REGISTER, oident=20)
+                temporary_result = VirtualVariable(
+                    manager.next_atom(), 69, 32, VirtualVariableCategory.REGISTER, oident=20
+                )
+                body = Block(
+                    0x80001CF,
+                    8,
+                    statements=[
+                        Assignment(manager.next_atom(), header_var, carrier),
+                        Assignment(manager.next_atom(), header_use_result, header_var),
+                        Assignment(manager.next_atom(), temporary, carrier),
+                        Assignment(manager.next_atom(), temporary_result, temporary),
+                    ],
+                )
+                if header_kind == "condition":
+                    condition = BinaryOp(
+                        manager.next_atom(), "CmpNE", [header_var, Const(manager.next_atom(), 1, 32)], False
+                    )
+                    iterator = None
+                else:
+                    condition = None
+                    iterator_var = VirtualVariable(
+                        manager.next_atom(), 21, 32, VirtualVariableCategory.REGISTER, oident=20
+                    )
+                    iterator = Assignment(
+                        manager.next_atom(),
+                        iterator_var,
+                        header_var,
+                    )
+                loop = LoopNode(
+                    "do-while" if condition is not None else "for",
+                    condition,
+                    SequenceNode(0x80001CF, nodes=[body]),
+                    addr=0x80001CF,
+                    iterator=iterator,
+                )
+                region = SequenceNode(0x80001CF, nodes=[loop])
+                simplifier = object.__new__(RegionSimplifier)
+                simplifier.arg_vvars = set()
+                simplifier.ail_manager = manager
+
+                simplifier._fold_oneuse_expressions(region)  # pylint:disable=protected-access
+
+                self.assertTrue(
+                    any(
+                        isinstance(stmt, Assignment)
+                        and isinstance(stmt.dst, VirtualVariable)
+                        and stmt.dst.varid == header_var.varid
+                        for stmt in body.statements
+                    )
+                )
+                self.assertFalse(
+                    any(
+                        isinstance(stmt, Assignment)
+                        and isinstance(stmt.dst, VirtualVariable)
+                        and stmt.dst.varid == temporary.varid
+                        for stmt in body.statements
+                    )
+                )
+
+    def test_arm_countdown_loop_condition_variable_is_defined(self):
+        bin_path = os.path.join(test_location, "armel", "decompiler", "blink_main_countdown.elf")
+        function_starts = [0x80001AD, 0x80001E1, 0x80001F5, 0x8000225, 0x8000229, 0x800022D]
+        option = get_structurer_option()
+
+        for structurer in ("Phoenix", "SAILR"):
+            with self.subTest(structurer=structurer):
+                proj = angr.Project(bin_path, auto_load_libs=False, load_debug_info=False)
+                cfg = proj.analyses.CFGFast(normalize=True, fail_fast=True, function_starts=function_starts)
+                dec = proj.analyses.Decompiler(
+                    cfg.kb.functions[0x80001AD],
+                    cfg=cfg.model,
+                    preset="full",
+                    options=[(option, structurer)],
+                    fail_fast=True,  # pyright: ignore[reportCallIssue]
+                    use_cache=False,
+                    update_cache=False,
+                )
+                codegen = dec.codegen
+                assert codegen is not None and codegen.text is not None
+                code = codegen.text
+                condition = re.search(r"while \(([A-Za-z_]\w*) != 1\);", code)
+                assert condition is not None
+                condition_variable = condition.group(1)
+                self.assertRegex(code[: condition.start()], rf"\b{re.escape(condition_variable)}\s*=")
+
     def test_expression_overfolding_56f41bc3(self):
         bin_path = os.path.join(
             test_location, "i386", "windows", "56f41bc38419e26de02bfb9438d7ddefd8561c668018fd29dc56521c060ab3e3"


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Full-preset decompilation of `main` at Thumb address `0x80001ad` in `tests/armel/decompiler/blink_main_countdown.elf` emits a condition that reads `i` without assigning it in the loop body:

```c
v6 = v4 - 1;
v4 = v6;
} while (i != 1);
```

The generated C no longer represents the machine-code countdown.

### Root cause

RegionSimplifier counted one-use expressions in the loop body separately from the loop header. It could fold away the body assignment to a virtual variable that the condition or iterator still uses, breaking the loop-header/body carrier invariant.

### Fix

Body-only folding now excludes loop-header virtual variables while continuing to fold ordinary body temporaries. The same path retains `i = v4` before the decrement.

### Testing

Synthetic condition and iterator regressions cover the carrier invariant. Paired current-revision captures produce the corrected complete C under both SAILR and Phoenix, identically in both revision orders. [Full before/after output](#issuecomment-5457625574). [Validation record](https://github.com/angr/angr/pull/6954#issuecomment-5422587255).

sync: angr/binaries#199

session: sharpen
