### PR TITLE
Pcode: define the output of an op the converter cannot model

### DIFF
--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -180,10 +180,31 @@ class PCodeIRSBConverter(Converter):
                 self._special_op_handlers[self._current_behavior.opcode]()
             except NotImplementedError as ex:
                 log.warning("Unsupported opcode: %s", ex)
+                self._set_unmodeled_output()
         elif self._current_behavior.is_unary:
             self._convert_unary()
         else:
             self._convert_binary()
+
+    def _set_unmodeled_output(self) -> None:
+        """
+        Define the output of an op that could not be converted, so that later reads of it
+        still find a definition.
+        """
+        out = self._current_op.output
+        if out is None:
+            return
+        expr = DirtyExpression(
+            self._manager.next_atom(),
+            self._current_op.opcode.__name__,
+            [],
+            bits=out.size * 8,
+        )
+        try:
+            stmt = self._set_value(out, expr)
+        except NotImplementedError:
+            return
+        self._statements.append(stmt)
 
     def _convert_unary(self) -> None:
         """

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -307,5 +307,45 @@ class TestVexOpParity(unittest.TestCase):
         assert not mismatches, "vexop parity mismatches:\n" + "\n".join(f"  {n}: {m}" for n, m in mismatches[:50])
 
 
+class TestPcodeUnmodeledOpOutput(unittest.TestCase):
+    """A p-code op the converter cannot model still writes its output varnode, so the
+    converter has to define that output. SuperH ``fsca`` computes its sine/cosine pair
+    with two CALLOTHER ops; dropping their writes left the uniques they define with no
+    definition at all, and the FLOAT2FLOAT that reads them back asserted."""
+
+    # test-instr_sh4 has six `fsca` blocks; this one is a single instruction.
+    fsca_addr = 0x45125C
+
+    def test_callother_output_is_defined(self):
+        path = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "binaries", "tests", "sh4", "test-instr_sh4")
+        )
+        proj = angr.Project(path, auto_load_libs=False, engine=angr.engines.UberEnginePcode)
+        block = proj.factory.block(self.fsca_addr)
+        ablock = ailment.IRSBConverter.convert(block.vex, ailment.Manager())
+
+        dirty: list[tuple[ailment.Expr.Tmp, ailment.Expr.DirtyExpression]] = []
+        read: set[int] = set()
+        for stmt in ablock.statements:
+            if not isinstance(stmt, ailment.Stmt.Assignment):
+                continue
+            src = stmt.src
+            dst = stmt.dst
+            if isinstance(src, ailment.Expr.DirtyExpression):
+                assert isinstance(dst, ailment.Expr.Tmp)
+                dirty.append((dst, src))
+            elif isinstance(dst, ailment.Expr.Register) and isinstance(src, ailment.Expr.Convert):
+                operand = src.operand
+                if isinstance(operand, ailment.Expr.Tmp):
+                    read.add(operand.tmp_idx)
+
+        assert len(dirty) == 2
+        for dst, src in dirty:
+            assert src.callee == "CALLOTHER"
+            assert dst.bits == 32
+        # both halves of the pair are read back out of the temporaries just defined
+        assert {dst.tmp_idx for dst, _ in dirty} == read
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`sub_4516fe` in `binaries` `tests/sh4/test-instr_sh4` decompiles to nothing on
master. `Clinic._convert_all` raises while converting the block at `0x4516fe`,
and `Decompiler` logs it and gives up:

```
File "angr/ailment/converter_pcode.py", line 315, in _convert_varnode
    assert unique_offset is not None, "Cannot find the source unique variable"
AssertionError: Cannot find the source unique variable
```

Six blocks in that fixture raise it, and the six functions containing them all
produce no output.

### Root cause

Every one of those blocks is a SuperH `fsca`. SLEIGH computes its sine/cosine
pair with two `CALLOTHER` ops writing uniques, and two `FLOAT2FLOAT` ops copy
the results into the halves of the destination double register. From
`fsca FPUL, dr12` at `0x45125c`:

```
CALLOTHER          (unique,0x16600,4) <- (const,0x0,4), (unique,0x15d00,4)
CALLOTHER          (unique,0x16800,4) <- (const,0x1,4), (unique,0x15d00,4)
FLOAT_FLOAT2FLOAT  fr12               <- (unique,0x16600,4)
FLOAT_FLOAT2FLOAT  fr13               <- (unique,0x16800,4)
```

`_convert_callother` raises `NotImplementedError`, and `_convert_current_op`
catches it, logs `Unsupported opcode`, and emits no statement — so `0x16600` is
never recorded in `_unique_tracker`. The `FLOAT2FLOAT` that reads it misses,
the partial-read fallback finds no parent within seven bytes, and the assertion
fires. The read path is correct: there really is no definition, because the
write was dropped.

### Fix

`_convert_unary` and `_convert_binary` already handle an opcode they cannot
model by assigning a `DirtyExpression` to the output. This does the same when a
special handler declines, so the destination is defined even though the
operation is not modelled. The block now converts:

```
t8 = [D] CALLOTHER()
t9 = [D] CALLOTHER()
reg564<32> = Conv(32F->s32F, t8)
reg560<32> = Conv(32F->s32F, t9)
```

`_set_value` is what decides whether the output is somewhere we can write, and
it raises when it is not — a `COPY` whose output SLEIGH puts in `const` space,
for instance. So the new method asks `_set_value` and leaves the write dropped
when it declines, rather than repeating its list of spaces. Repeating the list
would also go stale against #6798, which widens it.

The `DirtyExpression` carries no operands and is named for the opcode, matching
both existing sites. `CALLOTHER` could be named for the SLEIGH userop instead,
but that would need a `CALLOTHER`-specific branch in a method that has none, so
it is left out.

This is on the write path and is independent of #6934 and #7102, which change
the unique read path further down the file. `git merge-tree` is clean against
all three: #6934 at `e0722b000`, #7102 at `05661a987`, #6798 at `160fd72c4`.

### Testing

`tests/ailment/test_irsb.py::TestPcodeUnmodeledOpOutput` converts the `fsca`
block at `0x45125c` in the tracked fixture and asserts that both `CALLOTHER`
outputs are defined and that the two `FLOAT2FLOAT` reads resolve to them. It
fails on master with the assertion above. Across the three tracked fixtures
that lift through `ArchPcode`, six blocks start converting, none stops, and
every function whose decompilation changes is explained in the validation
record.

Validation: https://github.com/angr/angr/pull/7103#issuecomment-5557094596

session: sharpen
