### PR TITLE
RustCodeGen: keep the operands of an operator with no renderer

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/rust.py
+++ b/angr/analyses/decompiler/structured_codegen/rust.py
@@ -2088,11 +2088,18 @@ class RustUnaryOp(RustExpression):
         if handler is not None:
             yield from handler()
         else:
-            yield f"UnaryOp {self.op}", self
+            yield from self._c_repr_chunks_opfirst(self.op)
 
     #
     # Handlers
     #
+
+    def _c_repr_chunks_opfirst(self, op):
+        yield op, self
+        paren = RustClosingObject("(")
+        yield "(", paren
+        yield from RustExpression._try_c_repr_chunks(self.operand)
+        yield ")", paren
 
     def _c_repr_chunks_not(self):
         paren = RustClosingObject("(")
@@ -2265,7 +2272,7 @@ class RustBinaryOp(RustExpression):
         if handler is not None:
             yield from handler()
         else:
-            yield f"BinaryOp {self.op}", self
+            yield from self._c_repr_chunks_opfirst(self.op)
 
     def _has_const_null_rhs(self) -> bool:
         return isinstance(self.rhs, RustConstant) and self.rhs.value == 0
@@ -2273,6 +2280,15 @@ class RustBinaryOp(RustExpression):
     #
     # Handlers
     #
+
+    def _c_repr_chunks_opfirst(self, op):
+        yield op, self
+        paren = RustClosingObject("(")
+        yield "(", paren
+        yield from RustExpression._try_c_repr_chunks(self.lhs)
+        yield ", ", None
+        yield from RustExpression._try_c_repr_chunks(self.rhs)
+        yield ")", paren
 
     def _c_repr_chunks(self, op):
         skip_op_and_rhs = False

--- a/tests/analyses/decompiler/test_rust_codegen_handlers.py
+++ b/tests/analyses/decompiler/test_rust_codegen_handlers.py
@@ -72,6 +72,32 @@ class TestRustCodegenHandlers(unittest.TestCase):
         missing = set(c_dec.codegen._handlers) - set(self.codegen._handlers)
         assert not missing, f"Rust backend has no handler for {sorted(str(k) for k in missing)}"
 
+    def test_operators_without_a_renderer_keep_their_operands(self):
+        """The operator name is derived from the VEX op, so the renderer table cannot enumerate it."""
+        cases = [
+            # PowerPC renders essentially every conditional through CmpORD.
+            ("ppc", "brancher", 0x1000048C, "CmpORD("),
+            # ARM's division helper counts leading zeros.
+            ("armel", "test_division", 0x8678, "Clz("),
+        ]
+
+        for arch, name, function_addr, rendered in cases:
+            with self.subTest(binary=name):
+                proj = angr.Project(os.path.join(test_location, arch, name), auto_load_libs=False)
+                cfg = proj.analyses.CFGFast(normalize=True, data_references=True, show_progressbar=False)
+                proj.analyses.CompleteCallingConventions(recover_variables=True)
+                dec = proj.analyses.Decompiler(
+                    proj.kb.functions[function_addr], cfg=cfg.model, flavor="rust", fail_fast=True
+                )
+                assert dec.codegen is not None
+                text = dec.codegen.text
+                assert text is not None
+
+                self.assertIn(rendered, text)
+                # the operand used to be discarded, leaving the operator name as bare text
+                self.assertNotIn("UnaryOp ", text)
+                self.assertNotIn("BinaryOp ", text)
+
     def test_insert(self):
         m = self._manager()
         expr = Insert(


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

The Rust code generator prints an operator it has no renderer for as bare text and drops
the operands with it. PowerPC lowers essentially every comparison through `CmpORD`, which
the renderer table does not list, so `main` at `0x1000048c` in `binaries/tests/ppc/brancher`
comes out with three conditions, two of which are the same string and none of which says
what is being compared:

```rust
    if !(BinaryOp CmpORD & 4) {
    if !(BinaryOp CmpORD & 4) {
    if (BinaryOp CmpORD & 2) {
```

`Clz` does it on ARM. In `.divsi3_skip_div0_test` at `0x8678` in
`binaries/tests/armel/test_division` two different counts render as one expression:

```rust
    v11 = (!v9 ? 32 : UnaryOp Clz) - (!v10 ? 32 : UnaryOp Clz);
```

Measured at this branch's merge base `df4f8ba72` across every decompiled function of two
further PowerPC fixtures, `tests/ppc/fauxware` loses operands in 7 of 16 functions with 13
occurrences and `tests/ppc/test_loops` in 8 of 15 with 18; every occurrence in both is
`CmpORD`.

### Root cause

`RustUnaryOp.c_repr_chunks` and `RustBinaryOp.c_repr_chunks` look the operator up in
`_handlers` and, on a miss, yield the operator name as text and return:

```python
        if handler is not None:
            yield from handler()
        else:
            yield f"BinaryOp {self.op}", self
```

The operands are never walked, so they are not in the output at all. The table cannot be
completed by enumeration either — the operator name is derived from the VEX op.

### Fix

Both fallbacks now render `op(operands)`. That is what the C generator already does for
binary operators, in `CBinaryOp._c_repr_chunks_opfirst`, and what #6988 does for its
unary fallback, which is still bare text on master. The same three conditions read
`CmpORD(v1, 10)`, `CmpORD(v1, 19)` and `CmpORD(v1 & 1 & 0xff, 0)` at head, and the ARM
line becomes `Clz(v9) - Clz(v10)`. Complete before and after output is in the comment
below.

Nothing else changes: an operator that has a renderer still goes through it, so this
only affects expressions that were previously losing their operands.

### Testing

`test_operators_without_a_renderer_keep_their_operands` decompiles both functions above
under `flavor="rust"` and asserts the rendered operator is present and that no
`UnaryOp `/`BinaryOp ` text survives. With `rust.py` reverted to this branch's merge base
`df4f8ba72` it fails on both cases; at head `tests/analyses/decompiler/test_rust_codegen_handlers.py`
is 15 passed, 2 subtests passed.

Not addressed here: `rust.py` also diverges from `c.py` in `_handle_Stmt_Store`, where it
dereferences a type that can be `None`. Separate cause, no fixture, left for its own change.
Validation: https://github.com/angr/angr/pull/6996#issuecomment-5446343962

session: sharpen