### PR TITLE
Clinic.proto: Make _new_block_addrs repeated uint64.

### DIFF
--- a/angr/protos/clinic.proto
+++ b/angr/protos/clinic.proto
@@ -87,7 +87,7 @@ message Clinic {
     map<int32, StackItem> stack_items = 21;           // dict[int, StackItem]
     repeated AddressPair edges_to_remove = 22;
     repeated uint32 copied_var_ids = 23;
-    repeated uint32 _new_block_addrs = 24;
+    repeated uint64 _new_block_addrs = 24;
     optional AddressTuple entry_node_addr = 25;
 
     // ---- CLEAN scalars ----------------------------------------------------------------------------------------------

--- a/tests/serialization/test_decompilation_cache_serialization.py
+++ b/tests/serialization/test_decompilation_cache_serialization.py
@@ -520,5 +520,51 @@ class TestSpillingDecompilationDict(unittest.TestCase):
             manager.cached = old_cached
 
 
+class TestClinicSerializationAboveFourGigabytes(unittest.TestCase):
+    """Clinic._new_block_addrs holds real code addresses, which do not fit in 32 bits on a
+    64-bit PE at its usual image base."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.proj = angr.Project(
+            os.path.join(test_location, "x86_64", "decompiler", "vcruntime_test.exe"), auto_load_libs=False
+        )
+        cls.cfg = cls.proj.analyses.CFGFast(normalize=True)
+        # a tail jump to a known function makes Clinic mint a new block address for this one
+        cls.func = cls.proj.kb.functions[0x140001068]
+        dec = cls.proj.analyses.Decompiler(cls.func, cfg=cls.cfg.model, generate_code=True)
+        assert dec.clinic is not None and dec.cache is not None and dec.cache.codegen is not None
+        cls.clinic = dec.clinic
+        cls.cache = dec.cache
+        cls.text = dec.cache.codegen.text
+
+    def test_new_block_addrs_do_not_fit_in_32_bits(self):
+        assert self.proj.loader.main_object.mapped_base == 0x140000000
+        addrs = self.clinic._new_block_addrs
+        assert addrs
+        assert all(addr > 0xFFFFFFFF for addr in addrs)
+
+    def test_clinic_roundtrip_preserves_new_block_addrs(self):
+        back = type(self.clinic).parse(
+            self.clinic.serialize(),
+            project=self.proj,
+            kb=self.proj.kb,
+            function=self.clinic.function,
+            cfg=self.clinic._cfg,
+        )
+        assert back._new_block_addrs == self.clinic._new_block_addrs
+
+    def test_eviction_spills_instead_of_parking_in_memory(self):
+        d = SpillingDecompilationDict(self.proj.kb, cache_limit=0)
+        key = (self.func.addr, "pseudocode")
+        d[key] = self.cache
+
+        assert key in d._spilled
+        assert not d._unspillable
+        back = d[key]
+        assert back.codegen is not None
+        assert back.codegen.text == self.text
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling `0x140001068` in `binaries/tests/x86_64/decompiler/vcruntime_test.exe`, a 64-bit PE at the usual `0x140000000` image base, produces correct C and then a decompilation cache that cannot be serialized:

```
  File "angr/knowledge_plugins/structured_code.py", line 127, in _evict_lru
    blob = cache.serialize()
  File "angr/analyses/decompiler/clinic.py", line 4866, in serialize_to_cmessage
    msg._new_block_addrs.extend(sorted(self._new_block_addrs))
ValueError: Value out of range: 5368715428
```

`5368715428` is `0x1400018a4`, the block address `Clinic` minted for that function. 11 of 40 functions sampled evenly across that binary hit this, and every caller swallows the exception, so nothing reaches the user as an error:

- `SpillingDecompilationDict._evict_lru` logs one warning per knowledge base and parks the cache in `_unspillable`, an unbounded dict. The LRU limit that is supposed to bound decompilation memory does not apply to those entries.
- `SpillingDecompilationDict.export_serialized` catches it with no log at all, so `StructuredCodeManagerSerializer.dump` falls back to `_dump_legacy`: saving an angr database keeps only comments, constant formats and errors for that function and drops the clinic, both AIL graphs, the C AST and the notes.
- `pickle.dumps(project)` raises `TypeError: cannot pickle 'weakref.ReferenceType' object`, because the parked live cache is what `SpillingDecompilationDict.__getstate__` hands to pickle.

### Root cause

`angr/protos/clinic.proto` declares the field 32 bits wide:

```proto
repeated uint32 _new_block_addrs = 24;
```

but the set holds addresses in the binary's own address space. `Clinic.new_block_addr()` returns `max(self._new_block_addrs) + 1`, or `max(self.function.block_addrs_set) + 2048` for the first one, and its only two callers are in `Clinic._replace_tail_jumps_with_calls`. Above a 4 GB image base that value does not fit `uint32`.

Every other address-typed field in the same message is already 64 bits: `function_addr` and `_inlining_parents` are `uint64`, `_inlined_counts`'s key is `uint64`, `AddressTuple.addr` is `int64`. This is the one site that did not get the rule.

### Fix

The field becomes `repeated uint64`.

Both types are varints, so a blob written by the old schema parses unchanged under the new one and values below `2**32` still encode byte-identically -- an existing LMDB spill store or `.adb` keeps working. The reverse does not hold: a blob written under the new schema and read back by an older angr truncates the field silently.

With the fix, the same function serializes to 4758 bytes, the cache spills instead of being parked, and the project pickles.

Deliberately not done: the silent `except Exception` in `SpillingDecompilationDict.export_serialized`, which is what makes the database downgrade invisible, and the address fields declared `int64` elsewhere -- `AddressTuple.addr`, `callee_target_int`, `ident_ins_addr`, the comment map keys and others -- which a text address above `2**63` would overflow. Neither is observed here and both are their own change.

### Testing

Three tests in `tests/serialization/test_decompilation_cache_serialization.py` decompile that function: one asserts the minted addresses do not fit in 32 bits, one round-trips the clinic and compares `_new_block_addrs`, one evicts through `SpillingDecompilationDict` and asserts the entry is spilled rather than parked in `_unspillable`. Both of the last two fail on master -- the round-trip raises that `ValueError`, the eviction one fails its assertion with the same `ValueError` in the captured log, because eviction catches it.

The failure was found by a corpus decompilation sweep, whose logs hold over a thousand of these tracebacks, every one at that single line.

Validation: https://github.com/angr/angr/pull/7097#issuecomment-5555139073

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen