### PR TITLE
Emit every leftover node when structuring does not complete

### DIFF
--- a/angr/analyses/decompiler/structuring/recursive_structurer.py
+++ b/angr/analyses/decompiler/structuring/recursive_structurer.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 from typing import TYPE_CHECKING
 
+from angr import ailment
 from angr.analyses.analysis import Analysis, register_analysis
 from angr.analyses.decompiler.condition_processor import ConditionProcessor
 from angr.analyses.decompiler.empty_node_remover import EmptyNodeRemover
@@ -11,7 +12,17 @@ from angr.analyses.decompiler.jump_target_collector import JumpTargetCollector
 from angr.analyses.decompiler.jumptable_entry_condition_rewriter import JumpTableEntryConditionRewriter
 from angr.analyses.decompiler.redundant_label_remover import RedundantLabelRemover
 from angr.analyses.decompiler.region_overlay import RegionOverlay
-from angr.analyses.decompiler.structurer_nodes import BaseNode
+from angr.analyses.decompiler.structurer_nodes import (
+    BaseNode,
+    BreakNode,
+    CascadingConditionNode,
+    CodeNode,
+    ConditionNode,
+    ContinueNode,
+    IncompleteSwitchCaseHeadStatement,
+    MultiNode,
+    SequenceNode,
+)
 from angr.utils.graph import GraphUtils
 
 from .dream import DreamStructurer
@@ -47,7 +58,7 @@ class RecursiveStructurer(Analysis):
         self.ail_manager = ail_manager
         self.cond_proc = cond_proc if cond_proc is not None else ConditionProcessor(self.project.arch, self.ail_manager)
 
-        self.result: BaseNode | None = None
+        self.result: BaseNode | ailment.Block | MultiNode | None = None
         self.result_incomplete: bool = False
 
         self._analyze()
@@ -182,22 +193,108 @@ class RecursiveStructurer(Analysis):
 
         return entries
 
+    @staticmethod
+    def _exits_explicitly(node) -> bool:
+        """
+        Return True when control cannot fall out of the bottom of ``node``, i.e. every path through it ends in a
+        jump or a return. Anything this does not understand counts as falling through.
+        """
+        if isinstance(node, ailment.Block):
+            if not node.statements:
+                return False
+            last_stmt = node.statements[-1]
+            if isinstance(last_stmt, (ailment.Stmt.Jump, ailment.Stmt.ConditionalJump, ailment.Stmt.Return)):
+                return True
+            if isinstance(last_stmt, IncompleteSwitchCaseHeadStatement):
+                # the code generator renders this as an if-goto cascade, which only covers every path when the
+                # statement carries a default case
+                return any(case_value == "default" for _, case_value, _, _, _ in last_stmt.case_addrs)
+            return False
+        if isinstance(node, (SequenceNode, MultiNode)):
+            return bool(node.nodes) and RecursiveStructurer._exits_explicitly(node.nodes[-1])
+        if isinstance(node, CodeNode):
+            return RecursiveStructurer._exits_explicitly(node.node)
+        if isinstance(node, ConditionNode):
+            return (
+                node.true_node is not None
+                and node.false_node is not None
+                and RecursiveStructurer._exits_explicitly(node.true_node)
+                and RecursiveStructurer._exits_explicitly(node.false_node)
+            )
+        if isinstance(node, CascadingConditionNode):
+            return node.else_node is not None and all(
+                RecursiveStructurer._exits_explicitly(child)
+                for child in [n for _, n in node.condition_and_nodes] + [node.else_node]
+            )
+        return isinstance(node, (BreakNode, ContinueNode))
+
     def _pick_incomplete_result_from_region(self, region):
         """
-        Parse the region graph and get (a) the node with address equal to the function address, or (b) the node with
-        the lowest address.
+        Structuring did not complete for this region, so no single node covers it. Emit every leftover node instead
+        of one of them.
+
+        Keeping one node silently truncates the function: the transfers into the discarded nodes survive as jump
+        statements that name addresses no emitted block carries, GotoSimplifier then drops those jumps because
+        their targets are missing, and the remaining code falls through edges the binary does not have. Emitting
+        the whole leftover graph keeps every one of those transfers addressable.
+
+        Edges between leftover nodes are already explicit jump statements -- the structurer only strips a
+        terminator when it absorbs the edge into a matched schema -- so the order the nodes are emitted in is a
+        layout choice and not a semantic one. Where a node can still fall out of its bottom, an explicit jump to
+        its sole successor is appended so that the order stays inert there too.
         """
+        nodes = [node for node in region.graph.nodes if not isinstance(node, RegionOverlay)]
+        if not nodes:
+            return None
 
-        min_node = None
-        for node in region.graph.nodes:
-            if not isinstance(node, BaseNode):
-                continue
-            if self.function is not None and node.addr == self.function.addr:
-                return node
-            if min_node is None or (min_node.addr is not None and node.addr is not None and min_node.addr < node.addr):
-                min_node = node
+        entry_addr = self.function.addr if self.function is not None else region.head.addr
+        nodes.sort(key=lambda node: self._incomplete_result_sort_key(node, entry_addr))
+        if len(nodes) == 1:
+            return nodes[0]
 
-        return min_node
+        emitted = []
+        for idx, node in enumerate(nodes):
+            successors = list(region.graph.successors(node))
+            following = nodes[idx + 1] if idx + 1 < len(nodes) else None
+            if (
+                len(successors) == 1
+                and successors[0] is not following
+                and successors[0].addr is not None
+                and not self._exits_explicitly(node)
+            ):
+                goto_block = ailment.Block(
+                    node.addr,
+                    0,
+                    statements=[
+                        ailment.Stmt.Jump(
+                            self.ail_manager.next_atom(),
+                            ailment.Expr.Const(
+                                self.ail_manager.next_atom(), successors[0].addr, self.project.arch.bits
+                            ),
+                            ins_addr=node.addr,
+                            stmt_idx=0,
+                        )
+                    ],
+                )
+                node = SequenceNode(node.addr, nodes=[node, goto_block])
+            emitted.append(node)
+
+        return SequenceNode(emitted[0].addr, nodes=emitted)
+
+    @staticmethod
+    def _incomplete_result_sort_key(node, entry_addr: int | None):
+        """
+        Order the leftover nodes: the function entry first, then by address. Graph iteration order is not stable
+        across processes, so every component of this key must be derived from the node itself.
+        """
+        addr = node.addr
+        return (
+            0 if (entry_addr is not None and addr == entry_addr) else 1,
+            addr is None,
+            addr if addr is not None else 0,
+            type(node).__name__,
+            getattr(node, "idx", None) or 0,
+        )
 
 
 register_analysis(RecursiveStructurer, "RecursiveStructurer")

--- a/tests/analyses/decompiler/test_incomplete_structuring_salvage.py
+++ b/tests/analyses/decompiler/test_incomplete_structuring_salvage.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,no-member,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import unittest
+from typing import TYPE_CHECKING, cast
+
+import networkx
+
+from angr.ailment import Manager
+from angr.ailment.block import Block
+from angr.ailment.expression import Const
+from angr.ailment.statement import Jump, Label
+from angr.analyses.decompiler.structurer_nodes import MultiNode, SequenceNode
+from angr.analyses.decompiler.structuring.recursive_structurer import RecursiveStructurer
+
+if TYPE_CHECKING:
+    from angr.knowledge_plugins.functions import Function
+    from angr.project import Project
+
+
+class _Region:
+    """Stands in for a region overlay: the salvage step only reads .graph and .head."""
+
+    def __init__(self, graph, head):
+        self.graph = graph
+        self.head = head
+
+
+class _Arch:
+    bits = 64
+
+
+class _Project:
+    arch = _Arch()
+
+
+class _Function:
+    def __init__(self, addr):
+        self.addr = addr
+
+
+class TestIncompleteStructuringSalvage(unittest.TestCase):
+    """
+    When structuring fails to reduce the top-level region to one node, the leftover graph is all that is left of
+    the function. Keeping a single node out of it drops the rest of the code, and the jumps into the dropped
+    nodes are removed later because their targets are no longer present, so the emitted code falls through edges
+    the binary does not have.
+    """
+
+    @staticmethod
+    def _structurer(func_addr: int | None):
+        rs = object.__new__(RecursiveStructurer)
+        rs.ail_manager = Manager(arch=None)
+        rs.function = None if func_addr is None else cast("Function", _Function(func_addr))
+        rs.project = cast("Project", _Project())
+        return rs
+
+    @staticmethod
+    def _jump_block(m, addr, target):
+        return Block(
+            addr,
+            1,
+            statements=[
+                Label(m.next_atom(), f"LABEL_{addr:x}", ins_addr=addr),
+                Jump(m.next_atom(), Const(m.next_atom(), target, 64), ins_addr=addr),
+            ],
+        )
+
+    @staticmethod
+    def _fallthrough_block(m, addr):
+        return Block(
+            addr,
+            1,
+            # a block whose only statement is its label: nothing in it transfers control, so whatever is
+            # emitted after it is what runs next
+            statements=[Label(m.next_atom(), f"LABEL_{addr:x}", ins_addr=addr)],
+        )
+
+    def test_every_leftover_node_is_emitted_in_address_order(self):
+        rs = self._structurer(0x100)
+        m = rs.ail_manager
+        b100 = self._jump_block(m, 0x100, 0x300)
+        b200 = self._jump_block(m, 0x200, 0x100)
+        b300 = self._jump_block(m, 0x300, 0x200)
+        graph = networkx.DiGraph()
+        graph.add_edges_from([(b100, b300), (b300, b200), (b200, b100)])
+
+        result = rs._pick_incomplete_result_from_region(_Region(graph, b100))
+
+        assert isinstance(result, SequenceNode)
+        assert [node.addr for node in result.nodes] == [0x100, 0x200, 0x300]
+        assert result.addr == 0x100
+
+    def test_a_node_that_falls_through_gets_an_explicit_jump_to_its_successor(self):
+        rs = self._structurer(0x100)
+        m = rs.ail_manager
+        b100 = self._jump_block(m, 0x100, 0x300)
+        b200 = self._fallthrough_block(m, 0x200)
+        b300 = self._jump_block(m, 0x300, 0x200)
+        graph = networkx.DiGraph()
+        graph.add_edges_from([(b100, b300), (b300, b200), (b200, b100)])
+
+        result = rs._pick_incomplete_result_from_region(_Region(graph, b100))
+        assert isinstance(result, SequenceNode)
+
+        # 0x200 falls out of its bottom and its only successor 0x100 is not the node emitted after it, so the
+        # transfer is materialised rather than left to the layout
+        wrapped = result.nodes[1]
+        assert isinstance(wrapped, SequenceNode)
+        assert wrapped.nodes[0] is b200
+        goto = wrapped.nodes[1]
+        assert isinstance(goto, Block)
+        assert len(goto.statements) == 1
+        assert isinstance(goto.statements[0], Jump)
+        assert goto.statements[0].target.value == 0x100
+
+        # ...while 0x300, whose successor 0x200 is emitted next, keeps its own jump and gains nothing
+        assert result.nodes[2] is b300
+
+    def test_the_function_entry_is_emitted_first_even_when_it_is_not_the_lowest_address(self):
+        rs = self._structurer(0x300)
+        m = rs.ail_manager
+        b100 = self._jump_block(m, 0x100, 0x300)
+        b200 = self._jump_block(m, 0x200, 0x100)
+        b300 = self._jump_block(m, 0x300, 0x200)
+        graph = networkx.DiGraph()
+        graph.add_edges_from([(b300, b200), (b200, b100), (b100, b300)])
+
+        result = rs._pick_incomplete_result_from_region(_Region(graph, b300))
+
+        assert isinstance(result, SequenceNode)
+        assert [node.addr for node in result.nodes] == [0x300, 0x100, 0x200]
+        assert result.addr == 0x300
+
+    def test_nodes_that_are_not_structurer_nodes_are_kept(self):
+        # raw AIL blocks and MultiNodes are the common leaf types of a leftover region graph, and neither is a
+        # BaseNode; dropping them loses most of the graph
+        rs = self._structurer(0x100)
+        m = rs.ail_manager
+        b100 = self._jump_block(m, 0x100, 0x200)
+        inner_a = self._jump_block(m, 0x200, 0x210)
+        inner_b = self._jump_block(m, 0x210, 0x300)
+        multi = MultiNode([inner_a, inner_b])
+        b300 = self._jump_block(m, 0x300, 0x100)
+        graph = networkx.DiGraph()
+        graph.add_edges_from([(b100, multi), (multi, b300), (b300, b100)])
+
+        result = rs._pick_incomplete_result_from_region(_Region(graph, b100))
+
+        assert isinstance(result, SequenceNode)
+        assert [node.addr for node in result.nodes] == [0x100, 0x200, 0x300]
+        assert result.nodes[1] is multi
+
+    def test_a_single_leftover_node_is_returned_unwrapped(self):
+        rs = self._structurer(0x100)
+        m = rs.ail_manager
+        b100 = self._jump_block(m, 0x100, 0x100)
+        graph = networkx.DiGraph()
+        graph.add_node(b100)
+
+        assert rs._pick_incomplete_result_from_region(_Region(graph, b100)) is b100
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/decompiler/test_incomplete_structuring_salvage.py
+++ b/tests/analyses/decompiler/test_incomplete_structuring_salvage.py
@@ -53,7 +53,7 @@ class TestIncompleteStructuringSalvage(unittest.TestCase):
     @staticmethod
     def _structurer(func_addr: int | None):
         rs = object.__new__(RecursiveStructurer)
-        rs.ail_manager = Manager(arch=None)
+        rs.ail_manager = Manager()
         rs.function = None if func_addr is None else cast("Function", _Function(func_addr))
         rs.project = cast("Project", _Project())
         return rs


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

When structuring cannot reduce the top-level region to one node, the salvage path does not merely emit less — it emits something that misrepresents control flow. Decompiling `sub_415e50` at `0x415e50` in `angr/binaries` `tests/i386/ld-linux.so.2` under `structurer_cls=phoenix` gives 1654 characters covering 44 of the function's 307 instructions, ending mid-branch with no `return`:

```c
    if (sub_417760(3, ".", v16) < 0)
    {
LABEL_416223:
        v1 = 0xffffff9c;
        v34 = 0;
    }
    v7 = v16;
```

That arm is the error path. It falls straight into `v7 = v16;`, the success path, along an edge the binary does not have, and nothing in the output marks it.

### Root cause

`RecursiveStructurer._pick_incomplete_result_from_region` returns a single node of the leftover region graph and discards the rest. The transfers into the discarded nodes survive as real `Jump` statements, and `GotoSimplifier._handle_block` then deletes each one because its target is not in `self._node_addrs` — "the target block has been removed and is no longer exist. we assume this goto is useless". The surviving code is left falling out of the bottom of a block into whatever was emitted next.

That is measured, not inferred. Counting the deletions taken through that branch while decompiling the function above: three on the baseline and none on this head.

```
block 0x416223 -> 0x41622d
block 0x416252 -> 0x416258
block 0x415fa6 -> 0x415fc1
```

The first is the one visible in the output above.

Two smaller defects in the same function: it is documented as returning "the node with the lowest address" but compares `min_node.addr < node.addr`, so it returns the highest-addressed one when no node matches the function address; and its `isinstance(node, BaseNode)` filter skips raw AIL blocks and `MultiNode`s, returning `None` when the graph holds neither.

### Fix

Emit every leftover node, the function entry first and then by address. Edges between them are already explicit jump statements — a terminator is only stripped when a schema absorbs the edge — so the order is layout rather than meaning; where a node can still fall out of its bottom, an explicit jump to its sole successor keeps it that way. On the function above the same arm now ends `goto LABEL_41622d;`, and coverage goes to 164 of 307 instructions.

This does not compete with fixing the leftover cases themselves. It only changes what happens on the path that runs after structuring has already failed, so it shrinks as those cases are fixed and is dead code once none are left.

### Testing

`tests/analyses/decompiler/test_incomplete_structuring_salvage.py` — all five cases fail on the baseline and pass on the head.

The changed method is only reached on the incomplete path, so no already-complete function enters it. That is a statement about the code path, not about the emitted text of a whole-binary run: over 6890 fixture functions compared in both arms, 71 differ and 35 of those take the changed path. Of the 36 that do not, 30 are this pipeline's own run-to-run variation, 5 are an address-ordering side channel that exists on unpatched master and is filed separately as #7003, and 1 is a prototype difference on a parameter the body never references. None is a regression.

Validation: https://github.com/angr/angr/pull/7000#issuecomment-5452866215

session: sharpen