### PR TITLE
CFG: Do not scan an object the project's lifter cannot decode

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -64,6 +64,25 @@ if TYPE_CHECKING:
 l = logging.getLogger(name=__name__)
 
 
+def lifts_the_same_way(one: archinfo.Arch, other: archinfo.Arch) -> bool:
+    """
+    Whether blocks of one architecture can be lifted as the other.
+
+    archinfo compares architectures by name, which separates ARMEL from ARMHF; those differ in their float ABI
+    and in no instruction encoding. The lifter goes by the VEX guest, the width and the byte order instead. An
+    architecture VEX cannot lift has no guest to compare, so only equality counts for it.
+
+    It says yes to ARMCortexM in an ARM project deliberately. Thumb is a property of the address's low bit
+    rather than of the architecture, so those bytes decode; recovery is worse than a native Cortex-M project's,
+    whose function prologues differ, but the choice here is between that and not scanning the object at all.
+    """
+    if one == other:
+        return True
+    if one.vex_arch is None or other.vex_arch is None:
+        return False
+    return one.vex_arch == other.vex_arch and one.bits == other.bits and one.memory_endness == other.memory_endness
+
+
 class CFGBase(Analysis):
     """
     The base class for control flow graphs.
@@ -259,8 +278,13 @@ class CFGBase(Analysis):
         if regions is None:
             regions = self._exec_mem_regions
             if not self._skip_unmapped_addrs and not regions:
-                # fall back to using min and max addresses of all objects
-                regions = [(obj.min_addr, obj.max_addr) for obj in objects]
+                # Fall back to the min and max addresses of the objects, skipping the ones this analysis
+                # cannot decode. An object with no memory has no instruction set to disagree about.
+                regions = [
+                    (obj.min_addr, obj.max_addr)
+                    for obj in objects
+                    if not obj.has_memory or lifts_the_same_way(obj.arch, self.project.arch)
+                ]
 
         for start, end in regions:
             if end < start:
@@ -790,9 +814,25 @@ class CFGBase(Analysis):
 
         memory_regions = []
         has_executable = False
+        skipped_foreign_arch = False
 
         for b in binaries:
             if not b.has_memory:
+                continue
+
+            if isinstance(b, self._cle_pseudo_objects):
+                continue
+
+            if not lifts_the_same_way(b.arch, self.project.arch):
+                # Every block is lifted with the project's architecture, so an object holding a different
+                # instruction set - another slice of a fat Mach-O, say - cannot be decoded here.
+                l.warning(
+                    "Not scanning %r: it is %s, and this analysis decodes every block as %s.",
+                    b,
+                    b.arch.name,
+                    self.project.arch.name,
+                )
+                skipped_foreign_arch = True
                 continue
 
             if isinstance(b, ELF):
@@ -880,9 +920,6 @@ class CFGBase(Analysis):
                 # no code here
                 pass
 
-            elif isinstance(b, self._cle_pseudo_objects):
-                pass
-
             elif hasattr(b, "sections") and b.sections:
                 sections = []
                 # Get all executable sections
@@ -908,7 +945,9 @@ class CFGBase(Analysis):
                 tpl = (b.min_addr, b.max_addr + 1)
                 memory_regions.append(tpl)
 
-        if not memory_regions and not has_executable:
+        if not memory_regions and not has_executable and not skipped_foreign_arch:
+            # Scanning raw memory is the last resort for an object that never said where its code is. An object
+            # skipped just above did say, and was declined because this analysis cannot decode it.
             memory_regions = [(start, start + len(backer)) for start, backer in self.project.loader.memory.backers()]
 
         # A section or segment that maps no bytes, such as the empty .text of a data-only relocatable, is not a region.

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -968,6 +968,50 @@ class TestCfgfast(unittest.TestCase):
         assert "_accepted" in func_names
         assert "_authenticate" in func_names
 
+    def test_universal_binary_unspecified_arch(self):
+        # Without arch=, cle loads every slice of the fat binary and the project takes the architecture of the
+        # first one. CFGFast decodes every block with that one architecture, so the other slice must not be
+        # scanned at all.
+        path = os.path.join(test_location, "multi_arch", "fauxware_macho_multiarch")
+        proj = angr.Project(path, auto_load_libs=False)
+
+        assert proj.arch.name == "AMD64"
+        slices = [obj for obj in proj.loader.main_object.child_objects if obj.arch.name == "AARCH64"]
+        assert len(slices) == 1
+        arm64 = slices[0]
+
+        def reaches_arm64(start, end):
+            # any overlap at all, so a region starting below the slice and running into it is caught too
+            return start <= arm64.max_addr and arm64.min_addr < end
+
+        cfg = proj.analyses.CFGFast()
+
+        assert [region for region in cfg.regions if reaches_arm64(*region)] == []
+        assert [
+            node
+            for node in cfg.model.nodes()
+            if not node.is_simprocedure and reaches_arm64(node.addr, node.addr + (node.size or 1))
+        ] == []
+
+        # The slice angr can decode is still recovered in full.
+        func_names = {func.name for func in cfg.kb.functions.values()}
+        assert "_main" in func_names
+        assert "_accepted" in func_names
+        assert "_authenticate" in func_names
+
+        def fresh_arm64_slice():
+            # CFGFast clears the knowledge base the assertions above read, so each case gets its own project.
+            other = angr.Project(path, auto_load_libs=False)
+            return other, next(o for o in other.loader.main_object.child_objects if o.arch.name == "AARCH64")
+
+        # Naming the slice as the thing to analyze does not get it scanned.
+        named, named_slice = fresh_arm64_slice()
+        assert named.analyses.CFGFast(objects=[named_slice]).regions == []
+
+        # Neither does the whole-object fallback that skip_unmapped_addrs=False opens up.
+        spanned, spanned_slice = fresh_arm64_slice()
+        assert spanned.analyses.CFGFast(objects=[spanned_slice], skip_unmapped_addrs=False).regions == []
+
     def test_syscalls_resolved_with_constant_propagation(self):
         for arch in ["x86", "x86_64"]:
             with self.subTest(arch=arch):

--- a/tests/analyses/cfg/test_cfgfast_soot.py
+++ b/tests/analyses/cfg/test_cfgfast_soot.py
@@ -34,6 +34,21 @@ class TestCfgfastSoot(unittest.TestCase):
         cfg = p.analyses.CFGFastSoot()
         assert cfg.graph.nodes()
 
+    def test_jni_library_of_another_architecture_is_not_scanned(self):
+        # A JNI project's architecture is Soot and its native library's is not, so CFGFast cannot decode that
+        # library and does not scan it. Skipping it must not drop the region collector into its raw-memory last
+        # resort, which has nothing left to describe the program and would hand back the extern and kernel
+        # objects instead.
+        binary_path = os.path.join(test_location, "java", "fauxware_java_jni", "fauxware.jar")
+        p = angr.Project(binary_path, main_opts={"jni_libs": ["libfauxware.so"]}, auto_load_libs=True)
+
+        assert p.arch.name == "Soot"
+        assert [obj for obj in p.loader.all_objects if obj.has_memory and obj.arch != p.arch] != []
+
+        cfg = p.analyses.CFGFast()
+
+        assert cfg.regions == []
+
     def test_simple2_without_entry_point(self):
         # simple2.jar has no Main-Class manifest attribute, so without an explicit entry_point the loader leaves
         # Project.entry at 0. CFGFastSoot must still analyze every method of every class.


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Project("binaries/tests/multi_arch/fauxware_macho_multiarch")` with no `arch=` recovers 27 functions and 73 blocks. Seven functions and 34 blocks of that are the arm64 slice decoded as x86-64, six of them starting at addresses that are not 4-byte aligned -- not arm64 instruction boundaries. Nothing complains: those bytes decode cleanly as x86-64, so no `Ijk_NoDecode` block appears.

### Root cause

CFGFast lifts every block with `project.arch`, and `_executable_memory_regions` collected regions from every loaded object with no architecture filter. cle loads each slice as its own object and the project takes the first one's, so the other gets the wrong instruction set. A Java project with a JNI library is the other case: `project.arch` is Soot, the library's is not. Only the region map moves there; that graph is empty either way.

### Fix

Skip an object this analysis cannot decode, and warn. The guard covers the regions the analysis derives, not a region list a caller passes. The test is what the lifter decodes, not `Arch.__eq__`, which goes by name and splits ARMEL from ARMHF -- same encodings, different float ABI -- and would cut `armel/fauxware` loaded against `armhf/libc.so.6` from 5,354 functions, 1,639 correctly named, to 40 with none. `lifts_the_same_way` compares the VEX guest, width and byte order instead. CFGFast falls back to scanning raw addresses in two places when no object said where its code is. A skipped object did say, so both now leave it out. It stays loaded, so `describe_addr` and its symbols still work.

### Testing

That load now gives 19 functions and 39 blocks, matching `Project(path, arch=amd64)` exactly. New tests cover both and fail on master. Of the 1,066 files tracked in `angr/binaries/tests`, 961 load, and only the fat Mach-O holds an object this skips.

Validation: https://github.com/angr/angr/pull/7057#issuecomment-5488864854

session: sharpen
