### PR TITLE
Add a UEFI environment instead of loading UEFI images as Windows

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2716,22 +2716,25 @@ CC: dict[str, dict[str, list[type[SimCC]]]] = {
 }
 
 
+# "UEFI" covers the processor bindings of the UEFI specification. Only the two x86 ones depart from the
+# architecture's ordinary convention -- IA-32 is Microsoft cdecl and X64 is the Microsoft x64 convention -- but every
+# binding is spelled out, because default_cc() returns its caller's `default` before it falls back to "Linux".
 DEFAULT_CC: dict[str, dict[str, type[SimCC]]] = {
-    "AMD64": {"Linux": SimCCSystemVAMD64, "Win32": SimCCMicrosoftAMD64},
-    "X86": {"Linux": SimCCCdecl, "CGC": SimCCCdecl, "Win32": SimCCMicrosoftCdecl},
-    "ARMEL": {"Linux": SimCCARM},
+    "AMD64": {"Linux": SimCCSystemVAMD64, "Win32": SimCCMicrosoftAMD64, "UEFI": SimCCMicrosoftAMD64},
+    "X86": {"Linux": SimCCCdecl, "CGC": SimCCCdecl, "Win32": SimCCMicrosoftCdecl, "UEFI": SimCCMicrosoftCdecl},
+    "ARMEL": {"Linux": SimCCARM, "UEFI": SimCCARM},
     "ARMHF": {"Linux": SimCCARMHF},
     "ARMCortexM": {"Linux": SimCCARMHF},
     "MIPS32": {"Linux": SimCCO32},
     "MIPS64": {"Linux": SimCCN64},
     "PPC32": {"Linux": SimCCPowerPC},
     "PPC64": {"Linux": SimCCPowerPC64},
-    "AARCH64": {"Linux": SimCCAArch64},
+    "AARCH64": {"Linux": SimCCAArch64, "UEFI": SimCCAArch64},
     "Soot": {"Linux": SimCCSoot},
     "AVR8": {"Linux": SimCCUnknown},
     "MSP": {"Linux": SimCCUnknown},
     "S390X": {"Linux": SimCCS390X},
-    "RISCV64": {"Linux": SimCCRISCV64},
+    "RISCV64": {"Linux": SimCCRISCV64, "UEFI": SimCCRISCV64},
 }
 
 

--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -2716,9 +2716,6 @@ CC: dict[str, dict[str, list[type[SimCC]]]] = {
 }
 
 
-# "UEFI" covers the processor bindings of the UEFI specification. Only the two x86 ones depart from the
-# architecture's ordinary convention -- IA-32 is Microsoft cdecl and X64 is the Microsoft x64 convention -- but every
-# binding is spelled out, because default_cc() returns its caller's `default` before it falls back to "Linux".
 DEFAULT_CC: dict[str, dict[str, type[SimCC]]] = {
     "AMD64": {"Linux": SimCCSystemVAMD64, "Win32": SimCCMicrosoftAMD64, "UEFI": SimCCMicrosoftAMD64},
     "X86": {"Linux": SimCCCdecl, "CGC": SimCCCdecl, "Win32": SimCCMicrosoftCdecl, "UEFI": SimCCMicrosoftCdecl},

--- a/angr/simos/__init__.py
+++ b/angr/simos/__init__.py
@@ -13,6 +13,7 @@ from .javavm import SimJavaVM
 from .linux import SimLinux
 from .simos import SimOS
 from .snimmuc_nxp import SimSnimmucNxp
+from .uefi import SimUefi
 from .userland import SimUserland
 from .windows import SimWindows
 from .xbox import SimXbox
@@ -33,6 +34,7 @@ register_simos("windows", SimWindows)
 register_simos("cgc", SimCGC)
 register_simos("javavm", SimJavaVM)
 register_simos("snimmuc_nxp", SimSnimmucNxp)
+register_simos("uefi", SimUefi)
 register_simos("xbox", SimXbox)
 
 
@@ -42,6 +44,7 @@ __all__ = (
     "SimLinux",
     "SimOS",
     "SimSnimmucNxp",
+    "SimUefi",
     "SimUserland",
     "SimWindows",
     "os_mapping",

--- a/angr/simos/uefi.py
+++ b/angr/simos/uefi.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .simos import SimOS
+
+
+class SimUefi(SimOS):
+    """
+    Environment for UEFI images. UEFI is a boot-time environment with no process model and no syscall interface, so
+    what distinguishes it from a bare SimOS is its calling conventions: the x86 bindings of the UEFI specification
+    adopt the Microsoft conventions rather than the System V ones, which is what DEFAULT_CC records for "UEFI".
+    """
+
+    def __init__(self, project):
+        super().__init__(project, name="UEFI")

--- a/tests/simos/test_uefi.py
+++ b/tests/simos/test_uefi.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.simos"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from angr.calling_conventions import (
+    SimCCAArch64,
+    SimCCMicrosoftAMD64,
+    SimCCMicrosoftCdecl,
+    SimCCRISCV64,
+    default_cc,
+)
+from angr.simos import SimUefi
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+# angr's own CI checks out angr/binaries at master, so this fixture is absent until its pull request merges.
+riscv64_uefi_image = os.path.join(test_location, "riscv64", "uefi", "HighMemDxe.efi")
+
+
+class TestUefi(unittest.TestCase):
+    """
+    Tests for the UEFI environment.
+    """
+
+    @unittest.skipUnless(os.path.exists(riscv64_uefi_image), "needs the RISC-V UEFI fixture from angr/binaries")
+    def test_riscv64_image_does_not_become_windows(self):
+        # A UEFI module is a PE, and until cle told them apart every PE became a Windows binary. Windows has never
+        # run on RISC-V, so SimWindows reached for a Win32 syscall convention RISCV64 has no reason to have and
+        # raised KeyError: 'Win32' before the project was built.
+        project = angr.Project(riscv64_uefi_image, auto_load_libs=False)
+        assert project.arch.name == "RISCV64"
+        assert isinstance(project.simos, SimUefi)
+        assert project.simos.name == "UEFI"
+        # the RISC-V binding of the UEFI specification is the architecture's ordinary convention
+        assert isinstance(project.factory.cc(), SimCCRISCV64)
+
+    def test_ia32_image_uses_the_microsoft_convention(self):
+        # A Terse Executable only ever holds a UEFI module. The IA-32 binding of the UEFI specification is the C
+        # calling convention as the Microsoft toolchains implement it, not the System V one.
+        project = angr.Project(os.path.join(test_location, "i386", "te_sections.te"), auto_load_libs=False)
+        assert isinstance(project.simos, SimUefi)
+        assert isinstance(project.factory.cc(), SimCCMicrosoftCdecl)
+
+    def test_aarch64_image_uses_the_architecture_default(self):
+        # Only the x86 bindings depart from the architecture's ordinary convention; AArch64 UEFI is AAPCS64.
+        project = angr.Project(os.path.join(test_location, "aarch64", "te_sections.te"), auto_load_libs=False)
+        assert isinstance(project.simos, SimUefi)
+        assert isinstance(project.factory.cc(), SimCCAArch64)
+
+    def test_x64_binding_is_the_microsoft_convention(self):
+        # The X64 binding is the Microsoft x64 calling convention. angr/binaries carries no X64 UEFI image, so this
+        # asserts the table entry the environment reads rather than building a project.
+        assert default_cc("AMD64", platform="UEFI") is SimCCMicrosoftAMD64
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

angr has no UEFI environment, so a UEFI image is loaded as a Windows one. On
`HighMemDxe.efi`, a RISC-V UEFI boot service driver, the project cannot be built
at all:

```
$ python -c "import angr; angr.Project('HighMemDxe.efi', auto_load_libs=False)"
  File "angr/simos/windows.py", line 58, in __init__
    ...SYSCALL_CC[self.arch.name]["Win32"](self.arch)
KeyError: 'Win32'
```

Nothing about the image can be analysed after that -- no CFG, no decompilation,
no states. A corpus census over a sample of 11,989 objects found the exception on
2 of them, and on 2 of the 32 sampled from a Debian edk2 collection of 2,219.

### Root cause

`SimWindows.__init__` reads `SYSCALL_CC[self.arch.name]["Win32"]`, and
`SYSCALL_CC["RISCV64"]` has only `default` and `Linux`. Windows has never run on
RISC-V, so that entry is not missing by oversight; the image should never have
reached `SimWindows`. It did because cle called every PE a Windows binary, which
angr/cle#800 fixes by reading the optional header's subsystem, and because
`os_mapping` had nothing registered for `"uefi"`.

### Fix

Register `SimUefi` for `"uefi"`. UEFI is a boot-time environment with no process
model and no syscall interface, so it is a plain `SimOS`; what distinguishes it
is its calling conventions, and those go in `DEFAULT_CC` under the platform name
`"UEFI"`.

The UEFI specification's processor bindings are what the table records. IA-32 is
Microsoft cdecl and X64 is the Microsoft x64 convention -- the two that depart
from the System V norm -- while the ARM, AArch64 and RISC-V bindings are the
architectures' ordinary conventions. Those three are still written out rather
than left to a fallback, because `default_cc()` returns its caller's `default`
argument before it falls back to `"Linux"`, and `AngrObjectFactory` passes
`SimCCUnknown` as that default.

### Testing

`tests/simos/test_uefi.py` builds a project from the RISC-V driver added in
angr/binaries#218 and asserts the environment is `SimUefi` and the convention
`SimCCRISCV64`; it does the same for the two Terse Executables already in the
fixtures, which are UEFI by construction, and checks the X64 table entry
directly since no X64 UEFI image is available. On the merge base the RISC-V case
raises `KeyError: 'Win32'` and the two TE cases get a bare `SimOS`.

`python -m pytest tests/simos tests/test_calling_conventions.py`: 24 passed,
9 subtests passed.

The RISC-V case skips until angr/binaries#218 merges: this repository's
`ci.yml` checks out `angr/binaries` at master and does not resolve a referenced
pull request the way `cle`'s does, so the fixture is not present in `ci / Test`.

sync: angr/cle#800

session: sharpen
