### PR TITLE
RuntimeDb: Read RTDB_BASE when the database is created

### DIFF
--- a/angr/knowledge_plugins/rtdb/rtdb.py
+++ b/angr/knowledge_plugins/rtdb/rtdb.py
@@ -22,8 +22,6 @@ from angr.knowledge_plugins.plugin import KnowledgeBasePlugin
 if TYPE_CHECKING:
     from angr.knowledge_base import KnowledgeBase
 
-RTDB_BASEDIR: str | None = os.environ.get("RTDB_BASE")
-
 # Name of the pin file inside each rtdb directory. Every process (and every RuntimeDb instance) that opens the
 # directory holds a shared flock on this file; the process that acquires an exclusive lock during cleanup is the
 # last process and can safely remove the directory.
@@ -196,9 +194,8 @@ class RuntimeDb(KnowledgeBasePlugin):
         main_binary_path = self._kb._project.loader.main_object.binary
         basename = os.path.basename(main_binary_path) if isinstance(main_binary_path, str) else "angr_proj"
 
-        basedir = None
-        if RTDB_BASEDIR is not None:
-            basedir = RTDB_BASEDIR
+        basedir = os.environ.get("RTDB_BASE")
+        if basedir is not None:
             if not os.access(basedir, os.W_OK):
                 l.error("The directory %s is not writable. Falling back.", basedir)
                 basedir = None

--- a/tests/knowledge_plugins/rtdb/test_rtdb_basedir.py
+++ b/tests/knowledge_plugins/rtdb/test_rtdb_basedir.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# pylint:disable=no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.knowledge_plugins.rtdb"  # pylint:disable=redefined-builtin
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+import angr
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestRuntimeDbBaseDir(unittest.TestCase):
+    """
+    Test the directory that a run-time database is created in.
+    """
+
+    def test_rtdb_base_set_after_angr_is_imported(self):
+        # angr is imported when this module is imported, so setting RTDB_BASE here puts us in the situation of a
+        # pytest fixture, a conftest.py, or any wrapper that configures the environment after importing angr.
+        binary = os.path.join(test_location, "x86_64", "fauxware")
+        with tempfile.TemporaryDirectory() as tmpdir, mock.patch.dict(os.environ, {"RTDB_BASE": tmpdir}):
+            proj = angr.Project(binary, auto_load_libs=False)
+            proj.kb.rtdb.open_db("testdb")
+            try:
+                assert os.listdir(tmpdir) == ["fauxware_angr_rtdb"], (
+                    f"RTDB_BASE was set to {tmpdir}, which holds {os.listdir(tmpdir)}"
+                )
+            finally:
+                proj.kb.rtdb.cleanup()
+
+    def test_rtdb_defaults_to_the_directory_of_the_main_binary(self):
+        with tempfile.TemporaryDirectory() as bindir, mock.patch.dict(os.environ):
+            os.environ.pop("RTDB_BASE", None)
+            binary = shutil.copy(os.path.join(test_location, "x86_64", "fauxware"), bindir)
+            proj = angr.Project(binary, auto_load_libs=False)
+            proj.kb.rtdb.open_db("testdb")
+            try:
+                assert sorted(os.listdir(bindir)) == ["fauxware", "fauxware_angr_rtdb"], (
+                    f"the directory holding the binary holds {os.listdir(bindir)}"
+                )
+            finally:
+                proj.kb.rtdb.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`RTDB_BASE` names the directory angr creates its run-time database in. Setting it after `import angr` has no effect: the database is created beside the input binary instead. With `binaries/tests/x86_64/fauxware` copied to a scratch directory and `RTDB_BASE` set after the import, as a pytest fixture, a `conftest.py`, or a `monkeypatch.setenv` would set it:

```
RTDB_BASE           = /tmp/rtdbbase-v3x9ze1c
database created at = /tmp/bindir-je_x8eqv/fauxware_angr_rtdb
contents of RTDB_BASE       : []
contents of the binary's dir: ['fauxware', 'fauxware_angr_rtdb']
```

The variable exists to keep that directory out of the tree holding the binary. When it is ignored, every analysed fixture leaves a `<name>_angr_rtdb` directory beside itself, and a read-only binary directory falls through to the temporary directory rather than to the location that was asked for.

### Root cause

The variable was read once, at import time, into a module-level constant in `angr/knowledge_plugins/rtdb/rtdb.py`:

```python
RTDB_BASEDIR: str | None = os.environ.get("RTDB_BASE")
```

`_init_lmdb_attempt_multiple_locations` consulted that constant, so the value that decided the location was the environment as it stood when `angr` was first imported — which, for anything that imports angr at module scope and configures its environment in a fixture, is before the variable is set.

### Fix

Read the environment where the location is chosen:

```python
basedir = os.environ.get("RTDB_BASE")
```

That code runs only when a database is created, and already calls `os.access` and `lmdb.open`, so caching the lookup buys nothing. The order of candidate locations is unchanged — `RTDB_BASE`, then the main binary's directory, then the temporary directory. Same reproducer, after:

```
RTDB_BASE           = /tmp/rtdbbase-21p2o98e
database created at = /tmp/rtdbbase-21p2o98e/fauxware_angr_rtdb
contents of RTDB_BASE       : ['fauxware_angr_rtdb']
contents of the binary's dir: ['fauxware']
```

### Testing

`tests/knowledge_plugins/rtdb/test_rtdb_basedir.py` adds two tests. `test_rtdb_base_set_after_angr_is_imported` sets `RTDB_BASE` after the test module has imported angr, loads `binaries/tests/x86_64/fauxware`, and asserts the database was created under it; it fails on the baseline, where the directory is empty. `test_rtdb_defaults_to_the_directory_of_the_main_binary` unsets the variable and pins the fallback, so the reordering this could have caused is covered.

Validation: https://github.com/angr/angr/pull/7008#issuecomment-5451639383

session: mega-corpus
