### PR TITLE
Add the missing PPC64 and S390X entries to the calling-convention argument-register filter

### DIFF
--- a/angr/analyses/calling_convention/utils.py
+++ b/angr/analyses/calling_convention/utils.py
@@ -59,7 +59,9 @@ def is_sane_register_variable(
         return 28 <= reg_offset < 60  # r3-r10
 
     if arch_name == "PPC64":
-        return 40 <= reg_offset < 104  # r3-r10
+        # fpr1-fpr13 are the low halves of vsr1-vsr13, so an offset test admits a 16-byte
+        # vector access at the same offset as well.
+        return 40 <= reg_offset < 104 or 288 <= reg_offset < 488  # r3-r10  # fpr1-fpr13
 
     if arch_name == "X86":
         return 8 <= reg_offset < 24 or 160 <= reg_offset < 288  # eax, ebx, ecx, edx  # xmm0-xmm7

--- a/angr/analyses/calling_convention/utils.py
+++ b/angr/analyses/calling_convention/utils.py
@@ -67,5 +67,16 @@ def is_sane_register_variable(
     if arch_name == "RISCV64":
         return 96 <= reg_offset < 160  # a0-a7
 
+    if arch_name == "S390X":
+        # f0, f2, f4 and f6 are the low halves of v0, v2, v4 and v6, so an offset test admits
+        # a 16-byte vector read at the same offset as well.
+        return (
+            592 <= reg_offset < 632  # r2-r6
+            or 64 <= reg_offset < 72  # f0
+            or 96 <= reg_offset < 104  # f2
+            or 128 <= reg_offset < 136  # f4
+            or 160 <= reg_offset < 168  # f6
+        )
+
     l.critical("Unsupported architecture %s.", arch.name)
     return True

--- a/angr/analyses/calling_convention/utils.py
+++ b/angr/analyses/calling_convention/utils.py
@@ -58,6 +58,9 @@ def is_sane_register_variable(
     if arch_name == "PPC32":
         return 28 <= reg_offset < 60  # r3-r10
 
+    if arch_name == "PPC64":
+        return 40 <= reg_offset < 104  # r3-r10
+
     if arch_name == "X86":
         return 8 <= reg_offset < 24 or 160 <= reg_offset < 288  # eax, ebx, ecx, edx  # xmm0-xmm7
 

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -238,6 +238,16 @@ class TestCallingConventionAnalysis(unittest.TestCase):
             offset, size = arch.registers[reg_name]
             assert not is_sane_register_variable(arch, offset, size), reg_name
 
+    def test_s390x_argument_registers(self):
+        # r2-r6 and f0, f2, f4, f6 may be candidate arguments on S390X.
+        arch = archinfo.arch_from_id("s390x")
+        for reg_name in ["r2", "r3", "r4", "r5", "r6", "f0", "f2", "f4", "f6"]:
+            offset, size = arch.registers[reg_name]
+            assert is_sane_register_variable(arch, offset, size), reg_name
+        for reg_name in ["r1", "r7", "r8", "r9", "r10", "r11", "r12", "r13", "r14", "a0", "a1", "f1", "f8"]:
+            offset, size = arch.registers[reg_name]
+            assert not is_sane_register_variable(arch, offset, size), reg_name
+
     def test_x86_saved_regs(self):
         # Calling convention analysis should be able to determine calling convention of functions with registers
         # saved on the stack.

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -229,12 +229,14 @@ class TestCallingConventionAnalysis(unittest.TestCase):
                     assert ret_val.reg_name == r
 
     def test_ppc64_argument_registers(self):
-        # Only r3-r10 may be candidate arguments on PPC64.
+        # r3-r10 and fpr1-fpr13 may be candidate arguments on PPC64.
         arch = archinfo.arch_from_id("ppc64")
-        for reg_name in ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"]:
+        accepted = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"]
+        accepted += [f"fpr{i}" for i in range(1, 14)]
+        for reg_name in accepted:
             offset, size = arch.registers[reg_name]
             assert is_sane_register_variable(arch, offset, size), reg_name
-        for reg_name in ["r0", "r1", "r2", "r11", "r12", "r31", "lr", "ctr", "cr0"]:
+        for reg_name in ["r0", "r1", "r2", "r11", "r12", "r31", "lr", "ctr", "cr0", "fpr0", "fpr14", "fpr31"]:
             offset, size = arch.registers[reg_name]
             assert not is_sane_register_variable(arch, offset, size), reg_name
 

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -12,6 +12,7 @@ from functools import wraps
 import archinfo
 
 import angr
+from angr.analyses.calling_convention.utils import is_sane_register_variable
 from angr.analyses.complete_calling_conventions import (
     DEAD_WORKER_GRACE_PERIOD,
     CallingConventionAnalysisMode,
@@ -226,6 +227,16 @@ class TestCallingConventionAnalysis(unittest.TestCase):
                     ret_val = func.calling_convention.return_val(func.prototype.returnty)
                     assert isinstance(ret_val, SimRegArg)
                     assert ret_val.reg_name == r
+
+    def test_ppc64_argument_registers(self):
+        # Only r3-r10 may be candidate arguments on PPC64.
+        arch = archinfo.arch_from_id("ppc64")
+        for reg_name in ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"]:
+            offset, size = arch.registers[reg_name]
+            assert is_sane_register_variable(arch, offset, size), reg_name
+        for reg_name in ["r0", "r1", "r2", "r11", "r12", "r31", "lr", "ctr", "cr0"]:
+            offset, size = arch.registers[reg_name]
+            assert not is_sane_register_variable(arch, offset, size), reg_name
 
     def test_x86_saved_regs(self):
         # Calling convention analysis should be able to determine calling convention of functions with registers


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Running `CFGFast` and `CompleteCallingConventions` over the 62 objects under
`binaries/tests/s390x` that complete logs **31,080** CRITICAL records saying angr does not
support an architecture it does support:

```
CRITICAL | angr.analyses.calling_convention.utils | Unsupported architecture S390X.
```

Every s390x corpus figure here is measured with angr/angr#7144 applied; without it the analysis
aborts on s390x before completing, as Testing says.

Each record also means the filter answered `True`, so on s390x it accepts every one of the 104
names in the register file — `r14`, the return-address register, and the access registers `a0`
and `a1` among them. The 19 tracked PPC64 and PPC64EL objects that complete log **388,854**
more.

### Root cause

`is_sane_register_variable()` in `angr/analyses/calling_convention/utils.py` is a
per-architecture table of accepted register-file offset ranges. PPC64 and S390X have no entry,
so they fall off the end of the chain:

```python
    l.critical("Unsupported architecture %s.", arch.name)
    return True
```

That is not a conservative default, it is no filter at all. Of the 13 architecture names
`archinfo` registers, three reach that line: PPC64 in both endiannesses, S390X, and Soot,
which is Java bytecode and has no register file. So these are the last two VEX architectures
with no entry.

### Fix

Add the two missing entries, covering the ABI's floating-point argument registers as well as
its integer ones — `r3`-`r10` and `fpr1`-`fpr13` on PPC64, `r2`-`r6` and `f0`/`f2`/`f4`/`f6`
on S390X. Every offset is read out of `archinfo` at run time rather than written by hand; the
S390X set is set-equal to `SimCCS390X.arg_reg_offsets(arch)`, and `archinfo`'s own
`ArchS390X.argument_register_positions` names the same nine registers.

**The floating-point half is not decoration, and s390x is where it shows.** An integer-only
S390X entry — `592 <= reg_offset < 632`, the shape the merged `RISCV64` entry has — was built
and measured as a third arm over the same 62 objects. It moves **99 functions, every one by
dropping arguments**: `f0`, `f2`, `f4` and `f6` off 97 and `f0` off two more, nothing gained,
no convention changed. Four of them are `sum_doubles`, `sum_combo_doubles`,
`sum_segregated_doubles` and `sum_hell` in `binaries/tests/s390x/manyfloatsum`, whose source
declares those arguments as `double` in the first three and as a mix of `float` and `double` in
`sum_hell`.

### What it changes, and how far that has been checked

Neither entry changes anything that is recovered. Over 62 s390x objects (2,749 functions,
1,486 prototypes) and 19 PPC64/PPC64EL objects (21,918 functions, 16,025 prototypes), no
function's calling convention, prototype or register-argument list differs from master, while
the 31,080 and 388,854 CRITICAL records go to 0. `SimCCS390X` and `SimCCPowerPC64` both
inherit `CALLER_SAVED_REGS = []`, so the `STRICT_CALLER_SAVED_MATCH` branch in `SimCC._match`
cannot fire on either, and `_match` was already discarding every junk candidate the missing
entries let through.

**Those two zeros are not worth the same, and it would be easy to present them as if they
were.** The s390x zero is a real no-regression result, because the same corpus and the same
comparator do move 99 functions when the entry is narrowed. The ppc64 zero is not: a
calibration arm narrowing the PPC64 entry to `r3` alone — which flips `gpr4`-`gpr10` from
accepted to rejected, confirmed at the call site — also produces **0 differing functions** on
the same 19 objects. Every register argument in that pool comes from a declared library
prototype rather than from register-variable recovery: 1,282 functions carry an `r3` argument
and all of them are `exit`, `read`, `write`, `open` and their neighbours in the two `libc.so.6`
and in `ld64.so.1`, while the other 16 objects have no function with any register argument at
all. So on ppc64 this pull request's measurable effect is the log flood, and the zero is
structural rather than evidence that the filter's answers were checked against recovered
output.

### Deliberately not done

`RISCV64` has the same integer-only gap these two avoid — it excludes `fa0`-`fa7`, which
`SimCCRISCV64.FP_ARG_REGS` declares — and that costs real arguments today: `complex_func` in
`binaries/tests/riscv64/sim_args_riscv64.so` recovers four floating-point arguments with the
entry widened and none without. That is a behaviour change on an architecture that already has
an entry, so it goes in its own pull request.

These entries are the ELF/SysV default and cannot express a convention that uses other
registers. `ARG_REG_SANITY_FILTER` is the hook for one that does, only `SimCCGoAMD64` sets it,
and `DEFAULT_CC_BY_LANGUAGE["go"]` has no PPC64 entry — so a Go ppc64 binary reaches this chain
and is filtered against the SysV set. That limit is real and needs its own change.

The offset test also cannot tell an incoming floating-point argument from a vector access at
the same offset, because VEX aliases them — `translate_register_name(64, size=8)` is `f0` on
s390x and `size=16` is `v0`. These entries admit both, and the comments say so.

### Testing

`tests/analyses/test_calling_convention_analysis.py` gains `test_ppc64_argument_registers` and
`test_s390x_argument_registers`. Each reads the offsets from `archinfo` and asserts the
accepted and the rejected set; they load no binary. On master both fail on the first rejected
register, because master accepts all 280 PPC64 and all 104 S390X register names.

Reproducing the **s390x corpus figures** additionally needs angr/angr#7144, and this branch is
not stacked on it: without it `CompleteCallingConventions` raises
`ArchError: Arch s390x must be big endian` at `calling_conventions.py:1279` before completing.
The CRITICAL records are emitted before the crash, so the filter is reached either way, and
both unit tests are unaffected.

Validation: https://github.com/angr/angr/pull/7123#issuecomment-5582682731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen