### PR TITLE
CCA: Stop accepting eax as a candidate function argument on X86

### DIFF
--- a/angr/analyses/calling_convention/utils.py
+++ b/angr/analyses/calling_convention/utils.py
@@ -59,7 +59,7 @@ def is_sane_register_variable(
         return 28 <= reg_offset < 60  # r3-r10
 
     if arch_name == "X86":
-        return 8 <= reg_offset < 24 or 160 <= reg_offset < 288  # eax, ebx, ecx, edx  # xmm0-xmm7
+        return 12 <= reg_offset < 24 or 160 <= reg_offset < 288  # ecx, edx, ebx  # xmm0-xmm7
 
     if arch_name == "RISCV64":
         return 96 <= reg_offset < 160  # a0-a7

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -12,6 +12,7 @@ from functools import wraps
 import archinfo
 
 import angr
+from angr.analyses.calling_convention.utils import is_sane_register_variable
 from angr.analyses.complete_calling_conventions import (
     DEAD_WORKER_GRACE_PERIOD,
     CallingConventionAnalysisMode,
@@ -226,6 +227,28 @@ class TestCallingConventionAnalysis(unittest.TestCase):
                     ret_val = func.calling_convention.return_val(func.prototype.returnty)
                     assert isinstance(ret_val, SimRegArg)
                     assert ret_val.reg_name == r
+
+    def test_i386_return_register_is_not_an_argument(self):
+        # eax is the X86 return register. It is not an argument register in any X86 calling
+        # convention, so it must not be a candidate argument; ecx, edx, ebx and the xmm registers
+        # must still be. amd64 already excludes rax the same way.
+        arch = archinfo.arch_from_id("x86")
+        for reg_name in ["eax", "ax", "al", "ah"]:
+            offset, size = arch.registers[reg_name]
+            assert not is_sane_register_variable(arch, offset, size), reg_name
+        for reg_name in ["ecx", "edx", "ebx", "xmm0"]:
+            offset, size = arch.registers[reg_name]
+            assert is_sane_register_variable(arch, offset, size), reg_name
+
+        # A function whose fact collection reports an undefined read of eax must still get a
+        # calling convention: eax is caller-saved in every X86 convention, so admitting it as a
+        # candidate argument made SimCC._match reject all of them and left the function with none.
+        binary_path = os.path.join(test_location, "i386", "nl")
+        proj = angr.Project(binary_path, auto_load_libs=False)
+        cfg = proj.analyses.CFG(normalize=True)
+        proj.analyses.CompleteCallingConventions(recover_variables=True, cfg=cfg.model, analyze_callsites=True)
+        func = cfg.kb.functions["quotearg_n_options"]
+        assert isinstance(func.calling_convention, SimCCCdecl)
 
     def test_x86_saved_regs(self):
         # Calling convention analysis should be able to determine calling convention of functions with registers


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`quotearg_n_options` at `0x4032f0` in `binaries/tests/i386/nl` gets no calling convention:

```
WARNING | angr.analyses.calling_convention.calling_convention | _analyze_function(): Cannot find a calling convention for <Function quotearg_n_options (0x4032f0)> that fits the given arguments.
WARNING | angr.analyses.calling_convention.calling_convention | Cannot determine calling convention for <Function quotearg_n_options (0x4032f0)>.
```

It takes one pointer argument. Without a convention the decompiler renders it as taking none, demotes the argument to a stack local, and closes an `int` function with a bare `return`:

```c
int quotearg_n_options(void)
{
    ...
    struct_2 *v5;  // [bp+0x4]
    ...
    *(err) = v2;
    return;
}
```

Its callers then lose the argument entirely:

```c
int quotearg_n(unsigned int a0, unsigned int a1)
{
    unsigned int v0;  // edx

    __x86.get_pc_thunk.dx();
    a0 = v0 + 28043;
    return quotearg_n_options();
}
```

That is what a missing convention costs in general, not a detail of this function: `callsite_maker` emits a call with an empty argument list whenever the callee's `cc is None`, and `clinic._make_returns` skips `ReturnMaker` for such a function.

### Root cause

`is_sane_register_variable()` in `angr/analyses/calling_convention/utils.py` decides which register-file offsets may be candidate function arguments, one range per architecture. The AMD64 entry excludes `rax`, the return register, at offset 16. The X86 entry admits `eax` at offset 8, and its comment names it:

```python
    if arch_name == "X86":
        return 8 <= reg_offset < 24 or 160 <= reg_offset < 288  # eax, ebx, ecx, edx  # xmm0-xmm7
```

No X86 calling convention in the tree has `eax` in `ARG_REGS`. It is the `RETURN_VAL` of all seven of them, and it is in `CALLER_SAVED_REGS` for the five a normal function can match -- `SimCCCdecl`, `SimCCStdcall`, `SimCCMicrosoftCdecl`, `SimCCMicrosoftFastcall` and `SimCCMicrosoftThiscall` -- every one of which sets `STRICT_CALLER_SAVED_MATCH`. So when fact collection reports an undefined read of `eax` and the filter admits it, `SimCC._match` takes this branch for every candidate:

```python
                    # if we see an undefined use of a caller-saved register, this must not be right
                    return False
```

and `find_cc` returns `None`. `quotearg_n_options` is exactly that case: the arguments master hands `find_cc` are `<eax>` and `[0x4]`, and the `<eax>` alone rejects `SimCCCdecl`, the only candidate on X86/Linux.

`eax` is the only register the X86 entry admits for which that holds on every X86 platform. `ecx` is an argument register of `SimCCMicrosoftFastcall` and `SimCCMicrosoftThiscall`, and `edx` of `SimCCMicrosoftFastcall`, all candidates on Win32; `ebx` and `xmm0`-`xmm7` are dropped by `_match` rather than vetoing it anywhere.

### Fix

Start the X86 range at `ecx`, so the entry reads `12 <= reg_offset < 24`. `quotearg_n_options` then recovers `SimCCCdecl` and `void f(struct_2 *)`, and its callers pass the argument:

```c
void quotearg_n(unsigned int a0, unsigned int a1)
{
    unsigned int v1;  // edx
    struct_2 *v0;  // [bp+0x0]

    __x86.get_pc_thunk.dx();
    a0 = v1 + 28043;
    quotearg_n_options(v0);
    return;
}
```

The gain is not free, and the same function pays. Once a function has a convention, `_adjust_prototype` runs, and it sets `returnty` to `void` when the call sites it examines all ignore the return value. `quotearg_n_options` ends its one return block with `mov eax, esi; pop ebx; pop esi; pop edi; pop ebp; ret`, so it does return a value, and it is called `void` anyway -- and `quotearg_n`, which returns whatever its callee returns, drops from `int` to `void` with it. 456 of the 662 functions that gain a convention over the corpus below recover `void`, so the same question can be asked of each. `_adjust_prototype` never consults this filter and answers the same either way; this change only makes it reachable.

Deliberately not done, and this is the first of them: that rule of `_adjust_prototype`'s. It is wrong here, but changing it moves the return type, which is a separate change with its own corpus argument. Second, `ecx` and `edx` still veto `SimCCCdecl`, the only candidate on X86/Linux and X86/CGC -- but on Win32 `ecx` is an argument register of `SimCCMicrosoftFastcall` and `SimCCMicrosoftThiscall` and `edx` of `SimCCMicrosoftFastcall`, so narrowing further needs a per-platform answer rather than a smaller range. AMD64's entry admits `r10`, which vetoes `SimCCSystemVAMD64` the same way, but `r10` is an argument register of `SimCCAMD64LinuxSyscall`, so that is not the same clean call and is left alone.

### Testing

`tests/analyses/test_calling_convention_analysis.py::TestCallingConventionAnalysis::test_i386_return_register_is_not_an_argument` asserts that `eax`, `ax`, `al` and `ah` are rejected and that `ecx`, `edx`, `ebx` and `xmm0` are still accepted, then runs the analysis over `tests/i386/nl` and asserts `quotearg_n_options` recovers `SimCCCdecl`. It fails on master with `AssertionError: eax`.

Over the 107 i386 objects under `binaries/tests/i386` that load -- 54 ELF, 39 CGC and 14 PE, 8,827 functions -- 662 functions gain a calling convention and 3 lose one, and all three losses follow from a callee of theirs changing rather than from the filter.

Validation: https://github.com/angr/angr/pull/7125#issuecomment-5585746569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen