### PR TITLE
peephole optimizations: require stmt_idx and block in statement optimize

### DIFF
--- a/angr/analyses/decompiler/peephole_optimizations/arm_cmpf.py
+++ b/angr/analyses/decompiler/peephole_optimizations/arm_cmpf.py
@@ -234,4 +234,4 @@ class ARMCmpF(PeepholeOptimizationExprBase):
 
             if cmpf_0 is not None and cmpf_1 is not None and cmpf_0 == cmpf_1:
                 return True, cmpf_0
-        return None
+        return False, None

--- a/angr/analyses/decompiler/peephole_optimizations/base.py
+++ b/angr/analyses/decompiler/peephole_optimizations/base.py
@@ -63,7 +63,7 @@ class PeepholeOptimizationStmtBase:
         self.type_hints = [] if type_hints is None else type_hints
         self.fixpoint_reached = False
 
-    def optimize(self, stmt, stmt_idx: int | None = None, block=None, **kwargs):
+    def optimize(self, stmt, stmt_idx: int, block: Block, **kwargs):
         raise NotImplementedError("_optimize() is not implemented.")
 
 

--- a/angr/analyses/decompiler/peephole_optimizations/cmpord_rewriter.py
+++ b/angr/analyses/decompiler/peephole_optimizations/cmpord_rewriter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from angr.ailment.block import Block
 from angr.ailment.expression import BinaryOp, Const
 from angr.ailment.statement import ConditionalJump
 
@@ -16,7 +17,7 @@ class CmpORDRewriter(PeepholeOptimizationStmtBase):
     NAME = "CmpORD rewriter"
     stmt_classes = (ConditionalJump,)
 
-    def optimize(self, stmt: ConditionalJump, stmt_idx: int | None = None, block=None, **kwargs):
+    def optimize(self, stmt: ConditionalJump, stmt_idx: int, block: Block, **kwargs):
         # example:
         # 05 | 0x4011d4 | if ((((gpr9<4> CmpORD 0x0<32>) & 0x2<32>) != 0x0<32>)) { Goto ... } else { Goto ... }
         # or

--- a/angr/analyses/decompiler/peephole_optimizations/coalesce_same_cascading_ifs.py
+++ b/angr/analyses/decompiler/peephole_optimizations/coalesce_same_cascading_ifs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from angr.ailment.block import Block
 from angr.ailment.expression import ITE
 from angr.ailment.statement import ConditionalJump
 
@@ -12,7 +13,7 @@ class CoalesceSameCascadingIfs(PeepholeOptimizationStmtBase):
     NAME = "Coalescing cascading If constructs"
     stmt_classes = (ConditionalJump,)
 
-    def optimize(self, stmt: ConditionalJump, stmt_idx: int | None = None, block=None, **kwargs):
+    def optimize(self, stmt: ConditionalJump, stmt_idx: int, block: Block, **kwargs):
         cond = stmt.condition
         true_target_in = stmt.true_target
 

--- a/angr/analyses/decompiler/peephole_optimizations/remove_empty_if_body.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_empty_if_body.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from angr.ailment.block import Block
 from angr.ailment.expression import ITE, UnaryOp
 from angr.ailment.statement import ConditionalJump
 
@@ -12,7 +13,7 @@ class RemoveEmptyIfBody(PeepholeOptimizationStmtBase):
     NAME = "Remove empty If bodies"
     stmt_classes = (ConditionalJump,)
 
-    def optimize(self, stmt: ConditionalJump, stmt_idx: int | None = None, block=None, **kwargs):
+    def optimize(self, stmt: ConditionalJump, stmt_idx: int, block: Block, **kwargs):
         cond_in = stmt.condition
         true_target_in = stmt.true_target
         false_target_in = stmt.false_target

--- a/angr/analyses/decompiler/peephole_optimizations/rol_ror.py
+++ b/angr/analyses/decompiler/peephole_optimizations/rol_ror.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from angr.ailment.block import Block
 from angr.ailment.expression import BinaryOp, Const, Tmp
 from angr.ailment.statement import Assignment
 
@@ -17,7 +18,7 @@ class RolRorRewriter(PeepholeOptimizationStmtBase):
     NAME = "ROL/ROR rewriter"
     stmt_classes = (Assignment,)
 
-    def optimize(self, stmt: Assignment, stmt_idx: int | None = None, block=None, **kwargs):
+    def optimize(self, stmt: Assignment, stmt_idx: int, block: Block, **kwargs):
         # Rol example:
         #    61 | t304 = Shr32(t301,0x19)
         #    62 | t306 = Shl32(t301,0x07)


### PR DESCRIPTION
The statement dispatch always passes stmt_idx and block, so the None defaults only forced every implementation to type them Optional; require them across the Stmt hierarchy. ARMCmpF._match_ix now returns None on failure instead of a (False, ...) flag tuple, matching its annotation.
