### PR TITLE
RuntimeDb: claim the rtdb directory atomically instead of testing that it is free

### DIFF
--- a/angr/knowledge_plugins/rtdb/rtdb.py
+++ b/angr/knowledge_plugins/rtdb/rtdb.py
@@ -207,13 +207,10 @@ class RuntimeDb(KnowledgeBasePlugin):
                 l.error("The directory %s is not writable. Falling back.", basedir)
                 basedir = None
             else:
-                db_filename = self._get_unique_db_filename(basedir, basename)
-                lmdb_path = os.path.join(basedir, db_filename)
-                lmdb_env = self._attempt_creating_lmdb(lmdb_path)
-                if lmdb_env is not None:
-                    return lmdb_path, lmdb_env
+                r = self._open_new_lmdb_under(basedir, basename)
+                if r is not None:
+                    return r
                 basedir = None
-                db_filename = None
 
         if basedir is None and isinstance(main_binary_path, str):
             # get the base directory of the project binary
@@ -223,26 +220,37 @@ class RuntimeDb(KnowledgeBasePlugin):
                 l.error("The directory %s is not writable. Falling back to temporary directory.", basedir)
                 basedir = None
             else:
-                db_filename = self._get_unique_db_filename(basedir, basename)
-                lmdb_path = os.path.join(basedir, db_filename)
-                lmdb_env = self._attempt_creating_lmdb(lmdb_path)
-                if lmdb_env is not None:
-                    return lmdb_path, lmdb_env
+                r = self._open_new_lmdb_under(basedir, basename)
+                if r is not None:
+                    return r
                 basedir = None
-                db_filename = None
 
         if basedir is None:
             basedir = tempfile.gettempdir()
             if not os.access(basedir, os.W_OK):
                 raise OSError("No writable directory found for RTDB storage.")
-            db_filename = self._get_unique_db_filename(basedir, basename)
-            lmdb_path = os.path.join(basedir, db_filename)
-            lmdb_env = self._attempt_creating_lmdb(lmdb_path)
-            if lmdb_env is not None:
-                return lmdb_path, lmdb_env
+            r = self._open_new_lmdb_under(basedir, basename)
+            if r is not None:
+                return r
             raise OSError("No writable directory found for RTDB storage.")
 
         return None
+
+    def _open_new_lmdb_under(self, basedir: str, basename: str) -> tuple[str, lmdb.Environment] | None:
+        """
+        Reserve a directory under basedir and open an LMDB environment in it, giving the directory back if the
+        environment cannot be opened.
+        """
+        lmdb_path = self._reserve_unique_db_dir(basedir, basename)
+        lmdb_env = None
+        try:
+            lmdb_env = self._attempt_creating_lmdb(lmdb_path)
+        finally:
+            if lmdb_env is None:
+                # rmdir refuses a directory that holds anything, so a database is never removed here
+                with contextlib.suppress(OSError):
+                    os.rmdir(lmdb_path)
+        return None if lmdb_env is None else (lmdb_path, lmdb_env)
 
     def _attempt_creating_lmdb(self, lmdb_path: str):
         """
@@ -262,15 +270,21 @@ class RuntimeDb(KnowledgeBasePlugin):
             return None
 
     @staticmethod
-    def _get_unique_db_filename(basedir: str, basename: str) -> str:
-        # find a unique rtdb name
+    def _reserve_unique_db_dir(basedir: str, basename: str) -> str:
+        """
+        Create a directory under basedir for this database and return its path. Creating it is what reserves it.
+        """
         db_filename = basename + "_angr_rtdb"
         while True:
             db_path = os.path.join(basedir, db_filename)
-            if not os.path.exists(db_path):
-                break
-            db_filename = basename + f"_angr_rtdb_{uuid.uuid4().hex}"
-        return db_filename
+            try:
+                os.mkdir(db_path, 0o755)
+                return db_path
+            except FileExistsError:
+                db_filename = basename + f"_angr_rtdb_{uuid.uuid4().hex}"
+            except OSError:
+                # basedir is unusable; the caller's lmdb.open() reports that and falls back
+                return db_path
 
     def _pin_lmdb_dir(self) -> None:
         """

--- a/tests/knowledge_plugins/rtdb/test_rtdb_basedir.py
+++ b/tests/knowledge_plugins/rtdb/test_rtdb_basedir.py
@@ -10,6 +10,8 @@ import tempfile
 import unittest
 from unittest import mock
 
+import lmdb
+
 import angr
 from tests.common import bin_location
 
@@ -68,6 +70,26 @@ class TestRuntimeDbBaseDir(unittest.TestCase):
                     )
                 finally:
                     proj.kb.rtdb.cleanup()
+
+    def test_a_directory_is_only_handed_out_once(self):
+        reserve = angr.knowledge_plugins.rtdb.rtdb.RuntimeDb._reserve_unique_db_dir  # pylint:disable=protected-access
+        with tempfile.TemporaryDirectory() as basedir:
+            paths = [reserve(basedir, "fauxware") for _ in range(3)]
+            assert len(set(paths)) == 3, f"the same directory was handed out more than once: {paths}"
+            assert sorted(os.listdir(basedir)) == sorted(os.path.basename(p) for p in paths)
+
+    def test_a_reserved_directory_is_given_back_when_the_database_cannot_be_opened(self):
+        binary = os.path.join(test_location, "x86_64", "fauxware")
+        with tempfile.TemporaryDirectory() as basedir:
+            proj = angr.Project(binary, auto_load_libs=False)
+            rtdb = proj.kb.rtdb
+            with mock.patch("lmdb.open", side_effect=lmdb.Error("no")):
+                assert rtdb._open_new_lmdb_under(basedir, "fauxware") is None  # pylint:disable=protected-access
+            assert os.listdir(basedir) == []
+            # an exception _attempt_creating_lmdb does not catch leaves by the other path
+            with mock.patch("lmdb.open", side_effect=KeyboardInterrupt), self.assertRaises(KeyboardInterrupt):
+                rtdb._open_new_lmdb_under(basedir, "fauxware")  # pylint:disable=protected-access
+            assert os.listdir(basedir) == []
 
     def test_rtdb_defaults_to_the_directory_of_the_main_binary(self):
         with tempfile.TemporaryDirectory() as bindir, mock.patch.dict(os.environ):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Two angr processes analysing a binary of the same name at the same time can be
handed the same run-time database directory, and each then reads the other's
spilled CFG back as its own.

Ten processes, each running `CFGFast(normalize=True)` over
`binaries/tests/x86_64/decompiler/lighttpd`, two at a time in one directory:
nine of the ten raised. The last frames of one:

```
  ...
  File "angr/blade.py", line 415, in _backward_slice_recursive
    in_edges = self._graph.in_edges(next_node, data=True)
  File "angr/knowledge_plugins/cfg/spilling_cfg.py", line 584, in __call__
    (self._graph.get_node_by_key(src_id), self._graph.get_node_by_key(dst_id), edge_data)
  File "angr/knowledge_plugins/cfg/spilling_cfg.py", line 840, in get_node_by_key
    raise KeyError(block_key)
KeyError: (4345193, 12)
```

Five of the nine ended there and four in the spilling adjacency dict's
`__delitem__` under `remove_node`. Ten more processes with the naming untouched
all completed and agreed on 16713 nodes, 2954 functions and 25382 edges.

`pytest -n 5 tests/analyses/decompiler`, no `--forked`, with one `RTDB_BASE`
shared by the workers, failed 2 of 6 separate invocations; the same suite with a
per-worker base passed 4 of 4. Only 56 of that suite's 745 tests create a
run-time database at all, and all four tests that failed are among them.

With `RTDB_BASE` unset the shared directory is the one holding the binary, so
this reaches anyone running two analyses of one file at once, not only a test
run.

### Root cause

`RuntimeDb._get_unique_db_filename` decides `<binary>_angr_rtdb` is free with
`os.path.exists()` and returns the name. It creates nothing: the directory
appears later, when `_attempt_creating_lmdb` calls `lmdb.open()`. Both processes
then open one environment.

`RuntimeDb.open_db` names sub-databases from a per-instance counter, and two
unrelated processes each start that counter at zero, so both write `cfgnodes`,
`edges`, `dvars`, `functions` and `decompilations` into one environment. The
graph structure spills as well -- `spilling_digraph.py` opens `edges` -- which is
why the symptom above is a node lookup for a key the process never inserted.
`SpillingCFGNodeDict._cleanup_lmdb` and its siblings also `drop_db` three of
those names on teardown, which by inspection discards the other process's data;
the failures shown come from the read path, not from that.

This is not the sharing `_pin_lmdb_dir` is designed for. That coordinates a
directory shared *across `fork`*, where the child inherits the counter and so
does not collide with its parent. Two unrelated processes handed one name do.

### Fix

`os.mkdir` is atomic on POSIX and on Windows, so exactly one process can create
a given directory; the loser gets `FileExistsError` and falls through to the
uuid name the function already produced. Names, order and the resulting
directory are otherwise unchanged, so a run that never races behaves as before.
The function is renamed `_reserve_unique_db_dir` and returns the path, because
it now creates what it names.

`_init_lmdb_attempt_multiple_locations` repeated claim, open and fall-back three
times. `_open_new_lmdb_under` now does it once and gives the reservation back
with `os.rmdir` when the open does not produce an environment, on both the
returns-`None` path and the raises-through path. `rmdir` refuses a directory
that holds anything, so an open that fails after creating `data.mdb` leaves
exactly what master left. The give-back belongs there rather than in
`_attempt_creating_lmdb`, which is also called with a caller-supplied
`lmdb_path` this process never claimed.

Two things this costs. A process that dies without unwinding between the
`mkdir` and the `lmdb.open` leaves an empty directory holding the plain name,
where before that window left nothing. And always appending a uuid would be
race-free too and shorter, but it gives up the plain `<binary>_angr_rtdb` name
for everybody.

### Testing

`test_a_directory_is_only_handed_out_once` asks for the same base directory and
basename three times and requires three different answers with three
directories on disk. On master all three answers are `fauxware_angr_rtdb` and
nothing is created.
`test_a_reserved_directory_is_given_back_when_the_database_cannot_be_opened`
makes `lmdb.open` fail both ways and requires the base directory to be empty
afterwards.

Eight processes claiming directories in one `RTDB_BASE`, three repeats against
each revision with each arm running its own tree: on master 365 of 36,415 claims
found the directory already present at the moment of the open, and 323 pins
landed in a directory another process was holding, 56 of them named by
`/proc/locks`. On this branch, 0 of 36,000 pins landed in another process's
directory.

Eight runs of `tests/analyses/decompiler` on master's naming produced no
failure here; in four more the naming already created the directory, so a
collision was impossible.

Validation: https://github.com/angr/angr/pull/7053#issuecomment-5484852882

session: sharpen
