### PR TITLE
CodeGen: size a store from the store, not from its value's type

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -121,6 +121,12 @@ def qualifies_for_simple_cast(ty1, ty2):
     )
 
 
+def qualifies_for_width_cast(ty):
+    # converting ty to a different width - can a scalar cast do it?
+    # floats are excluded because a float cast converts the value, not the representation
+    return isinstance(ty, (SimTypeInt, SimTypeChar, SimTypeNum, SimTypePointer, SimTypeBottom))
+
+
 def qualifies_for_implicit_cast(ty1, ty2):
     # converting ty1 to ty2 - can this happen without a cast?
     # used to decide whether to omit typecasts from output during promotion
@@ -3823,8 +3829,23 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
     def _handle_Stmt_Store(self, stmt: Stmt.Store, **kwargs):
         cdata = self._handle(stmt.data)
 
-        if cdata.type is not None and cdata.type.size != stmt.size * self.project.arch.byte_width:
-            l.error("Store data lifted to a C type with a different size. Decompilation output will be wrong.")
+        store_bits = stmt.size * self.project.arch.byte_width
+        if cdata.type is not None and cdata.type.size != store_bits:
+            if cdata.type.size is not None:
+                l.error(
+                    "Store data lifted to a C type of a different size: %s is %d bits, the store is %d bits. "
+                    "Using the store width.",
+                    cdata.type,
+                    cdata.type.size,
+                    store_bits,
+                )
+            if qualifies_for_width_cast(unpack_typeref(cdata.type)):
+                cdata = CTypeCast(
+                    cdata.type,
+                    self.default_simtype_from_bits(store_bits, signed=getattr(cdata.type, "signed", False)),
+                    cdata,
+                    codegen=self,
+                )
 
         def negotiate(old_ty, proposed_ty):
             # transfer casts from the dst to the src if possible

--- a/tests/analyses/decompiler/test_structured_codegen.py
+++ b/tests/analyses/decompiler/test_structured_codegen.py
@@ -9,9 +9,15 @@ import unittest
 from types import SimpleNamespace
 
 import angr
-from angr.ailment import Expr
-from angr.analyses.decompiler.structured_codegen.c import CExpression, CGoto, CUnaryOp
-from angr.sim_type import SimTypeInt, SimTypePointer
+from angr.ailment import Expr, Stmt
+from angr.analyses.decompiler.structured_codegen.c import (
+    CAssignment,
+    CExpression,
+    CGoto,
+    CStructuredCodeGenerator,
+    CUnaryOp,
+)
+from angr.sim_type import SimTypeBottom, SimTypeInt, SimTypeLongLong, SimTypePointer
 from tests.common import bin_location
 
 test_location = os.path.join(bin_location, "tests")
@@ -97,6 +103,39 @@ class TestGotoRendering(unittest.TestCase):
         chunks = CGoto(0x400000, None, codegen=self.codegen).c_repr_chunks()
 
         self.assertEqual("".join(text for text, _ in chunks), "goto LABEL_0x400000;\n")
+
+
+class TestStoreWidth(unittest.TestCase):
+    """A store's emitted C must write as many bytes as the AIL store writes."""
+
+    @classmethod
+    def setUpClass(cls):
+        proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        codegen = proj.analyses.Decompiler(cfg.functions["main"], cfg=cfg).codegen
+        assert isinstance(codegen, CStructuredCodeGenerator)
+        cls.codegen = codegen
+
+    def _dst_bits(self, idx: int, value_type, value_bits: int, size: int) -> int:
+        # the destination is what _access renders as *(T*)addr, so its type is the width written
+        data = Expr.Const(idx, 0, value_bits, type=value_type)
+        stmt = Stmt.Store(idx, Expr.Const(idx, 0x400000, 64), data, size, "Iend_LE")
+        assignment = self.codegen._handle(stmt, is_expr=False)
+        assert isinstance(assignment, CAssignment)
+        assert assignment.lhs.type is not None
+        return assignment.lhs.type.size
+
+    def test_value_typed_narrower_than_the_store(self):
+        assert self._dst_bits(1, SimTypeInt(signed=False), 64, 8) == 64
+
+    def test_value_typed_wider_than_the_store(self):
+        assert self._dst_bits(2, SimTypeLongLong(signed=False), 8, 1) == 8
+
+    def test_value_with_no_inferred_type(self):
+        assert self._dst_bits(3, SimTypeBottom(), 128, 16) == 128
+
+    def test_value_typed_correctly_is_left_alone(self):
+        assert self._dst_bits(4, SimTypeLongLong(signed=False), 64, 8) == 64
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The C backend sized a store from the type recovered for the stored value rather than from the store itself. The destination is built as `*(T*)addr` from that same type, so a value typed narrower or wider than the store emitted C that writes the wrong number of bytes. On x86 a zeroed eight-byte global became `*((unsigned long *)&g) = 0;`, clearing half of it and contradicting the `extern g: u64` in its own output.

The store now casts its value to its own width, as `_handle_Expr_Call` and `_handle_Stmt_SideEffectStatement` already do against the same comparison. Floats are excluded because a float cast converts the value rather than the representation, and aggregates cannot be cast at all, so both keep the previous behaviour.

The diagnostic still fires wherever a type was recovered and disagrees, now naming both widths, since that disagreement is worth fixing in whichever layer produced the type.

Validation: https://github.com/angr/angr/pull/6999#issuecomment-5446918761
session: crazybins