### PR TITLE
Stop tests/gui importing the tests package

### DIFF
--- a/tests/gui/test_decompilation_workflows.py
+++ b/tests/gui/test_decompilation_workflows.py
@@ -6,11 +6,34 @@ __package__ = __package__ or "tests.gui.decompilation_workflows"  # pylint:disab
 import os
 import unittest
 
-import angr
-from angr.sim_type import SimTypeInt, TypeRef
-from tests.common import bin_location, print_decompilation_result
+from rich.console import Console
+from rich.syntax import Syntax
 
-test_location = os.path.join(bin_location, "tests")
+import angr
+from angr.misc.testing import is_testing
+from angr.sim_type import SimTypeInt, TypeRef
+
+# `tests/gui` has no `__init__.py`. Under pytest's default `prepend` import mode the directory that
+# goes on `sys.path` for a test module is its first ancestor without that marker, so this module
+# gets `tests/gui` and never the repository root: `from tests.common import ...` here is a
+# collection error unless an earlier test module happened to put the root on `sys.path` first, and
+# one collection error fails a whole shard. Derive what this module needs instead.
+# `tests/ailment/test_irsb.py` locates the binaries the same way.
+test_location = os.path.join(os.path.dirname(__file__), "..", "..", "..", "binaries", "tests")
+
+# Whether this is a batch run, in which case the decompiled code is not printed.
+WORKER = is_testing or bool(os.environ.get("WORKER", None))
+
+
+def print_decompilation_result(dec) -> None:
+    if WORKER:
+        return
+    print("Decompilation result:")
+    try:
+        console = Console()
+        console.print(Syntax(dec.codegen.text, "c", line_numbers=False))
+    except Exception:  # pylint:disable=broad-exception-caught
+        print(dec.codegen.text)
 
 
 class TestDecompilationWorkflows(unittest.TestCase):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`tests/gui/test_decompilation_workflows.py` opens with

```python
from tests.common import bin_location, print_decompilation_result
```

and `tests/gui` has no `__init__.py`. Collecting that directory on its own fails:

```
$ pytest -q tests/gui
==================================== ERRORS ====================================
__________ ERROR collecting tests/gui/test_decompilation_workflows.py __________
tests/gui/test_decompilation_workflows.py:11: in <module>
    from tests.common import bin_location, print_decompilation_result
E   ModuleNotFoundError: No module named 'tests.common'
=========================== short test summary info ============================
ERROR tests/gui/test_decompilation_workflows.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 error in 1.05s
```

(The importlib traceback and the timing tables pytest prints between those
lines are cut; the complete run is in the comment below.)

So does a single node id out of the file, which is what you reach for when one
of these four tests fails.

A whole-tree `pytest tests` is fine, and collection order is the only reason:
`tests/analyses` has a complete `__init__.py` chain and sorts before `gui`, so
by the time this module is imported an earlier one has already put the checkout
root on `sys.path`. Nothing about this module puts it there.

### Root cause

Under pytest's default `prepend` import mode the directory that goes on
`sys.path` for a test module is its first ancestor without an `__init__.py`.
For this module that ancestor is `tests/gui` itself, so the checkout root never
goes on `sys.path` on this module's account and `tests` does not resolve.

A development checkout hides it: angr installed editable puts the checkout root
on `sys.path` in every process -- pytest, pylint, a bare `python -c` -- so the
import resolves locally whatever pytest does.

### Fix

Derive the two values in the module instead of importing them from `tests`:
`test_location` from the module's own `__file__`, the way
`tests/ailment/test_irsb.py` already locates the binaries, and a local
`print_decompilation_result` with the same `WORKER` gate as the one in
`tests/common`. Nothing else in the file changes, and afterwards no module
under `tests/` imports the `tests` package from a directory without the marker.

Adding `tests/gui/__init__.py` would also fix the import and is deliberately
not done, because that marker changes which `angr` this module resolves. With
it, pytest's basedir walk reaches the checkout root and inserts that on
`sys.path`, so in the layout CI builds in -- checkout at `build/src/angr`,
compiled package installed in `build/virtualenv` -- `pytest tests/gui` imports
the uncompiled source tree and fails with `ModuleNotFoundError: No module named
'angr.rustylib'` instead. Deriving the values adds no `sys.path` entry at all.

### Testing

The four `TestDecompilationWorkflows` tests are unchanged apart from the
import. Run with the checkout root off `sys.path`, `pytest tests/gui` goes from
a collection error to 4 passed, and collecting the whole tree yields the same
2961 items before and after.

Validation: https://github.com/angr/angr/pull/7087#issuecomment-5542631629

session: sharpen