### PR TITLE
Tracer: make the trace argument required

### DIFF
--- a/angr/exploration_techniques/tracer.py
+++ b/angr/exploration_techniques/tracer.py
@@ -161,7 +161,7 @@ class Tracer(ExplorationTechnique):
 
     def __init__(
         self,
-        trace=None,
+        trace: list[int],
         resiliency=False,
         keep_predecessors=1,
         crash_addr=None,


### PR DESCRIPTION
Tracer(trace=None) has never worked: __init__ unconditionally evaluates self._trace[-1] and .count() and dies on None. Require the argument and type it list[int]; the only None-reader (_no_follow) is never read anywhere.
