### PR TITLE
Do not put a missing PowerPC64 TOC in r2

### DIFF
--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -395,8 +395,13 @@ class SimLinux(SimUserland):
                     # a pointer to the dynamic linker's destructor routine, to be called at exit
                     state.registers.store(reg, self._loader_destructor)
                 elif val == "toc":
-                    if self.project.loader.main_object.is_ppc64_abiv1:
-                        state.registers.store(reg, self.project.loader.main_object.ppc64_initial_rtoc)
+                    main_object = self.project.loader.main_object
+                    if (
+                        isinstance(main_object, MetaELF)
+                        and main_object.is_ppc64_abiv1
+                        and main_object.ppc64_initial_rtoc is not None
+                    ):
+                        state.registers.store(reg, main_object.ppc64_initial_rtoc)
                 elif val == "entry":
                     state.registers.store(reg, state.registers.load("pc"))
                 elif val == "thread_pointer" and self.project.loader.tls.threads:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ default-groups = ["dev", "extras"]
 angr-data = { git = "https://github.com/angr/angr-data.git", branch = "master" }
 archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
 pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
-cle = { git = "https://github.com/angr/cle.git", branch = "master" }
+cle = { git = "https://github.com/angr/cle.git", branch = "feature/ppc64-notype-extern-descriptor" }
 claripy = { git = "https://github.com/angr/claripy.git", branch = "master" }
 pysoot = { git = "https://github.com/angr/pysoot.git", branch = "master" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ default-groups = ["dev", "extras"]
 angr-data = { git = "https://github.com/angr/angr-data.git", branch = "master" }
 archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
 pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
-cle = { git = "https://github.com/angr/cle.git", branch = "feature/ppc64-notype-extern-descriptor" }
+cle = { git = "https://github.com/angr/cle.git", branch = "master" }
 claripy = { git = "https://github.com/angr/claripy.git", branch = "master" }
 pysoot = { git = "https://github.com/angr/pysoot.git", branch = "master" }
 

--- a/tests/simos/test_linux.py
+++ b/tests/simos/test_linux.py
@@ -6,8 +6,11 @@ __package__ = __package__ or "tests.simos"  # pylint:disable=redefined-builtin
 
 import os
 import unittest
+from typing import cast
 
 import archinfo
+import claripy
+from cle import MetaELF
 
 import angr
 from angr.errors import SimMemoryError
@@ -54,6 +57,36 @@ class TestSimLinuxStateBlank(unittest.TestCase):
         # pre-allocated stack pages are not backed by the loader, so clamping the pre-grow to the room that does
         # exist would hide the image behind blank pages
         assert state.solver.eval(state.memory.load(0x1000, 4, endness=archinfo.Endness.BE)) == 0x7F454C46
+
+
+class TestSimLinuxPpc64Toc(unittest.TestCase):
+    """
+    Tests for the initial TOC value SimLinux.state_entry() puts in r2 on PowerPC64 ELFv1.
+    """
+
+    # a relocatable object declares no entry point, so it has no ELFv1 function descriptor to take
+    # an initial TOC out of, and cle reports none for it
+    without_toc = os.path.join(test_location, "ppc64", "simple_object.o")
+    with_toc = os.path.join(test_location, "ppc64", "fauxware")
+
+    def test_entry_state_of_an_object_that_has_no_toc(self):
+        project = angr.Project(self.without_toc, auto_load_libs=False)
+        main_object = project.loader.main_object
+        assert isinstance(main_object, MetaELF)
+        assert main_object.is_ppc64_abiv1
+        assert main_object.ppc64_initial_rtoc is None
+
+        state = project.factory.entry_state()
+        assert state.solver.eval(cast(claripy.ast.BV, state.regs.r2)) == 0
+
+    def test_entry_state_of_an_object_that_has_one(self):
+        project = angr.Project(self.with_toc, auto_load_libs=False)
+        main_object = project.loader.main_object
+        assert isinstance(main_object, MetaELF)
+        assert main_object.ppc64_initial_rtoc == 0x10018E80
+
+        state = project.factory.entry_state()
+        assert state.solver.eval(cast(claripy.ast.BV, state.regs.r2)) == 0x10018E80
 
 
 if __name__ == "__main__":

--- a/tests/simos/test_linux.py
+++ b/tests/simos/test_linux.py
@@ -64,8 +64,6 @@ class TestSimLinuxPpc64Toc(unittest.TestCase):
     Tests for the initial TOC value SimLinux.state_entry() puts in r2 on PowerPC64 ELFv1.
     """
 
-    # a relocatable object declares no entry point, so it has no ELFv1 function descriptor to take
-    # an initial TOC out of, and cle reports none for it
     without_toc = os.path.join(test_location, "ppc64", "simple_object.o")
     with_toc = os.path.join(test_location, "ppc64", "fauxware")
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A PowerPC64 ELFv1 object for which the loader can work out no initial TOC has no entry state at all. `angr.Project("binaries/tests/ppc64/simple_object.o").factory.entry_state()`:

```
  File "angr/simos/linux.py", line 400, in set_entry_register_values
    state.registers.store(reg, self.project.loader.main_object.ppc64_initial_rtoc)
  File "angr/storage/memory_mixins/bvv_conversion_mixin.py", line 71, in _convert_to_ast
    raise TypeError("Bad value passed to memory", thing) from None
TypeError: ('Bad value passed to memory', None)
```

`entry_state()` is the entry point to everything else, so simulation, `SimulationManager`, and every analysis that needs a state are unreachable for such an object.

### Root cause

`MetaELF.ppc64_initial_rtoc` answers `None` when the loader cannot work out an initial TOC: a relocatable object declares no entry point, so there is no ELFv1 function descriptor to read a TOC out of. `set_entry_register_values` stored the answer regardless:

```python
elif val == "toc":
    if self.project.loader.main_object.is_ppc64_abiv1:
        state.registers.store(reg, self.project.loader.main_object.ppc64_initial_rtoc)
```

`registers.store` has no `None` case; `_convert_to_ast` raises. The branch also read `is_ppc64_abiv1` off whatever the main object happened to be, which is only a `MetaELF` attribute.

It became reachable once cle stopped inventing a TOC for an ELFv1 object with no entry point, which is every relocatable one; until then such an object either failed to load outright or carried a TOC read out of whatever its image began with.

### Fix

Leave the register alone when the loader supplies no value, as the rest of the entry-register table already does for what it cannot answer:

```python
main_object = self.project.loader.main_object
if (
    isinstance(main_object, MetaELF)
    and main_object.is_ppc64_abiv1
    and main_object.ppc64_initial_rtoc is not None
):
    state.registers.store(reg, main_object.ppc64_initial_rtoc)
```

On the same object the entry state now builds and r2 holds the register file's default, `<BV64 reg_gpr2_0_64>`, rather than a value invented for it; `binaries/tests/ppc64/fauxware`, which has a descriptor, still gets `<BV64 0x10018e80>`. `pyproject.toml` pins cle to the branch of angr/cle#766 until that merges.

### Testing

`TestSimLinuxPpc64Toc` in `tests/simos/test_linux.py` adds two tests. `test_entry_state_of_an_object_that_has_no_toc` loads `tests/ppc64/simple_object.o`, asserts `ppc64_initial_rtoc is None`, and builds an entry state — on master that raises the `TypeError` above. `test_entry_state_of_an_object_that_has_one` loads `tests/ppc64/fauxware` and pins r2 to `0x10018e80`, so the case that must not change is covered. `simple_object.o` comes from angr/binaries#185, and angr/cle#766 is what makes the `None` reachable.

Validation: https://github.com/angr/angr/pull/7002#issuecomment-5449729841

sync: angr/cle#766
sync: angr/binaries#185

session: sharpen