### PR TITLE
StructurerBase: do not cut a block where a temporary crosses the cut

### DIFF
--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -37,12 +37,34 @@ from angr.analyses.decompiler.utils import (
 )
 from angr.errors import AngrDecompilationError
 from angr.knowledge_plugins.cfg import IndirectJump
+from angr.utils.ssa.tmp_uses_collector import TmpUsesCollector
 
 if TYPE_CHECKING:
     from angr.analyses.decompiler.region_overlay import RegionOverlay
     from angr.knowledge_plugins.functions import Function
 
 _l = logging.getLogger(__name__)
+
+
+def _tmp_crosses_split(statements, start_idx: int, split_idx: int) -> bool:
+    """
+    True when a temporary defined at or after ``start_idx`` and before ``split_idx`` is read after
+    ``split_idx``. Cutting a block there would separate that definition from its use, and AIL
+    temporaries do not cross block boundaries.
+    """
+    defined = set()
+    for stmt in statements[start_idx:split_idx]:
+        if isinstance(stmt, ailment.Stmt.Assignment) and isinstance(stmt.dst, ailment.Expr.Tmp):
+            defined.add(stmt.dst.tmp_idx)
+        elif isinstance(stmt, ailment.Stmt.CAS):
+            for old_val in (stmt.old_lo, stmt.old_hi):
+                if isinstance(old_val, ailment.Expr.Tmp):
+                    defined.add(old_val.tmp_idx)
+    if not defined:
+        return False
+    collector = TmpUsesCollector()
+    collector.walk(ailment.Block(0, 0, statements=list(statements[split_idx + 1 :])))
+    return any(tmp_idx in defined for tmp_idx, _ in collector.tmp_and_uselocs)
 
 
 class StructurerBase(Analysis):
@@ -454,6 +476,14 @@ class StructurerBase(Analysis):
                     and isinstance(stmt.target, ailment.Expr.Const)
                     and parent.nodes[index + 1].addr == stmt.target.value
                 ):
+                    continue
+                if _tmp_crosses_split(node.statements, last_nonjump_stmt_idx, stmt_idx):
+                    # rewriting this jump into a break cuts the block open here, and the piece after the cut
+                    # becomes a block of its own. AIL temporaries are block-local, so a temporary defined
+                    # before the cut and read after it leaves that piece reading one it does not define, and
+                    # block simplification raises on the missing definition. A rep-prefixed string instruction
+                    # lifts to exactly that shape: its counter guard is an internal branch between statements
+                    # of the one instruction. Leave the jump alone; it stays a goto.
                     continue
                 targets = extract_jump_targets(stmt)
                 if any(target in successor_addrs for target in targets):

--- a/tests/analyses/decompiler/test_break_rewrite_instruction_boundary.py
+++ b/tests/analyses/decompiler/test_break_rewrite_instruction_boundary.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,no-member,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import collections
+import unittest
+
+from angr.ailment import Manager
+from angr.ailment.block import Block
+from angr.ailment.expression import BinaryOp, Const, Register, Tmp
+from angr.ailment.statement import Assignment, ConditionalJump, Jump
+from angr.analyses.decompiler.structurer_nodes import SequenceNode
+from angr.analyses.decompiler.structuring.structurer_base import StructurerBase
+
+
+def _blocks(node):
+    """Every AIL block reachable in a structured node, in tree order."""
+    out = []
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if isinstance(n, Block):
+            out.append(n)
+        elif isinstance(n, SequenceNode):
+            stack.extend(reversed(n.nodes))
+    return out
+
+
+class TestBreakRewriteInstructionBoundary(unittest.TestCase):
+    """
+    _rewrite_conditional_jumps_to_breaks cuts an AIL block at a loop-exit jump and builds one block per piece
+    from the ins_addr of that piece's first statement. A rep-prefixed string instruction lifts to a block whose
+    counter guard is an internal branch *between statements of the one instruction*, so both pieces take the
+    same ins_addr and keep the original idx: two blocks end up sharing one (addr, idx) identity, and the VEX
+    temporary defined before the cut is used after it. Temporaries are block-local, so the second piece reads
+    one that is no longer defined, and block simplification later raises KeyError on it.
+    """
+
+    @staticmethod
+    def _structurer():
+        st = object.__new__(StructurerBase)
+        st._loop_create_break_node = lambda stmt, addrs: Block(stmt.tags["ins_addr"], 0, statements=[], idx=None)
+        return st
+
+    @staticmethod
+    def _one_instruction_loop_body(m, ins_addr=0x1000, exit_addr=0x2000):
+        """The rep-movs shape: counter read, loop-exit branch, counter decrement -- all one instruction."""
+        t1 = Tmp(m.next_atom(), 1, 32)
+        stmts = [
+            Assignment(m.next_atom(), t1, Register(m.next_atom(), 12, 32), ins_addr=ins_addr),
+            ConditionalJump(
+                m.next_atom(),
+                t1,
+                Const(m.next_atom(), exit_addr, 32),
+                Const(m.next_atom(), ins_addr, 32),
+                ins_addr=ins_addr,
+            ),
+            Assignment(
+                m.next_atom(),
+                Register(m.next_atom(), 12, 32),
+                BinaryOp(m.next_atom(), "Sub", [t1, Const(m.next_atom(), 1, 32)], False),
+                ins_addr=ins_addr,
+            ),
+            # the tail needs two statements: with exactly one after the jump a *different* defect
+            # (the tail gate at the rebuild) drops it outright, and this one never gets to fire
+            Assignment(
+                m.next_atom(),
+                Register(m.next_atom(), 32, 32),
+                BinaryOp(m.next_atom(), "Add", [t1, Const(m.next_atom(), 2, 32)], False),
+                ins_addr=ins_addr,
+            ),
+        ]
+        return SequenceNode(ins_addr, nodes=[Block(ins_addr, 4, statements=stmts, idx=None)])
+
+    def test_a_cut_inside_one_instruction_is_not_taken(self):
+        m = Manager(arch=None)
+        body = self._one_instruction_loop_body(m)
+        StructurerBase._rewrite_conditional_jumps_to_breaks(self._structurer(), body, {0x2000})
+
+        blocks = [b for b in _blocks(body) if b.statements]
+        identities = collections.Counter((b.addr, b.idx) for b in blocks)
+        # the identity of an AIL block is (addr, idx); two pieces of one instruction would collide
+        assert all(n == 1 for n in identities.values()), f"duplicate block identities: {identities}"
+
+        # and the temporary keeps its definition in the same block as its use
+        for b in blocks:
+            defined = {s.dst.tmp_idx for s in b.statements if isinstance(s, Assignment) and isinstance(s.dst, Tmp)}
+            used = {
+                a.tmp_idx
+                for s in b.statements
+                if isinstance(s, Assignment) and isinstance(s.src, BinaryOp)
+                for a in s.src.operands
+                if isinstance(a, Tmp)
+            }
+            assert used <= defined, f"block {b.addr:#x} uses undefined temporaries {used - defined}"
+
+    def test_a_cut_on_an_instruction_boundary_is_still_taken(self):
+        m = Manager(arch=None)
+        # the loop-exit jump is the last statement of its own instruction, so cutting there is safe
+        stmts = [
+            Assignment(m.next_atom(), Register(m.next_atom(), 8, 32), Const(m.next_atom(), 0, 32), ins_addr=0x1000),
+            ConditionalJump(
+                m.next_atom(),
+                Const(m.next_atom(), 1, 32),
+                Const(m.next_atom(), 0x2000, 32),
+                Const(m.next_atom(), 0x1008, 32),
+                ins_addr=0x1004,
+            ),
+            Jump(m.next_atom(), Const(m.next_atom(), 0x1000, 32), ins_addr=0x1008),
+        ]
+        body = SequenceNode(0x1000, nodes=[Block(0x1000, 12, statements=stmts, idx=None)])
+        StructurerBase._rewrite_conditional_jumps_to_breaks(self._structurer(), body, {0x2000})
+
+        # the rewrite fired: the original block was emptied and replaced by pieces
+        assert len(_blocks(body)) > 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_break_rewrite_instruction_boundary.py
+++ b/tests/analyses/decompiler/test_break_rewrite_instruction_boundary.py
@@ -45,7 +45,7 @@ class TestBreakRewriteInstructionBoundary(unittest.TestCase):
     def _structurer():
         """The rewrite touches only cond_proc on the instance, so the real break-node path runs."""
         st = object.__new__(StructurerBase)
-        st.cond_proc = ConditionProcessor(archinfo.ArchX86(), Manager(arch=archinfo.ArchX86()))
+        st.cond_proc = ConditionProcessor(archinfo.ArchX86(), Manager())
         return st
 
     @staticmethod
@@ -79,7 +79,7 @@ class TestBreakRewriteInstructionBoundary(unittest.TestCase):
         return SequenceNode(ins_addr, nodes=[Block(ins_addr, 4, statements=stmts, idx=None)])
 
     def test_a_cut_inside_one_instruction_is_not_taken(self):
-        m = Manager(arch=None)
+        m = Manager()
         body = self._one_instruction_loop_body(m)
         StructurerBase._rewrite_conditional_jumps_to_breaks(self._structurer(), body, {0x2000})
 
@@ -101,7 +101,7 @@ class TestBreakRewriteInstructionBoundary(unittest.TestCase):
             assert used <= defined, f"block {b.addr:#x} uses undefined temporaries {used - defined}"
 
     def test_a_cut_on_an_instruction_boundary_is_still_taken(self):
-        m = Manager(arch=None)
+        m = Manager()
         # the loop-exit jump is the last statement of its own instruction, so cutting there is safe
         stmts = [
             Assignment(m.next_atom(), Register(m.next_atom(), 8, 32), Const(m.next_atom(), 0, 32), ins_addr=0x1000),

--- a/tests/analyses/decompiler/test_break_rewrite_instruction_boundary.py
+++ b/tests/analyses/decompiler/test_break_rewrite_instruction_boundary.py
@@ -7,10 +7,13 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 import collections
 import unittest
 
+import archinfo
+
 from angr.ailment import Manager
 from angr.ailment.block import Block
 from angr.ailment.expression import BinaryOp, Const, Register, Tmp
 from angr.ailment.statement import Assignment, ConditionalJump, Jump
+from angr.analyses.decompiler.condition_processor import ConditionProcessor
 from angr.analyses.decompiler.structurer_nodes import SequenceNode
 from angr.analyses.decompiler.structuring.structurer_base import StructurerBase
 
@@ -40,8 +43,9 @@ class TestBreakRewriteInstructionBoundary(unittest.TestCase):
 
     @staticmethod
     def _structurer():
+        """The rewrite touches only cond_proc on the instance, so the real break-node path runs."""
         st = object.__new__(StructurerBase)
-        st._loop_create_break_node = lambda stmt, addrs: Block(stmt.tags["ins_addr"], 0, statements=[], idx=None)
+        st.cond_proc = ConditionProcessor(archinfo.ArchX86(), Manager(arch=archinfo.ArchX86()))
         return st
 
     @staticmethod


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`_rewrite_conditional_jumps_to_breaks` cuts an AIL block at a loop-exit jump, and the piece after the cut becomes a block of its own. Where a temporary is defined before the cut and read after it, the second piece reads a definition it does not have, and block simplification dies on it:

```
  block (addr=0x1000, idx=None) READS undefined temporaries: [<Tmp 1>]
  File "angr/analyses/s_propagator.py", line 498, in _analyze
    tmp_def_stmtidx = tmp_deflocs[block_loc][tmp_atom]
KeyError: <Tmp 1>
```

`Decompiler` swallows that into `Decompiler.errors`, so the function yields no output while the binary as a whole reports success. Both pieces also inherit the same `ins_addr`, so they share one `(addr, idx)` identity — `Counter({(4096, None): 2})` — and anything keyed on it merges their definitions and uses.

### Root cause

AIL temporaries are block-local; the rewrite cuts wherever a loop-exit jump sits, with no test for what crosses. A `rep`-prefixed string instruction lifts to exactly the offending shape, because its counter guard is an internal branch *between statements of the one instruction*: the counter is read into a temporary before the branch and decremented after it, so the cut always separates the two. Nothing upstream is wrong — the block is well-formed until it is split.

### Fix

`_tmp_crosses_split()` asks whether a temporary defined at or after the start of the piece and before the cut is read after it; where one is, the jump is left alone and stays a goto. On the same input the block now survives whole and `SPropagator` runs over it cleanly.

The check is on a temporary actually crossing, not on the cut falling inside one instruction. The wider form was written first, and it refused harmless cuts: `test_single_instruction_loop` regressed, `x86_64/decompiler/level_12_teaching` `main` degrading from a `for` loop to `while(true)`.

### Testing

`tests/analyses/decompiler/test_break_rewrite_instruction_boundary.py` builds the shape from AIL statements and asserts no two live pieces share an identity and no piece reads an undefined temporary, with an instruction-boundary case alongside it to pin that ordinary cuts still happen. On the merge base it reports `1 failed, 1 passed`, the failure being `duplicate block identities: Counter({(4096, None): 2})`; on this head, `2 passed`. Before/after output of the reproducer: https://github.com/angr/angr/issues/6973#issuecomment-5452769113

No fixture: the sample this was found on is not public, and a scan of 43 public binaries counts 1,047 break-minting cuts with 0 that would separate a temporary, so there is no public binary to add. This edits the same function as #6978; `git merge-tree` reports no conflict.

Validation: https://github.com/angr/angr/pull/6973#issuecomment-5430737672

session: sharpen