### PR TITLE
StructurerBase: stop dropping a lone statement after a loop-exit jump

### DIFF
--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -489,8 +489,11 @@ class StructurerBase(Analysis):
                         new_nodes.append(break_node)
 
             if new_nodes:
-                if len(node.statements) - 1 > last_nonjump_stmt_idx:
-                    # insert the last node
+                if len(node.statements) - 1 >= last_nonjump_stmt_idx:
+                    # insert the last node. The slice below starts AT last_nonjump_stmt_idx, so the tail is
+                    # non-empty whenever that index is still within the block. A strict > skipped the tail
+                    # when exactly one statement followed the loop-exit jump, and the original block is
+                    # emptied below, so that statement was dropped without an error or a log message.
                     sub_block_statements = node.statements[last_nonjump_stmt_idx:]
                     new_sub_block = ailment.Block(
                         sub_block_statements[0].tags["ins_addr"],

--- a/tests/analyses/decompiler/test_break_rewrite_tail_statement.py
+++ b/tests/analyses/decompiler/test_break_rewrite_tail_statement.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,no-member,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import unittest
+
+from angr.ailment import Manager
+from angr.ailment.block import Block
+from angr.ailment.expression import Const, Register
+from angr.ailment.statement import Assignment, ConditionalJump
+from angr.analyses.decompiler.structurer_nodes import SequenceNode
+from angr.analyses.decompiler.structuring.structurer_base import StructurerBase
+
+
+def _statements(node):
+    """Every AIL statement reachable in a structured node, in tree order."""
+    out = []
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if isinstance(n, Block):
+            out.extend(n.statements)
+        elif isinstance(n, SequenceNode):
+            stack.extend(reversed(n.nodes))
+    return out
+
+
+class TestBreakRewriteTailStatement(unittest.TestCase):
+    """
+    _rewrite_conditional_jumps_to_breaks replaces an AIL block that exits a loop with one block per
+    piece: the statements before the loop-exit jump, the break itself, and the statements after it.
+    The original block is emptied once the pieces are in place, so any piece the rebuild does not
+    emit is gone from the output -- with no exception and no log record.
+    """
+
+    @staticmethod
+    def _structurer():
+        # the rewrite needs only this one collaborator, so the analysis is never constructed
+        st = object.__new__(StructurerBase)
+        setattr(  # noqa: B010
+            st,
+            "_loop_create_break_node",
+            lambda stmt, addrs: Block(stmt.tags["ins_addr"], 0, statements=[], idx=None),
+        )
+        return st
+
+    @staticmethod
+    def _loop_body(m, tail_len: int, ins_addr: int = 0x1000, exit_addr: int = 0x2000):
+        """A loop-exit branch with ``tail_len`` ordinary statements after it."""
+        stmts = [
+            Assignment(m.next_atom(), Register(m.next_atom(), 8, 32), Const(m.next_atom(), 0, 32), ins_addr=ins_addr),
+            ConditionalJump(
+                m.next_atom(),
+                Const(m.next_atom(), 1, 32),
+                Const(m.next_atom(), exit_addr, 32),
+                Const(m.next_atom(), ins_addr + 8, 32),
+                ins_addr=ins_addr + 4,
+            ),
+        ]
+        for i in range(tail_len):
+            stmts.append(
+                Assignment(
+                    m.next_atom(),
+                    Register(m.next_atom(), 20 + i, 32),
+                    Const(m.next_atom(), 42 + i, 32),
+                    ins_addr=ins_addr + 8 + 4 * i,
+                )
+            )
+        return stmts, SequenceNode(ins_addr, nodes=[Block(ins_addr, 8 + 4 * tail_len, statements=stmts, idx=None)])
+
+    def _rewrite(self, tail_len: int):
+        m = Manager(arch=None)
+        stmts, body = self._loop_body(m, tail_len)
+        StructurerBase._rewrite_conditional_jumps_to_breaks(self._structurer(), body, {0x2000})
+        return stmts, _statements(body)
+
+    def test_a_single_statement_after_the_exit_jump_survives(self):
+        stmts, surviving = self._rewrite(1)
+        # the jump itself becomes the break, so every other statement must still be there
+        assert any(s is stmts[2] for s in surviving), f"the statement after the loop-exit jump was dropped: {surviving}"
+        assert any(s is stmts[0] for s in surviving)
+
+    def test_two_statements_after_the_exit_jump_survive(self):
+        # the tail block was always emitted for a tail of two or more; pin that it still is
+        stmts, surviving = self._rewrite(2)
+        assert any(s is stmts[2] for s in surviving)
+        assert any(s is stmts[3] for s in surviving)
+        assert any(s is stmts[0] for s in surviving)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_break_rewrite_tail_statement.py
+++ b/tests/analyses/decompiler/test_break_rewrite_tail_statement.py
@@ -71,7 +71,7 @@ class TestBreakRewriteTailStatement(unittest.TestCase):
         return stmts, SequenceNode(ins_addr, nodes=[Block(ins_addr, 8 + 4 * tail_len, statements=stmts, idx=None)])
 
     def _rewrite(self, tail_len: int):
-        m = Manager(arch=None)
+        m = Manager()
         stmts, body = self._loop_body(m, tail_len)
         StructurerBase._rewrite_conditional_jumps_to_breaks(self._structurer(), body, {0x2000})
         return stmts, _statements(body)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling `__mpn_mul_1` at `0x80034338` in `binaries/tests/m68k/mul_add_sub_xor_m68k_be` loses the loop's counter decrement. `v21` is declared, read in the loop condition, and assigned nowhere in the function:

```c
    unsigned int v21;  // d2
    ...
        } while (*((unsigned short *)((void*)&v21 + 2)) != INT_2COMP());
```

The statement that vanished is the `dbf D2w, 0x8003435a` at the bottom of the loop, so the emitted `do`/`while` has no termination counter at all. There is no exception and no log line: the decompilation looks complete and is wrong.

### Root cause

`_rewrite_conditional_jumps_to_breaks` replaces a loop-exiting AIL block with one block per piece — the statements before the loop-exit jump, the break, and the statements after it. The gate on that last piece is

```python
if len(node.statements) - 1 > last_nonjump_stmt_idx:
    sub_block_statements = node.statements[last_nonjump_stmt_idx:]
```

The slice starts *at* `last_nonjump_stmt_idx`, so it is non-empty whenever that index is still in range, but the guard is strict. With exactly one statement after the jump the two are equal, no tail block is built — and the original block is emptied immediately below, so the statement is dropped rather than left where it was.

### Fix

Compare with `>=`, which is what the slice already assumes. Nothing else changes: the same reproducer now emits the missing definition and the rest of the function is byte-identical.

```c
+            v21 = _INSERT(iter, 2, *((unsigned short *)((void*)&iter + 2)) - 1);
         } while (*((unsigned short *)((void*)&v21 + 2)) != INT_2COMP());
```

### Testing

`tests/analyses/decompiler/test_break_rewrite_tail_statement.py` builds the shape from AIL statements and asserts the statement after the loop-exit jump survives the rewrite, with a two-statement tail alongside it to pin the case that always worked. On the merge base it reports `1 failed, 1 passed`, the failure being `the statement after the loop-exit jump was dropped: [reg8<32> = 0<32>]`; on this head, `2 passed`. Before/after output of the reproducer: https://github.com/angr/angr/issues/6978#issuecomment-5452755702

Best merged after #6973, whose guard stops a rebuilt tail from reading a temporary defined before the cut; the two edit the same function and `git merge-tree` reports no conflict.

Validation: https://github.com/angr/angr/pull/6978#issuecomment-5432249432

session: sharpen