### PR TITLE
LoweredSwitchSimplifier: name the switch head in the phis it rewires

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
+++ b/angr/analyses/decompiler/optimization_passes/lowered_switch_simplifier.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import networkx
 
 from angr.ailment import AILBlockViewer, Block
-from angr.ailment.expression import BinaryOp, Const, Expression, Load, VirtualVariable
+from angr.ailment.expression import BinaryOp, Const, Expression, Load, Phi, VirtualVariable
 from angr.ailment.statement import Assignment, ConditionalJump, Jump, Label
 from angr.analyses.decompiler.region_simplifiers.switch_cluster_simplifier import SwitchClusterFinder
 from angr.analyses.decompiler.structurer_nodes import (
@@ -17,6 +17,7 @@ from angr.analyses.decompiler.structurer_nodes import (
 )
 from angr.analyses.decompiler.utils import first_nonlabel_nonphi_statement, remove_last_statement
 from angr.analyses.decompiler.variable_map import variable_map_of
+from angr.utils.ail import is_phi_assignment
 from angr.utils.graph import GraphUtils
 
 from .optimization_pass import MultipleBlocksException, StructuringOptimizationPass
@@ -230,6 +231,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
         graph_copy = networkx.DiGraph(self._graph)
         self.out_graph = graph_copy
         node_to_heads = defaultdict(set)
+        folded_into: dict[tuple[int, int | None], tuple[int, int | None]] = {}
         modified = False
 
         for caselists in variablehash_to_cases.values():
@@ -377,6 +379,7 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
                         if succ not in original_nodes and (onode, succ.addr, succ.idx) not in copied_case_targets:
                             graph_copy.add_edge(new_head, succ)
                             node_to_heads[succ].add(new_head)
+                    folded_into[onode.addr, onode.idx] = new_head.addr, new_head.idx
                     graph_copy.remove_node(onode)
                 for onode in redundant_nodes:
                     if onode in original_nodes:
@@ -437,7 +440,53 @@ class LoweredSwitchSimplifier(StructuringOptimizationPass):
             # the graph is not modified
             self.out_graph = None
             return False
+
+        self._repoint_phi_sources(graph_copy, folded_into)
         return True
+
+    def _repoint_phi_sources(
+        self, graph: networkx.DiGraph, folded_into: dict[tuple[int, int | None], tuple[int, int | None]]
+    ) -> None:
+        """
+        Name the switch head in the phi variables that named a comparison node folded into it.
+
+        Every comparison node is removed once the head carries its out-edges, so a phi that still names one names a
+        block the graph no longer holds while leaving out the predecessor it now has.
+        """
+        if not folded_into:
+            return
+
+        for block in list(graph.nodes):
+            predecessors = {(pred.addr, pred.idx) for pred in graph.predecessors(block)}
+            statements = None
+            for idx, stmt in enumerate(block.statements):
+                if not is_phi_assignment(stmt):
+                    continue
+                assert isinstance(stmt, Assignment) and isinstance(stmt.src, Phi)
+                if all(src in predecessors for src, _ in stmt.src.src_and_vvars):
+                    continue
+
+                src_and_vvars = []
+                named = set()
+                for src, vvar in stmt.src.src_and_vvars:
+                    head = folded_into.get(src)
+                    if head is not None and src not in predecessors and head in predecessors:
+                        src = head
+                    # a chain folds several comparison nodes into one head, which is one predecessor
+                    if src in named:
+                        continue
+                    named.add(src)
+                    src_and_vvars.append((src, vvar))
+
+                if src_and_vvars == list(stmt.src.src_and_vvars):
+                    continue
+                if statements is None:
+                    statements = list(block.statements)
+                new_phi = Phi(stmt.src.idx, stmt.src.bits, src_and_vvars, **stmt.src.tags)
+                statements[idx] = Assignment(stmt.idx, stmt.dst, new_phi, **stmt.tags)
+
+            if statements is not None:
+                self._update_block(block, block.copy(statements=statements))
 
     def _find_cascading_switch_variable_comparisons(self):
         sorted_nodes = GraphUtils.quasi_topological_sort_nodes(self._graph)

--- a/tests/analyses/decompiler/test_lowered_switch_simplifier.py
+++ b/tests/analyses/decompiler/test_lowered_switch_simplifier.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-# pylint:disable=missing-class-docstring,no-self-use
+# pylint:disable=missing-class-docstring,no-self-use,protected-access
 from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
 
 import os
 import unittest
+from unittest import mock
 
 import angr
 from angr.analyses.decompiler.optimization_passes import LoweredSwitchSimplifier
 from angr.analyses.decompiler.presets import DECOMPILATION_PRESETS
+from angr.utils.ail import is_phi_assignment
 from tests.common import bin_location, load_project_with_scoped_cfg
 
 test_location = os.path.join(bin_location, "tests")
@@ -71,6 +73,44 @@ class TestLoweredSwitchSimplifier(unittest.TestCase):
         assert not dec.errors
         assert dec.codegen is not None and dec.codegen.text is not None
         assert "switch (" in dec.codegen.text
+
+    def test_folding_a_comparison_chain_repoints_the_phis_that_named_it(self):
+        # dd(1) at -O2: the comparison node 0x406e97 folds into the switch head at 0x406e92, and the phi
+        # variable in 0x406ee4 named 0x406e97, a block the fold removes.
+        proj, cfg = load_project_with_scoped_cfg(os.path.join(test_location, "x86_64", "decompiler", "dd"), 0x406E10)
+
+        mismatches = []
+        original_analyze = LoweredSwitchSimplifier._analyze
+
+        def analyze_and_check(pass_, cache=None):
+            result = original_analyze(pass_, cache=cache)
+            if pass_.out_graph is not None:
+                mismatches.append(_phis_that_miss_a_predecessor(pass_.out_graph))
+            return result
+
+        with mock.patch.object(LoweredSwitchSimplifier, "_analyze", analyze_and_check):
+            dec = proj.analyses.Decompiler(cfg.functions[0x406E10], cfg=cfg)
+
+        assert not dec.errors
+        assert dec.codegen is not None and dec.codegen.text is not None
+        # a run in which the pass never produced a graph would collect no mismatch either
+        assert mismatches, "LoweredSwitchSimplifier produced no graph for this function"
+        assert all(not m for m in mismatches), mismatches
+
+
+def _phis_that_miss_a_predecessor(graph) -> list[str]:
+    """Report every phi variable whose sources are not exactly the block's predecessors."""
+    reported = []
+    for block in graph.nodes():
+        predecessors = {(pred.addr, pred.idx) for pred in graph.predecessors(block)}
+        for stmt in block.statements:
+            if is_phi_assignment(stmt):
+                sources = {src for src, _ in stmt.src.src_and_vvars}
+                if sources != predecessors:
+                    reported.append(
+                        f"{block.addr:#x}-{block.idx}: {stmt.dst} from {sources}, reached from {predecessors}"
+                    )
+    return reported
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`LoweredSwitchSimplifier` leaves behind a phi variable whose operands are not the block's
predecessors. In `dd(1)` built at `-O2` (`binaries/tests/x86_64/decompiler/dd`), function
`0x406e10`, block `0x406ee4` comes out of the pass reached from `0x406e66`, `0x406e92` and
`0x406ee0` while its phi names `0x406e66`, `0x406e97` and `0x406ee0`. `0x406e97` is not in
the graph any more, and the predecessor `0x406e92` has no operand at all.

`ReturnDuplicatorLow` is what trips over it later in the preset:

```
WARNING angr.analyses.decompiler.optimization_passes.return_duplicator_base
Cannot find the virtual variable in Phi expression
Phi([((4222615, None), vvar_70{r16|4b}), ((4222688, None), vvar_81{r16|4b})])
that corresponds with node 0x406e92-None.
```

### Root cause

Lowering a comparison chain folds every comparison block into one switch head, hangs their
successors off that head, and removes them:

```python
for onode in original_nodes:
    successors = list(graph_copy.successors(onode))
    for succ in successors:
        if succ not in original_nodes and (onode, succ.addr, succ.idx) not in copied_case_targets:
            graph_copy.add_edge(new_head, succ)
            node_to_heads[succ].add(new_head)
    graph_copy.remove_node(onode)
```

Each successor loses `onode` as a predecessor and gains `new_head`, and nothing updates its
phi variables. Before this change the file held no reference to the `Phi` expression or to
`src_and_vvars`. `ITERegionConverter` does maintain them when it collapses a region into its
head, and `Clinic._inline_fix_block_phi_stmts` does the same when a callee's graph arrives
with a new block index.

### Fix

`_analyze` records which head each comparison block folded into as it removes them, and
`_repoint_phi_sources` rewrites the operands that named one. Several blocks fold into the
same head and the head is one predecessor, so a duplicate operand is dropped. An operand is
repointed only where the head really is a predecessor of the phi's own block, so the repair
never adds an operand for a block that does not reach there. Blocks are replaced through
`_update_block`, the way the pass already replaces the head, rather than edited in place:
`graph_copy` shares its block objects with the graph the pass was given.

This does not make every phi the pass emits well formed. Over the nine functions of `mv_0`
and `grep_gcc17.0.0_O2` that `check_ail_graph()` on the branch below catalogues as known-bad,
the count of phi statements whose operands are not the block's predecessors goes from 16 to
10, and no function gets worse. What is left needs the same-address expansion that branch
already has.

### Relationship to `fix/lowered-switch-ssa-repair`

That branch in this repository (unmerged) adds `angr/utils/ssa/repair.py` and calls
`repair_phi_sources()` from this pass. `repair_phi_sources` expands a stale operand into the
surviving predecessors **at the same address** and drops it when there are none, which covers
the copies this pass makes of a shared case body. It does not cover the fold: `0x406e97` is
replaced by a head at a *different* address, so that function drops the operand and still
leaves `0x406e92` unnamed. `6a98f722f` says as much -- "What remains needs more than an
address match: a block replaced by one at a different address (so nothing links the old
operand to the new predecessor)" -- and `5ed9a9876` leaves the "predecessor with no operand"
check out of `check_ail_graph()` because no pass repairs it yet. This change supplies that
link out of the mapping the pass already has, so nothing is guessed. The two are
complementary and both are still needed: three of the five stale operands that remain here
name blocks this pass recorded, and two of those three have a same-address surviving
predecessor, which is what `repair_phi_sources` handles.

### What this does not change

The decompiled output. On `dd` `0x406e10` the emitted C is byte-identical before and after,
and over 4,184 functions decompiled function by function no function's output changes
reproducibly. This repairs an invariant that later passes and dephication depend on; it is
not a change to what angr prints today.

### Testing

`test_folding_a_comparison_chain_repoints_the_phis_that_named_it` decompiles `dd` `0x406e10`
through the full preset and asserts that every phi in the graph `LoweredSwitchSimplifier`
produces names exactly that block's predecessors. It fails on master and passes here.

Validation: https://github.com/angr/angr/pull/7132#issuecomment-5596013378

session: sharpen