### PR TITLE
segmentlist: Guard release() against an overflowing range

### DIFF
--- a/native/angr/src/segmentlist.rs
+++ b/native/angr/src/segmentlist.rs
@@ -296,6 +296,10 @@ impl SegmentList {
         if size == 0 {
             return;
         }
+        // ensure address + size does not overflow
+        if address.checked_add(size).is_none() {
+            return;
+        }
         let rem = address..address + size;
         let removed: u64 = self
             .map
@@ -579,6 +583,19 @@ mod tests {
         sl.occupy(0, 10, None);
         sl.occupy(5, 10, None);
         assert_eq!(sl.occupied_size(), 15);
+    }
+
+    #[test]
+    fn release_past_the_end_of_the_address_space() {
+        let mut sl = SegmentList::new();
+        sl.occupy(u64::MAX - 4, 4, None);
+        sl.release(u64::MAX, 1);
+        sl.release(u64::MAX - 1, 2);
+        sl.release(1, u64::MAX);
+        assert_eq!(sl.occupied_size(), 4);
+        // the non-overflowing range that ends exactly at u64::MAX still releases
+        sl.release(u64::MAX - 4, 4);
+        assert_eq!(sl.occupied_size(), 0);
     }
 
     #[test]


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`SegmentList.release()` panics when `address + size` overflows `u64`. Through the public `angr.rustylib.SegmentList` API on master:

```python
from angr.rustylib import SegmentList

sl = SegmentList()
sl.occupy(2**64 - 1, 1, "code")
sl.release(2**64 - 1, 1)
```

```text
thread '<unnamed>' panicked at rangemap-1.8.0/src/map.rs:378:9:
assertion failed: range.start < range.end
pyo3_runtime.PanicException: assertion failed: range.start < range.end
```

`release(2**64 - 2, 2)` and `release(1, 2**64 - 1)` do the same. `occupy()` with the identical arguments returns cleanly.

### Root cause

`occupy()` and `release()` in `native/angr/src/segmentlist.rs` build the same half-open range from the same `(address, size)` pair. #5478 gave `occupy()` a `checked_add` guard against an end past the top of the address space; `release()` never got one, so in a release build the add wraps and the range inverts. `rangemap::RangeMap::remove` asserts `range.start < range.end` and panics, and pyo3 turns that into a `PanicException` at the call.

### Fix

Copy `occupy()`'s guard into `release()`, so an overflowing request is dropped by both. Dropping rather than raising is what `occupy()` already does with the same arguments. `occupy()` is untouched.

### Testing

A new unit test releases the three overflowing ranges above and asserts the list is unchanged, then releases the largest range that does not overflow — the four bytes ending exactly at `u64::MAX` — and asserts that one does take effect, so the guard cannot be over-broad. `cargo test --release --lib segmentlist` is 10 passed / 1 failed on the base revision and 11 passed with the guard.

This hardens the public API; it is not a live crash. The only caller inside angr is `CFGFast._cascading_remove_lifted_blocks`, which releases decoding assumptions, and `CFGFast` records those only when `is_arm_arch(project.arch)` holds. That predicate is `name.startswith("ARM")`, and every architecture it accepts is 32-bit — the three in `archinfo.all_arches` and all 22 pypcode `ARM*` languages — so no binary reaches this through `CFGFast`.

Validation: https://github.com/angr/angr/pull/7045#issuecomment-5473206190

session: sharpen
