### PR TITLE
Decompiler: make the redundant-bitmask Insert rule actually run

### DIFF
--- a/angr/analyses/decompiler/peephole_optimizations/remove_redundant_bitmasks.py
+++ b/angr/analyses/decompiler/peephole_optimizations/remove_redundant_bitmasks.py
@@ -46,7 +46,7 @@ class RemoveRedundantBitmasks(PeepholeOptimizationExprBase):
             and isinstance(expr.offset.value, int)
             and _MASKS.get(expr.value.bits, 0)
             << lsb_bit_offset(expr.bits, expr.value.bits, expr.offset.value, expr.endness, self.project.arch.byte_width)
-            == mask
+            == mask.value
         ):
             # Insert(v0 & mask, offset, v1) where mask/offset guarantee
             # that the only bits we get from v0 will just be replaced with v1

--- a/tests/analyses/decompiler/test_peephole_optimizations.py
+++ b/tests/analyses/decompiler/test_peephole_optimizations.py
@@ -37,6 +37,7 @@ from angr.analyses.decompiler.peephole_optimizations import (
     EagerEvaluation,
     OptimizedDivisionSimplifier,
     RemoveConstInsert,
+    RemoveRedundantBitmasks,
     RemoveRedundantShifts,
     SarToSignedDiv,
     SimplifyBitwiseInserts,
@@ -574,6 +575,51 @@ class TestRemoveConstInsertEndness(unittest.TestCase):
     def test_little_endian_keeps_the_bits_below_the_field(self):
         assert self._optimized(("x86_64", "fauxware"), 0, archinfo.Endness.LE) == (0, 0x0102030400000000)
         assert self._optimized(("x86_64", "fauxware"), 4, archinfo.Endness.LE) == (32, 0x0000000005060708)
+
+
+class TestRemoveRedundantBitmasksInsert(unittest.TestCase):
+    """
+    ``Insert(v0 & mask, offset, v1)`` where the mask covers exactly the bytes the insert overwrites keeps nothing
+    of v0, so the base can be replaced with zero.
+    """
+
+    @staticmethod
+    def _insert(manager: Manager, offset: int, endness: str) -> Insert:
+        # the shape the decompiler produces for a nibble swap: the low byte is masked out and then written back
+        vvar = VirtualVariable(manager.next_atom(), 224, 64, VirtualVariableCategory.REGISTER, oident=32)
+        masked = BinaryOp(
+            manager.next_atom(),
+            "And",
+            [vvar, Const(manager.next_atom(), 0xFF, 64)],
+            False,
+        )
+        return Insert(
+            manager.next_atom(),
+            masked,
+            Const(manager.next_atom(), offset, 64),
+            Convert(manager.next_atom(), 64, 8, False, masked),
+            endness,
+        )
+
+    def _optimized(self, bin_path, offset, endness):
+        proj = angr.Project(os.path.join(test_location, *bin_path), auto_load_libs=False)
+        manager = Manager()
+        opt = RemoveRedundantBitmasks(proj, proj.kb, manager)
+        return opt.optimize(self._insert(manager, offset, endness))
+
+    def test_little_endian_base_becomes_zero(self):
+        out = self._optimized(("x86_64", "fauxware"), 0, archinfo.Endness.LE)
+        assert isinstance(out, Insert)
+        assert isinstance(out.base, Const) and out.base.value == 0 and out.base.bits == 64
+
+    def test_big_endian_base_becomes_zero(self):
+        # byte 0 of a big-endian value is the most significant one, so the low byte is at offset 7
+        out = self._optimized(("ppc64", "fauxware"), 7, archinfo.Endness.BE)
+        assert isinstance(out, Insert)
+        assert isinstance(out.base, Const) and out.base.value == 0 and out.base.bits == 64
+
+    def test_a_mask_that_does_not_cover_the_field_is_left_alone(self):
+        assert self._optimized(("x86_64", "fauxware"), 1, archinfo.Endness.LE) is None
 
 
 class TestPeepholeBlockContextFixpoint(unittest.TestCase):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Depends on #7146 and is branched from it. #7146 corrects the shift this guard
computes and says in its own description that the branch is unreachable and that
nothing measures it. This is the measurement, and the token that turns it on.

**What this does today: almost nothing.** Across 366 tracked fixtures, 6,551
decompiled functions, the optimisation fires on exactly one expression, in one
function of one binary, and that function's decompiled C is byte-identical with
and without this change. The
argument for landing it is not a delta. It is that a guard which has never fired
is untested code that will run one day on somebody's binary, and `mask.value` is
the difference between it doing what it says and doing nothing at all.

## Problem

`RemoveRedundantBitmasks._optimize_Insert` has never run. Its last condition is

```python
and _MASKS.get(expr.value.bits, 0) << (expr.offset.value * self.project.arch.byte_width) == mask
```

`mask` is `expr.base.operands[1]`, an ailment `Const`; the left side is an `int`.
Ailment equality compares expressions, so it is never true against an `int`. On
an `Insert` matching every condition the branch's own comment describes:

```
Const == int      : False
int == Const      : False
INSERT expr       : Insert((vvar_100{r0|8b} And 4294967295<64>), 0<64>, vvar_101{r8|4b})
_optimize_Insert  : None

EXTRACT expr      : Extract((vvar_100{r0|8b} And 4294967295<64>), 32bits@0<64>)
_optimize_Extract : Conv(64->32, (vvar_100{r0|8b} And 4294967295<64>))
```

`_optimize_Extract` is the same rule for the other expression, and it fires.

## Root cause

A typo, not a regression. The branch arrived with the guard exactly as it reads
today, in `c4ca11b88` (#6009), whose diff writes both siblings in one hunk —
`== mask` for `Insert`, `== mask.value` for `Extract`. It has been unreachable at every revision since: `Expression.__eq__` type-checked
its operand while ailment was Python, and after the Rust migration `9235f7fd2` it
casts to `Expression` and returns false when the cast fails.

## Fix

Compare `mask.value`, matching the sibling.

The rewrite is safe by the guard's own condition: it matches only when the mask
covers exactly the bytes the insert overwrites, so every bit of `base` outside
the field is already zero and every bit inside it is about to be replaced.
Replacing `base` with `0` cannot change the value.

## What it does to decompiler output

Over 366 tracked fixtures in `angr/binaries` — every architecture directory,
capped at 40 files each, ELF and PE — decompiling the first 40 functions of each
gives **6,551 functions**. Both arms carried the same instrument on
`_optimize_Insert`: it calls the original and returns its result, recording each
rewrite. It rewrote **0** expressions on the base and
**1** here, over the 301 binaries that contributed a compared function.

The zero is a control, not a result. The branch cannot fire on the base, so a
non-zero count there would have meant the instrument was watching the wrong
thing and the 1 below would mean nothing. The one rewrite is:

```
x86_64/ld-linux-x86-64.so.2 @0x401910
  in : Insert((vvar_5083{r32|8b} And 255<64>), 0<64>, Conv(64->8, ((vvar_5083{r32|8b} And 255<64>) Shr 4<8>)))
  out: Insert(0<64>,                           0<64>, Conv(64->8, ((vvar_5083{r32|8b} And 255<64>) Shr 4<8>)))
```

That function's C is byte-identical before and after.

Eight other functions differ between the arms, and none of them is in a binary
where the branch fired. The only line that differs between the two builds is
inside `_optimize_Insert`, and in those binaries it returned `None` in both arms,
so the two arms executed identical behaviour and the differences cannot come from
this change. Re-running each arm a second time on those binaries bears that out from the other
side: three of the eight differ between two runs of *identical* code, and the
other five are identical between the arms in both repeats, so that difference
does not reproduce at all.

**Every firing measured is little-endian at offset 0**, where the shift is 0
under either arithmetic, so none of this constrains big-endian. That case rests
on #7146's `lsb_bit_offset` and on the regression below.

## Testing

`tests/analyses/decompiler/test_peephole_optimizations.py::TestRemoveRedundantBitmasksInsert`,
three cases, all loading fixtures the repository already tracks:

- little-endian, offset 0: the base becomes `Const 0`
- big-endian, offset 7 — the low byte of a big-endian 64-bit value, where
  `lsb_bit_offset(64, 8, 7, BE, 8)` is 0 and offset 0 gives 56: the base becomes
  `Const 0`
- little-endian, offset 1, where the mask does not cover the field: unchanged

On #7146's head without this commit they give **2 failed, 1 passed** — the one
that passes is the negative case — and **3 passed** with it.
`tests/analyses/decompiler` is 766 passed, 6 skipped here, and the repository's
diff-based lint and type check reports no regressions against master's tip.

Validation: https://github.com/angr/angr/pull/7149#issuecomment-5615192538

session: sharpen
