### PR TITLE
Decompiler: emit legal C prototypes for array returns

### DIFF
--- a/angr/analyses/decompiler/c_prototype.py
+++ b/angr/analyses/decompiler/c_prototype.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, overload
+
+from angr.sim_type import SimTypeArray, SimTypeFunction, SimTypePointer
+
+if TYPE_CHECKING:
+    from archinfo import Arch
+
+
+@overload
+def c_function_type_with_array_return_decay(prototype: None, arch: Arch) -> None: ...
+
+
+@overload
+def c_function_type_with_array_return_decay(prototype: SimTypeFunction, arch: Arch) -> SimTypeFunction: ...
+
+
+def c_function_type_with_array_return_decay(prototype: SimTypeFunction | None, arch: Arch) -> SimTypeFunction | None:
+    """Return a C view of *prototype*, applying the mandatory outermost array-to-pointer adjustment."""
+    if prototype is None:
+        return None
+    returnty = prototype.returnty
+    if not isinstance(returnty, SimTypeArray):
+        return prototype
+
+    elem_type = copy.copy(returnty.elem_type)
+    if returnty.qualifier:
+        elem_type.qualifier = tuple(dict.fromkeys((*tuple(elem_type.qualifier or ()), *tuple(returnty.qualifier))))
+
+    c_prototype = copy.copy(prototype)
+    c_prototype.returnty = SimTypePointer(elem_type).with_arch(arch)
+    return c_prototype

--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -30,6 +30,7 @@ from angr.sim_type import (
 )
 from angr.utils.types import dereference_simtype_by_lib
 
+from .c_prototype import c_function_type_with_array_return_decay
 from .stackarg_offset_manager import StackArgOffsetManager
 from .variable_map import variable_map_of
 
@@ -56,6 +57,7 @@ class CallSiteMaker:
         ail_manager: Manager,
         reaching_definitions: SRDAModel | None = None,
         stack_pointer_tracker=None,
+        flavor: str | None = None,
     ):
         self.project = project
         self.kb = project.kb
@@ -64,6 +66,7 @@ class CallSiteMaker:
         self._reaching_definitions = reaching_definitions
         self._stack_pointer_tracker = stack_pointer_tracker
         self._ail_manager: Manager = ail_manager
+        self._flavor = flavor
 
         self.result_block = None
         # block addr, call ins addr, stack offset, arg size (in bytes)
@@ -152,6 +155,8 @@ class CallSiteMaker:
             prototype_libname = func.prototype_libname
             if prototype_libname is not None:
                 prototype = cast(SimTypeFunction, dereference_simtype_by_lib(prototype, prototype_libname))
+        if prototype is not None and self._flavor == "pseudocode":
+            prototype = c_function_type_with_array_return_decay(prototype, self.project.arch)
 
         args = []
         arg_vvars = []

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -89,6 +89,7 @@ from angr.utils.types import dereference_simtype_by_lib
 
 from .ail_simplifier import AILSimplifier
 from .ailgraph_walker import AILGraphWalker, RemoveNodeNotice
+from .c_prototype import c_function_type_with_array_return_decay
 from .notes import DecompilationNote
 from .optimization_passes import (
     CONDENSING_OPTS,
@@ -1845,11 +1846,13 @@ class Clinic(Analysis, Serializable):
                 prototype_libname = func.prototype_libname
                 if prototype_libname is not None:
                     prototype = dereference_simtype_by_lib(prototype, prototype_libname)
+            assert prototype is None or isinstance(prototype, SimTypeFunction)
+            if prototype is not None and self.flavor == "pseudocode":
+                prototype = c_function_type_with_array_return_decay(prototype, self.project.arch)
 
             if cc is None:
                 l.warning("Call site %#x (callee %s) has an unknown calling convention.", block.addr, repr(func))
 
-            assert prototype is None or isinstance(prototype, SimTypeFunction)
             new_last_stmt = last_stmt.copy()
             self.variable_map.set_calling_convention(new_last_stmt.expr, cc)
             self.variable_map.set_prototype(new_last_stmt.expr, prototype)
@@ -2329,6 +2332,9 @@ class Clinic(Analysis, Serializable):
                 if self.function.prototype_libname
                 else self.function.prototype
             )
+            assert isinstance(proto, SimTypeFunction)
+            if self.flavor == "pseudocode":
+                proto = c_function_type_with_array_return_decay(proto, self.project.arch)
             args: list[SimFunctionArgument] = self.function.calling_convention.arg_locs(proto)
             if self._flatten_args:
                 new_args = []
@@ -2427,6 +2433,7 @@ class Clinic(Analysis, Serializable):
                 reaching_definitions=rd,
                 stack_pointer_tracker=stack_pointer_tracker,
                 ail_manager=self._ail_manager,
+                flavor=self.flavor,
             )
             stackarg_offset_manager.merge(csm.stackarg_offset_manager)
             if csm.removed_vvar_ids:
@@ -2460,7 +2467,10 @@ class Clinic(Analysis, Serializable):
             # unknown calling convention. cannot do much about return expressions.
             return ail_graph
 
-        ReturnMaker(self._ail_manager, self.project.arch, self.function, ail_graph)
+        prototype = self.function.prototype
+        if prototype is not None and self.flavor == "pseudocode":
+            prototype = c_function_type_with_array_return_decay(prototype, self.project.arch)
+        ReturnMaker(self._ail_manager, self.project.arch, self.function, ail_graph, prototype=prototype)
 
         return ail_graph
 
@@ -2507,7 +2517,6 @@ class Clinic(Analysis, Serializable):
                 returnty = self.function.prototype.returnty
             else:
                 returnty = SimTypeInt()
-
         self.function.prototype = SimTypeFunction(func_args, returnty).with_arch(self.project.arch)
         self.function.prototype_source = PrototypeSource.CCA_DECOMPILER
 

--- a/angr/analyses/decompiler/return_maker.py
+++ b/angr/analyses/decompiler/return_maker.py
@@ -4,7 +4,7 @@ import logging
 
 from angr import ailment
 from angr.calling_conventions import SimComboArg, SimRegArg
-from angr.sim_type import SimTypeBottom
+from angr.sim_type import SimTypeBottom, SimTypeFunction
 from angr.utils.types import dereference_simtype_by_lib
 
 from .ailgraph_walker import AILGraphWalker
@@ -17,11 +17,12 @@ class ReturnMaker(AILGraphWalker):
     Traverse the AILBlock graph of a function and update .ret_exprs of all return statements.
     """
 
-    def __init__(self, ail_manager, arch, function, ail_graph):
+    def __init__(self, ail_manager, arch, function, ail_graph, *, prototype: SimTypeFunction | None = None):
         super().__init__(ail_graph, self._handler, replace_nodes=True)
         self.ail_manager = ail_manager
         self.arch = arch
         self.function = function
+        self.prototype: SimTypeFunction | None = function.prototype if prototype is None else prototype
 
         self.walk()
 
@@ -32,16 +33,16 @@ class ReturnMaker(AILGraphWalker):
         if (
             block is not None
             and not stmt.ret_exprs
-            and self.function.prototype is not None
-            and self.function.prototype.returnty is not None
-            and type(self.function.prototype.returnty) is not SimTypeBottom
+            and self.prototype is not None
+            and self.prototype.returnty is not None
+            and type(self.prototype.returnty) is not SimTypeBottom
         ):
             new_stmt = stmt.copy()
             new_ret_exprs = list(new_stmt.ret_exprs)
             returnty = (
-                dereference_simtype_by_lib(self.function.prototype.returnty, self.function.prototype_libname)
+                dereference_simtype_by_lib(self.prototype.returnty, self.function.prototype_libname)
                 if self.function.prototype_libname
-                else self.function.prototype.returnty
+                else self.prototype.returnty
             )
             ret_val = self.function.calling_convention.return_val(returnty)
             if isinstance(ret_val, SimRegArg):

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -13,6 +13,7 @@ from angr.ailment.block_walker import _dispatch_key
 from angr.ailment.constant import UNDETERMINED_SIZE
 from angr.ailment.expression import BinaryOp, StackBaseOffset
 from angr.analyses.analysis import Analysis, register_analysis
+from angr.analyses.decompiler.c_prototype import c_function_type_with_array_return_decay
 from angr.analyses.decompiler.notes.deobfuscated_strings import DeobfuscatedStringsNote
 from angr.analyses.decompiler.peephole_optimizations.cas_intrinsics import cas_intrinsic_name
 from angr.analyses.decompiler.region_identifier import MultiNode
@@ -878,8 +879,22 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
 
         # return type
         assert self.functy.returnty is not None
-        yield self.functy.returnty.c_repr(name="").strip(" "), self.functy.returnty
-        yield " ", None
+        return_type_post = None
+        if (
+            isinstance(self.functy.returnty, SimTypePointer)
+            and self.functy.returnty.label is None
+            and isinstance(self.functy.returnty.pts_to, SimTypeArray)
+        ):
+            marker = "\x00"
+            pointer_qualifier = (
+                f"{' '.join(sorted(self.functy.returnty.qualifier))} " if self.functy.returnty.qualifier else ""
+            )
+            return_type_repr = self.functy.returnty.pts_to.c_repr(name=f"(*{pointer_qualifier}{marker})")
+            return_type_pre, return_type_post = return_type_repr.split(marker, 1)
+            yield return_type_pre, self.functy.returnty
+        else:
+            yield self.functy.returnty.c_repr(name="").strip(" "), self.functy.returnty
+            yield " ", None
         # function name
         if self.demangled_name and self.show_demangled_name:
             normalized_name = get_cpp_function_name(self.demangled_name)
@@ -900,6 +915,8 @@ class CFunction(CConstruct):  # pylint:disable=abstract-method
             yield from type_to_c_repr_chunks(arg_type, name=variable.name, name_type=cvariable, full=False)
 
         yield ")", paren
+        if return_type_post is not None:
+            yield return_type_post, CArrayTypeLength(return_type_post)
         # function body
         if self.codegen.braces_on_own_lines:
             yield "\n", None
@@ -1641,13 +1658,16 @@ class CFunctionCall(CExpression):
     @property
     def prototype(self) -> SimTypeFunction | None:  # TODO there should be a prototype for each callsite!
         if self.callee_func is not None and self.callee_func.prototype is not None:
-            proto = self.callee_func.prototype
+            proto = cast(SimTypeFunction, self.callee_func.prototype)
             if self.callee_func.prototype_libname is not None:
                 # we need to deref the prototype in case it uses SimTypeRef internally
                 proto = cast(SimTypeFunction, dereference_simtype_by_lib(proto, self.callee_func.prototype_libname))
-            return proto
+            return c_function_type_with_array_return_decay(proto, self.codegen.project.arch)
         returnty = SimTypeInt(signed=False)
-        return SimTypeFunction([arg.type for arg in self.args], returnty).with_arch(self.codegen.project.arch)
+        return cast(
+            SimTypeFunction,
+            SimTypeFunction([arg.type for arg in self.args], returnty).with_arch(self.codegen.project.arch),
+        )
 
     @property
     def prototype_returnty(self) -> SimType:
@@ -3096,10 +3116,12 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
 
         self.cnode2ailexpr = {v: k[0] for k, v in self.ailexpr2cnode.items()}
 
+        assert self._func.prototype is not None
+        c_prototype = c_function_type_with_array_return_decay(self._func.prototype, self.project.arch)
         self.cfunc = CFunction(
             self._func.addr,
             self._func.name,
-            self._func.prototype,
+            c_prototype,
             arg_list,
             obj,
             self._variables_in_use,
@@ -4689,7 +4711,8 @@ class MakeTypecastsImplicit(CStructuredCodeWalker):
         return super().handle_CFunctionCall(obj)
 
     def handle_CReturn(self, obj: CReturn):
-        obj.retval = self.collapse(obj.codegen._func.prototype.returnty, obj.retval)
+        assert obj.codegen.cfunc is not None and obj.codegen.cfunc.functy.returnty is not None
+        obj.retval = self.collapse(obj.codegen.cfunc.functy.returnty, obj.retval)
         return super().handle_CReturn(obj)
 
     def handle_CBinaryOp(self, obj: CBinaryOp):

--- a/tests/analyses/decompiler/test_clinic_function_prototype.py
+++ b/tests/analyses/decompiler/test_clinic_function_prototype.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import logging
+import os
+import unittest
+from typing import cast
+
+import archinfo
+
+import angr
+from angr import ailment
+from angr.analyses import Decompiler
+from angr.analyses.decompiler.c_prototype import c_function_type_with_array_return_decay
+from angr.analyses.decompiler.structured_codegen.c import CArrayTypeLength, CStructuredCodeGenerator
+from angr.calling_conventions import SimRegArg, default_cc
+from angr.knowledge_plugins.functions import Function
+from angr.knowledge_plugins.functions.function import PrototypeSource
+from angr.sim_type import SimTypeArray, SimTypeChar, SimTypeFunction, SimTypeInt, SimTypePointer
+from angr.sim_variable import SimRegisterVariable
+from tests.common import bin_location
+
+
+class TestClinicFunctionPrototype(unittest.TestCase):
+    """Tests for keeping the C prototype view separate from the shared function prototype."""
+
+    def test_c_array_return_decay_is_local_and_only_applies_once(self):
+        arch = archinfo.ArchAMD64()
+        argument_type = SimTypeArray(SimTypeInt(), 2, qualifier=("volatile",))
+        inner_return_type = SimTypeArray(SimTypeChar(), 4, qualifier=("volatile",))
+        return_type = SimTypeArray(inner_return_type, 8, qualifier=("const",))
+        prototype = cast(
+            SimTypeFunction,
+            SimTypeFunction(
+                [argument_type], return_type, label="array_return", arg_names=("items",), variadic=True
+            ).with_arch(arch),
+        )
+        original_return_type = prototype.returnty
+        self.assertIsInstance(original_return_type, SimTypeArray)
+        original_return_type = cast(SimTypeArray, original_return_type)
+        original_inner_return_type = original_return_type.elem_type
+        self.assertIsInstance(original_inner_return_type, SimTypeArray)
+
+        c_prototype = c_function_type_with_array_return_decay(prototype, arch)
+
+        self.assertIsNot(c_prototype, prototype)
+        self.assertIs(c_prototype.args, prototype.args)
+        self.assertIs(c_prototype.args[0], prototype.args[0])
+        self.assertEqual(c_prototype.label, prototype.label)
+        self.assertEqual(c_prototype.arg_names, prototype.arg_names)
+        self.assertTrue(c_prototype.variadic)
+        self.assertIsInstance(c_prototype.returnty, SimTypePointer)
+        c_return_type = cast(SimTypePointer, c_prototype.returnty)
+        self.assertIsInstance(c_return_type.pts_to, SimTypeArray)
+        pointed_to = cast(SimTypeArray, c_return_type.pts_to)
+        self.assertEqual(pointed_to.length, 4)
+        self.assertEqual(set(pointed_to.qualifier or ()), {"const", "volatile"})
+        self.assertFalse(pointed_to.elem_type.qualifier)
+
+        self.assertIs(prototype.returnty, original_return_type)
+        self.assertIs(original_return_type.elem_type, original_inner_return_type)
+        self.assertEqual(original_return_type.qualifier, ("const",))
+        self.assertEqual(original_inner_return_type.qualifier, ("volatile",))
+        self.assertIs(c_function_type_with_array_return_decay(c_prototype, arch), c_prototype)
+
+    def test_non_array_return_keeps_the_original_prototype(self):
+        prototype = SimTypeFunction([SimTypeArray(SimTypeChar(), 3)], SimTypeInt(signed=False))
+
+        self.assertIs(c_function_type_with_array_return_decay(prototype, archinfo.ArchAMD64()), prototype)
+
+    def test_c_array_return_view_does_not_mutate_shared_prototype(self):
+        for flavors in (("pseudocode", "rust"), ("rust", "pseudocode")):
+            with self.subTest(flavors=flavors):
+                project = angr.Project(
+                    os.path.join(bin_location, "tests", "x86_64", "fauxware"),
+                    auto_load_libs=False,
+                )
+                cfg = project.analyses.CFGFast(normalize=True, data_references=True)
+                function = cast(Function, cfg.functions["authenticate"])
+
+                inner_return_type = SimTypeArray(SimTypeChar(), 4, qualifier=("volatile",))
+                return_type = SimTypeArray(inner_return_type, 8, qualifier=("const",))
+                prototype = cast(
+                    SimTypeFunction,
+                    SimTypeFunction(
+                        [SimTypePointer(SimTypeChar()), SimTypePointer(SimTypeChar())],
+                        return_type,
+                        arg_names=("username", "password"),
+                    ).with_arch(project.arch),
+                )
+                function.prototype = prototype
+                function.prototype_source = PrototypeSource.USER
+                calling_convention = default_cc(project.arch.name)
+                if calling_convention is None:
+                    self.fail(f"No default calling convention for {project.arch.name}")
+                function.calling_convention = calling_convention(project.arch)
+
+                for flavor in flavors:
+                    if flavor == "pseudocode":
+                        log_context = self.assertNoLogs("angr.analyses.decompiler.return_maker", level=logging.WARNING)
+                        with log_context:
+                            decompilation = project.analyses[Decompiler].prep(fail_fast=True)(
+                                function,
+                                cfg=cfg.model,
+                                flavor=flavor,
+                            )
+                    else:
+                        decompilation = project.analyses[Decompiler].prep(fail_fast=True)(
+                            function,
+                            cfg=cfg.model,
+                            flavor=flavor,
+                        )
+
+                    codegen = decompilation.codegen
+                    if codegen is None or codegen.text is None:
+                        self.fail("Decompiler did not produce source text")
+                    text = codegen.text
+                    self.assertIs(function.prototype, prototype)
+                    self.assertIs(function.prototype_source, PrototypeSource.USER)
+                    self.assertIs(function.prototype.returnty, prototype.returnty)
+                    self.assertIs(function.prototype.args, prototype.args)
+
+                    clinic = decompilation.clinic
+                    if clinic is None:
+                        self.fail("Decompiler did not produce a Clinic result")
+                    assert clinic is not None and clinic.arg_list is not None
+                    expected_prototype = (
+                        c_function_type_with_array_return_decay(prototype, project.arch)
+                        if flavor == "pseudocode"
+                        else prototype
+                    )
+                    expected_arg_locs = function.calling_convention.arg_locs(expected_prototype)
+                    self.assertTrue(all(isinstance(arg_loc, SimRegArg) for arg_loc in expected_arg_locs))
+                    self.assertTrue(all(isinstance(arg, SimRegisterVariable) for arg in clinic.arg_list))
+                    self.assertEqual(
+                        [cast(SimRegisterVariable, arg).reg for arg in clinic.arg_list],
+                        [project.arch.registers[cast(SimRegArg, arg_loc).reg_name][0] for arg_loc in expected_arg_locs],
+                    )
+
+                    if flavor == "rust":
+                        self.assertIn("[8][4]", text)
+                        continue
+
+                    self.assertIsInstance(codegen, CStructuredCodeGenerator)
+                    c_codegen = cast(CStructuredCodeGenerator, codegen)
+                    c_function = c_codegen.cfunc
+                    if c_function is None:
+                        self.fail("C code generator did not produce a function")
+                    self.assertIs(c_function.functy.args, prototype.args)
+                    self.assertIsInstance(c_function.functy.returnty, SimTypePointer)
+                    c_return_type = cast(SimTypePointer, c_function.functy.returnty)
+                    self.assertIsInstance(c_return_type.pts_to, SimTypeArray)
+                    pointed_to = cast(SimTypeArray, c_return_type.pts_to)
+                    self.assertEqual(pointed_to.length, 4)
+                    self.assertEqual(set(pointed_to.qualifier or ()), {"const", "volatile"})
+                    self.assertIn(
+                        "const volatile char (*authenticate(char *username, char *password))[4]",
+                        text,
+                    )
+
+                    chunks = list(c_function.full_c_repr_chunks())
+                    self.assertTrue(any(text == "authenticate" and owner is c_function for text, owner in chunks))
+                    self.assertTrue(
+                        any(
+                            text == ")[4]" and isinstance(owner, CArrayTypeLength) and owner.text == ")[4]"
+                            for text, owner in chunks
+                        )
+                    )
+                    self.assertTrue(
+                        any(text.endswith("char (*") and owner is c_function.functy.returnty for text, owner in chunks)
+                    )
+
+    def test_c_array_return_callee_uses_local_callsite_prototype(self):
+        project = angr.Project(
+            os.path.join(bin_location, "tests", "x86_64", "fauxware"),
+            auto_load_libs=False,
+        )
+        cfg = project.analyses.CFGFast(normalize=True, data_references=True)
+        callee = cast(Function, cfg.functions["authenticate"])
+        prototype = cast(
+            SimTypeFunction,
+            SimTypeFunction(
+                [SimTypePointer(SimTypeChar()), SimTypePointer(SimTypeChar())],
+                SimTypeArray(SimTypeArray(SimTypeChar(), 4), 8),
+            ).with_arch(project.arch),
+        )
+        callee.prototype = prototype
+        callee.prototype_source = PrototypeSource.USER
+        calling_convention = default_cc(project.arch.name)
+        if calling_convention is None:
+            self.fail(f"No default calling convention for {project.arch.name}")
+        callee.calling_convention = calling_convention(project.arch)
+
+        caller = cast(Function, cfg.functions["main"])
+        decompilation = project.analyses[Decompiler].prep(fail_fast=True)(
+            caller,
+            cfg=cfg.model,
+            flavor="pseudocode",
+        )
+        clinic = decompilation.clinic
+        if clinic is None:
+            self.fail("Decompiler did not produce a Clinic result")
+        assert clinic is not None and clinic.graph is not None
+
+        call = None
+        for block in clinic.graph.nodes():
+            for statement in block.statements:
+                candidate = None
+                if isinstance(statement, ailment.Stmt.SideEffectStatement):
+                    candidate = statement.expr
+                elif isinstance(statement, ailment.Stmt.Assignment):
+                    candidate = statement.src
+                    if isinstance(candidate, ailment.Expr.Convert):
+                        candidate = candidate.operand
+                if (
+                    isinstance(candidate, ailment.Expr.Call)
+                    and isinstance(candidate.target, ailment.Expr.Const)
+                    and candidate.target.value == callee.addr
+                ):
+                    call = candidate
+                    break
+            if call is not None:
+                break
+
+        if call is None:
+            self.fail("Decompiler did not retain the call to authenticate")
+        callsite_prototype = clinic.variable_map.prototype(call)
+        self.assertIsNotNone(callsite_prototype)
+        assert callsite_prototype is not None
+        self.assertIsInstance(callsite_prototype.returnty, SimTypePointer)
+        self.assertIsInstance(callee.prototype.returnty, SimTypeArray)
+        self.assertIs(callee.prototype_source, PrototypeSource.USER)
+        codegen = decompilation.codegen
+        if codegen is None or codegen.text is None:
+            self.fail("Decompiler did not produce source text")
+        assert codegen is not None and codegen.text is not None
+        self.assertIn("authenticate(", codegen.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

This change has no verified real producer. Although `tests/analyses/decompiler/test_clinic_function_prototype.py` loads `fauxware`, it manually replaces `authenticate`'s return type with `SimTypeArray`; the binary neither supplies nor infers that impossible C function return, and no maintainer has confirmed an API-only change is wanted.

### Root cause

The test fixture was presented as real-path evidence even though the state under test is injected after loading it.

### Fix

This pull request is withdrawn instead of treating a fabricated prototype as a decompilation failure.

### Testing

The prior focused test and hosted checks establish the helper's behavior on the injected prototype only; they do not supply a real producer. Validation: https://github.com/angr/angr/pull/6983#issuecomment-5434368158

session: decbench
