### PR TITLE
Decompiler: collect data references from every expression it renders

### DIFF
--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -64,6 +64,54 @@ _PEEPHOLE_OPTIMIZATIONS_TYPE = (
 )
 
 
+class ConstantCollector(SequenceWalker):
+    """
+    Collect the values of all integer constants in a structured sequence, including the constants inside expressions
+    and statements that structuring lifts out of blocks and onto the nodes themselves.
+    """
+
+    # pylint:disable=unused-argument
+
+    def __init__(self):
+        self.const_values: set[int] = set()
+        self._block_viewer = ailment.AILBlockViewer()
+        # updating the default handler table keeps the handlers that descend into subexpressions; passing
+        # expr_handlers to the constructor would replace them, and no constant below the top level would be reached
+        self._block_viewer.expr_handlers[ailment.Expr.Const] = self._handle_Const
+        super().__init__(handlers={ailment.Block: self._handle_Block}, update_seqnode_in_place=False)
+
+    def _handle(self, node, **kwargs):
+        # a node's condition, switch expression, loop initializer and loop iterator are AIL expressions and
+        # statements rather than nodes, and the base walker has no handler for them
+        if isinstance(node, ailment.Expr.Expression):
+            self._block_viewer.walk_expression(node)
+            return None
+        if isinstance(node, ailment.Stmt.Statement):
+            self._block_viewer.walk_statement(node)
+            return None
+        return super()._handle(node, **kwargs)
+
+    #
+    # Handlers
+    #
+
+    def _handle_Const(self, expr_idx: int, expr: ailment.Expr.Const, *args, **kwargs):
+        if isinstance(expr.value, int):
+            self.const_values.add(expr.value)
+
+    def _handle_Block(self, block: ailment.Block, **kwargs):
+        self._block_viewer.walk(block)
+
+    def _handle_CascadingCondition(self, node, **kwargs):
+        for condition, _ in node.condition_and_nodes:
+            self._block_viewer.walk_expression(condition)
+        return super()._handle_CascadingCondition(node, **kwargs)
+
+    def _handle_ConditionalBreak(self, node, **kwargs):
+        self._block_viewer.walk_expression(node.condition)
+        return super()._handle_ConditionalBreak(node, **kwargs)
+
+
 class Decompiler(Analysis):
     """
     The decompiler analysis.
@@ -919,30 +967,11 @@ class Decompiler(Analysis):
     def find_data_references_and_update_memory_data(self, seq_node: SequenceNode):
         assert self._cfg is not None
 
-        const_values: set[int] = set()
-
-        def _handle_Const(expr_idx: int, expr: ailment.Expr.Const, *args, **kwargs):  # pylint:disable=unused-argument
-            if isinstance(expr.value, int):
-                const_values.add(expr.value)
-
-        def _handle_block(block: ailment.Block, **kwargs):  # pylint:disable=unused-argument
-            block_walker = ailment.AILBlockViewer(
-                expr_handlers={
-                    ailment.Expr.Const: _handle_Const,
-                }
-            )
-            block_walker.walk(block)
-
-        seq_walker = SequenceWalker(
-            handlers={
-                ailment.Block: _handle_block,
-            },
-            update_seqnode_in_place=False,
-        )
-        seq_walker.walk(seq_node)
+        collector = ConstantCollector()
+        collector.walk(seq_node)
 
         added_memory_data_addrs = []
-        for data_addr in const_values:
+        for data_addr in collector.const_values:
             if data_addr in self._cfg.memory_data:
                 continue
             if not self.project.loader.find_loadable_containing(data_addr):

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -21,6 +21,7 @@ from angr.rust.optimization_passes import get_rust_optimization_passes
 from angr.rust.typehoon.typehoon import RustTypehoon
 from angr.sim_variable import SimMemoryVariable, SimRegisterVariable, SimStackVariable
 from angr.utils import timethis
+from angr.utils.loader import is_in_readonly_section, is_in_readonly_segment
 
 from .ailgraph_walker import AILGraphWalker
 from .clinic import ClinicStage
@@ -975,6 +976,10 @@ class Decompiler(Analysis):
             if data_addr in self._cfg.memory_data:
                 continue
             if not self.project.loader.find_loadable_containing(data_addr):
+                continue
+            if not is_in_readonly_section(self.project, data_addr) and not is_in_readonly_segment(
+                self.project, data_addr
+            ):
                 continue
             if self._cfg.add_memory_data(data_addr, None):
                 added_memory_data_addrs.append(data_addr)

--- a/tests/analyses/decompiler/test_output_nondeterminism.py
+++ b/tests/analyses/decompiler/test_output_nondeterminism.py
@@ -6,6 +6,7 @@ __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redef
 
 import difflib
 import os
+import re
 import unittest
 
 import angr
@@ -43,6 +44,46 @@ class TestVariableNondeterminism(unittest.TestCase):
                 print(output[i])
                 print("=======")
                 assert False, f"Output differs at iteration {i}"
+
+    def test_data_references_do_not_depend_on_decompilation_order(self):
+        """Regression test for the memory_data half of https://github.com/angr/angr/issues/7003."""
+
+        binary_path = os.path.join(bin_location, "tests", "armel", "libsoap.so")
+        soap_attribute = 0x4122A0
+        # holds the same two string addresses in ordinary statements, where soap_attribute() reaches them
+        # only through the condition of an if-else chain
+        other = 0x412CC8
+        # "=\"" -- referenced by soap_attribute() and by `other`, and by neither one's blocks
+        shared_string = 0x4256C4
+
+        def decompile(order: tuple[int, ...]) -> tuple[str, bool]:
+            project = angr.Project(binary_path, auto_load_libs=False)
+            cfg = project.analyses.CFGFast(data_references=True, normalize=True)
+            assert shared_string not in cfg.model.memory_data, "CFGFast already found the constant"
+            texts = {}
+            contributed = False
+            for addr in order:
+                dec = project.analyses.Decompiler(project.kb.functions[addr], cfg=cfg.model)
+                assert dec.codegen is not None and dec.codegen.text is not None
+                texts[addr] = dec.codegen.text
+                if addr == soap_attribute and order[0] == soap_attribute:
+                    # whether soap_attribute() contributes the constant itself, before anything else runs
+                    contributed = shared_string in cfg.model.memory_data
+            return texts[soap_attribute], contributed
+
+        alone, contributed = decompile((soap_attribute, other))
+        assert contributed, (
+            f"decompiling {soap_attribute:#x} did not add {shared_string:#x} to memory_data, so whether it "
+            f"renders as a literal depends on some other function having been decompiled first"
+        )
+
+        after_other, _ = decompile((other, soap_attribute))
+        literals = re.compile(r'"(?:[^"\\]|\\.)*"')
+        assert sorted(set(literals.findall(alone))) == sorted(set(literals.findall(after_other))), (
+            f"the string literals in {soap_attribute:#x} depend on whether {other:#x} was decompiled first"
+        )
+        # all four are reached through call arguments inside conditions, which the collector used to walk past
+        assert set(literals.findall(alone)) >= {'"xmlns:"', '" "', r'"=\""', r'"\""'}
 
     def test_redecompilation_is_idempotent_for_referenced_stack_arrays(self):
         """Regression: Re-decompiling a function must not rename its stack arrays.

--- a/tests/analyses/decompiler/test_output_nondeterminism.py
+++ b/tests/analyses/decompiler/test_output_nondeterminism.py
@@ -10,6 +10,7 @@ import re
 import unittest
 
 import angr
+from angr.utils.loader import is_in_readonly_section, is_in_readonly_segment
 from tests.common import bin_location
 
 
@@ -84,6 +85,31 @@ class TestVariableNondeterminism(unittest.TestCase):
         )
         # all four are reached through call arguments inside conditions, which the collector used to walk past
         assert set(literals.findall(alone)) >= {'"xmlns:"', '" "', r'"=\""', r'"\""'}
+
+    def test_data_references_are_not_added_for_writable_memory(self):
+        """A constant pointing into writable memory must not gain a MemoryData entry.
+
+        The bytes at such an address are whatever the program will later write there, so classifying them
+        makes the code generator drop a typed global for a raw pointer dereference.
+        """
+
+        binary_path = os.path.join(bin_location, "tests", "armhf", "fauxware")
+        # in .data; decompiling 0x104c9 used to classify it as a pointer array
+        writable = 0x207D0
+
+        project = angr.Project(binary_path, auto_load_libs=False)
+        cfg = project.analyses.CFGFast(data_references=True, normalize=True)
+        assert writable not in cfg.model.memory_data, "CFGFast already recorded the address"
+        assert not is_in_readonly_section(project, writable) and not is_in_readonly_segment(project, writable)
+
+        for func in sorted(project.kb.functions.values(), key=lambda f: f.addr):
+            if func.is_simprocedure or func.is_plt or func.is_alignment or not func.size:
+                continue
+            project.analyses.Decompiler(func, cfg=cfg.model)
+
+        assert writable not in cfg.model.memory_data, (
+            f"decompilation added {writable:#x} to memory_data, but it is not in read-only memory"
+        )
 
     def test_redecompilation_is_idempotent_for_referenced_stack_arrays(self):
         """Regression: Re-decompiling a function must not rename its stack arrays.


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling one function changes the decompilation of another in the same
`Project`. On `binaries/tests/armel/libsoap.so`, decompiling `soap_attribute()`
at `0x4122a0` on its own and then again after `0x412cc8` gives two different
functions:

```c
-    struct_2 *v3;  // r3
+    unsigned int v3;  // r3
-    if (!soap_send_raw(index, &g_4256c4, 2) && ... && !soap_send_raw(index, &g_4256b4, 1))
+    if (!soap_send_raw(index, "=\"", 2) && ... && !soap_send_raw(index, "\"", 1))
```

Nothing about `0x4122a0` changed; it inherits state the first decompilation left
behind. Two independent shared-state channels produce that diff. This change
addresses the first: the `CFGModel.memory_data` entries that decide whether a
constant renders as a string literal.

### Root cause

`Decompiler.find_data_references_and_update_memory_data()` adds a `MemoryData`
entry for every constant in the function it has just structured, so that
`CStructuredCodeGenerator._handle_Expr_Const` can render a literal for it. Those
entries go into the shared `CFGModel`, which is what carries one function's
discovery into the next one's output. That sharing is deliberate. What is not is
that the collector reached far less of the function than the code generator
does:

- It built its viewer as `AILBlockViewer(expr_handlers={Const: ...})`.
  `AILBlockWalker` *replaces* its default handler table with that dict, where
  `SequenceWalker` *merges*, so every other expression kind fell through to
  `_top()`, which does not descend. Only a constant appearing directly as a
  statement operand was collected -- not one inside a call argument, a binary
  operation or a conversion. On `soap_attribute()` that is 1 constant of the 15
  reachable in its blocks.
- It walked `ailment.Block` nodes only. Expression folding lifts a call out of
  its block and onto a `ConditionNode` or `CascadingConditionNode` condition,
  which the sequence walk never visited and the code generator renders.

`soap_attribute()` reaches `0x4256b4` and `0x4256c4` only through an if-else
chain condition, so it never contributed them and `0x4256b4 in memory_data` was
`False` after decompiling it; `0x412cc8` holds the same addresses in ordinary
statements, so it did.

### Fix

Collect from the whole sequence: descend into subexpressions, and visit the
expressions and statements structuring attaches to nodes rather than to blocks
-- node conditions, switch expressions, and loop initializers and iterators.
Every constant the code generator can resolve against `memory_data` is then
contributed by the function that renders it. `0x4256b4 in memory_data` after
decompiling `0x4122a0` alone goes from `False` to `True`, the two string hunks
leave the order diff, and `soap_attribute()` recovers all four of its literals
in either order.

A wider collector also reaches constants pointing into writable memory, where
the bytes are whatever the program will later write and so are not evidence of
a type: classifying `0x20000004` in `libopencm3/lcd-dma.elf` as a string cost
that function its typed `unsigned short[4]` global. The second commit records
an entry only for read-only memory, using the pair of predicates
`_handle_Expr_Const` already applies before inlining a string constant, so the
site that writes the entry and the site that reads it agree.

The shared write itself is left alone; it is what makes decompilation results
visible to the rest of the knowledge base, and it is no longer what decides the
output. A residual order dependence remains and is **not** addressed here: with
`CompleteCallingConventions(analyze_callsites=True)`, `v3` is still recovered as
`struct_2 *` alone and `unsigned int` after `0x412cc8`, through variable and
type recovery rather than through `memory_data`. That channel stays open.

### Testing

A regression in `tests/analyses/decompiler/test_output_nondeterminism.py`
asserts that decompiling `0x4122a0` alone puts `0x4256c4` into `memory_data` and
that its string literals are the same in both orders; on master it fails at the
first assertion, which is the mechanism itself. Corpus runs over ARM and x86-64
report no status or coverage regressions.

Addresses the `memory_data` half of #7003; the variable-recovery half stays open. Validation: https://github.com/angr/angr/pull/7029#issuecomment-5458244798

session: emo-corpus