### PR TITLE
CCodeGen: stop rendering an anonymous aggregate that contains itself forever

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -273,7 +273,9 @@ def _is_anonymous_struct_or_union(ty) -> bool:
     return isinstance(ty, SimUnion) and ty.name == "<anon>"
 
 
-def _anonymous_struct_union_to_c_repr_chunks(ty, name, name_type, indent_str: str, indent_delta: int):
+def _anonymous_struct_union_to_c_repr_chunks(
+    ty, name, name_type, indent_str: str, indent_delta: int, memo: tuple[SimType, ...] = ()
+):
     """
     Render an anonymous struct or union inline, as ``struct { ... } name``.
     """
@@ -281,6 +283,7 @@ def _anonymous_struct_union_to_c_repr_chunks(ty, name, name_type, indent_str: st
     yield ("union {\n" if isinstance(ty, SimUnion) else "struct {\n"), None
 
     new_indent_str = (" " * indent_delta) + indent_str
+    new_memo = (*memo, ty)
     members = ty.members if isinstance(ty, SimUnion) else ty.fields
     for k, v in members.items():
         yield from type_to_c_repr_chunks(
@@ -290,6 +293,7 @@ def _anonymous_struct_union_to_c_repr_chunks(ty, name, name_type, indent_str: st
             full=False,
             indent_str=new_indent_str,
             indent_delta=indent_delta,
+            memo=new_memo,
         )
         yield ";\n", None
 
@@ -299,17 +303,32 @@ def _anonymous_struct_union_to_c_repr_chunks(ty, name, name_type, indent_str: st
 
 
 def type_to_c_repr_chunks(
-    ty: SimType, name=None, name_type=None, full=False, indent_str="", indent_delta: int = INDENT_DELTA
+    ty: SimType,
+    name=None,
+    name_type=None,
+    full=False,
+    indent_str="",
+    indent_delta: int = INDENT_DELTA,
+    memo: tuple[SimType, ...] = (),
 ):
     """
     Helper generator function to turn a SimType into generated tuples of (C-string, AST node).
 
     :param indent_delta:    Number of space characters used to indent each struct field one level deeper.
+    :param memo:            The anonymous aggregates already being rendered further up the stack, compared by
+                            identity, so that a self-referential type is elided instead of recursed into.
     """
     if not full and name is not None and _is_anonymous_struct_or_union(ty):
+        if any(ty is enclosing for enclosing in memo):
+            # A recovered type can contain itself. An anonymous aggregate has no name to refer back to,
+            # so the cycle is elided rather than named.
+            yield indent_str, None
+            yield ("union { /* recursive */ } " if isinstance(ty, SimUnion) else "struct { /* recursive */ } "), None
+            yield name, name_type
+            return
         # anonymous structs and unions must be output inline
         yield from _anonymous_struct_union_to_c_repr_chunks(
-            ty, name, name_type, indent_str=indent_str, indent_delta=indent_delta
+            ty, name, name_type, indent_str=indent_str, indent_delta=indent_delta, memo=memo
         )
     elif isinstance(ty, SimStruct):
         if full:
@@ -332,6 +351,7 @@ def type_to_c_repr_chunks(
             # each of the fields
             # fields should be indented
             new_indent_str = (" " * indent_delta) + indent_str
+            new_memo = (*memo, ty)
             for k, v in ty.fields.items():
                 yield from type_to_c_repr_chunks(
                     v,
@@ -340,6 +360,7 @@ def type_to_c_repr_chunks(
                     full=False,
                     indent_str=new_indent_str,
                     indent_delta=indent_delta,
+                    memo=new_memo,
                 )
                 yield ";\n", None
 

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -273,9 +273,7 @@ def _is_anonymous_struct_or_union(ty) -> bool:
     return isinstance(ty, SimUnion) and ty.name == "<anon>"
 
 
-def _anonymous_struct_union_to_c_repr_chunks(
-    ty, name, name_type, indent_str: str, indent_delta: int, memo: tuple[SimType, ...] = ()
-):
+def _anonymous_struct_union_to_c_repr_chunks(ty, name, name_type, indent_str: str, indent_delta: int, memo: set[int]):
     """
     Render an anonymous struct or union inline, as ``struct { ... } name``.
     """
@@ -283,7 +281,7 @@ def _anonymous_struct_union_to_c_repr_chunks(
     yield ("union {\n" if isinstance(ty, SimUnion) else "struct {\n"), None
 
     new_indent_str = (" " * indent_delta) + indent_str
-    new_memo = (*memo, ty)
+    memo.add(id(ty))
     members = ty.members if isinstance(ty, SimUnion) else ty.fields
     for k, v in members.items():
         yield from type_to_c_repr_chunks(
@@ -293,9 +291,10 @@ def _anonymous_struct_union_to_c_repr_chunks(
             full=False,
             indent_str=new_indent_str,
             indent_delta=indent_delta,
-            memo=new_memo,
+            memo=memo,
         )
         yield ";\n", None
+    memo.discard(id(ty))
 
     yield indent_str, None
     yield "} ", None
@@ -309,17 +308,21 @@ def type_to_c_repr_chunks(
     full=False,
     indent_str="",
     indent_delta: int = INDENT_DELTA,
-    memo: tuple[SimType, ...] = (),
+    memo: set[int] | None = None,
 ):
     """
     Helper generator function to turn a SimType into generated tuples of (C-string, AST node).
 
     :param indent_delta:    Number of space characters used to indent each struct field one level deeper.
-    :param memo:            The anonymous aggregates already being rendered further up the stack, compared by
-                            identity, so that a self-referential type is elided instead of recursed into.
+    :param memo:            IDs of the aggregates currently being rendered further up the stack, so that a
+                            self-referential type is elided instead of recursed into. An aggregate is added
+                            before its members are rendered and removed once they are done.
     """
+    if memo is None:
+        memo = set()
+
     if not full and name is not None and _is_anonymous_struct_or_union(ty):
-        if any(ty is enclosing for enclosing in memo):
+        if id(ty) in memo:
             # A recovered type can contain itself. An anonymous aggregate has no name to refer back to,
             # so the cycle is elided rather than named.
             yield indent_str, None
@@ -351,7 +354,7 @@ def type_to_c_repr_chunks(
             # each of the fields
             # fields should be indented
             new_indent_str = (" " * indent_delta) + indent_str
-            new_memo = (*memo, ty)
+            memo.add(id(ty))
             for k, v in ty.fields.items():
                 yield from type_to_c_repr_chunks(
                     v,
@@ -360,9 +363,10 @@ def type_to_c_repr_chunks(
                     full=False,
                     indent_str=new_indent_str,
                     indent_delta=indent_delta,
-                    memo=new_memo,
+                    memo=memo,
                 )
                 yield ";\n", None
+            memo.discard(id(ty))
 
             # struct def postamble
             yield "} ", None

--- a/tests/analyses/decompiler/test_structured_codegen.py
+++ b/tests/analyses/decompiler/test_structured_codegen.py
@@ -20,11 +20,13 @@ from angr.analyses.decompiler.structured_codegen.c import (
 )
 from angr.sim_type import (
     SimCppClass,
+    SimStruct,
     SimTypeBottom,
     SimTypeFunction,
     SimTypeInt,
     SimTypeLongLong,
     SimTypePointer,
+    SimUnion,
     parse_cpp_file,
 )
 from tests.common import bin_location
@@ -171,6 +173,76 @@ class TestClassDefinitionRendering(unittest.TestCase):
     def test_plain_class_name_is_unchanged(self):
         ty = SimCppClass(unique_name="DemoNs::DemoType", name="DemoNs::DemoType", members={"x": SimTypeInt()})
         assert self._render(ty) == "class DemoNs::DemoType {\n    int x;\n} DemoNs::DemoType;\n\n"
+
+
+class TestAnonymousAggregateRendering(unittest.TestCase):
+    """How type_to_c_repr_chunks renders anonymous aggregates that contain themselves."""
+
+    @staticmethod
+    def _render(ty) -> str:
+        return "".join(text for text, _ in type_to_c_repr_chunks(ty, full=True))
+
+    def test_nested_anonymous_structs_are_rendered_inline(self):
+        inner = SimStruct({"x": SimTypeInt()}, name="<anon>")
+        middle = SimStruct({"deep": inner}, name="<anon>")
+        outer = SimStruct({"mid": middle, "y": SimTypeInt()}, name="outer")
+        assert self._render(outer) == (
+            "typedef struct outer {\n"
+            "    struct {\n"
+            "        struct {\n"
+            "            int x;\n"
+            "        } deep;\n"
+            "    } mid;\n"
+            "    int y;\n"
+            "} outer;\n\n"
+        )
+
+    def test_a_reused_anonymous_struct_is_rendered_in_full_each_time(self):
+        # only the enclosing aggregates count as a cycle: the same object used by two sibling
+        # fields is rendered twice, in full
+        anon = SimStruct({"x": SimTypeInt()}, name="<anon>")
+        outer = SimStruct({"a": anon, "b": anon}, name="outer")
+        assert self._render(outer) == (
+            "typedef struct outer {\n"
+            "    struct {\n"
+            "        int x;\n"
+            "    } a;\n"
+            "    struct {\n"
+            "        int x;\n"
+            "    } b;\n"
+            "} outer;\n\n"
+        )
+
+    def test_self_referential_anonymous_struct_terminates(self):
+        # Type inference can hand codegen an anonymous aggregate that reaches itself. Anonymous
+        # aggregates are rendered inline, so there is no name to refer back to and the render
+        # descended until the interpreter stopped it.
+        anon = SimStruct({}, name="<anon>")
+        anon.fields["loop"] = anon
+        anon.fields["x"] = SimTypeInt()
+        outer = SimStruct({"mid": anon}, name="outer")
+        assert self._render(outer) == (
+            "typedef struct outer {\n"
+            "    struct {\n"
+            "        struct { /* recursive */ } loop;\n"
+            "        int x;\n"
+            "    } mid;\n"
+            "} outer;\n\n"
+        )
+
+    def test_self_referential_anonymous_union_terminates(self):
+        anon = SimUnion({}, name="<anon>")
+        anon.members["loop"] = anon
+        anon.members["x"] = SimTypeInt()
+        outer = SimStruct({"mid": anon}, name="outer")
+        assert self._render(outer) == (
+            "typedef struct outer {\n"
+            "    union {\n"
+            "        union { /* recursive */ } loop;\n"
+            "        int x;\n"
+            "    } mid;\n"
+            "} outer;\n\n"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A type that reaches itself makes the C backend recurse until the interpreter stops it, and the function carrying that type loses its decompilation entirely. angr's own C parser builds such a type today — it interns nested anonymous structs under the shared name `<anon>`, so `parse_type("struct outer { struct { struct { int x; } deep; } mid; int y; }")` gives `ty.fields["mid"].fields["deep"] is ty.fields["mid"]`, which prints `True` on master. Rendering it:

```
  File "angr/analyses/decompiler/structured_codegen/c.py", line 305, in type_to_c_repr_chunks
    yield from _anonymous_struct_union_to_c_repr_chunks(
  File "angr/analyses/decompiler/structured_codegen/c.py", line 280, in _anonymous_struct_union_to_c_repr_chunks
    yield from type_to_c_repr_chunks(
  [Previous 4 lines repeated 497 more times]
RecursionError: maximum recursion depth exceeded
```

### Root cause

`type_to_c_repr_chunks` and `_anonymous_struct_union_to_c_repr_chunks` call each other to render an anonymous aggregate inline, and neither records what it is already rendering. The named path does: `SimStruct.c_repr` and `SimUnion.c_repr` open with `if not full or (memo is not None and self in memo)` and thread `new_memo = (self,) + memo` down, falling back to a name reference on a revisit. The codegen pair bypasses those methods, so nothing bounds the descent.

### Fix

Thread the enclosing anonymous aggregates through both generators and compare them by identity, so the cycle is elided where it is found:

```c
typedef struct outer {
    struct {
        struct { /* recursive */ } deep;
    } mid;
    int y;
} outer;
```

Identity rather than `==`, because `SimStruct.__eq__` is structural and would collapse distinct-but-equal siblings that are not a cycle. An anonymous aggregate has no name to fall back on, unlike the named case, which is why it is elided in place rather than referenced. Everything acyclic renders unchanged.

### Testing

`tests/analyses/decompiler/test_structured_codegen.py::TestAnonymousAggregateRendering` — the two cyclic cases fail on the baseline with `RecursionError` at `c.py:303` and pass on the head; the other two are negative controls, an acyclic doubly nested anonymous struct and one anonymous struct reused by two sibling fields, whose rendering is unchanged. The test builds its cycle directly rather than through the parser, because #6951 removes that one producer without touching this recursion.

Over 53 public binaries, both structurers, 15,351 functions decompiled, anonymous aggregates were rendered 646 times and an aggregate identical to one already enclosing it was entered 0 times — type inference allocates a fresh object per anonymous aggregate where the parser interns them.

Validation: https://github.com/angr/angr/pull/6980#issuecomment-5432592363

session: sharpen

