### PR TITLE
SequenceWalker: raise the recursion limit before walking a structured tree

### DIFF
--- a/angr/analyses/decompiler/sequence_walker.py
+++ b/angr/analyses/decompiler/sequence_walker.py
@@ -1,6 +1,7 @@
 # pylint:disable=unused-argument,useless-return
 from __future__ import annotations
 
+import sys
 from collections import OrderedDict
 
 from angr import ailment
@@ -18,6 +19,20 @@ from .structurer_nodes import (
     SequenceNode,
     SwitchCaseNode,
 )
+
+# The walk spends two or three Python frames on every level of the structured tree, so CPython's default limit of
+# 1000 stops it at about 250 levels of nesting and a function that nests deeper decompiles to nothing. Raising the
+# limit is what that limit is for: since 3.11 a Python-to-Python call allocates its frame on the heap rather than on
+# the C stack, so a limit this high costs nothing until it is used.
+#
+# It does not make the walk unbounded. CPython keeps a second, separate budget for calls that do go through C, which
+# sys.setrecursionlimit does not govern -- `handler(node, **kwargs)` below is such a call -- and that budget stops
+# the walk at about 2500 levels with a RecursionError. That is a clean failure rather than a crash, and it is an
+# order of magnitude past the deepest tree we have measured, which was 519.
+#
+# The limit is only ever raised, never restored: lowering it aborts any other thread already deeper than the value
+# being restored.
+MIN_RECURSION_LIMIT = 100_000
 
 
 class SequenceWalker:
@@ -60,6 +75,8 @@ class SequenceWalker:
             self._handlers.update(handlers)
 
     def walk(self, sequence):
+        if sys.getrecursionlimit() < MIN_RECURSION_LIMIT:
+            sys.setrecursionlimit(MIN_RECURSION_LIMIT)
         return self._handle(sequence)
 
     #

--- a/tests/analyses/decompiler/test_sequence_walker.py
+++ b/tests/analyses/decompiler/test_sequence_walker.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import sys
+import unittest
+
+import claripy
+
+from angr.ailment.block import Block
+from angr.analyses.decompiler.sequence_walker import SequenceWalker
+from angr.analyses.decompiler.structurer_nodes import ConditionNode, SequenceNode
+
+CPYTHON_DEFAULT_RECURSION_LIMIT = 1000
+A_LIMIT_HIGHER_THAN_THE_WALKER_WANTS = 1_000_000
+
+
+def nested_conditions(levels: int) -> tuple[Block | ConditionNode, list[int]]:
+    """Build the shape a long chain of if statements structures into, plus the order its blocks are walked in.
+
+    Every level is a ConditionNode with no else branch whose body holds one block and the next condition, which is
+    what a function of several hundred sequentially guarded blocks produces.
+    """
+    node: Block | ConditionNode = Block(0, 1, statements=[])
+    order = [0]
+    for level in range(1, levels + 1):
+        addr = level
+        body = SequenceNode(addr, nodes=[Block(addr, 1, statements=[]), node])
+        # SequenceWalker visits a sequence's nodes back to front, so the block of this level comes after its body.
+        order.append(addr)
+        node = ConditionNode(addr, None, claripy.BoolS(f"cond_{level}"), body)
+    return node, order
+
+
+class TestSequenceWalker(unittest.TestCase):
+    def test_deeply_nested_tree_walks_at_the_default_recursion_limit(self):
+        # The default limit walks 248 levels and fails at 249; the deepest tree measured on a real function was
+        # 519. 800 is past both and inside the roughly 2500 that CPython's separate C budget still allows.
+        root, expected = nested_conditions(800)
+        visited = []
+
+        walker = SequenceWalker(handlers={Block: lambda block, **kwargs: visited.append(block.addr)})
+
+        old_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(CPYTHON_DEFAULT_RECURSION_LIMIT)
+        try:
+            walker.walk(root)
+        finally:
+            sys.setrecursionlimit(old_limit)
+
+        assert visited == expected
+
+    def test_walk_leaves_a_higher_recursion_limit_alone(self):
+        root, _ = nested_conditions(1)
+        old_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(A_LIMIT_HIGHER_THAN_THE_WALKER_WANTS)
+        try:
+            SequenceWalker().walk(root)
+            assert sys.getrecursionlimit() == A_LIMIT_HIGHER_THAN_THE_WALKER_WANTS
+        finally:
+            sys.setrecursionlimit(old_limit)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A function whose structured tree nests a few hundred levels deep decompiles to
nothing. `SequenceWalker.walk` exhausts CPython's recursion limit, the
decompiler records the exception, and the output is empty:

```
addr 0x18000f208  blocks 525   text_len 0   lines 0   errors 2
  terminal frame: sequence_walker.py:282:_handle_Condition
```

At the default limit of 1000 the walk manages 248 levels of nesting and fails at
249. The function above structures into a tree 519 deep, and it is not one pass
that trips: five `SequenceWalker` walks reach that depth on it, one inside
`StructurerBase._remove_redundant_jumps`, one in `JumpTargetCollector`, two in
`RedundantLabelRemover` and one in `EmptyNodeRemover`. Raising a limit inside
any one of them fixes nothing.

### Root cause

`SequenceWalker._handle` dispatches to a handler which calls `_handle` on each
child, so every level of the tree costs two or three Python frames. Nothing
about the walk is unbounded or wrong; the tree is simply deeper than the
interpreter's default budget, and the budget belongs to the interpreter rather
than to the walk.

### Fix

Raise the limit once, in `SequenceWalker.walk`, which is the entry point all
those passes share. Since CPython 3.11 a Python-to-Python call allocates its
frame on the heap instead of on the C stack, so a high limit costs nothing until
it is used, and angr requires 3.12. The limit is only ever raised, never
restored: lowering it aborts any other thread that is already deeper.

This does not make the walk unbounded, and the comment on the constant says so.
CPython keeps a second budget for calls that really do go through C -- the
`handler(node, **kwargs)` dispatch is one -- which `sys.setrecursionlimit` does
not govern, and that stops the walk at about 2500 levels of nesting with a
`RecursionError`. So the ceiling moves from 248 to roughly 2500, ten times past
the deepest tree measured, and past it the failure is still clean rather than a
crash.

Removing the ceiling altogether means giving `SequenceWalker` an explicit stack.
That is a real change and worth doing, but the recursive `_handle` protocol is
the interface 29 classes derive from -- each doing its own work before and after
the recursive call and returning a replacement node -- so converting it is a
separate piece of work from unbreaking these binaries.

### Testing

`tests/analyses/decompiler/test_sequence_walker.py` walks a tree of 800 nested
`ConditionNode`s with the limit pinned at CPython's default and asserts the
visit order, and checks that a limit already higher than the walker wants is
left alone. On the merge base the first raises
`RecursionError: maximum recursion depth exceeded`.

End to end on the function above: `text_len 0` with 2 errors before, and 676
characters over 29 lines with none after.

`python -m pytest tests/analyses/decompiler`: results in the validation record
below.

The binary is from a corpus that cannot be published, and no fixture in
`angr/binaries` reaches this depth -- the deepest tree across the 24 largest
functions of each of 14 public fixtures is 77 levels -- `libc.so.6` on eight architectures, `binutils_ld_bfd_O2`,
`redis_server_O2` and `cvs` among them. The regression is therefore on a
tree built directly rather than on an object.

session: sharpen
