### PR TITLE
CFGFast: Do not delete a block another function still owns

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1,6 +1,7 @@
 # pylint:disable=superfluous-parens,too-many-boolean-expressions,line-too-long
 from __future__ import annotations
 
+import bisect
 import itertools
 import logging
 import math
@@ -82,6 +83,7 @@ if TYPE_CHECKING:
     from angr.engines.pcode.lifter import IRSB as PcodeIRSB
     from angr.knowledge_plugins.cfg.spilling_cfg import SpillingCFG
     from angr.knowledge_plugins.cfg.types import CFGNODE_K
+    from angr.knowledge_plugins.functions import Function
 
 
 VEX_IRSB_MAX_SIZE = 400
@@ -4838,6 +4840,9 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
         nodes_to_remove: list[int] = []
         full_funcs_to_remove: list[int] = []
+        symbol_addrs = sorted(
+            get_real_address_if_arm(self.project.arch, addr) for addr in self._function_addresses_from_symbols
+        )
 
         for func_addr in self.kb.functions:
             # is this function starting in the middle of an instruction?
@@ -4869,6 +4874,12 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 continue
 
             func = self.kb.functions.get_by_addr(func_addr)
+            if self._body_names_a_symbol(func, symbol_addrs):
+                # removing this function deletes every block of it, so the exemption above has to reach past its
+                # entry point: a block the file's own symbol table names is the same evidence, and removal
+                # destroys it just as completely.
+                continue
+
             for block_addr in sorted(func.block_addrs, reverse=True):
                 cfg_node = self.model.get_any_node(block_addr)
                 if cfg_node is not None and cfg_node.size > 0:
@@ -4914,6 +4925,29 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                 self.model.remove_node_and_graph_node(cfg_node)
             if self.kb.functions.contains_addr(node_addr):
                 del self.kb.functions[func_addr]
+
+    def _body_names_a_symbol(self, func: Function, symbol_addrs: list[int]) -> bool:
+        """
+        Whether the binary's symbol table names an address inside any block of a function.
+
+        Both sides are masked on ARM: angr carries the Thumb flag in bit 0 of a block address, ELF states it
+        the same way in ``st_value``, and Mach-O keeps it in ``n_desc`` and leaves the address even. Comparing
+        them unmasked makes a Thumb function miss the symbol that starts it.
+
+        :param func:            The function whose blocks to test.
+        :param symbol_addrs:    ``self._function_addresses_from_symbols``, masked and sorted ascending.
+        :return:                True if any block of the function spans a symbol-named address.
+        """
+
+        for block_addr in func.block_addrs_set:
+            cfg_node = self.model.get_any_node(block_addr)
+            if cfg_node is None or not cfg_node.size:
+                continue
+            start = get_real_address_if_arm(self.project.arch, block_addr)
+            index = bisect.bisect_left(symbol_addrs, start)
+            if index < len(symbol_addrs) and symbol_addrs[index] < start + cfg_node.size:
+                return True
+        return False
 
     def _analyze_all_function_features(self, all_funcs_completed=False):
         """

--- a/angr/project.py
+++ b/angr/project.py
@@ -368,7 +368,9 @@ class Project:
             if func is None:
                 continue
             if isinstance(func, cle.backends.macho.symbol.SymbolTableSymbol):
-                # in macho we cannot determine if a symbol is a function symbol or not
+                # a Mach-O import is an undefined symbol, which states where it is *not* defined and nothing
+                # else, so it is not a function symbol and the test below would drop every simprocedure this
+                # object needs.
                 pass
             elif not func.is_function and func.type != cle.backends.symbol.SymbolType.TYPE_NONE:
                 continue

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1141,6 +1141,36 @@ class TestCfgfast(unittest.TestCase):
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
 
+    def test_symbol_exemption_covers_the_blocks_removal_deletes(self):
+        # Removing a function deletes every block of it, not just its entry, so the exemption above is tested
+        # against the blocks: a static function the scan merged into its neighbour, or a symbol-named tail the
+        # boundary pass has not split yet, is named evidence that removal destroys just as completely.
+        proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        func = cfg.kb.functions["main"]
+        blocks: list[tuple[int, int]] = []
+        for block_addr in func.block_addrs_set:
+            node = cfg.model.get_any_node(block_addr)
+            if node is None or not node.size:
+                continue
+            assert isinstance(node.addr, int)
+            blocks.append((node.addr, node.size))
+        blocks.sort()
+        assert len(blocks) > 1
+        entry_addr = blocks[0][0]
+        last_addr, last_size = blocks[-1]
+
+        names_a_symbol = cfg._body_names_a_symbol  # pylint:disable=protected-access
+        assert not names_a_symbol(func, [])
+        assert names_a_symbol(func, [entry_addr])
+        # Named only in the last block: what the entry test cannot see and removal deletes anyway.
+        assert names_a_symbol(func, [last_addr])
+        assert names_a_symbol(func, [last_addr + last_size - 1])
+        # Just outside the body on either side.
+        assert not names_a_symbol(func, [entry_addr - 1])
+        assert not names_a_symbol(func, [last_addr + last_size])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`drop_bad_functions` removes a function by deleting every block it owns, but the exemption that protects symbol-named code asks only about the function's entry:

```python
if func_addr in self._function_addresses_from_symbols:
    # the file's own symbol table names a function here, so this is not something the linear scan
    # invented out of data.
    continue
```

A function whose head no symbol names, but which owns a block the symbol table does name, reaches the removal tests with that named code inside it. On `binaries/tests/i386/libpthread.so.0` the function at `0x40f1d5` is one: no symbol names it, and it owns the block at `0x40f1f0`, which is `__libc_sigaction`.

```
removal candidates past the entry-symbol exemption and the block-count filter: 268
  spared after them by a whole-body symbol test : 0
  reaching the removal tests                    : 268

of those reaching the removal tests, the ones that own a block the symbol table names:
  function 0x40f1d5 (3 blocks): block 0x40f1f0 size=24 contains __libc_sigaction at 0x40f1f0
```

The block tests clear this one, so nothing is lost here; the exemption simply never saw what it exists to protect. On Mach-O the shape is the common case rather than the incident, but only once cle 796 makes Mach-O symbols report as functions at all: on one Mach-O object from a corpus that is not public, with that change applied, almost every remaining missed function body was a block inside a function whose head carries no symbol, and almost all of those owners had been removed here.

### Root cause

The entry test is usually enough because a symbol address is also a scan starting point:

```python
if self._use_symbols:
    starting_points |= self._function_addresses_from_symbols
```

so a symbol-named address normally ends up as a function head, where the entry test sees it. It fails when the scan does not keep it as its own function and the named address lands inside a block owned by a neighbour, as `__libc_sigaction` does above: the test is then answering about an address the symbol table never named, while removal reaches the one it did.

### Fix

`_body_names_a_symbol` asks whether the symbol table names any address inside any block of the function, bisecting a sorted copy of `_function_addresses_from_symbols`. It runs after the cheap filters, where a candidate has fewer than four blocks. ARM's Thumb bit is masked on both sides: angr carries it in bit 0 of a block address, ELF says it the same way in `st_value`, and Mach-O keeps it in `n_desc` and leaves the address even. Same reproducer, after:

```
removal candidates past the entry-symbol exemption and the block-count filter: 268
  spared after them by a whole-body symbol test : 1
  reaching the removal tests                    : 267

of those reaching the removal tests, the ones that own a block the symbol table names:
  none
```

Removal itself is unchanged; only the exemption is widened. The `project.py` hunk is a comment: it records why a Mach-O `SymbolTableSymbol` is deliberately not put through the `is_function` test below it.

### Testing

`test_symbol_exemption_covers_the_blocks_removal_deletes` pins `_body_names_a_symbol` on `binaries/tests/x86_64/fauxware`: a symbol in the entry block, in the last block and on the last byte of the last block all count as naming `main`; one byte outside the body on either side does not. The helper does not exist at the merge base, so the test cannot run there.

No fixture in `angr/binaries` moves under this. With cle 796 applied the exemption never fires on any of the 22 Mach-O fixtures there that load, and their function and block sets are identical on both sides; across the 716 ELF and PE fixtures under 600 KB, 709 of which load, it fires on two functions — in `i386/libpthread.so.0` and `mips64/ld.so.1` — and neither object's function set or block count changes. The reproducer above is what a public fixture can show: the named code the entry test cannot see.

Requires the sibling below, cle 796. Without it `is_function` is false for every Mach-O symbol — 0 of 548 on `armhf/FileProtection-05.armv7.macho`, against 74 with it — so `_function_addresses_from_symbols` is empty there and this change is inert.

Validation: https://github.com/angr/angr/pull/6984#issuecomment-5438429725

sync: angr/cle#796

session: sharpen
