### PR TITLE
CFGFast: cover CFG recovery on a p-code ARM architecture

### DIFF
--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -1101,6 +1101,28 @@ class TestCfgfast(unittest.TestCase):
             "MIPS64",
         )
 
+    def test_cfgfast_on_a_pcode_arm_blob(self):
+        # is_arm_arch() used to accept every ArchPcode ARM language, so CFGFast entered its ARM/Thumb
+        # handling with an architecture that carries none of the data that handling reads, and died
+        # before it decoded anything. See https://github.com/angr/angr/issues/4779.
+        path = os.path.join(test_location, "armel", "i2c_master_read-nucleol152re.bin")
+        proj = angr.Project(
+            path,
+            main_opts={
+                "backend": "blob",
+                "arch": archinfo.ArchPcode("ARM:LE:32:Cortex"),
+                "base_addr": 0x08000000,
+                "entry_point": 0x080016C8,
+            },
+            auto_load_libs=False,
+        )
+        cfg = proj.analyses.CFGFast(function_starts=[0x080016C8], normalize=True)
+
+        # p-code decodes Thumb without the low-bit convention, so these are the even addresses of
+        # functions that the ELF build of the same image names
+        for addr in (0x8005274, 0x8005E04, 0x80081DC):
+            assert addr in cfg.kb.functions, f"no function recovered at {addr:#x}"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

**Closed unmerged.** This pull request holds only a regression test, and the archinfo change it covered — angr/archinfo#376 — was rejected and closed on 2026-08-29: `is_arm_arch()` is meant to answer `True` for p-code ARM languages as well as VEX ones. The test asserts the addresses that change produced and would fail against the repair that respects that intent, so it cannot be re-pointed at the replacement. What supersedes it, and what the replacement regression has to assert, are in the closing comment: https://github.com/angr/angr/pull/7001#issuecomment-5464417705 . The crash itself is real and stays open at #4779.

### Problem

CFGFast cannot recover a CFG for a p-code ARM blob. Loading `binaries/tests/armel/i2c_master_read-nucleol152re.bin` as a blob under `archinfo.ArchPcode("ARM:LE:32:Cortex")` at base `0x08000000` and running `CFGFast(function_starts=[0x080016c8])` dies before an instruction is decoded:

```
  File "angr/analyses/cfg/cfg_fast.py", line 5585, in _generate_cfgnode
    switch_mode_on_nodecode = self._arch_options.switch_mode_on_nodecode
  File "angr/analyses/cfg/cfg_arch_options.py", line 76, in __getattr__
    return self.__getattribute__(option_name)
AttributeError: 'CFGArchOptions' object has no attribute 'switch_mode_on_nodecode'
```

It fires on the first block of the first job, so nothing is recovered at all, for any of the ARM SLEIGH languages. This part still reproduces, on angr `a9ca247a5` with archinfo `b8ffe85`.

### Root cause

`_generate_cfgnode` enters angr's ARM/Thumb handling behind one predicate:

```python
switch_mode_on_nodecode = False
if is_arm_arch(self.project.arch):
    switch_mode_on_nodecode = self._arch_options.switch_mode_on_nodecode
```

and `archinfo.arch_arm.is_arm_arch` is a test on the architecture's name:

```python
def is_arm_arch(a):
    return a.name.startswith("ARM")
```

`ArchPcode("ARM:LE:32:Cortex").name` is `"ARM:LE:32:Cortex"`, so it answers True. `CFGArchOptions.OPTIONS` is keyed by `arch.name` as well, but only for `"ARMEL"`, `"ARMHF"` and `"ARMCortexM"`, so `_options` is empty for a SLEIGH language and the read falls through `__getattr__` to `AttributeError`.

~~The same predicate guards the Thumb prologue scan, the itstate register and the low-bit address convention, none of which a p-code ARM language carries: it selects its instruction set through the SLEIGH language instead.~~ That was wrong. `ARM:LE:32:Cortex` declares the SLEIGH context variable `TMode` and decodes differently under it, so the language does carry the ARM/Thumb model. What is missing is the data on the `ArchPcode` object and in angr's option table, plus a lifter that sets `TMode`.

### Fix

~~The predicate belongs to archinfo, and the repair is angr/archinfo#376, which makes it `isinstance(a, ArchARM)`. This pull request changes no angr code; it is the regression covering that repair from angr's side. With archinfo#376 applied, `is_arm_arch(ArchPcode("ARM:LE:32:Cortex"))` is False, CFGFast stays out of the ARM-specific path, and the same run recovers 624 functions.~~ Superseded. The predicate stays a name test, and the repair gives `ArchPcode` ARM languages the ARM model its callers read — `thumb_prologs`, `function_prologs`, `cs_arch`/`cs_mode` in archinfo, `CFGArchOptions.OPTIONS` answering for a SLEIGH id in angr, and the p-code lifter setting `TMode` from the low bit of the address.

### Testing

`test_cfgfast_on_a_pcode_arm_blob` in `tests/analyses/cfg/test_cfgfast.py` loads that blob with entry point `0x080016c8` and asserts that `0x8005274`, `0x8005e04` and `0x80081dc` are recovered — the even addresses of three functions that the ELF build of the same image names, p-code decoding Thumb without the low-bit convention. ~~With archinfo at master the test fails with the `AttributeError` above; with archinfo#376 it passes. The jobs that install archinfo from its default branch stay red until the archinfo change merges.~~ Those three are `memcpy`, `strlen` and `_vfprintf_r`, which `i2c_master_read-nucleol152re.elf` names at `0x8005275`, `0x8005e05` and `0x80081dd`; all 364 of its function symbols are odd, because it is a Thumb-only Cortex-M image. Once the low bit is the Thumb marker on the p-code path, the recovered addresses are odd and every assertion here fails.

~~Fixes~~ Reported at https://github.com/angr/angr/issues/4779, which stays open. Validation: https://github.com/angr/angr/pull/7001#issuecomment-5448967900

session: sharpen