### PR TITLE
Decompiler: identify the function entry block by the entry node, not the address

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/mips_gp_setting_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/mips_gp_setting_simplifier.py
@@ -63,7 +63,7 @@ class MipsGpSettingSimplifier(OptimizationPass):
         if gp_value is None:
             return None
 
-        first_block = self._get_block(self._func.addr)
+        first_block = self._get_block(self.entry_node_addr[0], idx=self.entry_node_addr[1])
         if first_block is None:
             return None
 

--- a/angr/analyses/decompiler/optimization_passes/optimization_pass.py
+++ b/angr/analyses/decompiler/optimization_passes/optimization_pass.py
@@ -218,7 +218,7 @@ class OptimizationPass(BaseOptimizationPass):
         seen = set()
 
         if start_node is None:
-            start_node = self._get_block(self._func.addr)
+            start_node = self._get_block(self.entry_node_addr[0], idx=self.entry_node_addr[1])
         if start_node is None:
             return
 

--- a/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
@@ -83,7 +83,7 @@ class RegisterSaveAreaSimplifier(OptimizationPass):
                     )
 
     def _find_registers_stored_on_stack(self) -> list[tuple[int, int, CodeLocation]]:
-        first_block = self._get_block(self._func.addr)
+        first_block = self._get_block(self.entry_node_addr[0], idx=self.entry_node_addr[1])
         if first_block is None:
             return []
 

--- a/angr/analyses/decompiler/optimization_passes/ret_addr_save_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/ret_addr_save_simplifier.py
@@ -96,7 +96,7 @@ class RetAddrSaveSimplifier(OptimizationPass):
         :return:    A tuple of (block_addr, statement_idx, save_dst) or None if not found.
         """
 
-        first_block = self._get_block(self._func.addr)
+        first_block = self._get_block(self.entry_node_addr[0], idx=self.entry_node_addr[1])
         if first_block is None:
             return None
 

--- a/angr/analyses/decompiler/optimization_passes/win_stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/win_stack_canary_simplifier.py
@@ -155,7 +155,7 @@ class WinStackCanarySimplifier(OptimizationPass):
             )
 
     def _find_canary_init_stmt(self) -> tuple[ailment.Block, list[int]] | None:
-        first_block = self._get_block(self._func.addr)
+        first_block = self._get_block(self.entry_node_addr[0], idx=self.entry_node_addr[1])
         if first_block is None:
             return None
 

--- a/tests/analyses/decompiler/test_entry_block_identity.py
+++ b/tests/analyses/decompiler/test_entry_block_identity.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import unittest
+
+import networkx
+
+from angr.ailment import Block
+from angr.ailment.expression import Const
+from angr.ailment.manager import Manager
+from angr.ailment.statement import Jump
+from angr.analyses.decompiler.optimization_passes.optimization_pass import (
+    OptimizationPass,
+    OptimizationPassStage,
+)
+
+
+class _Probe(OptimizationPass):
+    """A pass that does nothing, so that the base class's entry-block lookup can be exercised alone."""
+
+    ARCHES = None
+    PLATFORMS = None
+    STAGE = OptimizationPassStage.AFTER_AIL_GRAPH_CREATION
+    NAME = "entry block lookup probe"
+    DESCRIPTION = NAME
+
+    def _check(self):
+        return False, None
+
+    def _analyze(self, cache=None):
+        pass
+
+
+class _Func:
+    def __init__(self, addr):
+        self.addr = addr
+
+
+def _block(addr, target, idx=None):
+    return Block(addr, 2, statements=[Jump(0, Const(1, target, 32), ins_addr=addr)], idx=idx)
+
+
+def _probe(func_addr, entry_node_addr, blocks):
+    graph = networkx.DiGraph()
+    graph.add_nodes_from(blocks)
+    by_addr: dict[int, set[Block]] = {}
+    by_addr_and_idx = {}
+    for b in blocks:
+        by_addr.setdefault(b.addr, set()).add(b)
+        by_addr_and_idx[(b.addr, b.idx)] = b
+    return graph, _Probe(
+        _Func(func_addr),
+        Manager(),
+        graph=graph,
+        blocks_by_addr=by_addr,
+        blocks_by_addr_and_idx=by_addr_and_idx,
+        entry_node_addr=entry_node_addr,
+    )
+
+
+class TestEntryBlockIdentity(unittest.TestCase):
+    """
+    A pass may not identify the function's first block by address alone. Clinic duplicates an orphaned
+    conditional jump to each of its predecessors before SSA, so the entry address can carry more than one
+    AIL block, and Clinic also moves the entry when it drops a leading alignment block.
+    """
+
+    def test_entry_lookup_survives_a_duplicated_entry_block(self):
+        entry = _block(0x400100, 0x400110)
+        clone = _block(0x400100, 0x400110, idx=1)
+        tail = _block(0x400110, 0x400100)
+        graph, probe = _probe(0x400100, (0x400100, None), [entry, clone, tail])
+        graph.add_edge(entry, tail)
+        graph.add_edge(clone, tail)
+
+        assert list(probe.bfs_nodes()) == [entry, tail]
+
+    def test_entry_lookup_follows_an_entry_clinic_moved(self):
+        # Clinic dropped a leading alignment block at the function address and recorded its successor as
+        # the entry node, so nothing is left in the graph at the function address at all
+        entry = _block(0x400110, 0x400120)
+        tail = _block(0x400120, 0x400110)
+        graph, probe = _probe(0x400100, (0x400110, None), [entry, tail])
+        graph.add_edge(entry, tail)
+
+        assert list(probe.bfs_nodes()) == [entry, tail]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A function's entry address does not identify a single AIL block, and four optimization passes plus the shared breadth-first walk asked for it by address alone. That fails in two ways.

Where the address became ambiguous the lookup raises, and the basic-preset retry raises too, so the function is lost outright:

```
angr/analyses/decompiler/optimization_passes/optimization_pass.py:279: MultipleBlocksException:
There are 2 blocks at address 0x400100 (block ID ignored) but only one is requested.
```

Where the entry moved, the lookup finds nothing at the function address and the pass silently skips the function. That is the case public fixtures hit: decompiling `sub_14000db16` at `0x14000db16` in `angr/binaries` `tests/x86_64/windows/TLS.exe` keeps a dead spill of `rdi` into `[bp-0x8]` and the two locals that exist only to carry it, because `RegisterSaveAreaSimplifier` never ran.

### Root cause

Clinic moves both things out from under the address before any pass runs. `_duplicate_orphaned_cond_jumps` copies a lone ccall-based conditional jump to each of its predecessors, giving several blocks one address distinguished only by `idx`; `_remove_alignment_blocks` drops a leading nop block and reassigns `self.entry_node_addr = succ.addr, None`. `_get_block(self._func.addr)` cannot express either.

### Fix

Ask for the block Clinic resolved. `OptimizationPass` already receives `entry_node_addr` as an `(addr, idx)` pair and several passes already use it; these five call sites use it now too, which is a one-line change in each. The `TLS.exe` function above then loses the spill and both locals, and its loop body is byte-identical either side.

Deliberately not changed, so a reviewer does not have to find them: `win_stack_canary_simplifier` also looks up the block *after* the first by address alone, and `SwitchDefaultCaseDuplicator` looks up switch-head and default-case addresses the same way. Neither is the function's entry block and neither has an authoritative block identity to use instead.

### Testing

`tests/analyses/decompiler/test_entry_block_identity.py` drives the shared lookup directly and needs no fixture. Both cases fail on the baseline — the first with the `MultipleBlocksException` above, the second because the walk starts at an address the graph no longer holds — and both pass on the head.

Computing both lookups at every call site over 5,640 functions in ten `angr/binaries` fixtures under both structurers: 14,196 agreements, 118 where the old lookup found nothing and the new one finds the entry, and 0 in the other direction. `MipsGpSettingSimplifier` is not measured — no MIPS fixture in the set reaches it — so its one-line change rests on the shared argument.

Validation: https://github.com/angr/angr/pull/6987#issuecomment-5441876739

session: sharpen