### PR TITLE
RegisterSaveAreaSimplifier: Drop a link register that is only restored

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
@@ -236,11 +236,14 @@ class RegisterSaveAreaSimplifier(OptimizationPass):
             lr_reg_offset = None
 
         for reg in list(result.keys()):
-            # stored link register should always be removed
-            if lr_reg_offset is not None and reg == lr_reg_offset:
-                if "restored" not in result[reg]:
-                    # add a dummy one
-                    result[reg]["restored"] = []
+            info = result[reg]
+
+            # a link register may be stored without a matching restore: such a function returns by loading the
+            # saved value into pc, which never appears as a write to the link register. one that is only restored
+            # has no save area behind it, and falls through to (b) like any other half-matched register.
+            if lr_reg_offset is not None and reg == lr_reg_offset and "stored" in info and "restored" not in info:
+                # add a dummy one
+                info["restored"] = []
                 continue
 
             if ret_val_reg_offset is not None and reg == ret_val_reg_offset:
@@ -248,7 +251,6 @@ class RegisterSaveAreaSimplifier(OptimizationPass):
                 del result[reg]
                 continue
 
-            info = result[reg]
             if len(info.keys()) != 2:
                 # (a) or (b)
                 del result[reg]

--- a/tests/analyses/decompiler/test_register_save_area_simplifier_adv.py
+++ b/tests/analyses/decompiler/test_register_save_area_simplifier_adv.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-class-docstring,no-self-use,no-member
+# pylint: disable=missing-class-docstring,no-self-use,no-member,protected-access
 from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
 
 import os
 import unittest
+from unittest.mock import patch
 
+import angr
+from angr.analyses.decompiler.optimization_passes.register_save_area_simplifier import RegisterSaveAreaSimplifier
 from tests.common import bin_location, load_project_with_scoped_cfg, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -37,6 +40,62 @@ class TestRegisterSaveAreaSimplifierAdv(unittest.TestCase):
         print_decompilation_result(dec)
 
         assert f"{callee.name}(" in dec.codegen.text
+
+    @staticmethod
+    def _decompile_recording_save_areas(bin_path: str, func_addr: int):
+        """Decompile one function, returning the result and every save-area cache handed to the pass."""
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        func = proj.kb.functions[func_addr]
+
+        caches = []
+        original_analyze = RegisterSaveAreaSimplifier._analyze
+
+        def record_cache(self, cache=None):
+            if cache is not None:
+                caches.append(cache["info"])
+            return original_analyze(self, cache=cache)
+
+        with patch.object(RegisterSaveAreaSimplifier, "_analyze", record_cache):
+            dec = proj.analyses.Decompiler(func, cfg=cfg.model)
+        return dec, caches
+
+    @staticmethod
+    def _assert_save_areas_have_both_halves(caches) -> None:
+        # An entry that reaches _analyze describes a register saved into a save area and reloaded from it, so both
+        # halves must be present. Defaulting a missing half to an empty list would stop the crash while deleting
+        # the statements of the half that is there, and a register with no save behind it is an ordinary
+        # definition that the pass has no liveness argument for removing.
+        for info in caches:
+            for data in info.values():
+                assert set(data) == {"stored", "restored"}
+
+    def test_link_register_restored_without_being_saved(self):
+        # 0x404070 loads $ra back from the stack near its return site, but nothing saves $ra in the entry block, so
+        # the link register reaches the pass with a "restored" half and no "stored" half. The pass used to keep that
+        # entry and then die with KeyError: 'stored', which the decompiler swallowed into an error log entry and
+        # turned into empty output.
+        bin_path = os.path.join(test_location, "mipsel", "darpa_ping")
+        dec, caches = self._decompile_recording_save_areas(bin_path, 0x404070)
+
+        assert not dec.errors
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+        assert "setsockopt(" in dec.codegen.text
+        self._assert_save_areas_have_both_halves(caches)
+
+    def test_link_register_popped_without_being_pushed(self):
+        # 0x40f144 is a resolver trampoline that pushes {r0, r1, r2, r3, r4} and pops {r0, r1, r2, r3, r4, lr}: lr
+        # comes back off the stack having never been saved there. Dropping that half-matched entry must not stop
+        # the pass from simplifying r2 and r3, which are saved and restored in the ordinary way.
+        bin_path = os.path.join(test_location, "armhf", "ld-linux.so.3")
+        dec, caches = self._decompile_recording_save_areas(bin_path, 0x40F144)
+
+        assert not dec.errors
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+        self._assert_save_areas_have_both_halves(caches)
+        assert caches, "dropping the link register must not disable the pass entirely"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`0x404070` in `binaries/tests/mipsel/darpa_ping` decompiles to nothing.
`RegisterSaveAreaSimplifier` raises `KeyError: 'stored'`, `Decompiler` swallows it into
an error log entry, and `codegen` comes back `None`:

```text
errors: ["<AnalysisLogEntry 'exception occurred' with KeyError: 'stored'>",
         "<AnalysisLogEntry 'exception occurred' with KeyError: 'stored'>"]
codegen: None
```

Nothing downstream raises; the function is simply absent from the output.
`0x40f144` in `binaries/tests/armhf/ld-linux.so.3` is lost the same way.

### Root cause

The pass records, per register, the stores into the save area and the loads back out of
it, then culls every entry that does not have both halves. A *stored* link register is
exempt from that cull: such a function returns by loading the saved value straight into
`pc`, which never appears as a write to the link register. But the exemption tested the
register number alone:

```python
if lr_reg_offset is not None and reg == lr_reg_offset:
    if "restored" not in result[reg]:
        # add a dummy one
        result[reg]["restored"] = []
    continue
```

The `continue` runs for every link-register entry, so the mirror case skipped the culls
below it too: a link register restored from the stack that was never saved there, which
ARM resolver trampolines produce by popping an `lr` they never pushed. That entry reached
`_analyze` with only its `restored` half and indexed the missing one.

### Fix

Narrow the exemption to the case its comment describes — `"stored" in info and "restored"
not in info` — so a half-matched link register falls through to the ordinary cull like any
other register, and every entry that survives has both halves. Dropping it rather than
defaulting the missing half to `[]` is deliberate: the default would stop the crash while
deleting the statements of the half that *is* there, and a register with no save area
behind it is an ordinary definition the pass has no liveness argument for removing.

`0x404070` then decompiles to 878 characters with no errors. Complete before and after
output is in the comment below.

### Testing

`tests/analyses/decompiler/test_register_save_area_simplifier_adv.py` gains one test per
direction — `0x404070` in `darpa_ping` for the restore-only MIPS case, `0x40f144` in
`ld-linux.so.3` for the ARM trampoline. Both also assert on the save-area cache the pass
was handed, so a later "default the missing half to `[]`" repair fails them instead of
passing quietly. With `register_save_area_simplifier.py` reverted to this branch's merge
base `df4f8ba72` both fail with `KeyError: 'stored'`; at head the file's 3 tests pass.

Touches the same file as #6987, which moves one line in `_find_registers_stored_on_stack`,
so the two do not overlap textually.
Validation: https://github.com/angr/angr/pull/6991#issuecomment-5444608290

session: sharpen