### PR TITLE
Decompiler: handle sizeless children in widening casts

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -4464,7 +4464,11 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
         # do we need an intermediate cast?
         if orig_child_signed != expr.is_signed and expr.to_bits > expr.from_bits and child.type is not None:
             # this is a problem. sign-extension only happens when the SOURCE of the cast is signed
-            child_ty = self.default_simtype_from_bits(child.type.size, expr.is_signed)
+            # child.type.size is None for a SimTypeBottom and 0 for a struct that reached us with no
+            # fields, and neither can be the width of an integer cast. The AIL conversion carries the
+            # source width, so fall back to it whenever the rendered type does not supply one.
+            child_size = child.type.size
+            child_ty = self.default_simtype_from_bits(child_size or expr.from_bits, expr.is_signed)
             child = CTypeCast(None, child_ty, child, codegen=self)
 
         return CTypeCast(None, dst_type.with_arch(self.project.arch), child, tags=expr.tags, codegen=self)

--- a/tests/analyses/decompiler/test_structured_codegen.py
+++ b/tests/analyses/decompiler/test_structured_codegen.py
@@ -9,15 +9,19 @@ import os
 import re
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import angr
 from angr.ailment import Expr, Stmt
 from angr.analyses.decompiler.structured_codegen.c import (
     CAssignment,
+    CBinaryOp,
+    CConstant,
     CExpression,
     CGoto,
     CReturn,
     CStructuredCodeGenerator,
+    CTypeCast,
     CUnaryOp,
     type_to_c_repr_chunks,
 )
@@ -35,7 +39,7 @@ from angr.sim_type import (
     SimUnion,
     parse_cpp_file,
 )
-from tests.common import WORKER, bin_location, print_decompilation_result
+from tests.common import WORKER, bin_location, load_project_with_scoped_cfg, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
 
@@ -57,11 +61,15 @@ class _RenderedExpression(CExpression):
 class TestConvertRendering(unittest.TestCase):
     """How CStructuredCodeGenerator renders Convert expressions of assorted widths."""
 
+    codegen: CStructuredCodeGenerator
+
     @classmethod
     def setUpClass(cls):
         proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
         cfg = proj.analyses.CFGFast(normalize=True)
-        cls.codegen = proj.analyses.Decompiler(cfg.functions["main"], cfg=cfg).codegen
+        codegen = proj.analyses.Decompiler(cfg.functions["main"], cfg=cfg).codegen
+        assert isinstance(codegen, CStructuredCodeGenerator)
+        cls.codegen = codegen
 
     def _render(self, from_bits: int, to_bits: int, value: int = 0x1234) -> str:
         conv = Expr.Convert(0, from_bits, to_bits, False, Expr.Const(0, value, from_bits))
@@ -84,6 +92,39 @@ class TestConvertRendering(unittest.TestCase):
         assert self._render(1, 5, value=1) == "(char)1"
         assert self._render(8, 12, value=3) == "(unsigned short)3"
         assert self._render(32, 64, value=3) == "(unsigned long long)3"
+
+    def test_widening_sizeless_child_uses_ail_source_width(self):
+        unknown_type = SimTypeBottom().with_arch(self.codegen.project.arch)
+        child = CBinaryOp(
+            "Shr",
+            CConstant(1, unknown_type, codegen=self.codegen),
+            CConstant(2, unknown_type, codegen=self.codegen),
+            codegen=self.codegen,
+        )
+        assert child.type.size is None
+
+        conv = Expr.Convert(0, 1, 64, True, Expr.Const(0, 1, 1))
+        with patch.object(self.codegen, "_handle", return_value=child):
+            rendered = self.codegen._handle_Expr_Convert(conv)
+
+        assert isinstance(rendered, CTypeCast)
+        assert isinstance(rendered.expr, CTypeCast)
+        assert rendered.expr.dst_type.size == conv.from_bits
+        assert getattr(rendered.expr.dst_type, "signed", None) is True
+        assert rendered.c_repr() == "(long long)(int1_t)(1 >> 2)"
+
+    def test_widening_known_child_keeps_inferred_width(self):
+        known_type = self.codegen.default_simtype_from_bits(16, signed=False)
+        child = CConstant(1, known_type, codegen=self.codegen)
+        conv = Expr.Convert(0, 32, 64, True, Expr.Const(0, 1, 32))
+        with patch.object(self.codegen, "_handle", return_value=child):
+            rendered = self.codegen._handle_Expr_Convert(conv)
+
+        assert isinstance(rendered, CTypeCast)
+        assert isinstance(rendered.expr, CTypeCast)
+        assert rendered.expr.dst_type.size == known_type.size
+        assert getattr(rendered.expr.dst_type, "signed", None) is True
+        assert rendered.c_repr() == "(long long)(short)1"
 
 
 class TestGotoRendering(unittest.TestCase):
@@ -366,6 +407,28 @@ class TestMultiRegisterReturnEndToEnd(unittest.TestCase):
         # decoderune's error path is Go's `return RuneError, 1`, so rax holds 0xfffd and rbx the size.
         # rbx is the second location, which is the high half, so it is the first operand.
         assert "return CONCAT(a2 + 1, 0xfffd);" in text, text
+
+
+class TestConvertOfZeroWidthChild(unittest.TestCase):
+    """A widening cast whose child is rendered with a type that has no width."""
+
+    def test_widening_a_child_typed_as_a_fieldless_struct(self):
+        # Go's runtime.setThreadCPUProfiler calls timer_create, and the kernel prototype spells that
+        # syscall's second argument as SimStruct({}, name="sigevent"). A struct with no fields has
+        # size 0, so a stack variable reaches the code generator with a type whose size is 0 rather
+        # than None. The intermediate sign-extension cast then asked for an integer of that width and
+        # got int0_t, and MakeTypecastsImplicit.collapse asserted on its size, so the whole function
+        # produced no C at all.
+        bin_path = os.path.join(test_location, "x86_64", "langdetect_go")
+        proj, cfg = load_project_with_scoped_cfg(bin_path, 0x430CA0, project_kwargs={"auto_load_libs": False})
+
+        dec = proj.analyses.Decompiler(cfg.functions[0x430CA0], cfg=cfg, fail_fast=True)
+        assert dec.codegen is not None
+        print_decompilation_result(dec)
+
+        text = dec.codegen.text or ""
+        assert text.strip()
+        assert "int0_t" not in text, text
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Go's `runtime.setThreadCPUProfiler` at `0x430ca0` in `tests/x86_64/langdetect_go`, a fixture `angr/binaries` already tracks, decompiles to nothing at all:

```text
  File "angr/analyses/decompiler/structured_codegen/c.py", line 4770, in handle_CFunctionCall
    obj.args[i] = self.collapse(arg_ty, c_arg)
  File "angr/analyses/decompiler/structured_codegen/c.py", line 4748, in collapse
    assert dst_ty.size and start_ty.size and intermediate_ty.size
AssertionError
```

The assertion fires while C is being generated, so the whole function is lost, not one expression: `Decompiler` returns an empty `codegen.text` and two caught `AssertionError`s.

### Root cause

`_handle_Expr_Convert` builds an intermediate sign-extension cast and asks `default_simtype_from_bits` for an integer as wide as the rendered child type:

```python
child_ty = self.default_simtype_from_bits(child.type.size, expr.is_signed)
```

`child.type.size` does not always answer that question. A `SimTypeBottom` reports `None`. A struct that reached the code generator with no fields reports `0`, and `default_simtype_from_bits(0)` returns `SimTypeNum(0)`, which prints as `int0_t`. Either way the intermediate cast ends up with a type that has no size, and `MakeTypecastsImplicit.collapse` asserts on exactly that.

`langdetect_go` hits the zero case. `runtime.setThreadCPUProfiler` calls `timer_create`, and `angr/procedures/definitions/linux_kernel.py:282` declares that syscall's second argument as `SimTypePointer(SimStruct({}, name="sigevent", pack=False, align=None), offset=0)`. The pointee has no fields, so its `.size` is 0, and a 4-byte stack slot arrives at the code generator carrying that type. The code generator says so on the way past:

```text
ERROR angr.analyses.decompiler.structured_codegen.c: Store data lifted to a C type of a
different size: sigevent is 0 bits, the store is 32 bits. Using the store width.
```

### Fix

Fall back to the AIL conversion's `from_bits`, which always carries the source width, whenever the rendered type does not supply one. A known width still takes precedence, so nothing changes for a child whose type has a size.

`runtime.setThreadCPUProfiler` now generates 7,201 characters of C. The output comment has all of it. Two things it shows are separate defects. The empty `typedef struct sigevent {}` is emitted and used to declare two 4-byte stack slots, and one variable is declared under its Python repr. Neither is introduced here, and neither was visible before, because the function emitted no C at all.

### Testing

`TestConvertOfZeroWidthChild::test_widening_a_child_typed_as_a_fieldless_struct` decompiles `runtime.setThreadCPUProfiler` from `tests/x86_64/langdetect_go` and asserts the C is non-empty and free of `int0_t`. On master it fails with the assertion above. Two unit regressions in `TestConvertRendering` cover the `SimTypeBottom` source, which reports `None` rather than `0`, and the unchanged known-width path; the first also fails on master.

This pull request was opened against two DecBench functions, libselinux `Sha1Finalise` at `0x42a0b2` and findutils `pred_perm` at `0x40a058`. Neither reproduces at `b4ad96cd3`: both decompile cleanly there, and this change leaves their C byte-identical. The evidence is the tracked `langdetect_go` fixture instead. Validation: https://github.com/angr/angr/pull/6966#issuecomment-5434739252

session: sharpen
