### PR TITLE
refine_locs_with_struct_type: lay out an opaque C++ class as an integer

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -174,7 +174,9 @@ def refine_locs_with_struct_type(
             for i in range(arg_type.length)
         ]
         return SimArrayArg(locs_list)
-    if isinstance(arg_type, SimStruct):
+    # An opaque class has a size and no members: nothing to lay out field by field, so leave it to the
+    # integer case below, which is how SimCCSystemVAMD64._classify already classifies it.
+    if isinstance(arg_type, SimStruct) and (arg_type.fields or not arg_type.size):
         locs_dict = {
             field: refine_locs_with_struct_type(arch, locs, field_ty, offset=offset + arg_type.offsets[field])
             for field, field_ty in arg_type.fields.items()

--- a/tests/analyses/decompiler/test_opaque_class_locations.py
+++ b/tests/analyses/decompiler/test_opaque_class_locations.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-class-docstring,no-self-use
+"""Tests for functions that pass or return a C++ class the binary never defines.
+
+A demangled C++ declaration names classes the binary does not define. Those become a
+SimCppClass with a size and no members, and the calling convention has to give them a
+location anyway.
+"""
+
+from __future__ import annotations
+
+__package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
+
+import os
+import unittest
+
+import angr
+from angr.analyses.decompiler.decompiler import Decompiler
+from angr.calling_conventions import SimRegArg
+from angr.sim_type import SimCppClass
+from tests.common import bin_location, print_decompilation_result
+
+test_location = os.path.join(bin_location, "tests")
+
+
+class TestOpaqueClassLocations(unittest.TestCase):
+    def test_opaque_class_return_value_has_a_location(self):
+        # Concurrency::location::current() is an MSVC-mangled method returning a class msvcr120.dll
+        # does not define.
+        bin_path = os.path.join(test_location, "x86_64", "windows", "msvcr120.dll")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(
+            force_smart_scan=False, normalize=True, regions=[(0x180009AF8, 0x180009AF8 + 0x200)]
+        )
+        proj.analyses.CompleteCallingConventions(recover_variables=True, cfg=cfg.model)
+
+        func = proj.kb.functions[0x180009AF8]
+        prototype = func.prototype
+        cc = func.calling_convention
+        assert prototype is not None and cc is not None
+        returnty = prototype.returnty
+        assert isinstance(returnty, SimCppClass)
+        assert not returnty.fields and returnty.size
+
+        ret_loc = cc.return_val(returnty)
+        assert isinstance(ret_loc, SimRegArg), f"Unexpected return location: {ret_loc}"
+        assert ret_loc.reg_name == "rax"
+        assert ret_loc.size == returnty.size // proj.arch.byte_width
+
+        d = proj.analyses[Decompiler].prep(fail_fast=True)(func, cfg=cfg.model)
+        assert d.codegen is not None and d.codegen.text is not None
+        print_decompilation_result(d)
+        # the prototype does not return void, so a bare return statement drops the returned value
+        assert "return;" not in d.codegen.text
+
+    def test_opaque_class_arguments_have_locations(self):
+        # plouf(std::string, std::string) takes two classes this binary does not define
+        bin_path = os.path.join(test_location, "i386", "cpp_regression_test_ch25")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, data_references=True)
+        proj.analyses.CompleteCallingConventions(recover_variables=True, cfg=cfg.model)
+
+        func = next(
+            f
+            for f in cfg.functions.values()
+            if f.demangled_name is not None and f.demangled_name.startswith("plouf(") and not f.is_plt
+        )
+        prototype = func.prototype
+        cc = func.calling_convention
+        assert prototype is not None and cc is not None
+        assert all(isinstance(arg, SimCppClass) and not arg.fields and arg.size for arg in prototype.args)
+
+        arg_locs = list(cc.arg_locs(prototype.with_arch(proj.arch)))
+        assert len(arg_locs) == 2
+        assert all(loc.size == 4 for loc in arg_locs), f"Unexpected argument locations: {arg_locs}"
+
+        d = proj.analyses[Decompiler].prep(fail_fast=True)(func, cfg=cfg.model)
+        assert d.codegen is not None and d.codegen.text is not None
+        print_decompilation_result(d)
+        # both arguments are declared, so neither may be dropped from the signature
+        assert "void plouf()" not in d.codegen.text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

When a demangled C++ declaration names a class the binary does not define, the calling
convention gives that value a location holding no storage. The decompiler then drops it.

An argument, in the tracked `tests/i386/cpp_regression_test_ch25`. `plouf` is declared
`plouf(std::string, std::string)` and decompiles with no parameters at all, its two argument
slots recovered as unnamed locals:

```c
void plouf()
{
    ...
    std::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string(v3, &g_8048db0, &v1);
    for (i = 0; *((char *)(unsigned int)std::string::operator[](v4, i)); i += 1)
```

A return value, in `tests/x86_64/windows/msvcr120.dll` -- a fixture this repository's own
decompiler tests already load. `Concurrency::location::current()` at `0x180009af8`:

```c
class Concurrency::location Concurrency::location::current(void* idx)
{
    ...
    if (!v2)
        return;
    ...
    return;
}
```

The only report is a log line:

```
WARNING angr.analyses.decompiler.return_maker | Unsupported type of return expression
        <class 'angr.calling_conventions.SimStructArg'>.
```

### Root cause

`SimCppClass` can carry a size with no members -- that is how a class named but never
defined is represented, and `_cpp_decl_to_type` builds one for every such name
(`opaque_classes=True`). A plain `SimStruct` with no fields has size zero, so "no
fields and a nonzero size" picks out exactly that case.

`refine_locs_with_struct_type` lays an aggregate out field by field:

```python
    if isinstance(arg_type, SimStruct):
        locs_dict = {
            field: refine_locs_with_struct_type(arch, locs, field_ty, offset=offset + arg_type.offsets[field])
            for field, field_ty in arg_type.fields.items()
        }
        return SimStructArg(arg_type, locs_dict)
```

With no fields there is nothing to iterate, so it answers `SimStructArg(arg_type, {})` -- a
location of size 0. The storage the convention allocated one call earlier is discarded.

`SimCCSystemVAMD64._classify` has already decided what this shape is passed as, and says so:

```python
        if isinstance(ty, SimCppClass) and not ty.fields and ty.size:
            # this is an opaque C++ class (likely unresolved); we cannot lay it out. so we must treat it as a native
            # integer.
            return ["INTEGER"]
```

It classifies the type as `INTEGER`, maps that to a register, and hands the register to
`refine_locs_with_struct_type`, which throws it away. That rule was put there deliberately:
#5979 made an opaque class raise `TypeError("Cannot lay out an opaque class")`, and #6546
replaced the raise with the integer classification. The layout helper never got it.

### Fix

Let the case reach the integer fallback the function already ends with -- "for all other
types, we basically treat them as integers until someone implements proper layouting logic"
-- rather than claiming a field-by-field layout it does not have. One condition:

```python
    if isinstance(arg_type, SimStruct) and (arg_type.fields or not arg_type.size):
```

A struct with fields is untouched. A struct that genuinely has no size keeps its empty
layout, so the empty-struct argument that
`tests/analyses/decompiler/test_combo_reg_args.py` covers behaves as before.

This does not invent a layout. The type reaching the integer case is `SimTypeInt`, so the
value is described as a 4-byte integer in the storage the convention had already allocated
-- `<rax>` for the return above, the first stack slot for each argument. That is not a
claim about the class's real width: the size an unresolved class carries is a placeholder,
and `_cpp_decl_to_type` is the only thing in the tree that builds one, always at 32 bits.

Deliberately not done: `SimCCRISCV64.next_arg` lays `SimStruct` arguments out itself in two
hand-written copies rather than calling this helper, so an opaque class passed by value on
RISCV64 still gets an empty `SimStructArg`. Same defect, second site, its own change.

### Testing

`tests/analyses/decompiler/test_opaque_class_locations.py` covers both directions on tracked
binaries: `plouf` in `tests/i386/cpp_regression_test_ch25` for arguments, and `0x180009af8`
in `tests/x86_64/windows/msvcr120.dll` for the return, scoped to a `regions=` window as
`test_decompiler.py` already does on that file. Each test asserts the recovered
location and the decompiled text. Against the base revision both fail on the location, and
with the location assertions removed both still fail -- one on `void plouf()`, the other on
the bare `return;` with the warning above in the captured log -- so neither half is idle.

Validation: https://github.com/angr/angr/pull/7140#issuecomment-5606490541

session: sharpen