### PR TITLE
Register MIPS n32 calling conventions

### DIFF
--- a/angr/analyses/calling_convention/calling_convention.py
+++ b/angr/analyses/calling_convention/calling_convention.py
@@ -1050,7 +1050,7 @@ class CallingConventionAnalysis(Analysis):
         if cc.STACKARG_SP_DIFF is not None and initial_stack_args:
             arg_by_offset = {a.stack_offset: a for a in initial_stack_args}
             init_stackarg_offset = cc.STACKARG_SP_DIFF + cc.STACKARG_SP_BUFF
-            int_arg_size = self.project.arch.bytes
+            int_arg_size = cc.arg_slot_size
             for stackarg_offset in range(init_stackarg_offset, max(arg_by_offset), int_arg_size):
                 if stackarg_offset not in arg_by_offset:
                     arg_by_offset[stackarg_offset] = SimStackArg(stackarg_offset, int_arg_size)
@@ -1068,7 +1068,7 @@ class CallingConventionAnalysis(Analysis):
                 # have we reached the end of the args list?
                 if [a for a in int_args if isinstance(a, SimRegArg)] or len(stack_int_args) > 0:
                     # haven't reached the end yet or there are stack args
-                    arg = SimRegArg(reg_name, self.project.arch.bytes)
+                    arg = SimRegArg(reg_name, cc.arg_slot_size)
                 else:
                     break
             reg_args.append(arg)
@@ -1086,7 +1086,7 @@ class CallingConventionAnalysis(Analysis):
                     # have we reached the end of the args list?
                     if [a for a in fp_args if isinstance(a, SimRegArg)] or len(stack_fp_args) > 0:
                         # haven't reached the end yet or there are stack args
-                        arg = SimRegArg(reg_name, self.project.arch.bytes)
+                        arg = SimRegArg(reg_name, cc.arg_slot_size)
                     else:
                         break
                 reg_args.append(arg)

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3389,7 +3389,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
         if target_addr is None:
             # The target address is not a concrete value
-            assert irsb is not None and ins_addr is not None and stmt_idx is not None
+            assert irsb is not None and stmt_idx is not None
 
             if jumpkind == "Ijk_Ret":
                 # This block ends with a return instruction.
@@ -3405,6 +3405,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 jumpkind in ("Ijk_Boring", "Ijk_Call", "Ijk_InvalICache") or jumpkind.startswith("Ijk_Sys")
             ):
                 # This is an indirect jump. Try to resolve it.
+                assert ins_addr is not None
                 # fast path: the target may have been constant-folded from a read-only region at lift time
                 # (e.g. an AMD64 PE IAT slot); consuming it here avoids re-lifting the block and running the
                 # indirect jump resolvers

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -666,9 +666,22 @@ class SimCC:
 
     STACK_ALIGNMENT = 1  # the alignment requirement of the stack pointer at function start BEFORE call
 
+    # The width in bytes of one argument slot. It can refer to an integer argument register or a stack argument slot.
+    # None means using the architecture's word size.
+    # Set ARG_SLOT_SIZE explicitly when the architecture's register width differs from its pointer width.
+    # A good example is MIPS n32, which passes arguments in its 64-bit registers while its has 32-bit pointers.
+    ARG_SLOT_SIZE: int | None = None
+
     #
     # Here are several things you MAY want to override to change your cc's convention
     #
+
+    @property
+    def arg_slot_size(self) -> int:
+        """
+        The width in bytes of one argument slot. See ``ARG_SLOT_SIZE``.
+        """
+        return self.ARG_SLOT_SIZE if self.ARG_SLOT_SIZE is not None else self.arch.bytes
 
     @property
     def int_args(self):
@@ -679,7 +692,7 @@ class SimCC:
         """
         if self.ARG_REGS is None:
             raise NotImplementedError
-        return SerializableListIterator([SimRegArg(reg, self.arch.bytes) for reg in self.ARG_REGS])
+        return SerializableListIterator([SimRegArg(reg, self.arg_slot_size) for reg in self.ARG_REGS])
 
     @property
     def memory_args(self):
@@ -689,7 +702,8 @@ class SimCC:
         Returns an iterator of SimFunctionArguments
         """
         start = self.STACKARG_SP_BUFF + self.STACKARG_SP_DIFF
-        return SerializableCounter(start, self.arch.bytes, lambda offset: SimStackArg(offset, self.arch.bytes))
+        slot = self.arg_slot_size
+        return SerializableCounter(start, slot, lambda offset: SimStackArg(offset, slot))
 
     @property
     def fp_args(self):
@@ -700,7 +714,7 @@ class SimCC:
         """
         if self.FP_ARG_REGS is None:
             raise NotImplementedError
-        return SerializableListIterator([SimRegArg(reg, self.arch.bytes) for reg in self.FP_ARG_REGS])
+        return SerializableListIterator([SimRegArg(reg, self.arg_slot_size) for reg in self.FP_ARG_REGS])
 
     def is_fp_arg(self, arg):
         """
@@ -748,7 +762,7 @@ class SimCC:
         out = self.STACKARG_SP_DIFF
         for arg in args:
             if isinstance(arg, SimStackArg):
-                out = max(out, arg.stack_offset + self.arch.bytes)
+                out = max(out, arg.stack_offset + self.arg_slot_size)
 
         out += self.STACKARG_SP_BUFF
         return out
@@ -1232,7 +1246,9 @@ class SimCC:
     def _guess_arg_count(cls, args, limit: int = 64) -> int:
         # pylint:disable=not-callable
         assert cls.ARCH is not None
-        if hasattr(cls, "LANGUAGE"):  # noqa: SIM108
+        if cls.ARG_SLOT_SIZE is not None:
+            stack_arg_size = cls.ARG_SLOT_SIZE
+        elif hasattr(cls, "LANGUAGE"):
             # this is a PCode SimCC where cls.ARCH is directly callable
             stack_arg_size = cls.ARCH().bytes  # type: ignore
         else:
@@ -2532,11 +2548,11 @@ SimCCO64 = SimCCN64  # compatibility
 
 class SimCCN32(SimCCN64):
     """
-    n32 passes its arguments exactly as n64 does -- eight 64-bit registers -- and differs only in
-    the width of a pointer, which lives in the architecture rather than in the convention.
+    n32 passes its arguments like n64 does and differs only in the width of a pointer.
     """
 
     ARCH = archinfo.ArchMIPSN32
+    ARG_SLOT_SIZE = 8
 
 
 class SimCCN64LinuxSyscall(SimCCSyscall):
@@ -2561,6 +2577,7 @@ class SimCCN64LinuxSyscall(SimCCSyscall):
 
 class SimCCN32LinuxSyscall(SimCCN64LinuxSyscall):
     ARCH = archinfo.ArchMIPSN32
+    ARG_SLOT_SIZE = 8
 
 
 class SimCCPowerPC(SimCC):

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2517,7 +2517,7 @@ class SimCCO32LinuxSyscall(SimCCSyscall):
         return state.regs.v0
 
 
-class SimCCN64(SimCC):  # TODO: add n32
+class SimCCN64(SimCC):
     ARG_REGS = ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"]
     CALLER_SAVED_REGS = ["t9", "gp"]
     FP_ARG_REGS = []  # TODO: ???
@@ -2528,6 +2528,15 @@ class SimCCN64(SimCC):  # TODO: add n32
 
 
 SimCCO64 = SimCCN64  # compatibility
+
+
+class SimCCN32(SimCCN64):
+    """
+    n32 passes its arguments exactly as n64 does -- eight 64-bit registers -- and differs only in
+    the width of a pointer, which lives in the architecture rather than in the convention.
+    """
+
+    ARCH = archinfo.ArchMIPSN32
 
 
 class SimCCN64LinuxSyscall(SimCCSyscall):
@@ -2548,6 +2557,10 @@ class SimCCN64LinuxSyscall(SimCCSyscall):
     @staticmethod
     def syscall_num(state):
         return state.regs.v0
+
+
+class SimCCN32LinuxSyscall(SimCCN64LinuxSyscall):
+    ARCH = archinfo.ArchMIPSN32
 
 
 class SimCCPowerPC(SimCC):
@@ -2696,6 +2709,10 @@ CC: dict[str, dict[str, list[type[SimCC]]]] = {
         "default": [SimCCN64],
         "Linux": [SimCCN64],
     },
+    "MIPSN32": {
+        "default": [SimCCN32],
+        "Linux": [SimCCN32],
+    },
     "PPC32": {
         "default": [SimCCPowerPC],
         "Linux": [SimCCPowerPC],
@@ -2724,6 +2741,7 @@ DEFAULT_CC: dict[str, dict[str, type[SimCC]]] = {
     "ARMCortexM": {"Linux": SimCCARMHF},
     "MIPS32": {"Linux": SimCCO32},
     "MIPS64": {"Linux": SimCCN64},
+    "MIPSN32": {"Linux": SimCCN32},
     "PPC32": {"Linux": SimCCPowerPC},
     "PPC64": {"Linux": SimCCPowerPC64},
     "AARCH64": {"Linux": SimCCAArch64, "UEFI": SimCCAArch64},
@@ -2759,6 +2777,7 @@ ARCH_NAME_ALIASES = {
     "AARCH64": ["arm64", "aarch64"],
     "MIPS32": [],
     "MIPS64": [],
+    "MIPSN32": ["mipsn32"],
     "PPC32": ["powerpc32"],
     "PPC64": ["powerpc64"],
     "RISCV64": ["riscv64"],
@@ -2876,6 +2895,10 @@ SYSCALL_CC: dict[str, dict[str, type[SimCCSyscall]]] = {
     "MIPS64": {
         "default": SimCCN64LinuxSyscall,
         "Linux": SimCCN64LinuxSyscall,
+    },
+    "MIPSN32": {
+        "default": SimCCN32LinuxSyscall,
+        "Linux": SimCCN32LinuxSyscall,
     },
     "PPC32": {
         "default": SimCCPowerPCLinuxSyscall,

--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -139,6 +139,8 @@ class SimLinux(SimUserland):
         # https://www.linux-mips.org/wiki/WhatsWrongWithO32N32N64
         elif self.arch.name == "MIPS32":
             syscall_abis = ["mips-o32"]
+        elif self.arch.name == "MIPSN32":
+            syscall_abis = ["mips-n32"]
         elif self.arch.name == "MIPS64":
             syscall_abis = ["mips-n32", "mips-n64"]
         elif self.arch.name == "PPC32":

--- a/angr/simos/simos.py
+++ b/angr/simos/simos.py
@@ -270,7 +270,7 @@ class SimOS:
 
         if state.arch.name == "PPC64" and toc is not None:
             state.regs.r2 = toc
-        elif state.arch.name in ("MIPS32", "MIPS64"):
+        elif state.arch.name in ("MIPS32", "MIPS64", "MIPSN32"):
             state.regs.t9 = addr
 
         return state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,9 +119,9 @@ default-groups = ["dev", "extras"]
 
 [tool.uv.sources]
 angr-data = { git = "https://github.com/angr/angr-data.git", branch = "master" }
-archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
-pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
-cle = { git = "https://github.com/angr/cle.git", branch = "master" }
+archinfo = { git = "https://github.com/angr/archinfo.git", branch = "feature/mips-n32-arch" }
+pyvex = { git = "https://github.com/angr/pyvex.git", branch = "feature/mips-n32-lifter" }
+cle = { git = "https://github.com/angr/cle.git", branch = "feature/elf-mips-n32" }
 claripy = { git = "https://github.com/angr/claripy.git", branch = "master" }
 pysoot = { git = "https://github.com/angr/pysoot.git", branch = "master" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ default-groups = ["dev", "extras"]
 angr-data = { git = "https://github.com/angr/angr-data.git", branch = "master" }
 archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
 pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
-cle = { git = "https://github.com/angr/cle.git", branch = "feature/elf-mips-n32" }
+cle = { git = "https://github.com/angr/cle.git", branch = "master" }
 claripy = { git = "https://github.com/angr/claripy.git", branch = "master" }
 pysoot = { git = "https://github.com/angr/pysoot.git", branch = "master" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,8 +119,8 @@ default-groups = ["dev", "extras"]
 
 [tool.uv.sources]
 angr-data = { git = "https://github.com/angr/angr-data.git", branch = "master" }
-archinfo = { git = "https://github.com/angr/archinfo.git", branch = "feature/mips-n32-arch" }
-pyvex = { git = "https://github.com/angr/pyvex.git", branch = "feature/mips-n32-lifter" }
+archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
+pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
 cle = { git = "https://github.com/angr/cle.git", branch = "feature/elf-mips-n32" }
 claripy = { git = "https://github.com/angr/claripy.git", branch = "master" }
 pysoot = { git = "https://github.com/angr/pysoot.git", branch = "master" }

--- a/tests/analyses/cfg/test_cfg_mips_n32.py
+++ b/tests/analyses/cfg/test_cfg_mips_n32.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests", "mipsn32")
+
+
+class TestCfgMipsN32(unittest.TestCase):
+    """
+    n32 and O64 hold a 64-bit MIPS instruction stream in an ELFCLASS32 container. Decoded as
+    32-bit MIPS, a function stops at the first 64-bit instruction -- typically the `sd $gp`
+    that a non-leaf prologue uses to spill the global pointer -- so almost nothing is
+    recovered as code.
+    """
+
+    def _project(self, name):
+        return angr.Project(os.path.join(test_location, name), auto_load_libs=False)
+
+    def test_n32_prologue_decodes(self):
+        for name in ("n32_be_static", "n32_el_dynamic", "o64_el_static"):
+            proj = self._project(name)
+            assert proj.arch.name == "MIPSN32", name
+            sym = proj.loader.main_object.get_symbol("accumulate")
+            assert sym is not None, name
+            block = proj.factory.block(sym.rebased_addr)
+            assert block.instructions > 1, name
+            assert "sd" in {insn.mnemonic for insn in block.capstone.insns}, name
+
+    def test_n32_cfg_covers_symbol_functions(self):
+        for name in ("n32_be_static", "n32_el_dynamic", "o64_el_static"):
+            proj = self._project(name)
+            cfg = proj.analyses.CFGFast(normalize=True)
+            covered: set[int] = set()
+            for node in cfg.model.nodes():
+                if node.size and isinstance(node.addr, int):
+                    covered.update(range(node.addr, node.addr + node.size))
+            for func_name in ("accumulate", "leaf_double", "main"):
+                sym = proj.loader.main_object.get_symbol(func_name)
+                assert sym is not None and sym.size, (name, func_name)
+                body = set(range(sym.rebased_addr, sym.rebased_addr + sym.size))
+                assert body <= covered, (name, func_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/simos/test_linux.py
+++ b/tests/simos/test_linux.py
@@ -14,6 +14,7 @@ from cle import MetaELF
 
 import angr
 from angr.errors import SimMemoryError
+from angr.simos import SimLinux
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
@@ -85,6 +86,34 @@ class TestSimLinuxPpc64Toc(unittest.TestCase):
 
         state = project.factory.entry_state()
         assert state.solver.eval(cast(claripy.ast.BV, state.regs.r2)) == 0x10018E80
+
+
+class TestSimLinuxMipsN32(unittest.TestCase):
+    """
+    MIPS n32 keeps the 64-bit MIPS register file behind 32-bit pointers, and SimLinux keys several
+    decisions on the architecture name rather than on its class.
+    """
+
+    binaries = os.path.join(test_location, "mipsn32")
+
+    def test_state_call_places_arguments_and_t9(self):
+        # A big-endian n32 target, where the argument goes into the top half of a0, the half the callee reads as sign
+        # extension.
+        for name in ("n32_be_static", "n32_el_dynamic"):
+            project = angr.Project(os.path.join(self.binaries, name), auto_load_libs=False)
+            assert project.arch.name == "MIPSN32", name
+            state = project.factory.call_state(project.entry, 1, 2)
+            assert state.solver.eval(state.regs.a0) == 1, name
+            assert state.solver.eval(state.regs.a1) == 2, name
+            # MIPS PIC calls arrive with the callee address in t9 and read the global pointer out
+            # of it; a symbolic t9 makes every gp-relative load unresolvable.
+            assert state.solver.eval(state.regs.t9) == project.entry, name
+
+    def test_syscall_abi_is_configured(self):
+        project = angr.Project(os.path.join(self.binaries, "n32_be_static"), auto_load_libs=False)
+        simos = project.simos
+        assert isinstance(simos, SimLinux)
+        assert "mips-n32" in simos.syscall_abis
 
 
 if __name__ == "__main__":

--- a/tests/test_calling_conventions.py
+++ b/tests/test_calling_conventions.py
@@ -14,6 +14,10 @@ from angr import Project, load_shellcode, types
 from angr.calling_conventions import (
     SimCCMicrosoftAMD64,
     SimCCMicrosoftFastcall,
+    SimCCN32,
+    SimCCN32LinuxSyscall,
+    SimCCN64,
+    SimCCN64LinuxSyscall,
     SimCCRISCV64,
     SimCCSystemVAMD64,
     SimReferenceArgument,
@@ -254,6 +258,67 @@ class TestCallingConvention(TestCase):
             # It should not raise any exception!
             arg_locs = list(cc.arg_locs(proto))
             assert arg_locs is not None
+
+    def _mips_int_arg_locs(self, cc_cls, arch, arg_types):
+        proto = SimTypeFunction(arg_types, SimTypeInt()).with_arch(arch)
+        locs = []
+        for loc in cc_cls(arch).arg_locs(proto):
+            if isinstance(loc, SimRegArg):
+                locs.append(("reg", loc.reg_name, loc.reg_offset, loc.size))
+            elif isinstance(loc, SimStackArg):
+                locs.append(("stack", loc.stack_offset, loc.size))
+            else:
+                locs.append(loc)
+        return locs
+
+    def test_mips_n32_agrees_with_n64_on_argument_slots(self):
+        # n32 passes arguments in the 64-bit MIPS register file even though its pointers, and so
+        # archinfo's ``bits``, are 32. Deriving the slot width from ``bits`` puts a 32-bit argument
+        # in the sign-extension half of a0 on big-endian, where the callee never reads it.
+        int_args = [SimTypeInt(), SimTypeInt()]
+        for endness in (archinfo.Endness.BE, archinfo.Endness.LE):
+            n32 = self._mips_int_arg_locs(SimCCN32, archinfo.ArchMIPSN32(endness), int_args)
+            n64 = self._mips_int_arg_locs(SimCCN64, archinfo.ArchMIPS64(endness), int_args)
+            assert n32 == n64, f"{endness}: n32 {n32} != n64 {n64}"
+
+        # Spelled out, so that a change to both conventions at once cannot make the check above vacuous:
+        # big-endian puts the low-order half of a 64-bit register at offset 4.
+        assert self._mips_int_arg_locs(SimCCN32, archinfo.ArchMIPSN32(archinfo.Endness.BE), int_args) == [
+            ("reg", "a0", 4, 4),
+            ("reg", "a1", 4, 4),
+        ]
+        assert self._mips_int_arg_locs(SimCCN32, archinfo.ArchMIPSN32(archinfo.Endness.LE), int_args) == [
+            ("reg", "a0", 0, 4),
+            ("reg", "a1", 0, 4),
+        ]
+
+    def test_mips_n32_passes_a_64_bit_scalar(self):
+        # The whole scalar lives in one 64-bit argument register, exactly as on n64; a four-byte
+        # slot cannot hold it and the base SimCC rejects the prototype outright.
+        args = [SimTypeLongLong(), SimTypeInt()]
+        for endness in (archinfo.Endness.BE, archinfo.Endness.LE):
+            n32 = self._mips_int_arg_locs(SimCCN32, archinfo.ArchMIPSN32(endness), args)
+            n64 = self._mips_int_arg_locs(SimCCN64, archinfo.ArchMIPS64(endness), args)
+            assert n32 == n64, f"{endness}: n32 {n32} != n64 {n64}"
+            assert n32[0] == ("reg", "a0", 0, 8)
+
+    def test_mips_n32_spills_to_n64_sized_stack_slots(self):
+        # Nine integers exhaust a0-a7; the tenth argument lands on the stack, whose slot is as wide
+        # as the register it follows.
+        args = [SimTypeInt()] * 10
+        for endness in (archinfo.Endness.BE, archinfo.Endness.LE):
+            n32 = self._mips_int_arg_locs(SimCCN32, archinfo.ArchMIPSN32(endness), args)
+            n64 = self._mips_int_arg_locs(SimCCN64, archinfo.ArchMIPS64(endness), args)
+            assert n32 == n64, f"{endness}: n32 {n32} != n64 {n64}"
+            assert n32[8][0] == "stack"
+            assert n32[9][1] - n32[8][1] == 8
+
+    def test_mips_n32_syscall_cc_agrees_with_n64(self):
+        args = [SimTypeInt(), SimTypeLongLong()]
+        for endness in (archinfo.Endness.BE, archinfo.Endness.LE):
+            n32 = self._mips_int_arg_locs(SimCCN32LinuxSyscall, archinfo.ArchMIPSN32(endness), args)
+            n64 = self._mips_int_arg_locs(SimCCN64LinuxSyscall, archinfo.ArchMIPS64(endness), args)
+            assert n32 == n64, f"{endness}: n32 {n32} != n64 {n64}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

With the loader, architecture and lifter branches of this chain applied, angr loads a MIPS n32 object but has no calling convention for it. On `binaries/tests/mipsn32/n32_be_static`:

```
arch: MIPSN32 32 bits, Iend_BE
default_cc: None
proj.factory.call_state(proj.entry, 1, 2)
  -> TypeError: 'NoneType' object is not callable   (angr/factory.py:203, simos.state_call)
syscall ABIs SimLinux configured: []
```

So no call state can be built, no syscall is recognised, and `CallingConventionAnalysis` has nothing to start from — every argument, prototype and variable recovery on an n32 binary is unavailable.

### Root cause

`DEFAULT_CC` and `SYSCALL_CC` are keyed by architecture name and `MIPSN32` is registered in neither, so `default_cc("MIPSN32")` answers `None`. `SimLinux`'s syscall-ABI chain and `SimOS.state_call`'s MIPS `t9` store are the same kind of name test — `("MIPS32", "MIPS64")` — and n32 matches neither.

Underneath that, base `SimCC` builds every argument location from `arch.bytes`, which assumes an argument register is as wide as a pointer. n32 keeps the 64-bit MIPS register file behind 32-bit pointers, so that assumption is wrong here, and it is wrong invisibly on little-endian. Measured on the head with the slot width forced back to `arch.bytes`, two `int` arguments big-endian:

```
n32, slot width from arch.bytes: [('a0', 0, 4), ('a1', 0, 4)]
```

Offset 0 of a 64-bit big-endian register is the sign-extension half — the half the callee never reads.

### Fix

Register `SimCCN32` and `SimCCN32LinuxSyscall`, using o32's argument registers at n64's width, and add `MIPSN32` to the syscall-ABI chain and to the `t9` store. Add `SimCC.ARG_SLOT_SIZE`, defaulting to `None` meaning `arch.bytes`, so a convention whose registers are wider than its pointers states the slot width instead of having it inferred; `CallingConventionAnalysis` uses `cc.arg_slot_size` in the three places it had `arch.bytes`. A third commit narrows a `CFGFast` assertion that a single-instruction `Ijk_SigILL` block trips, requiring `ins_addr` only on the indirect-jump path that uses it. After, on the same fixture:

```
default_cc: <class 'angr.calling_conventions.SimCCN32'>
a0 = 1   a1 = 2   t9 == entry: True
syscall ABIs SimLinux configured: ['mips-n32']
n32: [('a0', 4, 4), ('a1', 4, 4)]
n64: [('a0', 4, 4), ('a1', 4, 4)]
```

### Testing

Eight tests: two decode the n32 prologue and check CFG coverage of `accumulate`, `leaf_double` and `main` on three fixtures; two cover the call state and the syscall ABI; four compare `SimCCN32` against `SimCCN64` slot by slot in both endiannesses, for int arguments, a 64-bit scalar, stack spill slots and the syscall convention.

~~`[tool.uv.sources]` temporarily pins archinfo, pyvex and cle at the chain's branches; all three must return to `master` before this merges. The four must land together: with the loader and the architecture definition ahead of the lifter, `MIPSN32` reaches a lifter with no entry for it and recovery on these objects drops to zero blocks. Merge order: archinfo 375, then pyvex 576, then cle 795, then angr 6982.~~

**Updated 2026-08-29.** archinfo 375 merged at 14:15Z and pyvex 576 at 14:19Z, and GitHub deleted both branches on merge, so `uv sync` stopped at `failed to fetch branch feature/mips-n32-lifter` and all three `Test installation` jobs went red. Commit `6c089b2` points both pins back at `master`, which changes no content: archinfo master is byte-identical to the tree at that pull request's head, and pyvex master differs from its one only in a license identifier string in its own pyproject. The same two dead pins were in cle 795's `pyproject.toml`, and `uv` follows those through the git dependency on that branch, so repairing this file alone was not enough; cle `d5f9497` repairs them there. `[tool.uv.sources]` still pins cle at `feature/elf-mips-n32`, and that pin has to return to `master` before this merges. What is left of the merge order is cle 795, then angr 6982 — the partial state the sentence above warns about can no longer happen, because the architecture definition and the lifter are both on master now.

Validation: https://github.com/angr/angr/pull/6982#issuecomment-5439196875

sync: angr/cle#795
sync: angr/binaries#206
session: sharpen
