### PR TITLE
Big-endian: a narrow register access names the low-order bytes

### DIFF
--- a/angr/ailment/utils.py
+++ b/angr/ailment/utils.py
@@ -50,6 +50,18 @@ def is_none_or_matchable(arg1, arg2, is_list=False):
     return arg1 == arg2
 
 
+def lsb_bit_offset(base_bits: int, field_bits: int, byte_offset: int, endness: str, byte_width: int = 8) -> int:
+    """
+    Return where the low end of a field sits inside its base, counted in bits up from the low end of the base.
+
+    ``Extract`` and ``Insert`` count ``offset`` in bytes from the start of the base in memory order, so on a
+    big-endian value byte 0 holds the most significant bits and the field's low end is at the far side of the base.
+    """
+    if endness == archinfo.Endness.LE:
+        return byte_offset * byte_width
+    return base_bits - byte_offset * byte_width - field_bits
+
+
 def is_lsb_extract(expr: ailment.expression.Expression) -> bool:
     """
     Return ``True`` if ``expr`` is an ``Extract`` that takes the least-significant ``expr.bits`` bits of its base,
@@ -59,9 +71,7 @@ def is_lsb_extract(expr: ailment.expression.Expression) -> bool:
         return False
     if not isinstance(expr.offset, ailment.expression.Const):
         return False
-    if expr.endness == archinfo.Endness.LE:
-        return expr.offset.value == 0
-    return expr.offset.value * 8 + expr.bits == expr.base.bits
+    return lsb_bit_offset(expr.base.bits, expr.bits, expr.offset.value, expr.endness) == 0
 
 
 def is_lsb_overwrite(expr: ailment.expression.Expression) -> bool:
@@ -75,6 +85,4 @@ def is_lsb_overwrite(expr: ailment.expression.Expression) -> bool:
         return False
     if not (isinstance(expr.offset, ailment.expression.Const) and isinstance(expr.offset.value, int)):
         return False
-    if expr.endness == archinfo.Endness.LE:
-        return expr.offset.value == 0
-    return expr.offset.value * 8 + expr.value.bits == expr.bits
+    return lsb_bit_offset(expr.bits, expr.value.bits, expr.offset.value, expr.endness) == 0

--- a/angr/analyses/decompiler/callsite_maker.py
+++ b/angr/analyses/decompiler/callsite_maker.py
@@ -380,8 +380,14 @@ class CallSiteMaker:
             # try to narrow the non-float return expression if needed
             ret_type_bits = prototype.returnty.with_arch(self.project.arch).size
             if ret_type_bits is not None and ret_expr.bits > ret_type_bits:
-                ret_expr = ret_expr.copy()
-                ret_expr.bits = ret_type_bits
+                if isinstance(ret_expr, Expr.Register):
+                    offset = ret_expr.reg_offset
+                    if self.project.arch.register_endness == archinfo.Endness.BE:
+                        offset += (ret_expr.bits - ret_type_bits) // self.project.arch.byte_width
+                    ret_expr = Expr.Register(ret_expr.idx, offset, ret_type_bits, **ret_expr.tags)
+                else:
+                    ret_expr = ret_expr.copy()
+                    ret_expr.bits = ret_type_bits
             # TODO: Support narrowing virtual variables
 
         tags = call_expr.tags.copy()

--- a/angr/analyses/decompiler/peephole_optimizations/remove_const_insert.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_const_insert.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from angr.ailment.expression import BinaryOp, Const, Convert, Insert
+from angr.ailment.utils import lsb_bit_offset
 
 from .base import PeepholeOptimizationExprBase
 
@@ -22,9 +23,11 @@ class RemoveConstInsert(PeepholeOptimizationExprBase):
         ):
             return None
 
-        # TODO fix big-endian?
         assert self.project is not None
-        base = expr.base.value & ~((1 << expr.value.bits) - 1) << (expr.offset.value * self.project.arch.byte_width)
+        shift = lsb_bit_offset(
+            expr.bits, expr.value.bits, expr.offset.value, expr.endness, self.project.arch.byte_width
+        )
+        base = expr.base.value & ~(((1 << expr.value.bits) - 1) << shift)
         value = Convert(self.manager.next_atom(), expr.value.bits, expr.bits, False, expr.value)
         shifted = (
             BinaryOp(
@@ -32,11 +35,11 @@ class RemoveConstInsert(PeepholeOptimizationExprBase):
                 "Shl",
                 [
                     value,
-                    Const(self.manager.next_atom(), expr.offset.value * self.project.arch.byte_width, expr.bits),
+                    Const(self.manager.next_atom(), shift, expr.bits),
                 ],
                 signed=False,
             )
-            if expr.offset.value != 0
+            if shift != 0
             else value
         )
         return BinaryOp(expr.idx, "Or", [shifted, Const(self.manager.next_atom(), base, shifted.bits)], signed=False)

--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_bitmasks.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_bitmasks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from angr.ailment.expression import ITE, BinaryOp, Const, Convert, Extract, Insert
-from angr.ailment.utils import is_lsb_extract
+from angr.ailment.utils import is_lsb_extract, lsb_bit_offset
 
 from .base import PeepholeOptimizationExprBase
 
@@ -44,8 +44,9 @@ class RemoveRedundantBitmasks(PeepholeOptimizationExprBase):
             and isinstance(mask.value, int)
             and isinstance(expr.offset, Const)
             and isinstance(expr.offset.value, int)
-            # is this correct for big-endian??
-            and _MASKS.get(expr.value.bits, 0) << (expr.offset.value * self.project.arch.byte_width) == mask
+            and _MASKS.get(expr.value.bits, 0)
+            << lsb_bit_offset(expr.bits, expr.value.bits, expr.offset.value, expr.endness, self.project.arch.byte_width)
+            == mask
         ):
             # Insert(v0 & mask, offset, v1) where mask/offset guarantee
             # that the only bits we get from v0 will just be replaced with v1

--- a/angr/engines/ail/engine_light.py
+++ b/angr/engines/ail/engine_light.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import angr
 from angr import ailment, claripy, errors
+from angr.ailment.utils import lsb_bit_offset
 from angr.engines.ail.callstack import AILCallStack
 from angr.engines.light.engine import SimEngineLightAIL
 from angr.engines.successors import SimSuccessors
@@ -576,8 +577,7 @@ class SimEngineAILSimState(SimEngineLightAIL[StateType, DataType, bool, None]):
         child = self._expr_bv(expr.base)
         offset = self._expr_bv(expr.offset)
         assert offset.concrete
-        # does this need adjustment for big endian?
-        offset_bits = offset.concrete_value * self.arch.byte_width
+        offset_bits = lsb_bit_offset(len(child), expr.bits, offset.concrete_value, expr.endness, self.arch.byte_width)
         return child[expr.bits + offset_bits - 1 : offset_bits]
 
     def _handle_expr_Insert(self, expr: ailment.expression.Insert) -> DataType:
@@ -586,8 +586,7 @@ class SimEngineAILSimState(SimEngineLightAIL[StateType, DataType, bool, None]):
         base = self._expr_bv(expr.base)
         assert offset.concrete
 
-        # as above
-        offset_bits = offset.concrete_value * self.arch.byte_width
+        offset_bits = lsb_bit_offset(len(base), len(value), offset.concrete_value, expr.endness, self.arch.byte_width)
         return claripy.Concat(
             (
                 base[len(base) - 1 : offset_bits + len(value)]

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -36,6 +36,7 @@ from angr.analyses.decompiler.peephole_optimizations import (
     ConstantDereferences,
     EagerEvaluation,
     OptimizedDivisionSimplifier,
+    RemoveConstInsert,
     RemoveRedundantShifts,
     SarToSignedDiv,
     SimplifyBitwiseInserts,
@@ -536,6 +537,43 @@ class TestPeepholeOptimizations(unittest.TestCase):
             Register(manager.next_atom(), 0, 8)
         )
         assert isinstance(out.operands[1], Const) and out.operands[1].value == 44570 and out.operands[1].bits == 64
+
+
+class TestRemoveConstInsertEndness(unittest.TestCase):
+    """
+    RemoveConstInsert turns ``Insert(const_base, offset, value)`` into ``(base & ~mask) | (value << shift)``. The
+    offset is a byte position in memory order, so the shift depends on the expression's endness -- and the mask has
+    to be shifted before it is inverted, or every bit below the inserted field is cleared too.
+    """
+
+    BASE = 0x0102030405060708
+
+    def _optimized(self, bin_path, offset, endness):
+        proj = angr.Project(os.path.join(test_location, *bin_path), auto_load_libs=False)
+        manager = Manager()
+        opt = RemoveConstInsert(proj, proj.kb, manager)
+        out = opt.optimize(
+            Insert(
+                manager.next_atom(),
+                Const(manager.next_atom(), self.BASE, 64),
+                Const(manager.next_atom(), offset, 64),
+                Const(manager.next_atom(), 0xAABBCCDD, 32),
+                endness,
+            )
+        )
+        assert isinstance(out, BinaryOp) and out.op == "Or"
+        shifted, masked = out.operands
+        shift = shifted.operands[1].value if isinstance(shifted, BinaryOp) and shifted.op == "Shl" else 0
+        return shift, masked.value
+
+    def test_big_endian_offset_is_counted_from_the_high_end(self):
+        # byte 0 of a big-endian value is the most significant one, so offset 0 lands in the high word.
+        assert self._optimized(("ppc64", "fauxware"), 0, archinfo.Endness.BE) == (32, 0x0000000005060708)
+        assert self._optimized(("ppc64", "fauxware"), 4, archinfo.Endness.BE) == (0, 0x0102030400000000)
+
+    def test_little_endian_keeps_the_bits_below_the_field(self):
+        assert self._optimized(("x86_64", "fauxware"), 0, archinfo.Endness.LE) == (0, 0x0102030400000000)
+        assert self._optimized(("x86_64", "fauxware"), 4, archinfo.Endness.LE) == (32, 0x0000000005060708)
 
 
 class TestPeepholeBlockContextFixpoint(unittest.TestCase):

--- a/tests/sim/test_ail_exec.py
+++ b/tests/sim/test_ail_exec.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import angr
 from angr import ailment, claripy
+from angr.ailment.utils import is_lsb_extract, is_lsb_overwrite
 from angr.analyses.decompiler.clinic import Clinic
 from angr.engines.ail.callstack import AILCallStack
 from angr.engines.ail.engine_light import SimEngineAILSimState
@@ -437,3 +438,55 @@ class TestAILExec(unittest.TestCase):
         assert state.callstack.vars[v0.varid].concrete_value == 1
         assert state.callstack.vars[v1.varid].concrete_value == 2
         assert state.callstack.vars[v2.varid].concrete_value == 3
+
+
+class TestAILExecEndness(unittest.TestCase):
+    """
+    Extract and Insert count their offset in bytes from the start of the base in memory order, so on a big-endian
+    value byte 0 is the most significant one.
+    """
+
+    BASE = 0x0102030405060708
+
+    @staticmethod
+    def _engine(bin_path):
+        p = angr.Project(os.path.join(test_location, *bin_path), auto_load_libs=False)
+        state = p.factory.blank_state()
+        engine = SimEngineAILSimState(p, SimSuccessors(state.addr, state))
+        engine.state = state
+        return p, engine
+
+    def _check(self, bin_path, lsb_offset, msb_offset):
+        p, engine = self._engine(bin_path)
+        endness = p.arch.memory_endness
+        for offset, expected in ((lsb_offset, 0x05060708), (msb_offset, 0x01020304)):
+            extract = ailment.expression.Extract(
+                None,
+                32,
+                ailment.expression.Const(None, self.BASE, 64),
+                ailment.expression.Const(None, offset, 64),
+                endness,
+            )
+            assert is_lsb_extract(extract) is (offset == lsb_offset)
+            result = engine._handle_expr_Extract(extract)  # pylint: disable=protected-access
+            assert isinstance(result, claripy.ast.BV)
+            assert result.concrete and result.concrete_value == expected
+
+            insert = ailment.expression.Insert(
+                None,
+                ailment.expression.Const(None, self.BASE, 64),
+                ailment.expression.Const(None, offset, 64),
+                ailment.expression.Const(None, 0xAABBCCDD, 32),
+                endness,
+            )
+            assert is_lsb_overwrite(insert) is (offset == lsb_offset)
+            result = engine._handle_expr_Insert(insert)  # pylint: disable=protected-access
+            assert isinstance(result, claripy.ast.BV)
+            assert result.concrete
+            assert result.concrete_value == (0x01020304AABBCCDD if offset == lsb_offset else 0xAABBCCDD05060708)
+
+    def test_big_endian(self):
+        self._check(("ppc64", "fauxware"), lsb_offset=4, msb_offset=0)
+
+    def test_little_endian(self):
+        self._check(("x86_64", "fauxware"), lsb_offset=0, msb_offset=4)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Problem

`Extract` and `Insert` carry an `endness` because their `offset` counts bytes
from the start of the base the way the architecture stores it. On a big-endian
value byte 0 holds the most significant bits. That is what
`ailment.utils.is_lsb_extract` and `is_lsb_overwrite` say, and have said since
`c4ca11b88` gave both expressions an `endness` (as methods on the classes then;
they became functions in `utils.py` with the Rust migration, `9235f7fd2`):

```python
if expr.endness == archinfo.Endness.LE:
    return expr.offset.value == 0
return expr.offset.value * 8 + expr.bits == expr.base.bits
```

Four sites, in three files, convert that offset to a bit position with the
little-endian formula whatever the endness is, and each of the three files
carries the author's own question about it:

| file | comment |
|---|---|
| `angr/engines/ail/engine_light.py` | `# does this need adjustment for big endian?` |
| `.../peephole_optimizations/remove_redundant_bitmasks.py` | `# is this correct for big-endian??` |
| `.../peephole_optimizations/remove_const_insert.py` | `# TODO fix big-endian?` |

On PPC64, extracting 32 bits at byte 4 of `0x0102030405060708` — the slice
`is_lsb_extract` in the same tree calls the least significant one — came back as
`0x01020304`, the most significant word:

| endness | offset | before | after | `is_lsb_extract` |
|---|---|---|---|---|
| LE | 0 | 0x05060708 | 0x05060708 | True |
| LE | 4 | 0x01020304 | 0x01020304 | False |
| BE | 0 | **0x05060708** | 0x01020304 | False |
| BE | 4 | **0x01020304** | 0x05060708 | True |

## Root cause

The offsets those sites were handed are wrong the same way, and the two errors
cancel.

`CallSiteMaker` narrows a call's return register to the prototype's return type
by copying the expression and overwriting `bits`:

```python
ret_expr = ret_expr.copy()
ret_expr.bits = ret_type_bits
```

`reg_offset` stays at the register's base, which on a big-endian target names the
high-order bytes. On `tests/ppc64/manysum` that produced
`Register(reg_offset=40, bits=32)` for a 32-bit return in r3, where r3 starts at
40 and is 8 bytes long, so the low half is at 44. `SimCC.return_val` answers the
same question correctly for a location, through `SimRegArg.refine`.

The rule that line is missing is written down three times already:
`SimRegArg.refine` and `SimStackArg.refine` both narrow with
`offset = 0 if arch.register_endness == "Iend_LE" else self.size - size`, and
`refine_locs_with_struct_type` carries a comment saying it does not respect "the
need for big-endian integers to be stored at the end of words". The narrowing
line is from `d63881c041` (2022-04-18) and predates the endness work by nearly
four years.

## Fix

`lsb_bit_offset()` in `ailment/utils.py` is the one conversion those four sites
now share, and both `is_lsb_` predicates are it compared against zero.
Over a grid of 326 combinations of base width, field width, offset and endness
they answer identically to the formulas they replace.

`CallSiteMaker` moves `reg_offset` when it narrows a `Register` on a big-endian
target, so the offset it hands downstream means what `is_lsb_overwrite` says it
means.

Two things worth flagging about the diff:

- `RemoveConstInsert` also masked the base with `~mask << shift`, which parses as
  `(~mask) << shift` and clears every bit below the field as well as the field.
  That is wrong on little-endian too — inserting a 32-bit value at byte 4 of a
  64-bit constant dropped the low word — and the corrected big-endian shift is
  non-zero in the common case, so it had to move with the rest.
- `RemoveRedundantBitmasks._optimize_Insert` is currently unreachable: its last
  condition compares an `int` against an ailment `Const`, which is never equal.
  Its arithmetic is corrected here for when that is fixed, but nothing measures
  it today. Its sibling `_optimize_Extract` guards with `is_lsb_extract` and does
  fire.

## Testing

Every function of ten tracked fixtures — 210 functions across ppc64, ppc, mips
(big-endian) and x86_64, armel, mipsel, ppc64el (little-endian) — decompiles
byte-identically to master. Two further fixtures, `s390x/fauxware` and
`s390x/test_arrays`, were in the run and contributed nothing: `s390x` cannot get
through `CompleteCallingConventions` on master or here, so they are not evidence.

That identity is the intended result, because the two errors cancel. Each half
alone changes `ppc64/manysum sub_10000690`, measured separately: with only the
consumer half `CmpORD(sub_10000500() ^ 66, 0)` becomes
`CmpORD((sub_10000500() * 0 | 1) ^ 66, 0)`, and with only the producer half it
becomes `CmpORD(sub_10000500() * 0 ^ 66, 0)` — the call's value folded away
either way.

- `tests/analyses/decompiler`: 763 passed, 6 skipped.
- `tests/ailment`, `tests/sim/test_ail_exec.py`,
  `tests/analyses/decompiler/test_peephole_optimizations.py`,
  `tests/analyses/reaching_definitions`,
  `tests/analyses/decompiler/test_mips.py`: 217 passed.
- The four new test methods give 3 failed / 1 passed on master and 4 passed here.
  The one that passes on master is the little-endian engine case, which is the
  point.

Validation: https://github.com/angr/angr/pull/7146#issuecomment-5612751533

session: sharpen
