### PR TITLE
CFGFast: do not treat an ARM PIC literal-pool displacement as a code pointer

### DIFF
--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -3962,6 +3962,66 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             if ref.data_size == self.project.arch.bytes and is_arm_arch(self.project.arch):
                 self._process_irsb_data_ref_inlined_data(irsb_addr, ref)
 
+    def _arm_find_literal_pc_addition(self, ldr_addr: int, thumb: bool) -> int | None:
+        """
+        Position-independent ARM code loads a displacement from a literal pool and then adds pc to
+        it, so the word in the pool is not an address at all:
+
+            ldr r3, [pc, #0x328]
+            add r3, pc, r3
+
+        Disassemble forward from the load at ``ldr_addr`` and return the address of the instruction
+        that adds pc to the loaded register, or None if there is none. The scan stops at the first
+        control-flow instruction, at the first other write to the loaded register, and after 16
+        instructions.
+
+        :param ldr_addr:    Address of the pc-relative load, with the THUMB bit already cleared.
+        :param thumb:       True if the block is a THUMB block.
+        """
+
+        max_insns = 16
+        md = self.project.arch.capstone_thumb if thumb else self.project.arch.capstone  # type: ignore
+        data = self._fast_memory_load_bytes(ldr_addr, 4 * max_insns)
+        if not data:
+            return None
+        insns = list(md.disasm(bytes(data), ldr_addr, count=max_insns))
+        if not insns:
+            return None
+
+        ldr = insns[0]
+        if ldr.address != ldr_addr or ldr.id != capstone.arm.ARM_INS_LDR or len(ldr.operands) != 2:
+            return None
+        op0, op1 = ldr.operands
+        if (
+            op0.type != capstone.arm.ARM_OP_REG
+            or op1.type != capstone.arm.ARM_OP_MEM
+            or op1.mem.base != capstone.arm.ARM_REG_PC
+        ):
+            return None
+        reg_dst = op0.value.reg
+
+        for insn in insns[1:]:
+            regs_write = insn.regs_access()[1]
+            if insn.id == capstone.arm.ARM_INS_ADD:
+                ops = insn.operands
+                # add rD, pc, rD, and the two-operand THUMB form add rD, pc
+                if (
+                    len(ops) in (2, 3)
+                    and all(op.type == capstone.arm.ARM_OP_REG for op in ops)
+                    and ops[0].value.reg == reg_dst
+                    and capstone.arm.ARM_REG_PC in {op.value.reg for op in ops[1:]}
+                    and (len(ops) == 2 or reg_dst in {op.value.reg for op in ops[1:]})
+                ):
+                    return insn.address
+            if (
+                reg_dst in regs_write
+                or capstone.arm.ARM_REG_PC in regs_write
+                or insn.group(capstone.arm.ARM_GRP_JUMP)
+                or insn.group(capstone.arm.ARM_GRP_CALL)
+            ):
+                return None
+        return None
+
     def _process_irsb_data_ref_inlined_data(self, irsb_addr: int, ref):
         # ARM (and maybe a few other architectures as well) has inline pointers
         sec = self.project.loader.find_section_containing(ref.data_addr)
@@ -3971,40 +4031,48 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             if v is None:
                 return
 
+            thumb = (irsb_addr & 1) == 1
+            pc_add_addr = None
+
             # this value can either be a pointer or an offset from the pc... we need to try them both
             # attempt 1: a direct pointer
             sec_2nd = self.project.loader.find_section_containing(v)
             if sec_2nd is not None and sec_2nd.is_readable:
-                # found it!
-                self._add_data_reference(
-                    irsb_addr,
-                    ref.stmt_idx,
-                    ref.ins_addr,
-                    v,
-                    data_size=None,
-                    data_type=MemoryDataSort.Unknown,
-                )
+                # landing inside a readable section does not make it a pointer: a displacement that
+                # is about to have pc added to it lands wherever the linker happened to put things
+                pc_add_addr = self._arm_find_literal_pc_addition(ref.ins_addr & ~1 if thumb else ref.ins_addr, thumb)
 
-                if (
-                    sec_2nd.is_executable
-                    and not self._seg_list.is_occupied(v)
-                    and v % self.project.arch.instruction_alignment == 0
-                ):
-                    if is_arm_arch(self.project.arch) and not self._arch_options.has_arm_code and v % 2 != 1:
-                        # no ARM code in this binary!
-                        return
-
-                    # create a new CFG job
-                    ce = CFGJob(
+                if pc_add_addr is None:
+                    # found it!
+                    self._add_data_reference(
+                        irsb_addr,
+                        ref.stmt_idx,
+                        ref.ins_addr,
                         v,
-                        v,
-                        "Ijk_Boring",
-                        job_type=CFGJobType.DATAREF_HINTS,
+                        data_size=None,
+                        data_type=MemoryDataSort.Unknown,
                     )
-                    self._pending_jobs.add_job(ce)
-                    self._register_analysis_job(v, ce)
 
-                return
+                    if (
+                        sec_2nd.is_executable
+                        and not self._seg_list.is_occupied(v)
+                        and v % self.project.arch.instruction_alignment == 0
+                    ):
+                        if is_arm_arch(self.project.arch) and not self._arch_options.has_arm_code and v % 2 != 1:
+                            # no ARM code in this binary!
+                            return
+
+                        # create a new CFG job
+                        ce = CFGJob(
+                            v,
+                            v,
+                            "Ijk_Boring",
+                            job_type=CFGJobType.DATAREF_HINTS,
+                        )
+                        self._pending_jobs.add_job(ce)
+                        self._register_analysis_job(v, ce)
+
+                    return
 
             # attempt 2: pc + offset
             #   ldr r3, [pc, #0x328]
@@ -4019,7 +4087,15 @@ class CFGFast(ForwardAnalysis[CFGNode, CFGNode, CFGJob, int, object], CFGBase): 
             # - For all other instructions that use labels, the value of the PC is the address of the current
             #   instruction plus 4 bytes, with bit[1] of the result cleared to 0 to make it word-aligned.
             #
-            if (irsb_addr & 1) == 1:
+            # That last rule is about instructions that take a label -- ADR and LDR (literal). The pc that
+            # `add rD, pc` adds is a plain read of R[15], which is the address of the add plus 4 in THUMB and
+            # plus 8 in ARM, with no alignment. A THUMB `add` at a 2-mod-4 address would land two bytes low if
+            # bit[1] were cleared here.
+            if pc_add_addr is not None:
+                actual_ref_ins_addr = pc_add_addr
+                v += pc_add_addr + (4 if thumb else 8)
+                v &= 0xFFFF_FFFF
+            elif thumb:
                 actual_ref_ins_addr = ref.ins_addr + 2
                 v += 4 + actual_ref_ins_addr
                 v &= 0xFFFF_FFFF_FFFF_FFFE

--- a/tests/analyses/cfg/test_cfgfast.py
+++ b/tests/analyses/cfg/test_cfgfast.py
@@ -112,18 +112,28 @@ class TestCfgfast(unittest.TestCase):
 
         self.cfg_fast_functions_check("x86_64", "cfg_0_pe", functions, function_features)
 
-    def test_arm_function_merge(self):
-        # function 0x7bb88 is created due to a data hint in another block. this function should be merged with the
-        # previous function 0x7ba84
+    def test_arm_pic_literal_is_not_a_code_pointer(self):
+        # 0x83824 loads the literal at 0x8392c, which is 0x7bb88, and 0x83828 adds pc to it: the
+        # word is a displacement to .got, not a pointer to 0x7bb88. 0x7bb88 is a bl in the middle
+        # of the function at 0x7ba84, and treating the literal as a pointer used to start a block
+        # there and split that function's basic block in two.
+        #
+        # This replaces test_arm_function_merge, which asserted that the block at 0x7bb88 exists and
+        # belongs to 0x7ba84 -- the merge that CFGBase._process_irrational_function_starts performs
+        # after the split. That was the regression test for #4226. There is nothing left to merge
+        # once the split does not happen: reverting the predicate #4226 widened to
+        # `1 <= len(func_0.block_addrs_set) <= 4` leaves the CFG here byte-identical.
 
         path = os.path.join(test_location, "armel", "tenda-httpd")
         proj = angr.Project(path, auto_load_libs=False)
 
         cfg = proj.analyses.CFGFast()
 
-        node_7bb88 = cfg.model.get_any_node(0x7BB88)
-        assert node_7bb88 is not None
-        assert node_7bb88.function_address == 0x7BA84
+        assert cfg.model.get_any_node(0x7BB88) is None
+        node = cfg.model.get_any_node(0x7BB88, anyaddr=True)
+        assert node is not None
+        assert node.addr == 0x7BB78
+        assert node.function_address == 0x7BA84
 
     @broken
     def test_busybox(self):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

On ARM, `CFGFast` reads a word out of a literal pool, takes it for a pointer, and starts decoding code there. In position-independent code that word is usually a displacement of `_GLOBAL_OFFSET_TABLE_`, not an address at all.

`binaries/tests/armhf/test_division` shows it in one small object. `call_weak_fn` loads the pool word at `0x10444`, which is `0x000105fc`, and the next instruction adds pc to it:

```
0x10428  ldr r3, [pc, #0x14]     ; literal at 0x10444 = 0x000105fc
0x10430  add r3, pc, r3          ; pc = 0x10438  ->  r3 = 0x20a34
```

`_GLOBAL_OFFSET_TABLE_` is at `0x20a34`, so the word is a displacement. `.text` runs `0x103f8`-`0x108a8`, so the raw displacement lands inside it by arithmetic coincidence, and angr starts a function at `0x105fc`.

`0x105fc` is real code, but it is **THUMB** code: the mapping symbols are `$t` at `0x105a8` and then `$t` at `0x10858`, with `__divsi3` at `0x105a9` size 660 and no `$d` between them. angr starts an ARM-mode job there, so 516 bytes of `__divsi3`'s divide loop are decoded in the wrong instruction set: 97 spurious blocks under a `sub_105fc` that does not exist, and enough of the garbage decodes as `svc` that a 98th node appears at `0x4005f0`, a syscall stub in cle's kernel region reached from 63 of them. The real THUMB block covering `0x105ec` is truncated to 16 bytes.

The blast radius is any PIC ARM object: of the 161 ARM ELF objects tracked in `angr/binaries`, this change moves the CFG of seven.

### Root cause

`CFGFast._process_irsb_data_ref_inlined_data` tries two readings. The comment on the second describes exactly the idiom above -- but "attempt 1: a direct pointer" is tried first, succeeds whenever the raw value lands in a readable section, and `return`s, so attempt 2 is never reached for these words:

```python
# this value can either be a pointer or an offset from the pc... we need to try them both
# attempt 1: a direct pointer
sec_2nd = self.project.loader.find_section_containing(v)
if sec_2nd is not None and sec_2nd.is_readable:
    # found it!
```

Landing in a readable section is not evidence: a displacement lands wherever the linker happened to put things. Before returning, if the value is also in an executable section, instruction-aligned and not already occupied, a `DATAREF_HINTS` job is queued that starts a function there.

That last condition is a race, so whether a given misread becomes a function is intermittent: `binaries/tests/armel/tenda-httpd` gives 3024 or 3025 functions on the same bytes here, and 3026 as well in #7088, depending on nothing in the input. The misread itself is not intermittent.

### Fix

Ask the instruction stream whether pc is added to the loaded word. If it is, the word is a displacement whatever it points at, and attempt 1 must not run.

`_arm_find_literal_pc_addition` disassembles forward from the pc-relative `ldr`, takes the destination register, and returns the address of the `add rD, pc, rD` -- or the two-operand THUMB `add rD, pc` -- that consumes it. It gives up at the first control-flow instruction, at any other write to that register, at a write to pc, or after 16 instructions. It is asked only when attempt 1 is about to succeed, so it costs nothing on the paths that already fall through: on `tenda-httpd` it is called 1008 times against 15299 calls to the method around it.

When it fires, attempt 1 is skipped entirely -- both the data reference to the raw word and the function-start job -- and attempt 2 runs using that `add`'s own pc rather than a guess based on the load's address. When it does not fire, every existing path is unchanged.

The scan looks forward rather than only at the next instruction because the `add` is often not adjacent: on `binaries/tests/armhf/kepler_server` a window of 4 finds 198 of the 370 matches a window of 16 finds, and 24 finds one more. Every match on `tenda-httpd` resolves into `.got`.

Deliberately not done: the same wrong pc is used by attempt 2 on the paths where the discriminator is never asked. That is a separate defect and is left alone here.

### Testing

`test_arm_pic_literal_is_not_a_code_pointer` replaces `test_arm_function_merge`, which came in with #4226 and asserted a node at `0x7bb88` in `tenda-httpd` that this defect creates: the pool word at `0x8392c` is `0x7bb88`, `0x83828` adds pc to it, and `0x7bb88 + 0x83830` is `0xff3b8`, the first word of `.got`. `0x7bb88` is a `bl` in the middle of the function at `0x7ba84`. The new test asserts no node starts there and that the covering node belongs to `0x7ba84`; it fails on master and passes here.

That coverage cannot be kept: reverting the predicate #4226 widened now leaves both this binary's CFG and `tests/analyses/cfg` identical. The new test's comment records it.

A/B over every ARM ELF tracked in `angr/binaries` -- 161 objects, three runs per arm -- changes 7 of them, and **no object loses a symbol-backed function**: `STT_FUNC` coverage is identical in both arms, and `.ARM.exidx` coverage goes up by three. All seven differences are accounted for individually in the validation record.

Fixes #7088. Validation: https://github.com/angr/angr/pull/7100#issuecomment-5556332889.

session: sharpen
