### PR TITLE
Guard class-docstring DESCRIPTION assignments for type safety

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/base_ptr_save_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/base_ptr_save_simplifier.py
@@ -20,7 +20,7 @@ class BasePointerSaveSimplifier(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Simplify base pointer saving"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/call_stmt_rewriter.py
+++ b/angr/analyses/decompiler/optimization_passes/call_stmt_rewriter.py
@@ -18,7 +18,7 @@ class CallStatementRewriter(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_MAKING_CALLSITES
     NAME = "Unify call statements on demand."
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/code_motion.py
+++ b/angr/analyses/decompiler/optimization_passes/code_motion.py
@@ -51,7 +51,7 @@ class CodeMotionOptimization(OptimizationPass):
     PLATFORMS = None
     NAME = "Merge common statements in sub-scopes"
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
-    DESCRIPTION = __doc__
+    DESCRIPTION = __doc__ or ""
 
     def __init__(self, *args, max_iters=10, node_idx_start: int = 0, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/condition_constprop.py
+++ b/angr/analyses/decompiler/optimization_passes/condition_constprop.py
@@ -81,7 +81,7 @@ class ConditionConstantPropagation(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_SINGLE_BLOCK_SIMPLIFICATION
     NAME = "Propagate constants using information deduced from conditionals."
-    DESCRIPTION = __doc__.strip()  # type: ignore
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/const_derefs.py
+++ b/angr/analyses/decompiler/optimization_passes/const_derefs.py
@@ -108,7 +108,7 @@ class ConstantDereferencesSimplifier(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_SINGLE_BLOCK_SIMPLIFICATION
     NAME = "Simplify constant dereferences"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/const_prop_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/const_prop_reverter.py
@@ -69,7 +69,7 @@ class ConstPropOptReverter(OptimizationPass):
     STRUCTURING = [SAILRStructurer.NAME, DreamStructurer.NAME]
     STAGE = OptimizationPassStage.DURING_REGION_IDENTIFICATION
     NAME = "Revert Constant Propagation Optimizations"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, region_identifier=None, reaching_definitions=None, **kwargs):
         self.ri = region_identifier

--- a/angr/analyses/decompiler/optimization_passes/cross_jump_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/cross_jump_reverter.py
@@ -25,7 +25,7 @@ class CrossJumpReverter(StructuringOptimizationPass):
 
     STAGE = OptimizationPassStage.DURING_REGION_IDENTIFICATION
     NAME = "Duplicate linear blocks with gotos"
-    DESCRIPTION = inspect.cleandoc(__doc__).strip()
+    DESCRIPTION = inspect.cleandoc(__doc__ or "").strip()
 
     def __init__(
         self,

--- a/angr/analyses/decompiler/optimization_passes/deadblock_remover.py
+++ b/angr/analyses/decompiler/optimization_passes/deadblock_remover.py
@@ -25,7 +25,7 @@ class DeadblockRemover(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.BEFORE_REGION_IDENTIFICATION
     NAME = "Remove blocks with unsatisfiable conditions"
-    DESCRIPTION = __doc__.strip()  # type: ignore
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, node_cutoff: int = 200, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/determine_load_sizes.py
+++ b/angr/analyses/decompiler/optimization_passes/determine_load_sizes.py
@@ -48,7 +48,7 @@ class DetermineLoadSizes(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Determine sizes of loads whose sizes are undetermined"
-    DESCRIPTION = __doc__.strip()  # type: ignore
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/div_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/div_simplifier.py
@@ -400,7 +400,7 @@ class DivSimplifier(OptimizationPass):
     PLATFORMS = None  # everything
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Simplify arithmetic division"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -42,7 +42,7 @@ class DuplicationReverter(StructuringOptimizationPass):
     """
 
     NAME = "Revert Statement Duplication Optimizations"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, max_guarding_conditions=4, **kwargs):
         super().__init__(

--- a/angr/analyses/decompiler/optimization_passes/eager_std_string_concatenation.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_std_string_concatenation.py
@@ -25,7 +25,7 @@ class EagerStdStringConcatenationPass(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.BEFORE_VARIABLE_RECOVERY
     NAME = "Condense multiple constant std::string creation calls into one when possible"
-    DESCRIPTION = __doc__.strip()  # type: ignore
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/eager_std_string_eval.py
+++ b/angr/analyses/decompiler/optimization_passes/eager_std_string_eval.py
@@ -70,7 +70,7 @@ class EagerStdStringEvalPass(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.BEFORE_VARIABLE_RECOVERY
     NAME = "Eagerly evaluate std::string methods for constant std::string instances"
-    DESCRIPTION = __doc__.strip()  # type: ignore
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/expr_op_swapper.py
+++ b/angr/analyses/decompiler/optimization_passes/expr_op_swapper.py
@@ -145,7 +145,7 @@ class ExprOpSwapper(SequenceOptimizationPass):
     PLATFORMS = ["windows", "linux", "cgc"]
     STAGE = OptimizationPassStage.AFTER_STRUCTURING
     NAME = "Swap operands of expressions as requested"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, binop_operators: dict[OpDescriptor, str] | None = None, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/ite_expr_converter.py
+++ b/angr/analyses/decompiler/optimization_passes/ite_expr_converter.py
@@ -78,7 +78,7 @@ class ITEExprConverter(OptimizationPass):
     NAME = (
         "Transform single-use expressions that were assigned to in different If-Else branches into ternary expressions"
     )
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, ite_exprs=None, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/ite_region_converter.py
+++ b/angr/analyses/decompiler/optimization_passes/ite_region_converter.py
@@ -24,7 +24,7 @@ class ITERegionConverter(OptimizationPass):
     PLATFORMS = ["windows", "linux", "cgc"]
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Transform ITE-assignment regions into ternary expression assignments"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, max_updates=10, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/mips_gp_setting_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/mips_gp_setting_simplifier.py
@@ -18,7 +18,7 @@ class MipsGpSettingSimplifier(OptimizationPass):
     PLATFORMS = ["linux"]
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Remove MIPS $gp-setting statements"
-    DESCRIPTION = __doc__.strip()  # type: ignore
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/mod_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/mod_simplifier.py
@@ -71,7 +71,7 @@ class ModSimplifier(OptimizationPass):
     PLATFORMS = ["linux", "windows"]
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Simplify optimized mod forms"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier.py
@@ -30,7 +30,7 @@ class RegisterSaveAreaSimplifier(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_SINGLE_BLOCK_SIMPLIFICATION
     NAME = "Simplify register save areas"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier_adv.py
+++ b/angr/analyses/decompiler/optimization_passes/register_save_area_simplifier_adv.py
@@ -32,7 +32,7 @@ class RegisterSaveAreaSimplifierAdvanced(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_MAKING_CALLSITES
     NAME = "Simplify register save areas (advanced)"
-    DESCRIPTION = __doc__.strip()  # type: ignore
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/ret_addr_save_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/ret_addr_save_simplifier.py
@@ -21,7 +21,7 @@ class RetAddrSaveSimplifier(OptimizationPass):
     PLATFORMS = ["linux"]
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Simplify return address storage"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/ret_deduplicator.py
+++ b/angr/analyses/decompiler/optimization_passes/ret_deduplicator.py
@@ -29,7 +29,7 @@ class ReturnDeduplicator(OptimizationPass):
     PLATFORMS = ["windows", "linux", "cgc"]
     STAGE = OptimizationPassStage.DURING_REGION_IDENTIFICATION
     NAME = "Deduplicates return statements that may have been duplicated"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
     STRUCTURING = [SAILRStructurer.NAME, DreamStructurer.NAME]
 
     def __init__(self, *args, **kwargs):

--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_high.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_high.py
@@ -22,7 +22,7 @@ class ReturnDuplicatorHigh(OptimizationPass, ReturnDuplicatorBase):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Duplicate return-only blocks (high)"
-    DESCRIPTION = __doc__
+    DESCRIPTION = __doc__ or ""
     STRUCTURING = [SAILRStructurer.NAME, DreamStructurer.NAME]
 
     def __init__(

--- a/angr/analyses/decompiler/optimization_passes/return_duplicator_low.py
+++ b/angr/analyses/decompiler/optimization_passes/return_duplicator_low.py
@@ -43,7 +43,7 @@ class ReturnDuplicatorLow(StructuringOptimizationPass, ReturnDuplicatorBase):
     ARCHES = None
     PLATFORMS = None
     NAME = "Duplicate returns connect with gotos (low)"
-    DESCRIPTION = inspect.cleandoc(__doc__[: __doc__.index("Args:")])  # pylint:disable=unsubscriptable-object
+    DESCRIPTION = inspect.cleandoc((__doc__ or "").split("Args:")[0])
 
     def __init__(
         self,

--- a/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/stack_canary_simplifier.py
@@ -25,7 +25,7 @@ class StackCanarySimplifier(OptimizationPass):
     PLATFORMS = ["cgc", "linux"]
     STAGE = OptimizationPassStage.AFTER_GLOBAL_SIMPLIFICATION
     NAME = "Simplify stack canaries"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/static_vvar_rewriter.py
+++ b/angr/analyses/decompiler/optimization_passes/static_vvar_rewriter.py
@@ -304,7 +304,7 @@ class StaticVVarRewriter(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.BEFORE_VARIABLE_RECOVERY
     NAME = "Static virtual variable rewriter"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(
         self,

--- a/angr/analyses/decompiler/optimization_passes/switch_default_case_duplicator.py
+++ b/angr/analyses/decompiler/optimization_passes/switch_default_case_duplicator.py
@@ -30,7 +30,7 @@ class SwitchDefaultCaseDuplicator(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_AIL_GRAPH_CREATION
     NAME = "Duplicate default-case nodes to undo default-case node reuse caused by compiler code deduplication"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/switch_reused_entry_rewriter.py
+++ b/angr/analyses/decompiler/optimization_passes/switch_reused_entry_rewriter.py
@@ -32,7 +32,7 @@ class SwitchReusedEntryRewriter(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_AIL_GRAPH_CREATION
     NAME = "Rewrite switch-case entry nodes with multiple predecessors into goto statements."
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, max_entry_reuse_count: int = 10, max_reused_entries: int = 20, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/tag_slicer.py
+++ b/angr/analyses/decompiler/optimization_passes/tag_slicer.py
@@ -19,7 +19,7 @@ class TagSlicer(OptimizationPass):
     PLATFORMS = None
     STAGE = OptimizationPassStage.AFTER_VARIABLE_RECOVERY
     NAME = "Remove unmarked statements from the graph."
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/win_stack_canary_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/win_stack_canary_simplifier.py
@@ -31,7 +31,7 @@ class WinStackCanarySimplifier(OptimizationPass):
     PLATFORMS = ["windows"]
     STAGE = OptimizationPassStage.AFTER_SINGLE_BLOCK_SIMPLIFICATION
     NAME = "Simplify stack canaries in Windows PE files"
-    DESCRIPTION = __doc__.strip()  # type: ignore
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/analyses/decompiler/optimization_passes/x86_gcc_getpc_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/x86_gcc_getpc_simplifier.py
@@ -19,7 +19,7 @@ class X86GccGetPcSimplifier(OptimizationPass):
     PLATFORMS = ["linux"]
     STAGE = OptimizationPassStage.BEFORE_SSA_LEVEL0_TRANSFORMATION
     NAME = "Simplify getpc()"
-    DESCRIPTION = __doc__.strip()
+    DESCRIPTION = (__doc__ or "").strip()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/angr/rust/optimization_passes/pre_pattern_match_simplifier.py
+++ b/angr/rust/optimization_passes/pre_pattern_match_simplifier.py
@@ -52,7 +52,7 @@ class PrePatternMatchSimplifier(OptimizationPass, ReturnDuplicatorBase, DFAMixin
     PLATFORMS = None
     STAGE = OptimizationPassStage.BEFORE_VARIABLE_RECOVERY
     NAME = "Duplicate return blocks to prepare for pattern match simplification"
-    DESCRIPTION = __doc__
+    DESCRIPTION = __doc__ or ""
     STRUCTURING = [SAILRStructurer.NAME, DreamStructurer.NAME]
 
     def __init__(


### PR DESCRIPTION
__doc__ is str | None to the type checker (and genuinely None under python -OO), so DESCRIPTION = __doc__.strip() is a latent crash and a pyright error against the str-typed base declaration.