### PR TITLE
Decompiler: render a return value the ABI passes back through memory

### DIFF
--- a/angr/analyses/decompiler/return_maker.py
+++ b/angr/analyses/decompiler/return_maker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from angr import ailment
-from angr.calling_conventions import SimComboArg, SimRegArg
+from angr.calling_conventions import SimComboArg, SimReferenceArgument, SimRegArg, SimStructArg
 from angr.sim_type import SimTypeBottom
 from angr.utils.types import dereference_simtype_by_lib
 
@@ -43,7 +43,18 @@ class ReturnMaker(AILGraphWalker):
                 if self.function.prototype_libname
                 else self.function.prototype.returnty
             )
-            ret_val = self.function.calling_convention.return_val(returnty)
+            ret_val = self.function.calling_convention.return_val(returnty, perspective_returned=True)
+            deref_size = None
+            if isinstance(ret_val, SimReferenceArgument):
+                # This one comes back through memory: the callee leaves a pointer to the value in the return
+                # register and the caller reads the value through it. perspective_returned above is what makes
+                # ptr_loc that return register, rather than the register the caller passed the pointer in.
+                deref_size = (
+                    ret_val.main_loc.struct.size // self.arch.byte_width
+                    if isinstance(ret_val.main_loc, SimStructArg)
+                    else ret_val.main_loc.size
+                )
+                ret_val = ret_val.ptr_loc
             if isinstance(ret_val, SimRegArg):
                 reg = self.arch.registers[ret_val.reg_name]
                 new_ret_exprs.append(
@@ -85,6 +96,17 @@ class ReturnMaker(AILGraphWalker):
                         l.warning("Unsupported type of return expression %s.", type(ret_val_loc))
             else:
                 l.warning("Unsupported type of return expression %s.", type(ret_val))
+            if deref_size is not None:
+                new_ret_exprs = [
+                    ailment.Expr.Load(
+                        self._next_atom(),
+                        ret_expr,
+                        deref_size,
+                        self.arch.memory_endness,
+                        ins_addr=stmt.tags.get("ins_addr"),  # pyright: ignore[reportTypedDictNotRequiredAccess]
+                    )
+                    for ret_expr in new_ret_exprs
+                ]
             new_stmt.ret_exprs = new_ret_exprs
             return new_stmt
         return stmt

--- a/tests/analyses/decompiler/test_implicit_outparam_return.py
+++ b/tests/analyses/decompiler/test_implicit_outparam_return.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use,no-member
+"""Tests for decompiling a function whose result the calling convention passes back through memory.
+
+Anything too wide for the return register comes back through a hidden pointer: the caller hands the
+callee somewhere to put it and the callee leaves that address in the return register. ReturnMaker used
+to have no case for that location, so it logged "Unsupported type of return expression" and left the
+return statement with no expression at all -- a bare `return;` under a signature still declaring the
+wide return type.
+
+The fixtures are built from tests_src/decompiler/struct_return.c, which is also where these tests read
+the prototypes from. make_vec3 there returns a 24-byte struct on x86-64 and a 12-byte one on x86, and
+both conventions return those in memory.
+"""
+
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os
+import re
+import unittest
+
+import angr
+from angr.analyses.decompiler import Decompiler
+from angr.calling_conventions import SimFunctionArgument, SimReferenceArgument
+from angr.knowledge_plugins.functions.function import PrototypeSource
+from angr.sim_type import SimTypeFunction, parse_file
+from tests.common import bin_location, print_decompilation_result
+
+BINARIES = {
+    "x86-64": os.path.join(bin_location, "tests", "x86_64", "decompiler", "struct_return.o"),
+    "x86": os.path.join(bin_location, "tests", "i386", "decompiler", "struct_return.o"),
+}
+SOURCE = os.path.join(bin_location, "tests_src", "decompiler", "struct_return.c")
+
+# `return *((int192_t *)idx);` -- a load of the returned value through the pointer, capturing the
+# variable the pointer lives in so the test can check it is the one the body wrote the struct to
+LOADED_RETURN = re.compile(r"return \*\(\([^)]+ \*\)(\w+)\);")
+
+
+class TestImplicitOutparamReturn(unittest.TestCase):
+    @staticmethod
+    def _decompile(binary: str, name: str) -> tuple[SimFunctionArgument | None, str]:
+        proj = angr.Project(binary, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(fail_fast=True, normalize=True, data_references=True)
+        with open(SOURCE, encoding="utf-8") as fp:
+            prototype = parse_file(fp.read(), arch=proj.arch)[0][name]
+        assert isinstance(prototype, SimTypeFunction)
+
+        func = cfg.functions[name]
+        cc = proj.factory.cc()
+        func.prototype = prototype
+        func.calling_convention = cc
+        func.prototype_libname = None
+        func.prototype_source = PrototypeSource.USER
+
+        dec = proj.analyses[Decompiler].prep(fail_fast=True)(func, cfg=cfg.model)
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+
+        assert prototype.returnty is not None
+        return cc.return_val(prototype.returnty, perspective_returned=True), dec.codegen.text
+
+    @staticmethod
+    def _return_statements(text: str) -> list[str]:
+        return [line.strip() for line in text.splitlines() if line.strip().startswith("return")]
+
+    def test_a_struct_returned_through_a_hidden_pointer_reaches_the_c(self):
+        # x86 is not a duplicate of x86-64 here: cdecl passes the hidden pointer on the stack, so the
+        # location the caller sees is not a register at all and only the callee's half of the ABI
+        # gives ReturnMaker something it can render
+        for arch, binary in BINARIES.items():
+            with self.subTest(arch=arch):
+                return_val, text = self._decompile(binary, "make_vec3")
+                assert isinstance(return_val, SimReferenceArgument), "this one is supposed to return in memory"
+
+                returns = self._return_statements(text)
+                assert returns, text
+                assert all(line != "return;" for line in returns), text
+
+                # the value is loaded through the pointer, rather than the pointer being returned in
+                # its place
+                loaded = [LOADED_RETURN.fullmatch(line) for line in returns]
+                assert all(match is not None for match in loaded), text
+
+                # and it is a pointer the body wrote the struct through
+                for match in loaded:
+                    assert match is not None
+                    assert re.search(rf"\*\(\([^)]+\*\){re.escape(match.group(1))}\) = ", text), text
+
+    def test_a_return_value_in_a_register_is_unchanged(self):
+        # asking the calling convention for the callee's half of the ABI must not disturb the ordinary
+        # case, where the value is in the return register whichever half you ask about
+        return_val, text = self._decompile(BINARIES["x86-64"], "scale")
+        assert not isinstance(return_val, SimReferenceArgument), "this one returns in a register"
+
+        returns = self._return_statements(text)
+        assert returns, text
+        assert all(line != "return;" for line in returns), text
+        assert not any(LOADED_RETURN.fullmatch(line) for line in returns), text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A function whose return value the ABI passes back through memory decompiles to a body that
returns nothing, under a signature that still declares the value.

`make_vec3` in the new fixture `tests/x86_64/decompiler/struct_return.o`, built from
`tests_src/decompiler/struct_return.c`:

```c
struct vec3 make_vec3(long n)
{
    struct vec3 v;

    v.x = scale(n, 2);
    v.y = scale(n, 3);
    v.z = scale(n, 4);
    return v;
}
```

`struct vec3` is 24 bytes, so SysV AMD64 returns it through memory: the caller passes a
hidden pointer in rdi and the callee leaves that address in rax. angr master decompiles the
function to

```c
struct vec3 make_vec3(long n)
{
    unsigned long long *idx;  // rdi
    unsigned long long v0;  // [bp-0x28]
    unsigned long long v1;  // [bp-0x20]
    unsigned long long v2;  // [bp-0x18]

    v0 = scale(n, 2);
    v1 = scale(n, 3);
    v2 = scale(n, 4);
    *(idx) = v0;
    idx[1] = v1;
    idx[2] = v2;
    return;
}
```

The struct is built and then dropped. The only report is a warning from
`angr.analyses.decompiler.return_maker`:

```
Unsupported type of return expression <class 'angr.calling_conventions.SimReferenceArgument'>.
```

It is not a rare shape. On a Windows PE x86_64 build of a Rust program, where the Microsoft
x64 convention sends every non-floating-point value over eight bytes back through memory, a
scan of angr master counts 238 functions with a return location the decompiler drops, out of
the 1787 it recovered; three runs agree on the count and on the set. Some of those functions
leave nothing but the return:

```c
int128_t sub_140030a31(unsigned long a0, unsigned long a1, ...)
{
    return;
}
```

### Root cause

`ReturnMaker._handle_Return` fills a `Return` statement's `ret_exprs` from
`function.calling_convention.return_val(returnty)`. It has a case for `SimRegArg` and one for
`SimComboArg`, and nothing else:

```python
            else:
                l.warning("Unsupported type of return expression %s.", type(ret_val))
```

`SimCC.return_val` answers with a `SimReferenceArgument` when the convention returns the
value through a hidden pointer: an aggregate over `STRUCT_RETURN_THRESHOLD` on `SimCCCdecl`,
any non-floating-point value over 64 bits on `SimCCMicrosoftAMD64`, anything `_classify`
calls `MEMORY` on `SimCCSystemVAMD64`. The value has a location and the decompiler does not
read it, so `ret_exprs` stays empty and `CStructuredCodeGenerator._handle_Stmt_Return`
renders a bare `return;`.

There is a second half. `ReturnMaker` builds the *returning* function's own return statement
but asks `return_val` from the caller's side, so `SimReferenceArgument.ptr_loc` comes back as
whatever the caller puts the hidden pointer in: `rdi` on SysV AMD64, `rcx` on Microsoft x64,
and on x86 cdecl a `SimStackArg(0, 4)`, which is not a register at all and has no case in the
ladder either. `perspective_returned=True` asks the callee's side, where the pointer is in
the return register.

### Fix

Take the pointer location and load the value through it, which is what `CallsiteMaker`
already does for a reference argument on the other side of the call (`callsite_maker.py`,
`arg_loc = arg_loc.ptr_loc` then `Expr.Load(..., dereference_size)`). The register expression
comes from the existing `SimRegArg` branch, so the only new construction is the `Load`:

```c
struct vec3 make_vec3(long n)
{
    void* idx;  // rdi
    ...
    *((unsigned long long *)idx) = v0;
    *((unsigned long long *)&idx[8]) = v1;
    *((unsigned long long *)&idx[16]) = v2;
    return *((int192_t *)idx);
}
```

Deliberately not done: a `SimStructArg` return, a struct the convention returns in registers,
still falls to the same warning. `split_long` in the same fixture is one of those on x86-64 --
`return_val` puts both of its fields in `rax`. The open draft `#7075` adds that case in this
method.

### Testing

`tests/analyses/decompiler/test_implicit_outparam_return.py` decompiles `make_vec3` from the
new fixture on both its builds and asserts the return statement loads the value through the
pointer the body wrote the struct to. The prototypes come from `parse_file` over the
committed source, the way `tests/test_calling_conventions.py::test_struct_ffi` already reads
`tests_src/test_structs.c`. `scale`, which returns a `long` in a register, is the control and
must not change.

The struct case fails against `origin/master` on the bare `return;` above. It fails again with `perspective_returned` put back to `False`, on the
32-bit build, where the caller-side location is a stack slot the ladder cannot render, and
again with the `Load` dropped, so neither half of the change is unprotected.

The fixture is angr/binaries#231, and it has to merge before this one.

Validation: https://github.com/angr/angr/pull/7130#issuecomment-5595727972

sync: angr/binaries#231

session: sharpen
