### PR TITLE
reaching_definitions: size an AIL Extract/Insert from the expression, not its offset

### DIFF
--- a/angr/analyses/reaching_definitions/engine_ail.py
+++ b/angr/analyses/reaching_definitions/engine_ail.py
@@ -631,7 +631,7 @@ class SimEngineRDAIL(
 
         return cast(
             MultiValues[claripy.ast.BV | claripy.ast.FP],
-            base.extract(conc_offset, expr.offset.size, archinfo.Endness.BE),
+            base.extract(conc_offset, expr.size, expr.endness),
         )
 
     def _handle_expr_Insert(self, expr: ailment.expression.Insert):
@@ -646,15 +646,15 @@ class SimEngineRDAIL(
         if conc_offset is None:
             return self._top(expr.bits)
 
+        value_size = expr.value.size
+        before = base.extract(0, conc_offset, expr.endness)
+        after = base.extract(conc_offset + value_size, len(base) // 8 - conc_offset - value_size, expr.endness)
+        # concatenation is most-significant-first, so on a little-endian target the bytes stored after
+        # the inserted value are the high half
+        high, low = (before, after) if expr.endness == archinfo.Endness.BE else (after, before)
         return cast(
             MultiValues[claripy.ast.BV | claripy.ast.FP],
-            base.extract(0, conc_offset, archinfo.Endness.BE)
-            .concat(value)
-            .concat(
-                base.extract(
-                    conc_offset + expr.offset.size, len(base) // 8 - conc_offset - expr.offset.size, archinfo.Endness.BE
-                )
-            ),
+            high.concat(value).concat(low),
         )
 
     def _handle_unop_Not(self, expr) -> MultiValues[claripy.ast.BV | claripy.ast.FP]:

--- a/tests/analyses/reaching_definitions/test_engine_ail.py
+++ b/tests/analyses/reaching_definitions/test_engine_ail.py
@@ -34,7 +34,19 @@ class _ConstantState:
         pass
 
 
-def test_convert_handles_operand_width_mismatches():
+def _value(engine: SimEngineRDAIL, expr) -> claripy.ast.BV:
+    result = engine._expr(expr)  # pylint: disable=protected-access
+    assert len(result) == expr.bits
+    chunks: list[claripy.ast.BV] = []
+    for _, values in sorted(result.items(), key=lambda item: item[0]):
+        assert len(values) == 1
+        value = next(iter(values))
+        assert isinstance(value, claripy.ast.BV)
+        chunks.append(value)
+    return claripy.Concat(*chunks)
+
+
+def test_extract_and_insert_widths():
     project = angr.load_shellcode(b"\xc3", arch="amd64")
     engine = SimEngineRDAIL(project, FunctionHandler())
     engine.state = cast(ReachingDefinitionsState, _ConstantState())
@@ -43,15 +55,17 @@ def test_convert_handles_operand_width_mismatches():
     offset = ailment.Expr.Const(1, 0, 64)
 
     extracted = ailment.Expr.Extract(2, 32, base, offset, Endness.LE)
+    assert _value(engine, extracted).concrete_value == 0x89ABCDEF
     widened = ailment.Expr.Convert(3, 32, 64, False, extracted)
-    widened_result = engine._expr(widened)  # pylint: disable=protected-access
-    assert len(widened_result) == widened.bits
-    widened_value = widened_result.one_value()
-    assert widened_value is not None and widened_value.symbolic
+    assert _value(engine, widened).concrete_value == 0x89ABCDEF
 
     inserted = ailment.Expr.Insert(4, base, offset, ailment.Expr.Const(5, 1, 8), Endness.LE)
+    assert _value(engine, inserted).concrete_value == 0x0123456789ABCD01
     narrowed = ailment.Expr.Convert(6, 64, 32, False, inserted)
-    narrowed_result = engine._expr(narrowed)  # pylint: disable=protected-access
-    assert len(narrowed_result) == narrowed.bits
-    narrowed_value = narrowed_result.one_value()
-    assert narrowed_value is not None and narrowed_value.symbolic
+    assert len(engine._expr(narrowed)) == narrowed.bits  # pylint: disable=protected-access
+
+    be_offset = ailment.Expr.Const(7, 1, 64)
+    be_extracted = ailment.Expr.Extract(8, 16, base, be_offset, Endness.BE)
+    assert _value(engine, be_extracted).concrete_value == 0x2345
+    be_inserted = ailment.Expr.Insert(9, base, be_offset, ailment.Expr.Const(10, 0xEE, 8), Endness.BE)
+    assert _value(engine, be_inserted).concrete_value == 0x01EE456789ABCDEF


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

The reaching-definitions AIL engine loses values it should compute, because it
returns the wrong number of bits for `Extract` and `Insert`. Driving
`SimEngineRDAIL._expr` over the shapes ssailification emits, with
`base = 0x0123456789ABCDEF`:

```
                                     declared   master returns
Extract(32 bits, offset 0, LE)         32         64 bits, 0x0123456789ABCDEF
Insert(0x01, 8 bits, offset 0, LE)     64          8 bits, 0x01
Extract(16 bits, offset 1, BE)         16         56 bits, 0x23456789ABCDEF
Insert(0xEE, 8 bits, offset 1, BE)     64         16 bits, 0x01EE
```

Downstream that is a dropped value, not just a wrong width. `Convert` checks
the operand against its declared `from_bits` and falls back to TOP when they
disagree, so on master

```
Convert(32 -> 64, Extract(32 bits, base, offset 0, LE))   ->  TOP
```

where the answer is `0x89ABCDEF`. Every `Extract` and `Insert` in the tree is
affected.

### Root cause

Both handlers take the width of the slice from `expr.offset.size` -- the byte
width of the *offset* expression, not of the value being sliced:

```python
base.extract(conc_offset, expr.offset.size, archinfo.Endness.BE)
```

`SimEngineSSARewriting._vvar_extract` and `_vvar_update` build that offset as
`Const(self.ail_manager.next_atom(), offset, 64)` for every `Extract` and
`Insert` they emit, so `expr.offset.size` is 8 whatever `expr.bits` says.

The same two lines hardcode `Endness.BE`, while those same two producers tag
each node with `arch.register_endness` or `arch.memory_endness` -- little-endian
on x86, AMD64, ARM, AArch64 and RISC-V. The two are not separable. Correcting
only the width returns `0x01234567` for the first row above, the high half of
the base instead of the low one, and because that value is now consistent with
`from_bits` the `Convert` guard passes it through as a confident wrong answer
where master at least returns TOP.

### Fix

Size the slice from the expression (`expr.size` for `Extract`, `expr.value.size`
for `Insert`) and slice in the byte order the expression carries. For `Insert`
the two surviving pieces of the base swap places between the two byte orders,
because concatenation is most-significant-first. All four rows above then return
their declared width and the right bytes: `0x89ABCDEF`, `0x0123456789ABCD01`,
`0x2345`, `0x01EE456789ABCDEF`, and the `Convert` above returns a concrete
`0x89ABCDEF`.

`angr/engines/ail/engine_light.py` computes the same slice from `expr.bits`,
which is where this shape comes from. That engine hardcodes little-endian rather
than reading `expr.endness` and carries its own `# does this need adjustment for
big endian?`; it is deliberately not touched here, since it needs a big-endian
reproducer this change does not have.

#6749 hardened the consumer of these values instead of the producer, and that
guard stays. Its regression drove these two handlers directly and asserted the
fallback the wrong widths forced, so it is the natural home for this fix's test.

### Testing

`tests/analyses/reaching_definitions/test_engine_ail.py`, rewritten in place
from the file #6749 added; no new fixture. It now asserts the width and the
bytes of all four rows above. Against master it fails at
`assert len(result) == expr.bits` with `assert 64 == 32`; on this head it
passes.

An instrumented counter says the two handlers ran zero times in all 14 runs of
a decompilation A/B over 439 functions of `tests/x86_64/decompiler/morton`,
`tests/x86_64/decompiler/fmt_rust`, `tests/x86_64/true` and `tests/i386/all`, so
its result is a statement about the corpus and not about the change. I could not
find a tracked binary whose decompilation reaches them; the validation record
has the comparison and says which callers get close and where they stop.

Validation: https://github.com/angr/angr/pull/7143#issuecomment-5611482118

session: sharpen