### PR TITLE
CFG: Stop the executable-region map falling back to the whole loader

### DIFF
--- a/angr/analyses/cfg/cfg_base.py
+++ b/angr/analyses/cfg/cfg_base.py
@@ -794,14 +794,14 @@ class CFGBase(Analysis):
         binaries = self.project.loader.all_objects if objects is None else objects
 
         memory_regions = []
-        has_executable = False
+        examined_any_object = False
 
         for b in binaries:
             if not b.has_memory:
                 continue
+            examined_any_object = True
 
             if isinstance(b, ELF):
-                has_executable = True
                 # If we have sections, we get result from sections
                 sections = []
                 if not force_segment and b.sections:
@@ -834,7 +834,6 @@ class CFGBase(Analysis):
                             memory_regions.append(segment)
 
             elif isinstance(b, (Coff, PE)):
-                has_executable = True
                 for section in b.sections:
                     if section.is_executable:
                         max_mapped_addr = section.min_addr + min(section.memsize, section.filesize)
@@ -842,7 +841,6 @@ class CFGBase(Analysis):
                         memory_regions.append(tpl)
 
             elif isinstance(b, XBE):
-                has_executable = True
                 # some XBE files will mark the data sections as executable
                 for section in b.sections:
                     if (
@@ -854,7 +852,6 @@ class CFGBase(Analysis):
                         memory_regions.append(tpl)
 
             elif isinstance(b, MachO):
-                has_executable = True
                 if b.segments:
                     # Get all executable segments
                     for seg in b.segments:
@@ -913,7 +910,7 @@ class CFGBase(Analysis):
                 tpl = (b.min_addr, b.max_addr + 1)
                 memory_regions.append(tpl)
 
-        if not memory_regions and not has_executable:
+        if not memory_regions and not examined_any_object:
             memory_regions = [(start, start + len(backer)) for start, backer in self.project.loader.memory.backers()]
 
         # A section or segment that maps no bytes, such as the empty .text of a data-only relocatable, is not a region.

--- a/tests/analyses/cfg/test_cfg_no_executable_regions.py
+++ b/tests/analyses/cfg/test_cfg_no_executable_regions.py
@@ -36,6 +36,18 @@ class TestCfgNoExeutableRegions(unittest.TestCase):
         assert cfg.regions == []
         assert any("nothing to scan" in record for record in logs.output)
 
+    def test_cfg_scoped_to_an_object_that_holds_no_code(self):
+        # The extern object CLE builds holds no code, so scoping CFGFast to it gives an empty map rather
+        # than every backer in the loader.
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        p = angr.Project(bin_path, auto_load_libs=False)
+        main_object = p.loader.main_object
+        with self.assertLogs("angr.analyses.cfg.cfg_base", level=logging.WARNING) as logs:
+            cfg = p.analyses.CFGFast(binary=p.loader.extern_object)
+            assert cfg.regions == []
+            assert not [f for f in cfg.kb.functions.values() if main_object.min_addr <= f.addr <= main_object.max_addr]
+        assert any("nothing to scan" in record for record in logs.output)
+
     def test_cfg_elf_no_section_headers(self):
         # Regression test for #6409: stripped ELFs with no section headers fall back to segments.
         bin_path = os.path.join(test_location, "armel", "dbus-cleanup-sockets_stripped")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast(binary=...)` scopes the CFG to one loaded object. Scoping it to the extern object CLE builds, which holds no compiled code, scans the whole program instead. On `binaries/tests/x86_64/fauxware`:

```python
project = angr.Project(path, auto_load_libs=False)
cfg = project.analyses.CFGFast(binary=project.loader.extern_object)
```

```text
CFGFast(binary=extern_object)  map 8 regions 93421 bytes | regions 4 | blocks  98 | functions 42, 32 in the main object
```

That loader holds 8 backers over 93421 bytes, so the map is every byte it has, and 32 of the recovered functions are in the main object nobody asked about. `objects=` is discarded the same way.

### Root cause

`CFGBase._executable_memory_regions` ends with a fallback for a loader holding nothing it can read:

```python
if not memory_regions and not has_executable:
    memory_regions = [(start, start + len(backer)) for start, backer in self.project.loader.memory.backers()]
```

`has_executable` is set in four of that function's twelve branches. CLE's pseudo-objects are in one of the other eight:

```python
elif isinstance(b, self._cle_pseudo_objects):
    pass
```

so the map comes back empty, the fallback fires, and it answers a question about the whole loader. Every branch that neither sets the flag nor appends a region reaches it the same way, `Hex`/`SRec` and the two generic `sections` and `segments` branches among them. The validation record says which backend reaches which branch and what is tracked for each.

### Fix

The flag is not about executability: the ELF branch sets it for an ELF with no executable section at all. It asks whether the loop looked at an object, which is decided in one place, so set it there and drop the four per-branch assignments.

```text
CFGFast(binary=extern_object)  map 0 regions 0 bytes | regions 0 | blocks   7 | functions  7,  0 in the main object
```

The seven left are the SimProcedure hooks that live in that object, and the existing "CFG recovery has nothing to scan" warning fires and names it. `CFGFast()` and `CFGFast(binary=<the main object>)` on that fixture are unchanged at 4 regions, 93 blocks and 40 functions.

The two conditions disagree when the loop examined at least one object with memory, none of them an ELF, COFF, PE, XBE or Mach-O, and no branch appended anything. For a scoped request that is the repair above. For a whole-project `CFGFast()` it turns scanning every backer into scanning nothing and warning, which is what angr already answers for an ELF or a PE that reports nothing executable. The validation record says what was measured there and what was not. The fallback still fires when nothing in the set has memory at all.

angr/angr#6864 at `76acb7e4d7b3` adds the same assignment to the `Blob` branch. `git merge-tree` of that head and this one is clean, and the merged file then assigns a name this change removes, so whichever lands second drops that line.

### Testing

`tests/analyses/cfg/test_cfg_no_executable_regions.py` gains a test beside two of the same shape: it scopes `CFGFast` to the extern object and expects an empty region list, no recovered function inside the main object, and the "nothing to scan" warning. On master it fails at `assert cfg.regions == []`.

Validation: https://github.com/angr/angr/pull/7106#issuecomment-5559282827

session: sharpen
