### PR TITLE
AIL: Carry a gymrat Dirty statement through with its memory effects unset

### DIFF
--- a/native/angr/src/ailment/convert_vex.rs
+++ b/native/angr/src/ailment/convert_vex.rs
@@ -2359,9 +2359,9 @@ impl<'py> IrReader for PyReader<'py> {
                     callee: stmt.getattr("cee")?.getattr("name")?.extract()?,
                     args,
                     guard,
-                    mfx: Some(stmt.getattr("mFx")?.extract()?),
+                    mfx: stmt.getattr("mFx")?.extract()?,
                     maddr,
-                    msize: Some(stmt.getattr("mSize")?.extract()?),
+                    msize: stmt.getattr("mSize")?.extract()?,
                     tmp,
                     tmp_bits,
                 }

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -12,12 +12,15 @@ from pyvex.enums import irop_enums_to_ints
 
 import angr
 from angr import ailment
+from angr.ailment.expression import DirtyExpression
 from angr.engines.pcode.lifter import IRSB as PCodeIRSB
 from angr.engines.vex.claripy import irop
 from angr.rustylib.ailment import RoundingMode, VEXIRSBConverter, _vexop_debug
 
 # pylint: disable=missing-class-docstring
 # pylint: disable=line-too-long
+
+test_location = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "binaries", "tests"))
 
 
 class TestIrsb(unittest.TestCase):
@@ -32,6 +35,33 @@ class TestIrsb(unittest.TestCase):
         irsb = pyvex.IRSB(self.block_bytes, self.block_addr, arch, opt_level=0)
         ablock = ailment.IRSBConverter.convert(irsb, manager)
         assert ablock  # TODO: test if this conversion is valid
+
+    def test_convert_gymrat_dirty_leaves_memory_effects_unset(self):
+        # The block at 0x1400017c8 contains rdmsr, which libVEX cannot decode, so pyvex
+        # falls back to its gymrat lifter. That lifter leaves the Dirty statement's
+        # memory-effect fields unset, which the libVEX front end never does.
+        binary_path = os.path.join(test_location, "x86_64", "windows", "CorsairLLAccess64.sys")
+        proj = angr.Project(binary_path, auto_load_libs=False)
+        irsb = proj.factory.block(0x1400017C8).vex
+
+        dirty = [stmt for stmt in irsb.statements if isinstance(stmt, pyvex.stmt.Dirty)]
+        assert len(dirty) == 1
+        assert dirty[0].mFx is None
+        assert dirty[0].mSize is None
+
+        manager = ailment.Manager()
+        ablock = ailment.IRSBConverter.convert(irsb, manager)
+
+        converted = [
+            expr
+            for stmt in ablock.statements
+            for expr in (getattr(stmt, "src", None), getattr(stmt, "dst", None), getattr(stmt, "dirty", None))
+            if isinstance(expr, DirtyExpression)
+        ]
+        assert len(converted) == 1
+        assert converted[0].callee == "amd64g_dirtyhelper_RDMSR"
+        assert converted[0].mfx is None
+        assert converted[0].msize is None
 
     def test_convert_from_pcode_irsb(self):
         arch = archinfo.arch_from_id("AMD64")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ailment.IRSBConverter.convert` raises on an AMD64 block holding `iretq`, `rdmsr` or `sysret`, and on a 32-bit x86 block holding `rdmsr` or `xgetbv`. The function being decompiled is then lost: no AIL graph, no structuring and no C, on the first attempt and on the basic-preset retry.

```
File "angr/analyses/decompiler/clinic.py", line 1574, in _convert_vex
    return ailment.IRSBConverter.convert(block.vex, self._ail_manager)
File "angr/ailment/__init__.py", line 60, in convert
    return VEXIRSBConverter.convert(irsb, manager)
TypeError: 'None' is not an instance of 'str'
```

`Clinic._convert_vex` reaches that line whenever the direct libVEX re-lift in `_convert_vex_fast` declines the block. Both of these give the traceback above:

- `angr.load_shellcode(b"\x48\xcf", "amd64")`, then `CFGFast` and `Decompiler`. libVEX cannot lift a block that starts with `iretq`, so the re-lift raises and the Python IRSB is converted instead.
- `binaries/tests/x86_64/windows/CorsairLLAccess64.sys`, function `sub_1400017b4` at `0x1400017b4`, whose block `0x1400017c8` holds `rdmsr` at `0x1400017cd`, decompiled with anything in `kb.patches`. The re-lift declines for every patched project.

Loaded with no patches that function does survive, because the re-lift goes through libVEX alone and puts `__unsupported_jumpkind_Ijk_NoDecode()` where the `rdmsr` was, discarding the dirty helper pyvex had recovered — a separate gap this change does not close. `Clinic._create_triangle_for_ite_expression` calls the Python converter with no re-lift at all.

### Root cause

pyvex falls back to its gymrat lifters for what libVEX will not decode, and their `IRSBCustomizer.dirty` builds the statement with its memory-effect fields unset — the block above lifts to `t15 = DIRTY 1 TODO(effects) ::: amd64g_dirtyhelper_RDMSR(t14)`, with `mFx`, `mAddr`, `mSize` and `nFxState` all `None`. `Dirty._from_c` can never produce that shape, so it reaches the converter only on the Python-IRSB path.

`PyReader::stmt_kind` in `native/angr/src/ailment/convert_vex.rs` wraps two of those extractions in `Some(...)`:

```rust
mfx: Some(stmt.getattr("mFx")?.extract()?),
maddr,
msize: Some(stmt.getattr("mSize")?.extract()?),
```

which forces PyO3 to extract into non-optional `String` and `i64`, while `guard` and `maddr` in the same match arm extract into `Option` correctly. The struct fields are already `Option<String>` and `Option<i64>`, and `angr/rustylib/ailment.pyi` declares `mfx: str | None` and `msize: int | None`, so `None` is a legitimate value here rather than an error signal. Two are stacked: patching `mFx` alone moves the failure one line down to `mSize`, as `'NoneType' object cannot be interpreted as an integer`. This is a regression from the Rust port (`654fbcea8`, #6608) — the Python converter it replaced passed both through unchanged.

### Fix

Drop the two `Some(...)` wrappers so each field extracts into the optional type it already declares. Block `0x1400017c8` now converts to 33 AIL statements with the dirty expression carried through:

```
10 | 0x1400017cd | t15 = [D] amd64g_dirtyhelper_RDMSR(t14)
...
  [D] amd64g_dirtyhelper_RDMSR(t14)
    callee   = 'amd64g_dirtyhelper_RDMSR'
    guard    = 1<1>
    mfx      = None
    maddr    = None
    msize    = None
```

This is not a decompiler change and it does not model the instruction's effects; it stops an unset optional field from being read as a required one. Only four gymrat instructions call `.dirty()`, all of them in `pyvex/lifting/gym/x86_spotter.py` — `IRETQ`, `RDMSR`, `SYSRET` and `XGETBV` — so no ARM or AArch64 block reaches this at all.

### Testing

`tests/ailment/test_irsb.py::TestIrsb::test_convert_gymrat_dirty_leaves_memory_effects_unset` loads the committed fixture above, converts block `0x1400017c8`, and asserts the round trip preserves `mfx` and `msize` as `None`. It needs no CFG. It fails on the merge base with the `TypeError` above and passes on this head. It resolves the fixture root from `__file__` rather than through `tests.common`, because `tests/ailment` carries no `__init__.py` and `tests` does not resolve from a module imported out of it.

Validation: https://github.com/angr/angr/pull/6961#issuecomment-5425235444

session: sharpen