### PR TITLE
Variable recovery: give the CAS statement's results a variable

### DIFF
--- a/angr/analyses/variable_recovery/engine_ail.py
+++ b/angr/analyses/variable_recovery/engine_ail.py
@@ -139,6 +139,15 @@ class SimEngineVRAIL(
         if stmt.expd_hi is not None:
             self._expr(stmt.expd_hi)
 
+        for old in (stmt.old_lo, stmt.old_hi):
+            if isinstance(old, ailment.Expr.VirtualVariable):
+                self._assign_to_vvar(
+                    old,
+                    RichR(self.state.top(old.bits)),
+                    dst=old,
+                    vvar_id=self._mapped_vvarid(old.varid),
+                )
+
     def _handle_stmt_Store(self, stmt: ailment.Stmt.Store):
         addr_r = self._expr_bv(stmt.addr)
         data = self._expr(stmt.data)

--- a/tests/analyses/decompiler/test_cas_rewriting.py
+++ b/tests/analyses/decompiler/test_cas_rewriting.py
@@ -49,6 +49,22 @@ class TestCASRewriting(unittest.TestCase):
         assert dec.codegen.text.count("InterlockedExchangeAdd") == 1
         assert dec.codegen.text.count("InterlockedDecrement") == 1
 
+    def test_static_io_list_lock_cas_result_gets_a_variable(self):
+        # _IO_list_lock takes the lock with a lock cmpxchg. Variable recovery skipped the CAS
+        # statement's destinations, so its result had no variable and the C backend rendered the
+        # assignment's left-hand side as "/* unsupported instruction */".
+        bin_path = os.path.join(test_location, "x86_64", "static")
+        proj, cfg = load_project_with_scoped_cfg(bin_path, 0x4167E0, run_ccc=False)
+        func = cfg.functions[0x4167E0]
+        assert func is not None
+        dec = proj.analyses.Decompiler(func, cfg=cfg)
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+
+        text = dec.codegen.text
+        assert "atomic_compare_exchange(" in text
+        assert "/* unsupported instruction */" not in text
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`_IO_list_lock` at `0x4167e0` in `tests/x86_64/static` decompiles to an assignment whose left-hand side is a comment:

```c
/* unsupported instruction */ = atomic_compare_exchange(&list_all_lock, 1, 0);
v2 = (0 == /* unsupported instruction */ ? 0 : /* unsupported instruction */);
if (0 != /* unsupported instruction */)
    goto LABEL_416817;
```

Nothing raises. `Decompiler.errors` is empty and the analysis reports success, so no error census can see this. The compare-and-swap's result is never named, so all three reads of it are comments too and the lock's uncontended path cannot be read at all.

### Root cause

`SimEngineVRAIL._handle_stmt_CAS` visits the address and the compare and swap operands, and stops:

```python
def _handle_stmt_CAS(self, stmt) -> None:
    self._expr(stmt.addr)
    self._expr(stmt.data_lo)
    if stmt.data_hi is not None:
        self._expr(stmt.data_hi)
    self._expr(stmt.expd_lo)
    if stmt.expd_hi is not None:
        self._expr(stmt.expd_hi)
```

`old_lo` and `old_hi`, the destinations the statement writes, never reach `_assign_to_vvar`, so variable recovery creates no variable for them. `CStructuredCodeGenerator._handle_VirtualVariable` ends with `return CDirtyExpression(expr, codegen=self)` for a virtual variable that has none, and `CDirtyExpression.c_repr_chunks` yields `/* unsupported instruction */`.

`_handle_stmt_Assignment` already calls `_assign_to_vvar` for a `VirtualVariable` destination, and `_handle_stmt_SideEffectStatement` does the same for a call's `ret_expr`. CAS is the one statement that writes a destination and did not.

Both ways out of `CASIntrinsics` reach it. A compare-and-swap the pass leaves behind goes to `_handle_Stmt_CAS`, which builds `Stmt.Assignment(stmt.idx, stmt.old_lo, call)`; one the pass does rewrite becomes an ordinary `Assignment` whose destination is still `old_lo`. `sub_18000b7b0` in `tests/x86_64/windows/msvcr120.dll` is the second shape:

```c
/* unsupported instruction */ = InterlockedCompareExchange(&idx->field_40, (unsigned int)v7 | 1, v7);
```

The Rust backend has the same cause with a different symptom: it renders an unmapped virtual variable as `RustDirtyExpression`, whose `c_repr_chunks` yields `str(self.dirty)`, so a bare `vvar_276` reaches the output.

### Fix

Assign to `old_lo` and `old_hi` in `_handle_stmt_CAS`, the way every other statement that writes a destination already does. `_IO_list_lock` becomes:

```c
v2 = atomic_compare_exchange(&list_all_lock, 1, 0);
v3 = (0 == v2 ? 0 : v2);
if (0 != v2)
    goto LABEL_416817;
```

The value assigned is `top`. A variant modelling `old_lo` as a load from `stmt.addr` was tried and gave byte-identical text on the two reproducer functions, so the simpler form is what ships. Because the repair is in variable recovery it covers the C and Rust backends together.

This does not fix every comment on the left of an assignment. A write to the stack pointer in a function with a variable-length frame reaches the same fallback, because `_assign_to_vvar` deliberately gives no variable to a virtual variable whose register is `ip`, `sp` or `lr`. In the fixtures measured here that producer is the larger of the two, and this change leaves it alone.

### Testing

`test_static_io_list_lock_cas_result_gets_a_variable` decompiles `_IO_list_lock` and asserts that the intrinsic call is present and `/* unsupported instruction */` is not; on master it fails on the second assertion. Eleven of the 117 fixtures the scan flagged as holding an instruction libVEX lowers to `Ist_CAS` were decompiled on both sides, 1,458 functions in all: 32 functions lose every comment-lvalue they had, 37 of them, and each one is a compare-and-swap. Two functions change otherwise and both are angr's known per-process decompiler nondeterminism, reproduced on master alone.

Two existing tests assert `"atomic_compare_exchange" in text`, which the broken output satisfies, which is why nothing caught this. #6783 added `_handle_Stmt_CAS`.

Validation: https://github.com/angr/angr/pull/7133#issuecomment-5598732942

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen
