### PR TITLE
SimHostFilesystem: read the Unix-only os.stat fields portably

### DIFF
--- a/angr/state_plugins/filesystem.py
+++ b/angr/state_plugins/filesystem.py
@@ -478,6 +478,7 @@ class SimHostFilesystem(SimConcreteFilesystem):
             if dereference:
                 path = os.path.realpath(path)
             s = os.stat(path)
+            # st_rdev, st_blksize and st_blocks are present only on Unix hosts.
             return Stat(
                 s.st_dev,
                 s.st_ino,
@@ -485,10 +486,10 @@ class SimHostFilesystem(SimConcreteFilesystem):
                 s.st_mode,
                 s.st_uid,
                 s.st_gid,
-                s.st_rdev,
+                getattr(s, "st_rdev", 0),
                 s.st_size,
-                s.st_blksize,
-                s.st_blocks,
+                getattr(s, "st_blksize", 0x1000),
+                getattr(s, "st_blocks", (s.st_size + 511) // 512),
                 round(s.st_atime),
                 s.st_atime_ns,
                 round(s.st_mtime),

--- a/tests/state_plugins/test_filesystem.py
+++ b/tests/state_plugins/test_filesystem.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
+from __future__ import annotations
+
+__package__ = __package__ or "tests.state_plugins"  # pylint:disable=redefined-builtin
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import angr
+from angr.state_plugins.filesystem import SimHostFilesystem
+from angr.state_plugins.posix import Flags
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+# The fields os.stat_result carries on Windows. st_rdev, st_blksize and st_blocks are Unix-only.
+WINDOWS_STAT_FIELDS = (
+    "st_mode",
+    "st_ino",
+    "st_dev",
+    "st_nlink",
+    "st_uid",
+    "st_gid",
+    "st_size",
+    "st_atime",
+    "st_mtime",
+    "st_ctime",
+    "st_atime_ns",
+    "st_mtime_ns",
+    "st_ctime_ns",
+)
+
+_host_stat = os.stat
+
+
+def windows_stat(path, *args, **kwargs):
+    """
+    What os.stat reports for the same file on a Windows host.
+    """
+    s = _host_stat(path, *args, **kwargs)
+    return SimpleNamespace(
+        st_file_attributes=0x80,
+        st_reparse_tag=0,
+        **{name: getattr(s, name) for name in WINDOWS_STAT_FIELDS},
+    )
+
+
+class TestSimHostFilesystem(unittest.TestCase):
+    def _host_dir(self):
+        """
+        A host directory holding a five thousand byte hello.txt.
+        """
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, True)
+        with open(os.path.join(tmpdir, "hello.txt"), "wb") as fp:
+            fp.write(b"hello" * 1000)
+        return tmpdir
+
+    @unittest.skipIf(sys.platform == "win32", "the fields compared here exist only on Unix")
+    def test_stat_reports_the_host_values(self):
+        tmpdir = self._host_dir()
+        host = os.stat(os.path.join(tmpdir, "hello.txt"))
+
+        stat = SimHostFilesystem(tmpdir)._get_stat("hello.txt")
+
+        assert stat is not None
+        assert stat.st_size == host.st_size
+        assert stat.st_rdev == host.st_rdev
+        assert stat.st_blksize == host.st_blksize
+        assert stat.st_blocks == host.st_blocks
+
+    def test_stat_on_a_host_without_the_unix_only_fields(self):
+        tmpdir = self._host_dir()
+
+        with mock.patch("os.stat", windows_stat):
+            stat = SimHostFilesystem(tmpdir)._get_stat("hello.txt")
+
+        assert stat is not None
+        assert stat.st_size == 5000
+        assert stat.st_rdev == 0
+        assert stat.st_blksize == 0x1000
+        assert stat.st_blocks == 5000 // 512 + 1
+
+    def test_fstat_of_a_mounted_file_on_a_host_without_the_unix_only_fields(self):
+        tmpdir = self._host_dir()
+        project = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        state = project.factory.blank_state(concrete_fs=True, chroot=tmpdir)
+        fd = state.posix.open(b"/hello.txt", Flags.O_RDONLY)
+        assert fd is not None
+
+        with mock.patch("os.stat", windows_stat):
+            stat = state.posix.fstat(fd)
+
+        assert stat.st_size == 5000
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`SimHostFilesystem._get_stat` builds a `Stat` from `os.stat()` and reads `st_rdev`, `st_blksize` and `st_blocks`. `os.stat_result` carries those three only on Unix; on Windows they are absent, so anything that reaches the host filesystem — `fstat` on a mounted file, and the `chroot` SimProcedure — dies with:

```
AttributeError: 'os.stat_result' object has no attribute 'st_rdev'. Did you mean: 'st_dev'?
..\..\.venv-native\Lib\site-packages\angr\state_plugins\filesystem.py:488: AttributeError
```

### How it was found

The angr/mono monorepo runs angr's pytest suite on `windows-2022` in five shards. Run 33233913039, job `angr · windows-2022 py3.12 5/5`:

```
FAILED tests/procedures/posix/test_chroot.py::TestChroot::test_chroot_errors
FAILED tests/procedures/posix/test_chroot.py::TestChroot::test_chroot_on_host_filesystem_warns
```

Both terminate at `filesystem.py:488`, on `s.st_rdev`.

The read itself is long-standing — #2143 introduced it in 2020. What is new is the caller: a5b6ee127 ("Implement chroot properly", #7017) added those two tests, and they are the first thing to exercise `SimHostFilesystem._get_stat` on Windows.

Worth stating why this did not surface here first, since it is a whole class rather than one line. `ci.yml`'s Windows job runs `pytest --collect-only`, so no test executes on Windows on a pull request. `nightly-ci.yml` does run the suite on `windows-2022`, but only on the daily cron — it would have reported this a night after the merge rather than during review. And the only pre-existing test that reaches `_get_stat`, `tests/state_plugins/posix/test_files.py::test_concrete_fs_resolution`, has carried `@unittest.skipIf(sys.platform == "win32", "broken on windows")` since #4253 in 2023, so even the nightly Windows run has never executed this line. That skip is left alone here: the test also opens an absolute host path as a guest path, which is a separate Windows problem this change does not address.

### The values

angr is presenting a Linux guest's `struct stat` for a file that lives on the host, so the fallback is what `os.stat` would have reported for the same file on a Linux host.

- `st_rdev` is 0, the value Linux reports for everything that is not a device special file, which a path reached through `SimHostFilesystem` never is. `SimSystemPosix.fstat_with_result` already returns `claripy.BVV(0, 64)` for `st_rdev` on its unmounted path.
- `st_blksize` is 4096, the preferred I/O block size Linux reports on every common filesystem, and NTFS's default cluster size besides. The unmounted `fstat` path uses `0x400`, but that is a placeholder for a file with nothing behind it; 4096 is the more faithful answer for one backed by a real host file.
- `st_blocks` is the file's size in the 512-byte units the field is defined in. A flat `0` would make every file look empty to a guest computing disk usage.

`os.stat` is called in exactly one place in angr, so this is the only site of this shape, and no other platform-optional `stat_result` attribute (`st_flags`, `st_gen`, `st_birthtime`) is read anywhere in the repository.

### Test

`tests/state_plugins/test_filesystem.py` drives `_get_stat` and `state.posix.fstat` with `os.stat` reporting a Windows-shaped result: the field set `os.stat_result` actually carries on Windows, taken from a real host stat of the same file. The two new tests fail on master at `filesystem.py:488` with CI's message and pass with the change; a third asserts the Unix values still come through unmodified. Running the two failing chroot tests under the same Windows-shaped `os.stat` errors identically on master and passes here.

Validated on Linux: `tests/state_plugins`, `tests/procedures/posix`, `tests/storage` — 157 passed, 4 skipped.

session: sharpen
