### PR TITLE
Fix And/Or flattening

### DIFF
--- a/native/clarirs-core/src/algorithms/simplify/bool.rs
+++ b/native/clarirs-core/src/algorithms/simplify/bool.rs
@@ -48,7 +48,8 @@ pub(crate) fn simplify_bool<'c>(
 
             // Absorption simplification
             let absorbed_args = available_args
-                .into_iter()
+                .iter()
+                .cloned()
                 .flat_map(|arg| {
                     if let AstOp::And(nested_args) = arg.op() {
                         nested_args.clone()
@@ -122,7 +123,7 @@ pub(crate) fn simplify_bool<'c>(
                 }
             }
 
-            if absorbed_args.len() != args.len() {
+            if absorbed_args != available_args {
                 return state.rerun(ctx.and(absorbed_args)?);
             }
 
@@ -138,7 +139,8 @@ pub(crate) fn simplify_bool<'c>(
 
             // Absorption simplification
             let absorbed_args = available_args
-                .into_iter()
+                .iter()
+                .cloned()
                 .flat_map(|arg| {
                     if let AstOp::Or(nested_args) = arg.op() {
                         nested_args.clone()
@@ -212,7 +214,7 @@ pub(crate) fn simplify_bool<'c>(
                 }
             }
 
-            if absorbed_args.len() != args.len() {
+            if absorbed_args != available_args {
                 return state.rerun(ctx.or(absorbed_args)?);
             }
 

--- a/native/clarirs-core/src/algorithms/simplify/test_bool.rs
+++ b/native/clarirs-core/src/algorithms/simplify/test_bool.rs
@@ -764,3 +764,32 @@ fn test_eliminatable_non_relocatable_does_not_block_simplification() -> Result<(
 
     Ok(())
 }
+
+#[test]
+fn test_flatten_with_identity_keeps_argument_count() -> Result<()> {
+    let ctx = Context::new();
+    let x = ctx.bools("x")?;
+    let y = ctx.bools("y")?;
+    let z = ctx.bools("z")?;
+
+    // Flattening the nested node and dropping the identity leaves as many
+    // arguments as before, so a length comparison misses the change.
+    let nested_and = ctx.and(vec![
+        x.clone(),
+        ctx.true_()?,
+        ctx.and(vec![y.clone(), z.clone()])?,
+    ])?;
+    assert_eq!(
+        nested_and.simplify()?,
+        ctx.and(vec![x.clone(), y.clone(), z.clone()])?
+    );
+
+    let nested_or = ctx.or(vec![
+        x.clone(),
+        ctx.false_()?,
+        ctx.or(vec![y.clone(), z.clone()])?,
+    ])?;
+    assert_eq!(nested_or.simplify()?, ctx.or(vec![x, y, z])?);
+
+    Ok(())
+}


### PR DESCRIPTION
Flattening a nested And/Or while dropping an identity keeps the argument count unchanged, so the length check returned the node unsimplified. A regression test covers flattening under an identity for both And and Or.