### PR TITLE
decompiler: recognize unsigned range checks when reverting switch lowering

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -284,7 +284,8 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                 if default_reachable_from_case:
                     continue
 
-                original_nodes = [case.original_node for case in real_cases]
+                # one node can cover several cases now, so drop repeats
+                original_nodes = list(dict.fromkeys(case.original_node for case in real_cases))
                 original_head: Block = original_nodes[0]
                 original_nodes = original_nodes[1:]
                 existing_nodes_by_addr_and_idx = {(nn.addr, nn.idx): nn for nn in graph_copy}
@@ -294,13 +295,25 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                 # targets that are only reachable through a copied case node; the head must not get direct edges to
                 # these targets, or the direct edges would bypass the assignments held by the copied case nodes
                 copied_case_targets: set[tuple[Block, int, int | None]] = set()
+                # a contiguous group of case labels is one comparison node jumping to one body for every value in
+                # the group. the node must be emitted once and reused for the remaining values: copying it per
+                # value would put several blocks carrying its address into the graph, and the case bodies would
+                # then be reached through whichever of them an edge happened to be attached to.
+                group_entry: dict[tuple[Block, int, int | None], tuple[int, int | None]] = {}
                 for idx, case in enumerate(cases):
-                    if idx == 0 or all(
+                    group_key = (case.original_node, case.target, case.target_idx)
+                    if case.value != "default" and group_key in group_entry:
+                        emitted_target, emitted_target_idx = group_entry[group_key]
+                        case_addrs.append(
+                            (case.original_node, case.value, emitted_target, emitted_target_idx, case.next_addr)
+                        )
+                    elif idx == 0 or all(
                         isinstance(stmt, (Label, ConditionalJump)) for stmt in case.original_node.statements
                     ):
                         case_addrs.append(
                             (case.original_node, case.value, case.target, case.target_idx, case.next_addr)
                         )
+                        group_entry[group_key] = (case.target, case.target_idx)
                     else:
                         statements: list = [
                             stmt for stmt in case.original_node.statements if isinstance(stmt, (Label, Assignment))
@@ -326,6 +339,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         case_addrs.append(
                             (case_node_copy, case.value, case_node_copy.addr, case_node_copy.idx, case.next_addr)
                         )
+                        group_entry[group_key] = (case_node_copy.addr, case_node_copy.idx)
 
                         # add this copied node into the graph
                         delayed_edges.append((None, case_node_copy))
@@ -436,6 +450,16 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
             if r is not None:
                 variable_comparisons[node] = ("c", *r)
                 continue
+            r = self._find_switch_variable_comparison_type_d(node, variable_map_of(self.manager))
+            if r is not None:
+                _varhash, _op, _expr, lo, hi, *_targets = r
+                # a contiguous run this long is left as a jump table instead of being lowered to an if-tree
+                # (see RULE 1), so this block is not the comparison of a lowered switch-case. leaving it
+                # unrecognized is what makes the cascade walk stop at it and record it as the default case,
+                # which is the role it actually plays.
+                if hi - lo + 1 < self._max_case_values:
+                    variable_comparisons[node] = ("d", *r)
+                continue
 
         varhash_to_caselists: defaultdict[int, list[tuple[list[Case], list]]] = defaultdict(list)
         used_nodes = set()
@@ -462,6 +486,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                     op,
                     expr,
                     value,
+                    value_high,
                     target,
                     target_idx,
                     next_addr,
@@ -609,6 +634,49 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         # checking on a new variable... it probably was not a switch-case
                         continue
 
+                elif op == "range":
+                    # all values in the range jump to the same place, so emit one case each
+                    if head_varhash != variable_hash:
+                        # checking on a new variable... it probably was not a switch-case
+                        continue
+
+                    # like "gt", a range check is not supported as the head of a switch: on its own it is just as
+                    # much a two-way test as a case group, and the ones that head a chain are dominated by loop
+                    # conditions of the isspace(c) kind, whose "case body" is the next iteration of the loop
+                    if comp is head:
+                        break
+
+                    in_addr, in_idx, out_addr, out_idx = target, target_idx, next_addr, next_addr_idx
+                    successors = [succ for succ in self._graph.successors(comp) if succ is not comp]
+                    succ_addrs = {(succ.addr, succ.idx) for succ in successors}
+                    if succ_addrs != {(in_addr, in_idx), (out_addr, out_idx)}:
+                        break
+
+                    # the head is already excluded above, so this node has at most one predecessor
+                    if self._graph.in_degree[comp] > 1:
+                        break
+
+                    in_comp = next(iter(succ for succ in successors if (succ.addr, succ.idx) == (in_addr, in_idx)))
+                    if in_comp in variable_comparisons:
+                        # the target is another comparison, not the body of a case
+                        break
+
+                    # do not clip the range to the outer bounds: "gt" records its le-side bound as value - 1,
+                    # which would drop the top value of the group
+                    for case_value in range(value, value_high + 1):
+                        cases.append(Case(comp, comp_type, variable_hash, expr, case_value, in_addr, in_idx, None))
+                    used_nodes.add(comp)
+
+                    out_comp = next(iter(succ for succ in successors if (succ.addr, succ.idx) == (out_addr, out_idx)))
+                    if out_comp in variable_comparisons and out_comp not in visited:
+                        visited.add(out_comp)
+                        last_comp = comp
+                        stack.append((out_comp, min_, max_))
+                    elif out_addr not in default_case_candidates:
+                        default_case_candidates[out_addr] = Case(
+                            comp, None, variable_hash, expr, "default", out_addr, out_idx, None
+                        )
+
             if cases and len(default_case_candidates) <= 1:
                 if default_case_candidates:
                     cases.append(next(iter(default_case_candidates.values())))
@@ -698,7 +766,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
     def _find_switch_variable_comparison_type_a(
         node,
         variable_map,
-    ) -> tuple[int, str, Expression, int, int, int | None, int, int | None] | None:
+    ) -> tuple[int, str, Expression, int, int | None, int, int | None, int, int | None] | None:
         # the type a is the last statement is a var == constant comparison, but
         # there is more than one non-label statement in the block
 
@@ -738,6 +806,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         "eq",
                         cond.operands[0],
                         value,
+                        None,
                         target,
                         target_idx,
                         next_node_addr,
@@ -750,7 +819,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
     def _find_switch_variable_comparison_type_b(
         node,
         variable_map,
-    ) -> tuple[int, str, Expression, int, int, int | None, int, int | None] | None:
+    ) -> tuple[int, str, Expression, int, int | None, int, int | None, int, int | None] | None:
         # the type b is the last statement is a var == constant comparison, and
         # there is only one non-label statement
 
@@ -790,6 +859,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         "eq",
                         cond.operands[0],
                         value,
+                        None,
                         target,
                         target_idx,
                         next_node_addr,
@@ -802,7 +872,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
     def _find_switch_variable_comparison_type_c(
         node,
         variable_map,
-    ) -> tuple[int, str, Expression, int, int, int | None, int, int | None] | None:
+    ) -> tuple[int, str, Expression, int, int | None, int, int | None, int, int | None] | None:
         # the type c is where the last statement is a var < or > constant comparison, and
         # there is only one non-label statement
 
@@ -861,11 +931,84 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         op_str,
                         cond.operands[0],
                         value,
+                        None,
                         gt_node_addr,
                         gt_node_idx,
                         le_node_addr,
                         le_node_idx,
                     )
+
+        return None
+
+    @staticmethod
+    def _find_switch_variable_comparison_type_d(
+        node,
+        variable_map,
+    ) -> tuple[int, str, Expression, int, int | None, int, int | None, int, int | None] | None:
+        # type d matches an unsigned range check, (unsigned)(var - lo) <= hi - lo, which compilers emit for case
+        # labels with consecutive values. it means lo <= var <= hi. the signed form is just an upper bound (type c).
+
+        if isinstance(node, Block):
+            stmt = first_nonlabel_nonphi_statement(node)
+            if (
+                stmt is not None
+                and stmt is node.statements[-1]
+                and (
+                    isinstance(stmt, ConditionalJump)
+                    and isinstance(stmt.true_target, Const)
+                    and isinstance(stmt.false_target, Const)
+                )
+            ):
+                cond = stmt.condition
+                if (
+                    isinstance(cond, BinaryOp)
+                    and not cond.signed
+                    and isinstance(cond.operands[0], BinaryOp)
+                    and isinstance(cond.operands[1], Const)
+                ):
+                    range_expr = cond.operands[0]
+                    if (
+                        range_expr.op == "Sub"
+                        and isinstance(range_expr.operands[0], VirtualVariable)
+                        and isinstance(range_expr.operands[1], Const)
+                    ):
+                        if stmt.true_target.value == stmt.false_target.value:
+                            return None
+                        lo = range_expr.operands[1].value
+                        width = cond.operands[1].value
+                        op = cond.op
+                        if op in {"CmpLE", "CmpLT"}:
+                            in_node_addr = stmt.true_target.value
+                            in_node_idx = stmt.true_target_idx
+                            out_node_addr = stmt.false_target.value
+                            out_node_idx = stmt.false_target_idx
+                        elif op in {"CmpGT", "CmpGE"}:
+                            in_node_addr = stmt.false_target.value
+                            in_node_idx = stmt.false_target_idx
+                            out_node_addr = stmt.true_target.value
+                            out_node_idx = stmt.true_target_idx
+                        else:
+                            return None
+                        if op in {"CmpLT", "CmpGE"}:
+                            # < instead of <=, so the last value is not included
+                            width -= 1
+                        if width < 0:
+                            return None
+                        hi = lo + width
+                        if hi >= 1 << range_expr.operands[0].bits:
+                            # range runs past the variable's width
+                            return None
+                        return (
+                            StableVarExprHasher(range_expr.operands[0], variable_map).hash,
+                            "range",
+                            range_expr.operands[0],
+                            lo,
+                            hi,
+                            in_node_addr,
+                            in_node_idx,
+                            out_node_addr,
+                            out_node_idx,
+                        )
 
         return None
 

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -2670,6 +2670,43 @@ class TestDecompiler(unittest.TestCase):
         # assert d.codegen.text.count("break;") == 5
 
     @structuring_algo("sailr")
+    def test_reverting_switch_lowering_range_check_unzip(self, decompiler_options=None):
+        # case labels with consecutive values compile to an unsigned range check, (unsigned)(var - lo) <= hi - lo.
+        # when that is not recognized, the chain of comparisons is only half read, the switch is left pointing at a
+        # default it cannot reach, and most of the function is then dropped from the output.
+        bin_path = os.path.join(test_location, "x86_64", "decompiler", "unzip_gcc17_O0.stripped")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        all_optimization_passes = DECOMPILATION_PRESETS["full"].get_optimization_passes(
+            "AMD64", "linux", additional_opts=[LoweredSwitchSimplifier]
+        )
+
+        # TestExtraField(): a loop around a switch on the extra-field ID, whose cases switch again on a status
+        # code. PK_MEM3 (6) and PK_MEM4 (7) are the two consecutive values behind the range check.
+        f = proj.kb.functions[0x4131E7]
+        d = proj.analyses[Decompiler].prep(fail_fast=True)(
+            f, cfg=cfg.model, options=decompiler_options, optimization_passes=all_optimization_passes
+        )
+        print_decompilation_result(d)
+
+        assert d.codegen is not None
+        text = d.codegen.text
+        assert text is not None
+        # every goto needs a label to jump to; these used to point at blocks that were thrown away
+        used_labels = set(re.findall(r"goto\s+(LABEL_\w+);", text))
+        defined_labels = set(re.findall(r"^\s*(LABEL_\w+):", text, re.MULTILINE))
+        assert not used_labels - defined_labels, f"undefined labels: {sorted(used_labels - defined_labels)}"
+
+        # the range check covers 6 and 7, so both must appear as plain cases
+        assert "case 6:" in text
+        assert "case 7:" in text
+
+        # the outer switch and its shared-body group must still be there
+        for case_value in (9, 13133, 19521, 25922, 29761):
+            assert f"case {case_value}:" in text
+
+    @structuring_algo("sailr")
     def test_reverting_switch_clustering_and_lowering_cat_main(self, decompiler_options=None):
         # nested switch-cases
         bin_path = os.path.join(test_location, "x86_64", "decompiler", "cat.o")


### PR DESCRIPTION
### Problem

`LoweredSwitchSimplifier` fails to revert a lowered switch when the chain of comparisons contains an unsigned range check, and the failure is not contained: most of the function is dropped from the output and the emitted C references labels that do not exist.

Repro on `binaries/tests/x86_64/decompiler/unzip_O0.stripped`, function `TestExtraField` at `0x4131e7` — 141 basic blocks, of which 13 survive:

```c
    v9 = v5;
    if (v9 == 29761)
    {
        goto LABEL_0x41334a;
    }
    else if (v9 == 25922)
    {
        goto LABEL_0x41334a;
    }
    ...
    else
    {
        goto LABEL_0x413972;
    }
}
```

None of `LABEL_0x41334a`, `LABEL_0x41365f`, `LABEL_0x41390a`, `LABEL_0x413972` is ever defined. The dispatch is recovered correctly; every case body and the enclosing loop are gone.

### Root cause

Case labels with consecutive values compile to an unsigned range check, `(unsigned)(var - lo) <= hi - lo`. In `TestExtraField` the inner switch is on a `PK_*` status code, and `case PK_MEM3: case PK_MEM4:` (6 and 7) becomes, at `0x4134da`:

```
sub $0x6,%eax ; cmp $0x1,%eax ; ja 41359d
```
```
if (((vvar_860 Sub 6) CmpLE 1)) { Goto 0x413567 } else { Goto 0x41359d }
```

All three existing matchers require the compared expression to be a bare variable:

```python
isinstance(cond, BinaryOp)
and isinstance(cond.operands[0], VirtualVariable)
and isinstance(cond.operands[1], Const)
```

Here `operands[0]` is a `BinaryOp`, so all three return `None` and `_find_cascading_switch_variable_comparisons` stops in the middle of the chain.

The consequences compound. The `IncompleteSwitchCaseHeadStatement` that is then built records a default target that is not among the head's own graph successors, while the unconsumed remainder of the dispatch chain is rewired to the head as a successor claimed by no case entry. `_switch_find_default_node` fails its `has_edge` check, a placeholder default is synthesized, and the head is left with two out-edges that both recover as `<Bool True>`. No schema matches that shape, `_last_resort_refinement` finds no edge to virtualize, and `RecursiveStructurer` reports *"Structuring failed to complete … The output will miss code blocks"* and keeps a single node of the region, so codegen emits gotos into blocks that were discarded.

### Fix

Add `_find_switch_variable_comparison_type_d`, which matches the unsigned range check and reports the value range it pins the variable to, and an `op == "range"` branch in the comparison walk that expands that range into individual cases. Only the unsigned form denotes a range; the signed form is an ordinary upper bound already handled by type c. `original_nodes` is deduplicated, as one comparison node can now cover several cases.

The range is deliberately not clipped to the bounds carried down from earlier comparisons: the `gt` branch records its upper bound one too low, which would drop the last value of the group.

After:

```c
                switch (v6)
                {
                case 79:
                    ...
                case 2:
                    ...
                case 6: case 7:
                    v16 = sprintf(&g_533d98, " out of memory while inflating EAs\n");
                    ...
                default:
```

87 lines with 4 undefined labels becomes 223 lines with none, the enclosing loop is recovered, and all four switches in the function are structured. The recovered cases match unzip's source exactly: `IZ_EF_TRUNC` (79), `PK_ERR` (2), `PK_MEM3`/`PK_MEM4` (6, 7), and `PK_WARN | 0x4000` (16385) in the sibling switch.

### Testing

`test_reverting_switch_lowering_range_check_unzip` asserts that no emitted goto references an undefined label, that the group appears as ordinary cases, and that the outer switch survives. It fails on current master (87 lines, 4 undefined labels, no `case 6:`/`case 7:`).

Depends on angr/binaries#209, which adds the test binary.

Checked for regressions across `dir_gcc_-O0`, `sort_gcc17_O0`, `file_gcc17_O0`, `tiffinfo_gcc17_O0`, `ls_gcc_O0`, `du`, `fmt_O0`, `lighttpd`, `cvs` and `lighttpd_gcc17.0.0_O2`: the new matcher fires in 75 functions and the decompilation is unchanged in every one.
