### PR TITLE
RDA: keep the VEX result width when a vector comparison reaches a scalar handler

### DIFF
--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -975,11 +975,33 @@ class SimEngineRDVEX(
 
         return r
 
+    def _cmp_lane_mask_top(self, expr: pyvex.expr.Binop) -> MultiValues | None:
+        """The TOP of the right width for a comparison that is not a scalar one.
+
+        ``_handle_expr_Binop`` dispatches on the longest matching handler-name prefix, and
+        no vector comparison has a handler of its own, so ``Iop_CmpGT8Sx8``,
+        ``Iop_CmpEQ32Fx4`` and ``Iop_CmpEQ64F0x2`` all arrive at the scalar handlers below.
+        Their result is a per-lane mask as wide as the operands rather than a condition
+        bit. Answering those with one bit is not merely imprecise: it stores a value whose
+        width contradicts the tmp's VEX type, and the first consumer that combines it with
+        anything of the declared width raises ClaripyOperationError.
+
+        Returns None when the comparison really is scalar and the caller should go on.
+        """
+        bits = expr.result_size(self.tyenv)
+        if bits == 1:
+            return None
+        return self._top(bits)
+
     @binop_handler
     def _handle_binop_CmpEQ(self, expr: pyvex.expr.Binop) -> MultiValues:
         arg0, arg1 = expr.args
         expr_0 = self._expr(arg0)
         expr_1 = self._expr(arg1)
+
+        lane_mask = self._cmp_lane_mask_top(expr)
+        if lane_mask is not None:
+            return lane_mask
 
         e0 = expr_0.one_value()
         e1 = expr_1.one_value()
@@ -999,6 +1021,10 @@ class SimEngineRDVEX(
         expr_0 = self._expr(arg0)
         expr_1 = self._expr(arg1)
 
+        lane_mask = self._cmp_lane_mask_top(expr)
+        if lane_mask is not None:
+            return lane_mask
+
         e0 = expr_0.one_value()
         e1 = expr_1.one_value()
         if e0 is not None and e1 is not None:
@@ -1012,6 +1038,10 @@ class SimEngineRDVEX(
     def _handle_binop_CmpLT(self, expr: pyvex.expr.Binop) -> MultiValues:
         arg0, arg1 = expr.args
         expr_0, expr_1 = self._expr_pair(arg0, arg1)
+
+        lane_mask = self._cmp_lane_mask_top(expr)
+        if lane_mask is not None:
+            return lane_mask
 
         e0 = expr_0.one_value()
         e1 = expr_1.one_value()
@@ -1028,6 +1058,10 @@ class SimEngineRDVEX(
         arg0, arg1 = expr.args
         expr_0, expr_1 = self._expr_pair(arg0, arg1)
 
+        lane_mask = self._cmp_lane_mask_top(expr)
+        if lane_mask is not None:
+            return lane_mask
+
         e0 = expr_0.one_value()
         e1 = expr_1.one_value()
         if e0 is not None and e1 is not None:
@@ -1043,6 +1077,10 @@ class SimEngineRDVEX(
         arg0, arg1 = expr.args
         expr_0, expr_1 = self._expr_pair(arg0, arg1)
 
+        lane_mask = self._cmp_lane_mask_top(expr)
+        if lane_mask is not None:
+            return lane_mask
+
         e0 = expr_0.one_value()
         e1 = expr_1.one_value()
         if e0 is not None and e1 is not None:
@@ -1057,6 +1095,10 @@ class SimEngineRDVEX(
     def _handle_binop_CmpGE(self, expr: pyvex.expr.Binop) -> MultiValues:
         arg0, arg1 = expr.args
         expr_0, expr_1 = self._expr_pair(arg0, arg1)
+
+        lane_mask = self._cmp_lane_mask_top(expr)
+        if lane_mask is not None:
+            return lane_mask
 
         e0 = expr_0.one_value()
         e1 = expr_1.one_value()

--- a/tests/analyses/reaching_definitions/test_regressions.py
+++ b/tests/analyses/reaching_definitions/test_regressions.py
@@ -5,6 +5,7 @@ import os
 import struct
 from unittest import TestCase
 
+import pyvex
 from archinfo import ArchAArch64
 
 import angr
@@ -45,6 +46,41 @@ class TestRDARegressions(TestCase):
 
         # Used to raise RuntimeError("dictionary changed size during iteration").
         proj.analyses[ReachingDefinitionsAnalysis].prep()(subject=cfg.functions[func_addr], observe_all=False)
+
+    def test_vector_comparison_keeps_the_vex_result_width(self):
+        """
+        A NEON comparison such as Iop_CmpGT8Sx8 has no handler of its own, so the
+        longest-prefix dispatch in _handle_expr_Binop sends it to the scalar CmpGT
+        handler. Its result is a per-lane mask as wide as the operands, not a condition
+        bit, so a one-bit answer contradicts the tmp's declared I64 type and the next
+        statement that combines that tmp with anything of the declared width raises
+        ClaripyOperationError inside claripy.
+        """
+        # The two ARM entries raise before the fix. The x86 ones do not -- nothing in
+        # their blocks consumes the mask at its declared width -- but they pin the same
+        # contract on the CmpEQ and CmpLE handlers, which NEON does not reach here.
+        for arch, filename, block_addr, op in [
+            ("armhf", "float_int_conversion.elf", 0xC83B, "Iop_CmpGT8Sx8"),
+            ("armel", "i2c_master_read-nucleol152re.elf", 0x800254F, "Iop_CmpGT8Ux8"),
+            ("i386", "test_arrays.exe", 0x40C489, "Iop_CmpEQ8x16"),
+            ("i386", "test_arrays.exe", 0x409FE2, "Iop_CmpLE64Fx2"),
+        ]:
+            with self.subTest(filename=filename, op=op):
+                path = os.path.join(bin_location, "tests", arch, filename)
+                proj = angr.Project(path, auto_load_libs=False)
+                block = proj.factory.block(block_addr)
+
+                binops = {
+                    stmt.data.op
+                    for stmt in block.vex.statements
+                    if isinstance(stmt, pyvex.stmt.WrTmp) and isinstance(stmt.data, pyvex.expr.Binop)
+                }
+                assert op in binops, f"{filename} no longer carries {op} at {block_addr:#x}"
+
+                # Raised ClaripyOperationError("args' length must all be equal") before the
+                # scalar comparison handlers started respecting expr.result_size().
+                rda = proj.analyses[ReachingDefinitionsAnalysis].prep()(subject=block)
+                assert rda.model is not None
 
     def test_load_multiple_concrete_addresses(self):
         """


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ReachingDefinitions(subject=block)` on block `0xc83b` of `binaries/tests/armhf/float_int_conversion.elf` raises, and so does block `0x800254f` of `binaries/tests/armel/i2c_master_read-nucleol152re.elf`:

```
  File "angr/analyses/reaching_definitions/engine_vex.py", line 773, in _handle_binop_And
    r = MultiValues(expr0_v & expr1_v)
                    ~~~~~~~~^~~~~~~~~
  File "claripy/operations.py", line 60, in _op
    raise ClaripyOperationError(msg)
claripy.errors.ClaripyOperationError: args' length must all be equal
```

In the wild it arrives through `CompleteCallingConventions` -> `CallingConventionAnalysis._extract_and_analyze_callsites` -> `ReachingDefinitionsAnalysis`, and `work()` calls `_analyze_core` per function with nothing catching the raise, so one NEON comparison ends calling-convention recovery for the rest of the binary. Observed that way on decbench `O2-noinline/cleanflight/cleanflight_DALRCF405.elf` function `0x8054af5`.

### Root cause

`SimEngineRDVEX` defines no `_handle_binopv_*` handler at all, so `_handle_expr_Binop`'s vector branch finds nothing and falls through to the longest-prefix lookup over the scalar handlers: `Iop_CmpGT8Sx8` lands on `_handle_binop_CmpGT`, which ends in

```python
return MultiValues(self.state.top(1))
```

A scalar comparison does yield one bit; a NEON or SSE comparison yields a per-lane mask as wide as its operands. The tmp is declared `Ity_I64`, so the engine stores a 1-bit value under a 64-bit type, and the mismatch is invisible until something reads the tmp at its declared width — here the next statement, `And64(0x0000000100000001, t24)`, which hands claripy a `BV64 & BV1`.

### Fix

`_cmp_lane_mask_top()` answers TOP at `expr.result_size(self.tyenv)` whenever the declared result is wider than one bit, and the six scalar comparison handlers consult it first. Precision is unchanged for genuine scalar comparisons, which still return one bit and take the constant-folding path below. The same reproducer now completes with each tmp at the width its type declares:

```
VERDICT t24: declared 64 bits, RDA value 64 bits
VERDICT armhf: RDA completed, 13 definitions
```

`CmpORD` is deliberately left alone: it already sizes its answer from `bits`, and adding the guard there would replace a precise value with TOP.

### The same handler drops register definitions instead of raising

When the lane mask goes to a vector register rather than into an `And64` -- which
is what x86 and x86-64 SSE code does -- the mismatch does not raise.
`SizeNormalizationMixin.store` refuses a 1-bit value for a 16-byte register with
`SimMemoryError: Not enough data for store`, and
`LiveDefinitions.kill_and_add_definition` catches that, logs
`Failed to store register definition`, and carries on. The definition is dropped,
the analysis reports success, and nothing reaches a traceback.

`binaries/tests/x86_64/decompiler/ffs` holds one `pcmpeqb xmm1, xmm6`, at
`0x402d38`. Against master a `ReachingDefinitions(subject=block)` there leaves `xmm1` with only its external definition; on this branch the
instruction defines it. The runnable form and the counts are in the validation
comment.

#4289 and #5049 carry the same message on different paths, and this branch closes
neither: #4289 is the `MemoryLocation` branch of the same store, which has no
`except SimMemoryError` and so raises out of `AILSimplifier._narrow_exprs`, and
#5049 is the Propagator's own `store_register` hitting the same guard.

### Testing

`test_vector_comparison_keeps_the_vex_result_width` in `tests/analyses/reaching_definitions/test_regressions.py` runs the RDA over four existing `angr/binaries` blocks; no new fixture is needed. Against the merge base it reports `2 failed, 1 passed`, both failures the `ClaripyOperationError` above on the two ARM subtests; on this head, `1 passed, 4 subtests passed`. The two i386 subtests pass on both arms and are there to pin the same contract on the `CmpEQ` and `CmpLE` handlers, which the NEON blocks do not reach. Before/after output of the reproducer: https://github.com/angr/angr/issues/6975#issuecomment-5452629191

Validation: https://github.com/angr/angr/pull/6975#issuecomment-5432028752

session: sharpen