### PR TITLE
LoweredSwitchSimplifier: do not remove the switch head it just built

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -390,6 +390,13 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         node = worklist.popleft()
                         if node not in graph_copy:
                             continue
+                        if node is new_head:
+                            # the walk reached the switch head this iteration just built: a redundant
+                            # comparison upstream of it was removed and left it with no in-edges. taking it
+                            # would delete the switch and every case body hanging off it, so give up on the
+                            # rewrite instead and leave the graph to the rest of the preset.
+                            self.out_graph = None
+                            return False
                         successors = list(graph_copy.successors(node))
                         graph_copy.remove_node(node)
                         for succ in successors:

--- a/tests/analyses/decompiler/test_lowered_switch_simplifier.py
+++ b/tests/analyses/decompiler/test_lowered_switch_simplifier.py
@@ -72,6 +72,24 @@ class TestLoweredSwitchSimplifier(unittest.TestCase):
         assert dec.codegen is not None and dec.codegen.text is not None
         assert "switch (" in dec.codegen.text
 
+    def test_rewrite_is_abandoned_when_it_would_remove_the_switch_head(self):
+        # scan_request() in bash's man2html at -O2 has a lowered switch whose first case-emitting
+        # comparison is reached through a range-splitting comparison. That splitter is redundant once the
+        # switch head exists, and removing it left the head with no in-edges, so the same walk took the
+        # head and every case body hanging off it. The pass then read one of those bodies back out of the
+        # graph and raised, which sent the whole function to the basic preset.
+        proj, cfg = load_project_with_scoped_cfg(
+            os.path.join(test_location, "x86_64", "man2html_gcc11.4.0_O2"), 0x4051D0, window=0x3000
+        )
+
+        dec = proj.analyses.Decompiler(cfg.functions[0x4051D0], cfg=cfg)
+
+        # pytest sets is_testing, so fail_fast re-raises and this test fails at the call above rather than
+        # on the assertion. Outside a test run the same exception is caught, and the only sign of it is
+        # that the function was decompiled a second time on the basic preset.
+        assert not dec.errors
+        assert dec.codegen is not None and dec.codegen.text is not None
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`scan_request` at `0x4051d0` in bash's `man2html` built at -O2 never gets the full decompilation preset. `LoweredSwitchSimplifier` raises, `Analysis._resilience` catches it, and the whole function is decompiled a second time on `basic`:

```console
ERROR    | angr.analyses.analysis | Caught and logged NetworkXError with resilience: The node <AILBlock 0x406572> is not in the digraph.
errors: ['The node <AILBlock 0x406572> is not in the digraph.']
lines: 2515 gotos: 136
```

Nothing reaches the caller and `codegen.text` comes back non-empty, so the call looks like it worked. `basic` is twenty passes and none of them is structural, so what is lost is every full-preset optimization on that function, not this one pass.

The same removal raises in three shapes across our corpus: this `NetworkXError` out of `graph_copy.successors`, a `KeyError` on `existing_nodes_by_addr_and_idx`, and a second `NetworkXError` out of `graph_copy.in_edges`. They are one bug rather than three, established by matching the identity of the removed node against `new_head` rather than inferred from their sitting in the same file.

### Root cause

`original_head` is `real_cases[0].original_node` -- the first node that emitted a case, not the first node of the comparison cluster. A range-splitting comparison can therefore sit upstream of it, and that splitter is an `extra_cmp_nodes` entry, so the redundant-node walk removes it. The head is then left with no in-edges, the walk reads it as orphaned, and takes it and everything below it:

```text
remove <AILBlock 0x405979 of 3 statements> id=B   new_head id=B
remove <AILBlock 0x405e2b of 3 statements> preds=[]
remove <AILBlock 0x405fa8 of 2 statements> preds=[]
remove <AILBlock 0x406572 of 4 statements> preds=[]
```

`node_to_heads`, filled before the walk runs, then names a node that is gone. The guard above the walk skips nodes in `original_nodes`, and `original_nodes` was sliced to drop the head, so the head has never been covered by it.

This is not a regression from #6990. With only this file reverted to that commit's parent, the same function fails on the same node with the same output.

### Fix

Give up on the rewrite when the walk reaches the head, which is the `self.out_graph = None; return False` the pass already takes earlier in the same method when its own sanity check finds a node missing. The function keeps the rest of the full preset:

```console
errors: []
lines: 2473 gotos: 135
```

Two narrower repairs were measured and rejected, because each stops the exception and loses code instead. Keeping the head while still removing the splitter leaves the head unreachable: on another x86-64 sample that function drops from 100 lines to 27, ending in two `goto`s to labels that are never emitted. Handing the head the splitter's incoming edges is worse -- on `scan_request` only 39 of the function's 2,540 instruction addresses survive into the emitted code. Neither shows up as an exception.

The design problem underneath is untouched. `original_head` should be the entry of the comparison cluster rather than the first node that emitted a case; no redundant comparison could then sit upstream of the head, and the walk could not orphan it. Changing which node becomes the head also changes what `_update_block` has to inherit from it, so that is not this change.

### Testing

`test_rewrite_is_abandoned_when_it_would_remove_the_switch_head` decompiles `scan_request` and asserts `dec.errors` is empty; on master it fails with the `NetworkXError` above. It asserts the contract rather than the emitted code, because on this function the fix's effect is to leave the graph to the rest of the preset. On five objects measured across the three shapes -- this fixture, a second build of the same program, a macOS dylib and two objects in private corpora -- the exception is gone on all five, none of the five outputs contains a `goto` to a label that is never emitted, none reports a structuring failure, every one emits fewer `goto`s than today, and the share of each function's CFG instruction addresses reaching the emitted code falls by at most 2.5 points, which on the object where that happens is two instructions out of eighty.

The fixture is new, so `angr/binaries` has to merge first. Validation: https://github.com/angr/angr/pull/7111#issuecomment-5570235373

sync: angr/binaries#227

session: sharpen
