### PR TITLE
SimComboRegisterVariable: implement the key it inherits as abstract

### DIFF
--- a/angr/sim_variable.py
+++ b/angr/sim_variable.py
@@ -350,6 +350,10 @@ class SimComboRegisterVariable(SimVariable):
 
         return False
 
+    @property
+    def key(self) -> tuple[str | int | None, ...]:
+        return ("combo_reg", ":".join(str(reg_offset) for reg_offset in self.reg_offsets), self.size, self.ident)
+
     def copy(self) -> SimComboRegisterVariable:
         s = SimComboRegisterVariable(
             self.reg_offsets, self.size, ident=self.ident, name=self.name, region=self.region, category=self.category

--- a/tests/analyses/decompiler/test_combo_reg_args.py
+++ b/tests/analyses/decompiler/test_combo_reg_args.py
@@ -18,9 +18,11 @@ import unittest
 from collections import OrderedDict
 
 import angr
+from angr.analyses.decompiler.clinic import _pick_var, _pick_var_and_offset
 from angr.calling_conventions import SimCCSystemVAMD64
 from angr.knowledge_plugins.functions.function import PrototypeSource
 from angr.sim_type import SimStruct, SimTypeChar, SimTypeFunction, SimTypeInt, SimTypeLongLong, SimTypePointer
+from angr.sim_variable import SimComboRegisterVariable
 from tests.common import bin_location, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -63,6 +65,16 @@ class TestComboRegArgs(unittest.TestCase):
 
         text = self._decompile_authenticate(proto)
         assert "authenticate" in text
+
+    def test_combo_register_variable_is_orderable(self):
+        # SimVariable.key is an abstract marker that every concrete subclass must implement. Callers that
+        # order variables by it -- Clinic's _pick_var and _pick_var_and_offset when linking variables onto
+        # an expression, VariableManager's representative selection -- used to raise NotImplementedError
+        # as soon as a combo-register variable was among the candidates.
+        var = SimComboRegisterVariable((24, 80), 16, ident="arg_3")
+        assert isinstance(var.key, tuple)
+        assert _pick_var({var}) is var
+        assert _pick_var_and_offset({(var, 0)}) == (var, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`SimVariable.key` is an abstract marker, and `SimComboRegisterVariable` is the one concrete
subclass that never overrode it:

```text
  File "angr/sim_variable.py", line 94, in key
    raise NotImplementedError
NotImplementedError
```

Any caller that orders variables by key therefore raised as soon as a combo register
variable was among the candidates, and the function decompiled to nothing. On the ELF/AMD64
corpus object `3b160ff8126fa70107691aa6a908f0468ff07bb0eaecdd76642fc6cad5a079e9`, `0x4048b0`
is empty on the baseline and 877 characters at head.

### Root cause

The callers are ordinary ones, not an exotic path — `min(..., key=...)` over a candidate
set, in three places:

```python
angr/analyses/decompiler/clinic.py:123     return min(candidates, key=lambda var: str(var.key))
angr/analyses/decompiler/clinic.py:130     return min(candidates, key=lambda vo: (str(vo[1]), str(vo[0].key)))
angr/knowledge_plugins/variables/variable_manager.py:674   repre = min(variables, key=lambda val: val.key)
```

`Clinic` reaches the first two while linking variables onto an expression;
`VariableManager` reaches the third picking a representative. What produces the variable is
a 16-byte aggregate passed in two registers, which is what `0x4048b0` above takes as its
argument. Its producers, `variable_recovery/engine_base.py` and
`Clinic._make_argument_list`, are architecture-neutral; the Rust decompiler flavour meets
this argument shape more often, which is why the corpus hits are all Rust, not because the
cause is Rust-specific.

A corpus sweep had recorded the failure on 9 of the 135 Rust binaries it had reached at the
time of the snapshot in the validation record; the sweep was still running, so that count
only grows. The 9 are 7 ELF/AMD64 and 2 PE/X86, and they carry 5 distinct affected
addresses between them, so they are near-duplicate builds rather than 9 independent
programs.

### Fix

Implement `key` the way the sibling classes do: a discriminating tag, the register offsets,
the size and the ident. It is the only member the class was missing — `copy`, `__eq__`,
`__hash__` and `__repr__` are all already there — so this restores an invariant the base
class states rather than adding behaviour.

### Testing

`test_combo_register_variable_is_orderable` builds the variable directly and runs it through
`_pick_var` and `_pick_var_and_offset`, the two `Clinic` helpers above. It lives in the file
that already asserts this variable class is produced and decompiled, so the unit assertion
sits beside the end-to-end one. With `angr/sim_variable.py` reverted to this branch's merge
base `df4f8ba72` it fails with `NotImplementedError` at `sim_variable.py:94`; at head the
file's 3 tests pass. Before and after output is in the comment below.
Validation: https://github.com/angr/angr/pull/7006#issuecomment-5450963405

session: sharpen