### PR TITLE
Decompiler: drop stale extra_defs on synthesized branches

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -463,7 +463,9 @@ class DuplicationReverter(StructuringOptimizationPass):
             raise SAILRSemanticError("A condition would be too long for a fixup, this analysis must skip it")
 
         cond_block = Block(common_cond.addr, 1, idx=common_cond.idx + 1 if isinstance(common_cond.idx, int) else 1)
-        old_stmt_tags = common_cond.statements[0].tags
+        old_stmt_tags = common_cond.statements[0].tags.copy()
+        # extra_defs describes definitions made by the original statement, not by this synthesized conditional jump.
+        old_stmt_tags.pop("extra_defs", None)
         cond_jump = ConditionalJump(
             1,
             best_condition.copy() if best_condition is not None else None,

--- a/tests/analyses/decompiler/test_duplication_reverter_tags.py
+++ b/tests/analyses/decompiler/test_duplication_reverter_tags.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from typing import cast
+
+from angr.ailment import Block, Const
+from angr.ailment.statement import ConditionalJump, Jump
+from angr.analyses.decompiler.optimization_passes.duplication_reverter.duplication_reverter import (
+    DuplicationReverter,
+)
+
+
+class TestDuplicationReverterTags(unittest.TestCase):
+    """Tests statement-tag ownership in synthesized duplication-reverter blocks."""
+
+    def test_synthesized_condition_does_not_inherit_extra_defs(self):
+        common_condition = Block(
+            0x1000,
+            1,
+            statements=[
+                Jump(
+                    0,
+                    Const(0, 0x2000, 64),
+                    ins_addr=0x1000,
+                    vex_stmt_idx=7,
+                    extra_defs=[41, 42],
+                )
+            ],
+            idx=0,
+        )
+        true_block = Block(0x2000, 1)
+        condition = Const(1, 1, 1)
+        atom_ids = iter((2, 3))
+        reverter = cast(
+            DuplicationReverter,
+            SimpleNamespace(
+                shared_common_conditional_dom=lambda blocks, graph: common_condition,
+                collect_conditions_between_nodes=lambda graph, common, blocks: {true_block: condition},
+                boolean_operators_in_condition=lambda expr: 0,
+                max_guarding_conditions=4,
+                candidate_blacklist=set(),
+                manager=SimpleNamespace(next_atom=lambda: next(atom_ids)),
+                project=SimpleNamespace(arch=SimpleNamespace(bits=64)),
+            ),
+        )
+
+        result, selected = DuplicationReverter._construct_best_condition_block_for_merge(  # pylint: disable=protected-access
+            reverter, (true_block,), object()
+        )
+
+        statement = cast(ConditionalJump, result.statements[0])
+        self.assertIs(selected, true_block)
+        self.assertNotIn("extra_defs", statement.tags)
+        self.assertEqual(statement.tags["ins_addr"], 0x1000)
+        self.assertEqual(statement.tags["vex_stmt_idx"], 7)
+        self.assertEqual(common_condition.statements[0].tags["extra_defs"], [41, 42])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

- copy source statement tags before constructing a DuplicationReverter conditional jump
- remove only `extra_defs`, whose definition ownership does not transfer to the synthesized statement
- preserve source-location metadata and leave the original statement tags unchanged
- add a focused regression for tag ownership

## Why

`DuplicationReverter._construct_best_condition_block_for_merge()` builds a new conditional jump from a collected condition but inherited all tags from an unrelated source statement. An inherited `extra_defs` tag claims the synthesized jump defines virtual variables for which it has no matching extra-definition references, so the SSA consistency check raises `extra_def tag was dropped`.

## Validation

- focused regression: 1 passed
- nearby DuplicationReverter tests: 4 passed
- exact SAILR replays for both known DecBench failures complete successfully; Phoenix controls remain clean
- full Python repository gate: 2510 passed, 46 skipped, 2 xfailed, 260 subtests passed
- native Rust gate: 35 passed
- changed-file hooks and CI lint/type predictor pass