### PR TITLE
TestPickle: Give each test case its own directory for the pickle files.

### DIFF
--- a/tests/serialization/test_pickle.py
+++ b/tests/serialization/test_pickle.py
@@ -8,8 +8,8 @@ import gc
 import os
 import pickle
 import shutil
+import tempfile
 import unittest
-from contextlib import suppress
 
 from claripy import BVS
 
@@ -24,21 +24,24 @@ test_location = os.path.join(bin_location, "tests")
 
 
 class TestPickle(unittest.TestCase):
+    def setUp(self):
+        # Every test case gets its own directory for these files. They used to be written under
+        # fixed names in the working directory, which pytest-xdist workers share, so tearDown in
+        # one worker deleted the files another worker was still reading.
+        self.tmpdir = tempfile.mkdtemp(prefix="angr-test-pickle-")
+        self.good_pickle = os.path.join(self.tmpdir, "pickletest_good")
+        self.bad_pickle = os.path.join(self.tmpdir, "pickletest_bad")
+
     def tearDown(self):
-        shutil.rmtree("pickletest", ignore_errors=True)
-        shutil.rmtree("pickletest2", ignore_errors=True)
-        with suppress(FileNotFoundError):
-            os.remove("pickletest_good")
-        with suppress(FileNotFoundError):
-            os.remove("pickletest_bad")
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _load_pickles(self):
         # This is the working case
-        with open("pickletest_good", "rb"):
+        with open(self.good_pickle, "rb"):
             pass
 
         # This will not work
-        with open("pickletest_bad", "rb"):
+        with open(self.bad_pickle, "rb"):
             pass
 
     def _make_pickles(self):
@@ -56,7 +59,7 @@ class TestPickle(unittest.TestCase):
             mem = BVS(f, MEM_SIZE * 8)
             mem_bvv[f] = mem
 
-        with open("pickletest_good", "wb") as f:
+        with open(self.good_pickle, "wb") as f:
             pickle.dump(mem_bvv, f, -1)
 
         # If you do not have a state you cannot write
@@ -65,13 +68,26 @@ class TestPickle(unittest.TestCase):
             mem = mem_bvv[f]
             fo.write(0, mem, MEM_SIZE)
 
-        with open("pickletest_bad", "wb") as f:
+        with open(self.bad_pickle, "wb") as f:
             pickle.dump(mem_bvv, f, -1)
 
     def test_pickling(self):
         self._make_pickles()
         self._load_pickles()
         gc.collect()
+        self._load_pickles()
+
+    def test_pickles_survive_another_case_finishing(self):
+        # Regression test: pytest-xdist workers share a working directory, so a second TestPickle
+        # method finishing on another worker used to delete the files test_pickling was halfway
+        # through reading, and test_pickling failed with FileNotFoundError. Run the interleaving
+        # deterministically: another case starts, this one writes its files, the other one
+        # finishes, and this one must still be able to read what it wrote.
+        other = TestPickle("test_pickling")
+        other.setUp()
+        self.addCleanup(other.tearDown)  # in case _make_pickles raises; tearDown is idempotent
+        self._make_pickles()
+        other.tearDown()
         self._load_pickles()
 
     def test_project_pickling(self):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

One `ci / Test (N)` shard fails at random on branches that touch nothing near pickling.
Most recently on #6824, whose diff is four files under `angr/knowledge_plugins/`; every
other job in that run was green:

```text
FAILED src/angr/tests/serialization/test_pickle.py::TestPickle::test_pickling
    def _load_pickles(self):
        # This is the working case
>       with open("pickletest_good", "rb"):
E       FileNotFoundError: [Errno 2] No such file or directory: 'pickletest_good'
src/angr/tests/serialization/test_pickle.py:37: FileNotFoundError
```

https://github.com/angr/angr/actions/runs/33238884373

The cost is not the one shard. A red `ci / Test` sends whoever is shepherding that branch
into the diff looking for a defect that is not there, and it lands on a different shard
each time, so the same investigation gets repeated.

### Root cause

`TestPickle` writes `pickletest_good` and `pickletest_bad` under fixed names in the
process working directory, and `tearDown` deletes those two names after **every** one of
the class's five test methods:

```python
    def tearDown(self):
        shutil.rmtree("pickletest", ignore_errors=True)
        shutil.rmtree("pickletest2", ignore_errors=True)
        with suppress(FileNotFoundError):
            os.remove("pickletest_good")
```

pytest-xdist workers share one working directory, so a method finishing on one worker
deletes the files a method on another worker is halfway through reading. The failing
shard's own log records the interleaving inside a third of a second:

```text
11:48:12.4985  gw0  start   TestPickle::test_pickling                        # writes pickletest_good
11:48:12.4997  gw1  PASSED  TestPickle::test_cfg_pickling_with_active_spill  # its tearDown deletes it
11:48:12.7579  gw1  PASSED  TestPickle::test_cfg_pickling_with_rtdb          # and again
11:48:12.8253  gw0  FAILED  TestPickle::test_pickling
```

`test_pickling` calls `_load_pickles()` twice with a `gc.collect()` between them. The
first read succeeded and the second did not, which is exactly that window.

Nothing about it needs a branch under test. On master at `e780d8501`, `pytest -q -n 2
--forked tests/serialization/test_pickle.py` fails **11 of 12** consecutive runs, always
with the message above.

### Fix

`setUp` hands each test case its own `tempfile.mkdtemp()` and `tearDown` removes that
directory, so no two cases share a path. `tempfile` rather than pytest's `tmp_path`
because the file still runs under `unittest.main()`.

The `shutil.rmtree("pickletest")` and `shutil.rmtree("pickletest2")` calls go with it:
nothing in the repository creates either directory, and they are the same defect -- a
fixed name deleted out of a shared working directory.

The same command that failed 11 of 12 now passes 12 of 12, and leaves no `pickletest*`
entry behind in the working directory.

### Testing

`test_pickles_survive_another_case_finishing` runs the interleaving deterministically:
another `TestPickle` starts, this one writes its files, the other one finishes, and this
one must still read what it wrote. On the unfixed file it fails with the CI message
verbatim, at the same line:

```text
>       with open("pickletest_good", "rb"):
E       FileNotFoundError: [Errno 2] No such file or directory: 'pickletest_good'
tests/serialization/test_pickle.py:37: FileNotFoundError
```

`tests/serialization` is 76 passed, 2 xfailed.

Validation: https://github.com/angr/angr/pull/7040#issuecomment-5464303968

session: sharpen
