### PR TITLE
Keep the knowledge base name across a pickle round trip

### DIFF
--- a/angr/knowledge_base.py
+++ b/angr/knowledge_base.py
@@ -73,18 +73,11 @@ class KnowledgeBase:
         return self.indirect_jumps.resolved
 
     def __setstate__(self, state):
-        object.__setattr__(self, "_project", state["project"])
-        object.__setattr__(self, "_plugins", state["plugins"])
+        self.__dict__.update(state)
 
         # iterate over a copy: set_kb() may lazily create plugins (e.g., rtdb) and mutate self._plugins
         for plugin in list(self._plugins.values()):
             plugin.set_kb(self)
-
-    def __getstate__(self):
-        return {
-            "project": self._project,
-            "plugins": self._plugins,
-        }
 
     def __dir__(self):
         x = list(super().__dir__())

--- a/tests/serialization/test_pickle.py
+++ b/tests/serialization/test_pickle.py
@@ -12,7 +12,9 @@ import tempfile
 import unittest
 
 import angr
+from angr.angrdb import AngrDB
 from angr.claripy import BVS
+from angr.knowledge_base import KnowledgeBase
 from angr.knowledge_plugins.cfg.spilling_cfg import SpillingCFG
 from angr.knowledge_plugins.cfg.spilling_digraph import SpillingDiGraph
 from angr.knowledge_plugins.functions.function_manager import SpillingFunctionDict
@@ -253,6 +255,31 @@ class TestPickle(unittest.TestCase):
 
         p1 = pickle.loads(pickle.dumps(p, -1))
         assert p1.get_kb("other").functions["asdf"].addr == func_main.addr
+
+    def test_knowledge_base_name_survives_pickling(self):
+        # Regression test: KnowledgeBase.__getstate__ listed _project and _plugins but not name,
+        # the third and last attribute __init__ sets. Reading kb.name on a restored project fell
+        # through __getattr__ into the plugin lookup and raised AttributeError, so AngrDB.dump()
+        # on a restored project failed with AngrDBError while the same dump on the live project
+        # wrote a database.
+        p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        p.analyses.CFGFast()
+        assert p.kb.name == "global"
+
+        p1 = pickle.loads(pickle.dumps(p, -1))
+
+        # the consequence: AngrDB stores knowledge bases under kb.name, so dumping a restored
+        # project used to fail outright
+        db_file = os.path.join(self.tmpdir, "restored.adb")
+        AngrDB(p1, nullpool=True).dump(db_file)
+        p2 = AngrDB(nullpool=True).load(db_file)
+        assert set(p2.kb.functions) == set(p1.kb.functions)
+
+        assert p1.kb.name == "global"
+
+        # a knowledge base that is not the project default keeps its own name too
+        other = KnowledgeBase(p, name="other")
+        assert pickle.loads(pickle.dumps(other, -1)).name == "other"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A `KnowledgeBase` does not survive pickling with its name. On `binaries/tests/x86_64/fauxware` after `CFGFast()`, at master `87411a719c96ddc3f3954590b1833b1789e19697`:

```
live kb.name: global
restored kb.name -> AttributeError: name
```

`AngrDB` stores each knowledge base under `kb.name`, so a restored project cannot be written to a database at all:

```
live      AngrDB.dump ok 102400
restored  AngrDB.dump FAILED: angr.errors.AngrDBError
```

### Root cause

`KnowledgeBase.__init__` sets three attributes with `object.__setattr__` — `_project`, `_plugins` and `name` — and `__getstate__` hand-listed the first two. `name` is the whole of what the `KnowledgeBase` object itself loses: diffing its attributes across the round trip, it goes from `['_plugins', '_project', 'name']` to `['_plugins', '_project']`.

The failure does not look like a missing attribute because `__setattr__` is overridden to register a plugin and `__getattr__` falls back to the plugin table, so reading `kb.name` raises `KeyError: 'name'` inside `default_plugins[name]`, re-raised as `AttributeError: name`.

### Fix

Drop `__getstate__` — the default already returns `self.__dict__` — and let `__setstate__` apply the state with `self.__dict__.update`, which is what `Project.__setstate__` in the sibling module already does. No attribute added to `__init__` later can go stale the same way.

### Testing

`tests/serialization/test_pickle.py::TestPickle::test_knowledge_base_name_survives_pickling` loads the tracked `x86_64/fauxware` fixture, runs `CFGFast`, pickles the project, and asserts the `AngrDB` dump/load round trip on the *restored* project before checking the names. It fails on master with `AngrDBError` and passes with this change. [Validation record](https://github.com/angr/angr/pull/7098#issuecomment-5556012724).

session: sharpen