### PR TITLE
Pcode: Give a call's return register a fresh atom index

### DIFF
--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -562,8 +562,10 @@ class PCodeIRSBConverter(Converter):
         ret_expr = (
             None
             if ret_reg_offset is None
-            else Register(None, ret_reg_offset, self._irsb.arch.bits, ins_addr=self._manager.ins_addr)
-        )  # ???
+            else Register(
+                self._manager.next_atom(), ret_reg_offset, self._irsb.arch.bits, ins_addr=self._manager.ins_addr
+            )
+        )
         if self._irsb.next is not None:
             dest = Const(self._manager.next_atom(), self._irsb.next.con.value, self._irsb.arch.bits)
         else:
@@ -590,7 +592,9 @@ class PCodeIRSBConverter(Converter):
         Convert a p-code indirect call operation
         """
         ret_reg_offset = self._irsb.arch.ret_offset
-        ret_expr = Register(None, ret_reg_offset, self._irsb.arch.bits, ins_addr=self._manager.ins_addr)  # ???
+        ret_expr = Register(
+            self._manager.next_atom(), ret_reg_offset, self._irsb.arch.bits, ins_addr=self._manager.ins_addr
+        )
         dest = self._get_value(self._current_op.inputs[0])
         call_expr = Call(
             self._manager.next_atom(),

--- a/tests/analyses/decompiler/test_pcode_call_returns.py
+++ b/tests/analyses/decompiler/test_pcode_call_returns.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os.path
+import unittest
+
+from tests.common import bin_location, load_project_with_scoped_cfg, print_decompilation_result
+
+test_location = os.path.join(bin_location, "tests")
+
+
+# pylint: disable=missing-class-docstring, no-self-use
+class TestPcodeCallReturns(unittest.TestCase):
+    def test_two_calls_in_one_function_decompile(self):
+        bin_path = os.path.join(test_location, "m68k", "mul_add_sub_xor_m68k_be")
+        proj, cfg = load_project_with_scoped_cfg(bin_path, 0x80000138)
+
+        dec = proj.analyses.Decompiler(cfg.functions[0x80000138], cfg=cfg.model)
+        assert [str(error.exc_value) for error in dec.errors] == []
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+        assert "frame_dummy(" in dec.codegen.text
+        assert "__do_global_ctors_aux(" in dec.codegen.text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

On a p-code-lifted binary, a function with more than one call site can lose its
entire decompilation. `tests/m68k/mul_add_sub_xor_m68k_be` in `angr/binaries`
shows it at `_init`, `0x80000138`: the `Decompiler` returns no codegen at all and
records the same failure once per decompilation attempt. The tail of each, with
the complete pair in the output comment below:

```
File "angr/analyses/decompiler/ssailification/traversal_engine.py", line 219, in perform_def
    loc.is_extern
AssertionError: claiming an expression defines at two different locs
```

Nothing partial survives -- there is no output for the function, not a degraded
one. On that binary 600 of its 1,446 functions produce no code, and every one of
the 600 records this assertion and no other error.

### Root cause

`PCodeIRSBConverter` builds the `Register` that a call's `SideEffectStatement`
carries as its `ret_expr` with `idx=None`, at both `_convert_call` and
`_convert_callind`, each marked `# ???`. The AIL expression metaclass normalizes
a leading `None` to `0`, so every call site in a function gets index 0. AIL
`Register` equality and hashing are over the kind, the `idx`, the `reg_offset`
and the width; tags such as `ins_addr` take no part. Two calls in one function
therefore yield two `ret_expr` objects that compare equal and hash alike.

`Ssailification` keys on that expression. Its traversal engine's
`_handle_stmt_SideEffectStatement` hands `stmt.ret_expr` to `register_set`,
which passes it to `perform_def` as the definition, and `perform_def` looks it
up in `def_info`. The second call site finds the first site's entry, recorded at
a different code location, and asserts. That aborts the SSA transform, and with
it the whole function.

### Fix

Both sites take `self._manager.next_atom()`, which is what every other
expression `converter_pcode.py` builds already does. This layer owns the
invariant because `idx` is the only thing that distinguishes two otherwise
identical AIL expressions under `__eq__` and `__hash__`. The VEX path
already does exactly this -- `emit_call_tail` in
`native/angr/src/ailment/convert_vex.rs` mints a fresh atom for the same
`ret_expr` and `fp_ret_expr` -- which is why the failure is visible only on
p-code targets.

Relaxing the `def_info` keying in `Ssailification` instead was rejected: the
idx-aware equality is deliberate and documented in the Rust expression code, and
the VEX converter already satisfies it on every other target.

### Testing

`tests/analyses/decompiler/test_pcode_call_returns.py` decompiles `_init` at
`0x80000138` in the already-tracked `tests/m68k/mul_add_sub_xor_m68k_be` and
asserts that the `Decompiler` records no errors and that both callees appear in
the text. It fails on the base revision with the assertion above and passes
here. The fixture is already in `angr/binaries` master, so this change needs no
sibling pull request.

Running the head over just the functions the base revision also decompiles, on
the same whole-binary CFG, leaves every one of them byte-identical -- 846 such
functions on the m68k binary and 2,649 on `tests/sh4/test-instr_sh4`, none
differing in either. Suite results, the fixture counts, the corpus figures and
the added cost are in the validation record.

Validation: https://github.com/angr/angr/pull/7064#issuecomment-5522774485

session: sharpen
