### PR TITLE
FunctionManager: keep the key-function index when a function's info is replaced

### DIFF
--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -473,6 +473,8 @@ class Function(Serializable):
         self._info = info
         # update the owner
         self._info._func = self
+        if self._function_manager is not None:
+            self._function_manager.index_key_func_addrs(self)
 
     @property
     def is_plt(self) -> bool:

--- a/angr/knowledge_plugins/functions/function_manager.py
+++ b/angr/knowledge_plugins/functions/function_manager.py
@@ -1264,9 +1264,7 @@ class FunctionManager[K: (int, SootMethodDescriptor)](KnowledgeBasePlugin, colle
         self._func_from_signature[func.addr] = func.from_signature
 
         # update key function address cache
-        for key, value in func.info.items():
-            if key.startswith("is_") and value is True:
-                self.add_key_func_addr(key[3:], func.addr)
+        self.index_key_func_addrs(func)
 
         # make sure all functions exist in the call graph
         self.callgraph.add_node(func.addr)
@@ -1596,6 +1594,14 @@ class FunctionManager[K: (int, SootMethodDescriptor)](KnowledgeBasePlugin, colle
 
     def add_key_func_addr(self, func_type: str, addr: K) -> None:
         self._key_func_addrs[func_type].add(addr)
+
+    def index_key_func_addrs(self, func: Function) -> None:
+        """
+        Record every key-function flag that ``func.info`` carries in the key-function address cache.
+        """
+        for key, value in func.info.items():
+            if key.startswith("is_") and value is True:
+                self.add_key_func_addr(key[3:], func.addr)
 
     #
     # LRU Cache Management (delegates to SpillingFunctionDict when available)

--- a/tests/analyses/cfg/test_cfg_pe_msvc_eh.py
+++ b/tests/analyses/cfg/test_cfg_pe_msvc_eh.py
@@ -55,6 +55,7 @@ class TestCFGFastPEMsvcEH(unittest.TestCase):
         self._test_seh_prolog4_identified()
         self._test_seh_prolog4_gs_identified()
         self._test_identified_functions_are_mutually_exclusive()
+        self._test_key_func_addrs_survive_function_reconstruction()
         self._test_funcinfo_memory_data_created()
         self._test_funcinfo_memory_data_size()
         self._test_specific_funcinfo_exists()
@@ -144,6 +145,20 @@ class TestCFGFastPEMsvcEH(unittest.TestCase):
                     assert func.info.get(label) is True, f"Function at {addr:#x} should have {label}"
                 else:
                     assert not func.info.get(label), f"Function at {addr:#x} should NOT have {label}"
+
+    def _test_key_func_addrs_survive_function_reconstruction(self):
+        """Every identified function should still be in the key-function index once CFGFast is done."""
+        known = {
+            0x50B21222: "CxxFrameHandler3",
+            0x50B215BB: "EH_prolog3",
+            0x50B215F3: "EH_prolog3_catch",
+            0x50B2162E: "EH_prolog3_GS",
+            0x50B20E9C: "SEH_prolog4",
+            0x50B22E8C: "SEH_prolog4_GS",
+        }
+        for addr, func_type in known.items():
+            addrs = self.functions.get_key_func_addrs(func_type)
+            assert addr in addrs, f"{func_type} at {addr:#x} is missing from the key-function index"
 
     #
     # FuncInfo MemoryData items


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` identifies key functions as it goes -- the MSVC EH prologue helpers,
`___CxxFrameHandler3`, `__alloca_probe`, `__rust_probestack`, the Go runtime functions
that never return -- and records each one in `FunctionManager`'s key-function index.
`make_functions` then throws that index away. On
`binaries/tests/i386/windows/fd32071ceb9ef9bb2cde570c57cd6bf34b10920a6894e0b7a176e3f64d1fc95d`
nothing puts any of it back, so the analysis returns with an empty index:

```
add_key_func_addr_calls       SEH_prolog4 1, SEH_prolog4_GS 1, EH_prolog3 1, CxxFrameHandler3 132,
                              EH_prolog3_catch 1, EH_prolog3_GS 2  -- 138 calls
index_before_make_functions   SEH_prolog4 1, SEH_prolog4_GS 1, EH_prolog3 1, CxxFrameHandler3 1,
                              EH_prolog3_catch 1, EH_prolog3_GS 2
index_after_make_functions    {}
index_when_cfgfast_returns    {}
```

The seven functions are still there and still carry their `is_*` flags; only the index is
gone.

`CFGFast._apply_go_noreturn_funcs` runs after the rebuild and refills the index from its
own dict of Go verdicts, which is why a Go binary ends with a partly populated one. Its
second pass is also meant to pick up the jump thunks
`_propagate_key_func_info_to_jump_thunks` marked, and for those it reads the index while
it is still empty, so it never does. Six functions in
`binaries/tests/i386/langdetect_go` and one in `binaries/tests/x86_64/langdetect_go`
report `returning is True` where angr's own Go analysis had concluded they never return.

### Root cause

`CFGBase.make_functions` replaces `kb.functions` with a fresh `FunctionManager` and copies
each function's metadata onto the new objects (`cfg_base.py:1796` and `cfg_base.py:2379`,
`func.info = kf_meta.info.copy(func)`). The key-function index is a cache derived from
`func.info`: `FunctionManager._function_added` walks the `is_<type>` flags and calls
`add_key_func_addr` for each. In `make_functions` the function is created first and its
`info` assigned afterwards, and `Function.info`'s setter -- unlike the setters for `name`,
`from_signature` and `returning` -- never calls back into the manager. So the derivation
runs exactly once per function, against an empty `info`, and never again.

### Fix

The `info` setter now tells the manager, the way those three setters already do, and the
derivation `_function_added` was running inline moves into
`FunctionManager.index_key_func_addrs` so the two of them share it. `make_functions` is
unchanged: it assigns `info`, and the assignment carries the index with it.

Three things this deliberately leaves alone. `func.info["jmp_rax"]` is the one
key-function flag not spelled `is_<type>`, so no derivation can reach it; nothing reads
`get_key_func_addrs("jmp_rax")` and `clinic.py` reads `func.info` directly, so renaming
the key would be a change with no behaviour attached. The index still has no removal path,
so reassigning `info` with a flag dropped leaves the old entry behind, exactly as
`_function_added` already does. And `FunctionManager.__setstate__` reinitialises every
cache except this one, so on a manager restored from a pickle `get_key_func_addrs` already
raises `AttributeError` and assigning `info` there now raises it too. The last two belong
with the cache work in #6936, which rewrites `__setstate__` and adds the removal path;
restoring the cache in `__setstate__` here conflicts with it.

### Testing

`tests/analyses/cfg/test_cfg_pe_msvc_eh.py` gains
`_test_key_func_addrs_survive_function_reconstruction`, which asserts that the six
functions the suite already identifies by their `info` flags are also in the key-function
index once `CFGFast` has finished. That suite builds this CFG once and dispatches to
helpers, so the test costs no extra analysis. On master it fails with
`AssertionError: CxxFrameHandler3 at 0x50b21222 is missing from the key-function index`.

Function counts and CFG node and edge counts are identical with and without the change on
all three binaries above; what moves is `nonreturning_func_addrs()`, by 6 on
`tests/i386/langdetect_go` and 1 on `tests/x86_64/langdetect_go`.

Validation: https://github.com/angr/angr/pull/7099#issuecomment-5556137510

session: sharpen