### PR TITLE
Oxidizer: recover Rust strings from an image with no section table

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/rust.py
+++ b/angr/analyses/decompiler/structured_codegen/rust.py
@@ -44,6 +44,7 @@ from angr.analyses.decompiler.variable_map import VariableMap
 from angr.errors import UnsupportedNodeTypeError
 from angr.knowledge_plugins.cfg.memory_data import MemoryData, MemoryDataSort
 from angr.knowledge_plugins.functions import Function
+from angr.rust.optimization_passes.utils import extract_str_from_addr
 from angr.rust.sim_type import (
     EnumVariant,
     RustSimStruct,
@@ -77,7 +78,7 @@ from angr.sim_type import (
 )
 from angr.sim_variable import SimMemoryVariable, SimStackVariable, SimTemporaryVariable, SimVariable
 from angr.utils.constants import should_use_hex
-from angr.utils.loader import is_in_readonly_section, is_in_readonly_segment
+from angr.utils.loader import is_known_writable_address
 
 from .base import BaseStructuredCodeGenerator, InstructionMapping, PositionMapping, PositionMappingElement
 
@@ -3295,7 +3296,7 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
             )
             return self._access_constant_offset(result, remainder, data_type, lvalue, renegotiate_type)
 
-        if isinstance(base_type, SimStruct):
+        if isinstance(base_type, SimStruct) and base_type.offsets:
             # find the field that we're accessing
             field_name, field_offset = max(
                 ((x, y) for x, y in base_type.offsets.items() if y <= remainder), key=lambda x: x[1]
@@ -3516,7 +3517,7 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
 
             # nothing has the ability to escape the kernel
             # go in deeper
-            if isinstance(kernel_type, SimStruct):
+            if isinstance(kernel_type, SimStruct) and kernel_type.offsets:
                 field_name, field_offset = max(
                     ((x, y) for x, y in kernel_type.offsets.items() if y <= constant), key=lambda x: x[1]
                 )
@@ -4056,26 +4057,16 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                     reference_values[type_] = self.project.kb.functions[expr.value]
                     function_pointer = True
 
+                # the constant may be a Rust &str fat pointer: a data pointer followed by a length word
+                elif (decoded_str := extract_str_from_addr(self.project, expr.value)) is not None:
+                    type_ = RustSimTypeStrRef()
+                    reference_values[type_] = decoded_str
+                    inline_string = True
+
                 elif (section := self.project.loader.find_section_containing(expr.value)) and section.is_readable:
-                    memory = self.project.loader.memory
-                    str_addr = memory.unpack(expr.value, self.project.arch.struct_fmt())[0]
-                    if (
-                        (section := self.project.loader.find_section_containing(str_addr))
-                        and section.is_readable
-                        and not section.is_writable
-                    ):
-                        str_len = memory.unpack(expr.value + self.project.arch.bytes, self.project.arch.struct_fmt())[0]
-                        try:
-                            decoded_str = memory.load(str_addr, str_len).decode("utf-8")
-                            type_ = RustSimTypeStrRef()
-                            reference_values[type_] = decoded_str
-                            inline_string = True
-                        except UnicodeDecodeError:
-                            pass
                     # If we failed to extract UTF-8 characters, it might be an empty string
-                    if not inline_string and isinstance(type_, RustSimTypeStrRef):
-                        decoded_str = ""
-                        reference_values[type_] = decoded_str
+                    if isinstance(type_, RustSimTypeStrRef):
+                        reference_values[type_] = ""
                         inline_string = True
 
                 # pure guessing: is it possible that it's a string?
@@ -4091,20 +4082,16 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
                             self.project.arch
                         )
                         reference_values[type_] = self._cfg.memory_data[expr.value]
-                        # is it a constant string?
-                        if is_in_readonly_segment(self.project, expr.value) or is_in_readonly_section(
-                            self.project, expr.value
-                        ):
+                        # is it a constant string? an address the loader cannot call writable counts as one
+                        if not is_known_writable_address(self.project, expr.value):
                             inline_string = True
                     elif md.sort == MemoryDataSort.UnicodeString:
                         type_ = RustSimTypeReference(SimTypeWideChar().with_arch(self.project.arch)).with_arch(
                             self.project.arch
                         )
                         reference_values[type_] = self._cfg.memory_data[expr.value]
-                        # is it a constant string?
-                        if is_in_readonly_segment(self.project, expr.value) or is_in_readonly_section(
-                            self.project, expr.value
-                        ):
+                        # is it a constant string? an address the loader cannot call writable counts as one
+                        if not is_known_writable_address(self.project, expr.value):
                             inline_string = True
 
         if type_ is None:

--- a/angr/rust/optimization_passes/utils.py
+++ b/angr/rust/optimization_passes/utils.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
-import contextlib
-
 from angr import ailment
 from angr.ailment import AILBlockRewriter, Block
 from angr.ailment.expression import Call, Const
 from angr.ailment.statement import Jump, Label, SideEffectStatement, Statement
+from angr.utils.loader import is_in_section, is_known_writable_address, is_readable_address, object_has_sections
+
+# An upper bound on the length of a literal to read. A misidentified constant's length word is arbitrary,
+# and Clemory.load materialises the bytes before anything can reject them.
+MAX_STR_LEN = 0x100000
+
+# The shortest string to believe when the object it came from publishes no sections at all. One byte of a
+# pointer is valid UTF-8 about half the time.
+MIN_UNVERIFIED_STR_LEN = 2
 
 
 def extract_callee(obj, kb):
@@ -22,34 +29,83 @@ def extract_callee(obj, kb):
     return None
 
 
+def looks_like_text(decoded_str: str) -> bool:
+    """
+    Decide whether a decoded string is good enough to believe with no section behind it.
+    """
+    return len(decoded_str) >= MIN_UNVERIFIED_STR_LEN and all(c in "\t\n\r" or c.isprintable() for c in decoded_str)
+
+
+def _is_described_data(project, addr):
+    """
+    Decide whether `addr` is somewhere worth reading a literal out of.
+
+    An object that publishes sections and does not cover an address with one is saying something about that
+    address; an object with no sections at all -- a blob -- is not, and there the bytes have to speak for
+    themselves. So the loosening applies to the second and not to a hole in the first.
+    """
+    return is_readable_address(project, addr) and (
+        is_in_section(project, addr) or not object_has_sections(project, addr)
+    )
+
+
+def _points_at_constant_data(project, addr):
+    """
+    Decide whether `addr` may hold a string literal, before its bytes are read.
+    """
+    return _is_described_data(project, addr) and not is_known_writable_address(project, addr)
+
+
 def extract_str(project, str_ptr, str_len):
     """
-    Extract Rust string literal with given ptr and len
+    Extract a Rust string literal with the given pointer and length.
     """
-    decoded_str = None
     if str_len == 0:
         return ""
-    memory = project.loader.memory
-    if str_ptr >= 0 and (
-        (section := project.loader.find_section_containing(str_ptr)) and section.is_readable and not section.is_writable
-    ):
-        with contextlib.suppress(UnicodeDecodeError):
-            decoded_str = memory.load(str_ptr, str_len).decode("utf-8")
-            # decoded_str = decoded_str if decoded_str.replace(
-            #     "\n", "").replace("\t", "").replace("\r", "").isprintable() else None
+    if str_ptr < 0 or not 0 < str_len <= MAX_STR_LEN:
+        return None
+    if not _points_at_constant_data(project, str_ptr) or not is_readable_address(project, str_ptr + str_len - 1):
+        return None
+    try:
+        data = project.loader.memory.load(str_ptr, str_len)
+    except KeyError:
+        return None
+    if len(data) != str_len:
+        # Clemory.load stops at the end of a backer rather than raising
+        return None
+    try:
+        decoded_str = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    if not is_in_section(project, str_ptr) and not looks_like_text(decoded_str):
+        return None
     return decoded_str
 
 
 def extract_str_from_addr(project, addr):
-    memory = project.loader.memory
-    if addr >= 0 and ((section := project.loader.find_section_containing(addr)) and section.is_readable):
-        try:
-            str_ptr = memory.unpack(addr, project.arch.struct_fmt())[0]
-            str_len = memory.unpack(addr + project.arch.bytes, project.arch.struct_fmt())[0]
-            return extract_str(project, str_ptr, str_len)
-        except KeyError:
-            return None
-    return None
+    """
+    Read a Rust &str fat pointer -- a data pointer followed by a length word -- at the given address.
+
+    Reading the pointer says nothing about the word beside it: a constant at the end of a backer has no
+    following word, and cle reports that as a KeyError.
+    """
+    if addr < 0 or not _is_described_data(project, addr):
+        return None
+    try:
+        memory = project.loader.memory
+        str_ptr = memory.unpack(addr, project.arch.struct_fmt())[0]
+        str_len = memory.unpack(addr + project.arch.bytes, project.arch.struct_fmt())[0]
+    except KeyError:
+        return None
+    if str_len == 0:
+        # extract_str's short-circuit does not look at the pointer, and here we have not established that
+        # this is a fat pointer at all. An empty literal carries no bytes for looks_like_text to judge, so
+        # it is taken only where a section says the pointer is constant data -- never on the strength of an
+        # object having no sections, which is what the rest of this reader loosens for.
+        if is_in_section(project, str_ptr) and is_readable_address(project, str_ptr):
+            return "" if not is_known_writable_address(project, str_ptr) else None
+        return None
+    return extract_str(project, str_ptr, str_len)
 
 
 class SideEffectStatementRewriter(AILBlockRewriter):

--- a/angr/utils/loader.py
+++ b/angr/utils/loader.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 import archinfo
 
 if TYPE_CHECKING:
+    from cle.backends.region import Region
+
     from angr import Project
 
 
@@ -53,4 +55,87 @@ def is_in_readonly_segment(project: Project, addr: int) -> bool:
     seg = project.loader.find_segment_containing(addr)
     if seg is not None:
         return not seg.is_writable
+    return False
+
+
+def _region_permissions_are_known(region: Region) -> bool:
+    """
+    Check whether a cle region knows its own permissions.
+
+    cle's base :class:`cle.backends.region.Region` answers True to all three permission questions so that
+    SimOS has something to read. A blob's segments are plain ``Segment`` objects, so a blob claims read,
+    write and execute over every byte of the file; read that as "no information" rather than as "writable".
+
+    :param region:  The region to check.
+    :return:        True if the region's permissions say something, False if they are cle's placeholder.
+    """
+    return not (region.is_readable and region.is_writable and region.is_executable)
+
+
+def is_in_section(project: Project, addr: int) -> bool:
+    """
+    Check whether any section covers the specified address.
+
+    :param project:     An angr Project instance.
+    :param addr:        The address to check.
+    :return:            True if a section contains the address, False otherwise.
+    """
+    return project.loader.find_section_containing(addr) is not None
+
+
+def object_has_sections(project: Project, addr: int) -> bool:
+    """
+    Check whether the object containing the specified address publishes a section table at all.
+
+    This separates an object that has sections and leaves a gap between them -- the file headers inside a
+    read-only segment, for one -- from an object that has none, which is what cle's Blob backend produces.
+    A caller that has to guess without sections should loosen only for the second.
+
+    :param project:     An angr Project instance.
+    :param addr:        The address to check.
+    :return:            True if the object containing the address publishes sections.
+    """
+    obj = project.loader.find_object_containing(addr)
+    return obj is not None and bool(obj.sections)
+
+
+def is_readable_address(project: Project, addr: int) -> bool:
+    """
+    Check whether the specified address is mapped and readable.
+
+    Falls back from sections to segments to plain mappedness, so this answers on an object that publishes
+    no section table, where :func:`is_in_readonly_section` cannot.
+
+    :param project:     An angr Project instance.
+    :param addr:        The address to check.
+    :return:            True if the address is readable, False otherwise.
+    """
+    loader = project.loader
+    sec = loader.find_section_containing(addr)
+    if sec is not None:
+        return sec.is_readable
+    seg = loader.find_segment_containing(addr)
+    if seg is not None and _region_permissions_are_known(seg):
+        return seg.is_readable
+    return addr in loader.memory
+
+
+def is_known_writable_address(project: Project, addr: int) -> bool:
+    """
+    Check whether the loader positively knows that the specified address is writable.
+
+    This is not the negation of :func:`is_in_readonly_section`: an address whose permissions are unknown
+    answers False, so a caller excluding mutable data does not thereby exclude every address in a blob.
+
+    :param project:     An angr Project instance.
+    :param addr:        The address to check.
+    :return:            True if a section or an informative segment says the address is writable.
+    """
+    loader = project.loader
+    sec = loader.find_section_containing(addr)
+    if sec is not None:
+        return sec.is_writable
+    seg = loader.find_segment_containing(addr)
+    if seg is not None and _region_permissions_are_known(seg):
+        return seg.is_writable
     return False

--- a/tests/analyses/decompiler/test_rust_codegen_handlers.py
+++ b/tests/analyses/decompiler/test_rust_codegen_handlers.py
@@ -8,6 +8,8 @@ import os
 import unittest
 from unittest import mock
 
+from cle.backends.blob import Blob
+
 import angr
 from angr.ailment import Manager
 from angr.ailment.block import Block
@@ -19,14 +21,21 @@ from angr.ailment.expression import (
     VirtualVariableCategory,
 )
 from angr.ailment.statement import CAS, DirtyStatement, Jump, Store, WeakAssignment
-from angr.analyses.decompiler.structured_codegen.rust import RustExpression, RustStructuredCodeGenerator
+from angr.analyses.decompiler.structured_codegen.rust import (
+    RustConstant,
+    RustExpression,
+    RustSimTypeReference,
+    RustStructuredCodeGenerator,
+)
 from angr.analyses.decompiler.structurer_nodes import (
     IncompleteSwitchCaseHeadStatement,
     IncompleteSwitchCaseNode,
     SequenceNode,
 )
+from angr.rust.optimization_passes.utils import extract_str, extract_str_from_addr, looks_like_text
 from angr.rust.sim_type import RustSimTypeInt, RustSimTypeStrRef
-from angr.sim_type import SimTypeBottom
+from angr.sim_type import SimStruct, SimTypeBottom
+from angr.utils.loader import is_in_section, is_known_writable_address, is_readable_address, object_has_sections
 from tests.common import bin_location, load_project_with_scoped_cfg, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -51,7 +60,7 @@ class TestRustCodegenHandlers(unittest.TestCase):
         proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
         cfg = proj.analyses.CFGFast(normalize=True, show_progressbar=False)
         dec = proj.analyses.Decompiler(proj.kb.functions["main"], cfg=cfg.model, flavor="rust", fail_fast=True)
-        assert dec.codegen is not None
+        assert isinstance(dec.codegen, RustStructuredCodeGenerator)
         cls.proj = proj
         cls.codegen = dec.codegen
 
@@ -279,6 +288,159 @@ class TestRustStoreWidth(unittest.TestCase):
         with mock.patch.object(self.codegen, "_handle", handle):
             store = RustStructuredCodeGenerator._handle_Stmt_Store(self.codegen, stmt)
         assert store.lhs.type.size == 64
+
+
+class TestRustCodegenMalformedConstantReferences(unittest.TestCase):
+    """
+    The Rust backend treats a constant as a &str fat pointer and a pointer's pointee as a struct without
+    establishing that either really is one. Both guesses used to raise out of the code generator, and the
+    Decompiler's resilience turned that into an empty function body -- a silent, total loss of output.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # df.o holds a constant one word short of the end of a mapped region whose first word points into
+        # a read-only section, which is exactly what the &str heuristic accepts and then reads past.
+        bin_path = os.path.join(test_location, "x86_64", "df.o")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, show_progressbar=False)
+        dec = proj.analyses.Decompiler(proj.kb.functions[0x4033E5], cfg=cfg.model, flavor="rust", fail_fast=True)
+        assert isinstance(dec.codegen, RustStructuredCodeGenerator)
+        cls.proj = proj
+        cls.codegen = dec.codegen
+
+    def test_const_whose_str_length_word_is_unmapped(self):
+        proj = self.proj
+        m = Manager()
+        addr = 0x405600
+
+        # preconditions: the constant is in a readable section, its first word points into a read-only
+        # section -- so the &str heuristic engages -- but the length word beside it is not mapped at all.
+        section = proj.loader.find_section_containing(addr)
+        assert section is not None and section.is_readable
+        pointee = proj.loader.find_section_containing(proj.loader.memory.unpack(addr, proj.arch.struct_fmt())[0])
+        assert pointee is not None and pointee.is_readable and not pointee.is_writable
+        with self.assertRaises(KeyError):
+            proj.loader.memory.unpack(addr + proj.arch.bytes, proj.arch.struct_fmt())
+
+        out = self.codegen._handle_Expr_Const(Const(m.next_atom(), addr, proj.arch.bits))
+        # not a string: rendered as the plain constant it is
+        assert isinstance(out, RustConstant)
+        assert f"{addr:x}" in _render(out).lower().replace("_", "")
+
+    def test_access_constant_offset_through_a_struct_with_no_fields(self):
+        # a type database can hand the code generator a declared-but-empty struct; there is no field to
+        # select an offset within, so the access has to fall back to a pointer cast rather than blow up
+        proj = self.proj
+        struct_type = SimStruct({}, name="opaque").with_arch(proj.arch)
+        assert isinstance(struct_type, SimStruct)
+        assert not struct_type.offsets
+
+        expr = RustConstant(0x1000, RustSimTypeReference(struct_type).with_arch(proj.arch), codegen=self.codegen)
+        out = self.codegen._access_constant_offset(expr, 0, SimTypeBottom(), True)
+        # falls through to the pointer cast the C backend already produces
+        assert _render(out) == "*(0x1000 as *u8)"
+
+
+class TestRustStringRecoveryWithoutASectionTable(unittest.TestCase):
+    """
+    The Oxidizer asked ``find_section_containing`` before it would read a Rust ``&str``, so an object that
+    publishes no section table -- a monolithic image compiled from Rust, loaded through cle's Blob backend --
+    recovered no ``&str`` at all. Nothing raised and nothing was reported; the strings were simply absent.
+    """
+
+    BIN = os.path.join(test_location, "x86_64", "rust_hello_world")
+    MAIN = 0x408A20
+    FAT_POINTER = 0x45A148
+    LITERAL = "Hello, world!\n"
+    RENDERED = '"Hello, world!\\n"'  # how the code generator writes it back out
+    EMPTY_STR_REFS = (0x45A4B0, 0x45A4D0, 0x45A4F0, 0x45A848)  # fat pointers whose length word is zero
+
+    @classmethod
+    def setUpClass(cls):
+        cls.elf = angr.Project(cls.BIN, auto_load_libs=False)
+        base = cls.elf.loader.main_object.mapped_base
+        cls.base = base
+        # The same bytes with the section table removed: mapped the way the image's own program headers
+        # say, at the image's own link base, so every address the image stores in itself still resolves.
+        segments = [(s.offset, s.vaddr - base, s.filesize) for s in cls.elf.loader.main_object.segments if s.filesize]
+        cls.blob = angr.Project(
+            cls.BIN,
+            auto_load_libs=False,
+            main_opts={
+                "backend": "blob",
+                "arch": cls.elf.arch.name,
+                "base_addr": 0,
+                "entry_point": cls.elf.entry - base,
+                "segments": segments,
+            },
+        )
+
+    def test_the_blob_publishes_no_sections(self):
+        # the preconditions the recovery has to cope with, rather than an assumption about them
+        assert isinstance(self.blob.loader.main_object, Blob)
+        assert not self.blob.loader.main_object.sections
+        assert self.blob.loader.main_object.segments
+        assert not object_has_sections(self.blob, self.FAT_POINTER - self.base)
+        assert not is_in_section(self.blob, self.FAT_POINTER - self.base)
+        assert is_readable_address(self.blob, self.FAT_POINTER - self.base)
+        assert not is_known_writable_address(self.blob, self.FAT_POINTER - self.base)
+        # the same address in the ELF sits in .data.rel.ro, which is a writable section
+        assert object_has_sections(self.elf, self.FAT_POINTER)
+        assert is_in_section(self.elf, self.FAT_POINTER)
+        assert is_known_writable_address(self.elf, self.FAT_POINTER)
+
+    def test_str_ref_is_read_through_a_blob(self):
+        assert extract_str_from_addr(self.elf, self.FAT_POINTER) == self.LITERAL
+        assert extract_str_from_addr(self.blob, self.FAT_POINTER - self.base) == self.LITERAL
+
+    def test_one_byte_of_a_pointer_is_not_a_string(self):
+        # (0x45a148, 1) is a fat pointer and a piece count, not a pointer and a length. In the ELF the
+        # writable section says so; in the blob nothing does, and only the text filter keeps the low byte
+        # of the pointer -- "W" -- from being reported as a one-character literal.
+        assert extract_str(self.elf, self.FAT_POINTER, 1) is None
+        assert extract_str(self.blob, self.FAT_POINTER - self.base, 1) is None
+        assert not looks_like_text("W")
+        assert looks_like_text(self.LITERAL)
+
+    def test_a_hole_between_an_elf_s_sections_is_not_read(self):
+        # the ELF header sits inside a read-only segment and inside no section. An object that publishes
+        # sections and does not cover an address with one is saying something, so the loosening this change
+        # makes for a blob must not reach here -- including for bytes that would pass the text filter.
+        header = self.elf.loader.main_object.mapped_base
+        assert object_has_sections(self.elf, header)
+        assert not is_in_section(self.elf, header)
+        assert is_readable_address(self.elf, header)
+        assert extract_str(self.elf, header, 8) is None
+        assert bytes(self.elf.loader.memory.load(header + 1, 3)) == b"ELF"
+        assert extract_str(self.elf, header + 1, 3) is None
+
+        # and through the other entry point. fauxware's program headers hold what reads as a fat pointer,
+        # (0x400238, 28), whose data pointer is .interp -- so the text filter would not reject it either.
+        fauxware = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        hole = 0x400090
+        assert not is_in_section(fauxware, hole)
+        assert fauxware.loader.memory.unpack(hole, fauxware.arch.struct_fmt())[0] == 0x400238
+        assert is_in_section(fauxware, 0x400238)
+        assert extract_str_from_addr(fauxware, hole) is None
+
+    def test_an_empty_str_ref_reads_as_empty_where_a_section_says_so(self):
+        # a fat pointer whose length word is zero. The code generator has always rendered that as "" when
+        # a section said the pointer was constant data, and it still does; a blob has no section to say it.
+        for addr in self.EMPTY_STR_REFS:
+            assert is_in_section(self.elf, addr)
+            assert extract_str_from_addr(self.elf, addr) == ""
+            assert extract_str_from_addr(self.blob, addr - self.base) is None
+
+    def test_decompiling_a_blob_inlines_the_literal(self):
+        proj = self.blob
+        cfg = proj.analyses.CFGFast(normalize=True, show_progressbar=False)
+        func = proj.kb.functions.function(addr=self.MAIN - self.base)
+        assert func is not None
+        dec = proj.analyses.Decompiler(func, cfg=cfg.model, flavor="rust", fail_fast=True)
+        assert dec.codegen is not None
+        print_decompilation_result(dec)
+        assert self.RENDERED in dec.codegen.text
 
 
 if __name__ == "__main__":

--- a/tests/analyses/decompiler/test_rust_misc_passes.py
+++ b/tests/analyses/decompiler/test_rust_misc_passes.py
@@ -72,7 +72,7 @@ def _str_argument_simplifier() -> StrArgumentSimplifier:
     """Build a StrArgumentSimplifier without invoking its full ``__init__``.
 
     The ``try_str_literal`` helper only reads ``self.project`` (forwarded via
-    ``self._func.project``) for ``arch.bits`` and the section reader.
+    ``self._func.project``) for ``arch.bits`` and the string reader.
     """
     project = angr.load_shellcode(b"\x90", arch="amd64")
     func = project.kb.functions.function(addr=0x0, name="dummy", create=True)
@@ -87,9 +87,9 @@ def test_try_str_literal_returns_none_when_either_arg_is_not_const():
     assert simp.try_str_literal(_stack_vvar(), _const(4)) is None
 
 
-def test_try_str_literal_returns_none_when_section_lookup_fails():
-    # load_shellcode produces a Blob with no sections, so extract_str returns
-    # None and try_str_literal must propagate that as None.
+def test_try_str_literal_returns_none_when_the_address_is_not_mapped():
+    # load_shellcode produces a one-byte Blob, so 0xdead is not mapped, extract_str returns None,
+    # and try_str_literal must propagate that as None.
     simp = _str_argument_simplifier()
     assert simp.try_str_literal(_const(0xDEAD), _const(4)) is None
 

--- a/tests/analyses/test_rust_utils.py
+++ b/tests/analyses/test_rust_utils.py
@@ -228,9 +228,9 @@ def test_extract_str_rejects_negative_pointer():
     assert extract_str(project, str_ptr=-1, str_len=4) is None
 
 
-def test_extract_str_returns_none_when_no_readable_section_covers_pointer():
-    # load_shellcode produces a Blob with no sections, so find_section_containing
-    # always returns None and the helper falls through to None.
+def test_extract_str_returns_none_when_the_string_runs_off_the_end_of_memory():
+    # load_shellcode produces a one-byte Blob, so there is no section to consult and the four bytes asked
+    # for are not all mapped. Blobs are read on their mapped extent now, and this one is one byte long.
     project = angr.load_shellcode(b"\x90", arch="amd64")
     assert extract_str(project, str_ptr=0x0, str_len=4) is None
 
@@ -240,7 +240,8 @@ def test_extract_str_from_addr_rejects_negative_address():
     assert extract_str_from_addr(project, addr=-1) is None
 
 
-def test_extract_str_from_addr_returns_none_when_no_section_covers_address():
+def test_extract_str_from_addr_returns_none_when_the_fat_pointer_is_not_mapped():
+    # one byte of blob: the pointer word alone does not fit, so both reads are refused.
     project = angr.load_shellcode(b"\x90", arch="amd64")
     assert extract_str_from_addr(project, addr=0x0) is None
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Load a Rust binary through `cle.backends.blob.Blob` and the Oxidizer recovers **no `&str` literal at all**. Nothing raises and nothing is logged; the strings are simply absent. `binaries/tests/x86_64/rust_hello_world`, `main` at `0x408a20`, as an ELF and then as the same bytes with the ELF metadata thrown away:

```rust
// as an ELF
v0 = core::fmt::Arguments::new_const("Hello, world!\n", 1);

// the same image as a blob
v0 = sub_8900(&g_5a148, &g_1);
```

@ltfish rejected the narrow crash fix this pull request used to carry, on 2026-08-29: *"You cannot assume strings must exist in a section; users may analyze a monolithic binary blob that was compiled from Rust in the first place, in which case we may not have any information about section or segment of the blob."* Asked whether he wanted the crash fix now and the blob work as a separate change, he answered on 2026-08-31: *"please have the whole thing done together."* So this is the whole thing, and the narrow patch is gone.

### Root cause

Everything that reads a Rust `&str` asks `loader.find_section_containing` first, in four places: `_handle_Expr_Const`, twice, and `extract_str` / `extract_str_from_addr`, which feed five Rust passes. A blob publishes zero sections, so all four fail at every address.

Segments do not rescue it. `Blob._load` appends a plain `cle.backends.region.Segment`, whose base class answers True to `is_readable`, `is_writable` **and** `is_executable` — the comment above those properties in cle says they exist so `SimOS` has something to read. So a blob claims `rwx` over the whole file, `is_in_readonly_segment` is False everywhere, and the `MemoryDataSort.String` fallback is closed off too.

The section test is also the wrong question on an object that has sections. A section containing a constant says nothing about the word beside it. On `x86_64/df.o` the constant `0x405600` is the last word of its backer, `[0x4053c0, 0x405608)`, and the word the fat-pointer heuristic reads next is not mapped:

```
File "cle/memory.py", line 58, in unpack
    raise KeyError(addr)
KeyError: 4216328          # 0x405608
```

That traceback is `_handle_Expr_Const` called directly; no public function in `df.o` reaches it, because the one that references `0x405600` loads it rather than materialising it. Where one is materialised, the exception leaves the code generator, `Decompiler`'s resilience catches it, and the function comes out with no statements and no visible error.

### Fix

Ask what the callers need to know instead of asking for a section. Four predicates in `angr/utils/loader.py`:

`is_readable_address` falls back from sections to segments to plain mappedness. `is_known_writable_address` is True only where the loader really says writable, so excluding mutable data no longer excludes every address in a blob. `is_in_section` and `object_has_sections` separate a blob from an ELF with a gap between its sections.

`extract_str` and `extract_str_from_addr` gate on those, bound the length, and guard every read, including the truncated one `Clemory.load` returns silently at the end of a backer. An object that publishes sections and leaves an address out of all of them is saying something, so the loosening applies only where there is no section table at all — a hole between an ELF's sections is read exactly as before. Where there is none, the decoded bytes have to look like text, because that is the only evidence left: without it the blob arm reports the low byte of a pointer — `"W"` — as a one-character literal, where the ELF arm is saved by `.data.rel.ro` being writable. `_handle_Expr_Const` calls that one shared reader rather than re-implementing the same three reads inline, and the two `MemoryDataSort` inlining gates ask `is_known_writable_address` instead of `is_in_readonly_section or is_in_readonly_segment`. One thing tightens on an object with sections: master answered `""` for any readable-section address whose second word was zero, and that now needs a section saying the pointer is constant data.

Separately, `_access_constant_offset` and `_access` take `max()` over a `SimStruct`'s offsets, and a type database can hand them a declared-but-empty struct, raising `ValueError: max() iterable argument is empty` into the same silent empty body. `c.py` guards both of its `SimStruct` branches with `and ....offsets`; the Rust port dropped it at both sites. Restored.

Deliberately not done: three more sites carry the same blob-blind predicate pair. `c.py:4333` and `:4343` are the C backend's own copy of this gate, inside `CStructuredCodeGenerator`. `decompiler.py:1016` drops every data reference outside a read-only section or segment, and `simplify_pc_relative_loads.py:42` never fires on a blob at all — those two are flavour-agnostic, so changing them moves C output for every blob. They belong in one follow-up rather than smuggled in here.

### Testing

`TestRustStringRecoveryWithoutASectionTable`, six cases on `binaries/tests/x86_64/rust_hello_world` — the same tracked bytes loaded twice, once as an ELF and once through `Blob`, with the section table removed and the image's own program headers replayed at its link base. No fixture is added, assembled or compiled. It asserts the preconditions; that `extract_str_from_addr` reads `"Hello, world!\n"` through the blob; that neither `(fat pointer, 1)` nor a hole between an ELF's sections is read as a string, through either entry point; that a zero-length fat pointer still renders as `""`; and that decompiling `main` from the blob inlines the literal. The two `x86_64/df.o` cases stay.

Decompiling 41 functions around `main` in both arms: the blob arm goes from 0 recovered `&str` literals to 3 — `"Hello, world!\n"`, `"invalid args"` and a rustc source path — and the ELF arm is byte-identical in all 41 functions.

Validation: https://github.com/angr/angr/pull/7007#issuecomment-5450963481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen
