### PR TITLE
SimCCAArch64: lay out an aggregate argument the way AAPCS64 does

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2125,6 +2125,43 @@ class SimCCAArch64(SimCC):
     RETURN_VAL = SimRegArg("x0", 8)
     ARCH = archinfo.ArchAArch64
 
+    # https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#parameter-passing
+    def next_arg(self, session, arg_type):
+        if isinstance(arg_type, (SimTypeArray, SimTypeFixedSizeArray)):  # hack
+            arg_type = SimTypePointer(arg_type.elem_type).with_arch(self.arch)
+        composite = isinstance(arg_type, (SimStruct, SimUnion, SimTypeFixedSizeArray))
+        if arg_type.size is None or (not composite and arg_type.size <= self.arch.bits):
+            return super().next_arg(session, arg_type)
+        if composite and arg_type.size > 128:
+            # a composite larger than 16 bytes is copied to memory by the caller and replaced by a pointer
+            return self._reference_arg(session, arg_type)
+
+        double_words = self._double_words(arg_type)
+        state = session.getstate()
+        if double_words > 1 and arg_type.alignment == 16 and session.int_iter.getstate() % 2 == 1:
+            next(session.int_iter)  # a 16-byte-aligned argument starts on an even-numbered register
+        try:
+            locs = [next(session.int_iter) for _ in range(double_words)]
+        except StopIteration:
+            session.setstate(state)
+            session.int_iter.setstate(len(self.ARG_REGS))
+            locs = [next(session.both_iter) for _ in range(double_words)]
+        return refine_locs_with_struct_type(self.arch, locs, arg_type)
+
+    def _double_words(self, arg_type: SimType) -> int:
+        assert arg_type.size is not None
+        return max(1, (arg_type.size // self.arch.byte_width + self.arch.bytes - 1) // self.arch.bytes)
+
+    def _reference_arg(self, session, arg_type: SimType) -> SimReferenceArgument:
+        referenced_locs = [
+            SimStackArg(offset * self.arch.bytes, self.arch.bytes) for offset in range(self._double_words(arg_type))
+        ]
+        try:
+            ptr_loc = next(session.int_iter)
+        except StopIteration:
+            ptr_loc = next(session.both_iter)
+        return SimReferenceArgument(ptr_loc, refine_locs_with_struct_type(self.arch, referenced_locs, arg_type))
+
 
 class SimCCAArch64LinuxSyscall(SimCCSyscall):
     # TODO: Make sure all the information is correct

--- a/tests/test_calling_conventions.py
+++ b/tests/test_calling_conventions.py
@@ -12,6 +12,7 @@ import archinfo
 
 from angr import Project, load_shellcode, types
 from angr.calling_conventions import (
+    SimCCAArch64,
     SimCCMicrosoftAMD64,
     SimCCMicrosoftFastcall,
     SimCCRISCV64,
@@ -26,10 +27,12 @@ from angr.calling_conventions import (
 )
 from angr.sim_type import (
     SimCppClass,
+    SimStruct,
     SimStructValue,
     SimTypeChar,
     SimTypeDouble,
     SimTypeLongLong,
+    SimTypeNum,
     SimTypeRef,
     parse_file,
 )
@@ -243,6 +246,47 @@ class TestCallingConvention(TestCase):
         c_float = struct.unpack("<f", struct.pack("<I", c_bits))[0]
         assert abs(c_float - 102.3) < 0.00001
         assert (a3_val >> 32) == 60
+
+    def test_aarch64_aggregate_args(self):
+        arch = archinfo.arch_from_id("aarch64")
+        cc = SimCCAArch64(arch)
+
+        def locs(*args):
+            return cc.arg_locs(SimTypeFunction(list(args), SimTypeInt()).with_arch(arch))
+
+        integer = SimTypeInt()
+        small = SimStruct({"a": SimTypeInt(), "b": SimTypeInt()}, name="Small")
+        pair = SimStruct({"x": SimTypeLongLong(), "y": SimTypeLongLong()}, name="Pair")
+        big = SimStruct({"a": SimTypeLongLong(), "b": SimTypeLongLong(), "c": SimTypeLongLong()}, name="Big")
+
+        # A composite of one double-word takes one register, one of two takes a consecutive pair.
+        assert locs(small)[0].get_footprint() == {SimRegArg("x0", 8)}
+        assert locs(pair)[0].get_footprint() == {SimRegArg("x0", 8), SimRegArg("x1", 8)}
+
+        # A composite larger than 16 bytes is passed by reference.
+        big_loc = locs(big)[0]
+        assert isinstance(big_loc, SimReferenceArgument)
+        assert big_loc.ptr_loc == SimRegArg("x0", 8)
+        assert big_loc.main_loc.get_footprint() == {SimStackArg(0, 8), SimStackArg(8, 8), SimStackArg(0x10, 8)}
+
+        # Seven integers leave one register free, which a two-register composite cannot use: it goes on
+        # the stack, and the register it skipped is not given to the argument after it either.
+        spilled = locs(*[integer] * 7, pair, integer)
+        assert spilled[6] == SimRegArg("x6", 4)
+        assert spilled[7].get_footprint() == {SimStackArg(0, 8), SimStackArg(8, 8)}
+        assert spilled[8] == SimStackArg(0x10, 4)
+
+        # A 16-byte integral argument takes a register pair, starting on an even-numbered register.
+        assert locs(integer, SimTypeNum(128))[1].get_footprint() == {SimRegArg("x2", 8), SimRegArg("x3", 8)}
+
+    def test_aarch64_class_by_value_argument(self):
+        proj = Project(os.path.join(test_location, "aarch64", "struct_by_value_aarch64.so"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        proj.analyses.CompleteCallingConventions(recover_variables=True, analyze_callsites=True)
+        func = next(f for f in proj.kb.functions.values() if f.name == "_Z8take_big3Big" and not f.is_plt)
+        assert isinstance(func.prototype.args[0], SimCppClass)
+        assert len(proj.factory.cc().arg_locs(func.prototype.with_arch(proj.arch))) == 1
+        assert proj.analyses.Decompiler(func, cfg=cfg.model).codegen is not None
 
     def test_simcc_arg_locs_returnty_unresolved_simtyperef(self):
         func_proto = SimTypeFunction([], SimTypeRef("std::wstring_t", SimCppClass))

--- a/tests/test_calling_conventions.py
+++ b/tests/test_calling_conventions.py
@@ -279,6 +279,25 @@ class TestCallingConvention(TestCase):
         # A 16-byte integral argument takes a register pair, starting on an even-numbered register.
         assert locs(integer, SimTypeNum(128))[1].get_footprint() == {SimRegArg("x2", 8), SimRegArg("x3", 8)}
 
+    def test_aarch64_aggregate_args_reach_the_callsite(self):
+        proj = Project(os.path.join(test_location, "aarch64", "struct_by_value_aarch64.so"), auto_load_libs=False)
+        cc = SimCCAArch64(proj.arch)
+        pair = SimStruct({"x": SimTypeLongLong(), "y": SimTypeLongLong()}, name="Pair")
+        big = SimStruct({"a": SimTypeLongLong(), "b": SimTypeLongLong(), "c": SimTypeLongLong()}, name="Big")
+        proto = SimTypeFunction([SimTypeInt(), pair, big, SimTypeInt()], SimTypeInt()).with_arch(proj.arch)
+        addr = proj.loader.find_symbol("_Z9call_theml").rebased_addr
+
+        state = proj.factory.call_state(
+            addr, 7, {"x": 11, "y": 22}, {"a": 33, "b": 44, "c": 55}, 9, cc=cc, prototype=proto
+        )
+        evaluate = state.solver.eval
+        assert evaluate(state.regs.x0) == 7
+        assert evaluate(state.regs.x1) == 11
+        assert evaluate(state.regs.x2) == 22
+        referenced = evaluate(state.regs.x3)
+        assert [evaluate(state.memory.load(referenced + 8 * i, 8, endness="Iend_LE")) for i in range(3)] == [33, 44, 55]
+        assert evaluate(state.regs.x4) == 9
+
     def test_aarch64_class_by_value_argument(self):
         proj = Project(os.path.join(test_location, "aarch64", "struct_by_value_aarch64.so"), auto_load_libs=False)
         cfg = proj.analyses.CFGFast(normalize=True)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An AArch64 function that takes a struct or a class by value cannot be decompiled at all. On
`tests/aarch64/struct_by_value_aarch64.so` six of the eight recovered functions produce
nothing, and the resilience wrapper logs the reason rather than raising it:

```
Caught and logged TypeError with resilience: <SimCCAArch64> doesn't know how to store
aggregate type <class 'angr.sim_type.SimCppClass'>. Consider overriding next_arg to
implement its ABI logic
```

The same source compiled for x86-64 decompiles all eight, because `SimCCSystemVAMD64`
implements `next_arg`. Both sites that reach it lose the whole function: `Clinic` builds the
argument list on the callee side, `CallSiteMaker` on the caller side.

### Root cause

`SimCCAArch64` names the eight integer argument registers and nothing else, so it inherits
`SimCC.next_arg`, which refuses every `SimStruct`, `SimUnion` and `SimTypeFixedSizeArray`,
and refuses any argument wider than one register a few lines further down. AAPCS64 argument
classification was never written for it, and the raise says so. Every other non-trivial
convention in the file overrides `next_arg`.

### Fix

`SimCCAArch64.next_arg` implements the general-purpose half of AAPCS64 parameter passing: a
composite of at most 16 bytes goes in consecutive `x` registers, one larger than that is
passed indirectly with the pointer in a register, a 16-byte integral argument takes a
register pair starting on an even-numbered register, and a composite that does not fit in
the registers left goes on the stack without the skipped registers being handed to any later
argument. Everything the base convention already places is delegated to it unchanged.

Floating-point and short-vector arguments therefore stay on the base path. AAPCS64 assigns
them to the SIMD registers and `SimCCAArch64.FP_ARG_REGS` is empty, so modelling those -- and
with them the homogeneous aggregates that ride in the same registers -- is a separate change.
Aggregate return values still raise; this one is about arguments.

### Overlap with #7036

#7036 is that separate change, and it gives this same class a `next_arg` of its own. Git
merges the two versions of `angr/calling_conventions.py` with no conflict and leaves
`SimCCAArch64` holding two `def next_arg`. Python keeps the second, which is this one.

The merge cannot land unnoticed. `tests/test_calling_conventions.py` conflicts in both
orders, so whichever of the two is merged second has to be rebased first. On the merged file
pylint with the CI configuration reports `E0102: method already defined` and scores the file
9.98 where either change alone scores 10.00, and `ruff` reports `F811`. The rebase folds the
two into one method with #7036's homogeneous-aggregate test first, because AAPCS64 classifies
an HFA in C.2-C.6, before the general composite rules in C.10-C.15 that this change
implements.

### Testing

Two tests: one asserts the placements above on constructed prototypes, and one loads the
AArch64 object and asserts that the function whose prototype carries the class decompiles.
Both fail at master with the `TypeError` quoted above. Over a corpus sweep the same raise
emptied 80 distinct functions across 8 objects of a redistribution-restricted collection, and
the wider-than-a-register raise a further 10 functions across 10 objects; no committed
fixture reached either, which is why (angr/binaries#214) adds one.

Fixes #7028. Validation: https://github.com/angr/angr/pull/7030#issuecomment-5459986188

sync: angr/binaries#214

session: sharpen
