### PR TITLE
CFGFast: Restore the nodecode threshold that lets the smart scan escape

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -646,7 +646,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         exceptions=True,
         skip_unmapped_addrs=True,
         nodecode_window_size=2048,
-        nodecode_threshold=0.6,
+        nodecode_threshold=0.3,
         nodecode_step=16483,
         check_funcret_max_job=500,
         indirect_calls_always_return: bool | None = None,

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1027,7 +1027,7 @@ class TestCfgfast(unittest.TestCase):
         # scan used to cover it with thousands of one-block functions that drop_bad_functions() threw away again
         rng = random.Random(0xDEADBEEF)
         proj = self._blob_project(bytes(rng.getrandbits(8) for _ in range(32768)))
-        cfg = proj.analyses.CFGFast(normalize=True, nodecode_threshold=0.3)
+        cfg = proj.analyses.CFGFast(normalize=True)
 
         assert len(cfg.kb.functions) < 150, f"32 KB of random data produced {len(cfg.kb.functions)} functions"
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

With the shipped defaults, `CFGFast`'s smart scan never escapes a region of undecodable bytes. On the 32 KB blob that `tests/analyses/cfg/test_cfgfast.py::test_smart_scan_does_not_explode_on_random_data` builds — `random.Random(0xDEADBEEF)`, loaded as an AMD64 blob at base `0x0` — the escape branch of `_next_code_addr_smart` fires zero times:

```
nodecode_window_size = 2048, nodecode_threshold = 0.6
_next_code_addr_smart calls          : 3153
  escape branch taken                : 0
  max nodecode ratio seen            : 0.4226
highest address the scan handed out  : 0x7fe9
blob size                            : 0x8000
functions recovered                  : 714  (the test asserts < 150)
```

The scan walks the whole blob and invents 714 functions. The test's own assertion is fewer than 150; it is green today only because #6894 passed `nodecode_threshold=0.3` into the call, so the repository's guard has been measuring a configuration it does not ship.

### Root cause

#6894 raised `nodecode_window_size` from 512 to 2048 and `nodecode_threshold` from 0.3 to 0.6 together. The escape is one predicate in `angr/analyses/cfg/cfg_fast.py`:

```python
if nodecode_bytes_ratio >= self._nodecode_threshold and self._next_addr is not None:
    next_allowed_addr = self._next_addr + self._nodecode_step
```

`nodecode_bytes_ratio` is nodecode bytes over the trailing window. A failed lift occupies a single byte as `nodecode` while whatever lifted ahead of it is occupied as `code`, so the ratio over a window of undecodable bytes saturates well under 0.6 — 0.4226 at its highest on this input — and the branch is unreachable. The two constants multiply: 512 × 0.3 = 154 contiguous `nodecode` bytes to escape became 2048 × 0.6 = 1229.

### Fix

Put `nodecode_threshold` back to 0.3, leave `nodecode_window_size` at 2048, and delete the per-test override. Same blob, same defaults:

```
nodecode_window_size = 2048, nodecode_threshold = 0.3
  escape branch taken                : 2
  largest single advance             : 16483
highest address the scan handed out  : 0x5580
functions recovered                  : 117  (the test asserts < 150)
```

Correcting what this description said before: the threshold is **not** the half that makes the scan grind through memory that is not code. On the objects behind that claim the window is the dominant half, and this change deliberately leaves the window where #6894 put it, because the recovery #6894 was written for comes from the window. The validation record carries the per-object split between the two constants.

### Testing

`test_smart_scan_does_not_explode_on_random_data` runs against the defaults again with its `nodecode_threshold=0.3` argument removed; it fails on the baseline at 714 functions and passes here at 117, against its unmodified limit of 150. `test_smart_scan_does_not_miss_functions_armel_blob`, the test #6894 added, finds 7 of 7 functions on both revisions, since the window it depends on is untouched.

Validation: https://github.com/angr/angr/pull/6976#issuecomment-5431884103

session: sharpen
