### PR TITLE
SimType: normalize a fixed-width MSVC integer that no parameter name follows

### DIFF
--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -4487,10 +4487,12 @@ def normalize_cpp_function_name(name: str) -> str:
         # the return type is missing; give it a default type
         name = "int " + name
 
-    if " __int" in name:
-        name = name.replace(" __int64 ", " long long ")
-        name = name.replace(" __int32 ", " int ")
-        name = name.replace(" __int16 ", " short ")
+    if "__int" in name:
+        # a demangled signature carries no parameter names, so the type can end at a comma or a
+        # closing parenthesis rather than at a space
+        name = re.sub(r"\b__int64\b", "long long", name)
+        name = re.sub(r"\b__int32\b", "int", name)
+        name = re.sub(r"\b__int16\b", "short", name)
 
     return name.removesuffix(";")
 

--- a/tests/types/test_types.py
+++ b/tests/types/test_types.py
@@ -134,6 +134,25 @@ class TestTypes(unittest.TestCase):
         assert proto is not None
         assert len(proto.args) == 1
 
+    def test_cppproto_parse_msvc_fixed_width_integer(self):
+        # A demangled MSVC signature carries no parameter names, so a fixed-width integer ends at a
+        # comma or a closing parenthesis. Both of these are demangled symbols of
+        # binaries/tests/x86_64/windows/msvcr120.dll.
+        _, proto, _ = convert_cppproto_to_py(
+            "void Concurrency::set_task_execution_resources(unsigned __int64)", with_param_names=False
+        )
+        assert proto is not None
+        assert isinstance(proto.args[1], SimTypeLongLong)
+
+        _, proto, _ = convert_cppproto_to_py(
+            "unsigned __int64 Concurrency::event::wait_for_multiple("
+            "class Concurrency::event **, unsigned __int64, bool, unsigned int)",
+            with_param_names=False,
+        )
+        assert proto is not None
+        assert isinstance(proto.args[2], SimTypeLongLong)
+        assert isinstance(proto.returnty, SimTypeLongLong)
+
     def test_cppproto_parse_operator_shl(self):
         proto = "std::ostream::operator<<(std::ostream& (*)(std::ostream&))"
         _, proto, _ = convert_cppproto_to_py(proto)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

angr invents a C++ class for an argument that is a plain integer. On
`binaries/tests/x86_64/windows/msvcr120.dll`, after `CFGFast` and
`CompleteCallingConventions`, fourteen of the 3,483 recovered prototypes carry a fabricated
class or a size-less argument, and ten of them look like this:

```
?set_task_execution_resources@Concurrency@@YAX_K@Z
  Concurrency::set_task_execution_resources(void*, class unsigned __int64) -> void
```

There is no such class. The argument is `unsigned __int64`, and the opaque `SimCppClass` angr
puts in its place carries a fabricated 32-bit size, so the decompiled call renders a class
where the program passes a 64-bit integer, and the aggregate reaches every consumer of the
prototype as one.

### Root cause

`normalize_cpp_function_name` rewrites the MSVC fixed-width spellings with
`name.replace(" __int64 ", " long long ")` — a leading *and* a trailing space. A demangled
signature carries no parameter names, so the type ends at a comma or a closing parenthesis and
the rewrite does not fire. `ALL_TYPES` has `__int64` on its own but not `unsigned __int64`, so
the combined token resolves to nothing and `_cpp_decl_to_type` falls through to its
opaque-class branch, which is what names the class.

The tell is that adding a parameter name fixes it: `operator new(unsigned __int64)` parses as a
class and `operator new(unsigned __int64 x)` parses as `unsigned long long`.

### Fix

Match the token rather than the spaces around it, with `\b__int64\b` and its two siblings. The
three spellings the function already handled are the three it still handles; only the
requirement that a space follow them is gone.

Not done here, and separate: an unresolved `enum` name still becomes an opaque class the same
way, and a `SimCppClass` that survives the knowledge base's serialization round trip comes back
as a `SimTypeRef` with no size at all, because `SimCppClass.to_json` writes the reference
without one.

### Testing

A regression parses two demangled symbols of that DLL and asserts the integer argument and
return type; on master it fails with the class. On the same object the count of prototypes
carrying a fabricated class or a size-less argument falls from 14 to 4, and the four that
remain are the unresolved `enum` case above.

Validation: https://github.com/angr/angr/pull/7033#issuecomment-5460270696

session: sharpen