### PR TITLE
RegionIdentifier: take the function entry as the region start node

### DIFF
--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -214,24 +214,22 @@ class RegionIdentifier(Analysis):
         return block_only_regions
 
     def _get_start_node(self, graph: TGraph):
+        # a graph can hold more than one node without in-edges: edges dropped as jump-table or
+        # switch-case debris, and obfuscated control flow, both leave source nodes behind. Where the
+        # function entry is one of them it is the start node, because everything only the entry
+        # reaches is unreachable from any other choice -- and picking between equally-source-like
+        # nodes by iteration order is not a decision this analysis should be making.
+        entry_node = self._get_entry_node(graph)
+        if entry_node is not None and graph.in_degree(entry_node) == 0:
+            return entry_node
+
         try:
             return next(n for n in graph.nodes() if graph.in_degree(n) == 0)
         except StopIteration:
             pass
 
-        if self.entry_node_addr is not None:
-            try:
-                return next(
-                    n
-                    for n in graph.nodes()
-                    if (
-                        (n.addr, n.idx) == self.entry_node_addr
-                        if isinstance(n, Block)
-                        else n.addr == self.entry_node_addr[0]
-                    )
-                )
-            except StopIteration as ex:
-                raise AngrRuntimeError("Cannot find the start node from the graph!") from ex
+        if entry_node is not None:
+            return entry_node
         raise AngrRuntimeError("Cannot find the start node from the graph!")
 
     def _get_entry_node(self, graph: TGraph):

--- a/angr/analyses/decompiler/region_identifier.py
+++ b/angr/analyses/decompiler/region_identifier.py
@@ -123,7 +123,12 @@ class RegionIdentifier(Analysis):
 
         # the shared graph stays intact from here on (except for in-place block-statement rewrites); regions are
         # overlays on it. region identification collapses a separate working graph.
-        self.overlay_manager = OverlayManager(shared_graph, expose_loop_head_backedges=self._expose_loop_head_backedges)
+        # OverlayManager is parameterised on the bare node type and widens to Tx[T] internally, so bind T
+        # here rather than letting it infer Tx[...] from the shared graph and mismatch the attribute.
+        self.overlay_manager = OverlayManager(
+            cast("networkx.DiGraph[Block | MultiNode | ConditionNode]", shared_graph),
+            expose_loop_head_backedges=self._expose_loop_head_backedges,
+        )
         graph = cast(TGraph, networkx.DiGraph(shared_graph))
 
         self._start_node = self._get_start_node(graph)

--- a/tests/analyses/decompiler/test_region_identifier_start_node.py
+++ b/tests/analyses/decompiler/test_region_identifier_start_node.py
@@ -35,7 +35,7 @@ class TestRegionIdentifierStartNode(unittest.TestCase):
         return ri
 
     def test_entry_wins_the_tie_break_against_another_source_node(self):
-        m = Manager(arch=None)
+        m = Manager()
         entry, other, body = self._block(m, 0x100), self._block(m, 0x200), self._block(m, 0x300)
         graph = networkx.DiGraph()
         # `other` is inserted first, so iteration reaches it before the entry
@@ -46,7 +46,7 @@ class TestRegionIdentifierStartNode(unittest.TestCase):
         assert self._ri((0x100, None))._get_start_node(graph) is entry
 
     def test_a_sole_source_node_is_still_the_start_node(self):
-        m = Manager(arch=None)
+        m = Manager()
         entry, body = self._block(m, 0x100), self._block(m, 0x200)
         graph = networkx.DiGraph()
         graph.add_edge(entry, body)
@@ -54,7 +54,7 @@ class TestRegionIdentifierStartNode(unittest.TestCase):
         assert self._ri((0x100, None))._get_start_node(graph) is entry
 
     def test_an_entry_with_predecessors_does_not_displace_a_source_node(self):
-        m = Manager(arch=None)
+        m = Manager()
         entry, head = self._block(m, 0x100), self._block(m, 0x200)
         graph = networkx.DiGraph()
         # the entry sits inside a loop, so it is not a source: the real source still wins
@@ -68,7 +68,7 @@ class TestRegionIdentifierStartNode(unittest.TestCase):
         assert self._ri((0x100, None))._get_start_node(graph) is source
 
     def test_entry_is_the_fallback_when_the_graph_has_no_source_node(self):
-        m = Manager(arch=None)
+        m = Manager()
         entry, other = self._block(m, 0x100), self._block(m, 0x200)
         graph = networkx.DiGraph()
         graph.add_edge(entry, other)
@@ -77,7 +77,7 @@ class TestRegionIdentifierStartNode(unittest.TestCase):
         assert self._ri((0x100, None))._get_start_node(graph) is entry
 
     def test_no_source_node_and_no_entry_still_raises(self):
-        m = Manager(arch=None)
+        m = Manager()
         a, b = self._block(m, 0x100), self._block(m, 0x200)
         graph = networkx.DiGraph()
         graph.add_edge(a, b)

--- a/tests/analyses/decompiler/test_region_identifier_start_node.py
+++ b/tests/analyses/decompiler/test_region_identifier_start_node.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,no-member,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import unittest
+
+import networkx
+
+from angr.ailment import Manager
+from angr.ailment.block import Block
+from angr.ailment.expression import Const
+from angr.ailment.statement import Jump
+from angr.analyses.decompiler.region_identifier import RegionIdentifier
+from angr.errors import AngrRuntimeError
+
+
+class TestRegionIdentifierStartNode(unittest.TestCase):
+    """
+    A function graph can hold more than one node with no in-edges: edges dropped as jump-table debris leave
+    source nodes behind, and so does obfuscated control flow. _get_start_node() picked whichever the graph
+    happened to iterate first, so the entry could lose the tie-break -- and then everything only the entry
+    reaches is unreachable from the region head, which strands whole subregions.
+    """
+
+    @staticmethod
+    def _block(m, addr):
+        return Block(addr, 1, statements=[Jump(m.next_atom(), Const(m.next_atom(), addr + 1, 64), ins_addr=addr)])
+
+    @staticmethod
+    def _ri(entry_addr):
+        ri = object.__new__(RegionIdentifier)
+        ri.entry_node_addr = entry_addr
+        return ri
+
+    def test_entry_wins_the_tie_break_against_another_source_node(self):
+        m = Manager(arch=None)
+        entry, other, body = self._block(m, 0x100), self._block(m, 0x200), self._block(m, 0x300)
+        graph = networkx.DiGraph()
+        # `other` is inserted first, so iteration reaches it before the entry
+        graph.add_edge(other, body)
+        graph.add_edge(entry, body)
+        assert [n for n in graph if graph.in_degree(n) == 0] == [other, entry]
+
+        assert self._ri((0x100, None))._get_start_node(graph) is entry
+
+    def test_a_sole_source_node_is_still_the_start_node(self):
+        m = Manager(arch=None)
+        entry, body = self._block(m, 0x100), self._block(m, 0x200)
+        graph = networkx.DiGraph()
+        graph.add_edge(entry, body)
+
+        assert self._ri((0x100, None))._get_start_node(graph) is entry
+
+    def test_an_entry_with_predecessors_does_not_displace_a_source_node(self):
+        m = Manager(arch=None)
+        entry, head = self._block(m, 0x100), self._block(m, 0x200)
+        graph = networkx.DiGraph()
+        # the entry sits inside a loop, so it is not a source: the real source still wins
+        graph.add_edge(head, entry)
+        graph.add_edge(entry, head)
+        graph.add_edge(head, head)
+        graph.remove_edge(head, head)
+        source = self._block(m, 0x300)
+        graph.add_edge(source, head)
+
+        assert self._ri((0x100, None))._get_start_node(graph) is source
+
+    def test_entry_is_the_fallback_when_the_graph_has_no_source_node(self):
+        m = Manager(arch=None)
+        entry, other = self._block(m, 0x100), self._block(m, 0x200)
+        graph = networkx.DiGraph()
+        graph.add_edge(entry, other)
+        graph.add_edge(other, entry)
+
+        assert self._ri((0x100, None))._get_start_node(graph) is entry
+
+    def test_no_source_node_and_no_entry_still_raises(self):
+        m = Manager(arch=None)
+        a, b = self._block(m, 0x100), self._block(m, 0x200)
+        graph = networkx.DiGraph()
+        graph.add_edge(a, b)
+        graph.add_edge(b, a)
+
+        with self.assertRaises(AngrRuntimeError):
+            self._ri((0x999, None))._get_start_node(graph)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`scan_request` at `0x4051d0` in DecBench's `binaries/O2/bash/man2html` decompiles to a 9-line stub with a body of two assignments:

```c
void* scan_request(void* a0)
{
    void* node;  // r14
    unsigned long v16;  // rbp

    node = a0;
    v16 = *((char *)a0);
}
```

The log says `Structuring failed to complete ... output will miss code blocks` and no exception is raised, so the binary reports success while an 846-node function is reduced to nothing. `RegionIdentifier._get_start_node()` returned a non-entry node in all 22 of its multi-source calls on this function; with the entry as the head, the same function comes out at 2,154 lines.

### Root cause

`_get_start_node` returns whichever in-degree-0 node `networkx` iteration reaches first, and consults the known entry only when there is no source node at all:

```python
try:
    return next(n for n in graph.nodes() if graph.in_degree(n) == 0)
except StopIteration:
    pass

if self.entry_node_addr is not None:
    ...
```

Graphs do hold several sources — edges dropped as jump-table or switch-case debris leave them behind, as does obfuscated control flow. `RecursiveStructurer` walks from that head, so a subregion it cannot reach is never structured; the parent then meets a region overlay where it expects a graph node and `RegionOverlay.replace_nodes` trips a bare `assert`, which `Decompiler` swallows into `errors`. The same lookup raises when no candidate exists and picks silently wrong when two do.

### Fix

Prefer the entry when it is itself a source node, and reuse `_get_entry_node` for the fallback. That drops a branch, a duplicated derivation and the order-dependent pick. On `man2html` the entry then wins all 142 multi-source picks and the function is recovered whole. An entry with predecessors still does not displace a real source node, and a graph with neither still raises.

The second hunk binds `OverlayManager`'s type parameter at its construction site. `Typecheck` scores errors per line, this file already carried one diagnostic, and removing two lines from the function raised the ratio with the diagnostic count unchanged; the binding removes the diagnostic instead of masking it and is a no-op at runtime.

An alternative repair at the traversal was written and measured byte-identical in effect on the reproducer; both fix one chain, so only this one ships.

### Testing

`tests/analyses/decompiler/test_region_identifier_start_node.py` covers the entry winning the tie-break, a sole source node, an entry inside a loop not displacing a source, the entry as fallback when no source exists, and the existing raise when neither is available. On the merge base it reports `1 failed, 4 passed`, the failure being `assert <AILBlock 0x200 of 1 statements> is <AILBlock 0x100 of 1 statements>`; on this head, `5 passed`. It builds AIL blocks directly and needs no fixture. Before/after output on `man2html`: https://github.com/angr/angr/issues/6972#issuecomment-5452798655

Validation: https://github.com/angr/angr/pull/6972#issuecomment-5430566506

session: sharpen