### PR TITLE
SimState: make the project argument required

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1543,7 +1543,7 @@ class SimCCSyscall(SimCC):
     def linux_syscall_update_error_reg(self, state, expr):
         # special handling for Linux syscalls: on some architectures (mips/a3, powerpc/cr0_0) a bool indicating success
         # or failure of a system call is used as an error flag (0 for success, 1 for error). we have to set this
-        if state.project is None or state.project.simos is None or state.project.simos.name != "Linux":
+        if state.project.simos is None or state.project.simos.name != "Linux":
             return expr
         if type(expr) is int:
             expr = claripy.BVV(expr, state.arch.bits)

--- a/angr/engines/icicle.py
+++ b/angr/engines/icicle.py
@@ -196,8 +196,6 @@ class IcicleEngine(SuccessorsEngine):
         icicle_arch = IcicleEngine._make_icicle_arch(state.arch)
         if icicle_arch is None:
             raise ValueError("Unsupported architecture")
-        if state.project is None:
-            raise ValueError("IcicleEngine requires a project to be set")
 
         emu = Icicle(icicle_arch, PROCESSORS_DIR, True, True)
         translation_data = IcicleEngine._sync_state_to_emu(emu, state, None, icicle_arch)

--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -93,7 +93,7 @@ class SimSuccessors:
                     addendum = f".{idx}"
         else:
             return f"<{self.description} from {self.addr}: {result}>"
-        if self.initial_state is not None and self.initial_state.project is not None:
+        if self.initial_state is not None:
             whatsup = self.initial_state.project.loader.describe_addr(int_addr)
             hex_addr = hex(int_addr)
             if hex_addr in whatsup:
@@ -563,7 +563,6 @@ class SuccessorsEngine(SimEngine[HeavyState, SimSuccessors]):
         except SimException as e:
             if o.EXCEPTION_HANDLING not in old_state.options:
                 raise
-            assert old_state.project is not None
             old_state.project.simos.handle_exception(self.successors, self, e)
 
         new_state._inspect("engine_process", when=BP_AFTER, sim_successors=self.successors, address=addr)

--- a/angr/procedures/glibc/__libc_start_main.py
+++ b/angr/procedures/glibc/__libc_start_main.py
@@ -185,6 +185,8 @@ class __libc_start_main(angr.SimProcedure):
         self.exit(0)
 
     def static_exits(self, blocks, cfg=None, **kwargs):
+        # the caller (CFG recovery) sets self.project before calling this method
+        assert self.project is not None
         # Execute those blocks with a blank state, and then dump the arguments
         blank_state = angr.SimState(
             project=self.project,

--- a/angr/procedures/libc/error.py
+++ b/angr/procedures/libc/error.py
@@ -18,6 +18,8 @@ class error(angr.SimProcedure):
             self.exit(status)
 
     def dynamic_returns(self, blocks, **kwargs) -> bool | None:
+        # the caller (CFG recovery) sets self.project before calling this method
+        assert self.project is not None
         # Execute those blocks with a blank state, and then dump the arguments
         blank_state = angr.SimState(
             project=self.project,

--- a/angr/procedures/posix/pthread.py
+++ b/angr/procedures/posix/pthread.py
@@ -21,6 +21,8 @@ class pthread_create(angr.SimProcedure):
         self.exit(0)
 
     def static_exits(self, blocks, **kwargs):
+        # the caller (CFG recovery) sets self.project before calling this method
+        assert self.project is not None
         # Execute those blocks with a blank state, and then dump the arguments
         blank_state = angr.SimState(project=self.project, mode="fastpath", cle_memory_backer=self.project.loader.memory)
 

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -95,7 +95,7 @@ class SimState[IPTypeConc, IPTypeSym](PluginHub[SimStatePlugin]):
 
     def __init__(
         self,
-        project: Project | None = None,
+        project: Project,
         arch: Arch | None = None,
         plugins: dict[str, SimStatePlugin] | None = None,
         mode: str | None = None,
@@ -122,11 +122,11 @@ class SimState[IPTypeConc, IPTypeSym](PluginHub[SimStatePlugin]):
         self._addr: IPTypeConc | None = None
 
         # Java & Java JNI
-        self._is_java_project = self.project and self.project.is_java_project
-        self._is_java_jni_project = self.project and self.project.is_java_jni_project
+        self._is_java_project = self.project.is_java_project
+        self._is_java_jni_project = self.project.is_java_jni_project
 
         # Arch
-        if self._is_java_jni_project and project is not None:
+        if self._is_java_jni_project:
             if TYPE_CHECKING:
                 assert isinstance(project.simos, SimJavaVM)
             self._arch = {"soot": project.arch, "vex": project.simos.native_simos.arch}
@@ -137,7 +137,7 @@ class SimState[IPTypeConc, IPTypeSym](PluginHub[SimStatePlugin]):
             #       plugins that are getting toggled (=> mutual dependence).
             self.ip_is_soot_addr = False
         else:
-            self._arch = arch if arch is not None else project.arch if project is not None else None
+            self._arch = arch if arch is not None else project.arch
             if type(self._arch) is str:
                 self._arch = archinfo.arch_from_id(self._arch)
 

--- a/angr/state_plugins/view.py
+++ b/angr/state_plugins/view.py
@@ -74,8 +74,7 @@ class SimRegNameView(SimStatePlugin):
         # This flag will then toggle between the native and the java view of the
         # state.
         if (
-            self.state.project
-            and isinstance(self.state.project.arch, ArchSoot)
+            isinstance(self.state.project.arch, ArchSoot)
             and k == "ip"
             and self.state.project.simos.is_javavm_with_jni_support
         ):

--- a/angr/storage/memory_mixins/default_filler_mixin.py
+++ b/angr/storage/memory_mixins/default_filler_mixin.py
@@ -16,7 +16,7 @@ class DefaultFillerMixin(MemoryMixin):
     def _default_value(
         self, addr, size, *, name=None, inspect=True, events=True, key=None, fill_missing: bool = True, **kwargs
     ):
-        if self.state.project and self.state.project.concrete_target:
+        if self.state.project.concrete_target:
             mem = self.state.project.concrete_target.read_memory(addr, size)
             endness = kwargs["endness"]
             bvv = claripy.BVV(mem)
@@ -71,10 +71,7 @@ class DefaultFillerMixin(MemoryMixin):
 
             if is_mem:
                 refplace_int = self.state.solver.eval(self.state._ip)
-                if self.state.project:
-                    refplace_str = self.state.project.loader.describe_addr(refplace_int)
-                else:
-                    refplace_str = "unknown"
+                refplace_str = self.state.project.loader.describe_addr(refplace_int)
                 l.warning(
                     "Filling memory at %#x with %d unconstrained bytes referenced from %#x (%s)",
                     addr,
@@ -88,10 +85,7 @@ class DefaultFillerMixin(MemoryMixin):
                     refplace_str = "symbolic"
                 else:
                     refplace_int = self.state.solver.eval(self.state._ip)
-                    if self.state.project:
-                        refplace_str = self.state.project.loader.describe_addr(refplace_int)
-                    else:
-                        refplace_str = "unknown"
+                    refplace_str = self.state.project.loader.describe_addr(refplace_int)
                 reg_str = self.state.arch.translate_register_name(addr, size=size)
                 l.warning(
                     "Filling register %s with %d unconstrained bytes referenced from %#x (%s)",

--- a/docs/extending-angr/state_plugins.rst
+++ b/docs/extending-angr/state_plugins.rst
@@ -37,7 +37,8 @@ initializer!
    ...     def copy(self, memo):
    ...         return MyFirstPlugin(self.foo)
 
-   >>> state = angr.SimState(arch='AMD64')
+   >>> project = angr.load_shellcode(b'\x90', 'AMD64')
+   >>> state = angr.SimState(project=project)
    >>> state.register_plugin('my_plugin', MyFirstPlugin('bar'))
    >>> assert state.my_plugin.foo == 'bar'
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -42,6 +42,16 @@ if not os.path.isdir(bin_location) and not os.getenv("CI", "") == "true":
     )
 
 
+def minimal_project(arch="AMD64", **kwargs) -> Project:
+    """
+    Build a tiny single-nop shellcode Project for the given architecture (an ``archinfo.Arch`` or an arch name).
+
+    ``SimState`` requires a project; tests that construct states directly can use this instead of loading a real
+    binary. Nothing is backed into the state's memory unless ``cle_memory_backer`` is passed to ``SimState``.
+    """
+    return load_shellcode(b"\x90", arch, **kwargs)
+
+
 def broken(func):
     return skip(reason="Broken test method")(func)
 

--- a/tests/engines/pcode/test_emulate.py
+++ b/tests/engines/pcode/test_emulate.py
@@ -13,6 +13,7 @@ from angr.engines import SimSuccessors
 from angr.engines.pcode.behavior import BehaviorFactory
 from angr.engines.pcode.emulate import PcodeEmulatorMixin
 from angr.sim_state import SimState
+from tests.common import minimal_project
 
 log = logging.getLogger(__name__)
 
@@ -92,7 +93,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         emulator = PcodeEmulatorMixin(angr.load_shellcode(b"\x90", arch="AMD64"))
 
         if state is None:
-            state = SimState(arch=emulator.project.arch)
+            state = SimState(project=emulator.project)
         emulator.state = state
         emulator.state.history.recent_bbl_addrs.append(0)
         emulator.successors = SimSuccessors(0, emulator.state)
@@ -134,7 +135,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         target_pointer_addr = 0x100000
         target_pointer_size = 8
 
-        state = SimState(arch="AMD64")
+        state = SimState(project=minimal_project("AMD64"))
         state.memory.store(target_pointer_addr, claripy.BVV(target_addr, 8 * target_pointer_size), endness="IEnd_LE")
 
         successors = self._step_irsb(
@@ -170,7 +171,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         target_addr = 0x12345678
         fallthru_addr = 1
 
-        state = SimState(arch="AMD64")
+        state = SimState(project=minimal_project("AMD64"))
         state.memory.store(condition_addr, cond)
 
         successors = self._step_irsb(
@@ -228,7 +229,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         fallthru_addr = start_addr + instruction_len
         cbranch_idx = 2
 
-        state = SimState(arch="AMD64")
+        state = SimState(project=minimal_project("AMD64"))
         state.memory.store(condition_addr, cond)
 
         successors = self._step_irsb(
@@ -296,7 +297,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         addr = 0x133700000
         addr2 = 0x999900000
         value = claripy.BVV(0xFEDCBA9876543210, 64)
-        state = SimState(arch="AMD64")
+        state = SimState(project=minimal_project("AMD64"))
         state.memory.store(addr, value)
         state.regs.rax = addr
 
@@ -389,7 +390,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         x_addr, x = 0, claripy.BVS("x", operand_size * 8)
         y_addr, y = operand_size, claripy.BVS("y", operand_size * 8)
 
-        state = SimState(arch="AMD64", remove_options={"SIMPLIFY_MEMORY_WRITES"})
+        state = SimState(project=minimal_project("AMD64"), remove_options={"SIMPLIFY_MEMORY_WRITES"})
         state.memory.store(x_addr, x, endness="Iend_LE")
         state.memory.store(y_addr, y, endness="Iend_LE")
 
@@ -472,7 +473,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
 
         x_addr, x = 0, claripy.BVS("x", operand_size * 8)
 
-        state = SimState(arch="AMD64", remove_options={"SIMPLIFY_MEMORY_WRITES"})
+        state = SimState(project=minimal_project("AMD64"), remove_options={"SIMPLIFY_MEMORY_WRITES"})
         state.memory.store(x_addr, x, endness="Iend_LE")
 
         successors = self._step_irsb(
@@ -517,7 +518,7 @@ class TestPcodeEmulatorMixin(unittest.TestCase):
         result_addr = 0x100000
         result_size = expected_value.size() // 8
 
-        state = SimState(arch="AMD64", remove_options={"SIMPLIFY_MEMORY_WRITES"})
+        state = SimState(project=minimal_project("AMD64"), remove_options={"SIMPLIFY_MEMORY_WRITES"})
         state.memory.store(operand_addr, input_value, endness="Iend_LE")
         state.memory.store(result_addr, claripy.BVV(b"\xca" * result_size), endness="Iend_LE")
 

--- a/tests/engines/vex/test_vex.py
+++ b/tests/engines/vex/test_vex.py
@@ -11,6 +11,7 @@ import pyvex
 import angr.engines.vex.claripy.ccall as s_ccall
 from angr import SimState, load_shellcode
 from angr.engines import HeavyVEXMixin
+from tests.common import minimal_project
 
 l = logging.getLogger(__name__)
 
@@ -209,7 +210,7 @@ class TestVex(unittest.TestCase):
 
     def test_aarch64_32bit_ccalls(self):
         # GitHub issue #1238
-        s = SimState(arch="AArch64")
+        s = SimState(project=minimal_project("AArch64"))
 
         x = claripy.BVS("x", 32)
         # A normal operation

--- a/tests/procedures/libc/test_string.py
+++ b/tests/procedures/libc/test_string.py
@@ -13,13 +13,13 @@ import claripy
 
 import angr
 from angr import SIM_LIBRARIES, SimState
-from tests.common import broken
+from tests.common import broken, minimal_project
 
 log = logging.getLogger("angr.tests.string")
 
 
 def make_state_with_stdin(content):
-    s = SimState(arch="AMD64", mode="symbolic")
+    s = SimState(project=minimal_project("AMD64"), mode="symbolic")
     stdin_storage = angr.storage.file.SimFile("stdin", content=content)
     stdin = angr.storage.file.SimFileDescriptor(stdin_storage)
     s.register_plugin("posix", angr.state_plugins.SimSystemPosix(stdin=stdin_storage, fd={0: stdin}))
@@ -53,7 +53,7 @@ wcscmp = make_func("wcscmp")
 
 class TestStringSimProcedures(unittest.TestCase):
     def test_strlen(self):
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         log.info("fully concrete string")
         a_str = claripy.BVV(0x41414100, 32)
@@ -86,7 +86,7 @@ class TestStringSimProcedures(unittest.TestCase):
         # This tests if a strlen can influence a symbolic str.
         #
         log.info("Trying to influence length.")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_c = claripy.BVS("some_string", 8 * 16)
         c_addr = claripy.BVV(0x10, 64)
         s.memory.store(c_addr, str_c, endness="Iend_BE")
@@ -109,7 +109,7 @@ class TestStringSimProcedures(unittest.TestCase):
                 assert not test_s.solver.unique(test_s.memory.load(c_addr + j, 1))
 
     def test_strcmp(self):
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_a = claripy.BVV(0x41414100, 32)
         str_b = claripy.BVS("mystring", 32)
 
@@ -143,7 +143,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert not s_nomatch.solver.unique(str_b)
 
         log.info("concrete a, symbolic b")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_a = claripy.BVV(0x41424300, 32)
         str_b = claripy.BVS("mystring", 32)
         a_addr = claripy.BVV(0x10, 64)
@@ -166,7 +166,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert not s_nomatch.solver.solution(str_b, 0x41424300)
 
         log.info("symbolic a, symbolic b")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         a_addr = claripy.BVV(0x10, 64)
         b_addr = claripy.BVV(0xB0, 64)
 
@@ -187,7 +187,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strncmp(self):
         log.info("symbolic left, symbolic right, symbolic len")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         left = claripy.BVS("left", 32)
         left_addr = claripy.BVV(0x1000, 64)
         right = claripy.BVS("right", 32)
@@ -214,7 +214,7 @@ class TestStringSimProcedures(unittest.TestCase):
         # assert s_nomatch.solver.max_int(maxlen) == 2
 
         log.info("zero-length")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         left = claripy.BVS("left", 32)
         left_addr = claripy.BVV(0x1000, 64)
         right = claripy.BVS("right", 32)
@@ -232,7 +232,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strncmp_longer_limit(self):
         log.info("concrete a, concrete b, concrete n")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_a = claripy.BVV(b"ABC\0")
         str_b = claripy.BVV(b"AB\0")
         addr_a = claripy.BVV(0x10, 64)
@@ -246,7 +246,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strncmp_find_limits(self):
         log.info("concrete a, concrete b, symbolic n")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_a = claripy.BVV(b"ABCD\0")
         str_b = claripy.BVV(b"ABCE\0")
         addr_a = claripy.BVV(0x10, 64)
@@ -261,7 +261,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strncmp_find_prefix(self):
         log.info("concrete a, symbolic b, symbolic n")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_a = claripy.BVV(b"ABCD\0")
         str_b = claripy.BVS("str_b", len(str_a))
         addr_a = claripy.BVV(0x10, 64)
@@ -277,7 +277,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strncmp_find_prefix_unsat(self):
         log.info("concrete a, concrete b, symbolic n")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_a = claripy.BVV(b"\0\0\0\0\0")
         str_b = claripy.BVV(b"ABCE\0")
         addr_a = claripy.BVV(0x10, 64)
@@ -293,7 +293,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strncmp_find_input_for_limit(self):
         log.info("concrete a, symbolic b, symbolic n")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_a = claripy.BVV(b"ABCD\0")
         str_b = claripy.BVS("str_b", len(str_a))
         addr_a = claripy.BVV(0x10, 64)
@@ -316,7 +316,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strstr_conc_haystack_conc_needle(self):
         log.info("concrete haystack and needle")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_haystack = claripy.BVV(0x41424300, 32)
         str_needle = claripy.BVV(0x42430000, 32)
         addr_haystack = claripy.BVV(0x10, 64)
@@ -330,7 +330,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strstr_conc_haystack_sym_needle(self):
         log.info("concrete haystack, symbolic needle")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.libc.max_symbolic_strstr = 20
         haystack = b"ABCD"
         str_haystack = claripy.BVV(haystack + b"\0")
@@ -363,7 +363,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strstr_sym_haystack_conc_needle(self):
         log.info("symbolic haystack, concrete needle")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.libc.max_symbolic_strstr = 20
         str_haystack = claripy.BVS("haystack", 5 * 8).concat(claripy.BVV(0, 8))
         str_needle = claripy.BVV(b"ABC\0")
@@ -392,7 +392,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strstr_sym_haystack_sym_needle(self):
         log.info("symbolic haystack, symbolic needle")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.libc.max_symbolic_strstr = 20
         s.libc.buf_symbolic_bytes = 10
         str_haystack = claripy.BVS("haystack", s.libc.buf_symbolic_bytes * 8)
@@ -440,7 +440,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strstr_inconsistency(self):
         log.info("symbolic haystack, symbolic needle")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.libc.buf_symbolic_bytes = 2
         addr_haystack = claripy.BVV(0x10, 64)
         addr_needle = claripy.BVV(0xB0, 64)
@@ -464,7 +464,7 @@ class TestStringSimProcedures(unittest.TestCase):
     def test_memcpy(self):
         log.info("concrete src, concrete dst, concrete len")
         log.debug("... full copy")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414141, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVV(0x42424242, 32)
@@ -477,7 +477,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval_upto(new_dst, 2, cast_to=bytes) == [b"BBBB"]
 
         log.info("giant copy")
-        s = SimState(arch="AMD64", mode="symbolic", remove_options=angr.options.simplification)
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic", remove_options=angr.options.simplification)
         s.memory._maximum_symbolic_size = 0x2000000
         size = claripy.BVV(0x1000000, 64)
         data = claripy.BVS("giant", 8 * 0x1_000_000)
@@ -489,7 +489,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.memory.load(dst_addr, size) is s.memory.load(src_addr, size)
 
         log.debug("... partial copy")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.memory.store(dst_addr, dst)
         s.memory.store(src_addr, src)
         memcpy(s, arguments=[dst_addr, src_addr, claripy.BVV(2, 64)])
@@ -497,7 +497,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval_upto(new_dst, 2, cast_to=bytes) == [b"BBAA"]
 
         log.info("symbolic src, concrete dst, concrete len")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414141, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVS("src", 32)
@@ -513,7 +513,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert not s.satisfiable()
 
         log.info("symbolic src, concrete dst, symbolic len")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414141, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVS("src", 32)
@@ -544,7 +544,7 @@ class TestStringSimProcedures(unittest.TestCase):
         src = claripy.BVV(0x42424242, 32)
         src_addr = claripy.BVV(0x2000, 64)
 
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.memory.store(dst_addr, dst)
         s.memory.store(src_addr, src)
         cpylen = claripy.BVS("len", 64)
@@ -558,7 +558,7 @@ class TestStringSimProcedures(unittest.TestCase):
         log.info("concrete src, concrete dst, concrete len")
 
         log.debug("... full cmp")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414141, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVV(0x42424242, 32)
@@ -577,14 +577,14 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s_neg.satisfiable()
 
         log.debug("... zero cmp")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.memory.store(dst_addr, dst)
         s.memory.store(src_addr, src)
         r = memcmp(s, arguments=[dst_addr, src_addr, claripy.BVV(0, 64)])
         assert s.solver.eval_upto(r, 2) == [0]
 
         log.info("symbolic src, concrete dst, concrete len")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414141, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVS("src", 32)
@@ -608,7 +608,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert not s_nomatch.solver.solution(m, 0x41414141)
 
         log.info("symbolic src, concrete dst, symbolic len")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414141, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVS("src", 32)
@@ -644,7 +644,7 @@ class TestStringSimProcedures(unittest.TestCase):
     def test_strncpy(self):
         log.info("concrete src, concrete dst, concrete len")
         log.debug("... full copy")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414100, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVV(0x42420000, 32)
@@ -657,7 +657,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval(new_dst, cast_to=bytes) == b"BB\x00\x00"
 
         log.debug("... partial copy")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.memory.store(dst_addr, dst)
         s.memory.store(src_addr, src)
         strncpy(s, arguments=[dst_addr, src_addr, claripy.BVV(2, 64)])
@@ -665,7 +665,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval_upto(new_dst, 2, cast_to=bytes) == [b"BBA\x00"]
 
         log.info("symbolic src, concrete dst, concrete len")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414100, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVS("src", 32)
@@ -689,7 +689,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval_upto(c, 10) == [0]
 
         log.info("symbolic src, concrete dst, symbolic len")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414100, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVS("src", 32)
@@ -714,7 +714,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
         log.info("concrete src, concrete dst, symbolic len")
         log.debug("... full copy")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         dst = claripy.BVV(0x41414100, 32)
         dst_addr = claripy.BVV(0x1000, 64)
@@ -733,7 +733,7 @@ class TestStringSimProcedures(unittest.TestCase):
         log.info("concrete src, concrete dst")
 
         log.debug("... full copy")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         dst = claripy.BVV(0x41414100, 32)
         dst_addr = claripy.BVV(0x1000, 64)
         src = claripy.BVV(0x42420000, 32)
@@ -750,7 +750,7 @@ class TestStringSimProcedures(unittest.TestCase):
         src = claripy.BVS("src", 32)
         src_addr = claripy.BVV(0x2000, 64)
 
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.memory.store(dst_addr, dst)
         s.memory.store(src_addr, src)
 
@@ -780,7 +780,7 @@ class TestStringSimProcedures(unittest.TestCase):
     @broken
     def test_sprintf(self):
         log.info("concrete src, concrete dst, concrete len")
-        s = SimState(mode="symbolic", arch="PPC32")
+        s = SimState(mode="symbolic", project=minimal_project("PPC32"))
         format_str = claripy.BVV(0x25640000, 32)
         format_addr = claripy.BVV(0x2000, 32)
         # dst = claripy.BVV("destination", 128)
@@ -805,7 +805,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_memset(self):
         log.info("concrete src, concrete dst, concrete len")
-        s = SimState(arch="PPC32", mode="symbolic")
+        s = SimState(project=minimal_project("PPC32"), mode="symbolic")
         dst = claripy.BVV(0, 128)
         dst_addr = claripy.BVV(0x1000, 32)
         char = claripy.BVV(0x00000041, 32)
@@ -817,7 +817,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval(s.memory.load(dst_addr, 4)) == 0x41414100
 
         log.debug("Symbolic length")
-        s = SimState(arch="PPC32", mode="symbolic")
+        s = SimState(project=minimal_project("PPC32"), mode="symbolic")
         s.memory.store(dst_addr, dst)
         length = claripy.BVS("some_length", 32)
         s.add_constraints(length < 10)
@@ -840,7 +840,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strchr(self):
         log.info("concrete haystack and needle")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_haystack = claripy.BVV(0x41424300, 32)
         str_needle = claripy.BVV(0x42, 64)
         addr_haystack = claripy.BVV(0x10, 64)
@@ -851,7 +851,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval(ss_res) == 0x11
 
         log.info("concrete haystack, symbolic needle")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_haystack = claripy.BVV(0x41424300, 32)
         str_needle = claripy.BVS("wtf", 64)
         chr_needle = str_needle[7:0]
@@ -881,7 +881,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert sorted(s_match.solver.eval_upto(s_match.memory.load(0x13, 1), 300)) == [0x00, 0x44]
 
         # l.info("symbolic haystack, symbolic needle")
-        # s = SimState(arch="AMD64", mode="symbolic")
+        # s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         # s.libc.buf_symbolic_bytes = 5
         # addr_haystack = claripy.BVV(0x10, 64)
         # addr_needle = claripy.BVV(0xb0, 64)
@@ -915,7 +915,7 @@ class TestStringSimProcedures(unittest.TestCase):
     @broken
     def test_strtok_r(self):
         log.debug("CONCRETE MODE")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.memory.store(100, claripy.BVV(0x4141414241414241424300, 88), endness="Iend_BE")
         s.memory.store(200, claripy.BVV(0x4200, 16), endness="Iend_BE")
         str_ptr = claripy.BVV(100, s.arch.bits)
@@ -970,7 +970,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval_upto(st5, 10) == [0]
         assert s.solver.eval_upto(s.memory.load(3000, s.arch.bytes, endness=s.arch.memory_endness), 10) == [1009]
 
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_ptr = claripy.BVV(100, s.arch.bits)
         delim_ptr = claripy.BVV(200, s.arch.bits)
         state_ptr = claripy.BVV(300, s.arch.bits)
@@ -1034,7 +1034,7 @@ class TestStringSimProcedures(unittest.TestCase):
 
     def test_strcmp_concrete(self):
         log.info("concrete a, concrete b")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         a_addr = claripy.BVV(0x10, 64)
         b_addr = claripy.BVV(0xB0, 64)
 
@@ -1045,7 +1045,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval_upto(r, 2) == [0]
 
         log.info("concrete a, empty b")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         a_addr = claripy.BVV(0x10, 64)
         b_addr = claripy.BVV(0xB0, 64)
 
@@ -1056,7 +1056,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval_upto(r, 2) == [1]
 
         log.info("empty a, concrete b")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         a_addr = claripy.BVV(0x10, 64)
         b_addr = claripy.BVV(0xB0, 64)
 
@@ -1067,7 +1067,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert s.solver.eval_upto(r, 2) == [0xFFFFFFFF]
 
         log.info("empty a, empty b")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         a_addr = claripy.BVV(0x10, 64)
         b_addr = claripy.BVV(0xB0, 64)
 
@@ -1080,7 +1080,7 @@ class TestStringSimProcedures(unittest.TestCase):
     def test_wcscmp(self):
         # concrete cases for the wide char version sufficiently overlap with strcmp and friends
         log.info("concrete a, symbolic b")
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         heck = "heck\x00".encode("utf-16")[2:]  # remove encoding prefix
         a_addr = claripy.BVV(0x10, 64)
         b_addr = claripy.BVV(0xB0, 64)
@@ -1095,7 +1095,7 @@ class TestStringSimProcedures(unittest.TestCase):
         assert solutions == [heck]
 
     def test_string_without_null(self):
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         str_ = b"abcd"
         str_addr = claripy.BVV(0x10, 64)
         s.memory.store(str_addr, str_)

--- a/tests/procedures/linux_kernel/test_lseek.py
+++ b/tests/procedures/linux_kernel/test_lseek.py
@@ -6,6 +6,7 @@ import unittest
 import claripy
 
 from angr import SIM_PROCEDURES, SimFile, SimPosixError, SimState
+from tests.common import minimal_project
 
 FAKE_ADDR = 0x100000
 
@@ -25,7 +26,7 @@ SEEK_HOLE = 4  # Seek to next hole.
 
 class TestLseek(unittest.TestCase):
     def test_lseek_set(self):
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         # This could be any number above 2 really
         fd = 3
@@ -62,7 +63,7 @@ class TestLseek(unittest.TestCase):
         assert current_pos == 3
 
     def test_lseek_cur(self):
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         # This could be any number above 2 really
         fd = 3
@@ -90,7 +91,7 @@ class TestLseek(unittest.TestCase):
         assert current_pos == 9
 
     def test_lseek_end(self):
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         fd = 3
 
@@ -117,7 +118,7 @@ class TestLseek(unittest.TestCase):
         assert current_pos == 10
 
     def test_lseek_unseekable(self):
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         # Illegal seek
         current_pos = lseek(state, [0, 0, SEEK_SET]).ret_expr
@@ -143,7 +144,7 @@ class TestLseek(unittest.TestCase):
     def test_lseek_symbolic_whence(self):
         with self.assertRaises(SimPosixError):
             # symbolic whence is currently not possible
-            state = SimState(arch="AMD64", mode="symbolic")
+            state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
             # This could be any number above 2 really
             fd = 3
@@ -158,7 +159,7 @@ class TestLseek(unittest.TestCase):
 
     def test_lseek_symbolic_seek(self):
         # symbolic seek is currently not possible
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         # This could be any number above 2 really
         fd = 3

--- a/tests/procedures/posix/test_pwrite_pread.py
+++ b/tests/procedures/posix/test_pwrite_pread.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import unittest
 
 from angr import SIM_PROCEDURES, SimFile, SimState
+from tests.common import minimal_project
 
 
 class TestPwrite(unittest.TestCase):
     def test_pwrite(self):
         pwrite = SIM_PROCEDURES["posix"]["pwrite64"]()
 
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
         simfile = SimFile("concrete_file", content="hello world!\n")
         state.fs.insert("test", simfile)
         fd = state.posix.open(b"test", 1)
@@ -35,7 +36,7 @@ class TestPread(unittest.TestCase):
     def test_pread(self):
         pwrite = SIM_PROCEDURES["posix"]["pread64"]()
 
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
         simfile = SimFile("concrete_file", content="hello world!\n")
         state.fs.insert("test", simfile)
         fd = state.posix.open(b"test", 1)

--- a/tests/procedures/posix/test_sim_time.py
+++ b/tests/procedures/posix/test_sim_time.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import unittest
 
 import angr
+from tests.common import minimal_project
 
 
 class TestSimTime(unittest.TestCase):
     def test_gettimeofday(self):
         proc = angr.SIM_PROCEDURES["posix"]["gettimeofday"]()
 
-        s = angr.SimState(arch="amd64")
+        s = angr.SimState(project=minimal_project("amd64"))
         s.regs.rdi = 0x8000
         s.regs.rsi = 0
 
@@ -28,7 +29,7 @@ class TestSimTime(unittest.TestCase):
     def test_clock_gettime(self):
         proc = angr.SIM_PROCEDURES["posix"]["clock_gettime"]()
 
-        s = angr.SimState(arch="amd64")
+        s = angr.SimState(project=minimal_project("amd64"))
         s.regs.rdi = 0
         s.regs.rsi = 0x8000
 

--- a/tests/procedures/posix/test_unlink.py
+++ b/tests/procedures/posix/test_unlink.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import unittest
 
 import angr
+from tests.common import minimal_project
 
 
 class TestUnlink(unittest.TestCase):
     def test_file_unlink(self):
         # Initialize a blank state with an arbitrary errno location
-        state = angr.SimState(arch="AMD64", mode="symbolic")
+        state = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
         state.libc.errno_location = 0xA0000000
         state.libc.errno = 0
 

--- a/tests/sim/test_stack_alignment.py
+++ b/tests/sim/test_stack_alignment.py
@@ -13,7 +13,7 @@ from archinfo import ArchAMD64, ArchSoot, all_arches
 from angr import Project, SimState
 from angr import sim_options as o
 from angr.calling_conventions import DEFAULT_CC, SimCCUnknown, default_cc
-from tests.common import bin_location
+from tests.common import bin_location, minimal_project
 
 test_location = os.path.join(bin_location, "tests")
 
@@ -28,7 +28,7 @@ class TestStackAlignment(unittest.TestCase):
                 if isinstance(arch, ArchSoot):
                     continue
                 log.info("Testing stack alignment for %s", arch.name)
-                st = SimState(arch=arch)
+                st = SimState(project=minimal_project(arch))
                 cc = default_cc(arch.name, platform="Linux")(arch=arch)
 
                 st.regs.sp = -1
@@ -43,7 +43,7 @@ class TestStackAlignment(unittest.TestCase):
 
     def test_sys_v_abi_compliance(self):
         arch = ArchAMD64()
-        st = SimState(arch=arch)
+        st = SimState(project=minimal_project(arch))
         cc = default_cc(arch.name, platform="Linux")(arch=arch)
 
         st.regs.sp = -1

--- a/tests/sim/test_state.py
+++ b/tests/sim/test_state.py
@@ -13,14 +13,14 @@ import cle
 
 import angr
 from angr import SimState
-from tests.common import bin_location
+from tests.common import bin_location, minimal_project
 
 test_location = os.path.join(bin_location, "tests")
 
 
 class TestState(unittest.TestCase):
     def test_state(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         s.registers.store("sp", 0x7FFFFFFFFFF0000)
         assert s.solver.eval(s.registers.load("sp")) == 0x7FFFFFFFFFF0000
 
@@ -38,7 +38,7 @@ class TestState(unittest.TestCase):
         assert s.solver.eval(b, cast_to=bytes) == b"ABCDEFGH"
 
     def test_state_merge(self):
-        a = SimState(arch="AMD64", mode="symbolic")
+        a = SimState(project=minimal_project("AMD64"), mode="symbolic")
         a.memory.store(1, claripy.BVV(42, 8))
 
         b = a.copy()
@@ -96,7 +96,7 @@ class TestState(unittest.TestCase):
         assert a_c.solver.eval(a_c.memory.load(2, 1)) == 21
 
         # test different sets of plugins
-        a = SimState(arch="AMD64", mode="symbolic")
+        a = SimState(project=minimal_project("AMD64"), mode="symbolic")
         assert a.has_plugin("memory")
         assert a.has_plugin("registers")
         assert not a.has_plugin("libc")
@@ -111,7 +111,7 @@ class TestState(unittest.TestCase):
         assert d.has_plugin("libc")
 
         # test merging posix with different open files (illegal!)
-        a = SimState(arch="AMD64", mode="symbolic")
+        a = SimState(project=minimal_project("AMD64"), mode="symbolic")
         b = a.copy()
         a.posix.open(b"/tmp/idk", 1)
         self.assertRaises(angr.errors.SimMergeError, lambda: a.copy().merge(b.copy()))
@@ -119,7 +119,7 @@ class TestState(unittest.TestCase):
     def test_state_merge_static(self):
         # With abstract memory
         # Aligned memory merging
-        a = SimState(arch="AMD64", mode="static")
+        a = SimState(project=minimal_project("AMD64"), mode="static")
 
         addr = claripy.VS(32, "global", 0, 8)
         a.memory.store(addr, claripy.BVV(42, 32))
@@ -138,7 +138,7 @@ class TestState(unittest.TestCase):
         assert actual.identical(expected)
 
     def test_state_merge_3way(self):
-        a = SimState(arch="AMD64", mode="symbolic")
+        a = SimState(project=minimal_project("AMD64"), mode="symbolic")
         b = a.copy()
         c = a.copy()
         conds = [claripy.BoolS("cond_0"), claripy.BoolS("cond_1")]
@@ -159,7 +159,7 @@ class TestState(unittest.TestCase):
 
     def test_state_merge_with_merge_conditions(self):
         x = claripy.BVS("x", 32)
-        a = SimState(arch="AMD64", mode="symbolic")
+        a = SimState(project=minimal_project("AMD64"), mode="symbolic")
         a.memory.store(0x400000, x)
         b = a.copy()
         a.add_constraints(x == 1)
@@ -218,7 +218,7 @@ class TestState(unittest.TestCase):
         assert not s.solver.satisfiable(extra_constraints=(culprit == 12,))
 
     def test_state_pickle(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         s.memory.store(100, claripy.BVV(0x4141414241414241424300, 88), endness="Iend_BE")
         s.regs.rax = 100
 

--- a/tests/state_plugins/inspect/test_inspect.py
+++ b/tests/state_plugins/inspect/test_inspect.py
@@ -15,7 +15,7 @@ import angr
 from angr import BP_AFTER, BP_BEFORE, SIM_PROCEDURES, SimState, concretization_strategies
 from angr.engines import HeavyVEXMixin, ProcedureEngine, SimInspectMixin
 from angr.project import load_shellcode
-from tests.common import bin_location
+from tests.common import bin_location, minimal_project
 
 test_location = os.path.join(bin_location, "tests")
 
@@ -207,7 +207,7 @@ class TestInspect(unittest.TestCase):
             if state.inspect.attrs.address_concretization_action == "store":
                 state.inspect.attrs.address_concretization_expr = claripy.BVV(0x1000, state.arch.bits)
 
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         s.inspect.b("address_concretization", BP_BEFORE, action=change_symbolic_target)
         s.memory.store(x, "A")
         assert list(s.solver.eval_upto(x, 10)) == [0x1000]
@@ -220,7 +220,7 @@ class TestInspect(unittest.TestCase):
         def dont_add_constraints(state):
             state.inspect.attrs.address_concretization_add_constraints = False
 
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         s.inspect.b("address_concretization", BP_BEFORE, action=dont_add_constraints)
         s.memory.store(x, "A")
         assert len(s.solver.eval_upto(x, 10)) == 10
@@ -248,7 +248,7 @@ class TestInspect(unittest.TestCase):
             ):
                 raise UnconstrainedAbort("uh oh", state)
 
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         s.memory.write_strategies.insert(0, concretization_strategies.SimConcretizationStrategyRange(128))
         s.memory._write_address_range = 1
         s.memory._write_address_range_approx = 1

--- a/tests/state_plugins/posix/test_files.py
+++ b/tests/state_plugins/posix/test_files.py
@@ -10,26 +10,26 @@ import unittest
 
 import angr
 from angr.state_plugins.posix import Flags
-from tests.common import bin_location
+from tests.common import bin_location, minimal_project
 
 test_location = os.path.join(bin_location, "tests")
 
 
 class TestFile(unittest.TestCase):
     def test_files(self):
-        s = angr.SimState(arch="AMD64")
+        s = angr.SimState(project=minimal_project("AMD64"))
         s.posix.get_fd(1).write_data(b"HELLO")
         s.posix.get_fd(1).write_data(b"WORLD")
         assert s.posix.dumps(1) == b"HELLOWORLD"
         assert s.posix.stdout.concretize() == [b"HELLO", b"WORLD"]
 
-        s = angr.SimState(arch="AMD64")
+        s = angr.SimState(project=minimal_project("AMD64"))
         s.posix.get_fd(1).write_data(b"A" * 0x1000, 0x800)
         assert s.posix.dumps(1) == b"A" * 0x800
 
     def test_file_read_missing_content(self):
         # test in tracing mode since the Reverse operator will not be optimized away
-        s = angr.SimState(arch="AMD64", mode="tracing")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="tracing")
         fd = s.posix.open(b"/tmp/oops", Flags.O_RDWR)
         length = s.posix.get_fd(fd).read(0xC00000, 100)
 

--- a/tests/state_plugins/posix/test_posix.py
+++ b/tests/state_plugins/posix/test_posix.py
@@ -7,12 +7,13 @@ import unittest
 import claripy
 
 from angr import SimFile, SimState
+from tests.common import minimal_project
 
 
 class TestPosix(unittest.TestCase):
     def test_file_create(self):
         # Create a state first
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         # Create a file
         fd = state.posix.open(b"test", 1)
@@ -20,7 +21,7 @@ class TestPosix(unittest.TestCase):
         assert fd == 3
 
     def test_file_read(self):
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         content = claripy.BVV(0xBADF00D, 32)
         content_size = content.size() // 8
@@ -38,7 +39,7 @@ class TestPosix(unittest.TestCase):
     def test_file_seek(self):
         # TODO: Make this test more complete
 
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         # Normal seeking
         fd = state.posix.open(b"test1", 1)

--- a/tests/state_plugins/solver/test_simsolver.py
+++ b/tests/state_plugins/solver/test_simsolver.py
@@ -8,6 +8,7 @@ import unittest
 import claripy
 
 import angr
+from tests.common import minimal_project
 
 
 class TestSolverEvalCasting(unittest.TestCase):
@@ -16,19 +17,19 @@ class TestSolverEvalCasting(unittest.TestCase):
     """
 
     def test_eval_cast_bvv_to_bytes(self):
-        s = angr.SimState(arch="AMD64", mode="symbolic")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
         assert s.solver.eval(claripy.BVV(0, 0), cast_to=bytes) == b""
         assert s.solver.eval(claripy.BVV(0, 8), cast_to=bytes) == b"\x00"
         assert s.solver.eval(claripy.BVV(0x12345678, 32), cast_to=bytes) == b"\x12\x34\x56\x78"
 
     def test_eval_cast_bvv_to_bytes__non_8bit_length_multiple(self):
-        s = angr.SimState(arch="AMD64", mode="symbolic")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
         for nbits in [1, 2, 7]:
             with self.subTest(nbits=nbits), self.assertRaises(ValueError):
                 s.solver.eval(claripy.BVV(0, nbits), cast_to=bytes)
 
     def test_eval_cast_fpv_to_bytes(self):
-        s = angr.SimState(arch="AMD64", mode="symbolic")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
         value = 1.23456
         fpv = claripy.FPV(value, claripy.FSORT_FLOAT)
         assert s.solver.eval(fpv, cast_to=bytes) == struct.pack(">f", value)
@@ -36,7 +37,7 @@ class TestSolverEvalCasting(unittest.TestCase):
         assert s.solver.eval(fpv, cast_to=bytes) == struct.pack(">d", value)
 
     def test_eval_cast_fpv_to_int(self):
-        s = angr.SimState(arch="AMD64", mode="symbolic")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
         value = 1.23456
         fpv = claripy.FPV(value, claripy.FSORT_FLOAT)
         assert s.solver.eval(fpv, cast_to=int) == int.from_bytes(struct.pack(">f", value), "big")
@@ -44,12 +45,12 @@ class TestSolverEvalCasting(unittest.TestCase):
         assert s.solver.eval(fpv, cast_to=int) == int.from_bytes(struct.pack(">d", value), "big")
 
     def test_eval_cast_bool_to_bytes(self):
-        s = angr.SimState(arch="AMD64", mode="symbolic")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
         assert s.solver.eval(claripy.BoolV(False), cast_to=bytes) == b"\x00"
         assert s.solver.eval(claripy.BoolV(True), cast_to=bytes) == b"\x01"
 
     def test_eval_cast_bool_to_int(self):
-        s = angr.SimState(arch="AMD64", mode="symbolic")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
         assert s.solver.eval(claripy.BoolV(False), cast_to=int) == 0
         assert s.solver.eval(claripy.BoolV(True), cast_to=int) == 1
 

--- a/tests/state_plugins/solver/test_symbolic.py
+++ b/tests/state_plugins/solver/test_symbolic.py
@@ -9,7 +9,7 @@ import unittest
 import claripy
 
 import angr
-from tests.common import broken
+from tests.common import broken, minimal_project
 
 
 class TestSymbolic(unittest.TestCase):
@@ -31,7 +31,7 @@ class TestSymbolic(unittest.TestCase):
     def test_concretization_strategies(self):
         initial_memory = {0: b"A", 1: b"B", 2: b"C", 3: b"D"}
 
-        s = angr.SimState(arch="AMD64", dict_memory_backer=initial_memory)
+        s = angr.SimState(project=minimal_project("AMD64"), dict_memory_backer=initial_memory)
 
         # sanity check
         assert s.solver.eval_upto(s.memory.load(3, size=1), 2, cast_to=bytes) == [b"D"]
@@ -51,7 +51,7 @@ class TestSymbolic(unittest.TestCase):
         assert "symbolic" in next(iter(ss.memory.load(x, 1).variables))
 
     # def test_concretization(self):
-    #   s = angr.SimState(arch="AMD64", mode="symbolic")
+    #   s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
     #   dst = claripy.BVV(0x41424300, 32)
     #   dst_addr = claripy.BVV(0x1000, 64)
     #   s.memory.store(dst_addr, dst, 4)
@@ -78,7 +78,7 @@ class TestSymbolic(unittest.TestCase):
 
     @broken
     def test_symbolic_write(self):
-        s = angr.SimState(arch="AMD64", mode="symbolic")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         addr = claripy.BVS("addr", 64)
         s.add_constraints(claripy.Or(addr == 10, addr == 20, addr == 30))
@@ -130,7 +130,7 @@ class TestSymbolic(unittest.TestCase):
         assert sv.solver.eval_upto(sv.memory.load(30, 1), 3) == [3]
         assert sv.solver.eval_upto(addr, 10) == [10, 20]
 
-        s = angr.SimState(arch="AMD64", mode="symbolic")
+        s = angr.SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.memory.store(0, claripy.BVV(0x4141414141414141, 64))
         length = claripy.BVS("length", 32)
         # s.memory.store(0, claripy.BVV(0x4242424242424242, 64), symbolic_length=length)
@@ -142,7 +142,9 @@ class TestSymbolic(unittest.TestCase):
             assert ss.solver.eval(s.memory.load(0, 8), cast_to=bytes) == b"B" * i + b"A" * (8 - i)
 
     def test_unsat_core(self):
-        s = angr.SimState(arch="AMD64", mode="symbolic", add_options={angr.options.CONSTRAINT_TRACKING_IN_SOLVER})
+        s = angr.SimState(
+            project=minimal_project("AMD64"), mode="symbolic", add_options={angr.options.CONSTRAINT_TRACKING_IN_SOLVER}
+        )
         x = claripy.BVS("x", 32)
         s.add_constraints(claripy.BVV(0, 32) == x)
         s.add_constraints(claripy.BVV(1, 32) == x)

--- a/tests/state_plugins/solver/test_variable_registration.py
+++ b/tests/state_plugins/solver/test_variable_registration.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import unittest
 
 import angr
+from tests.common import minimal_project
 
 
 class TestVariableRegistration(unittest.TestCase):
     def test_registration(self):
-        s = angr.SimState(arch="AMD64")
+        s = angr.SimState(project=minimal_project("AMD64"))
 
         a1 = s.solver.BVS("a", 64, key=(1,), eternal=True)
         a2 = s.solver.BVS("a", 64, key=(1,), eternal=True)

--- a/tests/state_plugins/test_heap_lazy_mapping.py
+++ b/tests/state_plugins/test_heap_lazy_mapping.py
@@ -13,7 +13,7 @@ import claripy
 import angr
 from angr import SimHeapBrk, SimHeapPTMalloc, SimState
 from angr.state_plugins.heap.heap_base import HEAP_INITIAL_MAPPED_SIZE, HEAP_MAPPING_GROWTH_FACTOR
-from tests.common import bin_location
+from tests.common import bin_location, minimal_project
 
 gdb_data_location = os.path.join(bin_location, "tests_data", "test_gdb_plugin")
 
@@ -28,7 +28,7 @@ def make_state(heap=None, add_options=None):
     ``state.memory``.
     """
     plugins = {"heap": heap} if heap is not None else None
-    return SimState(arch="AMD64", plugins=plugins, add_options=ZERO_FILL | (add_options or set()))
+    return SimState(project=minimal_project("AMD64"), plugins=plugins, add_options=ZERO_FILL | (add_options or set()))
 
 
 def resident_heap_pages(state):
@@ -298,7 +298,7 @@ class TestHeapLazyMapping(unittest.TestCase):
         assert pickle.loads(pickle.dumps(state)).heap._mapped_end == extent
 
     def test_abstract_memory_does_not_manage_the_mapping(self):
-        state = SimState(arch="AMD64", add_options={angr.options.ABSTRACT_MEMORY})
+        state = SimState(project=minimal_project("AMD64"), add_options={angr.options.ABSTRACT_MEMORY})
         assert state.heap._mapped_end is None
         # ...and _ensure_mapped stays a no-op forever after
         state.heap._ensure_mapped(state.heap.heap_base + 0x100000)

--- a/tests/storage/test_address_concretization.py
+++ b/tests/storage/test_address_concretization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import archinfo
 
 import angr
+from tests.common import minimal_project
 
 
 class _StatefulStrategy(angr.concretization_strategies.SimConcretizationStrategy):
@@ -18,7 +19,7 @@ class _StatefulStrategy(angr.concretization_strategies.SimConcretizationStrategy
 
 
 def test_stateful_concretization_strategies_are_copied_with_memory():
-    state = angr.SimState(arch=archinfo.ArchAMD64())
+    state = angr.SimState(project=minimal_project(archinfo.ArchAMD64()))
     strategy = _StatefulStrategy([1])
     state.memory.read_strategies = [strategy, strategy]
     state.memory.write_strategies = [strategy]

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -26,6 +26,7 @@ from angr.storage.memory_mixins import (
 )
 from angr.storage.memory_mixins.paged_memory.pages.multi_values import MultiValues
 from angr.storage.memory_mixins.paged_memory.pages.symbolic_bitmap import SymbolicBitmap
+from tests.common import minimal_project
 
 
 class UltraPageMemory(
@@ -59,7 +60,7 @@ class MVPageMemory(
 
 class TestMemory(unittest.TestCase):
     def test_copy(self):
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.memory.store(0x100, b"ABCDEFGHIJKLMNOP")
         s.memory.store(0x200, b"XXXXXXXXXXXXXXXX")
         x = claripy.BVS("size", s.arch.bits)
@@ -78,7 +79,7 @@ class TestMemory(unittest.TestCase):
         ]
         assert sorted(s.solver.eval_upto(result, 100, cast_to=bytes, extra_constraints=[x == 3])) == [b"ABCXX"]
 
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.register_plugin(
             "posix", SimSystemPosix(stdin=SimFile(name="stdin", content=b"ABCDEFGHIJKLMNOP", has_end=True))
         )
@@ -99,7 +100,7 @@ class TestMemory(unittest.TestCase):
         ]
         assert sorted(s.solver.eval_upto(result, 100, cast_to=bytes, extra_constraints=[x == 3])) == [b"ABCXX"]
 
-        s = SimState(arch="AMD64", mode="symbolic")
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic")
         s.register_plugin("posix", SimSystemPosix(stdin=SimFile(name="stdin", content=b"ABCDEFGHIJKLMNOP")))
         s.memory.store(0x200, b"XXXXXXXXXXXXXXXX")
         x = claripy.BVS("size", s.arch.bits)
@@ -170,7 +171,7 @@ class TestMemory(unittest.TestCase):
     def test_memory(self):
         initial_memory = {0: b"A", 1: b"A", 2: b"A", 3: b"A", 10: b"B"}
         s = SimState(
-            arch="AMD64",
+            project=minimal_project("AMD64"),
             dict_memory_backer=initial_memory,
             add_options={o.REVERSE_MEMORY_NAME_MAP, o.REVERSE_MEMORY_HASH_MAP},
         )
@@ -316,7 +317,7 @@ class TestMemory(unittest.TestCase):
 
         s = SimState(
             mode="static",
-            arch="AMD64",
+            project=minimal_project("AMD64"),
             dict_memory_backer=initial_memory,
             add_options={o.ABSTRACT_SOLVER, o.ABSTRACT_MEMORY},
         )
@@ -449,7 +450,7 @@ class TestMemory(unittest.TestCase):
 
         s = SimState(
             mode="static",
-            arch="AMD64",
+            project=minimal_project("AMD64"),
             dict_memory_backer=initial_memory,
             add_options={o.ABSTRACT_SOLVER, o.ABSTRACT_MEMORY},
         )
@@ -470,7 +471,7 @@ class TestMemory(unittest.TestCase):
             assert r.clear_annotation_type(claripy.annotation.RegionAnnotation).identical(expected)
 
     def test_registers(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         expr = s.registers.load("rax")
         assert s.solver.symbolic(expr)
 
@@ -480,7 +481,7 @@ class TestMemory(unittest.TestCase):
         assert s.solver.eval(expr) == 0x00000031
 
     def test_fullpage_write(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         a = claripy.BVV(b"A" * 0x2000)
         s.memory.store(0, a)
         # assert len(s.memory.mem._pages) == 2
@@ -489,7 +490,7 @@ class TestMemory(unittest.TestCase):
         assert s.memory.load(0, 0x2000) is a
         assert a.variables != s.memory.load(0x2000, 1).variables
 
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         a = claripy.BVV(b"A" * 2)
         s.memory.store(0x1000, a)
         s.memory.store(0x2000, a)
@@ -497,7 +498,7 @@ class TestMemory(unittest.TestCase):
         assert a.variables == s.memory.load(0x2001, 1).variables
         assert a.variables != s.memory.load(0x2002, 1).variables
 
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         x = claripy.BVV(b"X")
         a = claripy.BVV(b"A" * 0x1000)
         s.memory.store(1, x)
@@ -505,7 +506,7 @@ class TestMemory(unittest.TestCase):
         s2.memory.store(0, a)
         assert len(s.memory.changed_bytes(s2.memory)) == 0x1000
 
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         s.memory._maximum_symbolic_size = 0x2000000
         a = claripy.BVS("A", 0x1000000 * 8)
         s.memory.store(0, a)
@@ -513,7 +514,7 @@ class TestMemory(unittest.TestCase):
         assert b is a
 
     def test_symbolic_write(self):
-        s = SimState(arch="AMD64", add_options={o.SYMBOLIC_WRITE_ADDRESSES})
+        s = SimState(project=minimal_project("AMD64"), add_options={o.SYMBOLIC_WRITE_ADDRESSES})
         x = claripy.BVS("x", 64)
         y = claripy.BVS("y", 64)
         a = claripy.BVV(b"A" * 0x10)
@@ -560,16 +561,16 @@ class TestMemory(unittest.TestCase):
 
         # Writes many zeros
         VAL = 0
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         _individual_test(s, BASE, VAL, SIZE)
 
         # Writes many ones
         VAL = 1
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         _individual_test(s, BASE, VAL, SIZE)
 
     def test_false_condition(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
 
         asdf = claripy.BVV(b"asdf")
         fdsa = claripy.BVV(b"fdsa")
@@ -581,7 +582,7 @@ class TestMemory(unittest.TestCase):
         assert 0 not in s.memory._pages
 
     def test_fast_memory(self):
-        s = SimState(arch="AMD64", add_options={o.FAST_REGISTERS, o.FAST_MEMORY})
+        s = SimState(project=minimal_project("AMD64"), add_options={o.FAST_REGISTERS, o.FAST_MEMORY})
 
         s.regs.rax = 0x4142434445464748
         s.regs.rbx = 0x5555555544444444
@@ -591,7 +592,7 @@ class TestMemory(unittest.TestCase):
         self._concrete_memory_tests(s)
 
     def test_light_memory(self):
-        s = SimState(arch="AMD64", plugins={"registers": SimLightRegisters()})
+        s = SimState(project=minimal_project("AMD64"), plugins={"registers": SimLightRegisters()})
         assert type(s.registers) is SimLightRegisters
 
         assert s.regs.rax.symbolic
@@ -615,7 +616,7 @@ class TestMemory(unittest.TestCase):
             UltraPageMemory,
             ListPageMemory,
         ]:
-            state = SimState(arch="x86", mode="symbolic", plugins={"memory": memcls()})
+            state = SimState(project=minimal_project("x86"), mode="symbolic", plugins={"memory": memcls()})
 
             state.regs.sp = 0xBAAAFFFC
             state.memory.store(state.regs.sp, b"\x01\x02\x03\x04" + b"\x05\x06\x07\x08")
@@ -635,7 +636,7 @@ class TestMemory(unittest.TestCase):
         for memcls in [
             MVPageMemory,
         ]:
-            state = SimState(arch="x86", mode="symbolic", plugins={"memory": memcls()})
+            state = SimState(project=minimal_project("x86"), mode="symbolic", plugins={"memory": memcls()})
 
             mv = MultiValues(offset_to_values={0: {claripy.BVV(1337, 32)}, 4: {claripy.BVV(13371337, 8 * 5)}})
             state.memory.store(4096 - 3, mv)
@@ -707,7 +708,7 @@ class TestMemory(unittest.TestCase):
             state.memory.store(0x7FFEFF9C, mv)  # should not crash
 
     def test_mv_crosspage_store_large_elements(self):
-        state = SimState(arch="amd64", mode="symbolic", plugins={"memory": MVPageMemory()})
+        state = SimState(project=minimal_project("amd64"), mode="symbolic", plugins={"memory": MVPageMemory()})
 
         data = {
             0: {claripy.BVS("TOP", 4095 * 8)},
@@ -718,7 +719,7 @@ class TestMemory(unittest.TestCase):
         state.memory.store(0x7FFEE1FF, mv)  # should not crash
 
     def test_crosspage_read(self):
-        state = SimState(arch="ARM")
+        state = SimState(project=minimal_project("ARM"))
         state.regs.sp = 0x7FFF0008
         state.stack_push(0x44556677)
         state.stack_push(0x1)
@@ -741,7 +742,7 @@ class TestMemory(unittest.TestCase):
 
     def test_address_wrap(self):
         for memcls in [UltraPageMemory, ListPageMemory]:
-            state = SimState(arch="x86", mode="symbolic", plugins={"memory": memcls()})
+            state = SimState(project=minimal_project("x86"), mode="symbolic", plugins={"memory": memcls()})
             symbol = claripy.BVS("symbol", 64)
 
             state.memory.store(0xFFFFFFFF, symbol.get_byte(0))
@@ -755,7 +756,7 @@ class TestMemory(unittest.TestCase):
             assert state.memory.load(0, 1) is symbol[64 - 8 - 1 : 64 - 16]
 
     def test_allocate_stack_pages_stops_at_address_zero(self):
-        state = SimState(arch=ArchAMD64(), stack_end=0x1000)
+        state = SimState(project=minimal_project(ArchAMD64()), stack_end=0x1000)
 
         # only one page exists below the top of this stack, so two of them do not fit under it
         with self.assertRaises(SimMemoryError):
@@ -769,7 +770,7 @@ class TestMemory(unittest.TestCase):
         assert state.memory.permissions(0) is not None
 
     def test_underconstrained(self):
-        state = SimState(arch="AMD64", add_options={o.UNDER_CONSTRAINED_SYMEXEC})
+        state = SimState(project=minimal_project("AMD64"), add_options={o.UNDER_CONSTRAINED_SYMEXEC})
 
         # test that under-constrained load is constrained
         ptr1 = state.memory.load(0x4141414141414000, size=8, endness="Iend_LE")
@@ -802,7 +803,7 @@ class TestMemory(unittest.TestCase):
         state.memory.load(ptr3, size=1)
 
     def test_concrete_load_non_adjacent_pages(self):
-        s = SimState(arch="AMD64", mode="symbolic", plugins={"memory": UltraPageMemory()})
+        s = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": UltraPageMemory()})
 
         s.memory.store(0x100000, b"\x01" * 4096)
         s.memory.store(0x100000 + 4096, b"\x02" * 4096)
@@ -811,7 +812,7 @@ class TestMemory(unittest.TestCase):
         assert mv == (b"\x01" * 6) + (b"\x02" * 394)
 
     def test_hex_dump(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         addr = s.heap.allocate(0x20)
         s.memory.store(addr, claripy.Concat(claripy.BVV("ABCDEFGH"), claripy.BVS("symbolic_part", 24 * s.arch.bits)))
         dump = s.memory.hex_dump(addr, 0x20)
@@ -841,7 +842,7 @@ class TestMemory(unittest.TestCase):
             return bytes(0 if is_symbolic(bitmap, i) else d for i, d in enumerate(data))
 
         for memcls in [UltraPageMemory, ListPageMemory]:
-            state = SimState(arch="AMD64", mode="symbolic", plugins={"memory": memcls()})
+            state = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": memcls()})
             state.memory.store(0x20000, b"aaaabbbbccccdddd")
 
             data, bitmap = state.memory.concrete_load(0x20000, 4, with_bitmap=True)
@@ -902,7 +903,7 @@ class TestMemory(unittest.TestCase):
             assert bitmap.tobytes() == b"\x06"
 
     def test_multivalued_list_page(self):
-        state = SimState(arch="AMD64", mode="symbolic", plugins={"memory": MultiValuedMemory()})
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": MultiValuedMemory()})
 
         # strong update
         state.memory.store(0x100, claripy.BVV(0x40, 64))
@@ -923,7 +924,7 @@ class TestMemory(unittest.TestCase):
             def _default_value(self, *args, size=None, **kwargs):  # pylint:disable=unused-argument
                 return claripy.BVV(0, size)
 
-        state = SimState(arch="AMD64", mode="symbolic", plugins={"memory": ZeroFillerMemory()})
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": ZeroFillerMemory()})
         state.options.add(o.ZERO_FILL_UNCONSTRAINED_MEMORY)
 
         cond = claripy.BoolS("cond")

--- a/tests/storage/test_memory_find_6744.py
+++ b/tests/storage/test_memory_find_6744.py
@@ -4,10 +4,11 @@ import archinfo
 import claripy
 
 import angr
+from tests.common import minimal_project
 
 
 def test_memory_find_empty_cases():
-    state = angr.SimState(arch=archinfo.ArchAMD64())
+    state = angr.SimState(project=minimal_project(archinfo.ArchAMD64()))
 
     addr = claripy.BVV(0x1204F0D, 64)
     target = claripy.BVV(0, 8)

--- a/tests/storage/test_memory_merge.py
+++ b/tests/storage/test_memory_merge.py
@@ -20,6 +20,7 @@ from angr.storage.memory_mixins import (
     UltraPagesMixin,
 )
 from angr.storage.memory_mixins.paged_memory.pages.history_tracking_mixin import MAX_HISTORY_DEPTH
+from tests.common import minimal_project
 
 
 class UltraPageMemory(
@@ -49,10 +50,10 @@ class ListPageMemory(
 class TestMemoryMerge(TestCase):
     def test_merge_memory_object_endness(self):
         for memcls in [UltraPageMemory, ListPageMemory]:
-            state0 = SimState(arch="AMD64", mode="symbolic", plugins={"memory": memcls()})
+            state0 = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": memcls()})
             state0.memory.store(0x20000, claripy.BVS("x", 64), endness="Iend_LE")
 
-            state1 = SimState(arch="AMD64", mode="symbolic", plugins={"memory": memcls()})
+            state1 = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": memcls()})
             state1.memory.store(0x20000, claripy.BVS("y", 64), endness="Iend_LE")
 
             state, _, _ = state0.merge(state1)
@@ -62,8 +63,8 @@ class TestMemoryMerge(TestCase):
             assert obj.op == "If"
 
     def test_merge_seq(self):
-        state1 = SimState(arch="AMD64", mode="symbolic", plugins={"memory": UltraPageMemory()})
-        state2 = SimState(arch="AMD64", mode="symbolic", plugins={"memory": UltraPageMemory()})
+        state1 = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": UltraPageMemory()})
+        state2 = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": UltraPageMemory()})
 
         state1.regs.rsp = 0x80000000
         state2.regs.rsp = 0x80000000
@@ -78,7 +79,7 @@ class TestMemoryMerge(TestCase):
         assert {0x1122, 0xAABB} == set(vals)
 
     def test_history_tracking(self):
-        state = SimState(arch="AMD64", mode="symbolic", plugins={"memory": UltraPageMemory()})
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": UltraPageMemory()})
 
         states = [state]
 
@@ -94,7 +95,7 @@ class TestMemoryMerge(TestCase):
         assert len(parents) == 24
 
     def test_history_tracking_collapse(self):
-        state = SimState(arch="AMD64", mode="symbolic", plugins={"memory": UltraPageMemory()})
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic", plugins={"memory": UltraPageMemory()})
         state.memory.store(1000, claripy.BVV(1, 8))
 
         states = [state]

--- a/tests/storage/test_memview.py
+++ b/tests/storage/test_memview.py
@@ -12,11 +12,12 @@ from archinfo import Endness
 import angr
 from angr import SimState
 from angr.sim_type import SimStruct, SimTypeNumOffset, parse_types, register_types
+from tests.common import minimal_project
 
 
 class TestMemView(unittest.TestCase):
     def test_simple_concrete(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         addr = 0xBA5E0
 
         def check_read(val):
@@ -38,7 +39,7 @@ class TestMemView(unittest.TestCase):
         check_read(0x11223344AABBEF6D)
 
     def test_string_concrete(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         addr = 0xBA5E0
 
         def check_read(val):
@@ -58,7 +59,7 @@ class TestMemView(unittest.TestCase):
         # check_read(b"a longer string")
 
     def test_array_concrete(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         addr = 0xBA5E0
 
         s.memory.store(addr, claripy.BVV(0x1, 32), endness=Endness.LE)
@@ -85,7 +86,7 @@ class TestMemView(unittest.TestCase):
         assert s.mem[addr].dword.array(4).concrete == [1, 2, 4, 3]
 
     def test_pointer_concrete(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
         addr = 0xBA5E0
         ptraddr = 0xCD0
 
@@ -98,7 +99,7 @@ class TestMemView(unittest.TestCase):
         assert s.mem[ptraddr].deref.dword.concrete == 123954
 
     def test_structs(self):
-        s = SimState(arch="AMD64")
+        s = SimState(project=minimal_project("AMD64"))
 
         register_types(
             parse_types("""
@@ -125,7 +126,7 @@ class TestMemView(unittest.TestCase):
         can be used with a memview
         :return:
         """
-        state = SimState(arch="AMD64")
+        state = SimState(project=minimal_project("AMD64"))
         register_types(
             SimStruct(
                 name="bitfield_struct",
@@ -189,7 +190,7 @@ class TestMemView(unittest.TestCase):
         }""")
 
         angr.types.register_types(bitfield_struct2)
-        state = SimState(arch="AMD64")
+        state = SimState(project=minimal_project("AMD64"))
         state.memory.store(0x1000, b"\xb3\xc7\xe9|\xad\xd7\xee$")  # store some random data
         struct = state.mem[0x1000].struct.bitfield_struct2.concrete
         assert struct.target == 0xD7CE9C7B3

--- a/tests/storage/test_mmap.py
+++ b/tests/storage/test_mmap.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import unittest
 
 from angr import SimState
+from tests.common import minimal_project
 
 
 class TestMmap(unittest.TestCase):
     def test_mmap_base_copy(self):
-        state = SimState(arch="AMD64", mode="symbolic")
+        state = SimState(project=minimal_project("AMD64"), mode="symbolic")
 
         mmap_base = 0x12345678
 

--- a/tests/storage/test_ptmalloc.py
+++ b/tests/storage/test_ptmalloc.py
@@ -6,6 +6,7 @@ import unittest
 import claripy
 
 from angr import SimHeapPTMalloc, SimState
+from tests.common import minimal_project
 
 
 # TODO: Make these tests more architecture-independent (note dependencies of some behavior on chunk metadata size)
@@ -30,7 +31,9 @@ class TestPtmalloc(unittest.TestCase):
         return state.libc.max_variable_size
 
     def _run_malloc_maximizes_sym_arg(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         sc = s.copy()
         x = claripy.BVS("x", 32)
         s.solver.add(x.UGE(0))
@@ -46,7 +49,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_free_maximizes_sym_arg("AMD64")
 
     def _run_free_maximizes_sym_arg(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         p = s.heap.malloc(50)
         sc = s.copy()
         x = claripy.BVS("x", 32)
@@ -63,7 +68,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_free_maximizes_sym_arg("AMD64")
 
     def _run_calloc_maximizes_sym_arg(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         sc = s.copy()
         x = claripy.BVS("x", 32)
         s.solver.add(x.UGE(0))
@@ -82,7 +89,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_calloc_maximizes_sym_arg("AMD64")
 
     def _run_realloc_maximizes_sym_arg(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         p = s.heap.malloc(50)
         sc = s.copy()
         x = claripy.BVS("x", 32)
@@ -102,7 +111,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_realloc_maximizes_sym_arg("AMD64")
 
     def _run_malloc_no_space_returns_null(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         sc = s.copy()
         p1 = s.heap.malloc(0x2000)
         assert p1 == 0
@@ -115,7 +126,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_malloc_no_space_returns_null("AMD64")
 
     def _run_calloc_no_space_returns_null(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         sc = s.copy()
         p1 = s.heap.calloc(0x500, 4)
         assert p1 == 0
@@ -128,7 +141,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_calloc_no_space_returns_null("AMD64")
 
     def _run_realloc_no_space_returns_null(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         p1 = s.heap.malloc(20)
         sc = s.copy()
         p2 = s.heap.realloc(p1, 0x2000)
@@ -142,7 +157,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_realloc_no_space_returns_null("AMD64")
 
     def _run_first_fit_and_free_malloced_makes_available(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.heap.malloc(20)
         p1 = s.heap.malloc(50)
         s.heap.free(p1)
@@ -156,7 +173,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_first_fit_and_free_malloced_makes_available("AMD64")
 
     def _run_free_calloced_makes_available(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.heap.calloc(20, 5)
         p1 = s.heap.calloc(30, 4)
         s.heap.free(p1)
@@ -170,7 +189,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_free_calloced_makes_available("AMD64")
 
     def _run_realloc_moves_and_frees(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.heap.malloc(20)
         p1 = s.heap.malloc(60)
         s.heap.malloc(200)
@@ -186,7 +207,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_realloc_moves_and_frees("AMD64")
 
     def _run_realloc_near_same_size(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.heap.malloc(20)
         p1 = s.heap.malloc(61)
         s.heap.malloc(80)
@@ -202,7 +225,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_realloc_near_same_size("AMD64")
 
     def _run_needs_space_for_metadata(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         sc = s.copy()
         p1 = s.heap.malloc(0x1000)
         assert p1 == 0
@@ -215,7 +240,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_needs_space_for_metadata("AMD64")
 
     def _run_unusable_amount_returns_null(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.heap.malloc(0x1000 - 4 * s.heap._chunk_size_t_size)
         sc = s.copy()
         p = s.heap.malloc(1)
@@ -229,7 +256,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_unusable_amount_returns_null("AMD64")
 
     def _run_free_null_preserves_state(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.heap.malloc(30)
         p = s.heap.malloc(40)
         s.heap.malloc(50)
@@ -245,7 +274,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_free_null_preserves_state("AMD64")
 
     def _run_skips_chunks_too_small(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.heap.malloc(30)
         p = s.heap.malloc(50)
         s.heap.malloc(40)
@@ -260,7 +291,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_skips_chunks_too_small("AMD64")
 
     def _run_calloc_multiplies(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.heap.malloc(30)
         sc = s.copy()
         s.heap.malloc(100)
@@ -274,7 +307,9 @@ class TestPtmalloc(unittest.TestCase):
         self._run_calloc_clears("AMD64")
 
     def _run_calloc_clears(self, arch):
-        s = SimState(arch=arch, plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)})
+        s = SimState(
+            project=minimal_project(arch), plugins={"heap": SimHeapPTMalloc(heap_base=0xD0000000, heap_size=0x1000)}
+        )
         s.memory.store(0xD0000000 + 2 * s.heap._chunk_size_t_size, claripy.BVV(-1, 100 * 8))
         sc = s.copy()
         p1 = s.heap.calloc(6, 5)


### PR DESCRIPTION
SimState.project was typed Project | None, which made every unguarded state.project access a pyright error (41 diagnostics across 17 files) even though every state constructed through a Project's factory always has a project set.

Make project a required argument of SimState.__init__ and simplify the None-handling in the initializer. Remove the now-dead None guards on state.project (icicle, successors, calling_conventions, view, default_filler_mixin), and assert self.project is not None in the procedures that build a blank SimState inside static_exits() / dynamic_returns(), where CFG recovery sets project before calling.

Update tests that constructed SimState without a project to pass one built by the new tests.common.minimal_project() helper, which loads a single-nop shellcode Project for the requested architecture, and update the docs example accordingly.