### PR TITLE
Give a named knowledge base the name it was asked for

### DIFF
--- a/angr/project.py
+++ b/angr/project.py
@@ -305,7 +305,7 @@ class Project:
         try:
             return self._knowledge_bases[name]
         except KeyError:
-            kb = KnowledgeBase(self, name)
+            kb = KnowledgeBase(self, name=name)
             self._knowledge_bases[name] = kb
             return kb
 

--- a/tests/serialization/test_db.py
+++ b/tests/serialization/test_db.py
@@ -958,6 +958,30 @@ class TestDb(unittest.TestCase):
             assert o1.min_addr == o2.min_addr
             assert o1.max_addr == o2.max_addr
 
+    def test_angrdb_non_default_kb_roundtrip(self):
+        # Regression test: Project.get_kb() passed the name into KnowledgeBase.__init__'s
+        # deprecated `obj` parameter, so the knowledge base was named kb_<n> instead. AngrDB
+        # stores each knowledge base under kb.name, so a non-default knowledge base went into
+        # the database under the generated name and AngrDB.load() returned nothing for the
+        # name it was asked for, losing the whole knowledge base without an error.
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        other = proj.get_kb("other")
+
+        proj.analyses.CFGFast()
+        proj.analyses.CFGFast(kb=other)
+        assert len(other.functions) > 0
+
+        with tempfile.TemporaryDirectory() as td:
+            db_file = os.path.join(td, "two-kbs.adb")
+            AngrDB(proj, nullpool=True).dump(db_file, kbs=[proj.kb, other])
+
+            restored_kbs = {}
+            AngrDB(nullpool=True).load(db_file, kb_names=["global", "other"], other_kbs=restored_kbs)
+
+        assert set(restored_kbs) == {"other"}
+        assert set(restored_kbs["other"].functions) == set(other.functions)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A knowledge base created by `Project.get_kb()` does not get the name it was asked for, and an `AngrDB` round trip then loses it without raising. On `binaries/tests/x86_64/fauxware` at master `87411a719c96ddc3f3954590b1833b1789e19697`:

```
The obj parameter in KnowledgeBase.__init__() has been deprecated.
get_kb('mykb').name       = 'kb_0'
functions in mykb         = 40
kb names stored in the db = ['global', 'kb_0']
other_kbs after load      = []
```

The second knowledge base and its 40 functions are gone. Nothing raised.

### Root cause

`Project.get_kb()` calls `KnowledgeBase(self, name)`, and the signature is `__init__(self, project, obj=None, name=None)`, so the name lands in the deprecated `obj` parameter and the knowledge base takes the generated `kb_<n>` name instead. That is also why every `get_kb()` call logs the `obj` deprecation warning. `AngrDB` stores each knowledge base under `kb.name`, so `AngrDB.load(kb_names=[...])` looks for a name the database does not contain and returns without that knowledge base.

The slip dates from `ced9ec67d` (#5008), the change that added `get_kb()` in order to support several named knowledge bases. `Project.__init__` passes `name="global"` for the default one and is unaffected.

### Fix

Pass the name as a keyword. Nothing depended on the generated name: at the base revision `git grep 'get_kb('` over `angr/` and `tests/` returns the definition and two call sites, both in `tests/serialization/test_pickle.py`, and both key on the `Project._knowledge_bases` dict rather than on `kb.name`.

### Testing

`tests/serialization/test_db.py::TestDb::test_angrdb_non_default_kb_roundtrip` loads the tracked `x86_64/fauxware` fixture, builds a second knowledge base with `get_kb("other")`, runs `CFGFast` into both, dumps both, and loads them back by name. It fails on master with `assert set() == {'other'}` and passes with this change. [Validation record](https://github.com/angr/angr/pull/7101#issuecomment-5556354416).

session: sharpen