### PR TITLE
CFGFast: Recover a CFG on a p-code ARM architecture

### DIFF
--- a/angr/analyses/cfg/cfg_arch_options.py
+++ b/angr/analyses/cfg/cfg_arch_options.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from archinfo.arch_arm import is_arm_arch
+
 
 class CFGArchOptions:
     """
@@ -10,6 +12,7 @@ class CFGArchOptions:
     it by `ao.ret_jumpkind_heuristics` and set its value via `ao.ret_jumpkind_heuristics = True`
 
     :ivar dict OPTIONS: A dict of all default options for different architectures.
+    :ivar dict ARM_DEFAULT_OPTIONS: Defaults for an ARM architecture that OPTIONS does not name.
     :ivar archinfo.Arch arch: The architecture object.
     :ivar dict _options: Values of all CFG options that are specific to the current architecture.
     """
@@ -42,8 +45,19 @@ class CFGArchOptions:
         },
     }
 
+    # Defaults for an ARM architecture OPTIONS does not name, which today means the p-code ARM languages. The
+    # p-code lifter gates its THUMB normalization on ArchARM, so an address there carries no mode: the options
+    # that only apply to THUMB code are off, and every address stays a candidate for ARM-mode code.
+    ARM_DEFAULT_OPTIONS = {
+        "ret_jumpkind_heuristics": (bool, True),
+        "switch_mode_on_nodecode": (bool, False),
+        "pattern_match_ifuncs": (bool, False),
+        "has_arm_code": (bool, True),
+    }
+
     arch = None
     _options = {}
+    _supported_options = {}
 
     def __init__(self, arch, **options):
         """
@@ -55,15 +69,18 @@ class CFGArchOptions:
 
         self.arch = arch
 
-        self._options = {}
+        if arch.name in self.OPTIONS:
+            self._supported_options = self.OPTIONS[arch.name]
+        elif is_arm_arch(arch):
+            self._supported_options = self.ARM_DEFAULT_OPTIONS
+        else:
+            self._supported_options = {}
 
-        if self.arch.name in self.OPTIONS:
-            for k, (_, value) in self.OPTIONS[self.arch.name].items():
-                self._options[k] = value
+        self._options = {k: value for k, (_, value) in self._supported_options.items()}
 
         # make sure options are valid
         for k in options:
-            if self.arch.name not in self.OPTIONS or k not in self.OPTIONS[self.arch.name]:
+            if k not in self._supported_options:
                 raise KeyError(f'Architecture {self.arch.name} does not support arch-specific option "{k}".')
 
         for k, v in options.items():
@@ -78,7 +95,7 @@ class CFGArchOptions:
     def __setattr__(self, option_name, option_value):
         if option_name in self._options:
             # Type checking
-            sort = self.OPTIONS[self.arch.name][option_name][0]
+            sort = self._supported_options[option_name][0]
 
             if sort is None or isinstance(option_value, sort):
                 self._options[option_name] = option_value

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -2436,7 +2436,9 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                         if bytes_prefix is None:
                             # we are out of the mapped memory range - just return
                             return
-                        if any(re.match(prolog, bytes_prefix) for prolog in self.project.arch.thumb_prologs):
+                        if hasattr(self.project.arch, "thumb_prologs") and any(
+                            re.match(prolog, bytes_prefix) for prolog in self.project.arch.thumb_prologs
+                        ):
                             addr |= 1
 
                     if addr % 2 == 0:
@@ -4418,6 +4420,10 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
         :return: None
         """
 
+        # This function requires Capstone engine support
+        if not self.project.arch.capstone_support:
+            return
+
         sorted_node_keys: list[CFGNODE_K] = sorted(block_key for block_key in self.graph.node_keys)
 
         all_plt_stub_addrs = set(
@@ -6036,7 +6042,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
                                 added_addrs.add(ref.data_addr)
 
             # detect if there are instructions that set r4 as a constant value
-            if (addr & 1) == 0 and addr == func_addr and irsb.size > 0:
+            if (addr & 1) == 0 and addr == func_addr and irsb.size > 0 and self.project.arch.capstone_support:
                 # re-lift the block to get capstone access
                 lifted_block = self._lift(irsb.addr, size=irsb.size, collect_data_refs=False, strict_block_end=True)
                 for i in range(len(lifted_block.capstone.insns) - 1):

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -11,6 +11,7 @@ import random
 import unittest
 
 import archinfo
+from archinfo.arch_arm import is_arm_arch
 
 import angr
 from angr.analyses.cfg.indirect_jump_resolvers import mips_elf_fast
@@ -1140,6 +1141,19 @@ class TestCfgfast(unittest.TestCase):
         assert block_size(4096, repeating_byte_run_threshold=0) == 99
         # nops are exempt at any length: a nop run is transparent, execution really does flow through it
         assert block_size(4096, filler=b"\x90") is not None
+
+    def test_cfgfast_on_a_pcode_arm_architecture(self):
+        # is_arm_arch() answers True for a p-code ARM language as well as for the three VEX ARM architectures,
+        # so CFGFast runs its ARM handling for one, and everything that handling reads has to be answerable.
+        path = os.path.join(test_location, "armel", "fauxware")
+        proj = angr.Project(path, arch=archinfo.ArchPcode("ARM:LE:32:v7"), auto_load_libs=False)
+        assert is_arm_arch(proj.arch)
+
+        cfg = proj.analyses.CFGFast(normalize=True)
+
+        for name in ("main", "authenticate", "accepted", "rejected"):
+            assert name in cfg.kb.functions, f"{name} was not recovered"
+            assert cfg.kb.functions[name].block_addrs_set, f"{name} was recovered with no blocks"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` raises on every p-code ARM architecture. Loading
`binaries/tests/armel/fauxware` as `ArchPcode("ARM:LE:32:v7")` and running
`proj.analyses.CFGFast(normalize=True)`:

```
  File "angr/analyses/cfg/cfg_fast.py", line 5586, in _generate_cfgnode
    switch_mode_on_nodecode = self._arch_options.switch_mode_on_nodecode
  File "angr/analyses/cfg/cfg_arch_options.py", line 76, in __getattr__
    return self.__getattribute__(option_name)
AttributeError: 'CFGArchOptions' object has no attribute 'switch_mode_on_nodecode'
```

All 22 SLEIGH ARM languages fail this way, so nothing that needs a CFG -- the
decompiler included -- runs on an ARM target loaded with `ArchPcode`. #4779 reports
the same crash at the `thumb_prologs` read.

### Root cause

`is_arm_arch()` is a name prefix test and answers True for the p-code ARM languages
on purpose, so `CFGFast` runs its ARM handling for them. Three of the things that
handling reads are carried only by the three VEX ARM architectures:

- `CFGArchOptions.OPTIONS` is keyed on `arch.name` and holds `ARMEL`, `ARMHF` and
  `ARMCortexM`, so `_options` is empty and `__getattr__` falls through to
  `__getattribute__`;
- `arch.thumb_prologs`, read unguarded in the complete-scan path while the sibling
  read in `_func_addrs_from_prologues` is `hasattr`-guarded;
- `Block.capstone`, in the r4-constant detection in `_process_block_arch_specific`
  and twice in `_remove_redundant_overlapping_blocks`, while the sibling nop scan
  `mark_function_alignments` already returns early on `not arch.capstone_support`.
  `ArchPcode.cs_arch` is `None`, so those raise `ArchError`.

### Fix

`CFGArchOptions` resolves a default ARM option set for any architecture
`is_arm_arch()` accepts that `OPTIONS` does not name, so the class answers for
exactly the architectures its consumer asks about. Those defaults differ from
`ARMEL`'s in the two options that only describe THUMB code: the p-code lifter gates
its THUMB normalization on `ArchARM`, so an address there carries no mode, and
`switch_mode_on_nodecode` has no second mode to reach while the ifunc pattern is a
THUMB instruction sequence; `has_arm_code` stays on because with no THUMB mode every
address is a candidate for ARM-mode code. The other two reads get the guards their
own siblings already carry. This is the shape #6803 was closed asking for: the
options do apply to a p-code ARM architecture, so it gets defaults the way the VEX
architectures do.

Giving `ArchPcode`'s ARM languages `cs_arch`/`cs_mode` would let the skipped
heuristics run instead; that is an archinfo change, and for `ARM:LEBE:*` the capstone
mode has to key on instruction endianness rather than on memory endianness. Giving
them `thumb_prologs` should wait for #4778, because until the p-code lifter selects
THUMB from the low bit, setting that bit on a prologue match only yields an address it
cannot decode. Nothing here narrows `is_arm_arch()`, which still answers True for both
families.

### Testing

`tests/analyses/cfg/test_cfgfast.py::TestCfgfast::test_cfgfast_on_a_pcode_arm_architecture`
loads `binaries/tests/armel/fauxware` as `ArchPcode("ARM:LE:32:v7")`, checks
`is_arm_arch()` still answers True, and asserts `main`, `authenticate`, `accepted` and
`rejected` come back with blocks; against the merge base's production files it fails
with the `AttributeError` above. Over all 22 p-code ARM languages, each against an ELF
of matching data endianness, `CFGFast` completes 22 of 22 where the merge base
completes 0 of 22. Of the 200 architectures archinfo and pypcode offer between them,
22 resolve a different option set and all 22 are p-code ARM languages.

Validation: https://github.com/angr/angr/pull/7041#issuecomment-5465056317

session: sharpen
