### PR TITLE
Structurer: drop a conditional jump once it has no target left

### DIFF
--- a/angr/analyses/decompiler/structuring/structurer_base.py
+++ b/angr/analyses/decompiler/structuring/structurer_base.py
@@ -45,6 +45,21 @@ if TYPE_CHECKING:
 _l = logging.getLogger(__name__)
 
 
+def _conditional_jump_is_redundant(stmt: ailment.Stmt.ConditionalJump, next_addr: int | None) -> bool:
+    """Whether a conditional jump has one target left and that target is ``next_addr``.
+
+    The rewrites below leave a conditional jump with a single target once its other
+    branch falls through to the next node. Structuring can reach the same statement
+    again with that surviving target now next in the sequence, and then the jump
+    decides nothing.
+    """
+    if stmt.true_target is None:
+        return isinstance(stmt.false_target, ailment.Expr.Const) and stmt.false_target.value == next_addr
+    if stmt.false_target is None:
+        return isinstance(stmt.true_target, ailment.Expr.Const) and stmt.true_target.value == next_addr
+    return False
+
+
 class StructurerBase(Analysis):
     """
     The base class for analysis passes that structures a region.
@@ -330,7 +345,9 @@ class StructurerBase(Analysis):
                     elif isinstance(jump_stmt, ailment.Stmt.ConditionalJump):
                         assert isinstance(this_node, ailment.Block)
                         next_node = node.nodes[i + 1]
-                        if (
+                        if _conditional_jump_is_redundant(jump_stmt, next_node.addr):
+                            this_node.statements = this_node.statements[:-1]
+                        elif (
                             isinstance(jump_stmt.true_target, ailment.Expr.Const)
                             and jump_stmt.true_target.value == next_node.addr
                         ):
@@ -394,7 +411,9 @@ class StructurerBase(Analysis):
                     elif isinstance(jump_stmt, ailment.Stmt.ConditionalJump):
                         assert isinstance(this_node, ailment.Block)
                         next_node = node.nodes[i + 1]
-                        if (
+                        if _conditional_jump_is_redundant(jump_stmt, next_node.addr):
+                            this_node.statements = this_node.statements[:-1]
+                        elif (
                             isinstance(jump_stmt.true_target, ailment.Expr.Const)
                             and jump_stmt.true_target.value == next_node.addr
                         ):
@@ -1005,7 +1024,11 @@ class StructurerBase(Analysis):
                 last_node.statements = last_node.statements[:-1]
             elif isinstance(last_node.statements[-1], ailment.Stmt.ConditionalJump):
                 last_stmt = last_node.statements[-1]
-                if isinstance(last_stmt.true_target, ailment.Expr.Const) and last_stmt.true_target.value == node_1.addr:
+                if _conditional_jump_is_redundant(last_stmt, node_1.addr):
+                    last_node.statements = last_node.statements[:-1]
+                elif (
+                    isinstance(last_stmt.true_target, ailment.Expr.Const) and last_stmt.true_target.value == node_1.addr
+                ):
                     new_stmt = ailment.Stmt.ConditionalJump(
                         last_stmt.idx,
                         ailment.Expr.UnaryOp(self.ail_manager.next_atom(), "Not", last_stmt.condition),

--- a/tests/analyses/decompiler/test_conditional_jump_without_target.py
+++ b/tests/analyses/decompiler/test_conditional_jump_without_target.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# pylint:disable=missing-class-docstring,no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from tests.common import bin_location, complete_calling_conventions_for
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestConditionalJumpWithoutTarget(unittest.TestCase):
+    """
+    Structuring drops the target of a conditional jump that falls through to the next node. It can
+    reach the same statement twice, and then the statement names no target at all. The code generator
+    cannot render that, so the branch used to reach the output as raw AIL instead of as C.
+    """
+
+    def test_a_conditional_jump_with_no_target_left_is_dropped(self):
+        func_addr = 0x408B90
+        proj = angr.Project(os.path.join(test_location, "i386", "windows", "rain32.upx"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        complete_calling_conventions_for(proj, [func_addr], recover_variables=True)
+        dec = proj.analyses.Decompiler(cfg.functions[func_addr], cfg=cfg.model)
+
+        assert dec.codegen is not None and dec.codegen.text is not None
+        # a target-less conditional jump reaches the output as raw AIL through CUnsupportedStatement
+        assert "Goto None" not in dec.codegen.text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

A conditional jump can reach the C code generator with no target left on either side. The
generator raises, `_handle_AILBlock` swallows the raise, and the statement's raw AIL text
lands in the middle of the decompiled C while `Decompiler` reports success. A
decompilation sweep puts that on **1,170 of the 16,974 objects it has decompiled**. This
change drops the jump in the structurer instead.

### Problem

`CStructuredCodeGenerator._handle_Stmt_ConditionalJump` guards a `None` `false_target` and
not a `None` `true_target`, so it calls `self._handle(None)`, which raises
`UnsupportedNodeTypeError: Node type NoneType is not supported yet.` `_handle_AILBlock`
catches that, logs it with `exc_info` and emits a `CUnsupportedStatement`. So the failure
never reaches the caller: `Decompiler` returns successfully, `errors` is empty, and only a
`WARNING` in the log says anything happened.
`RustStructuredCodeGenerator._handle_Stmt_ConditionalJump` has the same asymmetry.

Public reproducer, against `binaries/O2/riot-os/hello-world.elf` (sha256
`95cd4fbe94fc27af342b9de952615d6061c704f6b43a39fb131b5180ff7d1a3d`) from the HuggingFace
dataset `noelo-lab/decbench-dataset` at `4b42a0dc6158913db0648a9123e76d6ddd9ab9cf`:

```python
import sys, angr
proj = angr.Project(sys.argv[1], auto_load_libs=False)
cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
proj.analyses.CompleteCallingConventions(recover_variables=True, cfg=cfg.model)
d = proj.analyses.Decompiler(cfg.functions[0x8000EB9], cfg=cfg.model)
print("Goto None" in d.codegen.text, len(d.codegen.text))
print(d.codegen.text)
```

On master `b4ad96cd3` that prints `True 907`, and two lines of the C it prints next are
raw AIL rather than C. Here is one of them, in context:

```c
        v9 = armg_calculate_condition(229, 2, v8, v7);
        if (Conv(32->1, ((0<1>) ? (vvar_56) : (1<32>)))) { Goto None } else { Goto None }
        return pm_set(2);
```

With this branch merged into that master it prints `False 731` and no such line.

### How often

A decompilation sweep over five corpora, snapshotted 2026-09-11T06:16Z: **1,170 of the
16,974 objects it had decompiled**, both columns counted as distinct sha256. Every one of
the 1,170 is at the same site with the same message, so this is one defect and not a frame
several defects share. The lanes ran angr `a34418ad5`, 16 commits behind the `b4ad96cd3`
the reproducer above is measured on, and they were still appending when the snapshot was
taken, so the count is a lower bound.

| corpus | objects hit | objects decompiled |
| --- | ---: | ---: |
| `noelo-lab/decbench-dataset`, public | 5 | 801 |
| real-world malware, not redistributable | 491 | 1,212 |
| multi-architecture collection, not redistributable | 340 | 10,334 |
| generated binaries, not redistributable | 306 | 4,268 |
| third-party PE samples, not redistributable | 28 | 359 |

In that snapshot of the malware corpus it is the second-largest defect class by distinct
objects, on 478 of the 1,263 samples the corpus grades as ones angr should load, behind an
unrelated `c_serialize.py` failure on 534 and ahead of the next class, on 10, by a factor
of 47.

A partial scan of `angr/binaries` -- 140 objects, not a census -- found ten that hit this:
six i386 PE, two i386 ELF and two ARM ELF. The validation record below has that scan.

### Root cause

`StructurerBase.remove_redundant_jumps` (in `_handle_Sequence` and `_handle_MultiNode`)
and `StructurerBase._merge_nodes` rewrite a conditional jump whose one branch falls
through to the next node, keeping the other branch as the true target and setting the
false target to `None`:

```python
    this_node.statements[-1] = ailment.Stmt.ConditionalJump(
        jump_stmt.idx,
        ailment.Expr.UnaryOp(ail_manager.next_atom(), "Not", jump_stmt.condition),
        jump_stmt.false_target,
        None,
        ...
    )
```

Neither rewrite checks that the target it keeps exists. Structuring reaches the same
statement again with that surviving target now next in the sequence, and the statement
is left naming no target at all.

Correction: this paragraph used to end by calling these three sites the only places in
angr where a conditional jump that has a true target loses it. That claim is withdrawn.
`PCodeIRSBConverter._convert_cbranch` produces one too, by never setting the false
target rather than by losing it: it leaves it `None` whenever the p-code CBRANCH is not
the last op of the block, expecting a following `BRANCH` op to back-patch it, and nothing
guarantees one follows. This change does not cover that, and applying it alone does not
stop the `AssertionError` at `phoenix.py:3201` that the missing target causes. That is a
separate change.

### Fix

When the one target left is the next node, both outcomes reach it, so the statement
decides nothing. Drop it -- which is what the same loops already do for a redundant
unconditional `Jump` one branch above, and what `_remove_last_statement_if_jump` does
for a trailing conditional jump. The predicate is one helper, called from all three
sites.

Guarding the code generator instead was rejected: it would leave the structurer emitting
a statement no consumer can render, and would need the same guard again in
`RustStructuredCodeGenerator`.

### Testing

`tests/analyses/decompiler/test_conditional_jump_without_target.py` decompiles
`sub_408b90` at `0x408b90` in `tests/i386/windows/rain32.upx` and asserts the output
carries no target-less goto. It fails on master and passes here.

Decompiling every function of 28 binaries from `angr/binaries` on master and on this
branch: 1,578 functions compared, 5 differ, and every difference is the removal of one
such line and the addition of nothing.

Re-measured on the five objects of the public dataset above that the sweep flags: master `b4ad96cd3` emits 10 of these statements across them, and
the same master with this branch merged in emits none. Both arms decompile the same
functions on every object -- 131, 131, 174, 2,546 and 3,430 of them -- and on the two
largest objects both arms log the same other decompilation warnings, so the zero is this
class going away rather than decompilation stopping short.

Validation: https://github.com/angr/angr/pull/7104#issuecomment-5557552202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen
