### PR TITLE
Set keystone to use cmake<4 when building under uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ cle = { git = "https://github.com/angr/cle.git", branch = "master" }
 claripy = { git = "https://github.com/angr/claripy.git", branch = "master" }
 pysoot = { git = "https://github.com/angr/pysoot.git", branch = "master" }
 
+[tool.uv.extra-build-dependencies]
+keystone-engine = ["cmake<4"]
+
 [tool.ruff]
 line-length = 120
 target-version = "py312"


### PR DESCRIPTION
Running nightly CI to test: https://github.com/angr/angr/actions/runs/33414353887


Fixes #6777
Fixes #7046 