### PR TITLE
Bound stack variable extents at a size the ssailification traversal can afford

### DIFF
--- a/angr/analyses/decompiler/ssailification/consts.py
+++ b/angr/analyses/decompiler/ssailification/consts.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-MAX_STACK_VAR_SIZE = 2 * 1024 * 1024
+# Every byte of a stack variable's extent costs an entry in the traversal state's
+# stackvar_bases and stackvar_defs maps, so this bound is a memory limit.
+MAX_STACK_VAR_SIZE = 64 * 1024
 
 
 __all__ = ("MAX_STACK_VAR_SIZE",)

--- a/tests/analyses/decompiler/test_decompiler.py
+++ b/tests/analyses/decompiler/test_decompiler.py
@@ -5495,6 +5495,24 @@ class TestDecompiler(unittest.TestCase):
         # ensure decompling this function should not take over 30 seconds - it was taking at least two minutes before
         # recent optimizations
 
+    def test_decompiling_armel_go_boundserror(self, decompiler_options=None):
+        # An ARM32 register-offset store (strb rX, [rB, rI]) lets the traversal pair a stack base with a
+        # .rodata address in the index register, producing an ~800 KB stack variable that swallowed the
+        # frame of runtime.boundsError.Error.
+        bin_path = os.path.join(test_location, "armel", "decompiler", "errorpaths_go")
+        proj, cfg = load_project_with_scoped_cfg(bin_path, 0x2744C)
+
+        start = time.time()
+        dec = proj.analyses[Decompiler].prep(fail_fast=True)(
+            cfg.functions[0x2744C], cfg=cfg.model, options=decompiler_options
+        )
+        elapsed = time.time() - start
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+
+        assert "|Stack bp-" not in dec.codegen.text, "an unresolved stack variable leaked into the output"
+        assert elapsed <= 120, f"Decompiling runtime.boundsError.Error took {elapsed} seconds"
+
     def test_fastfail_intrinsic(self, decompiler_options=None):
         bin_path = os.path.join(test_location, "x86_64", "windows", "fastfail.exe")
         proj = angr.Project(bin_path, auto_load_libs=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

On ARM32 a register-offset store (`strb rX, [rB, rI]`) makes the ssailification traversal pair a stack base with whatever the index register holds — in a Go binary, a `.rodata` address. The traversal models a stack variable one entry per byte, so the bogus eight-hundred-kilobyte extent swallowed the frame.

The output was wrong, not merely slow: malformed stack placeholders disappear from the emitted C and distinct slots stop being conflated into one blob. The codegen warning that output would be wrong clears too.

`MAX_STACK_VAR_SIZE` exists to reject implausible extents, but at 2 MiB it never fired. Lowering it to 64 KiB makes the guard do its job; a direct stack access carries no displacement and cannot trip it, so large locals are unaffected.

This complements the RangeSetMap rework in #6327 rather than competing: that replaces the per-byte representation, this bounds it. #6327 leaves `stackvar_bases`, which dominates here.

Depends on angr/binaries#208 for the fixture.
Validation: https://github.com/angr/angr/pull/6992#issuecomment-5444690356

sync: angr/binaries#208
session: sharpen
