### PR TITLE
Decompiler: render a Rust return value split across several registers

### DIFF
--- a/angr/analyses/decompiler/structured_codegen/rust.py
+++ b/angr/analyses/decompiler/structured_codegen/rust.py
@@ -3914,10 +3914,37 @@ class RustStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis):
         if len(stmt.ret_exprs) == 1:
             ret_expr = stmt.ret_exprs[0]
             return RustReturn(self._handle(ret_expr), tags=stmt.tags, codegen=self)
-        # TODO: Multiple return expressions
-        l.warning("StructuredCodeGen does not support multiple return expressions yet. Only picking the first one.")
-        ret_expr = stmt.ret_exprs[0]
-        return RustReturn(self._handle(ret_expr), tags=stmt.tags, codegen=self)
+        if not self._returnty_holds_every_ret_expr(stmt.ret_exprs):
+            l.warning("StructuredCodeGen does not support multiple return expressions yet. Only picking the first one.")
+            return RustReturn(self._handle(stmt.ret_exprs[0]), tags=stmt.tags, codegen=self)
+        # SimComboArg lists its locations least significant first, so build the Concat up from the first
+        # expression: every piece joins on the left of what is already there, as the high half.
+        retval = self._handle(stmt.ret_exprs[0])
+        for ret_expr in stmt.ret_exprs[1:]:
+            retval = RustBinaryOp("Concat", self._handle(ret_expr), retval, tags=stmt.tags, codegen=self)
+        return RustReturn(retval, tags=stmt.tags, codegen=self)
+
+    def _returnty_holds_every_ret_expr(self, ret_exprs: list[Expr.Expression]) -> bool:
+        """
+        Whether the recovered return type accounts for every one of a return statement's expressions.
+
+        ``SimCC.return_val()`` answers with a :class:`SimComboArg` whenever the return type is wider than one
+        register -- a ``u128`` in ``rax:rdx`` on amd64 -- and ``ReturnMaker`` expands that into one return
+        expression per location. Two things can put the expressions and the return type out of step afterwards,
+        and in both the pieces must not be rendered as one value:
+
+        - The return type is an aggregate or a floating-point value spread over several registers, which is not a
+          scalar with a high and a low half. A ``&str`` is the common one in Rust: a data pointer beside a
+          length, also returned in ``rax:rdx``. angr/angr#6851 tracks carrying those through as one typed value.
+        - ``Clinic._make_function_prototype`` rewrote the prototype after ``ReturnMaker`` ran, leaving a return
+          type that is not as wide as the expressions it left behind.
+        """
+        if self._func.prototype is None or self._func.prototype.returnty is None:
+            return False
+        returnty = unpack_typeref(self._func.prototype.returnty).with_arch(self.project.arch)
+        if not qualifies_for_width_cast(returnty):
+            return False
+        return returnty.size == sum(ret_expr.bits for ret_expr in ret_exprs)
 
     def _handle_Stmt_Label(self, stmt: Stmt.Label, **kwargs):
         ins_addr = stmt.tags.get("ins_addr")

--- a/tests/analyses/decompiler/test_rust_codegen_handlers.py
+++ b/tests/analyses/decompiler/test_rust_codegen_handlers.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 __package__ = __package__ or "tests.analyses.decompiler"  # pylint:disable=redefined-builtin
 
+import itertools
 import os
+import re
 import unittest
 from unittest import mock
 
@@ -14,19 +16,25 @@ from angr.ailment.block import Block
 from angr.ailment.expression import (
     Const,
     DirtyExpression,
+    Expression,
     Insert,
     VirtualVariable,
     VirtualVariableCategory,
 )
-from angr.ailment.statement import CAS, DirtyStatement, Jump, Store, WeakAssignment
-from angr.analyses.decompiler.structured_codegen.rust import RustExpression, RustStructuredCodeGenerator
+from angr.ailment.statement import CAS, DirtyStatement, Jump, Return, Store, WeakAssignment
+from angr.analyses.decompiler.structured_codegen.rust import (
+    RustExpression,
+    RustReturn,
+    RustStructuredCodeGenerator,
+)
 from angr.analyses.decompiler.structurer_nodes import (
     IncompleteSwitchCaseHeadStatement,
     IncompleteSwitchCaseNode,
     SequenceNode,
 )
+from angr.calling_conventions import SimComboArg
 from angr.rust.sim_type import RustSimTypeInt, RustSimTypeStrRef
-from angr.sim_type import SimTypeBottom
+from angr.sim_type import SimTypeBottom, SimTypeFunction, SimTypeLongLong, SimTypeNum
 from tests.common import bin_location, load_project_with_scoped_cfg, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -206,6 +214,104 @@ class TestRustCodegenHandlers(unittest.TestCase):
         assert PLACEHOLDER not in text
         # the bit-insertions that used to be dropped are rendered now
         assert "_INSERT(" in text
+
+
+class TestRustMultiRegisterReturn(unittest.TestCase):
+    """A return value the calling convention splits across registers has to reach the Rust in one piece."""
+
+    # _handle memoizes on the AIL node, so every node any test builds needs an idx of its own
+    _idx = itertools.count(1)
+
+    @classmethod
+    def setUpClass(cls):
+        # any binary will do: we only need a constructed Rust code generator to drive the handler with
+        proj = angr.Project(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True, show_progressbar=False)
+        dec = proj.analyses.Decompiler(proj.kb.functions["main"], cfg=cfg.model, flavor="rust")
+        assert isinstance(dec.codegen, RustStructuredCodeGenerator)
+        cls.codegen = dec.codegen
+
+    def setUp(self):
+        self._original_prototype = self.codegen._func.prototype
+
+    def tearDown(self):
+        self.codegen._func.prototype = self._original_prototype
+
+    def _set_returnty(self, returnty) -> None:
+        self.codegen._func.prototype = SimTypeFunction([], returnty)
+
+    def _render_return(self, *pieces: Expression) -> str:
+        stmt = Return(next(self._idx), list(pieces))
+        rendered = self.codegen._handle(stmt, is_expr=False)
+        assert isinstance(rendered, RustReturn)
+        return _render(rendered).strip()
+
+    def _const(self, value: int, bits: int) -> Const:
+        return Const(next(self._idx), value, bits, type=SimTypeNum(bits, signed=False))
+
+    def test_no_return_expression_is_a_bare_return(self):
+        assert self._render_return() == "return;"
+
+    def test_one_return_expression_is_unchanged(self):
+        assert self._render_return(self._const(1, 64)) == "return 1;"
+
+    def test_two_registers_are_concatenated_most_significant_first(self):
+        self._set_returnty(SimTypeNum(128, signed=True))
+        assert self._render_return(self._const(1, 64), self._const(2, 64)) == "return CONCAT(2, 1);"
+
+    def test_more_than_two_pieces_are_all_placed(self):
+        self._set_returnty(SimTypeNum(96, signed=True))
+        assert (
+            self._render_return(self._const(1, 32), self._const(2, 32), self._const(3, 32))
+            == "return CONCAT(3, CONCAT(2, 1));"
+        )
+
+    def test_a_fat_pointer_return_type_keeps_the_old_conservative_behaviour(self):
+        # a &str is a pointer beside a length, not a scalar with a high and a low half
+        self._set_returnty(RustSimTypeStrRef())
+        with self.assertLogs("angr.analyses.decompiler.structured_codegen.rust", level="WARNING"):
+            assert self._render_return(self._const(1, 64), self._const(2, 64)) == "return 1;"
+
+    def test_a_return_type_that_does_not_account_for_every_piece_keeps_the_old_behaviour(self):
+        self._set_returnty(SimTypeLongLong(signed=False))
+        with self.assertLogs("angr.analyses.decompiler.structured_codegen.rust", level="WARNING"):
+            assert self._render_return(self._const(1, 64), self._const(2, 64)) == "return 1;"
+
+    def test_a_missing_prototype_keeps_the_old_behaviour(self):
+        self.codegen._func.prototype = None
+        with self.assertLogs("angr.analyses.decompiler.structured_codegen.rust", level="WARNING"):
+            assert self._render_return(self._const(1, 64), self._const(2, 64)) == "return 1;"
+
+
+class TestRustMultiRegisterReturnEndToEnd(unittest.TestCase):
+    """The two-word value a Rust function returns in rax:rdx has to survive into the Rust."""
+
+    def test_a_two_word_rust_return_keeps_its_high_half(self):
+        # std::path::Path::file_stem is recovered with a 128-bit return type, so every return gets two
+        # expressions. All five used to render as rax alone: 0, v9, v10, v17, v9.
+        bin_path = os.path.join(test_location, "x86_64", "rust_hello_world")
+        func_addr = 0x4245A0
+        proj, cfg = load_project_with_scoped_cfg(bin_path, func_addr)
+        dec = proj.analyses.Decompiler(func_addr, cfg=cfg.model, flavor="rust")
+        assert dec.codegen is not None
+        print_decompilation_result(dec)
+
+        func = proj.kb.functions[func_addr]
+        prototype = func.prototype
+        assert prototype is not None and prototype.returnty is not None
+        assert prototype.returnty.size == 128
+        cc = func.calling_convention
+        assert cc is not None
+        return_val = cc.return_val(prototype.returnty)
+        assert isinstance(return_val, SimComboArg)
+        assert len(return_val.locations) == 2
+
+        # every return carries the second location's value instead of dropping it
+        text = dec.codegen.text or ""
+        returns = [line.strip() for line in text.splitlines() if line.strip().startswith("return ")]
+        assert len(returns) == 5
+        for line in returns:
+            assert re.match(r"^return CONCAT\(.+, .+\);$", line), line
 
 
 class TestRustStoreWidth(unittest.TestCase):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`std::path::Path::file_stem` at 0x4245a0 in `tests/x86_64/rust_hello_world`, decompiled with the Rust backend, is declared `-> u128` and returns 64 bits. All five of its returns:

```rust
return 0;
return v9;
return v10;
return v17;
return v9;
```

The high half of the value is gone from every one of them, and the only trace is a log line. This hits any function whose calling convention returns a value in more than one register.

### Root cause

`RustStructuredCodeGenerator._handle_Stmt_Return` renders the first expression and discards the rest:

```python
# TODO: Multiple return expressions
l.warning("StructuredCodeGen does not support multiple return expressions yet. Only picking the first one.")
ret_expr = stmt.ret_exprs[0]
return RustReturn(self._handle(ret_expr), tags=stmt.tags, codegen=self)
```

`SimCC.return_val()` answers with a `SimComboArg` whenever the return type is wider than one register, and `ReturnMaker` expands that into one return expression per location, so everything after the first is dropped. #7126 fixed exactly this in `c.py` and changed how both generators render `Concat`, but left the Rust handler alone.

### Fix

Join the expressions with the `Concat` binary operation the Rust generator already renders, high half first, because `SimComboArg` lists its locations least significant first. The same five returns:

```rust
return CONCAT(v8, 0);
return CONCAT(v8, v9);
return CONCAT(v11, v10);
return CONCAT(v12 - 1, v17);
return CONCAT(v8, v9);
```

Only where the recovered return type accounts for every piece. An aggregate or floating-point return spread over several registers is not a scalar with a high and a low half -- in Rust the usual one is `&str`, a data pointer beside a length, also returned in `rax:rdx` -- and #6851 tracks carrying those through as one typed value. A prototype that `Clinic._make_function_prototype` rewrote after `ReturnMaker` ran can also be narrower than the expressions left beside it. Both keep the first expression and the warning.

`rust.py` is a port of `c.py` and carries its own copies of `unpack_typeref` and `qualifies_for_width_cast`, so the predicate is a method on the Rust generator rather than shared code.

### Testing

`tests/analyses/decompiler/test_rust_codegen_handlers.py` gains seven unit tests that drive the handler with constructed return statements -- one, two, three and no pieces, a `&str` return type, a return type narrower than its expressions, and no prototype at all -- and one end-to-end test that decompiles `Path::file_stem` from the tracked `rust_hello_world` and asserts every return carries both halves. On master the two concatenation tests and the end-to-end test fail; with the change the file is green.

Validation: https://github.com/angr/angr/pull/7142#issuecomment-5611222135

session: sharpen
