### PR TITLE
Pcode: take the high half of a wide unique on big-endian targets

### DIFF
--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -323,9 +323,7 @@ class PCodeIRSBConverter(Converter):
                 # little-endian machine the high half sits at the higher address, on a big-endian one at
                 # the lower. Computing this the big-endian way on a little-endian target silently
                 # returns the low half for both halves of a widening multiply.
-                arch = self._manager.arch
-                assert arch is not None
-                if arch.memory_endness == archinfo.Endness.LE:
+                if self._irsb.arch.memory_endness == archinfo.Endness.LE:
                     right_shift_amount = varnode.offset - unique_offset
                 else:
                     right_shift_amount = (unique_offset + ori_tmp_size) - (varnode.offset + varnode.size)

--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import archinfo
 import pypcode
 from pypcode import OpCode, PcodeOp, Varnode
 
@@ -314,10 +315,20 @@ class PCodeIRSBConverter(Converter):
                         break
                 assert unique_offset is not None, "Cannot find the source unique variable"
                 # TODO: Check size
-                _, ori_tmp_size = self._unique_tracker[unique_offset]
-                t = Tmp(self._manager.next_atom(), unique_offset, ori_tmp_size * 8)
-                # FIXME: Asserting BE
-                right_shift_amount = varnode.offset + varnode.size - (unique_offset + ori_tmp_size)
+                ori_tmp_idx, ori_tmp_size = self._unique_tracker[unique_offset]
+                # Index the parent by its remapped index, not by its unique-space address: the defining
+                # write went through _remap_temp, so a Tmp built from the raw offset names nothing.
+                t = Tmp(self._manager.next_atom(), ori_tmp_idx, ori_tmp_size * 8)
+                # Which end of the parent the sub-range names depends on the byte order: on a
+                # little-endian machine the high half sits at the higher address, on a big-endian one at
+                # the lower. Computing this the big-endian way on a little-endian target silently
+                # returns the low half for both halves of a widening multiply.
+                arch = self._manager.arch
+                assert arch is not None
+                if arch.memory_endness == archinfo.Endness.LE:
+                    right_shift_amount = varnode.offset - unique_offset
+                else:
+                    right_shift_amount = (unique_offset + ori_tmp_size) - (varnode.offset + varnode.size)
                 if right_shift_amount != 0:
                     t = BinaryOp(
                         self._manager.next_atom(),

--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -277,7 +277,7 @@ class PCodeIRSBConverter(Converter):
             self._unique_tracker[offset] = self._unique_counter, size
             self._unique_counter += 1
             return self._unique_tracker[offset][0]
-        if offset in self._unique_tracker:
+        if offset in self._unique_tracker and self._unique_tracker[offset][1] == size:
             return self._unique_tracker[offset][0]
         # this might be a partial access of an existing temporary variable. return None for now
         return None
@@ -309,7 +309,7 @@ class PCodeIRSBConverter(Converter):
             if offset is None:
                 # this might be a partial access of an existing temporary variable
                 unique_offset = None
-                for delta in range(-1, -8, -1):
+                for delta in range(0, -8, -1):
                     if varnode.offset + delta in self._unique_tracker:
                         unique_offset = varnode.offset + delta
                         break

--- a/tests/ailment/test_converter_pcode.py
+++ b/tests/ailment/test_converter_pcode.py
@@ -50,7 +50,7 @@ class TestPcodeConverter(unittest.TestCase):
         arch = archinfo.ArchPcode("SuperH4:LE:32:default")
         project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
 
-        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager(arch=arch))
+        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager())
 
         defined, used = _tmp_indices(block)
         assert used, "the block should read at least one tmp"
@@ -66,7 +66,7 @@ class TestPcodeConverter(unittest.TestCase):
         arch = archinfo.ArchPcode("SuperH4:LE:32:default")
         project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
 
-        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager(arch=arch))
+        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager())
 
         halves = [str(stmt.src) for stmt in block.statements if isinstance(stmt, Assignment)]
         shifted = [h for h in halves if "Shr" in h]

--- a/tests/ailment/test_converter_pcode.py
+++ b/tests/ailment/test_converter_pcode.py
@@ -1,0 +1,77 @@
+# pylint: disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.ailment"  # pylint:disable=redefined-builtin
+
+import unittest
+
+import archinfo
+
+import angr
+from angr import ailment
+from angr.ailment.expression import Tmp
+from angr.ailment.statement import Assignment
+
+
+def _tmp_indices(block):
+    """Return the tmp indices this block defines and the ones it reads, nested reads included."""
+    defined, used = set(), set()
+
+    def collect(expr):
+        if isinstance(expr, Tmp):
+            used.add(expr.tmp_idx)
+        for operand in getattr(expr, "operands", None) or ():
+            collect(operand)
+        for arg in getattr(expr, "args", None) or ():
+            collect(arg)
+        inner = getattr(expr, "operand", None)
+        if inner is not None:
+            collect(inner)
+
+    for stmt in block.statements:
+        dst = getattr(stmt, "dst", None)
+        if isinstance(dst, Tmp):
+            defined.add(dst.tmp_idx)
+        if isinstance(stmt, Assignment):
+            collect(stmt.src)
+    return defined, used
+
+
+class TestPcodeConverter(unittest.TestCase):
+    def test_partial_read_of_a_wide_unique_names_the_defining_tmp(self):
+        """
+        A SLEIGH multiply writes one wide value into unique space and the following instruction reads
+        half of it. The converter remaps unique-space addresses to tmp indices, and the partial read
+        used to name the parent by its unique-space address instead of its remapped index, producing a
+        tmp that no statement defines. Nothing rejects that until the decompiler indexes it.
+        """
+        # dmulu.l r1,r2 ; sts mach,r3 ; sts macl,r4 ; rts ; nop
+        code = bytes.fromhex("15320a031a040b000900")
+        arch = archinfo.ArchPcode("SuperH4:LE:32:default")
+        project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
+
+        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager(arch=arch))
+
+        defined, used = _tmp_indices(block)
+        assert used, "the block should read at least one tmp"
+        assert not (used - defined), f"tmp read without a definition: {sorted(used - defined)}"
+
+    def test_the_two_halves_of_a_widening_multiply_differ(self):
+        """
+        The high half of a little-endian wide unique lives at the higher address, so extracting it needs
+        a shift. Computing that offset the big-endian way returns the low half for both halves, which
+        decompiles to two identical assignments instead of MACH and MACL.
+        """
+        code = bytes.fromhex("15320a031a040b000900")
+        arch = archinfo.ArchPcode("SuperH4:LE:32:default")
+        project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
+
+        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager(arch=arch))
+
+        halves = [str(stmt.src) for stmt in block.statements if isinstance(stmt, Assignment)]
+        shifted = [h for h in halves if "Shr" in h]
+        assert shifted, f"neither half of the product is shifted: {halves}"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ailment/test_converter_pcode.py
+++ b/tests/ailment/test_converter_pcode.py
@@ -3,14 +3,36 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.ailment"  # pylint:disable=redefined-builtin
 
+import os
 import unittest
-
-import archinfo
 
 import angr
 from angr import ailment
 from angr.ailment.expression import Tmp
 from angr.ailment.statement import Assignment
+
+# 420e5c  dmulu.l r4, r5   -- SLEIGH writes the 64-bit product to one wide unique and reads a
+# 420e5e  sts     MACL, r1     32-bit half of it back for each of MACL and MACH, all under the
+# 420e60  sts     MACH, r2     first instruction. The two sts are register moves.
+# Derived the way tests/common.py derives bin_location. Importing it from here instead would be
+# the first `import tests` of a --collect-only run -- tests/ailment sorts before tests/analyses and
+# has no __init__.py, so pytest has only tests/ailment on sys.path at that point, and the "tests"
+# that binds is not this one. That poisons every later tests.* import: 337 collection errors.
+_binaries = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "binaries")
+TEST_BINARY = os.path.join(_binaries, "tests", "sh4", "test-instr_sh4")
+BLOCK_ADDR = 0x420E5C
+# The instruction bound is load-bearing. The natural block here is 8 instructions and contains two
+# shifts of its own, so without it test_the_two_halves_of_a_widening_multiply_differ finds a Shr and
+# passes on the unfixed converter. Three is a readable window; one would do.
+BLOCK_INSNS = 3
+
+
+def _convert():
+    """Convert the three-instruction block above to AIL. SuperH has no VEX lifter, so this goes
+    through pypcode and the p-code converter."""
+    project = angr.Project(TEST_BINARY, auto_load_libs=False)
+    block = project.factory.block(BLOCK_ADDR, num_inst=BLOCK_INSNS)
+    return ailment.IRSBConverter.convert(block.vex, ailment.Manager())
 
 
 def _tmp_indices(block):
@@ -45,12 +67,7 @@ class TestPcodeConverter(unittest.TestCase):
         used to name the parent by its unique-space address instead of its remapped index, producing a
         tmp that no statement defines. Nothing rejects that until the decompiler indexes it.
         """
-        # dmulu.l r1,r2 ; sts mach,r3 ; sts macl,r4 ; rts ; nop
-        code = bytes.fromhex("15320a031a040b000900")
-        arch = archinfo.ArchPcode("SuperH4:LE:32:default")
-        project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
-
-        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager())
+        block = _convert()
 
         defined, used = _tmp_indices(block)
         assert used, "the block should read at least one tmp"
@@ -62,11 +79,7 @@ class TestPcodeConverter(unittest.TestCase):
         a shift. Computing that offset the big-endian way returns the low half for both halves, which
         decompiles to two identical assignments instead of MACH and MACL.
         """
-        code = bytes.fromhex("15320a031a040b000900")
-        arch = archinfo.ArchPcode("SuperH4:LE:32:default")
-        project = angr.load_shellcode(code, arch=arch, load_address=0x1000, engine=angr.engines.UberEnginePcode)
-
-        block = ailment.IRSBConverter.convert(project.factory.block(0x1000).vex, ailment.Manager())
+        block = _convert()
 
         halves = [str(stmt.src) for stmt in block.statements if isinstance(stmt, Assignment)]
         shifted = [h for h in halves if "Shr" in h]

--- a/tests/ailment/test_converter_pcode.py
+++ b/tests/ailment/test_converter_pcode.py
@@ -8,7 +8,7 @@ import unittest
 
 import angr
 from angr import ailment
-from angr.ailment.expression import Tmp
+from angr.ailment.expression import Register, Tmp
 from angr.ailment.statement import Assignment
 
 # 420e5c  dmulu.l r4, r5   -- SLEIGH writes the 64-bit product to one wide unique and reads a
@@ -26,22 +26,31 @@ BLOCK_ADDR = 0x420E5C
 # passes on the unfixed converter. Three is a readable window; one would do.
 BLOCK_INSNS = 3
 
+# 200079a  mac.l @r0+, @r0+  -- the same shape on a big-endian SuperH, where SLEIGH puts the high
+# half of the product at the wide unique's own address rather than four bytes above it.
+BE_TEST_BINARY = os.path.join(_binaries, "tests", "sh4", "hello_32x_sh2be")
+BE_BLOCK_ADDR = 0x200079A
+BE_BLOCK_INSNS = 1
 
-def _convert():
-    """Convert the three-instruction block above to AIL. SuperH has no VEX lifter, so this goes
-    through pypcode and the p-code converter."""
-    project = angr.Project(TEST_BINARY, auto_load_libs=False)
-    block = project.factory.block(BLOCK_ADDR, num_inst=BLOCK_INSNS)
-    return ailment.IRSBConverter.convert(block.vex, ailment.Manager())
+FIXTURES = ((TEST_BINARY, BLOCK_ADDR, BLOCK_INSNS), (BE_TEST_BINARY, BE_BLOCK_ADDR, BE_BLOCK_INSNS))
 
 
-def _tmp_indices(block):
-    """Return the tmp indices this block defines and the ones it reads, nested reads included."""
-    defined, used = set(), set()
+def _convert(binary=TEST_BINARY, addr=BLOCK_ADDR, insns=BLOCK_INSNS):
+    """Convert one of the blocks above to AIL. SuperH has no VEX lifter, so this goes through
+    pypcode and the p-code converter."""
+    project = angr.Project(binary, auto_load_libs=False)
+    block = project.factory.block(addr, num_inst=insns)
+    return project.arch, ailment.IRSBConverter.convert(block.vex, ailment.Manager())
+
+
+def _tmp_widths(block):
+    """Return the width each tmp is defined with, and the widths each one is read at, nested
+    reads included."""
+    defined, used = {}, {}
 
     def collect(expr):
         if isinstance(expr, Tmp):
-            used.add(expr.tmp_idx)
+            used.setdefault(expr.tmp_idx, set()).add(expr.bits)
         for operand in getattr(expr, "operands", None) or ():
             collect(operand)
         for arg in getattr(expr, "args", None) or ():
@@ -53,10 +62,18 @@ def _tmp_indices(block):
     for stmt in block.statements:
         dst = getattr(stmt, "dst", None)
         if isinstance(dst, Tmp):
-            defined.add(dst.tmp_idx)
+            defined[dst.tmp_idx] = dst.bits
         if isinstance(stmt, Assignment):
             collect(stmt.src)
     return defined, used
+
+
+def _assignment_to(arch, block, reg_name):
+    offset = arch.get_register_offset(reg_name)
+    for stmt in block.statements:
+        if isinstance(stmt, Assignment) and isinstance(stmt.dst, Register) and stmt.dst.reg_offset == offset:
+            return stmt
+    raise AssertionError(f"no assignment to {reg_name} in {[str(s) for s in block.statements]}")
 
 
 class TestPcodeConverter(unittest.TestCase):
@@ -67,11 +84,12 @@ class TestPcodeConverter(unittest.TestCase):
         used to name the parent by its unique-space address instead of its remapped index, producing a
         tmp that no statement defines. Nothing rejects that until the decompiler indexes it.
         """
-        block = _convert()
+        _, block = _convert()
 
-        defined, used = _tmp_indices(block)
+        defined, used = _tmp_widths(block)
         assert used, "the block should read at least one tmp"
-        assert not (used - defined), f"tmp read without a definition: {sorted(used - defined)}"
+        missing = set(used) - set(defined)
+        assert not missing, f"tmp read without a definition: {sorted(missing)}"
 
     def test_the_two_halves_of_a_widening_multiply_differ(self):
         """
@@ -79,11 +97,41 @@ class TestPcodeConverter(unittest.TestCase):
         a shift. Computing that offset the big-endian way returns the low half for both halves, which
         decompiles to two identical assignments instead of MACH and MACL.
         """
-        block = _convert()
+        _, block = _convert()
 
         halves = [str(stmt.src) for stmt in block.statements if isinstance(stmt, Assignment)]
         shifted = [h for h in halves if "Shr" in h]
         assert shifted, f"neither half of the product is shifted: {halves}"
+
+    def test_a_tmp_is_read_at_the_width_it_is_defined_with(self):
+        """
+        The converter reached the shift path only when the read started above the wide unique's own
+        address. A read that starts at that address but is narrower took the whole-tmp path instead
+        and came out as a bare tmp of the read's width, so the same tmp index appeared defined at 64
+        bits and read at 32.
+        """
+        for binary, addr, insns in FIXTURES:
+            with self.subTest(binary=os.path.basename(binary)):
+                _, block = _convert(binary, addr, insns)
+
+                defined, used = _tmp_widths(block)
+                mismatched = {i: (defined[i], w) for i, w in used.items() if i in defined and w != {defined[i]}}
+                assert not mismatched, f"tmp read at a width it was not defined with: {mismatched}"
+
+    def test_mach_gets_the_high_half_in_either_byte_order(self):
+        """
+        Both of these multiplies put the product's high half in MACH and its low half in MACL. Which
+        end of the wide unique the high half sits at depends on the byte order, so on a big-endian
+        target MACH was read straight off the unique's own address and got the low half unshifted.
+        """
+        for binary, addr, insns in FIXTURES:
+            with self.subTest(binary=os.path.basename(binary)):
+                arch, block = _convert(binary, addr, insns)
+
+                mach = str(_assignment_to(arch, block, "mach").src)
+                macl = str(_assignment_to(arch, block, "macl").src)
+                assert "Shr" in mach, f"MACH is not shifted out of the wide unique: {mach}"
+                assert "Shr" not in macl, f"MACL is shifted, so it is not the low half: {macl}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

On a big-endian p-code target, an instruction that writes a wide value into one
`unique` varnode and reads a narrower half of it back gets the wrong half. On
`binaries tests/sh4/hello_32x_sh2be` at `0x200079a`, a single `mac.l @r0+, @r0+`,
MACH (`reg2048`) is assigned the low half that MACL already has (at this
branch's base, which is master with #6934 applied):

```
    t10 = (t7 Add t8)
    reg2052<32> = Conv(64->32, t10)
    reg2048<32> = t10
```

90 of that object's 313 blocks convert this way. Nothing raises; the AIL is
simply wrong, and the decompiler propagates it.

### Root cause

`_remap_temp` matches a unique-space read on its offset alone and ignores the
size, so a read that starts at the wide unique's own address but is narrower than
the write that defined it returns the parent's tmp index and `_convert_varnode`
emits a bare `Tmp(idx, read_bits)`. It never reaches the partial-read branch that
computes the shift.

Which half of the value that address holds depends on the byte order, and
SLEIGH's own p-code for `dmulu.l r4, r5` shows it:

```
SuperH4:BE:32:default   INT_MULT -> unique[0xdb00:8]
                        MACH (high half) <- unique[0xdb00:4]   the parent's own address
                        MACL (low half)  <- unique[0xdb04:4]
SuperH4:LE:32:default   INT_MULT -> unique[0xdb00:8]
                        MACL (low half)  <- unique[0xdb00:4]   the parent's own address
                        MACH (high half) <- unique[0xdb04:4]
```

So on little-endian the value is right and only the width is wrong -- the same
tmp is defined at 64 bits and read at 32 -- and on big-endian the high half comes off the wrong end.

### Fix

Require the sizes to agree before taking the whole-tmp path, and let the
partial-read search consider delta 0 so it can find a parent at the read's own
address. The shift itself is already byte-order aware, so that is the whole
change:

```
    reg2052<32> = Conv(64->32, t10)
    reg2048<32> = Conv(64->32, (t10 Shr 32<8>))
```

### Testing

Two tests in `tests/ailment/test_converter_pcode.py`, each run over a
little-endian and a big-endian SuperH fixture: every tmp must be read at the
width it was defined with, and MACH must carry the shift while MACL does not.
With the two production lines reverted, three subtests fail -- the width check on
both byte orders and the MACH check on big-endian.

Depends on #6934, which repairs the crash and the little-endian shift on this
same path; this branch sits on its head. The big-endian fixture is new.

Validation: https://github.com/angr/angr/pull/7102#issuecomment-5556384304

sync: angr/binaries#225

session: sharpen
