### PR TITLE
SimType: a type narrower than one byte aligns to one byte, not to zero

### DIFF
--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -128,7 +128,10 @@ class SimType:
         if self.size is None:
             l.debug("The size of the type %r is unknown; assuming word size of the arch.", self)
             return self._arch.bytes
-        return self.size // self._arch.byte_width
+        # A type narrower than one byte still occupies a byte-addressable location, so it aligns
+        # to one byte. Reporting the truncated quotient instead would be zero, which is not an
+        # alignment any ABI defines and which divides by zero wherever an offset is rounded up.
+        return max(1, self.size // self._arch.byte_width)
 
     def with_arch(self, arch: Arch | None, memo: dict[str, SimType] | None = None) -> SimType:
         if arch is None:

--- a/tests/types/test_types.py
+++ b/tests/types/test_types.py
@@ -19,6 +19,7 @@ from angr.sim_type import (
     SimTypeChar,
     SimTypeCppFunction,
     SimTypeDouble,
+    SimTypeFixedSizeArray,
     SimTypeFloat,
     SimTypeFunction,
     SimTypeInt,
@@ -354,6 +355,30 @@ class TestTypes(unittest.TestCase):
             (12, 3),
             (1, 7),
         ]
+
+    def test_sub_byte_types_align_to_one_byte(self):
+        # SimTypeNum is sized in bits, so a type narrower than a byte used to report an
+        # alignment of zero -- the truncated quotient -- and every struct laying such a
+        # field out divided by zero while rounding the running bit offset up.
+        arch = archinfo.ArchX86()
+
+        assert [SimTypeNum(bits).with_arch(arch).alignment for bits in range(1, 9)] == [1] * 8
+        assert SimTypeInt().with_arch(arch).alignment == 4  # wider types are unchanged
+
+        # Aggregates take a max() over their members, so they propagated the zero outwards.
+        assert SimTypeFixedSizeArray(SimTypeNum(4), 3).with_arch(arch).alignment == 1
+        assert SimUnion({"m": SimTypeNum(4)}, name="nibble_union").with_arch(arch).alignment == 1
+
+        nibble = cast(SimStruct, SimStruct({"b": SimTypeNum(4)}, name="nibble").with_arch(arch))
+        assert nibble.offsets == {"b": 0}
+        holds_union = cast(
+            SimStruct,
+            SimStruct(
+                {"a": SimTypeInt(), "u": SimUnion({"m": SimTypeNum(4)}, name="nibble_union2")},
+                name="holds_nibble_union",
+            ).with_arch(arch),
+        )
+        assert holds_union.offsets == {"a": 0, "u": 4}
 
     def test_dereference_type_anonymous_struct(self):
         angr.procedures.definitions.load_win32_type_collections()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Reading `.offsets` on a struct that holds one sub-byte field raises, on a struct with one field at bit offset zero:

```
  File "angr/sim_type.py", line 1704, in offsets
    if bitoffset_so_far % align != 0:
       ~~~~~~~~~~~~~~~~~^~~~~~~
ZeroDivisionError: integer modulo by zero
```

The zero propagates outwards, so the struct need not hold a sub-byte type of its own: `SimTypeFixedSizeArray(SimTypeNum(4), 3)` and `SimUnion({'m': SimTypeNum(4)})` each report alignment `0` themselves, because both aggregate overrides take a `max()` over their members.

### Root cause

`SimType.alignment` is documented in bytes and returns `self.size // self._arch.byte_width` (`angr/sim_type.py:131`). `SimTypeNum` is sized in bits, so the quotient truncates: measured on master, `SimTypeNum(n).alignment` is `0` for n in 1..7 and `1` at 8. Zero is not an alignment any ABI defines, and it is not the `NotImplemented` sentinel the caller's guard tests for either, so it passes that guard as an ordinary integer and reaches the modulo.

### Fix

Clamp the quotient at one, which leaves every type at least a byte wide computing exactly what it computed before. The reproducer then prints `{'b': 0}` — bit offset zero, which is where a one-byte alignment puts the field.

The base property is the site rather than each caller because `angr/rust/sim_type.py:57` already hand-rolls this same clamp (`align if align > 0 else 1`) over the same value. Deliberately not done here: `angr/analyses/typehoon/translator.py` bottoms out sub-byte `SimTypeNum` as a producer-side workaround for this defect and its test names zero alignment as the reason — that guard is now redundant, and removing it is a separate change with its own test update. The dead `NotImplemented` guard on the neighbouring line of `SimStruct.offsets` is a different producer and is already repaired by #6964; the two merge cleanly.

### Testing

`tests/types/test_types.py::TestTypes::test_sub_byte_types_align_to_one_byte` fails on the baseline at its first assertion and passes on the head.

No public binary reaches this: over 53 public binaries under both structurers, 15,351 functions decompiled, the truncating expression was evaluated 212,581,261 times and produced zero exactly 0 times, and a size histogram over the two heaviest units shows widths of 8, 16, 32 and 64 bits and nothing narrower. So the argument is the API-level crash and the now-redundant producer-side workaround, not corpus impact.

Validation: https://github.com/angr/angr/pull/6979#issuecomment-5432592197

session: sharpen