### PR TITLE
Decompiler: render an unnamed register as the register, not a comment

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -4590,6 +4590,14 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
                     dst_type = dst_type.with_arch(self.project.arch)
                     return CTypeCast(src_type, dst_type, cvar, tags=expr.tags, codegen=self)
             return cvar
+
+        if expr.was_reg:
+            # Variable recovery does not create variables for the stack pointer, the instruction
+            # pointer or the link register, so a surviving write to one of them arrives here with
+            # nothing mapped. A register we could not name as a variable is still a register.
+            reg_name = self.project.arch.translate_register_name(expr.oident, expr.size)
+            return CRegister(reg_name or f"reg{expr.oident}", tags=expr.tags, codegen=self)
+
         return CDirtyExpression(expr, codegen=self)
 
     def _handle_Expr_StackBaseOffset(self, expr: StackBaseOffset, **kwargs):

--- a/tests/analyses/decompiler/test_unmapped_register_rendering.py
+++ b/tests/analyses/decompiler/test_unmapped_register_rendering.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os.path
+import unittest
+
+import angr
+from tests.common import bin_location
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestUnmappedRegisterRendering(unittest.TestCase):
+    """Rendering of a register that variable recovery did not turn into a variable."""
+
+    def test_stack_pointer_in_a_variable_length_frame_is_named(self):
+        # sub_401690 adjusts esp by a value it computes at run time, so the stack pointer
+        # survives to the C backend and variable recovery has no variable for it.
+        proj = angr.Project(os.path.join(test_location, "i386", "simple_windows.exe"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        decompilation = proj.analyses.Decompiler(proj.kb.functions[0x401690], cfg=cfg.model)
+
+        assert decompilation.codegen is not None and decompilation.codegen.text is not None
+        text = decompilation.codegen.text
+        assert "/* unsupported instruction */" not in text
+        assert "esp = " in text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`sub_401690` at `0x401690` in `tests/i386/simple_windows.exe` decompiles to assignments whose left-hand side is a comment:

```c
v2 = &v1;
/* unsupported instruction */ = (char *)&v0 - a1;
/* unsupported instruction */ = /* unsupported instruction */ - 4;
*((unsigned int *)(/* unsupported instruction */ - 4)) = v7;
/* unsupported instruction */ = /* unsupported instruction */ - 4;
*((unsigned int *)(/* unsupported instruction */ - 4)) = v8;
```

Nothing raises; the decompiler reports success. A comment is not an expression, so these are not assignments at all, and every later read of the same value is a comment too, which is why four writes cost twelve placeholders and the function's frame setup cannot be followed.

Over 137 tracked fixtures that hold a stack-pointer write whose source is a register other than the frame pointer, decompiling the functions those writes fall in gives 2,375 such assignments across 618 functions.

### Root cause

`CStructuredCodeGenerator._handle_VirtualVariable` falls through when variable recovery produced no variable:

```python
        expr_var = self._variable_map.variable(expr)
        if expr_var is not None:
            ...
            return cvar
        return CDirtyExpression(expr, codegen=self)
```

`CDirtyExpression` exists for `ailment.expression.DirtyExpression`, an un-lifted VEX dirty helper, and asks it for a `callee`. A `VirtualVariable` has none, so `intrinsic_name()` returns `None` and `c_repr_chunks` yields the literal `/* unsupported instruction */`.

The virtual variable is ordinary; it just has no name, because variable recovery declines to name three registers on purpose. `SimEngineVRBase._assign_to_vvar` in `variable_recovery/engine_base.py` stores the value and returns for the instruction pointer, the stack pointer and the link register. That is fine while the stack pointer is folded away into stack offsets, and a function with a variable-length frame is where it is not: `sub_401690` adjusts `esp` by a value it computes at run time, so the write survives to the C backend with nothing mapped to it.

### Fix

Name the register. A register that variable recovery could not turn into a variable is still a register, and `CRegister` already renders one.

```c
v2 = &v1;
esp = (char *)&v0 - a1;
esp = esp - 4;
*((unsigned int *)(esp - 4)) = v7;
```

This is the layer that owns the invariant that everything reaching the C backend renders as an expression. `_handle_Expr_StackBaseOffset`, the next handler in the same file, already meets the same "no variable was recovered" state and falls back to a name rather than to a dirty expression. The same `was_reg` branch is on this repository's `feat/deobf-dump` branch as ac9d4d5c5; this brings it to master with a regression and a corpus measurement.

The alternative was to stop `_assign_to_vvar` skipping the stack pointer, and I built and measured it: it also removes every comment left-hand side, but it rewrites 181 of the 618 functions where this one rewrites 175, and not one of its rewrites is a plain substitution — each renumbers or restructures the function, so a reviewer has to read all 181.

Not done here: nine placeholders remain in a `&x` reference operand, eight of them on virtual variables in the parameter category, which `was_reg` does not cover. `structured_codegen/rust.py` has the same fallback and puts the virtual variable's internal repr in emitted Rust; that is a different backend and a different symptom.

### Testing

`test_stack_pointer_in_a_variable_length_frame_is_named` decompiles `sub_401690` and asserts that `/* unsupported instruction */` is absent and `esp = ` is present; on master it fails on the first assertion. Across the same 618 functions, 440 are byte-identical, 175 change by exactly that substitution and nothing else, and three differ across repeated runs of master alone.

The population is a lower bound: the scan that found those 137 fixtures reads 729 of the 1,101 files tracked under `binaries/tests`, and covers x86, AMD64 and AArch64 only.

Validation: https://github.com/angr/angr/pull/7138#issuecomment-5606331297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen