### PR TITLE
ReturnDuplicator: a graph with no statements is not a return graph

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_base.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_base.py
@@ -415,6 +415,12 @@ class ReturnDuplicatorBase:
             if node.statements:
                 stmts += node.statements
 
+        if not stmts:
+            # every node in this graph is statement-less. graph recovery emits a zero-size block for a
+            # fall-through that no instruction backs, and remove_labels() then strips the label that was its
+            # only statement. Such a graph carries no return statement, so it is not a simple return graph.
+            return False
+
         # all statements must be either a return, a jump, an assignment, or a side-effect statement (e.g. a call)
         type_white_list = (Return, Jump, Assignment, SideEffectStatement)
         for stmt in stmts:

--- a/tests/analyses/decompiler/test_return_duplicator_statementless_graph.py
+++ b/tests/analyses/decompiler/test_return_duplicator_statementless_graph.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import unittest
+
+import networkx
+
+from angr.ailment import Block
+from angr.ailment.expression import Const
+from angr.ailment.statement import Jump, Label, Return
+from angr.analyses.decompiler.optimization_passes.return_duplicator_base import ReturnDuplicatorBase
+
+
+def _label(addr):
+    return Label(0, f"LABEL_{addr:x}", ins_addr=addr, block_idx=None)
+
+
+class TestReturnDuplicatorStatementlessGraph(unittest.TestCase):
+    """
+    An AIL block in a decompilation graph may carry no statements: graph recovery emits a zero-size block
+    for a fall-through that no instruction backs, and Clinic drops empty nodes only once every stage has
+    run. _is_simple_return_graph strips labels before it looks, so such a block leaves it nothing at all.
+    """
+
+    def test_a_graph_whose_nodes_hold_no_statements_is_not_a_return_graph(self):
+        # the label is the block's only statement, and remove_labels() takes it away
+        block = Block(0x400100, 0, statements=[_label(0x400100)])
+        graph = networkx.DiGraph()
+        graph.add_node(block)
+
+        # no statements means no return statement
+        assert ReturnDuplicatorBase._is_simple_return_graph(graph) is False
+
+    def test_a_statementless_block_ahead_of_a_return_is_still_a_return_graph(self):
+        # the new check must reject only graphs that hold nothing, not graphs that merely start empty
+        empty = Block(0x400100, 0, statements=[_label(0x400100)])
+        returns = Block(0x400104, 1, statements=[_label(0x400104), Return(0, [], ins_addr=0x400104)])
+        graph = networkx.DiGraph()
+        graph.add_edge(empty, returns)
+
+        assert ReturnDuplicatorBase._is_simple_return_graph(graph) is True
+
+    def test_a_jump_only_graph_is_still_rejected(self):
+        block = Block(0x400100, 2, statements=[_label(0x400100), Jump(0, Const(1, 0x400200, 32), ins_addr=0x400100)])
+        graph = networkx.DiGraph()
+        graph.add_node(block)
+
+        assert ReturnDuplicatorBase._is_simple_return_graph(graph) is False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`_is_simple_return_graph` gathers the statements of every node under a region's root and reads the last one to decide whether the region ends in a return. It already declines a graph with no nodes, but not one whose nodes carry no statements, and the read raised there.

That state is reachable. Graph recovery emits a zero-size block for a fall-through that no instruction backs, and Clinic removes empty nodes only once every stage has run, so such a block can be the end node of a region while ReturnDuplicator is looking at it. Stripping labels then leaves it with nothing at all.

A graph holding no statements holds no return statement, so the check now says so. The caller uses the answer only to decide whether duplicating a region is worthwhile, so declining leaves the graph alone. The exception cost the function its whole full-preset decompilation.

The regression test builds the block directly and needs no fixture.

Validation: https://github.com/angr/angr/pull/6985#issuecomment-5440717780

session: emo-corpus
