### PR TITLE
Keep Block.bytes consistent with Block.size when a lift shortens the block

### DIFF
--- a/angr/block.py
+++ b/angr/block.py
@@ -316,6 +316,8 @@ class Block(Serializable):
             self._instructions = vex_block.instructions
             self._instruction_addrs = InsAddrList.from_addr_list(vex_block.instruction_addresses)
             self.size = vex_block.size
+            if self._bytes is not None:
+                self._bytes = self._bytes[: self.size]
 
     def __repr__(self):
         return f"<Block for {self.addr:#x}, {self.size} bytes>"

--- a/tests/factory/block/test_block_bytes.py
+++ b/tests/factory/block/test_block_bytes.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+__package__ = __package__ or "tests.factory.block"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+# pylint: disable=missing-class-docstring
+# pylint: disable=no-self-use
+class TestBlockBytes(unittest.TestCase):
+    def _lifted_blocks(self, p, addr, size):
+        state = p.factory.blank_state()
+        byte_string = p.loader.memory.load(addr, size)
+        blocks = [
+            p.factory.block(addr, size=size),
+            p.factory.block(addr, size=size, backup_state=state),
+            p.factory.block(addr, size=size, byte_string=byte_string),
+        ]
+        for block in blocks:
+            _ = block.vex_nostmt
+        return blocks
+
+    def test_bytes_follow_size_after_lift(self):
+        p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        blocks = self._lifted_blocks(p, p.entry, 1024)
+
+        assert blocks[0].size < 1024
+        for block in blocks:
+            assert block.size == blocks[0].size
+            assert len(block.bytes) <= block.size
+        assert blocks[0].bytes == blocks[1].bytes == blocks[2].bytes
+        assert blocks[0] == blocks[1] == blocks[2]
+        assert len({hash(block) for block in blocks}) == 1
+
+    def test_bytes_follow_size_after_nodecode(self):
+        p = angr.Project(os.path.join(test_location, "x86_64", "ALLSTAR_9base_awk"), auto_load_libs=False)
+        blocks = self._lifted_blocks(p, 0x4081B9, 1024)
+
+        for block in blocks:
+            assert block.vex_nostmt.jumpkind == "Ijk_NoDecode"
+            assert block.size == 0
+            assert block.bytes == b""
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A `Block` can end up holding more bytes than its own `size` says. `_bytes` is
filled once, at whatever `size` is current at that moment, and a later lift
shortens `size` without re-cutting the buffer. On
`binaries/tests/x86_64/fauxware`, with `p.factory.block(p.entry, size=1024)`:

| how the block was built, and the order it was read in | `block.size` | `len(block.bytes)` |
|---|---|---|
| no state, `.vex_nostmt` then `.bytes` | 41 | 41 |
| no state, `.bytes` then `.vex_nostmt` | 41 | 1024 |
| `backup_state=p.factory.blank_state()` | 41 | 1024 |
| `byte_string=<1024 bytes>` | 41 | 1024 |

`Block.__eq__` and `Block.__hash__` both read `self.bytes`, so blocks that
differ only in how they were built compare unequal and hash differently — same
project, same address, same final size.

Where a lift ends in `Ijk_NoDecode` the gap is the whole block. At `0x4081b9` in
`binaries/tests/x86_64/ALLSTAR_9base_awk` (a real `ud0`) the block ends with
`size == 0`; built lazily its `bytes` is `b""`, and built with `backup_state=`
or `byte_string=` it is 1024 bytes.

### Root cause

`Block.__init__` fills `_bytes` eagerly on two paths — from the backup state
when `backup_state=` is given, and from `byte_string` cut to the size known at
that moment. `self.size` is then reassigned in `_parse_vex_info`, which runs
from the `vex` and `vex_nostmt` properties long after `__init__` has returned.
The buffers keep the length they were built with while the block gets shorter.
The third path leaves `_bytes` as `None` until the first read of `.bytes`, so it
has the same problem whenever that read comes before the lift.

### Fix

`len(block.bytes) <= block.size` is a rule `block.py` already writes: `__init__`
cuts `byte_string` to `self.size`, and the `capstone` and `pcode` properties
both cut the buffer to `self.size` before disassembling. `cfg_fast.py` writes it
again when it takes `lifted_block.bytes[:irsb.size]`. This restores it at the
one place that shrinks `size` after `_bytes` exists — which is also the single
funnel for that assignment, since `_parse_vex_info` is reached from `__init__`
and from both properties.

Truncation changes how many bytes the block holds, never where they came from.
The eager `backup_state` path was added in b439cc3d40 so that `Block.bytes`
reflects self-modifying code in the state rather than the loader's image, and it
still does: storing sixteen `0x90` bytes into a blank state and building a block
there gives the state's bytes both before and after this change.

### The one consumer that wanted the longer buffer

The `ud0`/`ud1`/`ud2` guard in `_generate_cfgnode` reads
`lifted_block.bytes[irsb_size : irsb_size + 2]`, so it needs bytes past the end
of the block. **#6839 is the consumer's half of this change** and should land
before it or alongside it: it replaces that read with
`self._fast_memory_load_bytes(real_addr + irsb_size, 2)`, a read of loader
memory, which removes the dependence entirely.

This change is not behaviour-preserving for that guard, and here is what it
costs measured rather than asserted. Instrumenting the nodecode branch and
evaluating the guard's own condition over every entry:

| scan | `base_state=` | guard true today | guard true after |
|---|---|---|---|
| `ALLSTAR_9base_awk`, whole binary | no | 0 | 0 |
| `ALLSTAR_9base_awk`, whole binary | yes | 0 | 0 |
| `regions=[(0x4081b9, +0x40)]` | no | 0 | 0 |
| `regions=[(0x4081b9, +0x40)]` | yes | 1 | 0 |
| `i386/cfg_switches_O2`, whole binary | either | 0 | 0 |
| `x86_64/fauxware`, whole binary | either | 0 | 0 |

So the guard is dead under a default `CFGFast()` today, live only when a
`base_state` is supplied, and dead in both after this change until #6839 lands.
The recovered CFG for that region is the same either way — 2 nodes, 1 edge, 57
code bytes and 7 nodecode bytes in all four arms — because the guard changes
only how one byte is classified and the fallback reaches the same segment
layout there. One case is untouched: when `.vex_nostmt` raises
`SimTranslationError`, `_parse_vex_info` never runs, `size` is never shortened,
and the guard sees the same long buffer as before.

One other behaviour moves, in the same direction of making the paths agree.
Asking a nodecode block for `.vex` after `.vex_nostmt` used to return a
zero-size `Ijk_NoDecode` IRSB when the block was built with `backup_state=` or
`byte_string=`, because `_lift_nocache` passes `insn_bytes=self._bytes` and that
buffer still held the original bytes; built lazily it raised. All three now
raise `SimEngineError` — the lazy path raises its `SimTranslationError`
subclass — so the eager paths converge on what the default path already did.
Ordinary blocks are unaffected: `.vex` after `.vex_nostmt` gives the same IRSB
on all three paths, before and after.

This is one item on #4018, "State provided to analyses/methods is used
inconsistently" — the block a caller gets back should not depend on whether it
passed a state.

### Testing

`tests/factory/block/test_block_bytes.py` builds the same block all three ways
on tracked binaries and asserts `len(block.bytes) <= block.size`, that the three
buffers are equal, and that the three blocks compare equal and hash alike. Both
methods fail on the baseline.

`CFGFast()` and `CFGFast(base_state=...)` were compared before and after on
`x86_64/fauxware`, `x86_64/ALLSTAR_9base_awk`, `i386/fauxware` and
`i386/cfg_switches_O2`: identical node, edge, function and basic-block counts in
all eight configurations, in both arms.

Validation: https://github.com/angr/angr/pull/7129#issuecomment-5593886384

session: sharpen
