### PR TITLE
Stop sizing stack slots through a little-endian copy of the architecture

### DIFF
--- a/angr/calling_conventions.py
+++ b/angr/calling_conventions.py
@@ -1276,7 +1276,7 @@ class SimCC:
             # this is a PCode SimCC where cls.ARCH is directly callable
             stack_arg_size = cls.ARCH().bytes  # type: ignore
         else:
-            stack_arg_size = cls.ARCH(archinfo.Endness.LE).bytes
+            stack_arg_size = cls.ARCH(cls.ARCH.default_endness).bytes
         stack_args = [a for a in args if isinstance(a, SimStackArg)]
         stack_arg_count = (max(a.stack_offset for a in stack_args) // stack_arg_size + 1) if stack_args else 0
         return min(limit, max(len(args), stack_arg_count))

--- a/tests/analyses/test_calling_convention_analysis.py
+++ b/tests/analyses/test_calling_convention_analysis.py
@@ -192,6 +192,26 @@ class TestCallingConventionAnalysis(unittest.TestCase):
             self.check_args(func_name, self._a(funcs, func_name), args)
 
     @cca_mode("fast,variables")
+    def test_s390x_fauxware(self, *, mode):
+        binary_path = os.path.join(test_location, "s390x", "fauxware")
+        proj = angr.Project(binary_path, auto_load_libs=False, load_debug_info=False)
+
+        cfg = proj.analyses.CFG()  # fill in the default kb
+
+        proj.analyses.CompleteCallingConventions(mode=mode, recover_variables=True)
+
+        funcs = cfg.kb.functions
+
+        # check args
+        expected_args = {
+            "accepted": [],
+            "authenticate": ["r_r2", "r_r3"],
+        }
+
+        for func_name, args in expected_args.items():
+            self.check_args(func_name, self._a(funcs, func_name), args)
+
+    @cca_mode("fast,variables")
     def test_x8664_void(self, *, mode):
         binary_path = os.path.join(test_location, "x86_64", "types", "void")
         proj = angr.Project(binary_path, auto_load_libs=False, load_debug_info=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CompleteCallingConventions` recovers nothing at all on s390x. On
`binaries/tests/s390x/fauxware` the CFG finds 40 functions and the analysis then
raises before finishing any of them:

```
  File "angr/calling_conventions.py", line 1238, in _match
    max_args = cls._guess_arg_count(args)
  File "angr/calling_conventions.py", line 1279, in _guess_arg_count
    stack_arg_size = cls.ARCH(archinfo.Endness.LE).bytes
  File "archinfo/arch_s390x.py", line 27, in __init__
    raise ArchError("Arch s390x must be big endian")
archinfo.archerror.ArchError: Arch s390x must be big endian
```

0 of those 40 functions ends up with a prototype, so on this architecture
nothing gets argument locations or a return type and every consumer of
`Function.prototype`, the decompiler included, sees an empty signature.

### Root cause

`SimCC._guess_arg_count` builds an instance of the calling convention's
architecture only to read its word size in bytes, and it builds it
little-endian:

```python
stack_arg_size = cls.ARCH(archinfo.Endness.LE).bytes
```

`ArchS390X.__init__` refuses any endness but big and raises `ArchError`. That
call sits under `SimCC._match`, which `SimCC.find_cc` runs for every candidate
convention, so the exception escapes `CallingConventionAnalysis` and takes
`CompleteCallingConventions` down with it. The endness argument arrived in
76f46ca01 (#5334) to satisfy a type checker, since `Arch.__init__` takes endness
positionally; before that the line read `cls.ARCH()`, which picks each
architecture's own default.

### Fix

Build the architecture at its own default endness:

```python
stack_arg_size = cls.ARCH(cls.ARCH.default_endness).bytes
```

The quantity being read is a word size, which does not depend on endness, so
nothing else moves. `_guess_arg_count` picks its slot size from three branches: a
fixed `ARG_SLOT_SIZE`, which two conventions set; `cls.ARCH()` for the eight
PCode conventions, where `ARCH` is directly callable; and this one, which 33
conventions reach. Over those 33 only `SimCCS390X` and `SimCCS390XLinuxSyscall`
change, and they change from raising to 8. On the same binary 22 of the 40
functions now get a prototype, `authenticate` among them, with its two arguments
in `r_r2` and `r_r3`.

This does not make s390x fully supported. `is_sane_register_variable` in
`angr.analyses.calling_convention.utils` is the filter that rejects register
locations which cannot be arguments, and it has no s390x branch: on s390x it
falls through to `l.critical("Unsupported architecture %s.", arch.name)` and
`return True`, so it rejects nothing. That gap is separate and is not addressed
here.

### Testing

`tests/analyses/test_calling_convention_analysis.py::TestCallingConventionAnalysis::test_s390x_fauxware`
runs `CompleteCallingConventions` over `s390x/fauxware` in both `fast` and
`variables` modes and asserts that `authenticate` takes `r_r2` and `r_r3` and
that `accepted` takes no arguments. On master it fails with the `ArchError`
above. The fixture is already tracked on `angr/binaries` master, so no sibling
change is needed.

Validation: https://github.com/angr/angr/pull/7144#issuecomment-5612434127

session: sharpen
