### PR TITLE
CCodeGen: emit the class-key of a C++ class definition once

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -316,10 +316,17 @@ def type_to_c_repr_chunks(
             # struct def preamble
             yield indent_str, None
             if isinstance(ty, SimCppClass):
+                # A class name reaches codegen spelled either way: angr's C++ parser keeps the
+                # elaborated form on the class branch of _cpp_decl_to_type, while the STL
+                # definitions keep the plain one. SimCppClass.__repr__ already accounts for
+                # that; emitting the class-key unconditionally beside the name did not, so an
+                # elaborated name came out as "class class Ns::Type".
+                type_name = ty.name.removeprefix("class ")
                 yield "class ", None
             else:
+                type_name = ty.name
                 yield "typedef struct ", None
-            yield ty.name, ty
+            yield type_name, ty
             yield " {\n", None
 
             # each of the fields
@@ -338,7 +345,7 @@ def type_to_c_repr_chunks(
 
             # struct def postamble
             yield "} ", None
-            yield ty.name, ty
+            yield type_name, ty
             yield ";\n\n", None
 
         else:

--- a/tests/analyses/decompiler/test_structured_codegen.py
+++ b/tests/analyses/decompiler/test_structured_codegen.py
@@ -16,8 +16,17 @@ from angr.analyses.decompiler.structured_codegen.c import (
     CGoto,
     CStructuredCodeGenerator,
     CUnaryOp,
+    type_to_c_repr_chunks,
 )
-from angr.sim_type import SimTypeBottom, SimTypeInt, SimTypeLongLong, SimTypePointer
+from angr.sim_type import (
+    SimCppClass,
+    SimTypeBottom,
+    SimTypeFunction,
+    SimTypeInt,
+    SimTypeLongLong,
+    SimTypePointer,
+    parse_cpp_file,
+)
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
@@ -136,6 +145,32 @@ class TestStoreWidth(unittest.TestCase):
 
     def test_value_typed_correctly_is_left_alone(self):
         assert self._dst_bits(4, SimTypeLongLong(signed=False), 64, 8) == 64
+
+
+class TestClassDefinitionRendering(unittest.TestCase):
+    """How type_to_c_repr_chunks spells the class-key of a rendered C++ class definition."""
+
+    @staticmethod
+    def _render(ty) -> str:
+        return "".join(text for text, _ in type_to_c_repr_chunks(ty, full=True))
+
+    def test_elaborated_class_name_keeps_one_class_key(self):
+        # angr's own C++ parser keeps the class-key in the name on its class branch, so the
+        # definition used to come out as "class class DemoNs::DemoType".
+        decls, _ = parse_cpp_file("void f(class DemoNs::DemoType *p);", with_param_names=True)
+        assert decls is not None
+        prototype = decls["f"]
+        assert isinstance(prototype, SimTypeFunction)
+        pointer = prototype.args[0]
+        assert isinstance(pointer, SimTypePointer)
+        ty = pointer.pts_to
+        assert isinstance(ty, SimCppClass)
+        assert ty.name == "class DemoNs::DemoType"
+        assert self._render(ty) == "class DemoNs::DemoType {\n} DemoNs::DemoType;\n\n"
+
+    def test_plain_class_name_is_unchanged(self):
+        ty = SimCppClass(unique_name="DemoNs::DemoType", name="DemoNs::DemoType", members={"x": SimTypeInt()})
+        assert self._render(ty) == "class DemoNs::DemoType {\n    int x;\n} DemoNs::DemoType;\n\n"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling `sub_1400110a5` at `0x1400110a5` in `angr/binaries` `tests/x86_64/windows/vcstdlib_test.exe` emits the class-key twice, in both halves of the definition:

```c
class class std::locale::_Locimp {
} class std::locale::_Locimp;
```

The second one is worse than cosmetic: `} class X;` is a declarator position, where an elaborated-type-specifier was never valid C++. Over 53 public binaries this is 12 of the 14 `SimCppClass` definition preambles emitted, 86% — every one an MSVC-demangled name that carries its own class-key.

### Root cause

The struct-definition preamble in `type_to_c_repr_chunks` yields `"class "` and then `ty.name` unconditionally, and the postamble repeats `ty.name` after the closing brace. A `SimCppClass` name arrives spelled either way: angr's C++ parser keeps the elaborated form on the class branch of `_cpp_decl_to_type`, while the STL definitions in `angr/procedures/definitions/types_stl.py` keep the plain one. `SimCppClass.__repr__` guards exactly that case — `return f"class {self.name}" if not self.name.startswith("class") else self.name` — and its sibling in codegen did not.

### Fix

Strip the class-key once and use the stripped name in both places, so the key is emitted exactly once and the declarator after the brace spells the plain name:

```c
class std::locale::_Locimp {
} std::locale::_Locimp;
```

The function's own return type, `class std::locale::_Locimp *`, is unchanged on both revisions: a declaration may spell it that way, and only the definition was doubled.

This is the codegen half of #6977. The other half is that the name is built inconsistently in the first place — `_cpp_decl_to_type` strips the class-key on its `struct` branch and keeps it on its `class` branch. That one reassigns `.name`, which is a lookup key for `ALL_TYPES` and `extra_types`, so it is left to the issue rather than folded in here.

### Testing

`tests/analyses/decompiler/test_structured_codegen.py::TestClassDefinitionRendering` — `test_elaborated_class_name_keeps_one_class_key` fails on the baseline on both halves of that string and passes on the head; `test_plain_class_name_is_unchanged` is the negative control, a class whose name arrives without the key, rendering identically on both revisions.

The producing path is the local-type and extern-type emission in `CFunction.c_repr_chunks`, the only caller that passes `full=True`, so this is reachable whenever `show_local_types` or `show_externs` emits a class definition.

Validation: https://github.com/angr/angr/pull/6981#issuecomment-5432592505

session: sharpen