### PR TITLE
packaging: require networkx 2.5, the version that added all_simple_edge_paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "lmdb==2.1.1",
     "msgspec; implementation_name == 'cpython'",
     "mulpyplexer",
-    "networkx!=2.8.1,>=2.0",
+    "networkx!=2.8.1,>=2.5",
     "protobuf>=6.33.0",
     "psutil",
     "pycparser~=3.0",


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`pyproject.toml` declares `networkx!=2.8.1,>=2.0`. angr has needed networkx 2.5
since #4429 landed on 2024-02-01, because `angr/analyses/typehoon/dfa.py` calls
`networkx.all_simple_edge_paths` and networkx added that function in 2.5.

The window that leaves open is exactly networkx 2.4. angr's `requires-python` is
`>=3.12`, and on 3.12 networkx 2.0 through 2.3 do not import at all -- 2.0, 2.1
and 2.2 raise `ImportError: cannot import name 'Mapping' from 'collections'`,
2.3 raises
`cannot import name 'gcd' from 'fractions'`. 2.4 imports cleanly and has no
`all_simple_edge_paths`, and nothing checks for it: `dfa.py` does a plain
module-level `import networkx`, so type inference raises `AttributeError` the
first time `SimpleSolver` reaches the DFA constraint solver.

```python
# angr/analyses/typehoon/dfa.py:74
for path in networkx.all_simple_edge_paths(dfa_graph, min_dfa.start_state, final_state):
```

The caller at `angr/analyses/typehoon/simple_solver.py:1915` catches only
`EmptyEpsilonNFAError`, so the failure leaves Typehoon and takes variable typing
with it.

### Root cause

#1036 set the floor at `>=2.0` in 2018, and apart from a one-day `==2.3` pin in
October 2019 (8c1987b99, reverted the next day by 783ca109a) it has not moved
since. The code did. From the release sdists: `all_simple_edge_paths` is defined
at `networkx/algorithms/simple_paths.py:294` in networkx 2.5 and is in that
module's `__all__`; it is absent from the 2.0, 2.1, 2.2, 2.3 and 2.4 trees,
where `simple_paths.__all__` is `["all_simple_paths", "is_simple_path",
"shortest_simple_paths"]`.

Nothing catches the mismatch, because nothing resolves near the floor: a default
resolver takes the newest networkx, angr has no lockfile, and no CI job resolves
lowest versions. The floor is reachable, just never exercised -- networkx 2.0,
2.1 and 2.2 declare no `Requires-Python` at all, 2.3 and 2.4 declare `>=3.5` and
2.5 declares `>=3.6`, so angr's `requires-python = ">=3.12"` excludes none of
them.

### Fix

Raise the floor to the version that introduced the function angr calls, keeping
the `!=2.8.1` exclusion from #3351 untouched.

That is the shape this project has used before: on #1239 a contributor proposed
`sortedcontainers>2.0` for `SortedKeyList`, which sortedcontainers added in
2.0, and ltfish asked for `>=2.0` instead -- the exact version that introduced
the API, not the one after it.

**2.5 is a lower bound, not a proven exact answer.** It comes from an audit of
top-level `networkx.<name>` usage across `angr/**.py`, which turns up two names
newer than 2.0: `all_simple_edge_paths` (2.5), and `networkx.subgraph_view` at
`angr/analyses/decompiler/clinic.py:3174` (2.2). Three further checks looked for
what a name audit cannot see, and none of them raises the number. No member has
been added to `Graph`, `DiGraph`, `MultiGraph`, `MultiDiGraph` or the classes in
`reportviews`/`coreviews` between 2.5 and 3.6.1, so no graph method angr could
be calling postdates the floor. Every keyword angr passes to a networkx function
is in that function's signature at 2.5. And the one post-2.5 behaviour change
that could bind here, `simple_cycles` accepting undirected graphs from 3.1, does
not, because all four angr call sites build an explicit `networkx.DiGraph`. That
is not a proof of exactness -- a behaviour change elsewhere could still raise the
true floor -- but the kinds of change most likely to hide one were checked.

### Testing

No regression test. angr has no packaging or metadata suite for one to join, and
a test asserting the version string would restate the diff rather than check
anything. The claim the change rests on is a property of the networkx releases,
checked against the 2.0 through 2.5 sdists rather than against angr.

Validation: https://github.com/angr/angr/pull/7093#issuecomment-5545265793

session: sharpen
