### PR TITLE
RDA: Take the PowerPC64 TOC from the loader instead of raising

### DIFF
--- a/angr/analyses/reaching_definitions/rd_initializer.py
+++ b/angr/analyses/reaching_definitions/rd_initializer.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from archinfo import Arch
+from cle import MetaELF
 
 from angr import claripy
 from angr.analyses.reaching_definitions.call_trace import CallTrace
@@ -144,16 +145,25 @@ class RDAStateInitializer:
         Override this if you need to add support for an architecture that requires this, and isn't covered yet
         """
         if self.arch.name.startswith("PPC64"):
-            if rtoc_value is None:
-                raise TypeError("rtoc_value must be provided on PPC64.")
-            offset, size = self.arch.registers["rtoc"]
-            rtoc_atom = Register(offset, size)
-            rtoc_def = Definition(rtoc_atom, ex_loc, tags={InitialValueTag()})
-            state.all_definitions.add(rtoc_def)
-            if state.analysis is not None:
-                state.analysis.model.add_def(rtoc_def)
-            rtoc = state.annotate_with_def(claripy.BVV(rtoc_value, self.arch.bits), rtoc_def)
-            state.registers.store(offset, rtoc)
+            if rtoc_value is None and self.project is not None:
+                main_object = self.project.loader.main_object
+                # An ELFv1 shared object's ppc64_initial_rtoc is the link-time address cle read out of
+                # the entry descriptor, not the address it mapped the object at, so it is only an
+                # absolute TOC for the object the loader placed at its own base.
+                if (
+                    isinstance(main_object, MetaELF)
+                    and self.project.loader.find_object_containing(func_addr) is main_object
+                ):
+                    rtoc_value = main_object.ppc64_initial_rtoc
+            if rtoc_value is not None:
+                offset, size = self.arch.registers["rtoc"]
+                rtoc_atom = Register(offset, size)
+                rtoc_def = Definition(rtoc_atom, ex_loc, tags={InitialValueTag()})
+                state.all_definitions.add(rtoc_def)
+                if state.analysis is not None:
+                    state.analysis.model.add_def(rtoc_def)
+                rtoc = state.annotate_with_def(claripy.BVV(rtoc_value, self.arch.bits), rtoc_def)
+                state.registers.store(offset, rtoc)
         elif self.arch.name.startswith("MIPS64"):
             offset, size = self.arch.registers["t9"]
             t9_atom = Register(offset, size)

--- a/angr/analyses/reaching_definitions/rd_state.py
+++ b/angr/analyses/reaching_definitions/rd_state.py
@@ -47,7 +47,7 @@ class ReachingDefinitionsState:
                               Should be set to true when the analysis has counted uses and definitions for temporary
                               variables, false otherwise.
     :param analysis: The analysis that generated the state represented by this object.
-    :param rtoc_value: When the targeted architecture is ppc64, the initial function needs to know the `rtoc_value`.
+    :param rtoc_value: The TOC pointer to start a ppc64 function with. Taken from the loader when not given.
     :param live_definitions:
     :param canonical_size:
         The sizes (in bytes) that objects with an UNKNOWN_SIZE are treated as for operations where sizes are necessary.
@@ -287,14 +287,8 @@ class ReachingDefinitionsState:
             initializer = RDAStateInitializer(self.arch, project=project)
 
         if subject.type == SubjectType.Function:
-            if isinstance(self.arch, archinfo.arch_ppc64.ArchPPC64) and not rtoc_value:
-                raise ValueError("The architecture being ppc64, the parameter `rtoc_value` should be provided.")
-
             initializer.initialize_function_state(self, subject.cc, subject.content.addr, rtoc_value)
         elif subject.type == SubjectType.CallTrace:
-            if isinstance(self.arch, archinfo.arch_ppc64.ArchPPC64) and not rtoc_value:
-                raise ValueError("The architecture being ppc64, the parameter `rtoc_value` should be provided.")
-
             initializer.initialize_function_state(
                 self, subject.cc, subject.content.current_function_address(), rtoc_value
             )

--- a/tests/analyses/decompiler/test_ppc64.py
+++ b/tests/analyses/decompiler/test_ppc64.py
@@ -1,0 +1,33 @@
+# pylint:disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+import os
+import unittest
+
+import angr
+from angr.analyses import CFGFast
+from angr.analyses.decompiler import Decompiler
+from tests.common import bin_location, print_decompilation_result
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestDecompilerPPC64(unittest.TestCase):
+    def test_function_whose_calling_convention_is_recovered_from_its_callsites(self):
+        # Recovering this function's calling convention runs ReachingDefinitionsAnalysis over its
+        # callers. That used to raise on PowerPC64, and the decompiler swallowed the exception and
+        # returned nothing at all.
+        bin_path = os.path.join(test_location, "ppc64", "fauxware")
+        func_addr = 0x10000698
+
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses[CFGFast].prep()(normalize=True)
+
+        d = proj.analyses[Decompiler].prep()(proj.kb.functions[func_addr], cfg=cfg.model)
+
+        assert d.codegen is not None and d.codegen.text, f"decompilation produced nothing: {d.errors}"
+        print_decompilation_result(d)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/analyses/reaching_definitions/test_rd_state.py
+++ b/tests/analyses/reaching_definitions/test_rd_state.py
@@ -5,6 +5,7 @@ __package__ = __package__ or "tests.analyses.reaching_definitions"  # pylint:dis
 
 import os
 import random
+from typing import TYPE_CHECKING, cast
 from unittest import TestCase, main, mock
 
 import archinfo
@@ -13,8 +14,13 @@ from angr.analyses.reaching_definitions.heap_allocator import HeapAllocator
 from angr.analyses.reaching_definitions.rd_state import ReachingDefinitionsState
 from angr.analyses.reaching_definitions.subject import SubjectType
 from angr.code_location import CodeLocation
+from angr.knowledge_plugins.key_definitions.atoms import Register
 from angr.knowledge_plugins.key_definitions.live_definitions import LiveDefinitions
 from tests.common import bin_location
+
+if TYPE_CHECKING:
+    from angr.analyses.reaching_definitions.reaching_definitions import ReachingDefinitionsAnalysis
+    from angr.analyses.reaching_definitions.subject import Subject
 
 TESTS_LOCATION = os.path.join(bin_location, "tests")
 
@@ -31,15 +37,22 @@ class _MockFunctionSubject:  # pylint:disable=too-few-public-methods
 
 
 class TestReachingDefinitionsState(TestCase):
-    def test_initializing_rd_state_for_ppc_without_rtoc_value_should_raise_an_error(self):
+    def test_initializing_rd_state_for_ppc_without_an_rtoc_value_defines_no_toc_register(self):
         arch = archinfo.arch_ppc64.ArchPPC64()
-        self.assertRaises(
-            ValueError,
-            ReachingDefinitionsState,
+
+        state = ReachingDefinitionsState(
             CodeLocation(0x42, None),
             arch=arch,
-            subject=_MockFunctionSubject(),
-            analysis=None,
+            subject=cast("Subject", _MockFunctionSubject()),
+            analysis=cast("ReachingDefinitionsAnalysis", None),
+        )
+
+        rtoc_offset = arch.registers["rtoc"][0]
+        self.assertFalse(
+            any(
+                isinstance(definition.atom, Register) and definition.atom.reg_offset == rtoc_offset
+                for definition in state.all_definitions
+            )
         )
 
     def test_initializing_rd_state_for_ppc_with_rtoc_value(self):

--- a/tests/analyses/reaching_definitions/test_regressions.py
+++ b/tests/analyses/reaching_definitions/test_regressions.py
@@ -6,12 +6,14 @@ import struct
 from unittest import TestCase
 
 from archinfo import ArchAArch64
+from cle import MetaELF
 
 import angr
 from angr.analyses import CFGFast, ReachingDefinitionsAnalysis
 from angr.knowledge_plugins import Function
-from angr.knowledge_plugins.key_definitions.atoms import Atom
+from angr.knowledge_plugins.key_definitions.atoms import Atom, Register
 from angr.knowledge_plugins.key_definitions.constants import OP_BEFORE
+from angr.knowledge_plugins.key_definitions.tag import InitialValueTag
 from tests.common import bin_location
 
 
@@ -233,3 +235,109 @@ class TestRDARegressions(TestCase):
         }, (
             f"Expected selector to contain the pointers to 'startAnimating' and 'stopAnimating' i.e. 0x100191A4C, 0x100191A3D, but got: {selector}"
         )
+
+    def test_ppc64_elfv1_function_state_takes_the_toc_from_the_loader(self):
+        """
+        ReachingDefinitionsAnalysis never passes rtoc_value, so on PowerPC64 the analysis used to raise
+        ValueError instead of running at all. r2 holds the TOC pointer; take it from the loaded object.
+        """
+        binary = os.path.join(bin_location, "tests", "ppc64", "fauxware")
+        func_addr = 0x10000698
+
+        proj = angr.Project(binary, auto_load_libs=False)
+        main_object = proj.loader.main_object
+        assert isinstance(main_object, MetaELF)
+        assert main_object.ppc64_initial_rtoc == 0x10018E80
+
+        cfg = proj.analyses[CFGFast].prep()(normalize=True)
+        entry_observation = ("node", func_addr, OP_BEFORE)
+        rda = proj.analyses[ReachingDefinitionsAnalysis].prep()(
+            cfg.functions[func_addr], observation_points=[entry_observation]
+        )
+
+        rtoc = rda.observed_results[entry_observation].get_values(Atom.reg("rtoc", arch=proj.arch))
+        assert rtoc is not None
+        rtoc_value = rtoc.one_value()
+        assert rtoc_value is not None
+        assert rtoc_value.concrete_value == 0x10018E80
+
+    def test_ppc64_elfv2_function_state_takes_the_toc_from_the_loader(self):
+        """
+        The little-endian ELFv2 ABI keeps the TOC in r2 as well, and cle guesses its value from .got.
+        """
+        binary = os.path.join(bin_location, "tests", "ppc64el", "fauxware")
+        func_addr = 0x400A84
+
+        proj = angr.Project(binary, auto_load_libs=False)
+        main_object = proj.loader.main_object
+        assert isinstance(main_object, MetaELF)
+        assert main_object.is_ppc64_abiv2
+        assert main_object.ppc64_initial_rtoc == 0x427F00
+
+        cfg = proj.analyses[CFGFast].prep()(normalize=True)
+        entry_observation = ("node", func_addr, OP_BEFORE)
+        rda = proj.analyses[ReachingDefinitionsAnalysis].prep()(
+            cfg.functions[func_addr], observation_points=[entry_observation]
+        )
+
+        rtoc = rda.observed_results[entry_observation].get_values(Atom.reg("rtoc", arch=proj.arch))
+        assert rtoc is not None
+        rtoc_value = rtoc.one_value()
+        assert rtoc_value is not None
+        assert rtoc_value.concrete_value == 0x427F00
+
+    def test_ppc64_object_without_a_toc_puts_nothing_in_the_toc_register(self):
+        """
+        An object cle found no TOC in gets an analysis that runs and leaves r2 alone, rather than a
+        made-up TOC or an exception.
+        """
+        binary = os.path.join(bin_location, "tests", "ppc64", "simple_object.o")
+        func_addr = 0x400000
+
+        proj = angr.Project(binary, auto_load_libs=False)
+        main_object = proj.loader.main_object
+        assert isinstance(main_object, MetaELF)
+        assert main_object.ppc64_initial_rtoc is None
+
+        cfg = proj.analyses[CFGFast].prep()(normalize=True)
+        entry_observation = ("node", func_addr, OP_BEFORE)
+        rda = proj.analyses[ReachingDefinitionsAnalysis].prep()(
+            cfg.functions[func_addr], observation_points=[entry_observation]
+        )
+
+        assert rda.observed_results[entry_observation].get_values(Atom.reg("rtoc", arch=proj.arch)) is None
+
+    def test_ppc64_function_outside_the_main_object_gets_no_toc(self):
+        """
+        Every object has its own TOC, and cle leaves an ELFv1 shared object's ppc64_initial_rtoc at
+        its link-time address, so the main object's value is the right answer for exactly one object.
+        A library function used to be seeded with it, which is a wrong concrete address that the
+        analysis then propagates through every TOC-relative load.
+        """
+        binary = os.path.join(bin_location, "tests", "ppc64el", "fauxware")
+        main_func_addr = 0x400A84
+
+        proj = angr.Project(binary, auto_load_libs=True)
+        main_object = proj.loader.main_object
+        malloc = proj.loader.find_symbol("malloc")
+        assert malloc is not None
+        library_func_addr = malloc.rebased_addr
+        assert proj.loader.find_object_containing(library_func_addr) is not main_object
+
+        rtoc_offset = proj.arch.registers["rtoc"][0]
+
+        def initial_toc_definitions(func_addr):
+            cfg = proj.analyses[CFGFast].prep()(
+                regions=[(func_addr, func_addr + 0x400)], function_starts=[func_addr], normalize=True
+            )
+            rda = proj.analyses[ReachingDefinitionsAnalysis].prep()(cfg.functions[func_addr])
+            return [
+                definition
+                for definition in rda.all_definitions
+                if isinstance(definition.atom, Register)
+                and definition.atom.reg_offset == rtoc_offset
+                and any(isinstance(tag, InitialValueTag) for tag in definition.tags)
+            ]
+
+        assert initial_toc_definitions(library_func_addr) == []
+        assert len(initial_toc_definitions(main_func_addr)) == 1


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

This replaces the fix this pull request originally carried. The earlier head read `main_object.ppc64_initial_rtoc` for every function and kept the `ValueError` for objects the loader has no TOC for. The change below uses the loader's value only for functions in the main object, drops the raise, and adds a decompiler regression; the comment on the force-push has the details.

### Problem

Decompiling a PowerPC64 function gives back nothing at all:

```python
p = angr.Project("binaries/tests/ppc64/fauxware", auto_load_libs=False)
cfg = p.analyses.CFGFast(normalize=True)
d = p.analyses.Decompiler(cfg.functions[0x10000698], cfg=cfg.model)
# d.codegen is None; d.errors holds two copies of the same exception
```

```
  File "angr/analyses/reaching_definitions/rd_state.py", line 291, in _set_initialization_values
    raise ValueError("The architecture being ppc64, the parameter `rtoc_value` should be provided.")
ValueError: The architecture being ppc64, the parameter `rtoc_value` should be provided.
```

`Analysis._resilience` catches it, so `Decompiler` returns normally with an empty result and the caller is told nothing. 15 of the 28 functions in `binaries/tests/ppc64/fauxware` come out empty this way, and 22 of the 35 in the little-endian `binaries/tests/ppc64el/fauxware`.

This is #1915, open since January 2020.

### Root cause

`ReachingDefinitionsState._set_initialization_values` refuses to build a state on PowerPC64 unless the caller passed `rtoc_value`, and `RDAStateInitializer.initialize_architectural_state` raises `TypeError` on the same condition one layer down. Nothing passes it. `ReachingDefinitionsAnalysis._initial_abstract_state` builds the state without it, and `git grep -n 'rtoc_value='` over master finds exactly two hits: the parameter's own default in `rd_state.py`, and one unit test. So on PowerPC64 the analysis raised before it read a single block.

The decompiler gets there through `Clinic._recover_calling_conventions` -> `CallingConventionAnalysis._analyze_callsite_only` -> `_analyze_callsite`, which runs a `ReachingDefinitionsAnalysis` over the callers of a function whose prototype is not known yet. That is why some functions on an object decompile and others do not: only the ones whose calling convention has to be recovered from their callsites reach the raise.

### Fix

r2 holds the TOC pointer and the loader already worked out its value, so read it from there when the caller passed none, and set up no TOC register at all when the loader has nothing either:

```python
if self.arch.name.startswith("PPC64"):
    if rtoc_value is None and self.project is not None:
        main_object = self.project.loader.main_object
        if (
            isinstance(main_object, MetaELF)
            and self.project.loader.find_object_containing(func_addr) is main_object
        ):
            rtoc_value = main_object.ppc64_initial_rtoc
    if rtoc_value is not None:
        ...
```

That is the shape #7002 landed for the same register in `SimLinux.set_entry_register_values`: take the loader's value, leave the register alone when there is none, never invent one. Both `ValueError`s in `rd_state.py` go away with it, so the state class no longer knows about PowerPC64; an explicit `rtoc_value` argument still wins over the loader.

One deliberate difference from #7002: no `is_ppc64_abiv1` test. `MetaELF.ppc64_initial_rtoc` answers for ABIv2 as well, guessing it from `.got`, and little-endian PowerPC64 objects are ABIv2 — `binaries/tests/ppc64el/fauxware` is one, with a TOC at `0x427f00`.

Only the main object's value is used, because `ppc64_initial_rtoc` does not mean the same thing for every object. cle computes it from the mapped `.got` under ELFv2, but under ELFv1 it reads it out of the entry descriptor, where it is a link-time address that never gets rebased. Loading `tests/ppc64/fauxware` with its libraries, libc is mapped at `0x10100000` and reports `0x1cc6f0`, which only becomes the `0x102cc6f0` its `.got` implies once you add the base; under ELFv2 `tests/ppc64el/fauxware` reports libc's TOC as `0x707100`, already mapped.

Decompiling every function of each fixture, one fresh `Project` per function:

| fixture | before | after |
| --- | --- | --- |
| `tests/ppc64/fauxware` (big-endian, ELFv1) | 13 of 28 | 28 of 28 |
| `tests/ppc64el/fauxware` (little-endian, ELFv2) | 13 of 35 | 35 of 35 |
| `tests/ppc/fauxware` (PPC32 control) | 18 of 18 | 18 of 18 |

PPC32 is `archinfo.ArchPPC32`, a separate class that never reached the raise. The raises removed from `rd_state.py` were guarded by `isinstance(arch, ArchPPC64)` and the initializer's TOC branch by `arch.name.startswith("PPC64")`; over all 22 registered `archinfo` architectures those two predicates agree on every one, both true only for PowerPC64 big- and little-endian, so no other architecture is touched.

### Testing

Six tests, all of which fail on master and pass here.

`tests/analyses/reaching_definitions/test_regressions.py` gains four. Two run `ReachingDefinitionsAnalysis` over a function and assert r2 carries the loader's TOC at the function's entry: `0x10018e80` on `tests/ppc64/fauxware` and `0x427f00` on `tests/ppc64el/fauxware`, so both ABIs and both endiannesses are covered. The third loads `tests/ppc64/simple_object.o`, whose `ppc64_initial_rtoc` is `None`, and asserts the analysis runs and puts nothing in r2 — the case #7002 covers for the entry state. The fourth loads `tests/ppc64el/fauxware` with its libraries and asserts that `malloc`, which lives in libc, gets no initial TOC definition while the main object's function still gets exactly one.

`tests/analyses/decompiler/test_ppc64.py` is new and pins the user-visible symptom: `0x10000698` of `tests/ppc64/fauxware` decompiles to non-empty text in a fresh `Project`.

`test_initializing_rd_state_for_ppc_without_rtoc_value_should_raise_an_error` in `tests/analyses/reaching_definitions/test_rd_state.py` asserted the raise this change removes. It now asserts the other half of the same behaviour under the same inputs: a PowerPC64 state built with no rtoc value and no project defines no TOC register. Its sibling, which pins an explicit `rtoc_value`, is untouched and still passes.

Validation: https://github.com/angr/angr/pull/7069#issuecomment-5530915275

Closes #1915

session: sharpen
