### PR TITLE
CFGFast, CFGEmulated: follow the fall-through of cli and sti

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -2684,7 +2684,7 @@ class CFGBase(Analysis):
                     src_function.addr, src_snippet, returning_snippet, confirmed=True, to_outside=return_to_outside
                 )
 
-        elif jumpkind in ("Ijk_Boring", "Ijk_InvalICache", "Ijk_Exception"):
+        elif jumpkind in ("Ijk_Boring", "Ijk_InvalICache", "Ijk_Privileged", "Ijk_Exception"):
             # convert src_addr and dst_addr to CodeNodes
             src_node = src_addr if not self.model.has_node_addr(src_addr) else self._node_key_to_snippet(src_node_key)
             dst_node = dst_addr if not self.model.has_node_addr(dst_addr) else self._node_key_to_snippet(dst_node_key)

--- a/angr/analyses/cfg/cfg_emulated.py
+++ b/angr/analyses/cfg/cfg_emulated.py
@@ -2163,7 +2163,7 @@ class CFGEmulated(ForwardAnalysis, CFGBase):  # pylint: disable=abstract-method
                 confirmed=confirmed,
             )
 
-        elif jumpkind in ("Ijk_Boring", "Ijk_InvalICache"):
+        elif jumpkind in ("Ijk_Boring", "Ijk_InvalICache", "Ijk_Privileged"):
             src_obj = self.project.loader.find_object_containing(src_node.addr)
             dest_obj = self.project.loader.find_object_containing(dst_node.addr) if dst_node is not None else None
 

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3627,7 +3627,7 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             # This is a direct jump with a concrete target.
 
             # pylint: disable=too-many-nested-blocks
-            if jumpkind in {"Ijk_Boring", "Ijk_InvalICache", "Ijk_Exception"}:
+            if jumpkind in {"Ijk_Boring", "Ijk_InvalICache", "Ijk_Privileged", "Ijk_Exception"}:
                 to_outside, target_func_addr = self._is_branching_to_outside(
                     cfg_node, target_addr, current_function_addr, jumpkind, all_successors
                 )

--- a/tests/analyses/cfg/test_cfg_privileged.py
+++ b/tests/analyses/cfg/test_cfg_privileged.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.cfg"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+# pylint: disable=missing-class-docstring
+# pylint: disable=no-self-use
+class TestCfgPrivileged(unittest.TestCase):
+    def test_cfgfast_privileged_fallthrough(self):
+        # cli and sti lift to Ijk_Privileged with the following instruction as a concrete default exit
+        bin_path = os.path.join(test_location, "i386", "bios.bin.elf")
+        p = angr.Project(bin_path, auto_load_libs=False)
+        cfg = p.analyses.CFGFast()
+
+        privileged = 0
+        for node in cfg.model.nodes():
+            addr = node.addr
+            if not node.size or node.is_simprocedure or not isinstance(addr, int):
+                continue
+            if p.factory.block(addr, size=node.size).vex_nostmt.jumpkind != "Ijk_Privileged":
+                continue
+            privileged += 1
+            assert [succ.addr for succ in node.successors] == [addr + node.size]
+        assert privileged
+
+        # _start is a cli followed by a cld; without the fall-through _start is a one-byte non-returning
+        # function and the cld starts a function of its own
+        start = cfg.functions["_start"]
+        assert start.addr == 0xFF06E
+        assert {0xFF06E, 0xFF06F}.issubset(start.block_addrs_set)
+        assert start.returning is not False
+        assert 0xFF06F not in cfg.functions
+
+    def test_cfgemulated_privileged_fallthrough(self):
+        bin_path = os.path.join(test_location, "i386", "bios.bin.elf")
+        p = angr.Project(bin_path, auto_load_libs=False)
+        cfg = p.analyses.CFGEmulated(starts=(0xFF06E,), context_sensitivity_level=0)
+        node = cfg.model.get_any_node(0xFF06E)
+        assert node is not None
+        assert [succ.addr for succ in node.successors] == [0xFF06F]
+        assert {0xFF06E, 0xFF06F}.issubset(cfg.kb.functions[0xFF06E].block_addrs_set)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

On x86 and AMD64, CFGFast cuts a function off at the first `cli` or `sti`.

`tests/i386/bios.bin.elf`, which `angr/binaries` already tracks, shows it.
`_start` at `0xff06e` is a `cli` followed by a `cld`, and default `CFGFast()`
reports:

```
functions: 321
_start: 0xff06e size 1 returning False
_start blocks: ['0xff06e']
0xff06f is its own function: True
Ijk_Privileged blocks: 12 of which out-degree 0: 12
```

`_start` is one byte long, the `cld` at `0xff06f` has become a function of its
own, and every block in the binary that ends on `cli` or `sti` has no successor
at all.

The loss does not stop at the block. With no successor the function has no
return site, so `_determine_function_returning` marks it non-returning; CFGFast
then never creates the fall-through job at a call site to it, so every caller
loses everything after the call; the linear scan re-finds the abandoned bytes
and turns them into `sub_*` functions sitting inside the caller's own range.

### Root cause

`cli` (0xFA) and `sti` (0xFB) are the only instructions libVEX gives the
jumpkind `Ijk_Privileged`, and only on x86 and AMD64 — one site in each guest,
both saying "Treated as nop for now" and passing the address of the next
instruction to `jmp_lit`. So the fall-through is present in the IRSB as a
concrete constant in `irsb.next`.

angr drops it. `CFGFast._create_jobs` takes the concrete-target branch, tests
the jumpkind against `Ijk_Boring`/`Ijk_InvalICache`/`Ijk_Exception` and then
`Ijk_Call`/`Ijk_Sys`. `Ijk_Privileged` matches neither, so it falls to

```python
else:
    # TODO: Support more jumpkinds
    l.debug("Unsupported jumpkind %s", jumpkind)
```

which creates no successor job, and the node ends up with out-degree 0.
CFGEmulated does get the successor from execution, but
`_update_function_transition_graph` tests the same short list and drops the
edge, so the function stops at the `cli` there too.

### Fix

Add `Ijk_Privileged` to the three jumpkind sets that decide whether a concrete
default exit becomes a successor of the block and of the function:
`CFGFast._create_jobs`, `CFGBase._graph_traversal_handler` and
`CFGEmulated._update_function_transition_graph`. Three one-word changes.

This is the treatment `Ijk_InvalICache` already gets at those same sites, and
for the same reason: both are "carry on at the next instruction" jumpkinds. That
precedent was merged as angr#1273, "Treat Ijk_InvalICache like Ijk_Boring".

Same binary, same command, with the change:

```
functions: 309
_start: 0xff06e size 54 returning True
_start blocks: ['0xff06e', '0xff06f']
0xff06f is its own function: False
Ijk_Privileged blocks: 9 of which out-degree 0: 0
```

The jumpkind itself is kept. #6256, which reports this defect, suggests
remapping `Ijk_Privileged` to `Ijk_Boring` in the lifter instead, and a
maintainer agreed with that route in the issue. This change does not, because
ltfish's position on #1956 is "I'm not a big fan of changing lifting behaviors
just for privileged instructions", with interrupt support belonging to a SimOS
that keys on this jumpkind. Repairing the two CFG recoveries keeps the
information a SimOS would need.

Deliberately out of scope: `drop_bad_functions()`, which carries its own
`# TODO: Handle Ijk_Privileged in user-space binaries` and asks a different
question; and `hlt`, which lifts to `Ijk_SigTRAP` and is dropped at the same
`else`.

One caveat, stated plainly. At CPL 3 `cli` really does fault, so in a user-space
binary the block genuinely is terminal, and angr has no predicate for "this
image runs in ring 0" to condition the change on. The measured answer is in
Testing: a binary in which angr finds no privileged block is untouched.

### Testing

New regression `tests/analyses/cfg/test_cfg_privileged.py`, on
`tests/i386/bios.bin.elf` — already tracked in `angr/binaries` and already
loaded by `tests/analyses/cfg/test_cfgemulated.py`, so no new fixture. It
asserts that every `Ijk_Privileged` node has its fall-through as a successor,
and that `_start` owns both blocks and is not marked non-returning. Both tests
fail on master and pass here.

Two firmware images, under `CFGFast(normalize=True, data_references=False,
resolve_indirect_jumps=True)`. A NuttX 13.0.0 `qemu-i486-nsh` build goes from
4932 to 4397 functions, from 310 to 37 functions marked non-returning, and from
349 privileged blocks with zero out-degree to none; the share of
symbol-declared bytes owned by the function that starts at that symbol rises
from 81.0% to 91.8%. A `qemu-intel64-nsh` build goes from 2360 to 1738
functions, 1051 to 638 non-returning, and 84.5% to 99.0%. One repaired function
in the i486 build: `nxsched_get_tcb` is 18 of the 84 bytes its ELF symbol declares on
master and is marked non-returning; with the change it is 69 bytes over ten
blocks and returns.

The control that could have come out the other way: 42 x86 and x86-64 binaries
tracked in `angr/binaries`, compared under default `CFGFast()`. The 27 with no
privileged block are identical before and after — same function count, same
node count, same edge count. All 15 that do have one moved.

Scope, plainly: the firmware figures come from a 22-object set of ring-0 images
built from two projects, NuttX 13.0.0 and U-Boot 2026.07, of which only six are
x86 or AMD64. That is not a corpus-wide rate.

Refs #6256. Validation: https://github.com/angr/angr/pull/7086#issuecomment-5535753970

session: sharpen