### PR TITLE
CCodeGen: do not descend into a struct kernel that has no fields

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -3607,7 +3607,7 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
 
             # nothing has the ability to escape the kernel
             # go in deeper
-            if isinstance(kernel_type, SimStruct):
+            if isinstance(kernel_type, SimStruct) and kernel_type.offsets:
                 field_name, field_offset = max(
                     ((x, y) for x, y in kernel_type.offsets.items() if y <= constant), key=lambda x: x[1]
                 )

--- a/tests/analyses/decompiler/test_struct_member_access.py
+++ b/tests/analyses/decompiler/test_struct_member_access.py
@@ -6,9 +6,21 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 import os.path
 import unittest
 
+import archinfo
+
 import angr
 from angr import default_cc
-from angr.sim_type import PointerDisposition
+from angr.analyses.decompiler.structured_codegen.c import (
+    CBinaryOp,
+    CExpression,
+    CStructuredCodeGenerator,
+)
+from angr.sim_type import (
+    PointerDisposition,
+    SimCppClass,
+    SimTypeInt,
+    SimTypePointer,
+)
 from tests.common import bin_location, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -42,6 +54,70 @@ class TestStructMemberAccess(unittest.TestCase):
         assert '.a = "123"' in text
         assert ".b.a = 2" in text
         assert ".b.b = 3" in text
+
+
+class _MinimalCodegen(CStructuredCodeGenerator):
+    """The real code generator with only the state ``_access`` reads.
+
+    Constructing a full ``CStructuredCodeGenerator`` needs a decompilation; ``_access`` itself
+    needs an architecture and the node-numbering counters, so this initialises exactly those
+    and leaves the method under test untouched.
+    """
+
+    class _Project:  # pylint:disable=too-few-public-methods
+        def __init__(self, arch):
+            self.arch = arch
+
+    def __init__(self, arch):  # pylint:disable=super-init-not-called
+        self.project = self._Project(arch)
+        self.reset_ident_counters()
+        self._next_node_idx = 0
+        self.cstyle_null_cmp = False
+
+    def _access_constant_offset(self, *args, **kwargs):
+        # A tripwire rather than a stub: if the walk ever descends by a constant offset the test
+        # has taken a different path and would otherwise pass for the wrong reason.
+        raise AssertionError("_access should not reach _access_constant_offset here")
+
+
+class _TypedExpression(CExpression):
+    """A leaf expression that only has to carry a type."""
+
+    def __init__(self, ty, codegen):
+        super().__init__(codegen=codegen)
+        self._ty = ty
+
+    @property
+    def type(self):
+        return self._ty
+
+    def c_repr_chunks(self, indent=0, asexpr=False):
+        yield "x", self
+
+
+class TestAccessOpaqueAggregate(unittest.TestCase):
+    def test_access_through_pointer_to_member_less_class(self):
+        # An opaque C++ class - one whose layout angr does not know - is built with no members
+        # and a forced size, so its `offsets` is empty while its size is non-zero. Indexing
+        # through a pointer to one used to select the greatest field offset not past the running
+        # constant, which is `max()` over an empty sequence.
+        #
+        # The shape matters: two summed terms are needed for `_access` to enter its `while terms`
+        # loop at all, because a lone expression becomes the kernel and the loop never runs. With
+        # `p + i` the state on entry is a zero constant, a kernel stride of the class size and a
+        # next stride of one, which is the state observed on a real binary that hit this.
+        arch = archinfo.ArchX86()
+        codegen = _MinimalCodegen(arch)
+        opaque = SimCppClass(unique_name="Opaque", name="Opaque", members={}, size=32)
+        assert not opaque.with_arch(arch).offsets
+
+        pointer = _TypedExpression(SimTypePointer(opaque).with_arch(arch), codegen)
+        index = _TypedExpression(SimTypeInt(signed=True).with_arch(arch), codegen)
+        summed = CBinaryOp("Add", pointer, index, codegen=codegen)
+
+        # bails out to pointer arithmetic instead of raising
+        result = CStructuredCodeGenerator._access(codegen, summed, SimTypeInt(signed=True).with_arch(arch), False)
+        assert isinstance(result, CExpression)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`CStructuredCodeGenerator._access` descends into a struct kernel by selecting the field with the greatest offset not past the running constant. When the struct has no fields that selection runs over an empty sequence and `max` raises, so the function produces no output at all and the basic-preset retry fails identically.

The sibling `_access_constant_offset` already requires non-empty offsets before the identical expression, but that guard does not cover this site: `SimStruct.size` is zero when offsets is empty and `_access` bails out on a zero-sized kernel, so only a `SimCppClass`, whose size is forced because the class is opaque, arrives here with nothing to descend into.

Requiring non-empty offsets lets such a kernel fall through to the bail-out the method already uses when it cannot descend, rendering the access as pointer arithmetic. The condition is false only where the previous code raised.

Validation: https://github.com/angr/angr/pull/6965#issuecomment-5429060225

session: emo-corpus
