### PR TITLE
RuntimeDb: Create the directory RTDB_BASE names

### DIFF
--- a/angr/knowledge_plugins/rtdb/rtdb.py
+++ b/angr/knowledge_plugins/rtdb/rtdb.py
@@ -196,6 +196,13 @@ class RuntimeDb(KnowledgeBasePlugin):
 
         basedir = os.environ.get("RTDB_BASE")
         if basedir is not None:
+            try:
+                os.makedirs(basedir, exist_ok=True)
+            except OSError as ex:
+                l.error("The directory %s cannot be created: %s. Falling back.", basedir, ex)
+                basedir = None
+
+        if basedir is not None:
             if not os.access(basedir, os.W_OK):
                 l.error("The directory %s is not writable. Falling back.", basedir)
                 basedir = None

--- a/tests/knowledge_plugins/rtdb/test_rtdb_basedir.py
+++ b/tests/knowledge_plugins/rtdb/test_rtdb_basedir.py
@@ -35,6 +35,40 @@ class TestRuntimeDbBaseDir(unittest.TestCase):
             finally:
                 proj.kb.rtdb.cleanup()
 
+    def test_rtdb_base_that_does_not_exist_yet_is_created(self):
+        with tempfile.TemporaryDirectory() as bindir, tempfile.TemporaryDirectory() as parent:
+            binary = shutil.copy(os.path.join(test_location, "x86_64", "fauxware"), bindir)
+            basedir = os.path.join(parent, "rtdb", "bases")
+            with mock.patch.dict(os.environ, {"RTDB_BASE": basedir}):
+                proj = angr.Project(binary, auto_load_libs=False)
+                proj.kb.rtdb.open_db("testdb")
+                try:
+                    assert os.listdir(bindir) == ["fauxware"], (
+                        f"the directory holding the binary holds {os.listdir(bindir)}"
+                    )
+                    assert os.listdir(basedir) == ["fauxware_angr_rtdb"], (
+                        f"RTDB_BASE was set to {basedir}, which holds {os.listdir(basedir)}"
+                    )
+                finally:
+                    proj.kb.rtdb.cleanup()
+
+    def test_rtdb_base_that_cannot_be_created_falls_back(self):
+        with tempfile.TemporaryDirectory() as bindir, tempfile.TemporaryDirectory() as parent:
+            binary = shutil.copy(os.path.join(test_location, "x86_64", "fauxware"), bindir)
+            # a regular file at the path, so that creating the directory fails for every user
+            basedir = os.path.join(parent, "occupied")
+            with open(basedir, "w", encoding="utf-8"):
+                pass
+            with mock.patch.dict(os.environ, {"RTDB_BASE": basedir}):
+                proj = angr.Project(binary, auto_load_libs=False)
+                proj.kb.rtdb.open_db("testdb")
+                try:
+                    assert sorted(os.listdir(bindir)) == ["fauxware", "fauxware_angr_rtdb"], (
+                        f"the directory holding the binary holds {os.listdir(bindir)}"
+                    )
+                finally:
+                    proj.kb.rtdb.cleanup()
+
     def test_rtdb_defaults_to_the_directory_of_the_main_binary(self):
         with tempfile.TemporaryDirectory() as bindir, mock.patch.dict(os.environ):
             os.environ.pop("RTDB_BASE", None)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Pointing `RTDB_BASE` at a directory that has not been created yet is ignored. The run-time database is written beside the analysed binary, which is the outcome the variable exists to prevent, and the one diagnostic names the wrong cause:

```
ERROR | angr.knowledge_plugins.rtdb.rtdb | The directory /tmp/rtdb-base/does-not-exist is not writable. Falling back.
```

Loading `binaries/tests/x86_64/fauxware` from a copy in a temporary directory, with `RTDB_BASE` set to a path nothing has created, leaves `fauxware_angr_rtdb` in the directory holding the binary and leaves `RTDB_BASE` itself uncreated. A checkout of the fixtures repository in this workspace holds 299 stray `*_angr_rtdb` directories accumulated that way, written by workers that were exporting the variable faithfully, and the recurring conclusion was that it does not work.

### Root cause

`os.access` returns False for a path that does not exist, so `RuntimeDb._init_lmdb_attempt_multiple_locations` cannot tell a base that has not been made yet from one that may not be written:

```python
basedir = os.environ.get("RTDB_BASE")
if basedir is not None:
    if not os.access(basedir, os.W_OK):
        l.error("The directory %s is not writable. Falling back.", basedir)
        basedir = None
```

Both take the fallback, and both report the second cause.

### Fix

The value is passed to `os.makedirs` with `exist_ok=True` before it is tested. `RTDB_BASE` names where the caller wants databases written, and angr already creates a directory underneath it, since `lmdb.open` with `subdir=True` makes `RTDB_BASE/<binary>_angr_rtdb`, so creating the base is the same act one level up rather than a new kind of authority. A base that exists and still cannot be used keeps the existing fallback, because that is a hostile environment rather than a mistaken request, and it is the case the fallback chain added in #6004 was written for; the two now report different causes. Raising instead was considered and rejected, on the grounds that it honours the explicitness of the request rather than the request, and turns a misplaced cache into a failed analysis. The order of the candidate locations is unchanged.

### Testing

Two regressions load `binaries/tests/x86_64/fauxware` from a copy in a temporary directory. One points `RTDB_BASE` at a nested path that does not exist and asserts that the database lands there and nothing lands beside the binary; on the base revision it fails with the binary's directory holding `fauxware_angr_rtdb`. The other puts a regular file in the way of `RTDB_BASE` and pins the fallback. ~~This branch builds on #7008 and carries that change as its first commit.~~ #7008 merged on 2026-08-29; this branch has been rebased onto it and now carries only the `os.makedirs` change as a single commit.

Validation: https://github.com/angr/angr/pull/7022#issuecomment-5454919020

session: mega-corpus
