### PR TITLE
Big-endian: a narrowed register variable names the low-order bytes

### DIFF
--- a/angr/analyses/decompiler/expression_narrower.py
+++ b/angr/analyses/decompiler/expression_narrower.py
@@ -4,6 +4,8 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+import archinfo
+
 from angr.ailment import AILBlockRewriter, AILBlockWalker, Const
 from angr.ailment.expression import Atom, BinaryOp, Call, Convert, Extract, Phi, VirtualVariable
 from angr.ailment.statement import Assignment, SideEffectStatement
@@ -267,6 +269,25 @@ class ExpressionNarrower(AILBlockRewriter):
         for def_, narrow_info in narrowables:
             self.new_vvar_sizes[def_.atom.varid] = narrow_info.to_size
 
+    def _narrowed_oident(self, vvar: VirtualVariable, new_size: int):
+        """
+        Return the ``oident`` that a narrowed copy of ``vvar`` should carry.
+
+        Narrowing keeps the low-order ``new_size`` bytes of the variable: every use is rewritten to
+        ``Convert(new_bits -> old_bits, narrowed)`` and every definition to
+        ``Convert(old_bits -> new_bits, src)``. On a little-endian architecture the low-order bytes
+        start where the full register starts, so the register offset is unchanged. On a big-endian
+        architecture they sit at the *end* of the register, so the offset must move forward by the
+        number of bytes that were dropped; leaving it alone makes the narrowed variable name the
+        high-order bytes instead.
+
+        Only register variables are adjusted. A parameter variable's register placement is decided
+        by the calling convention (:meth:`angr.calling_conventions.SimRegArg.refine`), not here.
+        """
+        if not vvar.was_reg or self.project.arch.register_endness != archinfo.Endness.BE:
+            return vvar.oident
+        return vvar.reg_offset + vvar.size - new_size
+
     def walk(self, block: Block):
         self.narrowed_any = False
         return super().walk(block)
@@ -291,7 +312,7 @@ class ExpressionNarrower(AILBlockRewriter):
                         vvar.varid,
                         self.new_vvar_sizes[vvar.varid] * self.project.arch.byte_width,
                         category=vvar.category,
-                        oident=vvar.oident,
+                        oident=self._narrowed_oident(vvar, self.new_vvar_sizes[vvar.varid]),
                         **vvar.tags,
                     )
 
@@ -314,7 +335,7 @@ class ExpressionNarrower(AILBlockRewriter):
                 dst_in.varid,
                 self.new_vvar_sizes[dst_in.varid] * self.project.arch.byte_width,
                 category=dst_in.category,
-                oident=dst_in.oident,
+                oident=self._narrowed_oident(dst_in, self.new_vvar_sizes[dst_in.varid]),
                 **dst_in.tags,
             )
 
@@ -352,7 +373,7 @@ class ExpressionNarrower(AILBlockRewriter):
                 expr.varid,
                 self.new_vvar_sizes[expr.varid] * self.project.arch.byte_width,
                 category=expr.category,
-                oident=expr.oident,
+                oident=self._narrowed_oident(expr, self.new_vvar_sizes[expr.varid]),
                 **expr.tags,
             )
 
@@ -394,7 +415,7 @@ class ExpressionNarrower(AILBlockRewriter):
                 stmt.ret_expr.varid,
                 self.new_vvar_sizes[stmt.ret_expr.varid] * self.project.arch.byte_width,
                 category=stmt.ret_expr.category,
-                oident=stmt.ret_expr.oident,
+                oident=self._narrowed_oident(stmt.ret_expr, self.new_vvar_sizes[stmt.ret_expr.varid]),
                 **tags,
             )
             self.replacement_core_vvars[new_ret_expr.varid].append(new_ret_expr)

--- a/angr/sim_variable.py
+++ b/angr/sim_variable.py
@@ -258,7 +258,23 @@ class SimRegisterVariable(SimVariable):
         return f"<{region_str}{ident_str}|Reg {self.reg}, {self.size}B>"
 
     def loc_repr(self, arch):
-        return arch.translate_register_name(self.reg, self.size)
+        name = arch.translate_register_name(self.reg, self.size)
+        if name != str(self.reg):
+            return name
+        # Nothing is declared at exactly this offset and size, so translate_register_name() handed back
+        # the offset as a string. That is the normal case for a partial access on an architecture whose
+        # sub-registers archinfo does not model -- the low-order half of a big-endian register, say.
+        # Name the smallest declared register that contains the access instead of printing a number.
+        containing = min(
+            (
+                reg
+                for reg in arch.register_list
+                if reg.vex_offset <= self.reg and self.reg + self.size <= reg.vex_offset + reg.size
+            ),
+            key=lambda reg: reg.size,
+            default=None,
+        )
+        return name if containing is None else containing.name
 
     def __hash__(self):
         if self._hash is None:

--- a/tests/analyses/decompiler/test_narrowing_exprs.py
+++ b/tests/analyses/decompiler/test_narrowing_exprs.py
@@ -9,9 +9,19 @@ import os
 import unittest
 
 import angr
-from angr.ailment.expression import BinaryOp, Const, Extract, Insert, VirtualVariable, VirtualVariableCategory
+from angr.ailment.block import Block
+from angr.ailment.expression import (
+    BinaryOp,
+    Const,
+    Convert,
+    Extract,
+    Insert,
+    VirtualVariable,
+    VirtualVariableCategory,
+)
+from angr.ailment.manager import Manager
 from angr.ailment.statement import Assignment
-from angr.analyses.decompiler.expression_narrower import EffectiveSizeExtractor
+from angr.analyses.decompiler.expression_narrower import EffectiveSizeExtractor, ExpressionNarrower
 from tests.common import WORKER, bin_location, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -43,6 +53,56 @@ class TestNarrowingExpressions(unittest.TestCase):
         # ...while the byte-1 Extract occurrence stays narrow
         assert occurrences[ah_vvar.idx] == (8, 16)
         assert 44 in walker.vvars_used_as_insert_base
+
+    def test_narrowing_a_register_variable_moves_the_offset_on_big_endian(self):
+        # A narrowed variable keeps the low-order bytes of the original: every use is rewritten to
+        # Convert(narrow -> wide) and every definition to Convert(wide -> narrow). On a little-endian
+        # architecture those bytes start where the register starts, so its offset is unchanged. On a
+        # big-endian one they sit at the end of the register, so the offset must move forward by the
+        # number of bytes dropped -- PPC64 r3 is (offset 40, 8 bytes) and its low 4 bytes are at 44.
+        # Leaving the offset alone made the narrowed variable name the high-order bytes instead.
+        for binary, register, big_endian in (("ppc64", "r3", True), ("x86_64", "rax", False)):
+            with self.subTest(binary=binary):
+                proj = angr.Project(os.path.join(test_location, binary, "fauxware"), auto_load_libs=False)
+                arch = proj.arch
+                reg_offset, reg_size = arch.registers[register]
+                new_size = reg_size // 2
+                bits = reg_size * arch.byte_width
+
+                varid = 0x100
+                dst = VirtualVariable(1, varid, bits, VirtualVariableCategory.REGISTER, oident=reg_offset)
+                use = VirtualVariable(2, varid, bits, VirtualVariableCategory.REGISTER, oident=reg_offset)
+                sink = VirtualVariable(3, 0x101, bits, VirtualVariableCategory.REGISTER, oident=reg_offset)
+                block = Block(
+                    0x400000,
+                    0,
+                    statements=[Assignment(10, dst, Const(11, 0, bits)), Assignment(12, sink, use)],
+                )
+
+                narrower = ExpressionNarrower(proj, None, Manager(), [], {}, {})
+                narrower.new_vvar_sizes[varid] = new_size
+                new_block = narrower.walk(block)
+
+                expected = reg_offset + reg_size - new_size if big_endian else reg_offset
+                assert (arch.register_endness == "Iend_BE") is big_endian
+
+                new_def_stmt, new_use_stmt = new_block.statements
+                assert isinstance(new_def_stmt, Assignment)
+                assert isinstance(new_use_stmt, Assignment)
+
+                narrowed_def = new_def_stmt.dst
+                assert isinstance(narrowed_def, VirtualVariable)
+                assert narrowed_def.size == new_size
+                assert narrowed_def.reg_offset == expected
+
+                # the use became Convert(narrow -> wide) around the same narrowed variable
+                widened = new_use_stmt.src
+                assert isinstance(widened, Convert)
+                narrowed_use = widened.operand
+                assert isinstance(narrowed_use, VirtualVariable)
+                assert narrowed_use.varid == varid
+                assert narrowed_use.size == new_size
+                assert narrowed_use.reg_offset == expected
 
     def test_narrowing_expressions_after_making_callsite_only(self):
         # narrowing expressions before making callsites may incorrectly remove some definitions that the calls use


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`ExpressionNarrower` shrinks a virtual variable to the bytes its uses actually read, but never moves the register offset. On a big-endian architecture the narrowed variable then names the high-order bytes of the register.

#7146 fixes the same arithmetic where a call's return `Register` is narrowed in `callsite_maker.py`. The two branches share no file — #7146 touches seven paths, none of them these three — and `git merge-tree` against its head `3df1a783c` reports no conflict.

## Problem

Narrowing keeps the **low-order** bytes of a variable. `AILSimplifier._extract_expression_effective_size` reports only the highest bit any use reads, so the surviving range always starts at bit 0; uses are rewritten to `Convert(narrow -> wide)` and definitions to `Convert(wide -> narrow)`.

All four places in `expression_narrower.py` that rebuild the narrowed `VirtualVariable` passed the original `oident` straight through:

```python
new_expr = VirtualVariable(
    expr.idx,
    expr.varid,
    self.new_vvar_sizes[expr.varid] * self.project.arch.byte_width,
    category=expr.category,
    oident=expr.oident,          # <- the register offset, unchanged
    **expr.tags,
)
```

## Root cause

On a little-endian architecture that is correct: the low-order bytes begin where the register begins. On a big-endian one they sit at the *end* of it. PPC64 `r3` is `(offset 40, 8 bytes)`, so its low 4 bytes are at offset 44, and narrowing left a 4-byte variable sitting at offset 40 — the high half.

`oident` is meant to say where the variable's bytes live, and after narrowing it no longer did.

## Fix

One helper, `ExpressionNarrower._narrowed_oident()`, called from all four rebuild sites:

```python
if not vvar.was_reg or self.project.arch.register_endness != archinfo.Endness.BE:
    return vvar.oident
return vvar.reg_offset + vvar.size - new_size
```

The four sites have to move together. `new_vvar_sizes` is keyed by `varid`, so if the definition moved its offset and the uses did not, one variable would come out of the walk carrying two different `oident`s.

Only register variables are adjusted. `AILSimplifier` also offers parameter variables to the narrower, and those are left alone because `oident` means something different for them: `was_reg` is false, and the value is a `(category, offset)` tuple rather than a bare offset, so returning an int raises `TypeError: PARAMETER oident must be a 2-tuple (inner_category, inner_payload)`. Whether a narrowed big-endian *parameter* needs the same correction is a separate question this change does not answer, and the fixture set cannot answer it either — no parameter variable is narrowed on any big-endian fixture measured here.

### Why `angr/sim_variable.py` is in the diff

Moving the offset alone costs a register name, and the second half pays it back.

`SimRegisterVariable.loc_repr()` asks archinfo for the name at the exact offset and size. PPC64 declares no 4-byte sub-registers: `register_size_names[(44, 4)]` and `register_names[44]` are both absent and `get_base_register(44, 4)` is `None`, so `translate_register_name` returns the string `"44"`. With the offset fix alone, 13 declaration comments degraded to a bare offset — four `// gpr3` to `// 44`, the other nine `gpr4` through `gpr10`.

Master's `gpr3` was never a name for the narrow value — it is what you get by asking for a name at the wrong offset. So `loc_repr()` now falls back to the smallest declared register that *contains* the access. It has exactly two callers, both in code generation (`structured_codegen/c.py`, `structured_codegen/rust.py`), so this is display-only, and it returns the bare offset unchanged when nothing contains the access — which is why `armel/fauxware`'s pre-existing `unsigned int v4;  // 4111` is byte-identical on every arm.

## Testing

**Whole-fixture A/B.** Every function of ten tracked fixtures decompiled against master and against this branch: `ppc64/fauxware`, `ppc64/manysum`, `ppc/fauxware`, `mips/fauxware`, `mips/test_arrays`, `mips/test_loops`, `x86_64/fauxware`, `armel/fauxware`, `mipsel/fauxware`, `ppc64el/fauxware` — **210 functions, byte-identical**, comments included.

Coverage is narrower than the fixture count suggests. Counting the narrowings of a register variable per fixture: `ppc64/manysum` 17, `ppc64/fauxware` 5, `mips/test_arrays` 2, and `x86_64/fauxware` 21 on the little-endian side. `ppc/fauxware`, `mips/fauxware` and `mips/test_loops` narrow nothing at all. So three fixtures across two big-endian architectures exercise the change.

Each half was measured separately, because a no-op pair can hide two errors that cancel:

| arm | result |
|---|---|
| offset fix only | 4 functions move, across `ppc64/fauxware` and `ppc64/manysum` |
| naming fallback only | no effect: all 210 byte-identical to master |
| both | byte-identical to master |

The four functions the offset half moves change **only** the register-name comment on a declaration; the generated C is identical in all four. The whole of the `ppc64/fauxware` difference is:

```diff
-    unsigned int v11;  // gpr3
+    unsigned int v11;  // 44
```

Counting the numeric comments in `ppc64/manysum` shows the fallback is not vacuous: master 0, offset-fix-only 12, both halves 0.

**Regression test**, `tests/analyses/decompiler/test_narrowing_exprs.py::TestNarrowingExpressions::test_narrowing_a_register_variable_moves_the_offset_on_big_endian`. It drives `ExpressionNarrower.walk` over a two-statement AIL block on a real `angr.Project` of a fixture the repository already tracks — no binary is assembled, compiled, or generated — and checks the definition and the use of the narrowed variable.

On the unfixed tree the `binary='ppc64'` subtest fails at

```
assert narrowed_def.reg_offset == expected
AssertionError: assert 40 == 44
  where 40 = vvar_256{r40|4b}.reg_offset
```

and the `binary='x86_64'` subtest passes, on the unfixed tree and the fixed one alike. That little-endian arm is the point of the test: it is what distinguishes "the offset moves on big-endian targets" from "the offset moves".

Validation: https://github.com/angr/angr/pull/7147#issuecomment-5614351306

session: sharpen