### PR TITLE
SequenceWalker: walk a structured tree on an explicit stack

### DIFF
--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -73,6 +73,9 @@ class ConstantCollector(SequenceWalker):
 
     # pylint:disable=unused-argument
 
+    # _handle below only adds AIL expressions and statements, which this walker never handles itself.
+    HANDLE_SEES_EVERY_NODE = False
+
     def __init__(self):
         self.const_values: set[int] = set()
         self._block_viewer = ailment.AILBlockViewer()

--- a/angr/analyses/decompiler/empty_node_remover.py
+++ b/angr/analyses/decompiler/empty_node_remover.py
@@ -46,14 +46,14 @@ class EmptyNodeRemover:
         self.replaced_sequences = {}
 
         handlers = {
-            SequenceNode: self._handle_Sequence,
-            CodeNode: self._handle_Code,
-            ConditionNode: self._handle_Condition,
-            CascadingConditionNode: self._handle_CascadingCondition,
-            SwitchCaseNode: self._handle_SwitchCase,
-            LoopNode: self._handle_Loop,
+            SequenceNode: self._walk_Sequence,
+            CodeNode: self._walk_Code,
+            ConditionNode: self._walk_Condition,
+            CascadingConditionNode: self._walk_CascadingCondition,
+            SwitchCaseNode: self._walk_SwitchCase,
+            LoopNode: self._walk_Loop,
             ContinueNode: self._handle_Continue,
-            MultiNode: self._handle_MultiNode,
+            MultiNode: self._walk_MultiNode,
             BreakNode: self._handle_Default,
             ConditionalBreakNode: self._handle_Default,
             ailment.Block: self._handle_Block,
@@ -72,10 +72,10 @@ class EmptyNodeRemover:
     # Handlers
     #
 
-    def _handle_Sequence(self, node, **kwargs):
+    def _walk_Sequence(self, node, **kwargs):
         new_nodes = []
         for node_ in node.nodes:
-            new_node = self._walker._handle(node_)
+            new_node = yield node_, {}
             if new_node is not None:
                 if isinstance(new_node, SequenceNode):
                     new_nodes.extend(new_node.nodes)
@@ -94,10 +94,10 @@ class EmptyNodeRemover:
         self.replaced_sequences[node] = sn
         return sn
 
-    def _handle_MultiNode(self, node: MultiNode, **kwargs):
+    def _walk_MultiNode(self, node: MultiNode, **kwargs):
         new_nodes = []
         for node_ in node.nodes:
-            new_node = self._walker._handle(node_)
+            new_node = yield node_, {}
             if new_node is not None:
                 if isinstance(new_node, MultiNode):
                     new_nodes.extend(new_node.nodes)
@@ -111,8 +111,8 @@ class EmptyNodeRemover:
             return new_nodes[0]
         return MultiNode(new_nodes)
 
-    def _handle_Code(self, node, **kwargs):
-        inner_node = self._walker._handle(node.node)
+    def _walk_Code(self, node, **kwargs):
+        inner_node = yield node.node, {}
         if inner_node is None:
             return None
         if (
@@ -127,9 +127,9 @@ class EmptyNodeRemover:
             return CodeNode(inner_node.node, claripy.And(node.reaching_condition, inner_node.reaching_condition))
         return CodeNode(inner_node, node.reaching_condition)
 
-    def _handle_Condition(self, node, **kwargs):
-        true_node = self._walker._handle(node.true_node)
-        false_node = self._walker._handle(node.false_node)
+    def _walk_Condition(self, node, **kwargs):
+        true_node = yield node.true_node, {}
+        false_node = yield node.false_node, {}
 
         if true_node is None and false_node is None:
             # empty node
@@ -156,12 +156,12 @@ class EmptyNodeRemover:
             return node.true_node
         return ConditionNode(node.addr, node.reaching_condition, node.condition, true_node, false_node=false_node)
 
-    def _handle_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
-        new_else_node = None if node.else_node is None else self._walker._handle(node.else_node)
+    def _walk_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
+        new_else_node = None if node.else_node is None else (yield node.else_node, {})
 
         new_cond_and_nodes = []
         for cond, child_node in node.condition_and_nodes:
-            new_node = self._walker._handle(child_node)
+            new_node = yield child_node, {}
             if new_node is not None:
                 new_cond_and_nodes.append((cond, new_node))
             else:
@@ -174,8 +174,8 @@ class EmptyNodeRemover:
             return None
         return CascadingConditionNode(node.addr, new_cond_and_nodes, else_node=new_else_node)
 
-    def _handle_Loop(self, node: LoopNode, **kwargs):
-        new_seq = self._walker._handle(node.sequence_node)
+    def _walk_Loop(self, node: LoopNode, **kwargs):
+        new_seq = yield node.sequence_node, {}
 
         if (
             new_seq is None
@@ -191,15 +191,15 @@ class EmptyNodeRemover:
     def _handle_Continue(self, node: ContinueNode, **kwargs):
         return node
 
-    def _handle_SwitchCase(self, node, **kwargs):
+    def _walk_SwitchCase(self, node, **kwargs):
         new_cases = OrderedDict()
 
         for idx, case in node.cases.items():
-            new_case = self._walker._handle(case)
+            new_case = yield case, {}
             if new_case is not None:
                 new_cases[idx] = new_case
 
-        new_default_node = self._walker._handle(node.default_node)
+        new_default_node = yield node.default_node, {}
 
         if not new_cases and new_default_node is None:
             return None

--- a/angr/analyses/decompiler/optimization_passes/flip_boolean_cmp.py
+++ b/angr/analyses/decompiler/optimization_passes/flip_boolean_cmp.py
@@ -33,7 +33,7 @@ class FlipBooleanWalker(SequenceWalker):
         self._last_node = last_node
         self._flip_size = flip_size
 
-    def _handle_Sequence(self, seq_node, **kwargs):
+    def _walk_Sequence(self, seq_node, **kwargs):
         # Type 1:
         # if (cond) { ... }  else  { return; }   -->   if (!cond) { return; } else { ... }
         #
@@ -87,7 +87,7 @@ class FlipBooleanWalker(SequenceWalker):
                 cond_node.true_node = successor
                 seq_node.nodes.insert(idx + 2, successor)
 
-        return super()._handle_Sequence(seq_node, **kwargs)
+        return (yield from super()._walk_Sequence(seq_node, **kwargs))
 
 
 class FlipBooleanCmp(SequenceOptimizationPass):

--- a/angr/analyses/decompiler/optimization_passes/peephole_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/peephole_simplifier.py
@@ -15,6 +15,9 @@ class ExpressionSequenceWalker(SequenceWalker):
     Walks sequences with generic expression handling.
     """
 
+    # _handle below only adds AIL expressions, which this walker never handles itself.
+    HANDLE_SEES_EVERY_NODE = False
+
     def _handle(self, node, **kwargs):
         if isinstance(node, ailment.Expr.Expression):
             handler = self._handlers.get(ailment.Expr.Expression, None)

--- a/angr/analyses/decompiler/redundant_label_remover.py
+++ b/angr/analyses/decompiler/redundant_label_remover.py
@@ -26,7 +26,7 @@ class RedundantLabelRemover:
         self._new_jump_target: dict[tuple[int, int | None], tuple[int, int | None]] = {}
 
         handlers0 = {
-            SequenceNode: self._handle_Sequence,
+            SequenceNode: self._walk_Sequence,
         }
         self._walker0 = SequenceWalker(handlers=handlers0)
         self._walker0.walk(self.root)
@@ -59,7 +59,7 @@ class RedundantLabelRemover:
     # Handlers
     #
 
-    def _handle_Sequence(self, node: SequenceNode, **kwargs):
+    def _walk_Sequence(self, node: SequenceNode, **kwargs):
         # merge consecutive labels
         last_label_addr: tuple[int, int | None] | None = None
         for node_ in node.nodes:
@@ -82,7 +82,7 @@ class RedundantLabelRemover:
             else:
                 last_label_addr = None
 
-        return self._walker0._handle_Sequence(node, **kwargs)
+        return (yield from self._walker0._walk_Sequence(node, **kwargs))
 
     def _handle_Block(self, block: ailment.Block, **kwargs):
         if block.statements:

--- a/angr/analyses/decompiler/region_simplifiers/cascading_cond_transformer.py
+++ b/angr/analyses/decompiler/region_simplifiers/cascading_cond_transformer.py
@@ -20,7 +20,7 @@ class CascadingConditionTransformer(SequenceWalker):
 
     def __init__(self, node, manager: Manager):
         handlers = {
-            ConditionNode: self._handle_Condition,
+            ConditionNode: self._walk_Condition,
         }
         super().__init__(handlers)
         self.manager = manager
@@ -28,7 +28,7 @@ class CascadingConditionTransformer(SequenceWalker):
 
         self.walk(node)
 
-    def _handle_Condition(self, cond_node: ConditionNode, **kwargs):
+    def _walk_Condition(self, cond_node: ConditionNode, **kwargs):
         if (
             cond_node.false_node is not None
             and isinstance(cond_node.false_node, (ConditionNode, CascadingConditionNode))
@@ -53,11 +53,11 @@ class CascadingConditionTransformer(SequenceWalker):
             remaining_node = cond_node.true_node
 
         else:
-            return super()._handle_Condition(cond_node, **kwargs)
+            return (yield from super()._walk_Condition(cond_node, **kwargs))
 
         # structure else_node
         if not isinstance(remaining_node, CascadingConditionNode):
-            structured = self._handle_Condition(remaining_node)
+            structured = yield remaining_node, {}
             if structured is None:
                 structured = remaining_node
         else:

--- a/angr/analyses/decompiler/region_simplifiers/cascading_ifs.py
+++ b/angr/analyses/decompiler/region_simplifiers/cascading_ifs.py
@@ -37,7 +37,7 @@ class CascadingIfsRemover(SequenceWalker):
             CodeNode: self._handle_Code,
             MultiNode: self._handle_MultiNode,
             LoopNode: self._handle_Loop,
-            ConditionNode: self._handle_Condition,
+            ConditionNode: self._walk_Condition,
             CascadingConditionNode: self._handle_CascadingCondition,
         }
 
@@ -45,7 +45,7 @@ class CascadingIfsRemover(SequenceWalker):
         self.manager = manager
         self.walk(node)
 
-    def _handle_Condition(self, node, parent=None, index=None, **kwargs):
+    def _walk_Condition(self, node, parent=None, index=None, **kwargs):
         """
 
         :param ConditionNode node:
@@ -54,9 +54,9 @@ class CascadingIfsRemover(SequenceWalker):
         """
 
         if node.true_node is not None:
-            self._handle(node.true_node, parent=node, index=0)
+            yield node.true_node, {"parent": node, "index": 0}
         if node.false_node is not None:
-            self._handle(node.false_node, parent=node, index=1)
+            yield node.false_node, {"parent": node, "index": 1}
 
         if node.true_node is not None and node.false_node is None:
             if isinstance(node.true_node, SequenceNode):

--- a/angr/analyses/decompiler/region_simplifiers/expr_folding.py
+++ b/angr/analyses/decompiler/region_simplifiers/expr_folding.py
@@ -164,15 +164,15 @@ class LoopNodeFinder(SequenceWalker):
 
     def __init__(self, node: SequenceNode):
         handlers = {
-            LoopNode: self._handle_Loop,
+            LoopNode: self._walk_Loop,
         }
         super().__init__(handlers, update_seqnode_in_place=False, force_forward_scan=True)
         self.loop_nodes: list[LoopNode] = []
 
         self.walk(node)
 
-    def _handle_Loop(self, node: LoopNode, **kwargs):
-        super()._handle_Loop(node, **kwargs)
+    def _walk_Loop(self, node: LoopNode, **kwargs):
+        yield from super()._walk_Loop(node, **kwargs)
         self.loop_nodes.append(node)
 
 
@@ -260,9 +260,9 @@ class ExpressionCounter(SequenceWalker):
     def __init__(self, node):
         handlers = {
             ConditionalBreakNode: self._handle_ConditionalBreak,
-            ConditionNode: self._handle_Condition,
-            LoopNode: self._handle_Loop,
-            SwitchCaseNode: self._handle_SwitchCase,
+            ConditionNode: self._walk_Condition,
+            LoopNode: self._walk_Loop,
+            SwitchCaseNode: self._walk_SwitchCase,
             ailment.Block: self._handle_Block,
         }
 
@@ -359,19 +359,19 @@ class ExpressionCounter(SequenceWalker):
         self._collect_uses(node.condition, ConditionalBreakLocation(node.addr))
         return super()._handle_ConditionalBreak(node, **kwargs)
 
-    def _handle_Condition(self, node: ConditionNode, **kwargs):
+    def _walk_Condition(self, node: ConditionNode, **kwargs):
         # collect uses on the condition expression
         self._collect_assignments(node.condition, node)
         self._collect_uses(node.condition, ConditionLocation(node.addr))
-        return super()._handle_Condition(node, **kwargs)
+        return (yield from super()._walk_Condition(node, **kwargs))
 
-    def _handle_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
+    def _walk_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
         for idx, (condition, _) in enumerate(node.condition_and_nodes):
             self._collect_assignments(condition, node)
             self._collect_uses(condition, ConditionLocation(node.addr, idx))
-        return super()._handle_CascadingCondition(node, **kwargs)
+        return (yield from super()._walk_CascadingCondition(node, **kwargs))
 
-    def _handle_Loop(self, node: LoopNode, **kwargs):
+    def _walk_Loop(self, node: LoopNode, **kwargs):
         # collect uses on the condition expression
         if node.initializer is not None:
             self._collect_uses(node.initializer, ConditionLocation(node.addr))
@@ -383,12 +383,12 @@ class ExpressionCounter(SequenceWalker):
 
         outer_scope = self._outer_scope
         self._outer_scope = False
-        super()._handle_Loop(node, **kwargs)
+        yield from super()._walk_Loop(node, **kwargs)
         self._outer_scope = outer_scope
 
-    def _handle_SwitchCase(self, node: SwitchCaseNode, **kwargs):
+    def _walk_SwitchCase(self, node: SwitchCaseNode, **kwargs):
         self._collect_uses(node.switch_expr, ConditionLocation(node.addr))
-        return super()._handle_SwitchCase(node, **kwargs)
+        return (yield from super()._walk_SwitchCase(node, **kwargs))
 
 
 class ExpressionSpotter(VVarUsesCollector):
@@ -426,9 +426,9 @@ class InterferenceChecker(SequenceWalker):
     def __init__(self, assignments: dict[int, Any], uses: dict[int, Any], node, variable_map):
         handlers = {
             ailment.Block: self._handle_Block,
-            ConditionNode: self._handle_Condition,
+            ConditionNode: self._walk_Condition,
             ConditionalBreakNode: self._handle_ConditionalBreak,
-            SwitchCaseNode: self._handle_SwitchCase,
+            SwitchCaseNode: self._walk_SwitchCase,
         }
 
         super().__init__(handlers, update_seqnode_in_place=False, force_forward_scan=True)
@@ -517,7 +517,7 @@ class InterferenceChecker(SequenceWalker):
         self._after_spotting(node, spotter)
         return super()._handle_ConditionalBreak(node, **kwargs)
 
-    def _handle_Condition(self, node: ConditionNode, **kwargs):
+    def _walk_Condition(self, node: ConditionNode, **kwargs):
         spotter = ExpressionSpotter()
         spotter.walk_expression(node.condition)
         self._after_spotting(node, spotter)
@@ -526,9 +526,9 @@ class InterferenceChecker(SequenceWalker):
         for vid in self._assignment_interferences:
             self._assignment_interferences[vid].append(node)
 
-        return super()._handle_Condition(node, **kwargs)
+        return (yield from super()._walk_Condition(node, **kwargs))
 
-    def _handle_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
+    def _walk_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
         spotter = ExpressionSpotter()
         for cond, _ in node.condition_and_nodes:  # pylint:disable=consider-using-enumerate
             spotter.walk_expression(cond)
@@ -538,9 +538,9 @@ class InterferenceChecker(SequenceWalker):
         for vid in self._assignment_interferences:
             self._assignment_interferences[vid].append(node)
 
-        return super()._handle_CascadingCondition(node, **kwargs)
+        return (yield from super()._walk_CascadingCondition(node, **kwargs))
 
-    def _handle_Loop(self, node: LoopNode, **kwargs):
+    def _walk_Loop(self, node: LoopNode, **kwargs):
         spotter = ExpressionSpotter()
 
         # iterator
@@ -557,13 +557,13 @@ class InterferenceChecker(SequenceWalker):
 
         self._after_spotting(node, spotter)
 
-        return super()._handle_Loop(node, **kwargs)
+        return (yield from super()._walk_Loop(node, **kwargs))
 
-    def _handle_SwitchCase(self, node: SwitchCaseNode, **kwargs):
+    def _walk_SwitchCase(self, node: SwitchCaseNode, **kwargs):
         spotter = ExpressionSpotter()
         spotter.walk_expression(node.switch_expr)
         self._after_spotting(node, spotter)
-        return super()._handle_SwitchCase(node, **kwargs)
+        return (yield from super()._walk_SwitchCase(node, **kwargs))
 
 
 class ExpressionReplacer(AILBlockRewriter):
@@ -660,9 +660,9 @@ class ExpressionFolder(SequenceWalker):
     def __init__(self, assignments: dict[int, Any], uses: dict[int, Any], node, variable_map):
         handlers = {
             ailment.Block: self._handle_Block,
-            ConditionNode: self._handle_Condition,
+            ConditionNode: self._walk_Condition,
             ConditionalBreakNode: self._handle_ConditionalBreak,
-            SwitchCaseNode: self._handle_SwitchCase,
+            SwitchCaseNode: self._walk_SwitchCase,
             LoopNode: self._handle_Loop,
         }
 
@@ -707,21 +707,21 @@ class ExpressionFolder(SequenceWalker):
             node.condition = r
         return super()._handle_ConditionalBreak(node, **kwargs)
 
-    def _handle_Condition(self, node: ConditionNode, **kwargs):
+    def _walk_Condition(self, node: ConditionNode, **kwargs):
         replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
         r = replacer.walk_expression(node.condition)
         if r is not None and r is not node.condition:
             node.condition = r
-        return super()._handle_Condition(node, **kwargs)
+        return (yield from super()._walk_Condition(node, **kwargs))
 
-    def _handle_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
+    def _walk_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
         replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
         for idx in range(len(node.condition_and_nodes)):  # pylint:disable=consider-using-enumerate
             cond, _ = node.condition_and_nodes[idx]
             r = replacer.walk_expression(cond)
             if r is not None and r is not cond:
                 node.condition_and_nodes[idx] = (r, node.condition_and_nodes[idx][1])
-        return super()._handle_CascadingCondition(node, **kwargs)
+        return (yield from super()._walk_CascadingCondition(node, **kwargs))
 
     def _handle_Loop(self, node: LoopNode, **kwargs):
         replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
@@ -746,27 +746,27 @@ class ExpressionFolder(SequenceWalker):
 
         # again, do not replace into the loop body
 
-    def _handle_SwitchCase(self, node: SwitchCaseNode, **kwargs):
+    def _walk_SwitchCase(self, node: SwitchCaseNode, **kwargs):
         replacer = ExpressionReplacer(self._assignments, self._uses, self._variable_map)
 
         r = replacer.walk_expression(node.switch_expr)
         if r is not None and r is not node.switch_expr:
             node.switch_expr = r
 
-        return super()._handle_SwitchCase(node, **kwargs)
+        return (yield from super()._walk_SwitchCase(node, **kwargs))
 
 
 class StoreStatementFinder(SequenceWalker):
     """
     Determine if there are any Store statements between two given statements.
 
-    This class overrides _handle_Sequence() and _handle_MultiNode() to ensure they traverse nodes from top to bottom.
+    This class overrides _walk_Sequence() and _walk_MultiNode() to ensure they traverse nodes from top to bottom.
     """
 
     def __init__(self, node, intervals: Iterable[tuple[StatementLocation, LocationBase]]):
         handlers = {
-            ConditionNode: self._handle_Condition,
-            CascadingConditionNode: self._handle_CascadingCondition,
+            ConditionNode: self._walk_Condition,
+            CascadingConditionNode: self._walk_CascadingCondition,
             ConditionalBreakNode: self._handle_ConditionalBreak,
             ailment.Block: self._handle_Block,
         }
@@ -785,18 +785,18 @@ class StoreStatementFinder(SequenceWalker):
         super().__init__(handlers)
         self.walk(node)
 
-    def _handle_Sequence(self, node, **kwargs):
+    def _walk_Sequence(self, node, **kwargs):
         i = 0
         while i < len(node.nodes):
             node_ = node.nodes[i]
-            self._handle(node_, parent=node, index=i)
+            yield node_, {"parent": node, "index": i}
             i += 1
 
-    def _handle_MultiNode(self, node, **kwargs):
+    def _walk_MultiNode(self, node, **kwargs):
         i = 0
         while i < len(node.nodes):
             node_ = node.nodes[i]
-            self._handle(node_, parent=node, index=i)
+            yield node_, {"parent": node, "index": i}
             i += 1
 
     def _handle_Block(self, node: ailment.Block, **kwargs):
@@ -813,21 +813,21 @@ class StoreStatementFinder(SequenceWalker):
                 for interval in self._active_intervals:
                     self.interval_to_hasstore[interval] = True
 
-    def _handle_Condition(self, node, **kwargs):
+    def _walk_Condition(self, node, **kwargs):
         cond_loc = ConditionLocation(node.addr)
         if cond_loc in self._end_to_starts:
             for start in self._end_to_starts[cond_loc]:
                 self._active_intervals.discard((start, cond_loc))
-        super()._handle_Condition(node, **kwargs)
+        yield from super()._walk_Condition(node, **kwargs)
 
-    def _handle_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
+    def _walk_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
         cond_loc = ConditionLocation(node.addr, None)
         for idx in range(len(node.condition_and_nodes)):
             cond_loc.case_idx = idx
             if cond_loc in self._end_to_starts[cond_loc]:
                 for start in self._end_to_starts[cond_loc]:
                     self._active_intervals.discard((start, cond_loc))
-        super()._handle_CascadingCondition(node, **kwargs)
+        yield from super()._walk_CascadingCondition(node, **kwargs)
 
     def _handle_ConditionalBreak(self, node: ConditionalBreakNode, **kwargs):
         cond_break_loc = ConditionalBreakLocation(node.addr)

--- a/angr/analyses/decompiler/region_simplifiers/goto.py
+++ b/angr/analyses/decompiler/region_simplifiers/goto.py
@@ -1,4 +1,4 @@
-# pylint:disable=unused-argument,arguments-differ
+# pylint:disable=unused-argument,arguments-differ,no-self-use
 from __future__ import annotations
 
 import logging
@@ -34,12 +34,12 @@ class GotoSimplifier(SequenceWalker):
 
     def __init__(self, node, function=None, kb=None):
         handlers = {
-            SequenceNode: self._handle_sequencenode,
-            CodeNode: self._handle_codenode,
-            MultiNode: self._handle_multinode,
-            LoopNode: self._handle_loopnode,
-            ConditionNode: self._handle_conditionnode,
-            CascadingConditionNode: self._handle_cascadingconditionnode,
+            SequenceNode: self._walk_sequencenode,
+            CodeNode: self._walk_codenode,
+            MultiNode: self._walk_multinode,
+            LoopNode: self._walk_loopnode,
+            ConditionNode: self._walk_conditionnode,
+            CascadingConditionNode: self._walk_cascadingconditionnode,
             ailment.Block: self._handle_block,
         }
         self._function = function
@@ -51,7 +51,7 @@ class GotoSimplifier(SequenceWalker):
 
         self.walk(node)
 
-    def _handle_sequencenode(self, node, successor=None, **kwargs):
+    def _walk_sequencenode(self, node, successor=None, **kwargs):
         """
 
         :param SequenceNode node:
@@ -59,18 +59,18 @@ class GotoSimplifier(SequenceWalker):
         """
 
         for n0, n1 in zip(node.nodes, [*node.nodes[1:], successor]):
-            self._handle(n0, successor=n1)
+            yield n0, {"successor": n1}
 
-    def _handle_codenode(self, node, successor=None, **kwargs):
+    def _walk_codenode(self, node, successor=None, **kwargs):
         """
 
         :param CodeNode node:
         :return:
         """
 
-        self._handle(node.node, successor=successor)
+        yield node.node, {"successor": successor}
 
-    def _handle_conditionnode(self, node, successor=None, **kwargs):
+    def _walk_conditionnode(self, node, successor=None, **kwargs):
         """
 
         :param ConditionNode node:
@@ -79,17 +79,17 @@ class GotoSimplifier(SequenceWalker):
         """
 
         if node.true_node is not None:
-            self._handle(node.true_node, successor=successor)
+            yield node.true_node, {"successor": successor}
         if node.false_node is not None:
-            self._handle(node.false_node, successor=successor)
+            yield node.false_node, {"successor": successor}
 
-    def _handle_cascadingconditionnode(self, node: CascadingConditionNode, successor=None, **kwargs):
+    def _walk_cascadingconditionnode(self, node: CascadingConditionNode, successor=None, **kwargs):
         for _, child_node in node.condition_and_nodes:
-            self._handle(child_node, successor=successor)
+            yield child_node, {"successor": successor}
         if node.else_node is not None:
-            self._handle(node.else_node, successor=successor)
+            yield node.else_node, {"successor": successor}
 
-    def _handle_loopnode(self, node, successor=None, **kwargs):
+    def _walk_loopnode(self, node, successor=None, **kwargs):
         """
 
         :param LoopNode node:
@@ -97,12 +97,10 @@ class GotoSimplifier(SequenceWalker):
         :return:
         """
 
-        self._handle(
-            node.sequence_node,
-            successor=node,  # the end of a loop always jumps to the beginning of its body
-        )
+        # the end of a loop always jumps to the beginning of its body
+        yield node.sequence_node, {"successor": node}
 
-    def _handle_multinode(self, node, successor=None, **kwargs):
+    def _walk_multinode(self, node, successor=None, **kwargs):
         """
 
         :param MultiNode node:
@@ -110,9 +108,9 @@ class GotoSimplifier(SequenceWalker):
         """
 
         for n0, n1 in zip(node.nodes, [*node.nodes[1:], successor]):
-            self._handle(n0, successor=n1)
+            yield n0, {"successor": n1}
 
-    def _handle_block(self, block, successor=None, **kwargs):  # pylint:disable=no-self-use
+    def _handle_block(self, block, successor=None, **kwargs):
         """
         This will also record irreducible gotos into the kb if found.
 
@@ -164,12 +162,15 @@ class GotoSimplifier(SequenceWalker):
 
         # normal Goto Label
         if branch_target is None:
+            assert isinstance(goto_stmt, ailment.Stmt.Jump)
             dst_target = goto_stmt.target
         # true branch of a conditional jump
         elif branch_target:
+            assert isinstance(goto_stmt, ailment.Stmt.ConditionalJump)
             dst_target = goto_stmt.true_target
         # false branch of a conditional jump
         else:
+            assert isinstance(goto_stmt, ailment.Stmt.ConditionalJump)
             dst_target = goto_stmt.false_target
 
         src_ins_addr = goto_stmt.tags.get("ins_addr", block.addr)

--- a/angr/analyses/decompiler/region_simplifiers/if_.py
+++ b/angr/analyses/decompiler/region_simplifiers/if_.py
@@ -1,4 +1,4 @@
-# pylint:disable=unused-argument,arguments-differ
+# pylint:disable=unused-argument,arguments-differ,no-self-use
 from __future__ import annotations
 
 import logging
@@ -24,19 +24,19 @@ class IfSimplifier(SequenceWalker):
 
     def __init__(self, node):
         handlers = {
-            SequenceNode: self._handle_sequencenode,
-            CodeNode: self._handle_codenode,
-            MultiNode: self._handle_multinode,
-            LoopNode: self._handle_loopnode,
-            ConditionNode: self._handle_conditionnode,
-            CascadingConditionNode: self._handle_cascadingconditionnode,
+            SequenceNode: self._walk_sequencenode,
+            CodeNode: self._walk_codenode,
+            MultiNode: self._walk_multinode,
+            LoopNode: self._walk_loopnode,
+            ConditionNode: self._walk_conditionnode,
+            CascadingConditionNode: self._walk_cascadingconditionnode,
             ailment.Block: self._handle_block,
         }
 
         super().__init__(handlers)
         self.walk(node)
 
-    def _handle_sequencenode(self, node, successor=None, **kwargs):
+    def _walk_sequencenode(self, node, successor=None, **kwargs):
         """
 
         :param SequenceNode node:
@@ -44,18 +44,18 @@ class IfSimplifier(SequenceWalker):
         """
 
         for n0, n1 in zip(node.nodes, [*node.nodes[1:], successor]):
-            self._handle(n0, successor=n1)
+            yield n0, {"successor": n1}
 
-    def _handle_codenode(self, node, successor=None, **kwargs):
+    def _walk_codenode(self, node, successor=None, **kwargs):
         """
 
         :param CodeNode node:
         :return:
         """
 
-        self._handle(node.node, successor=successor)
+        yield node.node, {"successor": successor}
 
-    def _handle_conditionnode(self, node, successor=None, **kwargs):
+    def _walk_conditionnode(self, node, successor=None, **kwargs):
         """
 
         :param ConditionNode node:
@@ -64,17 +64,17 @@ class IfSimplifier(SequenceWalker):
         """
 
         if node.true_node is not None:
-            self._handle(node.true_node, successor=successor)
+            yield node.true_node, {"successor": successor}
         if node.false_node is not None:
-            self._handle(node.false_node, successor=successor)
+            yield node.false_node, {"successor": successor}
 
-    def _handle_cascadingconditionnode(self, node: CascadingConditionNode, successor=None, **kwargs):
+    def _walk_cascadingconditionnode(self, node: CascadingConditionNode, successor=None, **kwargs):
         for _, child_node in node.condition_and_nodes:
-            self._handle(child_node, successor=successor)
+            yield child_node, {"successor": successor}
         if node.else_node is not None:
-            self._handle(node.else_node, successor=successor)
+            yield node.else_node, {"successor": successor}
 
-    def _handle_loopnode(self, node, successor=None, **kwargs):
+    def _walk_loopnode(self, node, successor=None, **kwargs):
         """
 
         :param LoopNode node:
@@ -82,9 +82,9 @@ class IfSimplifier(SequenceWalker):
         :return:
         """
 
-        self._handle(node.sequence_node, successor=successor)
+        yield node.sequence_node, {"successor": successor}
 
-    def _handle_multinode(self, node, successor=None, **kwargs):
+    def _walk_multinode(self, node, successor=None, **kwargs):
         """
 
         :param MultiNode node:
@@ -92,9 +92,9 @@ class IfSimplifier(SequenceWalker):
         """
 
         for n0, n1 in zip(node.nodes, [*node.nodes[1:], successor]):
-            self._handle(n0, successor=n1)
+            yield n0, {"successor": n1}
 
-    def _handle_block(self, block, successor=None, **kwargs):  # pylint:disable=no-self-use
+    def _handle_block(self, block, successor=None, **kwargs):
         """
         Remove unnecessary jump or conditional jump statements if they jump to the successor right afterwards.
 

--- a/angr/analyses/decompiler/region_simplifiers/ifelse.py
+++ b/angr/analyses/decompiler/region_simplifiers/ifelse.py
@@ -27,19 +27,19 @@ class IfElseFlattener(SequenceWalker):
             CodeNode: self._handle_Code,
             MultiNode: self._handle_MultiNode,
             LoopNode: self._handle_Loop,
-            ConditionNode: self._handle_Condition,
-            CascadingConditionNode: self._handle_CascadingCondition,
+            ConditionNode: self._walk_Condition,
+            CascadingConditionNode: self._walk_CascadingCondition,
         }
 
         super().__init__(handlers)
         self.functions = functions
         self.walk(node)
 
-    def _handle_Condition(self, node: ConditionNode, parent=None, index=None, **kwargs):
+    def _walk_Condition(self, node: ConditionNode, parent=None, index=None, **kwargs):
         if node.true_node is not None:
-            self._handle(node.true_node, parent=node, index=0)
+            yield node.true_node, {"parent": node, "index": 0}
         if node.false_node is not None:
-            self._handle(node.false_node, parent=node, index=1)
+            yield node.false_node, {"parent": node, "index": 1}
 
         if node.true_node is not None and node.false_node is not None:
             try:
@@ -67,8 +67,8 @@ class IfElseFlattener(SequenceWalker):
                     node.false_node = None
                     insert_node(parent, "after", else_node, index, **kwargs)
 
-    def _handle_CascadingCondition(self, node: CascadingConditionNode, parent=None, index=None, **kwargs):
-        super()._handle_CascadingCondition(node, parent=parent, index=index, **kwargs)
+    def _walk_CascadingCondition(self, node: CascadingConditionNode, parent=None, index=None, **kwargs):
+        yield from super()._walk_CascadingCondition(node, parent=parent, index=index, **kwargs)
 
         if node.else_node is not None:
             last_stmts = []

--- a/angr/analyses/decompiler/region_simplifiers/loop.py
+++ b/angr/analyses/decompiler/region_simplifiers/loop.py
@@ -1,4 +1,4 @@
-# pylint:disable=unused-argument,arguments-differ
+# pylint:disable=unused-argument,arguments-differ,no-self-use
 from __future__ import annotations
 
 from collections import defaultdict
@@ -26,12 +26,12 @@ class LoopSimplifier(SequenceWalker):
 
     def __init__(self, node, functions):
         handlers = {
-            SequenceNode: self._handle_sequencenode,
-            CodeNode: self._handle_codenode,
-            MultiNode: self._handle_multinode,
-            LoopNode: self._handle_loopnode,
-            ConditionNode: self._handle_conditionnode,
-            CascadingConditionNode: self._handle_cascadingconditionnode,
+            SequenceNode: self._walk_sequencenode,
+            CodeNode: self._walk_codenode,
+            MultiNode: self._walk_multinode,
+            LoopNode: self._walk_loopnode,
+            ConditionNode: self._walk_conditionnode,
+            CascadingConditionNode: self._walk_cascadingconditionnode,
             ailment.Block: self._handle_block,
         }
 
@@ -47,40 +47,48 @@ class LoopSimplifier(SequenceWalker):
             (ailment.Stmt.SideEffectStatement, ailment.Stmt.Return, ailment.Stmt.Jump, ailment.Stmt.ConditionalJump),
         )
 
-    def _handle_sequencenode(self, node, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
+    def _walk_sequencenode(self, node, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
         for n0, n1, n2 in zip(node.nodes, [*node.nodes[1:], successor], [predecessor, *node.nodes[:-1]]):
-            self._handle(n0, predecessor=n2, successor=n1, loop=loop, loop_successor=loop_successor)
+            yield n0, {"predecessor": n2, "successor": n1, "loop": loop, "loop_successor": loop_successor}
 
-    def _handle_codenode(self, node, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
-        self._handle(node.node, predecessor=predecessor, successor=successor, loop=loop, loop_successor=loop_successor)
+    def _walk_codenode(self, node, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
+        yield (
+            node.node,
+            {"predecessor": predecessor, "successor": successor, "loop": loop, "loop_successor": loop_successor},
+        )
 
-    def _handle_conditionnode(self, node, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
+    def _walk_conditionnode(self, node, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
         if node.true_node is not None:
-            self._handle(
-                node.true_node, predecessor=predecessor, successor=successor, loop=loop, loop_successor=loop_successor
+            yield (
+                node.true_node,
+                {"predecessor": predecessor, "successor": successor, "loop": loop, "loop_successor": loop_successor},
             )
         if node.false_node is not None:
-            self._handle(
-                node.false_node, predecessor=predecessor, successor=successor, loop=loop, loop_successor=loop_successor
+            yield (
+                node.false_node,
+                {"predecessor": predecessor, "successor": successor, "loop": loop, "loop_successor": loop_successor},
             )
 
-    def _handle_cascadingconditionnode(
+    def _walk_cascadingconditionnode(
         self, node: CascadingConditionNode, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs
     ):
         for _, child_node in node.condition_and_nodes:
-            self._handle(
-                child_node, predecessor=predecessor, successor=successor, loop=loop, loop_successor=loop_successor
+            yield (
+                child_node,
+                {"predecessor": predecessor, "successor": successor, "loop": loop, "loop_successor": loop_successor},
             )
         if node.else_node is not None:
-            self._handle(
-                node.else_node, predecessor=predecessor, successor=successor, loop=loop, loop_successor=loop_successor
+            yield (
+                node.else_node,
+                {"predecessor": predecessor, "successor": successor, "loop": loop, "loop_successor": loop_successor},
             )
 
-    def _handle_loopnode(
+    def _walk_loopnode(
         self, node: LoopNode, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs
     ):
-        self._handle(
-            node.sequence_node, predecessor=predecessor, successor=successor, loop=node, loop_successor=successor
+        yield (
+            node.sequence_node,
+            {"predecessor": predecessor, "successor": successor, "loop": node, "loop_successor": successor},
         )
 
         # find for-loop iterators
@@ -126,11 +134,11 @@ class LoopSimplifier(SequenceWalker):
             node.initializer = predecessor.statements[-1]
             predecessor.statements = predecessor.statements[:-1]
 
-    def _handle_multinode(self, node, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
+    def _walk_multinode(self, node, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
         for n0, n1, n2 in zip(node.nodes, [*node.nodes[1:], successor], [predecessor, *node.nodes[:-1]]):
-            self._handle(n0, predecessor=n2, successor=n1, loop=loop, loop_successor=loop_successor)
+            yield n0, {"predecessor": n2, "successor": n1, "loop": loop, "loop_successor": loop_successor}
 
-    def _handle_block(self, block, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):  # pylint:disable=no-self-use
+    def _handle_block(self, block, predecessor=None, successor=None, loop=None, loop_successor=None, **kwargs):
         if isinstance(successor, ContinueNode) or successor is loop_successor:
             # ensure this block is not returning or exiting
             try:

--- a/angr/analyses/decompiler/region_simplifiers/switch_cluster_simplifier.py
+++ b/angr/analyses/decompiler/region_simplifiers/switch_cluster_simplifier.py
@@ -87,8 +87,8 @@ class SwitchClusterFinder(SequenceWalker):
 
     def __init__(self, node, variable_map):
         handlers = {
-            SwitchCaseNode: self._handle_SwitchCase,
-            ConditionNode: self._handle_Condition,
+            SwitchCaseNode: self._walk_SwitchCase,
+            ConditionNode: self._walk_Condition,
             ailment.Block: self._handle_Block,
         }
         super().__init__(handlers)
@@ -104,17 +104,17 @@ class SwitchClusterFinder(SequenceWalker):
             cond = node.statements[-1].condition
             self._process_condition(cond, node, parent)
 
-    def _handle_Condition(self, node, parent=None, **kwargs):
+    def _walk_Condition(self, node, parent=None, **kwargs):
         cond = node.condition
         self._process_condition(cond, node, parent)
-        return super()._handle_Condition(node, parent=parent, **kwargs)
+        return (yield from super()._walk_Condition(node, parent=parent, **kwargs))
 
-    def _handle_SwitchCase(self, node: SwitchCaseNode, parent=None, **kwargs):
+    def _walk_SwitchCase(self, node: SwitchCaseNode, parent=None, **kwargs):
         cond = node.switch_expr
         variable = self._variable_map.variable(cond)
         scr = SwitchCaseRegion(variable, node, parent)
         self.var2switches[variable].append(scr)
-        return super()._handle_SwitchCase(node, parent=parent, **kwargs)
+        return (yield from super()._walk_SwitchCase(node, parent=parent, **kwargs))
 
     def _process_condition(self, cond: ailment.Expr.Expression, node: ConditionNode | ailment.Block, parent):
         negated = False

--- a/angr/analyses/decompiler/sequence_walker.py
+++ b/angr/analyses/decompiler/sequence_walker.py
@@ -1,7 +1,8 @@
-# pylint:disable=unused-argument,useless-return
+# pylint:disable=unused-argument,useless-return,no-self-use
 from __future__ import annotations
 
 from collections import OrderedDict
+from inspect import isgeneratorfunction
 
 from angr import ailment
 from angr.errors import UnsupportedNodeTypeError
@@ -22,8 +23,13 @@ from .structurer_nodes import (
 
 class SequenceWalker:
     """
-    Walks a SequenceNode and all its nodes, recursively.
+    Walks a SequenceNode and all its nodes.
     """
+
+    # A subclass that replaces _handle keeps the recursive walk, because only that walk passes every node through
+    # _handle. Set this to False on a subclass whose _handle only adds node types this class does not walk itself,
+    # such as AIL expressions and statements: those already reach it, and its children stay on the stack.
+    HANDLE_SEES_EVERY_NODE = True
 
     def __init__(
         self,
@@ -59,6 +65,42 @@ class SequenceWalker:
         if handlers:
             self._handlers.update(handlers)
 
+        self._walk_children_through_handle = (
+            type(self)._handle is not SequenceWalker._handle and self.HANDLE_SEES_EVERY_NODE
+        )
+
+        # A handler that is a generator yields the children it wants walked, and _drive runs it, and the generators
+        # of everything it reaches, on one stack, so the depth of the tree costs no interpreter frames. Ours are
+        # generators through the _walk_ method beside each one; a caller can pass its own. A plain handler is called
+        # as before and recurses through _handle for its children.
+        self._walkers = {
+            node_cls: handler for node_cls, handler in self._handlers.items() if isgeneratorfunction(handler)
+        }
+        self._walkers.update(
+            (node_cls, walker)
+            for node_cls, default, walker in (
+                (CodeNode, SequenceWalker._handle_Code, self._walk_Code),
+                (SequenceNode, SequenceWalker._handle_Sequence, self._walk_Sequence),
+                (ConditionNode, SequenceWalker._handle_Condition, self._walk_Condition),
+                (
+                    CascadingConditionNode,
+                    SequenceWalker._handle_CascadingCondition,
+                    self._walk_CascadingCondition,
+                ),
+                (SwitchCaseNode, SequenceWalker._handle_SwitchCase, self._walk_SwitchCase),
+                (PatternMatchNode, SequenceWalker._handle_PatternMatch, self._walk_PatternMatch),
+                (IfLetNode, SequenceWalker._handle_IfLet, self._walk_IfLet),
+                (
+                    IncompleteSwitchCaseNode,
+                    SequenceWalker._handle_IncompleteSwitchCase,
+                    self._walk_IncompleteSwitchCase,
+                ),
+                (LoopNode, SequenceWalker._handle_Loop, self._walk_Loop),
+                (MultiNode, SequenceWalker._handle_MultiNode, self._walk_MultiNode),
+            )
+            if getattr(self._handlers.get(node_cls), "__func__", None) is default
+        )
+
     def walk(self, sequence):
         return self._handle(sequence)
 
@@ -67,6 +109,9 @@ class SequenceWalker:
     #
 
     def _handle(self, node, **kwargs):
+        walker = self._walkers.get(node.__class__, None)
+        if walker is not None:
+            return self._drive(walker(node, **kwargs))
         handler = self._handlers.get(node.__class__, None)
         if handler is not None:
             return handler(node, **kwargs)
@@ -74,19 +119,48 @@ class SequenceWalker:
             raise UnsupportedNodeTypeError(f"Node type {type(node)} is not supported yet.")
         return None
 
+    def _drive(self, walk):
+        """
+        Run one walker generator, and the generators of every node it reaches, on a single stack. A generator yields
+        the child it wants walked and the keyword arguments to walk it with, and is resumed with that child's
+        replacement.
+        """
+        stack = [walk]
+        replacement = None
+        while stack:
+            try:
+                child, child_kwargs = stack[-1].send(replacement)
+            except StopIteration as walked:
+                stack.pop()
+                replacement = walked.value
+                continue
+            walker = None if self._walk_children_through_handle else self._walkers.get(child.__class__, None)
+            if walker is None:
+                replacement = self._handle(child, **child_kwargs)
+            else:
+                stack.append(walker(child, **child_kwargs))
+                replacement = None
+        return replacement
+
     def _handle_Code(self, node: CodeNode, **kwargs):
-        new_inner_node = self._handle(node.node, parent=node, index=0)
+        return self._drive(self._walk_Code(node, **kwargs))
+
+    def _walk_Code(self, node: CodeNode, **kwargs):
+        new_inner_node = yield node.node, {"parent": node, "index": 0}
         if new_inner_node is None:
             return None
         return CodeNode(new_inner_node, node.reaching_condition)
 
     def _handle_Sequence(self, node, **kwargs):
+        return self._drive(self._walk_Sequence(node, **kwargs))
+
+    def _walk_Sequence(self, node, **kwargs):
         nodes_copy = list(node.nodes)
         changed = False
 
         if self._force_forward_scan:
             for i, node_ in enumerate(nodes_copy):
-                new_node = self._handle(node_, parent=node, index=i)
+                new_node = yield node_, {"parent": node, "index": i}
                 if new_node is not None:
                     changed = True
                     nodes_copy[i] = new_node
@@ -97,7 +171,7 @@ class SequenceWalker:
             i = len(nodes_copy) - 1
             while i > -1:
                 node_ = nodes_copy[i]
-                new_node = self._handle(node_, parent=node, index=i)
+                new_node = yield node_, {"parent": node, "index": i}
                 if new_node is not None:
                     changed = True
                     if self._update_seqnode_in_place:
@@ -113,12 +187,15 @@ class SequenceWalker:
         return SequenceNode(node.addr, nodes=nodes_copy)
 
     def _handle_MultiNode(self, node, **kwargs):
+        return self._drive(self._walk_MultiNode(node, **kwargs))
+
+    def _walk_MultiNode(self, node, **kwargs):
         changed = False
         nodes = node.nodes if self._update_seqnode_in_place else list(node.nodes)
 
         if self._force_forward_scan:
             for i, node_ in enumerate(nodes):
-                new_node = self._handle(node_, parent=node, index=i)
+                new_node = yield node_, {"parent": node, "index": i}
                 if new_node is not None:
                     changed = True
                     nodes[i] = new_node
@@ -126,7 +203,7 @@ class SequenceWalker:
             i = len(nodes) - 1
             while i > -1:
                 node_ = nodes[i]
-                new_node = self._handle(node_, parent=node, index=i)
+                new_node = yield node_, {"parent": node, "index": i}
                 if new_node is not None:
                     changed = True
                     nodes[i] = new_node
@@ -138,13 +215,16 @@ class SequenceWalker:
         return MultiNode(nodes, addr=node.addr, idx=node.idx)
 
     def _handle_SwitchCase(self, node, **kwargs):
-        self._handle(node.switch_expr, parent=node, label="switch_expr")
+        return self._drive(self._walk_SwitchCase(node, **kwargs))
+
+    def _walk_SwitchCase(self, node, **kwargs):
+        yield node.switch_expr, {"parent": node, "label": "switch_expr"}
 
         changed = False
         new_cases = OrderedDict()
         for idx in list(node.cases.keys()):
             case = node.cases[idx]
-            new_case = self._handle(case, parent=node, index=idx, label="case")
+            new_case = yield case, {"parent": node, "index": idx, "label": "case"}
             if new_case is not None:
                 changed = True
                 new_cases[idx] = new_case
@@ -153,7 +233,7 @@ class SequenceWalker:
 
         new_default_node = None
         if node.default_node is not None:
-            new_default_node = self._handle(node.default_node, parent=node, index=0, label="default")
+            new_default_node = yield node.default_node, {"parent": node, "index": 0, "label": "default"}
             if new_default_node is not None:
                 changed = True
             else:
@@ -165,12 +245,15 @@ class SequenceWalker:
         return None
 
     def _handle_PatternMatch(self, node: PatternMatchNode, **kwargs):
-        self._handle(node.scrutinee, parent=node, label="scrutinee")
+        return self._drive(self._walk_PatternMatch(node, **kwargs))
+
+    def _walk_PatternMatch(self, node: PatternMatchNode, **kwargs):
+        yield node.scrutinee, {"parent": node, "label": "scrutinee"}
 
         changed = False
         new_arms = OrderedDict()
         for key, arm in node.arms.items():
-            new_arm = self._handle(arm, parent=node, label="arm")
+            new_arm = yield arm, {"parent": node, "label": "arm"}
             if new_arm is not None:
                 changed = True
                 new_arms[key] = new_arm
@@ -179,7 +262,7 @@ class SequenceWalker:
 
         new_default_node = None
         if node.default_node is not None:
-            new_default_node = self._handle(node.default_node, parent=node, index=0, label="default")
+            new_default_node = yield node.default_node, {"parent": node, "index": 0, "label": "default"}
             if new_default_node is not None:
                 changed = True
             else:
@@ -191,9 +274,12 @@ class SequenceWalker:
         return None
 
     def _handle_IfLet(self, node: IfLetNode, **kwargs):
+        return self._drive(self._walk_IfLet(node, **kwargs))
+
+    def _walk_IfLet(self, node: IfLetNode, **kwargs):
         changed = False
 
-        new_scrutinee = self._handle(node.scrutinee, parent=node, label="scrutinee")
+        new_scrutinee = yield node.scrutinee, {"parent": node, "label": "scrutinee"}
         if new_scrutinee is not None:
             changed = True
         else:
@@ -202,13 +288,13 @@ class SequenceWalker:
         variant, bound_vars = node.pattern
         new_bound_vars = []
         for bound_var in bound_vars:
-            new_bound_var = self._handle(bound_var, parent=node, label="bound_var")
+            new_bound_var = yield bound_var, {"parent": node, "label": "bound_var"}
             new_bound_vars.append(new_bound_var if new_bound_var is not None else bound_var)
             if new_bound_var is not None:
                 changed = True
         new_pattern = (variant, new_bound_vars)
 
-        new_true_node = self._handle(node.true_node, parent=node, label="true_node")
+        new_true_node = yield node.true_node, {"parent": node, "label": "true_node"}
         if new_true_node is not None:
             changed = True
         else:
@@ -216,7 +302,7 @@ class SequenceWalker:
 
         new_false_node = None
         if node.false_node is not None:
-            new_false_node = self._handle(node.false_node, parent=node, label="false_node")
+            new_false_node = yield node.false_node, {"parent": node, "label": "false_node"}
             if new_false_node is not None:
                 changed = True
             else:
@@ -228,10 +314,13 @@ class SequenceWalker:
         return None
 
     def _handle_IncompleteSwitchCase(self, node: IncompleteSwitchCaseNode, **kwargs):
+        return self._drive(self._walk_IncompleteSwitchCase(node, **kwargs))
+
+    def _walk_IncompleteSwitchCase(self, node: IncompleteSwitchCaseNode, **kwargs):
         changed = False
         new_cases = []
         for idx, case in enumerate(node.cases):
-            new_case = self._handle(case, parent=node, index=idx, label="case")
+            new_case = yield case, {"parent": node, "index": idx, "label": "case"}
             if new_case is not None:
                 changed = True
                 new_cases.append(new_case)
@@ -240,7 +329,7 @@ class SequenceWalker:
 
         new_head = None
         if node.head is not None:
-            new_head = self._handle(node.head, parent=node, index=0, label="default")
+            new_head = yield node.head, {"parent": node, "index": 0, "label": "default"}
             if new_head is not None:
                 changed = True
             else:
@@ -252,10 +341,13 @@ class SequenceWalker:
         return None
 
     def _handle_Loop(self, node: LoopNode, **kwargs) -> LoopNode | None:
-        new_initializer = self._handle(node.initializer) if node.initializer is not None else None
-        new_iterator = self._handle(node.iterator) if node.iterator is not None else None
+        return self._drive(self._walk_Loop(node, **kwargs))
+
+    def _walk_Loop(self, node: LoopNode, **kwargs):
+        new_initializer = (yield node.initializer, {}) if node.initializer is not None else None
+        new_iterator = (yield node.iterator, {}) if node.iterator is not None else None
         new_condition = (
-            self._handle(node.condition, parent=node, label="condition") if node.condition is not None else None
+            (yield node.condition, {"parent": node, "label": "condition"}) if node.condition is not None else None
         )
 
         # note that initializer and iterator are both statements, so they can return empty tuples
@@ -265,7 +357,7 @@ class SequenceWalker:
         if new_iterator == ():
             new_iterator = None
 
-        seq_node = self._handle(node.sequence_node, parent=node, label="body", index=0)
+        seq_node = yield node.sequence_node, {"parent": node, "label": "body", "index": 0}
         if seq_node is not None or new_initializer is not None or new_iterator is not None or new_condition is not None:
             return LoopNode(
                 node.sort,
@@ -279,12 +371,15 @@ class SequenceWalker:
         return None
 
     def _handle_Condition(self, node, **kwargs):
-        new_true_node = self._handle(node.true_node, parent=node, index=0) if node.true_node is not None else None
+        return self._drive(self._walk_Condition(node, **kwargs))
 
-        new_false_node = self._handle(node.false_node, parent=node, index=1) if node.false_node is not None else None
+    def _walk_Condition(self, node, **kwargs):
+        new_true_node = (yield node.true_node, {"parent": node, "index": 0}) if node.true_node is not None else None
+
+        new_false_node = (yield node.false_node, {"parent": node, "index": 1}) if node.false_node is not None else None
 
         new_condition = (
-            self._handle(node.condition, parent=node, label="condition") if node.condition is not None else None
+            (yield node.condition, {"parent": node, "label": "condition"}) if node.condition is not None else None
         )
 
         if new_true_node is None and new_false_node is None and new_condition is None:
@@ -299,10 +394,13 @@ class SequenceWalker:
         )
 
     def _handle_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
+        return self._drive(self._walk_CascadingCondition(node, **kwargs))
+
+    def _walk_CascadingCondition(self, node: CascadingConditionNode, **kwargs):
         cond_nodes_changed = False
         new_condition_and_nodes = []
         for index, (cond, child_node) in enumerate(node.condition_and_nodes):
-            new_child = self._handle(child_node, parent=node, index=index)
+            new_child = yield child_node, {"parent": node, "index": index}
             if new_child is not None:
                 cond_nodes_changed = True
                 new_condition_and_nodes.append((cond, new_child))
@@ -311,7 +409,7 @@ class SequenceWalker:
 
         new_else = None
         if node.else_node is not None:
-            new_else = self._handle(node.else_node, parent=node, index=-1)
+            new_else = yield node.else_node, {"parent": node, "index": -1}
 
         if cond_nodes_changed or new_else is not None:
             return CascadingConditionNode(
@@ -321,8 +419,8 @@ class SequenceWalker:
             )
         return None
 
-    def _handle_ConditionalBreak(self, node: ConditionalBreakNode, **kwargs):  # pylint:disable=no-self-use
+    def _handle_ConditionalBreak(self, node: ConditionalBreakNode, **kwargs):
         return None
 
-    def _handle_Noop(self, *args, **kwargs):  # pylint:disable=no-self-use
+    def _handle_Noop(self, *args, **kwargs):
         return None

--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -295,7 +295,7 @@ class StructurerBase(Analysis):
         :return:                    A processed SequenceNode.
         """
 
-        def _handle_Sequence(node: SequenceNode, **kwargs):
+        def _walk_Sequence(node: SequenceNode, **kwargs):
             if len(node.nodes) > 1:
                 for i in range(len(node.nodes) - 1):
                     this_node = node.nodes[i]
@@ -357,9 +357,9 @@ class StructurerBase(Analysis):
                                 **jump_stmt.tags,
                             )
 
-            return walker._handle_Sequence(node, **kwargs)
+            return (yield from walker._walk_Sequence(node, **kwargs))
 
-        def _handle_MultiNode(node: MultiNode, **kwargs):
+        def _walk_MultiNode(node: MultiNode, **kwargs):
             if len(node.nodes) > 1:
                 for i in range(len(node.nodes) - 1):
                     this_node = node.nodes[i]
@@ -421,11 +421,11 @@ class StructurerBase(Analysis):
                                 **jump_stmt.tags,
                             )
 
-            return walker._handle_MultiNode(node, **kwargs)
+            return (yield from walker._walk_MultiNode(node, **kwargs))
 
         handlers = {
-            SequenceNode: _handle_Sequence,
-            MultiNode: _handle_MultiNode,
+            SequenceNode: _walk_Sequence,
+            MultiNode: _walk_MultiNode,
         }
 
         walker = SequenceWalker(handlers=handlers)

--- a/tests/analyses/decompiler/test_sequence_walker.py
+++ b/tests/analyses/decompiler/test_sequence_walker.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,unused-argument
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from angr import claripy
+from angr.ailment.block import Block
+from angr.analyses.decompiler.sequence_walker import SequenceWalker
+from angr.analyses.decompiler.structurer_nodes import ConditionNode, SequenceNode
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+# A recursive walk of this tree needs four interpreter frames per level, so it stops at 248 levels under CPython's
+# default limit. The deepest tree measured on a real function was 519. This is far enough past both that no
+# recursion limit a caller could reasonably have raised would let the recursive walk through.
+LEVELS = 5000
+
+
+def nested_conditions(levels: int) -> tuple[Block | ConditionNode, list[int]]:
+    """
+    Build the shape a long chain of guarded statements structures into, and the order its blocks are walked in.
+
+    Every level is a ConditionNode with no else branch whose body holds one block and the next condition.
+    """
+    node: Block | ConditionNode = Block(0, 1, statements=[])
+    order = [0]
+    for level in range(1, levels + 1):
+        body = SequenceNode(level, nodes=[Block(level, 1, statements=[]), node])
+        # A sequence's nodes are walked back to front, so the block of this level comes after its body.
+        order.append(level)
+        node = ConditionNode(level, None, claripy.BoolS(f"cond_{level}"), body)
+    return node, order
+
+
+class TestSequenceWalker(unittest.TestCase):
+    def test_a_deeply_nested_function_decompiles(self):
+        # main is two hundred guarded statements, which structures into a tree about four hundred nodes deep. A
+        # recursive walk of it runs out of interpreter frames and the decompiler records the RecursionError instead
+        # of producing any output.
+        proj = angr.Project(os.path.join(test_location, "x86_64", "deeply_nested_ifs"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        decompiler = proj.analyses.Decompiler(proj.kb.functions["main"], cfg=cfg.model)
+
+        codegen = decompiler.codegen
+        assert not decompiler.errors
+        assert codegen is not None
+        text = codegen.text
+        assert text is not None
+        assert text.count("if (") >= 200
+
+    def test_deeply_nested_tree_is_walked_in_order(self):
+        root, expected = nested_conditions(LEVELS)
+        visited = []
+
+        SequenceWalker(handlers={Block: lambda block, **kwargs: visited.append(block.addr)}).walk(root)
+
+        assert visited == expected
+
+    def test_deeply_nested_tree_is_rebuilt_from_the_replacements(self):
+        root, _ = nested_conditions(LEVELS)
+
+        walker = SequenceWalker(
+            handlers={Block: lambda block, **kwargs: Block(block.addr + 1, block.original_size, statements=[])},
+            update_seqnode_in_place=False,
+        )
+        new_root = walker.walk(root)
+
+        node = new_root
+        for level in range(LEVELS, 0, -1):
+            assert isinstance(node, ConditionNode)
+            assert node.addr == level
+            block, node = node.true_node.nodes
+            assert block.addr == level + 1
+        assert isinstance(node, Block)
+        assert node.addr == 1
+
+    def test_a_generator_handler_is_walked_on_the_stack(self):
+        root, _ = nested_conditions(LEVELS)
+        visited = []
+
+        def walk_condition(node, **kwargs):
+            visited.append(node.addr)
+            return (yield node.true_node, {"parent": node, "index": 0})
+
+        SequenceWalker(
+            handlers={
+                ConditionNode: walk_condition,
+                Block: lambda block, **kwargs: visited.append(block.addr),
+            }
+        ).walk(root)
+
+        # Every condition on the way down, then every block on the way back up.
+        assert visited == list(range(LEVELS, -1, -1)) + list(range(1, LEVELS + 1))
+
+    def test_a_replaced_handler_runs_for_every_node_of_its_type(self):
+        seen_by_subclass = []
+        seen_by_argument = []
+
+        class CountingWalker(SequenceWalker):
+            def _handle_Condition(self, node, **kwargs):
+                seen_by_subclass.append(node.addr)
+                return super()._handle_Condition(node, **kwargs)
+
+        CountingWalker().walk(nested_conditions(3)[0])
+        SequenceWalker(handlers={ConditionNode: lambda node, **kwargs: seen_by_argument.append(node.addr)}).walk(
+            nested_conditions(3)[0]
+        )
+
+        assert seen_by_subclass == [3, 2, 1]
+        # A handler passed in replaces the walk into the node as well as the work done at it, so nothing below the
+        # outermost condition is reached.
+        assert seen_by_argument == [3]
+
+    def test_a_replaced_handle_sees_every_node(self):
+        seen = []
+
+        class RecordingWalker(SequenceWalker):
+            def _handle(self, node, **kwargs):
+                seen.append(node.__class__.__name__)
+                return super()._handle(node, **kwargs)
+
+        RecordingWalker().walk(nested_conditions(3)[0])
+
+        assert seen == [
+            "ConditionNode",
+            "SequenceNode",
+            "ConditionNode",
+            "SequenceNode",
+            "ConditionNode",
+            "SequenceNode",
+            "Block",
+            "Block",
+            "Bool",
+            "Block",
+            "Bool",
+            "Block",
+            "Bool",
+        ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`main` in `tests/x86_64/deeply_nested_ifs` is two hundred sequentially guarded statements
and structures into a tree about four hundred nodes deep. It decompiles to nothing:

```
blocks 202   text 0 chars   lines 0   errors 2
  RecursionError: maximum recursion depth exceeded
  terminal frame: sequence_walker.py:282:_handle_Condition
  997 frames, 789 of them in sequence_walker.py
```

`Decompiler` catches the `RecursionError` and records it, so the function comes back empty
rather than the run failing, and nothing downstream says why.

### Root cause

`SequenceWalker._handle` dispatches to a handler that calls `_handle` on each child, so
every level of the tree costs two to four interpreter frames. At CPython's default limit
the walk manages 248 levels of this shape and fails at 249. Nothing about the walk is
unbounded; the tree is deeper than the interpreter's budget for recursion.

### Fix

A handler may now be a generator: it yields the child it wants walked together with the
keyword arguments to walk it with, and is resumed with that child's replacement. `_drive`
runs a handler generator, and the generators of everything it reaches, on one explicit
stack, so the depth of the tree costs no interpreter frames.

Every `_handle_X` stays where it was and drives the `_walk_X` generator beside it, so the
protocol is unchanged for the classes that derive from `SequenceWalker` and for callers
that pass a `handlers` dict: a handler takes a node and returns its replacement or `None`,
and the visit order is the same. A handler that is not a generator is called as before and
recurses through `_handle` for its children. The passes that walk the deep chain adopt the
generator form; each conversion is the same edit, `self._handle(child, ...)` becoming
`yield child, {...}` and `super()._handle_X(...)` becoming `yield from
super()._walk_X(...)`.

A subclass that replaces `_handle` keeps the recursive walk, because only that walk passes
every node through `_handle`; `HANDLE_SEES_EVERY_NODE` lets the two whose `_handle` only
adds AIL expressions and statements keep the stack instead. Deliberately not done: the
recursion in `AILBlockWalker` over deeply nested AIL expressions, which is a different
walker over a different structure and is what #5293 is about. This replaces #7038 and
touches no recursion limit anywhere.

### Testing

`tests/analyses/decompiler/test_sequence_walker.py` decompiles the fixture above and
asserts it produces the two hundred `if` statements with no recorded errors, walks a tree
five thousand levels deep and asserts the visit order and the rebuilt tree, and pins that a
replaced `_handle_X` and a replaced `_handle` still see every node they saw before. Four of
the six fail on master, three of them raising the `RecursionError`. Suite counts are in the validation record. Validation: https://github.com/angr/angr/pull/7044#issuecomment-5468993530

Merge angr/binaries#220 first; the test loads the fixture it adds.

sync: angr/binaries#220

session: sharpen