### PR TITLE
MultiValues: make copy construction copy the offset map

### DIFF
--- a/angr/storage/memory_mixins/paged_memory/pages/multi_values.py
+++ b/angr/storage/memory_mixins/paged_memory/pages/multi_values.py
@@ -42,8 +42,10 @@ class MultiValues[MVType: claripy.ast.BV | claripy.ast.FP]:
             self._single_value = v
             self._values = None
         elif isinstance(v, MultiValues):
+            # copy-construction: the new object must own its offset map, otherwise mutating either object
+            # (e.g. add_value()) silently mutates the other, and mutating one while iterating the other raises
             self._single_value = v._single_value
-            self._values = v._values
+            self._values = None if v._values is None else {offset: set(values) for offset, values in v._values.items()}
         elif isinstance(v, dict):
             self._single_value = None
             self._values = v

--- a/tests/analyses/reaching_definitions/test_regressions.py
+++ b/tests/analyses/reaching_definitions/test_regressions.py
@@ -1,6 +1,7 @@
 # pylint: disable=R0201,C0111,line-too-long,bad-builtin,expression-not-assigned,no-member
 from __future__ import annotations
 
+import os
 import struct
 from unittest import TestCase
 
@@ -11,12 +12,39 @@ from angr.analyses import CFGFast, ReachingDefinitionsAnalysis
 from angr.knowledge_plugins import Function
 from angr.knowledge_plugins.key_definitions.atoms import Atom
 from angr.knowledge_plugins.key_definitions.constants import OP_BEFORE
+from tests.common import bin_location
 
 
 class TestRDARegressions(TestCase):
     """
     Test misc regressions for the ReachingDefinitionsAnalysis.
     """
+
+    def test_concat_of_a_multivalues_with_itself(self):
+        """
+        Iop_16HLto32(t, t) reads the same VEX temporary for both operands, and _expr_bv() returns the live
+        object stored in self.tmps, so MultiValues.concat() used to receive one object as both self and
+        other. It copy-constructed MultiValues(self), which aliased the offset map rather than copying it,
+        and the add_value() that followed inserted into the dict its own items() iteration was walking.
+        """
+        binary = os.path.join(
+            bin_location,
+            "tests",
+            "x86_64",
+            "windows",
+            "dd56403d14ffe220a645a964a19f8b488e200b84ae5a414b0c020b561ae40880.sys",
+        )
+        func_addr = 0x1400DF7BF
+
+        proj = angr.Project(binary, auto_load_libs=False)
+        # Scope the scan to the one function that carries the pattern: the whole binary is 18k functions.
+        cfg = proj.analyses[CFGFast].prep()(
+            regions=[(func_addr, func_addr + 0x200)], function_starts=[func_addr], normalize=True
+        )
+        assert func_addr in cfg.functions, "fixture no longer contains the function under test"
+
+        # Used to raise RuntimeError("dictionary changed size during iteration").
+        proj.analyses[ReachingDefinitionsAnalysis].prep()(subject=cfg.functions[func_addr], observe_all=False)
 
     def test_load_multiple_concrete_addresses(self):
         """

--- a/tests/storage/test_multivalues.py
+++ b/tests/storage/test_multivalues.py
@@ -42,6 +42,46 @@ class TestMultiValues(TestCase):
         assert v.concrete_value == mv2._single_value.concrete_value
         assert len(mv2) == 64
 
+    def test_copy_construction_does_not_alias_the_source(self):
+        src = MultiValues(offset_to_values={0: {claripy.BVV(0x11, 8)}, 1: {claripy.BVV(0x22, 8)}})
+        copied = MultiValues(src)
+
+        assert copied._values is not src._values
+        assert copied._values[0] is not src._values[0]
+
+        copied.add_value(2, claripy.BVV(0x33, 8))
+        assert src.keys() == {0, 1}
+
+    def test_concat_does_not_mutate_the_receiver(self):
+        lhs = MultiValues(offset_to_values={0: {claripy.BVV(0x11, 8)}, 1: {claripy.BVV(0x22, 8)}})
+        rhs = MultiValues(claripy.BVV(0x33, 8))
+
+        result = lhs.concat(rhs)
+
+        assert lhs.keys() == {0, 1}
+        assert result.keys() == {0, 1, 2}
+        assert result._values[2] == {claripy.BVV(0x33, 8)}
+
+    def test_concat_with_an_aliasing_operand(self):
+        # RDA hands the same MultiValues object to both operands of e.g. Iop_16HLto32(t, t), so concat must
+        # tolerate self is other. It used to raise "dictionary changed size during iteration".
+        mv = MultiValues(offset_to_values={0: {claripy.BVV(0x11, 8)}, 1: {claripy.BVV(0x22, 8)}})
+
+        result = mv.concat(mv)
+
+        assert mv.keys() == {0, 1}
+        assert result.keys() == {0, 1, 2, 3}
+
+    def test_concat_with_a_copy_constructed_operand(self):
+        lhs = MultiValues(offset_to_values={0: {claripy.BVV(0x11, 8)}, 1: {claripy.BVV(0x22, 8)}})
+        rhs = MultiValues(lhs)
+
+        result = lhs.concat(rhs)
+
+        assert lhs.keys() == {0, 1}
+        assert rhs.keys() == {0, 1}
+        assert result.keys() == {0, 1, 2, 3}
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ReachingDefinitions` on function `0x1400df7bf` of `binaries/tests/x86_64/windows/dd56403d14ffe220a645a964a19f8b488e200b84ae5a414b0c020b561ae40880.sys` raises:

```
  File "angr/analyses/reaching_definitions/engine_vex.py", line 616, in _handle_binop_16HLto32
    return expr0.concat(expr1)
  File "angr/storage/memory_mixins/paged_memory/pages/multi_values.py", line 282, in concat
    for k, v in other.items():
  File "angr/storage/memory_mixins/paged_memory/pages/multi_values.py", line 243, in items
    yield from self._values.items()
RuntimeError: dictionary changed size during iteration
```

`CompleteCallingConventions.work()` calls `_analyze_core` once per function with nothing catching a raise, so this does not cost one function: it ends calling-convention recovery for the rest of the binary, and every function the stage had not yet reached keeps no convention and no prototype.

### Root cause

`MultiValues.__init__`'s copy-construct branch aliased the source's offset map rather than copying it:

```python
elif isinstance(v, MultiValues):
    self._single_value = v._single_value
    self._values = v._values
```

`concat()` is its only caller in `angr/`, and it mutates the copy — so `x.concat(y)` rewrote `x` in place. `SimEngineRDVEX._expr_bv()` returns the live `self.tmps[t]` object, so `Iop_16HLto32(t, t)` passes one object as both operands: `concat` then inserts into the very dict its own `items()` generator is walking. The exception is the visible half. The silent half is that a concat on any multi-offset receiver corrupts that receiver, which in the RDA is the tmp state the rest of the analysis reads.

### Fix

Copy the offset map, and its value sets, in the constructor. That puts the invariant where the aliasing is introduced rather than where it is noticed, so both halves go at once; the same reproducer now completes:

```
function sub_1400df7bf @ 0x1400df7bf: 1 blocks
RDA completed: 40 definitions, 254 observed results
```

Deliberately not done: materialising `items()` with `list()`. It suppresses the exception, leaves the receiver corruption in place, and pays a copy on every `items()` call rather than on the copy-constructions the defect actually uses.

### Testing

`tests/storage/test_multivalues.py` gains four tests — copy construction must not alias, `concat` must not mutate its receiver, `concat` with `self is other`, `concat` with a copy-constructed operand — and `tests/analyses/reaching_definitions/test_regressions.py` gains an end-to-end test that scopes `CFGFast` to a `0x200` region around `0x1400df7bf` so it costs about a second. Against the merge base all five fail — the two files together report `5 failed, 4 passed`; on this head, `9 passed`. Before/after output of the reproducer: https://github.com/angr/angr/issues/6971#issuecomment-5452629050

Validation: https://github.com/angr/angr/pull/6971#issuecomment-5430360033

session: emo-corpus