### PR TITLE
AIL: give a p-code conditional branch a fall-through when no BRANCH follows it

### DIFF
--- a/angr/ailment/converter_pcode.py
+++ b/angr/ailment/converter_pcode.py
@@ -91,6 +91,7 @@ class PCodeIRSBConverter(Converter):
     """
 
     _current_op: PcodeOp
+    _next_op: PcodeOp | None
 
     @staticmethod
     def convert(irsb: IRSB, manager: Manager):  # pylint:disable=arguments-differ
@@ -110,6 +111,7 @@ class PCodeIRSBConverter(Converter):
         self._next_ins_addr = None
         self._current_behavior = None
         self._statement_idx = 0
+        self._next_op = None
 
         # Remap all uniques s.t. they are write-once with values starting from 0
         self._unique_tracker: dict[int, tuple[int, int]] = {}
@@ -147,8 +149,10 @@ class PCodeIRSBConverter(Converter):
         """
         self._statement_idx = 0
 
-        for op in self._irsb._ops:
+        ops = self._irsb._ops
+        for idx, op in enumerate(ops):
             self._current_op = op
+            self._next_op = ops[idx + 1] if idx + 1 < len(ops) else None
             if op.opcode == pypcode.OpCode.IMARK:
                 self._manager.ins_addr = op.inputs[0].offset
                 self._next_ins_addr = op.inputs[-1].offset + op.inputs[-1].size
@@ -520,16 +524,15 @@ class PCodeIRSBConverter(Converter):
         cval = Const(self._manager.next_atom(), 0, cond.bits)
         condition = BinaryOp(self._manager.next_atom(), "CmpNE", [cond, cval], signed=False)
         dest = Const(self._manager.next_atom(), dest_addr, self._irsb.arch.bits)
-        if self._irsb._ops[-1] is self._current_op:
-            # if the cbranch op is the last op, then we need to generate a fallthru target
+        if self._next_op is not None and self._next_op.opcode == OpCode.BRANCH:
+            # _convert_branch back-patches this statement with the branch destination
+            fallthru = None
+        else:
             fallthru = Const(
                 self._manager.next_atom(),
                 self._next_ins_addr,
                 self._irsb.arch.bits,
             )
-        else:
-            # there will be a Jump statement that follows the cbranch
-            fallthru = None
         stmt = ConditionalJump(self._statement_idx, condition, dest, fallthru, ins_addr=self._manager.ins_addr)
         self._statements.append(stmt)
 

--- a/tests/ailment/test_irsb.py
+++ b/tests/ailment/test_irsb.py
@@ -55,6 +55,33 @@ class TestIrsb(unittest.TestCase):
         ablock = ailment.IRSBConverter.convert(irsb, manager)
         assert ablock  # TODO: test if this conversion is valid
 
+    def test_pcode_cbranch_gets_a_fallthrough_when_no_branch_follows(self):
+        # A p-code CBRANCH takes its fall-through from the BRANCH op that follows it. The PA-RISC
+        # SLEIGH spec emits its nullification bookkeeping after the CBRANCH instead, so nothing
+        # follows to supply one and the conditional jump used to reach structuring with no false
+        # target at all.
+        base = os.path.join(os.path.dirname(__file__), "..", "..", "..", "binaries", "tests")
+        path = os.path.normpath(os.path.join(base, "hppa", "ruby-bindex-cruby.so"))
+        if not os.path.exists(path):
+            self.skipTest(f"missing binary {path}")
+        proj = angr.Project(
+            path,
+            auto_load_libs=False,
+            main_opts={"backend": "elf", "arch": archinfo.ArchPcode("pa-risc:BE:32:default")},
+        )
+        cfg = proj.analyses.CFGFast(normalize=True)
+        manager = ailment.Manager()
+        checked = 0
+        for function in cfg.functions.values():
+            for block_addr in function.block_addrs_set:
+                block = ailment.IRSBConverter.convert(proj.factory.block(block_addr).vex, manager)
+                for stmt in block.statements:
+                    if isinstance(stmt, ailment.Stmt.ConditionalJump):
+                        assert stmt.true_target is not None, f"no true target at {block_addr:#x}"
+                        assert stmt.false_target is not None, f"no false target at {block_addr:#x}"
+                        checked += 1
+        assert checked > 0, "no conditional jumps converted, so the assertions above proved nothing"
+
     def test_convert_pcode_uppercase_memory_space(self):
         arch = archinfo.ArchPcode("6502:LE:16:default")
         manager = ailment.Manager()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`sub_409c10` at `0x409c10` in `kmail_antivirusplugin.so` (Debian Ports hppa
`kdepim-addons` 16.04.3-1, member sha256 `3a37f1a7f91b7270...`), loaded with
`main_opts={"backend": "elf", "arch": archinfo.ArchPcode("pa-risc:BE:32:default")}`,
decompiles to nothing:

```
  File "angr/analyses/decompiler/structuring/phoenix.py", line 3112, in _last_resort_refinement
    if not self._virtualize_edge(src, dst):
  File "angr/analyses/decompiler/structuring/phoenix.py", line 3201, in _virtualize_edge
    assert goto0_target is not None and goto1_target is not None
AssertionError
```

`Decompiler` catches it and returns with `codegen` at `None`, so the caller gets an
empty string and no exception.

Where the assertion does not fire the same statement costs a branch instead of the
whole function. `sub_402780` at `0x402780` in a `sparc:BE:32` corpus object that `angr/binaries` does
not track, on master:

```c
int sub_402780(void)
{
    char v0;  // decompile_mode

    if (v0)
        goto LABEL_0x59;
}
```

There is no `else`. The function does not end when `v0` is false; the fall-through
is not rendered at all.

### Root cause

`PCodeIRSBConverter._convert_cbranch` chooses the conditional jump's fall-through:

```python
        if self._irsb._ops[-1] is self._current_op:
            # if the cbranch op is the last op, then we need to generate a fallthru target
            fallthru = Const(self._manager.next_atom(), self._next_ins_addr, self._irsb.arch.bits)
        else:
            # there will be a Jump statement that follows the cbranch
            fallthru = None
```

The comment on the `else` is a prediction, and nothing enforces it. `_convert_branch`
back-patches a `None` false target with its own destination, but only while the
conditional jump is still `self._statements[-1]`. Put an op that emits a statement in
between and nothing ever supplies the fall-through.
That `else` arrived in angr/ailment#124 (merged 2023-03-07), which fixed the opposite
case: before it, the fall-through was never synthesised at all.

PA-RISC usually puts something else in between. Of the 2,098 CBRANCH operations the
object below lifts to, 1,858 have no `BRANCH` after them. `LDW -0x54(sp), rp` at
`0x409c4c` lifts to a CBRANCH followed by the SLEIGH nullification bookkeeping:

```
   46 | rp = *[ram]unique[e300:4]
   47 | if (unique[800:1]) goto ram[409c38:4]
   48 | nullifyCond = nullifyNextCond
   NEXT: 409c50; Ijk_Boring
```

so the converted AIL block ends with

```
if ((t20 CmpNE 0<8>)) { Goto 4234296<32> } else { Goto None }
```

`4234296` is `0x409c38`, the taken target. `0x409c50` is never named.
`_virtualize_edge` matches `true_target` against the edge it is virtualizing and
asserts on the missing `false_target`.

### Fix

Emit `None` only when the `BRANCH` that back-patches it is actually the next op.
Otherwise synthesise the fall-through from `_next_ins_addr`, which is what the
"the CBRANCH is the last op" branch already did.

The assertion in `phoenix.py` is deliberately left alone: it is the invariant check,
and it should keep failing if a conditional jump loses a target some other way.

Two nearby changes are not this one. angr/angr#6727 is the other assertion reached
through `_virtualize_edge`, `assert old_node_0 in graph` in
`RegionOverlay.replace_nodes`; its stack continues past `_virtualize_edge` into
`replace_nodes_both`, this one never leaves it. angr/angr#7104 repairs three sites in
`structurer_base.py` that take a conditional jump with two targets and leave it
holding one -- there a target is lost, here it is never set, and applying only that
branch's hunks leaves all three functions below still asserting.

### Testing

`tests/ailment/test_irsb.py::TestIrsb::test_pcode_cbranch_gets_a_fallthrough_when_no_branch_follows`
converts every block of `tests/hppa/ruby-bindex-cruby.so` and asserts that no
conditional jump the converter produces is missing a target, with a count assertion
so it cannot pass by converting nothing. On master 58 of that object's 61 conditional
jumps are missing their fall-through target -- never their true target -- and it fails.

`0x409c10`, `0x40ee0c` and `0x4114fc` in the reproducer decompile to 0 characters on
master and to 1,543, 26,568 and 11,654 here.

Decompiling up to 40 functions of each of 127 p-code objects, with and without this
change. 186 PA-RISC functions that produced nothing now decompile, across 83 of the 107
PA-RISC objects. No function that produced output stopped producing it: of 4,215 PA-RISC
functions compared the transitions are 4,002 ok-to-ok, 186 empty-to-ok and 27 that are
empty either way, with no ok-to-empty and nothing newly raising. `CFGFast` function
counts are identical in both arms on all 119 objects that load (8 of the 20 controls
never load, identically in both arms, on a separate `s_propagator` defect).

Output moves in both directions, and the losing side is real. Among the 4,002 functions
that decompiled in both arms, 967 gain gotos and **168 lose** them; 887 get longer and
**305 get shorter**. One shortening was read line by line, in another corpus object. `sub_22c00` on master ends a
`while (1)` with `if (!(0xfffffff2 == v7)) goto LABEL_0x3;` and a bare `continue`; here
the same function is a `do { ... } while (~(0 == 176(v4, &v1)));` -- 517 characters and
one goto become 394 and none. The structurer recognises the loop once the branch names
both targets, and `0x3` is not an address that object maps at all (it spans
`0x10000`-`0x2acab`). That is one worked example, not a characterisation of all 168;
the other shortenings were not individually explained.

Two non-PA-RISC objects change, on `sparc:BE:32` and `SuperH4:LE:32`, which is what
makes this a p-code converter defect rather than a PA-RISC one.

Not fixed here, because it is a different defect with a different blast radius: the
guard against p-code relative branches in this same file compares an `AddrSpace`
object to the string `"const"` and so has never fired.

This needs the fixture that angr/binaries#229 adds. Validation: https://github.com/angr/angr/pull/7124#issuecomment-5583776409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen