### PR TITLE
BlockSimplifier: bound the simplification loop by the block, not by thirty

### DIFF
--- a/angr/analyses/decompiler/block_simplifier.py
+++ b/angr/analyses/decompiler/block_simplifier.py
@@ -193,7 +193,6 @@ class BlockSimplifier:
         block = self.block
         assert block is not None
         ctr = 0
-        max_ctr = 30
 
         new_block, changed = self._eliminate_self_assignments(block)
         # True once dead-assignment elimination is known to have nothing to do on the block the loop below starts
@@ -206,6 +205,10 @@ class BlockSimplifier:
         if changed:
             self._clear_cache()
             block = new_block
+
+        # Where the stack pointer is unresolved the propagator folds one link of a definition chain per
+        # pass, so a block can legitimately need one iteration for each statement it starts out with.
+        max_ctr = max(30, len(block.statements))
 
         while True:
             ctr += 1

--- a/tests/analyses/decompiler/test_block_simplifier.py
+++ b/tests/analyses/decompiler/test_block_simplifier.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os.path
+import unittest
+
+import angr
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestBlockSimplifier(unittest.TestCase):
+    """How many simplification passes a block is allowed before the loop gives up on it."""
+
+    def test_a_long_stack_pointer_chain_reaches_a_fixed_point(self):
+        proj = angr.Project(os.path.join(test_location, "i386", "deep_sp_chain"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        func = proj.kb.functions["caller100"]
+
+        with self.assertNoLogs("angr.analyses.decompiler.block_simplifier", level="ERROR"):
+            decompilation = proj.analyses.Decompiler(func, cfg=cfg.model)
+        assert decompilation.codegen is not None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling `caller100` at `0x8049203` in `binaries/tests/i386/deep_sp_chain` makes angr report,
three times, that its own output is wrong:

```
ERROR | angr.analyses.decompiler.block_simplifier | Simplification does not reach a fixed point after 30 iterations. Block comparison is probably incorrect.
```

Nothing is wrong with it. Dumping the emitted C with the bound raised gives the same 6328 bytes,
byte for byte. It is an ERROR-level claim about the correctness of angr's own output, and this
one has no defect behind it.

### Root cause

The bound has been a literal `30` since it was added as a resiliency guard in `cfdc6214f`, in
2019. Where `StackPointerTracker` cannot resolve the frame -- a realignment through a register
in the fixture, an undecodable instruction in the packed binaries where this shows up in the
wild -- `SPropagator` records the first stack-pointer definition as foldable and every later one
as a `vvar` minus a constant, so exactly one link of the chain is folded per pass. The block in
the fixture holds a 98-link chain, progress is strictly monotone at one link per iteration, and
the loop is cut off at 30. The diagnostic then blames the change comparison, which is the one
part that is working.

### Fix

Take the bound from the block the loop starts with, as `max(30, len(block.statements))`. A pass
folds at least one definition and a chain cannot be longer than the definitions in the block, so
that is generous enough for any legitimate progress while still bounding a genuine oscillation
at the block's own size. The floor keeps the existing behaviour for small blocks, and the count
is taken once rather than per pass, because the fixture's first pass shrinks the block from 300
statements to 200 while it still needs 98 iterations.

The message is left as it is. With the bound sized to what legitimate progress can need, it
fires only on an oscillation, which is what it already describes. What the new bound admits is
capped structurally rather than by the constant: VEX lifts at most 99 instructions per IRSB, so
one block's dependent chain cannot run much past 99 links, and scaling the fixture to 400 and to
1000 arguments leaves the iteration count at 99 either way.

### Testing

A regression decompiles that function and asserts the block simplifier logs nothing at ERROR;
on master it fails with the three records above. Over the two largest committed Windows PE
objects, 35,819 blocks, the deepest simplification any block needed was 8 passes, so the new
bound is not reached anywhere the old one was not. The fixture comes from (angr/binaries#215)

Validation: https://github.com/angr/angr/pull/7032#issuecomment-5460256449

session: sharpen