### PR TITLE
SimCCMicrosoftFastcall: return aggregates the way the convention says

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1461,6 +1461,43 @@ class SimCCMicrosoftFastcall(SimCC):
             locs_size += locs[-1].size
         return refine_locs_with_struct_type(self.arch, locs, arg_type)
 
+    STRUCT_RETURN_THRESHOLD = 64
+
+    def return_val(self, ty, perspective_returned=False):
+        # __fastcall changes how arguments are passed, not how values are returned: on Windows x86 an
+        # aggregate of at most eight bytes comes back in EAX:EDX and a larger one is written through a
+        # hidden pointer, exactly as for __cdecl. OVERFLOW_RETURN_VAL above already states this, but
+        # without an override the base class refuses every aggregate return type.
+        #
+        # The hidden pointer's location is taken from next_arg rather than assumed, because it is the
+        # call's first argument and __fastcall passes that in ECX -- not in the stack slot that
+        # SimCCCdecl.return_val hard-codes for its own convention. That is why this cannot simply
+        # inherit or delegate to the cdecl implementation.
+        if ty._arch is None:
+            ty = ty.with_arch(self.arch)
+        if not isinstance(ty, SimStruct):
+            return super().return_val(ty, perspective_returned)
+
+        if ty.size > self.STRUCT_RETURN_THRESHOLD:
+            byte_size = ty.size // self.arch.byte_width
+            referenced_locs = [SimStackArg(offset, self.arch.bytes) for offset in range(0, byte_size, self.arch.bytes)]
+            referenced_loc = refine_locs_with_struct_type(self.arch, referenced_locs, ty)
+            if perspective_returned:
+                ptr_loc = self.RETURN_VAL
+            else:
+                ptr_loc = self.next_arg(self.ArgSession(self), SimTypePointer(SimTypeBottom()).with_arch(self.arch))
+            assert ptr_loc is not None
+            return SimReferenceArgument(ptr_loc, referenced_loc)
+
+        return refine_locs_with_struct_type(self.arch, [self.RETURN_VAL, self.OVERFLOW_RETURN_VAL], ty)
+
+    def return_in_implicit_outparam(self, ty):
+        # Kept consistent with return_val: when the aggregate comes back through a hidden pointer that
+        # pointer is the first argument, so it must consume ECX and push the declared arguments along.
+        if isinstance(ty, SimTypeBottom):
+            return False
+        return isinstance(ty, SimStruct) and ty.size > self.STRUCT_RETURN_THRESHOLD
+
 
 class MicrosoftAMD64ArgSession(ArgSession):
     pass

--- a/tests/test_calling_conventions.py
+++ b/tests/test_calling_conventions.py
@@ -13,6 +13,7 @@ import archinfo
 from angr import Project, load_shellcode, types
 from angr.calling_conventions import (
     SimCCMicrosoftAMD64,
+    SimCCMicrosoftCdecl,
     SimCCMicrosoftFastcall,
     SimCCN32,
     SimCCN32LinuxSyscall,
@@ -23,6 +24,7 @@ from angr.calling_conventions import (
     SimReferenceArgument,
     SimRegArg,
     SimStackArg,
+    SimStructArg,
     SimTypeFixedSizeArray,
     SimTypeFunction,
     SimTypeInt,
@@ -30,10 +32,12 @@ from angr.calling_conventions import (
 )
 from angr.sim_type import (
     SimCppClass,
+    SimStruct,
     SimStructValue,
     SimTypeChar,
     SimTypeDouble,
     SimTypeLongLong,
+    SimTypePointer,
     SimTypeRef,
     parse_file,
 )
@@ -319,6 +323,45 @@ class TestCallingConvention(TestCase):
             n32 = self._mips_int_arg_locs(SimCCN32LinuxSyscall, archinfo.ArchMIPSN32(endness), args)
             n64 = self._mips_int_arg_locs(SimCCN64LinuxSyscall, archinfo.ArchMIPS64(endness), args)
             assert n32 == n64, f"{endness}: n32 {n32} != n64 {n64}"
+
+    def test_microsoft_fastcall_aggregate_return(self):
+        # Regression test: __fastcall changes how arguments are passed, not how values are returned.
+        # Without a return_val override the base class refuses every aggregate return type, and a
+        # decompiled function returning a small struct comes out empty. This is the return-side
+        # counterpart of test_microsoft_fastcall_large_arg above.
+        arch = archinfo.arch_from_id("x86")
+        fastcall = SimCCMicrosoftFastcall(arch)
+        cdecl = SimCCMicrosoftCdecl(arch)
+
+        small = SimStruct({"ptr": SimTypePointer(SimTypeChar()), "len": SimTypeInt()}, name="fatptr").with_arch(arch)
+        large = SimStruct({f"f{i}": SimTypeInt() for i in range(8)}, name="big").with_arch(arch)
+
+        # An eight-byte aggregate comes back in EAX:EDX, the same as __cdecl on Windows x86.
+        small_ret = fastcall.return_val(small)
+        assert isinstance(small_ret, SimStructArg)
+        assert list(small_ret.locs.values()) == [SimRegArg("eax", 4), SimRegArg("edx", 4)]
+        cdecl_small = cdecl.return_val(small)
+        assert isinstance(cdecl_small, SimStructArg)
+        assert set(small_ret.get_footprint()) == set(cdecl_small.get_footprint())
+        assert fastcall.return_in_implicit_outparam(small) is False
+
+        # A larger one is written through a hidden pointer. That pointer is the call's first
+        # argument, so __fastcall passes it in ECX -- not in the stack slot __cdecl uses. This is
+        # why the implementation cannot simply be inherited from the cdecl convention.
+        large_ret = fastcall.return_val(large)
+        assert isinstance(large_ret, SimReferenceArgument)
+        assert large_ret.ptr_loc == SimRegArg("ecx", 4)
+        cdecl_large = cdecl.return_val(large)
+        assert isinstance(cdecl_large, SimReferenceArgument)
+        assert cdecl_large.ptr_loc == SimStackArg(0, 4)
+        assert fastcall.return_in_implicit_outparam(large) is True
+
+        # The hidden pointer consumes ECX, so the declared arguments shift along.
+        proto = SimTypeFunction([SimTypeInt(), SimTypeInt()], large).with_arch(arch)
+        assert [list(loc.get_footprint()) for loc in fastcall.arg_locs(proto)] == [
+            [SimRegArg("edx", 4)],
+            [SimStackArg(0x4, 4)],
+        ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Problem

`SimCCMicrosoftFastcall.return_val` raises on every aggregate return type:

```
AngrTypeError: <SimCCMicrosoftFastcall> doesn't know how to return aggregate types
(<class 'angr.sim_type.SimStruct'>). Consider overriding return_val to implement its ABI logic
```

The decompiler reaches it through `return_maker._handle_Return`, so the affected
function decompiles to nothing at all.

This is not specific to any one language. `SimCCMicrosoftFastcall` is one of the four
conventions `CallingConventionAnalysis` guesses from for Win32 x86 (`OTHER_CC["Win32"]`
in `angr/calling_conventions.py`), and it is picked from register usage alone, so any
Win32 x86 binary whose arguments sit in ECX/EDX and which returns a small struct is
affected -- C, C++, Go and Rust alike.

## Root cause

`__fastcall` changes how arguments are passed, not how values are returned. On Windows
x86 an aggregate of at most eight bytes comes back in EAX:EDX and a larger one is written
through a hidden pointer, exactly as for `__cdecl`. The class already says so, in the
comment beside its own `OVERFLOW_RETURN_VAL`. It simply never implemented it: it derives
from `SimCC` rather than `SimCCCdecl`, so it inherits the base `return_val`, which
refuses every aggregate.

Its siblings already answer the same two-word aggregate return, which is why this went
unnoticed -- x86-64 works by coincidence of the C ABI rather than by design:

```
SimCCSystemVAMD64       -> SimStructArg [<rax>, <rdx>]
SimCCMicrosoftCdecl     -> SimStructArg [<eax>, <edx>]
SimCCMicrosoftFastcall  -> AngrTypeError
```

## Fix

Implement `return_val` and the matching `return_in_implicit_outparam` on
`SimCCMicrosoftFastcall`, with `STRUCT_RETURN_THRESHOLD = 64` as for
`SimCCMicrosoftCdecl`.

This deliberately does not inherit from or delegate to `SimCCCdecl.return_val`, which
hard-codes the hidden return pointer to `SimStackArg(0, 4)`. That pointer is the call's
first argument, and `__fastcall` passes the first argument in ECX:

```
SimCCMicrosoftCdecl.next_arg(void*)     -> [0x4]
SimCCMicrosoftFastcall.next_arg(void*)  -> <ecx>
```

Delegating would therefore be right for the eight-byte case and wrong for every larger
aggregate. The location is instead taken from `self.next_arg(...)`, the same
convention-neutral derivation `SimCCMicrosoftAMD64.return_val` already uses.
`return_in_implicit_outparam` is overridden alongside because `arg_locs` consults it to
decide whether the hidden pointer consumes ECX; without it the declared arguments would
be laid out over the pointer.

## Testing

`tests/test_calling_conventions.py::test_microsoft_fastcall_aggregate_return`, the
return-side counterpart of the existing `test_microsoft_fastcall_large_arg`. It asserts
EAX:EDX for an eight-byte struct with a footprint identical to `SimCCMicrosoftCdecl`,
an ECX hidden pointer for a thirty-two-byte struct where cdecl uses a stack slot, and
that the pointer shifts the declared arguments along. With the `calling_conventions.py`
change reverted it fails with the exact `AngrTypeError` above.

Observed on a Win32 x86 binary at `0x402a10`, which decompiles to nothing before the
change and to 2682 bytes after it, with no other function on that binary affected.

Validation: https://github.com/angr/angr/pull/7011#issuecomment-5454074534

session: sharpen