### PR TITLE
clarirs: Stop nsplit panicking on a wrapping strided interval

### DIFF
--- a/native/clarirs-vsa/src/strided_interval.rs
+++ b/native/clarirs-vsa/src/strided_interval.rs
@@ -256,7 +256,22 @@ impl StridedInterval {
                 if straddling {
                     // Split into two parts
                     // First part: [lower_bound, north_pole_left] aligned to stride
-                    let a_upper = &north_pole_left - ((&north_pole_left - lower_bound) % stride);
+                    //
+                    // A wrapping interval can start above the north pole -- 8-bit
+                    // 1[0xf0, 0x90] -- so north_pole_left - lower_bound can be negative.
+                    let modulus = BigUint::one() << *bits;
+                    let offset = if lower_bound <= &north_pole_left {
+                        (&north_pole_left - lower_bound) % stride
+                    } else {
+                        let overshoot = (lower_bound - &north_pole_left) % stride;
+                        if overshoot.is_zero() {
+                            BigUint::zero()
+                        } else {
+                            stride - overshoot
+                        }
+                    };
+                    let a_upper =
+                        (&modulus + &north_pole_left - offset % &modulus) & max_int(*bits);
                     let a = Self::new(*bits, stride.clone(), lower_bound.clone(), a_upper.clone());
 
                     // Second part: [north_pole_right or next stride point, upper_bound]
@@ -3160,6 +3175,76 @@ mod si_bounds_tests {
         let (min_s, max_s) = si.get_signed_bounds();
         assert_eq!(min_s, BigInt::zero());
         assert_eq!(max_s, BigInt::zero());
+    }
+
+    #[test]
+    fn test_nsplit_wrapping_above_north_pole() {
+        // Wrapping interval starting above the north pole: 1[0xf0, 0x90] covers
+        // 0xf0..=0xff and 0x00..=0x90, so it crosses 0x7f -> 0x80 once.
+        let si = StridedInterval::Normal {
+            bits: 8,
+            stride: BigUint::one(),
+            lower_bound: BigUint::from(0xf0u32),
+            upper_bound: BigUint::from(0x90u32),
+        };
+        assert_eq!(
+            si.nsplit(),
+            vec![
+                StridedInterval::new(8, 1u32, 0xf0u32, 0x7fu32),
+                StridedInterval::new(8, 1u32, 0x80u32, 0x90u32),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_nsplit_wrapping_above_north_pole_odd_stride() {
+        // A stride that does not divide 2^bits: 0x7f - ((0x7f - 0xf0) mod 3) is
+        // 0x7e under a floored remainder and 0x7d under a modulo-2^bits one.
+        let si = StridedInterval::Normal {
+            bits: 8,
+            stride: BigUint::from(3u32),
+            lower_bound: BigUint::from(0xf0u32),
+            upper_bound: BigUint::from(0x90u32),
+        };
+        assert_eq!(
+            si.nsplit(),
+            vec![
+                StridedInterval::new(8, 3u32, 0xf0u32, 0x7eu32),
+                StridedInterval::new(8, 3u32, 0x81u32, 0x90u32),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_nsplit_wrapping_above_north_pole_stride_wider_than_bits() {
+        // Nothing masks the stride to the bit width, so the split has to hold
+        // for one that exceeds it. 0x7f - ((0x7f - 0xf0) mod 385) is -145, and
+        // claripy stores that as -145 & 0xff = 0x6f.
+        let si = StridedInterval::Normal {
+            bits: 8,
+            stride: BigUint::from(385u32),
+            lower_bound: BigUint::from(0xf0u32),
+            upper_bound: BigUint::from(0x90u32),
+        };
+        assert_eq!(
+            si.nsplit(),
+            vec![
+                StridedInterval::new(8, 385u32, 0xf0u32, 0x6fu32),
+                StridedInterval::new(8, 385u32, 0xf0u32, 0x90u32),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mul_wrapping_above_north_pole() {
+        // mul splits both operands at the poles, which is how nsplit is reached.
+        let si = StridedInterval::Normal {
+            bits: 8,
+            stride: BigUint::one(),
+            lower_bound: BigUint::from(0xf0u32),
+            upper_bound: BigUint::from(0x90u32),
+        };
+        assert!(!si.mul(&StridedInterval::constant(8, 2u32)).is_empty());
     }
 }
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` aborts with a Rust panic on `usr/bin/vdr` from the Debian ports x32
archive, sha256 `8054c72481d1e142fe17f9b18771511c59f5f5eec1a71c466558743595d2501f`:

```
>>> p = angr.Project(path, auto_load_libs=False)
>>> p.analyses.CFGFast(normalize=True, data_references=False, resolve_indirect_jumps=True)

thread '<unnamed>' panicked at num-bigint-0.4.8/src/biguint/subtraction.rs:71:5:
Cannot subtract b from a because b is larger than a.
Traceback (most recent call last):
  [8 frames]
  File "angr/analyses/cfg/cfg_base.py", line 3185, in _process_one_indirect_jump
    resolved, targets = resolver.resolve(
  File "angr/analyses/cfg/indirect_jump_resolvers/jumptable.py", line 858, in resolve
    r, targets = self._resolve(
  File "angr/analyses/cfg/indirect_jump_resolvers/jumptable.py", line 1084, in _resolve
    simgr.run()
  [42 frames]
  File "angr/state_plugins/callstack.py", line 423, in _manage
    if not rself.state.solver.is_true(cur_sp > rself.top.stack_ptr):
  [4 frames]
pyo3_runtime.PanicException: Cannot subtract b from a because b is larger than a.
```

58 frames. The elisions are marked, paths are shortened, and the thread id, the
`RUST_BACKTRACE` note and the caret lines are dropped. The complete, unedited
output is in the output comment.

The analysis is lost, not the one jump table. `_process_one_indirect_jump` has
no handler, and the only guard around `simgr.run()` is an `except KeyError`, so
the panic unwinds out of `CFGFast`. The caller cannot contain it either:
`pyo3_runtime.PanicException` derives from `BaseException` rather than
`Exception`, so an `except Exception` around the analysis does not see it. What
is left is a Rust panic message, no angr-level diagnostic and no partial CFG.

### Root cause

`StridedInterval::nsplit` splits an interval at the north pole and aligns the
first half's upper bound to the stride:

```rust
let a_upper = &north_pole_left - ((&north_pole_left - lower_bound) % stride);
```

One of the two cases it calls straddling is `upper_bound >= north_pole_right &&
lower_bound > upper_bound` -- an interval that *wraps* and whose lower bound is
above the north pole. 8-bit `1[0xf0, 0x90]` is one: it covers `0xf0..=0xff` and
`0x00..=0x90`, so it crosses the north pole once on the way up. There
`lower_bound > north_pole_left` and the inner subtraction goes below zero.

The line is a port of claripy's Python `_nsplit`, which writes the same
expression and is correct there for two reasons that do not carry over. Python's
integers are unbounded and its `%` floors, so the remainder is non-negative even
when the subtraction is negative; and `StridedInterval.normalize` then does
`self._upper_bound &= 2**self.bits - 1`, which on a negative Python integer is a
reduction modulo `2**bits`. `BigUint` has neither property, so the first of those
panics and the second is missing.

`nsplit` is reached only through `psplit`, and `psplit` only from `mul` and
`sdiv`.

### Fix

Compute the same remainder without leaving the unsigned range, and reduce the
result modulo `2**bits`, which is what claripy's mask does. Nothing bounds the
stride to the bit width -- `normalize` masks the bounds and not the stride -- so
the reduction is written to hold for a stride larger than the modulus too. On
the binary above, `CFGFast` now completes with 28273 functions and 66466 blocks.

`nsplit`'s sibling `ssplit` has the same shape and is safe: `normalize` masks
`lower_bound` to at most `max_int`, which is `ssplit`'s own `south_pole_right`,
so neither of its subtractions can underflow. `contains_value` in this file has
a second underflow of the same kind, reached through `contains_zero` from the
division paths rather than through the splits. It is a separate defect with a
separate reproducer and it is deliberately not folded in here.

### Testing

Four tests in `si_bounds_tests`, all of which fail on master with the panic
message above and pass with this change: the wrapping split itself; the same
interval with stride 3, which pins the alignment to Python's floored remainder
(`0x7e`) rather than a modulo-`2**bits` one (`0x7d`); a stride larger than the
modulus, which nothing masks away; and `mul` reaching the split through
`psplit`.

The aligned bound depends only on the stride and the lower bound, so those are
what I enumerated: at 8 bits, every stride from 1 to 3999 against every lower
bound. This change returns claripy's `_nsplit` value on all 1,023,744 pairs, and
master's value on every one of them where master returns a value at all.

Validation: https://github.com/angr/angr/pull/7112#issuecomment-5571835444

session: sharpen
