### PR TITLE
Fix FpToSBV of negative floats

### DIFF
--- a/native/clarirs-core/src/algorithms/simplify/bv.rs
+++ b/native/clarirs-core/src/algorithms/simplify/bv.rs
@@ -1398,11 +1398,8 @@ pub(crate) fn simplify_bv<'c>(
                     // Convert the float to a signed integer representation (BigInt)
                     let signed_value = float.to_signed_bigint().unwrap_or(BigInt::zero());
 
-                    // Convert the signed value to BigUint for BitVec construction
-                    let unsigned_value = signed_value.to_biguint().unwrap_or(BigUint::zero());
-
                     // Create a BitVec with the result, truncating or extending to fit within the specified bit size
-                    let result_bitvec = BitVec::from((unsigned_value, *bit_size));
+                    let result_bitvec = BitVec::from((signed_value, *bit_size));
 
                     Ok(ctx.bvv(result_bitvec)?)
                 }

--- a/native/clarirs-core/src/algorithms/simplify/test_bv.rs
+++ b/native/clarirs-core/src/algorithms/simplify/test_bv.rs
@@ -1134,3 +1134,13 @@ fn test_debug_extract_size() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_fp_to_sbv_negative_value() -> Result<()> {
+    let ctx = Context::new();
+    let converted = ctx
+        .fp_to_sbv(ctx.fpv(Float::from(-3.0_f64))?, 32, FPRM::NearestTiesToEven)?
+        .simplify()?;
+    assert_eq!(converted, ctx.bvv(BitVec::from((0xffff_fffd, 32)))?);
+    Ok(())
+}


### PR DESCRIPTION
The concrete fold converted the signed value through BigUint, which is None for negative numbers, so every negative float became 0. A regression test covers a negative float.