### PR TITLE
SwitchDefaultCaseDuplicator: do not select constructs with no default-case block

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/switch_default_case_duplicator.py
+++ b/angr/analyses/decompiler/optimization_passes/switch_default_case_duplicator.py
@@ -62,7 +62,12 @@ class SwitchDefaultCaseDuplicator(OptimizationPass):
                     default_case_node = next(
                         iter(nn for nn in self._func.graph.successors(pred) if nn.addr != node_addr)
                     )
-                    if self._func.graph.out_degree[default_case_node] == 1:
+                    # clinic drops CFG nodes on the way to the AIL graph: unreachable blocks are never converted,
+                    # and a default case that is a bare jump is removed with its predecessor rewired past it. Such a
+                    # default case has no block for _analyze() to rewrite.
+                    if self._func.graph.out_degree[default_case_node] == 1 and self._blocks_by_addr.get(
+                        default_case_node.addr
+                    ):
                         default_case_node_addrs.add((pred.addr, node_addr, default_case_node.addr))
 
         if not default_case_node_addrs:

--- a/tests/analyses/decompiler/test_switch_default_case_duplicator.py
+++ b/tests/analyses/decompiler/test_switch_default_case_duplicator.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
 
+import os
 import unittest
 
 import angr
+from angr.analyses import Decompiler
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
 
 
 class TestSwitchDefaultCaseDuplicatorSplitPred(unittest.TestCase):
@@ -166,6 +171,32 @@ class TestSwitchDefaultCaseDuplicatorSplitPred(unittest.TestCase):
         func = cfg.functions[self.BASE]
         # fail_fast=True: this raised NetworkXError in SwitchDefaultCaseDuplicator before the split-predecessor fix.
         dec = proj.analyses.Decompiler(func, cfg=cfg, fail_fast=True)
+        assert dec.codegen is not None and dec.codegen.text is not None
+
+
+class TestSwitchDefaultCaseDuplicatorUnreachableDefault(unittest.TestCase):
+    """
+    SwitchDefaultCaseDuplicator collects switch-case constructs from the function-level CFG graph, but clinic builds
+    the AIL graph out of the blocks reachable from the function entry only, so a construct the CFG recovered in
+    unreachable code has no default-case block. _get_block() returned None for it and self._graph.successors(None)
+    raised a NetworkXError, which escaped clinic and made Decompiler redo the whole function with the basic preset.
+
+    sub_140109110 carries two jump tables inside a region nothing reaches, at 0x140109608 and 0x140109b88. Their
+    switch heads are 0x1401095df and 0x140109b5f, and their default cases are 0x140109765 and 0x140109ce1.
+    """
+
+    def test_default_case_outside_the_ail_graph(self):
+        bin_path = os.path.join(
+            test_location, "x86_64", "windows", "7995a0325b446c462bdb6ae10b692eee2ecadd8e888e9d7729befe4412007afb"
+        )
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        func_addr = 0x140109110
+        # the unreachable jump tables sit a couple of kilobytes into the function
+        cfg = proj.analyses.CFGFast(
+            normalize=True, regions=[(func_addr, func_addr + 0x2000)], function_starts=[func_addr]
+        )
+        # fail_fast=True: this raised NetworkXError in SwitchDefaultCaseDuplicator before the fix.
+        dec = proj.analyses[Decompiler].prep(fail_fast=True)(func_addr, cfg=cfg.model)
         assert dec.codegen is not None and dec.codegen.text is not None
 
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`SwitchDefaultCaseDuplicator` raises on a function whose switch constructs sit outside the AIL graph. On `binaries/tests/x86_64/windows/7995a0325b446c462bdb6ae10b692eee2ecadd8e888e9d7729befe4412007afb`, function `sub_140109110` at `0x140109110`:

```
  File "angr/analyses/decompiler/optimization_passes/switch_default_case_duplicator.py", line 140, in _analyze
    default_case_succ_block = next(iter(self._graph.successors(default_case_block)))
networkx.exception.NetworkXError: The node None is not in the digraph.
```

The exception leaves the pass and clinic together, so with `fail_fast` off it is never seen: `Decompiler` records an error and silently redoes the whole function under the `basic` preset. The caller gets worse output and no indication that anything failed.

### Root cause

`_check` enumerates switch-case constructs over the function-level CFG graph, while `_analyze` rewrites the AIL graph, and the two do not hold the same blocks. Clinic converts only what is reachable from the function entry, and it removes a default case whose sole statement is a jump, rewiring the switch head past it. `_analyze` then looks the default case up by address and asks networkx for its successors:

```python
default_case_block = self._get_block(default_addr)
default_case_succ_block = next(iter(self._graph.successors(default_case_block)))
```

`_get_block` returns `None` when no block carries that address, and networkx then raises `NetworkXError: The node None is not in the digraph` at `switch_default_case_duplicator.py:140`. In this function the CFG has 262 nodes of which 41 are reachable from the entry, and both switch constructs lie in the unreachable remainder.

### Fix

Ask for the block when the construct is selected, in `_check`, rather than when it is dereferenced in `_analyze`:

```python
if self._func.graph.out_degree[default_case_node] == 1 and self._blocks_by_addr.get(
    default_case_node.addr
):
```

The pass now declines the construct instead of raising: `errors recorded by Decompiler: 1` becomes `0`, the function keeps its own preset instead of the `basic` retry, and its 132 lines of C become 141 with 11 gotos falling to 4 — the single-return plumbing through `v31`/`LABEL_140109d69` is gone, a `do`/`while` nested in an `if` becomes an early `return 0;`, and the `while (*((char *)v20))` loop variable is recognised and named `i`.

The switch itself is recovered on neither side: the indirect `goto (unsigned long long)&(&g_140000000)[...]` is present in both outputs, because the dispatch is in the part of the CFG clinic never converted. What the change recovers is the rest of the function.

This cannot change a run that previously completed. `_analyze` fetches the block only when the default case has an unexpected predecessor or is shared by another switch head, and an absent block raised in both places; a construct with neither property was already a no-op. Measured rather than argued: across both corpora the new condition rejects 4 constructs in total, and re-running `_analyze` on the baseline with each one alone shows 3 raised at `:140` and 1 never set `out_graph`, with 0 mutating the graph.

### Testing

`tests/analyses/decompiler/test_switch_default_case_duplicator.py::TestSwitchDefaultCaseDuplicatorUnreachableDefault::test_default_case_outside_the_ail_graph` decompiles the function above with the CFG scoped to `[0x140109110, +0x2000)`. On the merge base it fails with the `NetworkXError` above (`1 failed, 1 passed`); on this head the file is `2 passed`.

Validation: https://github.com/angr/angr/pull/6969#issuecomment-5430052390

session: sharpen