### PR TITLE
tests: assert the shape of the packer-filler decompilation cost, not the clock

### DIFF
--- a/tests/analyses/decompiler/test_dead_assignment_removal.py
+++ b/tests/analyses/decompiler/test_dead_assignment_removal.py
@@ -90,14 +90,18 @@ class TestDeadAssignmentRemoval(unittest.TestCase):
 
 
 class TestPackerFillerDecompilation(unittest.TestCase):
-    def test_xchg_filler_decompiles_quickly(self):
-        # issue #6968: 0x91 (xchg ecx, eax) filler decodes cleanly, so CFGFast happily builds one long chain of
-        # 99-instruction blocks out of it. Every instruction turns into a pair of dead virtual variables, and retiring
-        # that chain used to be quadratic.
-        block_count = 39
+    @staticmethod
+    def _decompile_xchg_filler(block_count: int):
+        """
+        Decompile ``block_count`` blocks of 0x91 (xchg ecx, eax) filler. Returns the CPU seconds it cost and the
+        decompiler.
+
+        CPU time rather than wall clock: CI runs this suite several tests at a time on a shared runner, so wall
+        clock here measures the neighbours as much as it measures the decompiler.
+        """
         code = b"\x91" * (99 * block_count) + b"\xc3"
 
-        start = time.time()
+        start = time.process_time()
         proj = angr.load_shellcode(code, arch="x86", load_address=0x400000)
         # repeating_byte_run_threshold=0: CFGFast refuses to decode this filler by default (the CFG-side fix for the
         # same issue). This test targets the decompiler, so the chain has to be built anyway.
@@ -105,32 +109,56 @@ class TestPackerFillerDecompilation(unittest.TestCase):
             normalize=True, cross_references=False, function_starts=[0x400000], repeating_byte_run_threshold=0
         )
         dec = proj.analyses.Decompiler(proj.kb.functions[0x400000], cfg=cfg.model, preset="malware")
+        elapsed = time.process_time() - start
+
+        assert dec.clinic is not None
+        assert dec.codegen is not None and dec.codegen.text is not None
+        return elapsed, dec
+
+    def test_xchg_filler_decompiles_quickly(self):
+        # issue #6968: 0x91 (xchg ecx, eax) filler decodes cleanly, so CFGFast happily builds one long chain of
+        # 99-instruction blocks out of it. Every instruction turns into a pair of dead virtual variables, and retiring
+        # that chain used to be quadratic.
+        block_count = 39
+        elapsed, dec = self._decompile_xchg_filler(block_count)
         print_decompilation_result(dec)
-        elapsed = time.time() - start
 
         assert dec.clinic is not None
         assert dec.clinic._cross_insn_opt_for_large_blocks is False
-        assert dec.codegen is not None and dec.codegen.text is not None
         assert elapsed < 20.0, f"decompiling {block_count} blocks of filler took {elapsed:.1f}s"
 
-    def test_xchg_filler_decompiles_quickly_cross_insn_opt(self):
-        # we should hit cross-insn-opt = True
-        block_count = 5000
-        code = b"\x91" * (99 * block_count) + b"\xc3"
+    def test_xchg_filler_decompiles_in_linear_time_cross_insn_opt(self):
+        # both sizes are past the 40 large blocks that turn cross-insn-opt on, so both take that path.
+        #
+        # issue #7054: this used to time one 5,000-block run and require it to finish inside 60 seconds. A constant
+        # cannot say what the test is for. The same run costs about twice as much under the coverage job as it does
+        # without instrumentation, and a run that shares a machine with its neighbours spreads about 1.5x either way,
+        # so the bound was one slow shard away from firing and fired four times. What #6968 was about is the shape of
+        # the cost, not its size: the fixed point that retired dead virtual variables re-scanned every definition once
+        # per retired use-def link. Five times the blocks costs the worklist about five times the work and costs that
+        # scan loop roughly nine to sixteen times, and a ratio of two runs on the same machine says which of the two
+        # this is without having to know how fast the machine is.
+        #
+        # The baseline is the smaller of two 1,000-block runs. A busy machine can only ever make a run slower, and a
+        # baseline that came out slow is what would let a real regression through: it divides the large run by too
+        # much. Taking the smaller of two is what keeps the marginal case caught.
+        first, dec_small = self._decompile_xchg_filler(1000)
+        second, _ = self._decompile_xchg_filler(1000)
+        small = min(first, second)
+        large, dec_large = self._decompile_xchg_filler(5000)
+        print_decompilation_result(dec_large)
 
-        start = time.time()
-        proj = angr.load_shellcode(code, arch="x86", load_address=0x400000)
-        cfg = proj.analyses.CFGFast(
-            normalize=True, cross_references=False, function_starts=[0x400000], repeating_byte_run_threshold=0
+        assert dec_small.clinic is not None
+        assert dec_large.clinic is not None
+        assert dec_small.clinic._cross_insn_opt_for_large_blocks is True
+        assert dec_large.clinic._cross_insn_opt_for_large_blocks is True
+        assert large < small * 8.0, (
+            f"five times the filler cost {large / small:.1f} times the work "
+            f"({small:.1f}s for 1,000 blocks, {large:.1f}s for 5,000)"
         )
-        dec = proj.analyses.Decompiler(proj.kb.functions[0x400000], cfg=cfg.model, preset="malware")
-        print_decompilation_result(dec)
-        elapsed = time.time() - start
-
-        assert dec.clinic is not None
-        assert dec.clinic._cross_insn_opt_for_large_blocks is True
-        assert dec.codegen is not None and dec.codegen.text is not None
-        assert elapsed < 60.0, f"decompiling {block_count} blocks of filler took {elapsed:.1f}s"
+        # a ratio cancels a slowdown that hits both sizes alike, so bound the large run as well. This is a backstop,
+        # not the guard: it is roughly twice the worst wall clock this run has ever recorded on CI.
+        assert large < 120.0, f"decompiling 5,000 blocks of filler took {large:.1f}s of CPU"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Fixes #7054.

### Problem

`tests/analyses/decompiler/test_dead_assignment_removal.py`'s
`TestPackerFillerDecompilation::test_xchg_filler_decompiles_quickly_cross_insn_opt` decompiled
5,000 blocks of `xchg` filler and ended in `assert elapsed < 60.0`. Nothing about that bound
holds still. Measured on one machine:

- **Instrumentation moves the level.** 10 runs of the test without coverage span 9.82 s to
  14.02 s (median 10.83); 20 runs of the same commit under `pytest --cov=angr --cov=tests` span
  16.51 s to 24.34 s (median 19.96). Coverage costs 1.84x.
- **Sharing the machine moves it again.** Each of those sets spreads about 1.45x max/min with
  nothing changing but the neighbours. `Test with coverage` runs ten shards of
  `pytest -n auto --forked`, so this test always has three others beside it.
- **The bound had less headroom than the spread.** #7054 counts the 233 `Test with coverage` runs
  that recorded a duration for it between #7039 landing and 2026-09-09: median 48.30 s, minimum
  33.35 s, maximum 62.39 s — 1.24x of headroom against a 1.87x spread. Four runs crossed the
  bound, one passed at 59.998 s, and the `Test Results` check goes red on pull requests that have
  nothing to do with the decompiler.

Raising the constant is not a fix; #7039 already raised it once, from 30.0 to 60.0.

### Root cause

The test measures the wrong quantity. #6968 was about the *shape* of the cost, not its size:
`_remove_dead_assignments` retired dead virtual variables with a `while True` fixed point that
re-scanned every definition in the function, and deadness propagates backwards along use-def
edges, so each scan retired one link of a chain. #7039 replaced it with the use-count worklist in
`_find_dead_vvars` — O(V+E) instead of O(V*E). A wall-clock constant cannot state that property,
so the bound ends up encoding how fast the runner is and how much instrumentation is on it.

### Fix

Decompile the same filler at 1,000 blocks and at 5,000 and require the large run to cost less
than 8.0x the small one. Five times the input costs the worklist about five times the work and
costs the scan loop it replaced roughly nine to sixteen times, so the ratio says which one this is
without having to know the machine.

The baseline is the smaller of two 1,000-block runs. A busy machine can only make a run slower,
and a baseline that came out slow divides the large run by too much, which is how a real
regression gets through: the closest reverted-tree run measured 8.99x with the min and 8.84x
without it.

The large run also gets a loose absolute bound of 120 s of CPU. A ratio cancels a slowdown that
hits both sizes alike, and nothing else covers this path: the sibling 39-block test asserts
`_cross_insn_opt_for_large_blocks is False`, so it runs the other one. 120 s is about twice the
worst wall clock this run has ever recorded on CI, so it is a backstop, not the guard.

Both tests now measure `time.process_time()` instead of `time.time()`, so the three neighbours a
shard runs alongside no longer count against them.

To be clear about what a ratio buys: a *level* shift cancels, run-to-run *noise* does not — it
compounds across the two measurements, and instrumentation is not quite a pure level shift. The
numbers below are therefore given as ranges, and all of them come from one 20-core machine.

### Testing

The ratio, in CPU seconds, measured with this test's own shape and object lifetimes:

| build | runs | ratio |
| --- | --- | --- |
| this branch | 5 | 4.79x .. 5.07x |
| the same tree with #7039's worklist reverted to the scan loop it replaced | 9 | 8.99x .. 16.01x |

8.0 sits 58% above the highest branch run and 11% below the lowest reverted one, and no run on
either side falls on the wrong side of it. Under `coverage run --source=angr` — the job that
flakes — four branch runs give 5.02x, 5.26x, 5.49x and 6.27x, so instrumentation raises this
ratio rather than lowering it, and 8.0 is 28% above the worst of those. On a machine loaded to
2.3x its cores, an earlier single-baseline form of this test measured 7.14x on the branch, which
8.0 still clears by 12%.

Before, on the reverted tree, the test fails:

```
AssertionError: five times the filler cost 14.7 times the work
(2.2s for 1,000 blocks, 31.9s for 5,000)
```

After, on this branch, the file passes: `5 passed in 18.75s`.

`ci / Typecheck` compares pyright's error count per changed file between base and head. This file
reports 3 errors at both, all three predating this change.

The test decompiles 7,000 blocks where it decompiled 5,000. Each 1,000-block run costs 1.4 s to
1.6 s of CPU uninstrumented here, and 3.5 s to 5.0 s under coverage.

Validation: https://github.com/angr/angr/pull/7151#issuecomment-5618985694

session: sharpen
