### PR TITLE
unicorn: seed Uniwrapper.id and _symbolic_offsets with real values

### DIFF
--- a/angr/state_plugins/unicorn_engine.py
+++ b/angr/state_plugins/unicorn_engine.py
@@ -308,7 +308,7 @@ class Uniwrapper:
         self.cache_key = cache_key
         self.wrapped_mapped = set()
         self.wrapped_hooks = set()
-        self.id = None
+        self.id = next(_unicounter)
         uc_mode = arch.uc_mode_thumb if thumb else arch.uc_mode
         self._uc = unicorn.Uc(arch.uc_arch, uc_mode)
 
@@ -657,7 +657,7 @@ class Unicorn(SimStatePlugin):
         self.steps = 0
         self._mapped = 0
         self._uncache_regions = []
-        self._symbolic_offsets = None
+        self._symbolic_offsets = set()
         self.gdt = None
 
         # following variables are used in python level hook


### PR DESCRIPTION
Uniwrapper.id is always overwritten with a counter value before any read, and _symbolic_offsets is reassigned to a set at the top of set_regs before every reader; initializing them with their real types instead of None lets the type checker see them as non-Optional with no behavior change.
