### PR TITLE
CFG analyses: remove Optional from always-assigned attributes

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -155,7 +155,7 @@ class CFGBase(Analysis):
 
         # Initialization
         self._edge_map = None
-        self._loop_back_edges = None
+        self._loop_back_edges = []
         self._overlapped_loop_headers = None
         self._thumb_addrs = set()
         self._tail_calls = set()

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -269,8 +269,10 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
         else:
             if isinstance(starts, (list, set)):
                 self._starts = tuple(starts)
-            elif isinstance(starts, tuple) or starts is None:
+            elif isinstance(starts, tuple):
                 self._starts = starts
+            elif starts is None:
+                self._starts = ((self.project.entry, None),)
             else:
                 raise AngrCFGError("Unsupported type of the `starts` argument.")
 
@@ -302,7 +304,6 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
         # more initialization
 
         self._symbolic_function_initial_state = {}
-        self._function_input_states = None
         self._unresolvable_runs = set()
 
         # Stores the index for each CFGNode in this CFG after a quasi-topological sort (currently a DFS)
@@ -404,11 +405,8 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
 
         self._should_abort = False
 
-        self._starts = starts
+        self._starts = starts if starts is not None else []
         self._max_steps = max_steps
-
-        if self._starts is None:
-            self._starts = []
 
         if self._starts:
             self._sanitize_starts()

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -885,7 +885,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
         self._remaining_eh_frame_addrs: list[int] | None = None
         self._remaining_function_prologue_addrs: list[int] | None = None
-        self._used_function_prologue_addrs: set[int] | None = None
+        self._used_function_prologue_addrs: set[int] = set()
         self._ptr_hints: SortedDict | None = None
         self._processed_eh_prolog3_callsites: set[int] = set()
         self._processed_cxx_frame_handler3_callsites: set[int] = set()
@@ -5554,7 +5554,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
 
             # also check the distance between `addr` and the closest function.
             # we don't want to have a basic block that spans across function boundaries
-            next_func_addr_adjustment = None
+            next_func_addr_adjustment = 0
             next_func_addr = self.functions.ceiling_addr(addr + 1)
             if next_func_addr is not None:
                 next_func_addr_adjustment = 0


### PR DESCRIPTION
CFGBase._loop_back_edges, CFGFast._used_function_prologue_addrs, CFGEmulated._function_input_states and CFGEmulated._starts are always given real containers before use; initialize them as such instead of None so their types are non-Optional.