### PR TITLE
packaging: ship the angr.rustylib type stubs in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,9 @@ extras = ["angr[angrdb,keystone,unicorn,llm]", "pysoot"]
 include-package-data = true
 
 [tool.setuptools.packages.find]
+include = ["angr*"]
 exclude = ["tests*"]
-namespaces = false
+namespaces = true
 
 [tool.setuptools.package-data]
 angr = ["py.typed", "unicornlib.*", "rustylib.*"]


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

angr declares itself typed -- `angr/py.typed` is in the tree and in every wheel
-- but an installed angr has no type information for `angr.rustylib`, which is
where `angr.ailment`'s classes come from. `site-packages/angr/` holds
`rustylib.abi3.so` and no `rustylib/` directory at all, so
`angr/rustylib/__init__.pyi`, `angr/rustylib/ailment.pyi`,
`angr/rustylib/automaton.pyi`, `angr/rustylib/fuzzer.pyi` and
`angr/rustylib/icicle.pyi` never reach the user. Two independently built angr
wheels here agree: their `RECORD` lists nine `angr/protos/*_pb2.pyi` and zero
`angr/rustylib/` entries.

Every name in that module is then unknown to a type checker, and `isinstance()`
narrowing on those classes stops working. Over the 85 test files in
`tests/ailment` and `tests/analyses/decompiler`, checked against an installed
angr wheel, pyright reports 939 errors; with `angr/rustylib/` present, 794.
`tests/analyses/decompiler/test_ccall_rewriter_arm.py` accounts for 71 of them
and goes to 0:

```
tests/analyses/decompiler/test_ccall_rewriter_arm.py:95:23 - error: "value_int" is not a known attribute of "None" (reportOptionalMemberAccess)
```

A source checkout has the stub directory sitting next to the extension, so this
is invisible while working on angr and shows up only against an installed
wheel.

### Root cause

`[tool.setuptools.package-data]` names `rustylib.*`, which globs the files in
`angr/`. It matches the compiled `angr/rustylib.abi3.so` and not the
`angr/rustylib/` directory beside it. setuptools also ships `*.pyi` unasked --
`_IMPLICIT_DATA_FILES = ('*.pyi', 'py.typed')` in
`setuptools/command/build_py.py`, applied once per package -- which is why the
generated `angr/protos/*_pb2.pyi` are in the wheel with no pattern naming them.
`angr/rustylib/` is not a package, so it gets neither. It also must not become
one the obvious way: an `__init__.py` there makes `importlib` resolve
`angr.rustylib` to the directory instead of the extension module.

### Fix

Let package discovery see the directory. `namespaces = true` makes
`angr.rustylib` a discovered package without an `__init__.py`, so its stubs
ship by the same implicit route as the protobuf ones, and `include = ["angr*"]`
keeps the widened discovery from also picking up `docs/` and the `native/`
sources that `MANIFEST.in` grafts -- without it the stand-in below ships
`native/thing/main.c` at the top level of the wheel. Measured through
setuptools' own config reader on this pyproject, the package list goes from 117
to 118 and the only addition is `angr.rustylib`.

The one-line alternative, adding `"rustylib/*.pyi"` to `package-data`, produces
a byte-identical wheel but makes every build print

```
setuptools/command/build_py.py:215: _Warning: Package 'angr.rustylib' is absent from the `packages` configuration.
############################
# Package would be ignored #
############################
```

because the stubs then arrive through the manifest one directory below a
package that discovery does not know about. Routing them through `MANIFEST.in`
instead warns identically, for the same reason. That warning is only cosmetic
-- the stubs ship either way -- but it says the opposite of what happens, in
every angr build, so this takes the shape that does not produce it.

### Testing

angr's extension could not be rebuilt where this was written, so the packaging
was checked on a throwaway setuptools project with angr's layout -- a package
holding `py.typed`, a placeholder `rustylib.abi3.so`, a non-package `rustylib/`
of five `.pyi`, a `protos/` package with a generated `_pb2.pyi`, and angr's
`MANIFEST.in`, `package-data` and `packages.find` blocks -- built with
setuptools 84.0.0 through `build_meta`. Before, the wheel has
`rustylib.abi3.so` and no `rustylib/`, matching the real wheels above; after,
wheel and sdist carry all five stubs and still carry `rustylib.abi3.so` and
`unicornlib.so`, with no warning. Unpacking that wheel,
`importlib.util.find_spec` for the stub module returns the `.so` through
`ExtensionFileLoader` with `submodule_search_locations` `None`; the same holds
for an editable install built from the same tree.

The pyright counts above move in both directions: shipping the stubs removes
172 errors across five files and adds 27 across seven, net 145. The added ones
are code the checker previously could not see at all -- a `float` where a stub
says `int`, an attribute read off a base `Expression`, a test double passed
where an `AILObject` is declared -- not a regression this introduces. No angr
workflow runs pyright, so nothing turns red either way.

`unicornlib` needs no equivalent: it is a `ctypes.CDLL` opened by path in
`angr/state_plugins/unicorn_engine.py`, not an importable module, and it has no
stubs.

Validation: https://github.com/angr/angr/pull/7059#issuecomment-5504379868

session: sharpen