### PR TITLE
clarirs: Stop contains_value underflowing on a wrapping strided interval

### DIFF
--- a/native/clarirs-vsa/src/strided_interval.rs
+++ b/native/clarirs-vsa/src/strided_interval.rs
@@ -497,9 +497,10 @@ impl StridedInterval {
         match self {
             StridedInterval::Empty { .. } => false,
             StridedInterval::Normal {
+                bits,
                 stride,
                 lower_bound,
-                ..
+                upper_bound,
             } => {
                 let (min, max) = self.get_unsigned_bounds();
                 if value < &min || value > &max {
@@ -507,6 +508,21 @@ impl StridedInterval {
                 }
                 if stride.is_zero() {
                     return lower_bound == value;
+                }
+                if value < lower_bound {
+                    // Only a wrapping interval gets here: a non-wrapping one has
+                    // `min == lower_bound`, so the range test above has already
+                    // rejected anything smaller. `get_unsigned_bounds` answers
+                    // `(0, MAX)` for a wrapping interval, so that test admits every
+                    // value and the second half has to be handled by hand. The gap
+                    // between `upper_bound` and `lower_bound` is not in the
+                    // interval, and the offset from `lower_bound` wraps, so it is a
+                    // subtraction modulo `2**bits`; a plain one underflows the
+                    // `BigUint`.
+                    if value > upper_bound {
+                        return false;
+                    }
+                    return (modular_sub(value, lower_bound, *bits) % stride).is_zero();
                 }
                 (&(value - lower_bound) % stride).is_zero()
             }
@@ -3267,6 +3283,69 @@ mod si_properties_tests {
             BigUint::from(10u32),
         );
         assert!(si.contains_zero());
+    }
+
+    #[test]
+    fn test_contains_value_wrapping() {
+        // 8-bit 1[0xf0, 0x10] covers 0xf0..=0xff and 0x00..=0x10. Every value below
+        // the lower bound panicked with "Cannot subtract b from a because b is
+        // larger than a" before this was fixed: `get_unsigned_bounds` answers
+        // `(0, 0xff)` for a wrapping interval, so the range test admits the value
+        // and `value - lower_bound` underflows the `BigUint`.
+        let si = StridedInterval::new(
+            8,
+            BigUint::from(1u32),
+            BigUint::from(0xf0u32),
+            BigUint::from(0x10u32),
+        );
+
+        // The second half of the interval, reached by wrapping past the maximum.
+        assert!(si.contains_zero());
+        assert!(si.contains_value(&BigUint::from(0x01u32)));
+        assert!(si.contains_value(&BigUint::from(0x10u32)));
+
+        // The first half, which never underflowed and is unchanged.
+        assert!(si.contains_value(&BigUint::from(0xf0u32)));
+        assert!(si.contains_value(&BigUint::from(0xffu32)));
+
+        // The gap between the two halves is not in the interval.
+        assert!(!si.contains_value(&BigUint::from(0x11u32)));
+        assert!(!si.contains_value(&BigUint::from(0x80u32)));
+        assert!(!si.contains_value(&BigUint::from(0xefu32)));
+    }
+
+    #[test]
+    fn test_contains_value_wrapping_stride() {
+        // 8-bit 3[0xf0, 0x0b] is 0xf0, 0xf3, 0xf6, 0xf9, 0xfc, 0xff, 0x02, 0x05,
+        // 0x08, 0x0b. The offset from the lower bound wraps, so it has to be taken
+        // modulo 2**bits before the stride divides it: 0x02 is at offset 18 and is a
+        // member, 0x03 is at offset 19 and is not, and zero is at offset 16 and is
+        // not.
+        let si = StridedInterval::new(
+            8,
+            BigUint::from(3u32),
+            BigUint::from(0xf0u32),
+            BigUint::from(0x0bu32),
+        );
+        assert!(si.contains_value(&BigUint::from(0x02u32)));
+        assert!(si.contains_value(&BigUint::from(0x0bu32)));
+        assert!(!si.contains_value(&BigUint::from(0x03u32)));
+        assert!(!si.contains_zero());
+    }
+
+    #[test]
+    fn test_division_by_wrapping_divisor() {
+        // Both division paths ask `contains_zero()` of the divisor, which is how a
+        // CFG run reaches the underflow above.
+        let dividend = StridedInterval::range(8, 1u32, 10u32);
+        let divisor = StridedInterval::new(
+            8,
+            BigUint::from(1u32),
+            BigUint::from(0xf0u32),
+            BigUint::from(0x10u32),
+        );
+        assert!(dividend.udiv(&divisor).is_ok());
+        assert!(dividend.sdiv(&divisor).is_ok());
     }
 
     #[test]

--- a/tests/claripy/test_vsa_bv_ops.py
+++ b/tests/claripy/test_vsa_bv_ops.py
@@ -964,3 +964,21 @@ class TestVSAPrecisionLoss(unittest.TestCase):
                 break
 
         self.assertTrue(found, "Result should contain some expected values after operations")
+
+
+class TestVSAWrappingIntervalDivision(unittest.TestCase):
+    """Dividing by a wrapping strided interval used to panic the Rust VSA backend."""
+
+    def setUp(self):
+        self.solver = claripy.SolverVSA()
+        # 8-bit 1[0xF0, 0x10]: 0xF0..0xFF followed by 0x00..0x10, so it contains zero.
+        self.wrapping = claripy.SI(bits=8, stride=1, lower_bound=0xF0, upper_bound=0x10)
+        self.dividend = claripy.SI(bits=8, stride=1, lower_bound=1, upper_bound=10)
+
+    def test_udiv_by_wrapping_interval(self):
+        """contains_value underflowed a BigUint on the wrapped-round half of the divisor."""
+        self.assertEqual(len(self.solver.eval(self.dividend // self.wrapping, 1)), 1)
+
+    def test_sdiv_by_wrapping_interval(self):
+        """sdiv asks contains_zero() of the divisor too, and reached the same subtraction."""
+        self.assertEqual(len(self.solver.eval(self.dividend.SDiv(self.wrapping), 1)), 1)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` dies with `pyo3_runtime.PanicException` when the VSA backend asks a wrapping
strided interval whether it contains a value. One line, no binary:

```python
>>> from angr import claripy
>>> w = claripy.SI(bits=8, stride=1, lower_bound=0xF0, upper_bound=0x10)   # SI8_1_240_16
>>> claripy.SolverVSA().eval(claripy.SI(bits=8, stride=1, lower_bound=1, upper_bound=10) // w, 1)
pyo3_runtime.PanicException: Cannot subtract b from a because b is larger than a.
```

`.SDiv(w)` panics the same way. `PanicException.__mro__` measures as `(PanicException,
BaseException, object)`, so `except Exception` does not see it and no handler in angr does.
One unresolvable jump table should cost one jump table; this costs the whole CFG.

A public reproducer, NetBSD 10.1 i386
[`comp.tgz`](https://cdn.netbsd.org/pub/NetBSD/NetBSD-10.1/i386/binary/sets/comp.tgz),
member `asan_allocator.po` of `usr/lib/libasan_p.a`, sha256
`c4702de498e280cfeca42b4d009b7ccceadab69515c379442ab505ec670e9803`:

```python
proj = angr.Project(path, auto_load_libs=False)
proj.analyses.CFGFast(normalize=True, data_references=False, resolve_indirect_jumps=True)
```

On master that raises `PanicException` and no CFG is produced; with this change it
completes with 153 functions, 1995 blocks and 3152 edges. Two more members of the same
release set behave the same way: `asan_allocator.o` of `usr/lib/libasan.a`
(`ebf1f53b05c8e79e96b11ac26b0e2d575102aea1f5edb3a01df60a8e8aa94e07`) and
`lsan_allocator.o` of `usr/lib/liblsan.a`
(`99a9d5072a74e3800c29a0c665cfdd0e3fdfe81eff3c79a5ab7ac005b1d1b465`).

### Root cause

`RUST_BACKTRACE=full` on the one-liner, elisions marked:

```
<num_bigint::biguint::BigUint as core::ops::arith::Sub<&BigUint>>::sub
<clarirs_vsa::strided_interval::StridedInterval>::contains_value
<clarirs_vsa::strided_interval::StridedInterval>::udiv
clarirs_vsa::reduce::bv::reduce_bv
    ... the reduce cache, walk and Reduce::reduce ...
<clarirs_vsa::solver::VSASolver as clarirs_core::solver::Solver>::eval_n
    ... the solver mixins ...
<rustylib::claripy::solver::PySolver>::eval
```

panicking at `num-bigint-0.4.8/src/biguint/subtraction.rs:71:5`. Under `CFGFast` every
frame down to `Reduce::reduce` is the same and the solver below it is
`VSASolver::is_false`, reached from `state_plugins/solver.py:641`.

`contains_value` bounds the value with `get_unsigned_bounds` and then divides the offset
from the lower bound by the stride:

```rust
let (min, max) = self.get_unsigned_bounds();
if value < &min || value > &max {
    return false;
}
...
(&(value - lower_bound) % stride).is_zero()
```

`get_unsigned_bounds` answers `(0, MAX)` for a wrapping interval, because that is the hull
of `[lower_bound, MAX]` and `[0, upper_bound]`. So for a wrapping interval the range test
admits **every** value, including every value in the second half, where
`value < lower_bound` and the `BigUint` subtraction underflows. It also admits the gap
between `upper_bound` and `lower_bound`, which the interval does not cover at all.

`contains_zero` passes `value = 0`, so it underflows for every wrapping interval with a
non-zero lower bound. Instrumenting the branch printed the operands: the binary above
reaches it eight times, always on the 64-bit interval `16[16, 0]` -- every 16-aligned
address, written as `[16, 2**64-1]` followed by `{0}` -- asking whether it contains `0`, so
the subtraction is `0 - 16`. Both operands are the right ones; the offset wraps and an
unsigned subtraction cannot express it. The answer should be `(0 + 2**64 - 16) % 16 == 0`,
which is `true`: zero is in that interval. `udiv` and `sdiv` both ask `contains_zero()` of
the divisor before dividing, which is how a CFG run reaches it.

### Fix

Handle `value < lower_bound` before the subtraction: reject the gap, and take the offset
modulo `2**bits` with the file's own `modular_sub`.

That branch is reachable only where master underflowed: for a non-wrapping interval `min` is
`lower_bound`, so the range test has already rejected anything smaller, and a wrapping one
reached `value - lower_bound` with `value < lower_bound`, which underflows a `BigUint`
unconditionally. There is no third case, so nothing that returned before returns differently.

Measured as well as argued. Over every 6-bit strided interval, every stride from 0 to 63
and every value -- 16,777,216 (interval, value) pairs -- master panics on 5,462,016 and
returns on 11,315,200, and this change returns **master's answer on all 11,315,200** and
panics on none. On the 25,600 of those intervals that are well formed, meaning the stride
divides the span, it also agrees with the interval's true member set, computed by stepping
from the lower bound, on all 1,638,400 values.

#7112 fixed a subtraction of the same kind in `nsplit`, and the open #7150 fixes two in
`urem`. This one is reached through `contains_zero` from the division paths instead, and
#7150 avoids `contains_zero` on purpose so the two do not depend on each other.

### Testing

Three Rust tests in `mod si_properties_tests` and two Python tests in
`tests/claripy/test_vsa_bv_ops.py`, all five failing on master with the panic above. They
cover the wrapped-round half (`contains_zero` on `1[0xf0, 0x10]`), the gap between the two
halves, a stride that makes the modulo do work (`3[0xf0, 0x0b]`, where `0x02` is a member at
offset 18 and `0x03` is not at offset 19), and both `udiv` and `sdiv` reaching it through
`contains_zero`. The Python file's other 28 tests pass on master and on this change, which
is the control that the two failures are the new tests and not the file.

A CFG sweep over several corpora reached this panic on **5 distinct objects**, three of them
the public NetBSD members named above and two in a corpus that is not redistributable. Read
at 2026-09-10T11:19:33Z over 171,745 ledger rows, keyed on the num-bigint panic site and
deduplicated by sha256, on lanes pinned at angr `a34418ad5`, which contains #7112 and not
#7150. Four of the five reach `contains_value` from `udiv` and one from `sdiv`; both are
covered, because the fix is in `contains_value` rather than in either caller.

Validation: https://github.com/angr/angr/pull/7152#issuecomment-5619434658

session: sharpen
