### PR TITLE
CallingConventionAnalysis: drop the sub-register a rejected argument came from

### DIFF
--- a/angr/analyses/calling_convention/calling_convention.py
+++ b/angr/analyses/calling_convention/calling_convention.py
@@ -541,9 +541,9 @@ class CallingConventionAnalysis(Analysis):
             )
 
         # update input_args according to the difference between full_input_args and full_input_args_copy
-        for a in full_input_args:
-            if a not in full_input_args_copy and a in input_args:
-                input_args.remove(a)
+        for a, original_args in full_input_args.items():
+            if a not in full_input_args_copy:
+                input_args.difference_update(original_args)
 
         if cc is None:
             l.warning(
@@ -993,16 +993,18 @@ class CallingConventionAnalysis(Analysis):
 
         return args.difference(restored_reg_vars)
 
-    def _consolidate_input_args(self, input_args: set[SimRegArg | SimStackArg]) -> set[SimRegArg | SimStackArg]:
+    def _consolidate_input_args(
+        self, input_args: set[SimRegArg | SimStackArg]
+    ) -> dict[SimRegArg | SimStackArg, list[SimRegArg | SimStackArg]]:
         """
         Consolidate register arguments by converting partial registers to full registers on certain architectures.
 
         :param input_args:  A set of input arguments.
-        :return:            A set of consolidated input args.
+        :return:            A map from each consolidated argument to the input arguments it stands for.
         """
 
         if self.project.arch.name in {"AMD64", "X86"}:
-            new_input_args = set()
+            new_input_args: defaultdict[SimRegArg | SimStackArg, list[SimRegArg | SimStackArg]] = defaultdict(list)
             for a in input_args:
                 if isinstance(a, SimRegArg) and a.size < self.project.arch.bytes:
                     # use complete registers on AMD64 and X86
@@ -1011,14 +1013,12 @@ class CallingConventionAnalysis(Analysis):
                         reg_offset, self.project.arch, size=reg_size
                     )
                     full_reg_name = self.project.arch.translate_register_name(full_reg_offset, size=full_reg_size)
-                    arg = SimRegArg(full_reg_name, full_reg_size)
-                    if arg not in new_input_args:
-                        new_input_args.add(arg)
+                    new_input_args[SimRegArg(full_reg_name, full_reg_size)].append(a)
                 else:
-                    new_input_args.add(a)
+                    new_input_args[a].append(a)
             return new_input_args
 
-        return set(input_args)
+        return {a: [a] for a in input_args}
 
     def _reorder_args(self, args: set[SimRegArg | SimStackArg], cc: SimCC) -> list[SimRegArg | SimStackArg]:
         """

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -293,6 +293,20 @@ class TestCallingConventionAnalysis(unittest.TestCase):
         assert cca.prototype is not None
         assert cca.prototype.returnty is not None
 
+    def test_i386_rejected_partial_register_is_not_an_argument(self):
+        # sub_fe744 reads bx before writing it, so bx is a candidate argument. It consolidates to ebx, and
+        # cdecl passes no argument in a register, so _match drops it: the function has no arguments.
+        binary_path = os.path.join(test_location, "i386", "bios.bin.elf")
+        proj = angr.Project(binary_path, auto_load_libs=False)
+        _ = proj.analyses.CFGFast(normalize=True, regions=[(0xFE700, 0xFE800)], start_at_entry=False)
+        func = proj.kb.functions[0xFE744]
+        proj.analyses.VariableRecoveryFast(func)
+        cca = proj.analyses.CallingConvention(func, collect_facts=True)
+
+        assert isinstance(cca.cc, SimCCCdecl)
+        assert cca.prototype is not None
+        assert len(cca.prototype.args) == 0, f"sub_fe744 takes no arguments, got {cca.prototype}"
+
     def test_armhf_thumb_movcc(self):
         binary_path = os.path.join(test_location, "armhf", "amp_challenge_07.gcc")
         proj = angr.Project(binary_path, auto_load_libs=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CallingConventionAnalysis` gives a function a parameter that `SimCC._match` has already
rejected. `sub_fe744` at `0xfe744` in `binaries/tests/i386/bios.bin.elf`:

```c
void sub_fe744(unsigned short a0)
```

`a0` is `bx`, and it appears nowhere else in the decompiled body. The convention the function
matched is `SimCCCdecl`, which passes no argument in a register at all. Every sub-register
candidate that `_match` rejects on X86 and AMD64 survives this way, and the wrong prototype then
reaches the decompiled output.

### Root cause

`_analyze_function` matches on a consolidated argument set and reconciles against the
un-consolidated one:

```python
full_input_args = self._consolidate_input_args(input_args)
full_input_args_copy = list(full_input_args)  # input_args might be modified by find_cc()
...
# update input_args according to the difference between full_input_args and full_input_args_copy
for a in full_input_args:
    if a not in full_input_args_copy and a in input_args:
        input_args.remove(a)
```

`_consolidate_input_args` widens a partial register to its full register on X86 and AMD64, so
`SimRegArg("bx", 2)` goes in and `SimRegArg("ebx", 4)` comes out. `SimRegArg.__eq__` compares
name, offset and size, so `a in input_args` is false for every argument that was widened: `<ebx>`
is not `<bx>`. Nothing is removed, and `_reorder_args` — which does resolve sub-registers, through
`_is_same_reg` — carries the rejected register into the prototype.

`_consolidate_input_args` and this loop both arrived in #5258 (`fa055f41b`), which moved the
register widening to just before convention matching.

### Fix

`_consolidate_input_args` returns a map from each consolidated argument to the originals it stands
for, and the loop discards those originals:

```c
void sub_fe744(void)
```

This adds no rule about which registers can carry an argument. It removes an argument only where
the matched convention's own `_match` already rejected it, so where a convention does pass in that
register `_match` keeps it and nothing is removed. Outside X86 and AMD64 the map is
`{a: [a] for a in input_args}` and the loop does exactly what it did before.

Deliberately not touched: whether `_match` should be rejecting a given register in the first
place. This only makes its answer reach the prototype.

### Testing

`test_i386_rejected_partial_register_is_not_an_argument` recovers `sub_fe744` and asserts that the
prototype takes no arguments. On master it fails with
`AssertionError: sub_fe744 takes no arguments, got (short (16 bits)) -> void`.

Over 107 of the 150 files tracked under `binaries/tests/i386` at `angr/binaries fc07821c8`, 8827
recovered prototypes, 21 change and not one gains an argument. The rest of the numbers, the AMD64
arm and the gate are in the validation record.

Validation: https://github.com/angr/angr/pull/7139#issuecomment-5606440497

session: sharpen
