### PR TITLE
Decompiler: Respect the updated entry node address in DeadblockRemover

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/deadblock_remover.py
+++ b/angr/analyses/decompiler/optimization_passes/deadblock_remover.py
@@ -59,7 +59,7 @@ class DeadblockRemover(OptimizationPass):
         to_remove = {
             blk
             for blk in self._graph.nodes()
-            if (blk.addr != self._func.addr and self._graph.in_degree(blk) == 0)
+            if ((blk.addr, blk.idx) != self.entry_node_addr and self._graph.in_degree(blk) == 0)
             or claripy.is_false(cond_proc.reaching_conditions.get(blk, claripy.true()))
         }
 

--- a/tests/analyses/decompiler/test_optimization_passes.py
+++ b/tests/analyses/decompiler/test_optimization_passes.py
@@ -318,13 +318,14 @@ class TestDeadblockRemover(unittest.TestCase):
         assert dec.clinic.entry_node_addr == (self.ENTRY_ADDR, None)
         assert dec.clinic.entry_node_addr[0] != func.addr
 
+        assert dec.clinic.graph is not None
         block_addrs = {block.addr for block in dec.clinic.graph}
         # DeadblockRemover really ran: the block behind the opaque predicate is gone
         assert self.DEAD_ADDR not in block_addrs
         # ... and it left the entry block alone
         assert self.ENTRY_ADDR in block_addrs
 
-        assert dec.codegen is not None
+        assert dec.codegen is not None and isinstance(dec.codegen.text, str)
         assert func.name in dec.codegen.text
 
 

--- a/tests/analyses/decompiler/test_optimization_passes.py
+++ b/tests/analyses/decompiler/test_optimization_passes.py
@@ -239,5 +239,94 @@ class TestDetermineLoadSizes(unittest.TestCase):
         assert stmt.src.size == UNDETERMINED_SIZE
 
 
+class TestDeadblockRemover(unittest.TestCase):
+    """
+    Test DeadblockRemover optimization pass.
+    """
+
+    # AMD64 shellcode loaded at 0x400000. It holds three functions; the one under test is sub_400010.
+    #
+    #   0x400000  e8 0b 00 00 00   call  0x400010          ; sub_400000 calls the function under test ...
+    #   0x400005  e8 36 00 00 00   call  0x400040          ; ... and the helper below
+    #   0x40000a  c3               ret
+    #   0x40000b  cc cc cc cc cc                            ; padding
+    #
+    #   0x400010  0f 1f 00         nop   dword ptr [rax]   ; sub_400010: alignment padding, a block of its own
+    #   0x400013  48 ff c1         inc   rcx               ; the function's real entry block
+    #   0x400016  48 83 ff 05      cmp   rdi, 5            ; loop head
+    #   0x40001a  75 0b            jne   0x400027
+    #   0x40001c  48 83 ff 07      cmp   rdi, 7            ; only reached when rdi == 5 ...
+    #   0x400020  74 09            je    0x40002b          ; ... so this needs rdi == 5 and rdi == 7
+    #   0x400022  48 ff c2         inc   rdx
+    #   0x400025  eb ef            jmp   0x400016          ; back edge to the loop head
+    #   0x400027  48 ff c6         inc   rsi
+    #   0x40002a  c3               ret
+    #   0x40002b  48 ff c7         inc   rdi               ; the opaque-predicate target
+    #   0x40002e  c3               ret
+    #   0x40002f  cc ... cc                                 ; padding
+    #
+    #   0x400040  48 85 c0         test  rax, rax          ; sub_400040
+    #   0x400043  74 ce            je    0x400013          ; jumps into the middle of sub_400010
+    #   0x400045  49 ff c0         inc   r8
+    #   0x400048  c3               ret
+    #
+    # The layout is built so that three things hold at once, which is what it takes to reach the defect:
+    #
+    # 1. sub_400010 starts with a nop-only block that has in-degree 0 and out-degree 1, so
+    #    Clinic._remove_alignment_blocks drops it and moves entry_node_addr from 0x400010 to 0x400013.
+    #    0x400013 is a block boundary only because sub_400040 jumps there; without that the nop would be
+    #    lifted as part of one larger block and there would be no alignment block to remove. sub_400010 is
+    #    reached by a call, which keeps CFGFast from splitting the nop off into a function of its own.
+    # 2. DeadblockRemover._check fires: the graph is far below the 200-node cutoff, and 0x40002b is
+    #    reachable only along a path that requires rdi == 5 and rdi == 7, so its reaching condition is
+    #    unsatisfiable.
+    # 3. The new entry block at 0x400013 has in-degree 0 in the AIL graph. Its only predecessor was the
+    #    alignment block, and the edge from sub_400040 is an outside transition that does not appear in
+    #    sub_400010's own graph.
+    #
+    # The rest of the function is a loop, so once 0x400013 and the dead 0x40002b are swept every remaining
+    # block still has a predecessor and RegionIdentifier._get_start_node cannot fall back to an in-degree-0
+    # node -- it raises AngrRuntimeError("Cannot find the start node from the graph!").
+    SHELLCODE = (
+        b"\xe8\x0b\x00\x00\x00\xe8\x36\x00\x00\x00\xc3\xcc\xcc\xcc\xcc\xcc"
+        b"\x0f\x1f\x00\x48\xff\xc1\x48\x83\xff\x05\x75\x0b\x48\x83\xff\x07"
+        b"\x74\x09\x48\xff\xc2\xeb\xef\x48\xff\xc6\xc3\x48\xff\xc7\xc3\xcc"
+        b"\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc"
+        b"\x48\x85\xc0\x74\xce\x49\xff\xc0\xc3"
+    )
+    BASE = 0x400000
+    FUNC_ADDR = 0x400010
+    ENTRY_ADDR = 0x400013
+    DEAD_ADDR = 0x40002B
+
+    def test_entry_block_moved_by_alignment_removal_is_not_swept(self):
+        """
+        DeadblockRemover used to compare each in-degree-0 block against the *function* address. When
+        Clinic._remove_alignment_blocks has moved the entry off the function address, that comparison deletes
+        the real entry block and decompilation dies in RegionIdentifier. It must compare against
+        entry_node_addr instead.
+        """
+        proj = angr.load_shellcode(self.SHELLCODE, "AMD64", load_address=self.BASE)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        func = cfg.functions[self.FUNC_ADDR]
+
+        dec = proj.analyses[angr.analyses.Decompiler].prep(fail_fast=True)(func, cfg=cfg.model)
+
+        # the construction still does what the comment claims: the alignment block was removed and the entry
+        # was moved off the function address
+        assert dec.clinic is not None
+        assert dec.clinic.entry_node_addr == (self.ENTRY_ADDR, None)
+        assert dec.clinic.entry_node_addr[0] != func.addr
+
+        block_addrs = {block.addr for block in dec.clinic.graph}
+        # DeadblockRemover really ran: the block behind the opaque predicate is gone
+        assert self.DEAD_ADDR not in block_addrs
+        # ... and it left the entry block alone
+        assert self.ENTRY_ADDR in block_addrs
+
+        assert dec.codegen is not None
+        assert func.name in dec.codegen.text
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A function whose entry is a nop alignment block loses its real entry block and cannot be structured. Reproducer: `tests/analyses/decompiler/test_optimization_passes.py::TestDeadblockRemover::test_entry_block_moved_by_alignment_removal_is_not_swept`, function `sub_400010` at `0x400010`, whose entry alignment block is dropped and whose entry therefore moves to `0x400013`. With `fail_fast=True`:

```
File "angr/analyses/decompiler/region_identifier.py", line 234, in _get_start_node
    raise AngrRuntimeError("Cannot find the start node from the graph!") from ex
angr.errors.AngrRuntimeError: Cannot find the start node from the graph!
```

The raise site is two stages downstream of the cause. Off the fail-fast path it is worse than an error: `Decompiler` swallows it and redoes the whole function under the `basic` preset, which does not run this pass at all, so the caller gets output that still carries the unsatisfiable branch at `0x40002b` and no indication that anything failed.

### Root cause

`Clinic._remove_alignment_blocks` (`clinic.py:1231-1248`) removes a nop-only first block with in-degree 0 and out-degree 1 and sets `self.entry_node_addr = (successor.addr, None)`; `clinic.py:1244` is the only place `entry_node_addr` ever diverges from `func.addr`. `Decompiler._run_graph_simplification_passes` hands that updated address to every `BEFORE_REGION_IDENTIFICATION` pass (`decompiler.py:673`) for exactly this reason. `DeadblockRemover._analyze` ignored it and recognised the entry by the function address instead:

```python
if (blk.addr != self._func.addr and self._graph.in_degree(blk) == 0)
```

so on such a function the real entry block is swept as an unreachable orphan. `RegionIdentifier._get_start_node` then finds no in-degree-0 node, its fallback lookup by entry node address finds nothing, and it raises. This is the omission #4892 was meant to close: that PR touched `clinic.py`, `decompiler.py`, `optimization_pass.py` and `region_identifier.py`, but not `DeadblockRemover`, which predates it (#4649).

### Fix

Guard the entry with the entry node address the pass already receives, the way the passes updated alongside it do:

```python
if ((blk.addr, blk.idx) != self.entry_node_addr and self._graph.in_degree(blk) == 0)
```

The entry block at `0x400013` now survives, the unsatisfiable block at `0x40002b` is swept as intended, and the function structures under its own preset rather than under the basic-preset retry.

### Testing

The new case builds the three conditions this needs — an alignment-padded entry, `DeadblockRemover` firing on an unsatisfiable reaching condition, and a residual graph with no in-degree-0 node — and asserts each structurally: that the entry really moved, that the opaque-predicate block really was swept, and that the entry block survives. It fails on the merge base with the traceback above (`1 failed`) and passes on this head (`1 passed`).

There is no public binary to point at, and that is measured rather than assumed: a scan of 1752 public binaries and 1,431,329 functions found 1673 functions meeting the first condition and 54 meeting the first two, but none meeting all three, because the residual graph has to be fully cyclic. The corpus function that exposed this is not public.

Validation: https://github.com/angr/angr/pull/6962#issuecomment-5425241200

session: sharpen