### PR TITLE
Decompiler: repair chained AIL merge graph splits and their jump targets

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/ail_merge_graph.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/ail_merge_graph.py
@@ -479,11 +479,33 @@ class AILMergeGraph:
         graph = copy_graph_and_nodes(graph)
 
         # replace every block that has been split
-        updated_blocks = {}
+        updated_blocks: dict[Block, Block] = {}
+
+        def resolve_updated_block(block: Block) -> Block:
+            path = []
+            while block in updated_blocks:
+                updated_block = updated_blocks[block]
+                if updated_block is block:
+                    break
+                path.append(block)
+                block = updated_block
+            for replaced_block in path:
+                updated_blocks[replaced_block] = block
+            return block
+
         for original_node, new_node in split_map.items():
+            block = resolve_updated_block(original_node)
+            predecessors = list(graph.predecessors(block))
+            successors = list(graph.successors(block))
+            if any(pred == block for pred in predecessors):
+                new_node.statements[-1] = correct_jump_targets(
+                    new_node.statements[-1], {original_node.addr: new_node.addr}, new_stmt=True
+                )
             graph.add_node(new_node)
             # correct every in_edge to this node, with new targets for jumps
-            for pred in list(graph.predecessors(original_node)):
+            for pred in predecessors:
+                if pred == block:
+                    continue
                 new_pred = pred.copy()
                 new_pred.statements[-1] = correct_jump_targets(
                     new_pred.statements[-1], {original_node.addr: new_node.addr}, new_stmt=True
@@ -493,12 +515,16 @@ class AILMergeGraph:
                 graph.add_edge(new_pred, new_node)
 
             # re-add every out_edge
-            blk = updated_blocks.get(original_node, original_node)
-            for succ in graph.successors(blk):
-                graph.add_edge(new_node, succ)
+            for succ in successors:
+                graph.add_edge(new_node, new_node if succ == block else resolve_updated_block(succ))
 
             # finally, kill the original
-            if original_node in graph:
-                graph.remove_node(original_node)
+            graph.remove_node(block)
+            for replaced_block in list(updated_blocks):
+                if resolve_updated_block(replaced_block) is block:
+                    del updated_blocks[replaced_block]
+
+        for replaced_block in list(updated_blocks):
+            updated_blocks[replaced_block] = resolve_updated_block(replaced_block)
 
         return graph, updated_blocks

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/ail_merge_graph.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/ail_merge_graph.py
@@ -7,6 +7,7 @@ import networkx as nx
 
 from angr.ailment.block import Block
 from angr.ailment.statement import ConditionalJump
+from angr.analyses.decompiler.utils import extract_jump_targets
 
 from .errors import SAILRSemanticError
 from .similarity import ail_similarity_to_orig_blocks
@@ -480,6 +481,7 @@ class AILMergeGraph:
 
         # replace every block that has been split
         updated_blocks: dict[Block, Block] = {}
+        split_addrs: dict[int, int] = {}
 
         def resolve_updated_block(block: Block) -> Block:
             path = []
@@ -497,10 +499,16 @@ class AILMergeGraph:
             block = resolve_updated_block(original_node)
             predecessors = list(graph.predecessors(block))
             successors = list(graph.successors(block))
-            if any(pred == block for pred in predecessors):
-                new_node.statements[-1] = correct_jump_targets(
-                    new_node.statements[-1], {original_node.addr: new_node.addr}, new_stmt=True
-                )
+            split_addrs[original_node.addr] = new_node.addr
+            # a replacement is cut out of the unsplit original, so its terminator still names
+            # pre-split addresses; retarget only the ones that moved
+            terminator = new_node.statements[-1]
+            moved = {
+                addr: split_addrs[addr]
+                for addr in extract_jump_targets(terminator)
+                if split_addrs.get(addr, addr) != addr
+            }
+            new_node.statements[-1] = correct_jump_targets(terminator, moved, new_stmt=True)
             graph.add_node(new_node)
             # correct every in_edge to this node, with new targets for jumps
             for pred in predecessors:

--- a/tests/analyses/decompiler/test_ail_merge_graph_split_chain.py
+++ b/tests/analyses/decompiler/test_ail_merge_graph_split_chain.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import unittest
+from typing import cast
+
+import networkx as nx
+
+from angr.ailment import Block, Const
+from angr.ailment.statement import ConditionalJump, Jump, Label, Return
+from angr.analyses.decompiler.optimization_passes.duplication_reverter.ail_merge_graph import AILMergeGraph
+
+
+class TestAILMergeGraphSplitChain(unittest.TestCase):
+    """Tests replacement chains and cyclic graph shapes."""
+
+    def test_split_chain_uses_live_predecessor_copy(self):
+        target = Block(0x4010, 4, statements=[Return(0, [])])
+        predecessor = Block(0x4000, 4, statements=[Jump(0, Const(0, target.addr, 64))])
+        graph = nx.DiGraph([(predecessor, target)])
+
+        split_target = Block(0x5010, 4, statements=[Return(0, [])])
+        split_predecessor = Block(0x5000, 4, statements=[Jump(0, Const(0, split_target.addr, 64))])
+
+        cloned_graph, updated_blocks = AILMergeGraph.clone_graph_replace_splits(
+            graph, {target: split_target, predecessor: split_predecessor}
+        )
+
+        self.assertEqual(set(cloned_graph.nodes), {split_predecessor, split_target})
+        self.assertEqual(set(cloned_graph.edges), {(split_predecessor, split_target)})
+        self.assertEqual(updated_blocks, {})
+
+    def test_fanout_replacements_resolve_to_live_blocks(self):
+        first_target = Block(0x4010, 4, statements=[Return(0, [])])
+        second_target = Block(0x4020, 4, statements=[Return(0, [])])
+        condition = Const(0, 1, 1)
+        split_source = Block(
+            0x4000,
+            4,
+            statements=[
+                ConditionalJump(
+                    0,
+                    condition,
+                    Const(1, first_target.addr, 64),
+                    Const(2, second_target.addr, 64),
+                )
+            ],
+        )
+        unsplit_source = Block(
+            0x4100,
+            4,
+            statements=[
+                ConditionalJump(
+                    0,
+                    condition,
+                    Const(1, first_target.addr, 64),
+                    Const(2, second_target.addr, 64),
+                )
+            ],
+        )
+        graph = nx.DiGraph(
+            [
+                (split_source, first_target),
+                (split_source, second_target),
+                (unsplit_source, first_target),
+                (unsplit_source, second_target),
+            ]
+        )
+
+        split_first_target = Block(0x5010, 4, statements=[Return(0, [])])
+        split_second_target = Block(0x5020, 4, statements=[Return(0, [])])
+        split_source_replacement = Block(
+            0x5000,
+            4,
+            statements=[
+                ConditionalJump(
+                    0,
+                    condition,
+                    Const(1, split_first_target.addr, 64),
+                    Const(2, split_second_target.addr, 64),
+                )
+            ],
+        )
+
+        cloned_graph, updated_blocks = AILMergeGraph.clone_graph_replace_splits(
+            graph,
+            {
+                first_target: split_first_target,
+                second_target: split_second_target,
+                split_source: split_source_replacement,
+            },
+        )
+
+        live_unsplit_source = updated_blocks[unsplit_source]
+        self.assertEqual(
+            set(cloned_graph.nodes),
+            {split_source_replacement, live_unsplit_source, split_first_target, split_second_target},
+        )
+        self.assertEqual(
+            set(cloned_graph.edges),
+            {
+                (split_source_replacement, split_first_target),
+                (split_source_replacement, split_second_target),
+                (live_unsplit_source, split_first_target),
+                (live_unsplit_source, split_second_target),
+            },
+        )
+        self.assertTrue(all(replacement is live_unsplit_source for replacement in updated_blocks.values()))
+        self.assertTrue(all(replacement in cloned_graph for replacement in updated_blocks.values()))
+        jump = cast(ConditionalJump, live_unsplit_source.statements[-1])
+        self.assertIsInstance(jump, ConditionalJump)
+        self.assertEqual(
+            {jump.true_target.value, jump.false_target.value},
+            {split_first_target.addr, split_second_target.addr},
+        )
+
+    def test_split_self_loop(self):
+        loop = Block(0x6000, 4, statements=[Jump(0, Const(0, 0x6000, 64))])
+        graph = nx.DiGraph([(loop, loop)])
+        split_loop = Block(0x7000, 4, statements=[Jump(0, Const(0, loop.addr, 64))])
+
+        cloned_graph, updated_blocks = AILMergeGraph.clone_graph_replace_splits(graph, {loop: split_loop})
+
+        self.assertEqual(set(cloned_graph.nodes), {split_loop})
+        self.assertEqual(set(cloned_graph.edges), {(split_loop, split_loop)})
+        jump = cast(Jump, split_loop.statements[-1])
+        self.assertEqual(jump.target.value, split_loop.addr)
+        self.assertEqual(updated_blocks, {})
+
+    def test_split_two_node_loop_uses_live_successor_copy(self):
+        first = Block(0x6000, 4, statements=[Jump(0, Const(0, 0x6010, 64))])
+        second = Block(0x6010, 4, statements=[Jump(0, Const(0, 0x6000, 64))])
+        graph = nx.DiGraph([(first, second), (second, first)])
+        split_second = Block(0x7010, 4, statements=[Jump(0, Const(0, first.addr, 64))])
+
+        cloned_graph, updated_blocks = AILMergeGraph.clone_graph_replace_splits(graph, {second: split_second})
+
+        live_first = updated_blocks[first]
+        self.assertEqual(set(cloned_graph.nodes), {live_first, split_second})
+        self.assertEqual(set(cloned_graph.edges), {(live_first, split_second), (split_second, live_first)})
+        self.assertTrue(all(replacement in cloned_graph for replacement in updated_blocks.values()))
+
+    def test_equal_predecessor_copy_resolves_by_identity(self):
+        target = Block(0x8010, 8, statements=[Label(0, "target"), Return(1, [])])
+        predecessor = Block(0x8000, 4, statements=[Jump(0, Const(0, target.addr, 64))])
+        graph = nx.DiGraph([(predecessor, target)])
+        split_target = Block(target.addr, 4, statements=[Return(1, [])])
+
+        cloned_graph, updated_blocks = AILMergeGraph.clone_graph_replace_splits(graph, {target: split_target})
+
+        live_predecessor = updated_blocks[predecessor]
+        self.assertEqual(set(cloned_graph.nodes), {live_predecessor, split_target})
+        self.assertEqual(set(cloned_graph.edges), {(live_predecessor, split_target)})
+        self.assertTrue(all(replacement in cloned_graph for replacement in updated_blocks.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_ail_merge_graph_split_chain.py
+++ b/tests/analyses/decompiler/test_ail_merge_graph_split_chain.py
@@ -139,6 +139,61 @@ class TestAILMergeGraphSplitChain(unittest.TestCase):
         self.assertEqual(set(cloned_graph.edges), {(live_first, split_second), (split_second, live_first)})
         self.assertTrue(all(replacement in cloned_graph for replacement in updated_blocks.values()))
 
+    def test_replacement_jump_retargeted_to_earlier_replacement(self):
+        # a replacement is cut out of the unsplit original, so its terminator names the
+        # successor's pre-split address; here that successor was already replaced
+        target = Block(0x4010, 4, statements=[Return(0, [])])
+        source = Block(0x4000, 4, statements=[Jump(0, Const(0, target.addr, 64))])
+        graph = nx.DiGraph([(source, target)])
+
+        split_target = Block(0x5010, 4, statements=[Return(0, [])])
+        split_source = Block(0x5000, 4, statements=[Jump(0, Const(0, target.addr, 64))])
+
+        cloned_graph, _ = AILMergeGraph.clone_graph_replace_splits(graph, {target: split_target, source: split_source})
+
+        self.assertEqual(set(cloned_graph.nodes), {split_source, split_target})
+        self.assertEqual(set(cloned_graph.edges), {(split_source, split_target)})
+        jump = cast(Jump, split_source.statements[-1])
+        self.assertEqual(jump.target.value, split_target.addr)
+
+    def test_copied_replacement_keeps_earlier_retarget(self):
+        # the replacement for source becomes the predecessor of a later split and is
+        # copied again; the retarget it already carries must survive that copy
+        condition = Const(0, 1, 1)
+        first_target = Block(0x4010, 4, statements=[Return(0, [])])
+        second_target = Block(0x4020, 4, statements=[Return(0, [])])
+        source = Block(
+            0x4000,
+            4,
+            statements=[
+                ConditionalJump(0, condition, Const(1, first_target.addr, 64), Const(2, second_target.addr, 64))
+            ],
+        )
+        graph = nx.DiGraph([(source, first_target), (source, second_target)])
+
+        split_first_target = Block(0x5010, 4, statements=[Return(0, [])])
+        split_second_target = Block(0x5020, 4, statements=[Return(0, [])])
+        split_source = Block(
+            0x5000,
+            4,
+            statements=[
+                ConditionalJump(0, condition, Const(1, first_target.addr, 64), Const(2, second_target.addr, 64))
+            ],
+        )
+
+        cloned_graph, updated_blocks = AILMergeGraph.clone_graph_replace_splits(
+            graph,
+            {first_target: split_first_target, source: split_source, second_target: split_second_target},
+        )
+
+        live_source = updated_blocks[split_source]
+        self.assertEqual(set(cloned_graph.nodes), {live_source, split_first_target, split_second_target})
+        jump = cast(ConditionalJump, live_source.statements[-1])
+        self.assertEqual(
+            {jump.true_target.value, jump.false_target.value},
+            {split_first_target.addr, split_second_target.addr},
+        )
+
     def test_equal_predecessor_copy_resolves_by_identity(self):
         target = Block(0x8010, 8, statements=[Label(0, "target"), Return(1, [])])
         predecessor = Block(0x8000, 4, statements=[Jump(0, Const(0, target.addr, 64))])


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

SAILR decompilation of `logTask` at `0x802590d` in a stripped `binaries/O2/crazyflie/cf2.elf` fails with `NetworkXError` after chained AIL merge-graph splits remove a node a later split still references.

Fixing that exposes a second defect in the same function's code path. `AILMergeGraph.clone_graph_replace_splits` returns a graph in which a block's terminating jump names an address the same call has just removed:

```
graph        0x4000 -> 0x4010
split_map    0x4010 -> 0x5010, then 0x4000 -> 0x5000
returned     nodes 0x5000, 0x5010; edge 0x5000 -> 0x5010
             but 0x5000 ends in "Jump 0x4010", and 0x4010 is gone
```

`DuplicationReverter._correct_all_broken_jumps` repairs some of that afterwards, on the merged graph: an out-degree-1 node whose `Jump` names the wrong address, and an out-degree-2 node with exactly one wrong `ConditionalJump` target. It cannot repair a conditional jump with both targets wrong, and it does not look at a node whose out-degree is anything else. Over the enumeration in the validation record that leaves 1,372 of 4,312 stale targets standing. It also runs at the end of `_reinsert_merged_candidate`, while `create_mapping_to_merge_graph` and `add_edges_to_condition` read this graph before that.

### Root cause

Two commits, two causes.

**Resolve chained AIL merge graph splits.** A split updated immediate edges but did not resolve subsequent split endpoints through the replacement chain, so a later split asked the graph for a node an earlier split had already replaced.

**Retarget a split replacement block's own jump targets.** Replacement blocks arrive as `AILBlockSplit.match_split` values. `split_ail_block` cuts those out of the unsplit original's statement list without rewriting them, so when the matched run reaches the end of the block the replacement's terminator still names its successors' pre-split addresses. The loop retargets a copied predecessor's terminator with a one-entry map for the split it is processing, and never retargets the replacement's own terminator except when the block is among its own predecessors.

### Fix

Merge-graph splitting follows and updates chained replacements before applying each later split, preserving valid endpoints across split orders. On top of that, it keeps the replacement address of every split done so far and retargets each replacement's terminator through the entries it names that moved — restricting the map to entries that moved keeps `correct_jump_targets` from rebuilding a statement it does not change, which would drop the jump's `target_idx`.

### Testing

Seven regressions in `tests/analyses/decompiler/test_ail_merge_graph_split_chain.py`. The two new ones fail on the first commit alone and pass on the second. On master five of the seven fail, four of them on the removed-node `NetworkXError`.

The second commit has no binary reproducer: of 293 real calls probed, only 6 split more than one block and none left a stale target, and on `logTask` it is inert. The record has the population.

Two things this deliberately does not change, both pre-existing and measured rather than guessed. `correct_jump_targets` rebuilds and re-indexes a jump whenever its map is non-empty without checking that a target matches, which is on master's real path today at the copied-predecessor call; #6963 proposes a helper for the same problem in `add_edges_to_condition`. And `resolve_updated_block` would not terminate on a cyclic `updated_blocks`; that needs two replacements to swap addresses, and `split_ail_block` gives a replacement either its block's own address or one inside it, so 150,000 generated cases over those two choices produce no cycle while a control that allows any address produces 30.

Validation: https://github.com/angr/angr/pull/6958#issuecomment-5424909418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen