### PR TITLE
FastMemory: fix conditional loads and stores

### DIFF
--- a/angr/storage/memory_mixins/simple_interface_mixin.py
+++ b/angr/storage/memory_mixins/simple_interface_mixin.py
@@ -58,7 +58,7 @@ class SimpleInterfaceMixin(MemoryMixin):
         return self.state.solver.eval(s)
 
     def _translate_cond(self, c):
-        if isinstance(c, claripy.ast.Base) and not c.singlevalued:
+        if isinstance(c, claripy.ast.Base) and c.cardinality != 1:
             raise SimMemoryError("condition not supported")
         if c is None:
             return True

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -592,6 +592,24 @@ class TestMemory(unittest.TestCase):
 
         self._concrete_memory_tests(s)
 
+    def test_fast_memory_condition(self):
+        s = SimState(project=minimal_project("AMD64"), add_options={o.FAST_REGISTERS, o.FAST_MEMORY})
+
+        s.registers.store("rax", claripy.BVV(0x4142434445464748, 64))
+        s.registers.store("rax", claripy.BVV(0x1111111122222222, 64), condition=claripy.false())
+        assert s.solver.eval_upto(s.registers.load("rax", size=8), 2) == [0x4142434445464748]
+        s.registers.store("rax", claripy.BVV(0x1111111122222222, 64), condition=claripy.true())
+        assert s.solver.eval_upto(s.registers.load("rax", size=8, condition=claripy.true()), 2) == [0x1111111122222222]
+
+        s.memory.store(0x1000, claripy.BVV(b"asdf"), condition=claripy.true())
+        s.memory.store(0x1000, claripy.BVV(b"fdsa"), condition=claripy.false())
+        assert s.solver.eval_upto(s.memory.load(0x1000, 4, condition=claripy.true()), 2) == [0x61736466]
+
+        with self.assertRaises(SimMemoryError):
+            s.registers.store("rax", claripy.BVV(0, 64), condition=claripy.BoolS("cond"))
+        with self.assertRaises(SimMemoryError):
+            s.memory.load(0x1000, 4, condition=claripy.BoolS("cond"))
+
     def test_light_memory(self):
         s = SimState(project=minimal_project("AMD64"), plugins={"registers": SimLightRegisters()})
         assert type(s.registers) is SimLightRegisters


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A conditional load or store through `FastMemory` raises `AttributeError` when the
condition is a claripy `Bool`, which is what the callers pass. `fastpath` mode
turns on `FAST_REGISTERS`, so `state.registers` is a `FastMemory` on the path
`CFGEmulated` and `Veritesting` run, and executing a `cpuid` instruction there
crashes on master `87411a719`:

```python
>>> import angr
>>> p = angr.load_shellcode(b"\x0f\xa2\x90\x90", "AMD64")  # cpuid; nop; nop
>>> s = p.factory.blank_state(addr=0, mode="fastpath")
>>> p.factory.successors(s)
AttributeError: 'angr.rustylib.claripy.ast.bool.Bool' object has no attribute 'singlevalued'
```

`cpuid` reaches it through `SET_ABCD` in `angr/engines/vex/heavy/dirty.py`, which
stores rax/rbx/rcx/rdx under a condition. The memory call underneath, with the
condition and without:

```python
>>> from angr import claripy
>>> s = angr.SimState(project=p, add_options={angr.options.FAST_REGISTERS})
>>> type(s.registers).__name__
'FastMemory'
>>> s.registers.store("rax", claripy.BVV(1, 64), condition=claripy.true())
AttributeError: 'angr.rustylib.claripy.ast.bool.Bool' object has no attribute 'singlevalued'
>>> s.registers.store("rax", claripy.BVV(1, 64))    # the same call with no condition
>>> s.solver.eval(s.registers.load("rax", size=8))
1
```

### Root cause

`SimpleInterfaceMixin._translate_cond` asks the condition for `singlevalued`. A
condition is a `Bool`, and since the clarirs migration (#6550) `singlevalued` and
`multivalued` are defined on `BV` only. An `int` or a bare `bool` condition never
reaches the property and still works.

### Fix

`Bool` does have `cardinality`, and `BV.singlevalued` is defined as
`cardinality == 1`, so asking for the cardinality is the same test for a
bitvector and works for a condition. A symbolic condition still raises
`SimMemoryError("condition not supported")`.

The other two calls in the file read the property off an address and a size, and
get a bitvector whenever they get an AST at all. So do the remaining readers in
the tree: `angr/analyses/variable_recovery/variable_recovery.py` guards its two
with `isinstance(..., claripy.ast.BV)`, and
`angr/concretization_strategies/signed_add.py` reads the operands of a bitvector
addition. This is the only site that gets a `Bool`.

### Testing

`tests/storage/test_memory.py::TestMemory::test_fast_memory_condition`, beside the
existing `test_fast_memory`: a false condition leaves the register alone, a true
one stores, a conditional load reads it back, and a symbolic condition still
raises `SimMemoryError`. It fails on master with the `AttributeError` above and
passes here.

Validation: https://github.com/angr/angr/pull/7096#issuecomment-5555136299

session: sharpen
