### PR TITLE
ReturnMaker: report a return register the architecture does not have

### DIFF
--- a/angr/analyses/decompiler/return_maker.py
+++ b/angr/analyses/decompiler/return_maker.py
@@ -28,6 +28,35 @@ class ReturnMaker(AILGraphWalker):
     def _next_atom(self) -> int:
         return self.ail_manager.next_atom()
 
+    def _ret_expr_for_reg(self, loc: SimRegArg, stmt: ailment.Stmt.Return) -> ailment.Expr.Register | None:
+        """
+        Build the AIL register expression a return location denotes, or None when it denotes no
+        register this architecture has.
+
+        A calling convention may name a location that is not a static register. On X86 a
+        floating-point return lives at the top of the x87 stack, which VEX models as ``fpreg``
+        indexed by the run-time value of ``ftop``; ``st0`` therefore resolves only against a
+        state, and ``arch.registers`` has no entry for it. No AIL expression can reference the
+        value, so report that instead of raising.
+        """
+        reg = self.arch.registers.get(loc.reg_name)
+        if reg is None:
+            l.warning(
+                "Cannot reference the return value of %s: its calling convention returns in %s, "
+                "which is not a register on %s.",
+                self.function.name,
+                loc.reg_name,
+                self.arch.name,
+            )
+            return None
+        return ailment.Expr.Register(
+            self._next_atom(),
+            reg[0],
+            loc.size * self.arch.byte_width,
+            reg_name=self.arch.translate_register_name(reg[0], loc.size),
+            ins_addr=stmt.tags.get("ins_addr"),  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        )
+
     def _handle_Return(self, stmt_idx: int, stmt: ailment.Stmt.Return, block: ailment.Block | None):  # pylint:disable=unused-argument
         if (
             block is not None
@@ -45,16 +74,9 @@ class ReturnMaker(AILGraphWalker):
             )
             ret_val = self.function.calling_convention.return_val(returnty)
             if isinstance(ret_val, SimRegArg):
-                reg = self.arch.registers[ret_val.reg_name]
-                new_ret_exprs.append(
-                    ailment.Expr.Register(
-                        self._next_atom(),
-                        reg[0],
-                        ret_val.size * self.arch.byte_width,
-                        reg_name=self.arch.translate_register_name(reg[0], ret_val.size),
-                        ins_addr=stmt.tags.get("ins_addr"),  # pyright: ignore[reportTypedDictNotRequiredAccess]
-                    )
-                )
+                ret_expr = self._ret_expr_for_reg(ret_val, stmt)
+                if ret_expr is not None:
+                    new_ret_exprs.append(ret_expr)
             elif isinstance(ret_val, SimComboArg):
                 # TODO: we currently only support the first register in the combo, but we should support all of them
                 # ret_val = ret_val.locations[0]
@@ -71,16 +93,9 @@ class ReturnMaker(AILGraphWalker):
                 # )
                 for ret_val_loc in ret_val.locations:
                     if isinstance(ret_val_loc, SimRegArg):
-                        reg = self.arch.registers[ret_val_loc.reg_name]
-                        new_ret_exprs.append(
-                            ailment.Expr.Register(
-                                self._next_atom(),
-                                reg[0],
-                                ret_val_loc.size * self.arch.byte_width,
-                                reg_name=self.arch.translate_register_name(reg[0], ret_val_loc.size),
-                                ins_addr=stmt.tags.get("ins_addr"),  # pyright: ignore[reportTypedDictNotRequiredAccess]
-                            )
-                        )
+                        ret_expr = self._ret_expr_for_reg(ret_val_loc, stmt)
+                        if ret_expr is not None:
+                            new_ret_exprs.append(ret_expr)
                     else:
                         l.warning("Unsupported type of return expression %s.", type(ret_val_loc))
             else:

--- a/tests/analyses/decompiler/test_x87_float_return.py
+++ b/tests/analyses/decompiler/test_x87_float_return.py
@@ -7,6 +7,8 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 import os.path
 import unittest
 
+import cle
+
 import angr
 from angr.calling_conventions import SimCCCdecl
 from angr.knowledge_plugins.functions.function import PrototypeSource
@@ -49,7 +51,9 @@ class TestX87FloatReturn(unittest.TestCase):
         # hard-coded; a full scan of this library costs minutes and none of it is needed here.
         proj = angr.Project(os.path.join(test_location, "i386", "libstdc++.so.6"), auto_load_libs=False)
         wanted = ("floor", "frexpl", "ceil")
-        plt = {name: addr for addr, name in proj.loader.main_object.reverse_plt.items() if name in wanted}
+        main_object = proj.loader.main_object
+        assert isinstance(main_object, cle.MetaELF)
+        plt = {name: addr for addr, name in main_object.reverse_plt.items() if name in wanted}
         assert set(plt) == set(wanted), f"fixture no longer exposes these PLT stubs: {sorted(plt)}"
 
         regions = [(addr, addr + 0x10) for addr in plt.values()]
@@ -59,6 +63,7 @@ class TestX87FloatReturn(unittest.TestCase):
         for name, addr in sorted(plt.items()):
             func = cfg.functions.get_by_addr(addr)
             assert func.name == name and func.is_plt
+            assert func.prototype is not None
             assert isinstance(func.prototype.returnty, SimTypeDouble)
             self._assert_reported_not_raised(proj, cfg, func, "phoenix")
 
@@ -77,7 +82,9 @@ class TestX87FloatReturn(unittest.TestCase):
             func = cfg.functions.function(name=func_name)
             assert func is not None
             func.calling_convention = SimCCCdecl(proj.arch)
-            func.prototype = SimTypeFunction([], returnty()).with_arch(proj.arch)
+            prototype = SimTypeFunction([], returnty()).with_arch(proj.arch)
+            assert isinstance(prototype, SimTypeFunction)
+            func.prototype = prototype
             func.prototype_source = PrototypeSource.USER
             for structurer in ("phoenix", "sailr"):
                 text = self._assert_reported_not_raised(proj, cfg, func, structurer)

--- a/tests/analyses/decompiler/test_x87_float_return.py
+++ b/tests/analyses/decompiler/test_x87_float_return.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,line-too-long
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os.path
+import unittest
+
+import angr
+from angr.calling_conventions import SimCCCdecl
+from angr.knowledge_plugins.functions.function import PrototypeSource
+from angr.sim_type import SimTypeDouble, SimTypeFloat, SimTypeFunction
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestX87FloatReturn(unittest.TestCase):
+    """
+    A 32-bit x86 function returns a float at the top of the x87 stack, and the calling convention
+    names that location "st0". VEX models the stack as ``fpreg`` indexed by the run-time value of
+    ``ftop``, so "st0" resolves only against a state and ``ArchX86.registers`` has no entry for it.
+    ``ReturnMaker`` indexed the register map with that name and lost the whole function.
+
+    The value itself stays unrepresentable: it reaches the return through VEX ``GetI``/``PutI``,
+    which the AIL converter does not support. These tests pin that the failure is reported and the
+    rest of the function still decompiles, not that the returned value appears.
+    """
+
+    def _assert_reported_not_raised(self, proj, cfg, func, structurer: str) -> str:
+        ret_val = func.calling_convention.return_val(func.prototype.returnty)
+        assert ret_val.reg_name == "st0"
+        assert "st0" not in proj.arch.registers
+
+        with self.assertLogs("angr.analyses.decompiler.return_maker", level="WARNING") as logs:
+            dec = proj.analyses.Decompiler(
+                func, cfg=cfg.model, options=[("structurer_cls", structurer)], update_cache=False
+            )
+        assert any("not a register on X86" in line for line in logs.output)
+        assert not dec.errors
+        assert dec.codegen is not None and dec.codegen.text
+        return dec.codegen.text
+
+    def test_library_declared_double_return(self):
+        # The prototype here comes from the binary as shipped: these PLT stubs resolve to libc
+        # declarations returning double, so nothing about the test manufactures the condition.
+        # The CFG is scoped to the stubs themselves, taken from CLE's PLT map rather than
+        # hard-coded; a full scan of this library costs minutes and none of it is needed here.
+        proj = angr.Project(os.path.join(test_location, "i386", "libstdc++.so.6"), auto_load_libs=False)
+        wanted = ("floor", "frexpl", "ceil")
+        plt = {name: addr for addr, name in proj.loader.main_object.reverse_plt.items() if name in wanted}
+        assert set(plt) == set(wanted), f"fixture no longer exposes these PLT stubs: {sorted(plt)}"
+
+        regions = [(addr, addr + 0x10) for addr in plt.values()]
+        cfg = proj.analyses.CFGFast(normalize=True, regions=regions, force_complete_scan=False)
+        proj.analyses.CompleteCallingConventions(cfg=cfg.model, recover_variables=True)
+
+        for name, addr in sorted(plt.items()):
+            func = cfg.functions.get_by_addr(addr)
+            assert func.name == name and func.is_plt
+            assert isinstance(func.prototype.returnty, SimTypeDouble)
+            self._assert_reported_not_raised(proj, cfg, func, "phoenix")
+
+    def test_declared_float_and_double_return(self):
+        # manyfloatsum.c declares these as float and double. angr's own inference reports them as
+        # returning void, because the same missing register name leaves _guess_retval_type unable
+        # to recognise an x87 return, so the true prototype is stated here.
+        proj = angr.Project(os.path.join(test_location, "i386", "manyfloatsum"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        proj.analyses.CompleteCallingConventions(cfg=cfg.model, recover_variables=True)
+
+        for func_name, returnty, decl in (
+            ("sum_floats", SimTypeFloat, "float sum_floats"),
+            ("sum_doubles", SimTypeDouble, "double sum_doubles"),
+        ):
+            func = cfg.functions.function(name=func_name)
+            assert func is not None
+            func.calling_convention = SimCCCdecl(proj.arch)
+            func.prototype = SimTypeFunction([], returnty()).with_arch(proj.arch)
+            func.prototype_source = PrototypeSource.USER
+            for structurer in ("phoenix", "sailr"):
+                text = self._assert_reported_not_raised(proj, cfg, func, structurer)
+                assert text.startswith(decl)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A 32-bit x86 function whose prototype returns a float or a double is discarded whole. On `binaries/tests/i386/libstdc++.so.6` the PLT stubs `floor` at `0x469dd0`, `frexpl` at `0x46ac30` and `ceil` at `0x46c280` resolve to libc declarations returning `double` straight from the binary as shipped, and each one decompiles to nothing:

```
  File "angr/analyses/decompiler/return_maker.py", line 48, in _handle_Return
    reg = self.arch.registers[ret_val.reg_name]
KeyError: 'st0'

    dec.errors      : 2
      | <AnalysisLogEntry 'exception occurred' with KeyError: 'st0'>
      | <AnalysisLogEntry 'exception occurred' with KeyError: 'st0'>
    codegen         : None
    characters      : 0
```

The loss is total rather than partial: the function produces 0 characters under every structurer, and `Decompiler`'s basic-preset retry fails the same way, so there is no degraded output either.

### Root cause

`SimCCCdecl.FP_RETURN_VAL` is `SimLyingRegArg("st0")` (`calling_conventions.py:1352`), inherited by `SimCCMicrosoftCdecl`, `SimCCMicrosoftThiscall` and `SimCCStdcall`. `st0` is the top of the x87 stack, which VEX models as `fpreg` indexed by the run-time value of `ftop`: `storage/memory_mixins/name_resolution_mixin.py:21-24` resolves `st{n}` as `fpu_regs + 8*((ftop + n) & 7)`. Because that index is a run-time value, `st0` cannot be a static `arch.registers` entry and on `ArchX86` it is not one — it appears only in `dwarf_registers`. `ReturnMaker._handle_Return` indexed the map with it anyway:

```python
reg = self.arch.registers[ret_val.reg_name]
```

angr already applies the missing precondition to this very field elsewhere: `fact_collector.py:900-906` wraps **only** `FP_RETURN_VAL`'s `check_offset` in `try`/`except KeyError`, commented `# register name does not exist`, while the `RETURN_VAL` and `OVERFLOW_RETURN_VAL` reads immediately above it call the identical method unguarded. `ReturnMaker` is the consumer that did not get the rule.

### Fix

Both `arch.registers[...]` reads in `_handle_Return` now go through one `_ret_expr_for_reg` helper, which reports the unrepresentable location and returns no expression instead of raising:

```python
reg = self.arch.registers.get(loc.reg_name)
if reg is None:
    l.warning("Cannot reference the return value of %s: its calling convention returns in %s, "
              "which is not a register on %s.", self.function.name, loc.reg_name, self.arch.name)
    return None
```

All three now emit code with 0 errors and one warning each:

```c
// attributes: PLT stub
double ceil()
{
    double v0;  // [bp+0x0]
    unsigned int v1;  // [bp+0x4]

    ::libc.so.0::ceil(v0, v1);
    return;
}
```

This deliberately does **not** make x87 returns decompile. The value reaches the return through VEX `GetI`/`PutI`, which the AIL converter does not support, so no AIL expression can name it; emitting a static `Register` for `st0` would name a location the value is not in. Other consumers of `cc.return_val(...)` were audited and left alone — neutralising `_handle_Return` and re-decompiling the reproducer showed none of them fires.

### Testing

`tests/analyses/decompiler/test_x87_float_return.py` adds two cases. `test_library_declared_double_return` takes the three `libstdc++.so.6` PLT stubs above, reading their addresses from CLE's own `reverse_plt` map and scoping the CFG to them so it runs in seconds rather than the minutes a full scan of that library costs, and asserts each one warns, records no error and emits text. `test_declared_float_and_double_return` states the prototypes `tests_src/manyfloatsum.c` itself declares for `sum_floats` and `sum_doubles`, since angr cannot infer them for the reason above, and asserts both under phoenix and sailr. Both fail on the merge base with `KeyError: 'st0'` at `return_maker.py:48` (`2 failed`) and pass on this head (`2 passed`).

Fixes #4455. Validation: https://github.com/angr/angr/pull/6970#issuecomment-5430213434

session: sharpen