### PR TITLE
CFGBase: Do not let a zero-size node anchor a normalization group

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -1306,7 +1306,11 @@ class CFGBase(Analysis):
         end_addr_to_nodes = defaultdict(list)  # a dictionary from node key to nodes *if* more than one node exist
 
         for n in graph.nodes():
-            if n.is_simprocedure:
+            if n.is_simprocedure or not n.size:
+                # a zero-size node has no extent, so it cannot overlap anything and cannot be split at. Indexing it
+                # by its end address puts it in the group of every node that ends where it starts, where its address
+                # is the highest one and it is therefore picked as the node to break the others at - which shortens
+                # nothing and leaves the real overlap in that group unsplit.
                 continue
             end_addr = n.addr + n.size
             key = (end_addr, n.callstack_key)

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -875,6 +875,30 @@ class TestCfgfast(unittest.TestCase):
         assert node is not None
         assert node.function_address == 0x40F770
 
+    def test_normalize_does_not_anchor_a_group_on_a_zero_size_node(self):
+        # a UDF instruction lifts to a zero-byte IRSB, and CFGFast still records an ordinary (non-SimProcedure)
+        # CFGNode for it. Two overlapping blocks end where that node starts, so grouping nodes by end address
+        # collects all three, and the zero-extent node has the highest address in the group.
+        path = os.path.join(test_location, "armel", "normalize_zero_size_anchor")
+        proj = angr.Project(path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        assert cfg.normalized
+
+        nodes = [n for n in cfg.model.nodes() if not n.is_simprocedure]
+        sized = [n for n in nodes if n.size]
+
+        # guard the fixture: it stops covering this defect if it ever loses the zero-size node that shares an
+        # end address with sized blocks
+        end_addrs = {n.addr + n.size for n in sized}
+        assert any(not n.size and n.addr in end_addrs for n in nodes)
+
+        # normalization's contract: no block may start at a non-leading instruction of another block
+        block_starts = {n.addr for n in sized}
+        for n in sized:
+            instruction_addrs = list(n.instruction_addrs)
+            inner_starts = [i for i in instruction_addrs[1:] if i in block_starts]
+            assert not inner_starts, f"{n!r} was left unsplit at {[hex(i) for i in inner_starts]}"
+
     def test_removing_lock_edges(self):
         path = os.path.join(
             test_location, "x86_64", "windows", "6f289eb8c8cd826525d79b195b1cf187df509d56120427b10ea3fb1b4db1b7b5.sys"


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGBase.normalize()` reports the model normalized while leaving overlapping blocks behind. On `binaries/tests/armel/normalize_zero_size_anchor`, after `CFGFast(normalize=True)`:

```
cfg.normalized = True

nodes grouped by end address, groups with more than one member:
  end=0x100a0 -> (0x10098, size 8), (0x1009c, size 4), (0x100a0, size 0)

blocks left starting at a non-leading instruction of another block:
  0x10098 (size 8) is unsplit at 0x1009c
```

The block at `0x10098` still covers the block that starts at `0x1009c`, which is the state normalization exists to remove, and `normalized` is set unconditionally at the end of the pass regardless. That flag is the only signal a consumer has.

### Root cause

`normalize()` indexes nodes by end address, then breaks each group at its highest-addressed member:

```python
for n in graph.nodes():
    if n.is_simprocedure:
        continue
    end_addr = n.addr + n.size
    key = (end_addr, n.callstack_key)
```
```python
all_nodes = sorted(all_nodes, key=lambda node: node.addr, reverse=True)
smallest_node = all_nodes[0]  # take the one that has the highest address
```

A node of size zero ends where it starts, so it joins the group of every node that ends at its address and wins that comparison in all of them. `_normalize_core` then shortens the other members to end at the anchor's address — where they already end — and its one guard against a no-op,

```python
if new_size == 0:
    # This node has the same size as the smallest one. Don't touch it.
    continue
```

only skips the member whose address equals the anchor's. Its comment describes grouping by end address alone, where a zero difference did mean the node was the group's smallest; pairs with different end addresses now reach the same path.

`0x100a0` above is a `UDF` word. It lifts to an empty IRSB, and `_gen_cfgnode` records an ordinary, non-SimProcedure `CFGNode` of size 0 for it, which is what makes it eligible to anchor the group. The real overlap, `0x10098` against `0x1009c`, is never considered.

### Fix

Skip zero-size nodes when the index is built, alongside the SimProcedure nodes skipped there already: neither has an extent, so neither can overlap anything or be split at. Same fixture, after:

```
nodes grouped by end address, groups with more than one member:
  end=0x100a0 -> (0x1009c, size 4), (0x100a0, size 0)

blocks left starting at a non-leading instruction of another block:
  none
```

`0x10098` is shortened from 8 bytes to 4 and the node set is otherwise identical — ten non-SimProcedure nodes at the same ten addresses on both sides. Only anchor selection is touched: normalization still does not iterate to a fixed point, and the architecture gate on `_remove_redundant_overlapping_blocks` is left alone.

### Testing

`test_normalize_does_not_anchor_a_group_on_a_zero_size_node` asserts the structural contract — no block starts at a non-leading instruction of another block — and guards the fixture by requiring a zero-size node sharing an end address with sized blocks to still be present. On the merge base it fails with `AssertionError: <CFGNode entangle+0x14 [8]> was left unsplit at ['0x1009c']`. Thirteen existing fixtures carry splittable overlaps reached by a different route, and this head leaves every one of them exactly as it found them.

The fixture is added by binaries 201, and the test fails until that merges.

Validation: https://github.com/angr/angr/pull/6960#issuecomment-5424979068

sync: angr/binaries#201

session: mega-corpus
