### PR TITLE
ailment: drop Manager.arch and Manager.name

### DIFF
--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -257,7 +257,7 @@ class PCodeIRSBConverter(Converter):
         #        faster mapping method than going through trans
         reg_name = varnode.getRegisterName()
         try:
-            reg_offset = self._manager.arch.get_register_offset(reg_name.lower())
+            reg_offset = self._irsb.arch.get_register_offset(reg_name.lower())
             log.debug("Mapped register '%s' to offset %x", reg_name, reg_offset)
         except ValueError:
             reg_offset = varnode.offset + 0x100000
@@ -331,13 +331,13 @@ class PCodeIRSBConverter(Converter):
             return Tmp(self._manager.next_atom(), offset, size)
         if space_name.lower() in ["ram", "mem"]:
             assert not is_write
-            addr = Const(self._manager.next_atom(), varnode.offset, self._manager.arch.bits)
+            addr = Const(self._manager.next_atom(), varnode.offset, self._irsb.arch.bits)
             # Note: Load takes bytes, not bits, for size
             return Load(
                 self._manager.next_atom(),
                 addr,
                 varnode.size,
-                self._manager.arch.memory_endness,
+                self._irsb.arch.memory_endness,
                 ins_addr=self._manager.ins_addr,
             )
         raise NotImplementedError
@@ -360,13 +360,13 @@ class PCodeIRSBConverter(Converter):
                 self._statement_idx, self._convert_varnode(varnode, True), value, ins_addr=self._manager.ins_addr
             )
         if space_name.lower() in ["ram", "mem"]:
-            addr = Const(self._manager.next_atom(), varnode.offset, self._manager.arch.bits)
+            addr = Const(self._manager.next_atom(), varnode.offset, self._irsb.arch.bits)
             return Store(
                 self._statement_idx,
                 addr,
                 value,
                 varnode.size,
-                self._manager.arch.memory_endness,
+                self._irsb.arch.memory_endness,
                 ins_addr=self._manager.ins_addr,
             )
         raise NotImplementedError
@@ -455,7 +455,7 @@ class PCodeIRSBConverter(Converter):
                 self._manager.next_atom(),
                 off,
                 self._current_op.output.size,
-                self._manager.arch.memory_endness,
+                self._irsb.arch.memory_endness,
                 ins_addr=self._manager.ins_addr,
             )
             stmt = self._set_value(out, res)
@@ -484,7 +484,7 @@ class PCodeIRSBConverter(Converter):
                 off,
                 data,
                 self._current_op.inputs[2].size,
-                self._manager.arch.memory_endness,
+                self._irsb.arch.memory_endness,
                 ins_addr=self._manager.ins_addr,
             )
         self._statements.append(stmt)
@@ -499,7 +499,7 @@ class PCodeIRSBConverter(Converter):
 
         # special handling: if the previous statement is a ConditionalJump with a None destination address, then we
         # back-patch the previous statement
-        dest = Const(self._manager.next_atom(), dest_addr, self._manager.arch.bits)
+        dest = Const(self._manager.next_atom(), dest_addr, self._irsb.arch.bits)
         if self._statements:
             last_stmt = self._statements[-1]
             if isinstance(last_stmt, ConditionalJump) and last_stmt.false_target is None:
@@ -519,13 +519,13 @@ class PCodeIRSBConverter(Converter):
         cond = self._get_value(self._current_op.inputs[1])
         cval = Const(self._manager.next_atom(), 0, cond.bits)
         condition = BinaryOp(self._manager.next_atom(), "CmpNE", [cond, cval], signed=False)
-        dest = Const(self._manager.next_atom(), dest_addr, self._manager.arch.bits)
+        dest = Const(self._manager.next_atom(), dest_addr, self._irsb.arch.bits)
         if self._irsb._ops[-1] is self._current_op:
             # if the cbranch op is the last op, then we need to generate a fallthru target
             fallthru = Const(
                 self._manager.next_atom(),
                 self._next_ins_addr,
-                self._manager.arch.bits,
+                self._irsb.arch.bits,
             )
         else:
             # there will be a Jump statement that follows the cbranch
@@ -558,14 +558,14 @@ class PCodeIRSBConverter(Converter):
         """
         Convert a p-code call operation
         """
-        ret_reg_offset = self._manager.arch.ret_offset
+        ret_reg_offset = self._irsb.arch.ret_offset
         ret_expr = (
             None
             if ret_reg_offset is None
-            else Register(None, ret_reg_offset, self._manager.arch.bits, ins_addr=self._manager.ins_addr)
+            else Register(None, ret_reg_offset, self._irsb.arch.bits, ins_addr=self._manager.ins_addr)
         )  # ???
         if self._irsb.next is not None:
-            dest = Const(self._manager.next_atom(), self._irsb.next.con.value, self._manager.arch.bits)
+            dest = Const(self._manager.next_atom(), self._irsb.next.con.value, self._irsb.arch.bits)
         else:
             dest = None
         call_expr = Call(
@@ -589,8 +589,8 @@ class PCodeIRSBConverter(Converter):
         """
         Convert a p-code indirect call operation
         """
-        ret_reg_offset = self._manager.arch.ret_offset
-        ret_expr = Register(None, ret_reg_offset, self._manager.arch.bits, ins_addr=self._manager.ins_addr)  # ???
+        ret_reg_offset = self._irsb.arch.ret_offset
+        ret_expr = Register(None, ret_reg_offset, self._irsb.arch.bits, ins_addr=self._manager.ins_addr)  # ???
         dest = self._get_value(self._current_op.inputs[0])
         call_expr = Call(
             self._manager.next_atom(),

--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -491,7 +491,7 @@ class Clinic(Analysis, Serializable):
 
     def _analyze_for_decompiling(self):
         # initialize the AIL conversion manager
-        self._ail_manager = ailment.Manager(arch=self.project.arch)
+        self._ail_manager = ailment.Manager()
         # attach the VariableMap so passes/peephole-opts/region-simplifiers that hold the manager can reach it
         self._ail_manager.variable_map = self.variable_map
 
@@ -1150,7 +1150,7 @@ class Clinic(Analysis, Serializable):
             return
 
         # initialize the AIL conversion manager
-        self._ail_manager = ailment.Manager(arch=self.project.arch)
+        self._ail_manager = ailment.Manager()
         self._ail_manager.variable_map = self.variable_map
 
         # Track stack pointers

--- a/angr/rustylib/ailment.pyi
+++ b/angr/rustylib/ailment.pyi
@@ -530,15 +530,13 @@ class Block:
 class Manager:
     """AIL manager: hands out atom indices and holds per-conversion scratch state."""
 
-    name: str | None
-    arch: Any | None
     variable_map: Any | None
     ins_addr: int | None
     vex_stmt_idx: int | None
     tyenv: Any | None
     block_addr: int | None
     atom_ctr: int
-    def __init__(self, name: str | None = ..., arch: Any | None = ...) -> None: ...
+    def __init__(self) -> None: ...
     def next_atom(self) -> int: ...
     def reset(self) -> None: ...
 

--- a/native/angr/src/ailment/convert_vex.rs
+++ b/native/angr/src/ailment/convert_vex.rs
@@ -2175,14 +2175,8 @@ impl VEXIRSBConverter {
         manager: Bound<'_, Manager>,
     ) -> PyResult<Block> {
         vex_ffi::init_symbols(py);
-        let arch = match &manager.borrow().arch {
-            Some(a) => a.bind(py).clone(),
-            None => {
-                return Err(PyValueError::new_err(
-                    "manager.arch must be set for VEX conversion",
-                ));
-            }
-        };
+        // The arch comes from the IRSB itself -- the block was lifted under it.
+        let arch = irsb.getattr("arch")?;
         let tyenv = irsb.getattr("tyenv")?;
         let block_addr: i64 = irsb.getattr("addr")?.extract()?;
         // Keep manager state in sync with the legacy converter.

--- a/native/angr/src/ailment/convert_vex.rs
+++ b/native/angr/src/ailment/convert_vex.rs
@@ -2175,7 +2175,6 @@ impl VEXIRSBConverter {
         manager: Bound<'_, Manager>,
     ) -> PyResult<Block> {
         vex_ffi::init_symbols(py);
-        // The arch comes from the IRSB itself -- the block was lifted under it.
         let arch = irsb.getattr("arch")?;
         let tyenv = irsb.getattr("tyenv")?;
         let block_addr: i64 = irsb.getattr("addr")?.extract()?;

--- a/native/angr/src/ailment/manager.rs
+++ b/native/angr/src/ailment/manager.rs
@@ -4,7 +4,11 @@
 //! the per-conversion scratch state (current instruction address, VEX
 //! statement index, type environment, block address). Porting it to Rust
 //! lets the VEX converter bump the atom counter natively (no Python call per
-//! atom). The public Python API mirrors the original class exactly.
+//! atom).
+//!
+//! It deliberately carries no `arch`: the two converters that need one read it
+//! off the IRSB they are converting, which is the arch the block was lifted
+//! under, so the manager cannot disagree with the block.
 
 use pyo3::prelude::*;
 
@@ -18,8 +22,6 @@ use pyo3::prelude::*;
 )]
 #[derive(Debug)]
 pub struct Manager {
-    pub name: Option<Py<PyAny>>,
-    pub arch: Option<Py<PyAny>>,
     /// Next atom index to hand out (the original used `itertools.count()`).
     pub atom_ctr: i64,
     /// Attached by Clinic so that optimization passes, peephole optimizations,
@@ -34,11 +36,8 @@ pub struct Manager {
 #[pymethods]
 impl Manager {
     #[new]
-    #[pyo3(signature = (name=None, arch=None))]
-    fn new(name: Option<Py<PyAny>>, arch: Option<Py<PyAny>>) -> Self {
+    fn new() -> Self {
         Self {
-            name,
-            arch,
             atom_ctr: 0,
             variable_map: None,
             ins_addr: None,

--- a/native/angr/src/ailment/manager.rs
+++ b/native/angr/src/ailment/manager.rs
@@ -4,11 +4,7 @@
 //! the per-conversion scratch state (current instruction address, VEX
 //! statement index, type environment, block address). Porting it to Rust
 //! lets the VEX converter bump the atom counter natively (no Python call per
-//! atom).
-//!
-//! It deliberately carries no `arch`: the two converters that need one read it
-//! off the IRSB they are converting, which is the arch the block was lifted
-//! under, so the manager cannot disagree with the block.
+//! atom). The public Python API mirrors the original class exactly.
 
 use pyo3::prelude::*;
 

--- a/tests/ailment/test_hash_eq_contract.py
+++ b/tests/ailment/test_hash_eq_contract.py
@@ -97,7 +97,7 @@ class TestHashEqContract(unittest.TestCase):
     """Per-variant sweeps plus the individual node-local regressions."""
 
     def _sweep(self, factories):
-        manager = Manager(arch=None)
+        manager = Manager()
         for name, build in factories.items():
             with self.subTest(variant=name):
                 kids_a, kids_b = _Kids(manager), _Kids(manager)
@@ -121,7 +121,7 @@ class TestHashEqContract(unittest.TestCase):
 
     def test_nested_statement_over_expression(self):
         """The original report: a statement whose src subtree differs only in idx."""
-        manager = Manager(arch=None)
+        manager = Manager()
         n = manager.next_atom
 
         def src():

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -12,6 +12,7 @@ from pyvex.enums import irop_enums_to_ints
 
 import angr
 from angr import ailment
+from angr.engines.pcode.lifter import IRSB as PCodeIRSB
 from angr.engines.vex.claripy import irop
 from angr.rustylib.ailment import RoundingMode, VEXIRSBConverter, _vexop_debug
 
@@ -27,14 +28,14 @@ class TestIrsb(unittest.TestCase):
 
     def test_convert_from_vex_irsb(self):
         arch = archinfo.arch_from_id("AMD64")
-        manager = ailment.Manager(arch=arch)
+        manager = ailment.Manager()
         irsb = pyvex.IRSB(self.block_bytes, self.block_addr, arch, opt_level=0)
         ablock = ailment.IRSBConverter.convert(irsb, manager)
         assert ablock  # TODO: test if this conversion is valid
 
     def test_convert_from_pcode_irsb(self):
         arch = archinfo.arch_from_id("AMD64")
-        manager = ailment.Manager(arch=arch)
+        manager = ailment.Manager()
         p = angr.load_shellcode(
             self.block_bytes, arch, self.block_addr, self.block_addr, engine=angr.engines.UberEnginePcode
         )
@@ -44,7 +45,7 @@ class TestIrsb(unittest.TestCase):
 
     def test_convert_pcode_uppercase_memory_space(self):
         arch = archinfo.ArchPcode("6502:LE:16:default")
-        manager = ailment.Manager(arch=arch)  # pyright: ignore[reportArgumentType]
+        manager = ailment.Manager()
         translation = pypcode.Context(arch.name).translate(bytes.fromhex("ad34128d7856"), base_address=0)
         load_varnode = translation.ops[1].inputs[0]
         store_varnode = translation.ops[5].output
@@ -53,6 +54,7 @@ class TestIrsb(unittest.TestCase):
         assert load_varnode.space.name == store_varnode.space.name == "RAM"
 
         converter = object.__new__(ailment.PCodeIRSBConverter)
+        converter._irsb = PCodeIRSB.empty_block(arch, 0)
         converter._manager = manager
         converter._statement_idx = 0
 
@@ -73,9 +75,9 @@ class TestIrsb(unittest.TestCase):
         converting a cached pyvex Python IRSB."""
         arch = archinfo.arch_from_id("AMD64")
         irsb = pyvex.IRSB(self.block_bytes, self.block_addr, arch, opt_level=0)
-        from_py = VEXIRSBConverter.convert(irsb, ailment.Manager(arch=arch))
+        from_py = VEXIRSBConverter.convert(irsb, ailment.Manager())
         from_lift = VEXIRSBConverter.convert_from_lift(
-            arch, self.block_addr, self.block_bytes, ailment.Manager(arch=arch), opt_level=0
+            arch, self.block_addr, self.block_bytes, ailment.Manager(), opt_level=0
         )
         assert from_py == from_lift
         assert from_py.statements  # non-empty
@@ -105,10 +107,8 @@ class TestNonConstRoundingMode(unittest.TestCase):
     def test_tmp_rounding_mode_is_expression(self):
         arch = archinfo.arch_from_id("armel")
         irsb = pyvex.IRSB(self.block_bytes, 0x1000, arch, opt_level=1)
-        from_py = VEXIRSBConverter.convert(irsb, ailment.Manager(arch=arch))
-        from_lift = VEXIRSBConverter.convert_from_lift(
-            arch, 0x1000, self.block_bytes, ailment.Manager(arch=arch), opt_level=1
-        )
+        from_py = VEXIRSBConverter.convert(irsb, ailment.Manager())
+        from_lift = VEXIRSBConverter.convert_from_lift(arch, 0x1000, self.block_bytes, ailment.Manager(), opt_level=1)
         assert from_py == from_lift
 
         conv = next(c for c in (self._find_convert(getattr(s, "src", s)) for s in from_py.statements) if c is not None)
@@ -134,7 +134,7 @@ class TestNonConstRoundingMode(unittest.TestCase):
     def test_const_rounding_mode_still_enum(self):
         arch = archinfo.arch_from_id("i386")
         irsb = pyvex.IRSB(bytes.fromhex("d8c1c3"), 0x1000, arch, opt_level=1)  # fadd st0, st1 ; ret
-        blk = VEXIRSBConverter.convert(irsb, ailment.Manager(arch=arch))
+        blk = VEXIRSBConverter.convert(irsb, ailment.Manager())
         binop = next(
             s.src
             for s in blk.statements
@@ -161,9 +161,9 @@ class TestVectorSignedness(unittest.TestCase):
         ):
             with self.subTest(instruction=name):
                 irsb = pyvex.IRSB(block_bytes, 0x1000, arch, opt_level=0)
-                from_py = VEXIRSBConverter.convert(irsb, ailment.Manager(arch=arch))
+                from_py = VEXIRSBConverter.convert(irsb, ailment.Manager())
                 from_lift = VEXIRSBConverter.convert_from_lift(
-                    arch, 0x1000, block_bytes, ailment.Manager(arch=arch), opt_level=0
+                    arch, 0x1000, block_bytes, ailment.Manager(), opt_level=0
                 )
 
                 assert from_py == from_lift
@@ -214,13 +214,13 @@ class TestVexConverterAcrossArches(unittest.TestCase):
             try:
                 from_py = VEXIRSBConverter.convert(
                     pyvex.IRSB(data, lift_addr, arch, opt_level=1, bytes_offset=bytes_offset),
-                    ailment.Manager(arch=arch),
+                    ailment.Manager(),
                 )
             except Exception:
                 continue
             try:
                 from_lift = VEXIRSBConverter.convert_from_lift(
-                    arch, lift_addr, data, ailment.Manager(arch=arch), opt_level=1, bytes_offset=bytes_offset
+                    arch, lift_addr, data, ailment.Manager(), opt_level=1, bytes_offset=bytes_offset
                 )
             except Exception:
                 # The fast path defers blocks with statements/expressions it can't
@@ -255,17 +255,15 @@ class TestLiftWindowOverread(unittest.TestCase):
 
     def test_lift_does_not_read_past_window(self):
         arch = archinfo.arch_from_id("s390x")
-        from_py = VEXIRSBConverter.convert(
-            pyvex.IRSB(self.window, self.addr, arch, opt_level=1), ailment.Manager(arch=arch)
-        )
+        from_py = VEXIRSBConverter.convert(pyvex.IRSB(self.window, self.addr, arch, opt_level=1), ailment.Manager())
         # 0x04 completes the truncated `lg`: an unguarded overread decodes it
         # and ends the block Ijk_Boring instead of Ijk_NoDecode.
         backing = bytearray(self.window + b"\x04" * 8)
         from_lift_mv = VEXIRSBConverter.convert_from_lift(
-            arch, self.addr, memoryview(backing)[: len(self.window)], ailment.Manager(arch=arch), opt_level=1
+            arch, self.addr, memoryview(backing)[: len(self.window)], ailment.Manager(), opt_level=1
         )
         from_lift_bytes = VEXIRSBConverter.convert_from_lift(
-            arch, self.addr, self.window, ailment.Manager(arch=arch), opt_level=1
+            arch, self.addr, self.window, ailment.Manager(), opt_level=1
         )
         assert from_py == from_lift_mv
         assert from_py == from_lift_bytes

--- a/tests/analyses/decompiler/test_ccall_rewriting.py
+++ b/tests/analyses/decompiler/test_ccall_rewriting.py
@@ -346,7 +346,7 @@ _PROJECT = angr.load_shellcode(b"\x90", arch="AMD64")
 
 
 def _rewrite(ccall):
-    return AMD64CCallRewriter(ccall, _PROJECT, Manager(arch=_PROJECT.arch)).result
+    return AMD64CCallRewriter(ccall, _PROJECT, Manager()).result
 
 
 def _mask(v, bits):

--- a/tests/analyses/decompiler/test_condition_processor.py
+++ b/tests/analyses/decompiler/test_condition_processor.py
@@ -9,7 +9,7 @@ from angr.analyses.decompiler.condition_processor import ConditionProcessor
 
 def test_extract_placeholders_include_semantic_properties():
     arch = archinfo.ArchAMD64()
-    manager = ailment.Manager(arch=arch)
+    manager = ailment.Manager()
     condition_processor = ConditionProcessor(arch, manager)
 
     base = VirtualVariable(0, 1, 64, VirtualVariableCategory.REGISTER, oident=arch.registers["rax"][0])

--- a/tests/analyses/decompiler/test_dephication_rewriting.py
+++ b/tests/analyses/decompiler/test_dephication_rewriting.py
@@ -31,8 +31,8 @@ class TestDephicationRewriting(unittest.TestCase):
         return proj, SimEngineDephiRewriting(proj, mapping)
 
     def test_remapped_dst_survives_non_vvar_src(self):
-        proj, engine = self._engine({2759: 1330})
-        m = Manager(arch=proj.arch)
+        _, engine = self._engine({2759: 1330})
+        m = Manager()
         stmt = Assignment(
             m.next_atom(),
             VirtualVariable(m.next_atom(), 2759, 64, VirtualVariableCategory.REGISTER),
@@ -51,8 +51,8 @@ class TestDephicationRewriting(unittest.TestCase):
         assert out.dst.varid == 1330
 
     def test_remapped_dst_survives_const_src(self):
-        proj, engine = self._engine({7: 3})
-        m = Manager(arch=proj.arch)
+        _, engine = self._engine({7: 3})
+        m = Manager()
         stmt = Assignment(
             m.next_atom(),
             VirtualVariable(m.next_atom(), 7, 64, VirtualVariableCategory.REGISTER),
@@ -67,8 +67,8 @@ class TestDephicationRewriting(unittest.TestCase):
     def test_self_assignment_is_still_dropped(self):
         # the reason the return used to sit behind the both-sides-are-vvars guard: once both sides map onto the same
         # variable the statement is a no-op and has to go away
-        proj, engine = self._engine({11: 3, 12: 3})
-        m = Manager(arch=proj.arch)
+        _, engine = self._engine({11: 3, 12: 3})
+        m = Manager()
         stmt = Assignment(
             m.next_atom(),
             VirtualVariable(m.next_atom(), 11, 64, VirtualVariableCategory.REGISTER),
@@ -79,8 +79,8 @@ class TestDephicationRewriting(unittest.TestCase):
         assert engine._handle_stmt_Assignment(stmt) == ()
 
     def test_unmapped_assignment_is_left_alone(self):
-        proj, engine = self._engine({2759: 1330})
-        m = Manager(arch=proj.arch)
+        _, engine = self._engine({2759: 1330})
+        m = Manager()
         stmt = Assignment(
             m.next_atom(),
             VirtualVariable(m.next_atom(), 99, 64, VirtualVariableCategory.REGISTER),
@@ -94,8 +94,8 @@ class TestDephicationRewriting(unittest.TestCase):
     def test_ite_branches_are_not_swapped(self):
         # ailment's ITE takes (idx, cond, iftrue, iffalse): a rebuild that feeds the branches in
         # the wrong order silently inverts the ternary, e.g. `c ? x : -1` comes out as `c ? -1 : x`
-        proj, engine = self._engine({5: 6})
-        m = Manager(arch=proj.arch)
+        _, engine = self._engine({5: 6})
+        m = Manager()
         cond = VirtualVariable(m.next_atom(), 5, 1, VirtualVariableCategory.REGISTER)
         iffalse = Const(m.next_atom(), 0xFFFFFFFF, 32)
         iftrue = Const(m.next_atom(), 0x11, 32)

--- a/tests/analyses/decompiler/test_dowhile_latch_continue.py
+++ b/tests/analyses/decompiler/test_dowhile_latch_continue.py
@@ -23,13 +23,13 @@ test_location = os.path.join(bin_location, "tests")
 LATCH_ADDR = 0x200
 
 
-def _loop_body_with(stmt, arch=None):
+def _loop_body_with(stmt):
     """A do-while whose latch at LATCH_ADDR was folded into its condition, with stmt somewhere in its body.
 
     The statement is kept off the body's tail on purpose: a continue at the very end of a do-while body is redundant
     and gets dropped again, which would hide what we are testing.
     """
-    m = Manager(arch=arch)
+    m = Manager()
     block = Block(0x110, 1, statements=[stmt])
     inner = SequenceNode(0x110, nodes=[block])
     loop_seq = SequenceNode(0x100, nodes=[inner, Block(0x180, 1, statements=[])])
@@ -84,7 +84,7 @@ class TestDoWhileLatchContinue(unittest.TestCase):
         jumps to it have to become continues. Anything left behind is emitted as a goto to a label that no longer
         exists anywhere in the function.
         """
-        m = Manager(arch=None)
+        m = Manager()
         jump = Jump(m.next_atom(), Const(m.next_atom(), LATCH_ADDR, 64), ins_addr=0x110)
         block, inner, loop_seq, loop_node = _loop_body_with(jump)
 
@@ -104,7 +104,7 @@ class TestDoWhileLatchContinue(unittest.TestCase):
         into a condition guarding the other target plus a continue.
         """
         arch = archinfo.arch_from_id("amd64")
-        m = Manager(arch=arch)
+        m = Manager()
         condition = BinaryOp(
             m.next_atom(), "CmpEQ", [Register(m.next_atom(), 16, 64), Const(m.next_atom(), 0, 64)], False
         )
@@ -115,7 +115,7 @@ class TestDoWhileLatchContinue(unittest.TestCase):
             Const(m.next_atom(), 0x300, 64),
             ins_addr=0x110,
         )
-        block, inner, loop_seq, loop_node = _loop_body_with(condjump, arch=arch)
+        block, inner, loop_seq, loop_node = _loop_body_with(condjump)
 
         structurer = object.__new__(PhoenixStructurer)
         structurer.cond_proc = ConditionProcessor(arch, m)

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -333,7 +333,7 @@ class TestPeepholeOptimizations(unittest.TestCase):
         # gcc's `x / k` / `x % k` magic-multiply quotients; the rewritten 64-bit Div must keep the 32-bit width
         for magic, shift, divisor in [(0xCCCCCCCD, 34, 5), (0xAAAAAAAB, 33, 3), (0xD1B71759, 45, 10000)]:
             with self.subTest(divisor=divisor):
-                mgr = Manager(arch=archinfo.arch_from_id("AMD64"))
+                mgr = Manager()
                 x = Register(mgr.next_atom(), 16, 64)
                 mul = BinaryOp(mgr.next_atom(), "Mul", [Const(mgr.next_atom(), magic, 64), x], False)
                 shr = BinaryOp(mgr.next_atom(), "Shr", [mul, Const(mgr.next_atom(), shift, 8)], False)
@@ -348,7 +348,7 @@ class TestPeepholeOptimizations(unittest.TestCase):
         # (x << N) Sar N is a sign-extension of the low (bits - N) bits and must NOT be turned into a
         # zero-extending bitmask. Regression test for the simplifier dropping the sign bit, decompiling
         # `(int)(x << 20) >> 20` (sign-extend the low 12 bits) into the wrong `x & 0xfff` (zero-extend).
-        mgr = Manager(arch=archinfo.arch_from_id("AMD64"))
+        mgr = Manager()
 
         # Arithmetic shift, standard resulting width (32 - 16 = 16): sign-extend via a *signed* outer Convert.
         x = Register(mgr.next_atom(), 16, 32)

--- a/tests/analyses/decompiler/test_phoenix_last_resort_isolation.py
+++ b/tests/analyses/decompiler/test_phoenix_last_resort_isolation.py
@@ -71,7 +71,7 @@ class TestPhoenixLastResortIsolation(unittest.TestCase):
         return progressed, chosen
 
     def test_edge_that_would_orphan_its_destination_is_not_picked(self):
-        m = Manager(arch=None)
+        m = Manager()
         head = self._block(m, 0x100)
         # x -> y hangs off the region unreachable from head, and it is y's only way in
         x, y = self._block(m, 0x200), self._block(m, 0x300)
@@ -86,7 +86,7 @@ class TestPhoenixLastResortIsolation(unittest.TestCase):
         assert not chosen
 
     def test_a_safe_edge_is_still_picked(self):
-        m = Manager(arch=None)
+        m = Manager()
         head = self._block(m, 0x100)
         a, b = self._block(m, 0x200), self._block(m, 0x300)
         # b keeps a second way in, so cutting a -> b orphans nothing
@@ -101,7 +101,7 @@ class TestPhoenixLastResortIsolation(unittest.TestCase):
         assert chosen == [(a, b)]
 
     def test_orphaning_edge_is_skipped_in_favour_of_a_safe_one(self):
-        m = Manager(arch=None)
+        m = Manager()
         head = self._block(m, 0x100)
         a, b = self._block(m, 0x200), self._block(m, 0x300)
         x, y = self._block(m, 0x400), self._block(m, 0x500)

--- a/tests/analyses/decompiler/test_propagator_loops.py
+++ b/tests/analyses/decompiler/test_propagator_loops.py
@@ -25,7 +25,7 @@ class TestPropagatorLoops(unittest.TestCase):
         f = p.kb.functions[0]
         banner("Raw AIL Nodes")
         nodes = sorted(f.nodes, key=lambda n: n.addr)
-        am = ailment.Manager(arch=p.arch)
+        am = ailment.Manager()
         for n in nodes:
             b = p.factory.block(n.addr, n.size)
             ab = ailment.IRSBConverter.convert(b.vex, am)

--- a/tests/analyses/decompiler/test_rust_cfg_transformation.py
+++ b/tests/analyses/decompiler/test_rust_cfg_transformation.py
@@ -48,7 +48,7 @@ class TestRustCFGTransformation(unittest.TestCase):
 
     @staticmethod
     def _graph_with_condjump():
-        m = Manager(arch=None)
+        m = Manager()
         cond = BinaryOp(m.next_atom(), "CmpEQ", [Register(m.next_atom(), 16, 64), Const(m.next_atom(), 0, 64)], False)
         head = Block(
             0x100,

--- a/tests/analyses/decompiler/test_rust_codegen_handlers.py
+++ b/tests/analyses/decompiler/test_rust_codegen_handlers.py
@@ -56,7 +56,7 @@ class TestRustCodegenHandlers(unittest.TestCase):
         cls.codegen = dec.codegen
 
     def _manager(self):
-        return Manager(arch=self.proj.arch)
+        return Manager()
 
     @staticmethod
     def _vvar(m, varid, bits=64, category=VirtualVariableCategory.REGISTER):

--- a/tests/analyses/decompiler/test_switch_cluster_simplifier.py
+++ b/tests/analyses/decompiler/test_switch_cluster_simplifier.py
@@ -36,7 +36,7 @@ class TestSwitchClusterSimplifier(unittest.TestCase):
         sharing an address -- what SwitchDefaultCaseDuplicator plus structuring produce. The merged switch-case can
         only carry one default node, so merging here would drop the blocks under the other copy.
         """
-        m = Manager(arch=None)
+        m = Manager()
 
         def block(addr, target):
             return Block(addr, 1, statements=[Jump(m.next_atom(), Const(m.next_atom(), target, 64))])

--- a/tests/analyses/test_callsite_maker.py
+++ b/tests/analyses/test_callsite_maker.py
@@ -24,7 +24,7 @@ class TestCallsiteMaker(unittest.TestCase):
             auto_load_libs=False,
         )
 
-        manager = ailment.Manager(arch=project.arch)
+        manager = ailment.Manager()
 
         # Generate a CFG
         cfg = project.analyses.CFG()


### PR DESCRIPTION
Manager carried an optional `arch` that only two consumers ever read, and both of them already hold the IRSB they are converting. `name` goes too: nothing ever read it and nothing ever passed it.
