### PR TITLE
RustCodeGen: size a store from the store, not from its value's type

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/rust.py
+++ b/angr/analyses/decompiler/structured_codegen/rust.py
@@ -70,6 +70,7 @@ from angr.sim_type import (
     SimTypeLength,
     SimTypeLongLong,
     SimTypeNum,
+    SimTypePointer,
     SimTypeReg,
     SimTypeWideChar,
     TypeRef,
@@ -130,6 +131,14 @@ def qualifies_for_simple_cast(ty1, ty2):
         and isinstance(ty1, (RustSimTypeInt, RustSimTypeReference))
         and isinstance(ty2, (RustSimTypeInt, RustSimTypeReference))
     )
+
+
+def qualifies_for_width_cast(ty):
+    # converting ty to a different width - can a scalar cast do it?
+    # floats are excluded because a float cast converts the value, not the representation
+    # the Rust scalar types are subclasses of these: RustSimTypeInt of SimTypeInt,
+    # RustSimTypeReference of SimTypePointer, RustSimTypeBottom of SimTypeBottom
+    return isinstance(ty, (SimTypeInt, SimTypeChar, SimTypeNum, SimTypePointer, SimTypeBottom))
 
 
 def qualifies_for_implicit_cast(ty1, ty2):
@@ -3747,8 +3756,25 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
     def _handle_Stmt_Store(self, stmt: Stmt.Store, **kwargs):
         cdata = self._handle(stmt.data)
 
-        if cdata.type.size != stmt.size * self.project.arch.byte_width:
-            l.error("Store data lifted to a C type with a different size. Decompilation output will be wrong.")
+        store_bits = stmt.size * self.project.arch.byte_width
+        if cdata.type is None or cdata.type.size != store_bits:
+            if cdata.type is not None and cdata.type.size is not None:
+                l.error(
+                    "Store data lifted to a type of a different size: %s is %d bits, the store is %d bits. "
+                    "Using the store width.",
+                    cdata.type,
+                    cdata.type.size,
+                    store_bits,
+                )
+            if cdata.type is None or qualifies_for_width_cast(unpack_typeref(cdata.type)):
+                # an untyped or mis-sized scalar must still write stmt.size bytes: retype the value at the
+                # store width so _access renders the access at that width instead of the inferred one.
+                cdata = RustTypeCast(
+                    cdata.type,
+                    self.default_simtype_from_size(stmt.size, signed=getattr(cdata.type, "signed", False)),
+                    cdata,
+                    codegen=self,
+                )
 
         def negotiate(old_ty, proposed_ty):
             # transfer casts from the dst to the src if possible

--- a/tests/analyses/decompiler/test_rust_codegen_handlers.py
+++ b/tests/analyses/decompiler/test_rust_codegen_handlers.py
@@ -6,6 +6,7 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 
 import os
 import unittest
+from unittest import mock
 
 import angr
 from angr.ailment import Manager
@@ -17,12 +18,15 @@ from angr.ailment.expression import (
     VirtualVariable,
     VirtualVariableCategory,
 )
-from angr.ailment.statement import CAS, DirtyStatement, Jump, WeakAssignment
+from angr.ailment.statement import CAS, DirtyStatement, Jump, Store, WeakAssignment
+from angr.analyses.decompiler.structured_codegen.rust import RustExpression, RustStructuredCodeGenerator
 from angr.analyses.decompiler.structurer_nodes import (
     IncompleteSwitchCaseHeadStatement,
     IncompleteSwitchCaseNode,
     SequenceNode,
 )
+from angr.rust.sim_type import RustSimTypeInt, RustSimTypeStrRef
+from angr.sim_type import SimTypeBottom
 from tests.common import bin_location, load_project_with_scoped_cfg, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -176,6 +180,79 @@ class TestRustCodegenHandlers(unittest.TestCase):
         assert PLACEHOLDER not in text
         # the bit-insertions that used to be dropped are rendered now
         assert "_INSERT(" in text
+
+
+class TestRustStoreWidth(unittest.TestCase):
+    """A store's emitted Rust has to write as many bytes as the AIL store writes."""
+
+    @classmethod
+    def setUpClass(cls):
+        # any binary will do: we only need a constructed Rust code generator to drive the handler with
+        proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, show_progressbar=False)
+        dec = proj.analyses.Decompiler(proj.kb.functions["main"], cfg=cfg.model, flavor="rust", fail_fast=True)
+        assert isinstance(dec.codegen, RustStructuredCodeGenerator)
+        cls.codegen = dec.codegen
+
+    def _store(self, idx: int, value_type, value_bits: int, size: int):
+        # the destination is what _access turns into the dereference, so its type is the width written
+        data = Const(idx, 0, value_bits, type=value_type)
+        # an address inside no section, so the constant handler cannot retype it as a string or a function pointer
+        stmt = Store(idx, Const(idx, 0x7FFF00000000, 64), data, size, "Iend_LE")
+        return self.codegen._handle(stmt, is_expr=False)
+
+    def test_value_typed_narrower_than_the_store(self):
+        assert self._store(1, RustSimTypeInt(size=32, signed=False), 32, 8).lhs.type.size == 64
+
+    def test_value_typed_wider_than_the_store(self):
+        assert self._store(2, RustSimTypeInt(size=64, signed=False), 64, 1).lhs.type.size == 8
+
+    def test_value_with_no_inferred_type(self):
+        # SimTypeBottom carries no size at all, so the store width is the only information there is
+        store = self._store(3, SimTypeBottom(), 128, 16)
+        assert store.lhs.type.size == 128
+        # Rust has a native 128-bit integer, so the repaired width is spelled directly
+        assert "u128" in _render(store)
+
+    def test_value_typed_correctly_is_left_alone(self):
+        assert self._store(4, RustSimTypeInt(size=64, signed=False), 64, 8).lhs.type.size == 64
+
+    def test_aggregate_value_is_not_cast(self):
+        # a scalar cast cannot change the width of a &str, so the mismatch is reported, not "repaired"
+        store = self._store(5, RustSimTypeStrRef(), 128, 8)
+        assert store.lhs.type.size == 128
+
+    def test_value_with_no_type_at_all(self):
+        """A value whose type comes back None must not take the handler down.
+
+        RustIndexedVariable and RustBinaryOp both return None for a type they cannot work out.
+        Guarding only the diagnostic, as the C backend does, moves the crash from the diagnostic
+        into _access ("no type whatsoever for dereference"), so the value is retyped instead.
+        """
+
+        class Untyped(RustExpression):
+            """stands in for any Rust expression whose type comes back None"""
+
+            __slots__ = ()
+
+            @property
+            def type(self):
+                return None
+
+            def c_repr_chunks(self, indent=0, asexpr=False):
+                yield "UNTYPED", self
+
+        untyped = Untyped(codegen=self.codegen)
+        real_handle = self.codegen._handle
+
+        def handle(node, **kwargs):
+            # the AIL layer does not preserve object identity, so key on the constant's value
+            return untyped if getattr(node, "value", None) == 0xD1CE else real_handle(node, **kwargs)
+
+        stmt = Store(6, Const(6, 0x7FFF00000000, 64), Const(6, 0xD1CE, 64), 8, "Iend_LE")
+        with mock.patch.object(self.codegen, "_handle", handle):
+            store = RustStructuredCodeGenerator._handle_Stmt_Store(self.codegen, stmt)
+        assert store.lhs.type.size == 64
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Problem

The Rust code generator sizes a store from the type recovered for the stored value, not from the store. `_handle_Stmt_Store` noticed the disagreement and only logged it, so the function decompiled with status `ok` and output that writes the wrong number of bytes.

In `core::ops::function::FnOnce::call_once{{vtable.shim}}` at `0x411160` in `tests/x86_64/langdetect_rust`, four sixteen- and one-byte stores all render as eight-byte dereferences:

```
-    *(v4 as &&u64) = &g_0.field_0;                 // the AIL store is 16 bytes
+    *(v4 as &u128) = &g_0.field_0 as u128;
-    *((v4 + 48) as &&u64) = &g_0.field_0;          // the AIL store is 1 byte
+    *((v4 + 48) as &u8) = &g_0.field_0 as u8;
```

This is the defect angr/angr#6999 fixed in `c.py`, ported to `rust.py`, which never received it.

## Root cause

`_handle_Stmt_Store` built the destination through `_access(addr, cdata.type, ...)`, so the value's type became the dereference type. `stmt.size` was consulted only to decide whether to log.

Two things differ from the C backend. `cdata.type` can be `None` here: `RustIndexedVariable` and `RustBinaryOp` return `None` for a type they cannot work out, and `.size` on that raises `AttributeError` before the log line is reached. Restoring #6999's guard verbatim would only move the failure, because `data_type=None` then reaches `_access_constant_offset`, whose `base_type is None` branch raises `RustStructuredCodeGenerator programming error: no type whatsoever for dereference`.

## Fix

The store retypes its value at `stmt.size * arch.byte_width` before building the access, as `_handle_Expr_Call` and the `Convert` handler already do against the same comparison. `qualifies_for_width_cast` gates it: the Rust scalar types subclass the C ones (`RustSimTypeInt` of `SimTypeInt`, `RustSimTypeReference` of `SimTypePointer`), while `RustSimStruct`, `RustSimTypeStrRef`, `RustSimTypeOption` and the other aggregates subclass none of them and keep the previous behaviour, since a scalar cast cannot change a `&str`'s width. Floats are excluded because a float cast converts the value rather than the representation.

Two things are Rust-specific rather than transcribed. `rust.py` has no `default_simtype_from_bits`; its `default_simtype_from_size` takes **bytes**, so `stmt.size` is passed and not `stmt.size * byte_width`, which would produce a type eight times too wide. And the `None` case is retyped as well as the mismatched case, which is what removes the crash: after the cast the value carries a real type and `_access` has something to dereference through. Where C has to quarantine a repaired 128-bit store because `(uint128_t)x` is not valid C, Rust spells it `x as u128`.

The diagnostic still fires whenever a recovered type disagrees, now naming both widths, because that disagreement is worth fixing in whichever layer produced the type.

## Testing

Six regression cases in `tests/analyses/decompiler/test_rust_codegen_handlers.py`, driving the handler on a code generator built from the existing `x86_64/fauxware` fixture: value narrower than the store, wider, untyped, correctly typed, an aggregate that must not be cast, and a value whose `type` is `None`, which is an `AttributeError` on master. No input is assembled, compiled or downloaded.

Paired before/after measurement over the nine x86_64 Rust fixtures in `angr/binaries`, first 700 functions of each by address, SAILR structurer with `flavor="rust"`: 6,300 functions, 3,230 stores lowered. Stores emitted at a width other than the store's fall from **68 in 42 functions to 28 in 26 functions** — 40 stores in 16 functions repaired. Every repaired one was scalar; all 28 that remain are aggregates the predicate excludes by design. No function changed status, and both arms lowered the same 3,230 stores with no errors or timeouts.

Validation: https://github.com/angr/angr/pull/7025#issuecomment-5455911831

session: crazybins