### PR TITLE
claripy: seed the AST hasher at build time instead of per process

### DIFF
--- a/native/clarirs-core/src/ast/annotation.rs
+++ b/native/clarirs-core/src/ast/annotation.rs
@@ -1,6 +1,3 @@
-use std::hash::{Hash, Hasher};
-
-use ahash::AHasher;
 use num_bigint::BigUint;
 
 /// A wrapper excluded from identity: all `Ignored<T>` compare equal and hash to
@@ -100,8 +97,6 @@ impl Annotation {
     }
 
     pub fn identity_hash(&self) -> u64 {
-        let mut hasher = AHasher::default();
-        self.hash(&mut hasher);
-        hasher.finish()
+        crate::context::HASHER.hash_one(self)
     }
 }

--- a/native/clarirs-core/src/context.rs
+++ b/native/clarirs-core/src/context.rs
@@ -1,8 +1,8 @@
-use ahash::AHasher;
+use ahash::RandomState;
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::Debug,
-    hash::{Hash, Hasher},
+    hash::{BuildHasher, Hash, Hasher},
     sync::{Arc, RwLock},
 };
 
@@ -12,6 +12,16 @@ use crate::{
     prelude::*,
 };
 
+/// The hasher for AST identity. `AHasher::default()` draws its keys from the
+/// operating system on first use, so the same AST hashes to a different number
+/// in every process; these keys are fixed so that it does not.
+pub(crate) const HASHER: RandomState = RandomState::with_seeds(
+    0x9e37_79b9_7f4a_7c15,
+    0xbf58_476d_1ce4_e5b9,
+    0x94d0_49bb_1331_11eb,
+    0x2545_f491_4f6c_dd1d,
+);
+
 /// The hash a node is interned under: type, op (which folds in child hashes),
 /// then annotations. Shared so construction and algorithms that need a node's
 /// key without building it (e.g. `excavate_ite`) agree.
@@ -20,7 +30,7 @@ pub(crate) fn structural_hash(
     op: &AstOp<'_>,
     annotations: &BTreeSet<Annotation>,
 ) -> u64 {
-    let mut hasher = AHasher::default();
+    let mut hasher = HASHER.build_hasher();
     ast_type.hash(&mut hasher);
     op.hash(&mut hasher);
     for a in annotations {

--- a/tests/claripy/test_hash_stability.py
+++ b/tests/claripy/test_hash_stability.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+
+from angr import claripy
+
+HASH_SCRIPT = """\
+import angr
+from angr import claripy
+
+x = claripy.BVS("x", 64, explicit_name=True)
+y = claripy.BVS("y", 64, explicit_name=True)
+for ast in (x, y, x + y, (x - 48).ULE(9), claripy.Or((x - 48).ULE(9), (x - 43).ULE(2))):
+    print(hash(ast))
+"""
+
+
+def _asts():
+    x = claripy.BVS("x", 64, explicit_name=True)
+    y = claripy.BVS("y", 64, explicit_name=True)
+    return (x, y, x + y, (x - 48).ULE(9), claripy.Or((x - 48).ULE(9), (x - 43).ULE(2)))
+
+
+class TestHashStability(unittest.TestCase):
+    """Two processes hash the same expression to the same number."""
+
+    def test_hashes_agree_with_another_process(self):
+        """angr reads these hashes back out. The decompiler names sympy symbols after them and
+        sympy orders the operands of a disjunction by symbol name, so a hash that varies per
+        process makes decompiled C depend on which process produced it.
+        """
+        here = [hash(ast) for ast in _asts()]
+
+        result = subprocess.run(
+            [sys.executable, "-c", HASH_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=True,
+        )
+        there = [int(line) for line in result.stdout.split()]
+
+        self.assertEqual(here, there)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling the same function twice, in two processes, gives two different C files.

`time.tzsetName` in `tests/x86_64/windows/131252a8059fdbb12d77cd4711e597c45bb48e6d4bc3ddc808697a5e0488ff2c` (a Go PE tracked in angr/binaries) came out one of two ways over 20 fresh processes on `5dc307805`. Thirteen of them wrote

```c
                if (v7 - 48 <= 9 || v7 - 43 <= 2)
```

and the other seven wrote

```c
                if (v7 - 43 <= 2 || v7 - 48 <= 9)
```

That line is the entire difference between the two files. `PYTHONHASHSEED` was pinned to `0` in every one of those processes, so this is not Python's string-hash seed.

The number the operand order depends on is `hash()` of a claripy AST, and it is different in every process:

```
$ for i in 1 2 3; do python -c 'from angr import claripy; a = claripy.BVS("a", 64, explicit_name=True); print(hash((a - 48).ULE(9)))'; done
6030197575043215251
-8213956419433140107
581606580832152120
```

So the blast radius is larger than one `||`. Any comparison of AST hashes across processes -- a multiprocessing worker pool, a cache keyed on the hash, a diff of two decompilation runs -- is comparing numbers that were never going to agree.

### Root cause

`clarirs-core` hashes an AST with `ahash::AHasher::default()`:

```rust
pub(crate) fn structural_hash(
    ast_type: AstType,
    op: &AstOp<'_>,
    annotations: &BTreeSet<Annotation>,
) -> u64 {
    let mut hasher = AHasher::default();
```

ahash's own documentation for that constructor says the keys "will be generated upon first invocation" when `std` is enabled, and `AHasher::default()` is `RandomState::with_fixed_keys().build_hasher()`, whose keys come from `getrandom` -- once per process. `Annotation::identity_hash` did the same. `Base::__hash__` returns that number to Python unchanged.

The decompiler then reads it back. `ConditionProcessor.claripy_ast_to_sympy_expr` names a sympy symbol after it:

```python
symbol = sympy.Symbol(str(hash(ast)))
```

`simplify_condition` hands the result to `sympy.simplify_logic` and rebuilds the claripy condition from `expr.args`. sympy orders the arguments of `Or` and `And` by symbol name, so the operand order that comes back out is the order of two decimal strings drawn from `getrandom` at interpreter start.

angr's AIL nodes already state the rule this violates. `ailment::hash_of` requires a node's hash to be

> **Process-independent** -- for a given build, the same AIL node hashes to the same value in every process, so hashes can be compared across e.g. multiprocessing workers.

and picks `FxHasher` for it, "unlike `RandomState`, which would break cross-process comparison". clarirs is the site that did not get the rule.

### Fix

Give `structural_hash` and `Annotation::identity_hash` one `ahash::RandomState` whose four keys are written in the source. Same hash function and same distribution -- which matters, because `structural_hash` is also the key ASTs are interned under -- with the per-process draw removed. The one-liner above then prints `-7705958886785785665` three times, and `time.tzsetName` decompiles to the `48 || 43` form in 20 of 20 fresh processes.

`Annotation::identity_hash` has no consumer today that can see the difference -- it keys an in-process cache -- and is changed anyway so the two sibling hashes follow one rule.

Deliberately not done, three things.

The decompiler still names sympy symbols after `hash()`. That is a reasonable thing to do once the hash identifies the AST rather than the process, and it is the producer, not the consumer, that broke the rule quoted above.

An AST carrying a Python-defined annotation whose class leaves `__hash__` alone still hashes differently in each process, because such an annotation is identified by the Python object's hash, which is its address. That is claripy's annotation identity rule, not this hasher, and changing it is a separate argument.

This does not make the decompiler deterministic; it closes one mechanism. `strings.EqualFold` in the same binary still gives two different structurings over 20 fresh processes with this change applied, and the difference there is goto and label placement, which is #7009. Over ten processes each, `vfprintf` in `tests/i386/libc.so.6` gave 2 distinct outputs before this change and 3 after, and `_nl_load_domain` in `tests/x86_64/static` gave 6 and 8. Ten processes is far too few to say whether those counts moved; what they do show is that both functions are still unstable. #6437, #6840, #6267 and #4760/#4761/#4762 cover the other known sources of decompiler nondeterminism.

### Testing

`tests/claripy/test_hash_stability.py` hashes five ASTs, hashes the same five in a fresh subprocess, and asserts the two lists are equal. It fails on `5dc307805` and passes with this change.

For the decompiler itself: 402 functions of the Go PE above -- every third by address of the 1,533 that are between 4 and 80 blocks, up to 400, plus the two named here -- decompiled in three separate processes on each side. 400 are stable on both sides, and **none of those 400 changes its output**. Of the two that are not stable on the base side, this change settles `time.tzsetName` and leaves `strings.EqualFold` alone: over 20 fresh processes it gives the same two outputs on either side, in much the same proportion.

Validation: https://github.com/angr/angr/pull/7141#issuecomment-5608909858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen