### PR TITLE
Decompiler: Recover variadic arguments through gettext

### DIFF
--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 
 l = logging.getLogger(name=__name__)
 
+_GETTEXT_MESSAGE_ARG_INDEX = {"gettext": 0, "dcgettext": 1}
+
 
 class CallSiteMaker:
     """
@@ -564,6 +566,35 @@ class CallSiteMaker:
 
         return s
 
+    def _find_format_string(self, value: Expr.Expression, resolved_vvars: set[int] | None = None) -> bytes | None:
+        if isinstance(value, Const) and isinstance(value.value, int):
+            return self._load_string(value.value) or None
+
+        if isinstance(value, Expr.VirtualVariable):
+            if self._reaching_definitions is None:
+                return None
+            if resolved_vvars is None:
+                resolved_vvars = set()
+            if value.varid in resolved_vvars:
+                return None
+            resolved_vvars.add(value.varid)
+            resolved = SRDAView(self._reaching_definitions).get_vvar_value(value)
+            if resolved is None or isinstance(resolved, Expr.Phi):
+                return None
+            return self._find_format_string(resolved, resolved_vvars)
+
+        if isinstance(value, Expr.Call) and value.args:
+            target = self._get_call_target(value)
+            if target is None or target not in self.kb.functions:
+                return None
+            callee = self.kb.functions[target]
+            message_arg_idx = _GETTEXT_MESSAGE_ARG_INDEX.get(callee.name)
+            if message_arg_idx is None or len(value.args) <= message_arg_idx:
+                return None
+            return self._find_format_string(value.args[message_arg_idx], resolved_vvars)
+
+        return None
+
     def _determine_variadic_arguments(self, func: Function, cc: SimCC, call_expr: Expr.Call) -> list[SimType]:
         if "printf" in func.name or "scanf" in func.name:
             return self._determine_variadic_arguments_for_format_strings(func, cc, call_expr)
@@ -610,14 +641,12 @@ class CallSiteMaker:
                 l.warning("Unexpected type of argument type %s.", arg_loc.__class__)
                 continue
 
-            if not isinstance(value, Const) and call_expr.args is not None and len(call_expr.args) > fmt_arg_idx:
-                value = call_expr.args[fmt_arg_idx]
-            if isinstance(value, Const) and isinstance(value.value, int):
-                value = value.value
-            if isinstance(value, int):
-                fmt_str = self._load_string(value)
-                if fmt_str:
-                    break
+            if value is not None:
+                fmt_str = self._find_format_string(value)
+            if not fmt_str and call_expr.args is not None and len(call_expr.args) > fmt_arg_idx:
+                fmt_str = self._find_format_string(call_expr.args[fmt_arg_idx])
+            if fmt_str:
+                break
 
         if not fmt_str:
             return []

--- a/tests/analyses/decompiler/test_variadic_callsite_args.py
+++ b/tests/analyses/decompiler/test_variadic_callsite_args.py
@@ -24,8 +24,13 @@ import logging
 import os
 import re
 import unittest
+from typing import cast
 
 import angr
+from angr.analyses import Decompiler
+from angr.analyses.decompiler.decompilation_options import get_structurer_option
+from angr.analyses.decompiler.structured_codegen.base import PositionMapping
+from angr.analyses.decompiler.structured_codegen.c import CFunctionCall
 from tests.common import bin_location, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -43,6 +48,80 @@ class _RecordingHandler(logging.Handler):
 
 
 class TestVariadicCallsiteArgs(unittest.TestCase):
+    def test_format_returned_by_gettext(self):
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "dirname")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        func = cfg.functions[0x402946]
+
+        for structurer in ("Phoenix", "SAILR"):
+            with self.subTest(structurer=structurer):
+                dec = proj.analyses[Decompiler].prep(fail_fast=True)(
+                    func,
+                    cfg=cfg.model,
+                    options=[(get_structurer_option(), structurer)],
+                    preset="full",
+                )
+                codegen = dec.codegen
+                if codegen is None or codegen.text is None:
+                    self.fail("decompilation did not produce C code")
+                position_map = cast(PositionMapping | None, codegen.map_pos_to_node)
+                if position_map is None:
+                    self.fail("decompilation did not produce a C position map")
+                print_decompilation_result(dec)
+
+                formatted_output_calls = [
+                    element.obj
+                    for element in position_map.values()
+                    if isinstance(element.obj, CFunctionCall)
+                    and element.obj.callee_func is not None
+                    and element.obj.callee_func.name in {"fprintf", "printf"}
+                ]
+                self.assertEqual(
+                    len(formatted_output_calls), 3, f"expected three formatted output calls:\n{codegen.text}"
+                )
+                self.assertCountEqual(
+                    [len(call.args) for call in formatted_output_calls],
+                    [3, 2, 4],
+                    "format strings returned by gettext() did not recover their variadic arguments",
+                )
+
+    def test_format_returned_by_dcgettext(self):
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "ls_ubuntu2204")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        func = cfg.functions[0x417E80]
+
+        for structurer in ("Phoenix", "SAILR"):
+            with self.subTest(structurer=structurer):
+                dec = proj.analyses[Decompiler].prep(fail_fast=True)(
+                    func,
+                    cfg=cfg.model,
+                    options=[(get_structurer_option(), structurer)],
+                    preset="full",
+                )
+                codegen = dec.codegen
+                if codegen is None or codegen.text is None:
+                    self.fail("decompilation did not produce C code")
+                position_map = cast(PositionMapping | None, codegen.map_pos_to_node)
+                if position_map is None:
+                    self.fail("decompilation did not produce a C position map")
+                print_decompilation_result(dec)
+
+                printf_calls = [
+                    element.obj
+                    for element in position_map.values()
+                    if isinstance(element.obj, CFunctionCall)
+                    and element.obj.callee_func is not None
+                    and element.obj.callee_func.name == "__printf_chk"
+                ]
+                self.assertEqual(len(printf_calls), 3, f"expected three __printf_chk() calls:\n{codegen.text}")
+                self.assertCountEqual(
+                    [len(call.args) for call in printf_calls],
+                    [3, 4, 3],
+                    "format strings returned by dcgettext() did not recover their variadic arguments",
+                )
+
     def test_mixed_size_defs_of_variadic_arg_reg_are_phi_merged(self):
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "variadic_mixed_size_args")
         proj = angr.Project(bin_path, auto_load_libs=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

DecBench `O2/dpkg/dpkg-trigger` loses printf-family substitutions in `printversion` at `0x404010` and `usage` at `0x4040a0` when the format is returned by `gettext` or `dcgettext`.

### Root cause

CallSiteMaker only extracted formats from directly loadable constants; it did not follow SRDA aliases through the documented translation-function return value.

### Fix

Format recovery follows SRDA aliases only through argument 0 of `gettext` and argument 1 of `dcgettext`. Other `char *` returners, including `getenv`, remain unsupported.

### Testing

Existing binaries exercise both translation functions under Phoenix and SAILR. The pinned DecBench cases recover the expected two, two, and one previously omitted substitutions. Validation: https://github.com/angr/angr/pull/6956#issuecomment-5423676429

session: sharpen
