### PR TITLE
Clinic: do not build an ITE triangle onto a block with no statements

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -3266,7 +3266,8 @@ class Clinic(Analysis, Serializable):
 
         # corner-case: the last statement of original_block might have been patched by _remove_redundant_jump_blocks.
         # we detect such case and fix it in new_head_ail
-        self._remove_redundant_jump_blocks_repatch_relifted_block(original_block, end_block_ail)
+        if not self._remove_redundant_jump_blocks_repatch_relifted_block(original_block, end_block_ail):
+            return None
 
         ail_graph.remove_node(original_block)
 
@@ -3700,7 +3701,7 @@ class Clinic(Analysis, Serializable):
     @staticmethod
     def _remove_redundant_jump_blocks_repatch_relifted_block(
         patched_block: ailment.Block, new_block: ailment.Block
-    ) -> None:
+    ) -> bool:
         """
         The last statement of patched_block might have been patched by _remove_redundant_jump_blocks. In this case, we
         fix the last instruction for new_block, which is a newly lifted (from VEX) block that ends at the same address
@@ -3708,7 +3709,14 @@ class Clinic(Analysis, Serializable):
 
         :param patched_block:   Previously patched block.
         :param new_block:       Newly lifted block.
+        :return:                False if new_block cannot stand in for patched_block, in which case the caller must
+                                not rewrite the graph; True otherwise.
         """
+
+        if not patched_block.statements or not new_block.statements:
+            # graph recovery emits a zero-size block for a fall-through that no instruction backs. Such a block
+            # has no last statement to repatch, so it cannot carry the transfer patched_block ends with.
+            return False
 
         if (
             isinstance(patched_block.statements[-1], ailment.Stmt.Jump)
@@ -3729,6 +3737,8 @@ class Clinic(Analysis, Serializable):
         ):
             new_block.statements[-1].true_target = patched_block.statements[-1].true_target
             new_block.statements[-1].false_target = patched_block.statements[-1].false_target
+
+        return True
 
     def _insert_block_labels(self, ail_graph):
         for node in ail_graph.nodes:

--- a/tests/analyses/decompiler/test_ite_triangle_relifted_block.py
+++ b/tests/analyses/decompiler/test_ite_triangle_relifted_block.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import unittest
+
+from angr.ailment import Block
+from angr.ailment.expression import Const, Register
+from angr.ailment.statement import Assignment, Jump
+from angr.analyses.decompiler.clinic import Clinic
+
+
+def _jump(target, ins_addr=0x400100):
+    return Jump(0, Const(1, target, 32), ins_addr=ins_addr)
+
+
+class TestITETriangleRelistedBlock(unittest.TestCase):
+    """
+    _create_triangle_for_ite_expression truncates the head block at the ITE statement and leaves the end
+    block to carry whatever the original block ended with. An end block with no statements cannot carry
+    it, so the rewrite has to be declined rather than performed.
+    """
+
+    def test_a_statementless_end_block_refuses_the_rewrite(self):
+        # graph recovery emits a zero-size block for a fall-through that no instruction backs
+        patched = Block(0x400100, 4, statements=[_jump(0x400200)])
+        relifted = Block(0x400104, 0, statements=[])
+
+        assert Clinic._remove_redundant_jump_blocks_repatch_relifted_block(patched, relifted) is False
+
+    def test_a_relifted_block_that_carries_the_jump_is_repatched(self):
+        patched = Block(0x400100, 4, statements=[_jump(0x400200)])
+        relifted = Block(0x400100, 4, statements=[_jump(0x400104)])
+
+        assert Clinic._remove_redundant_jump_blocks_repatch_relifted_block(patched, relifted) is True
+        assert relifted.statements[-1].likes(_jump(0x400200))
+
+    def test_a_head_that_does_not_end_in_a_jump_is_accepted_unchanged(self):
+        patched = Block(0x400100, 4, statements=[Assignment(0, Register(1, 8, 32), Const(2, 1, 32), ins_addr=0x400100)])
+        relifted = Block(0x400100, 4, statements=[_jump(0x400104)])
+
+        assert Clinic._remove_redundant_jump_blocks_repatch_relifted_block(patched, relifted) is True
+        assert relifted.statements[-1].likes(_jump(0x400104))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Rewriting an ITE expression into a triangle relifts the head of a block, truncates it at the ITE statement and replaces it with a conditional jump, then joins both arms into an end block expected to carry the rest of the original block, the transfer it ended with included.

An end block taken from the graph can have no statements: graph recovery emits a zero-size block for a fall-through that no instruction backs, and Clinic removes empty nodes only once every stage has run. Rewriting onto one drops whatever jump the head ended with. Where that jump had been patched earlier, the repatch helper raised instead, and both the full and the basic preset lost the function.

The helper now reports whether the relifted block can stand in for the patched one, and the caller declines the rewrite when it cannot, leaving the graph alone as its other bail-outs do.

Validation: https://github.com/angr/angr/pull/6986#issuecomment-5440912657

session: emo-corpus
