### PR TITLE
Ssailification: agree on what a head-controlled loop is

### DIFF
--- a/angr/analyses/decompiler/ssailification/rewriting_engine.py
+++ b/angr/analyses/decompiler/ssailification/rewriting_engine.py
@@ -47,6 +47,7 @@ from angr.ailment.tagged_object import TaggedObject
 from angr.analyses.decompiler.variable_map import variable_map_of
 from angr.calling_conventions import call_clobbered_regs
 from angr.engines.light.engine import SimEngineNostmtAIL
+from angr.utils.ail import is_head_controlled_loop_jump
 
 from .consts import MAX_STACK_VAR_SIZE
 from .rewriting_state import RewritingState
@@ -98,19 +99,6 @@ class SimEngineSSARewriting(
     @property
     def current_vvar_id(self) -> int:
         return self._current_vvar_id
-
-    #
-    # Util functions
-    #
-
-    @staticmethod
-    def _is_head_controlled_loop_jump(block, jump_stmt: ConditionalJump) -> bool:
-        concrete_targets = []
-        if isinstance(jump_stmt.true_target, Const):
-            concrete_targets.append(jump_stmt.true_target.value)
-        if isinstance(jump_stmt.false_target, Const):
-            concrete_targets.append(jump_stmt.false_target.value)
-        return not all(block.addr <= t < block.addr + block.original_size for t in concrete_targets)
 
     #
     # Handlers
@@ -256,7 +244,7 @@ class SimEngineSSARewriting(
         new_true_target = self._expr(stmt.true_target) if stmt.true_target is not None else None
         new_false_target = self._expr(stmt.false_target) if stmt.false_target is not None else None
 
-        if self.stmt_idx != len(self.block.statements) - 1 and self._is_head_controlled_loop_jump(self.block, stmt):
+        if self.stmt_idx != len(self.block.statements) - 1 and is_head_controlled_loop_jump(stmt):
             # the conditional jump is in the middle of the block (e.g., the block generated from lifting rep stosq).
             # we need to make a copy of the state and use the state of this point in its successor
             self.hclb_side_exit_state = self.state.copy()

--- a/angr/analyses/decompiler/ssailification/traversal_engine.py
+++ b/angr/analyses/decompiler/ssailification/traversal_engine.py
@@ -27,6 +27,7 @@ from angr.code_location import AILCodeLocation
 from angr.engines.light import SimEngineLightAIL
 from angr.knowledge_plugins.functions.function import Function
 from angr.sim_type import PointerDisposition, SimTypePointer
+from angr.utils.ail import is_head_controlled_loop_jump
 from angr.utils.ssa import get_reg_offset_base_and_size
 
 from .consts import MAX_STACK_VAR_SIZE
@@ -505,12 +506,7 @@ class SimEngineSSATraversal(SimEngineLightAIL[TraversalState, Value, None, None]
         if stmt.false_target is not None:
             self._expr(stmt.false_target)
 
-        if (
-            isinstance(stmt.true_target, Const)
-            and isinstance(stmt.false_target, Const)
-            and self.stmt_idx != len(self.block.statements) - 1
-            and self.ins_addr in (stmt.true_target.value, stmt.false_target.value)
-        ):
+        if self.stmt_idx != len(self.block.statements) - 1 and is_head_controlled_loop_jump(stmt):
             self.hclb_side_exit_state = self.state.copy()
 
     def _handle_stmt_SideEffectStatement(self, stmt: SideEffectStatement):

--- a/angr/utils/ail.py
+++ b/angr/utils/ail.py
@@ -73,7 +73,32 @@ def is_head_controlled_loop_block(block: Block) -> bool:
     last_stmt = block.statements[-1]
     if isinstance(last_stmt, ConditionalJump):
         return False
-    return any(isinstance(stmt, ConditionalJump) for stmt in block.statements[:-1])
+    return any(is_head_controlled_loop_jump(stmt) for stmt in block.statements[:-1])
+
+
+def is_head_controlled_loop_jump(stmt: Statement) -> bool:
+    """
+    Determine if a statement is the conditional jump of a head-controlled loop: a conditional jump that jumps back to
+    the instruction it belongs to, so that the statements after it are the loop body. Callers that care about
+    position, such as the two ssailification engines, check that the jump is not the block's last statement as well.
+
+    Other mid-block conditional jumps are not head-controlled loop jumps. VEX emits one for the compare-and-swap
+    effects of x86 xchg, and a branch delay slot leaves one behind on a delay-slot architecture such as MIPS, where
+    the statements after the jump belong to the delay slot instead of to a loop body.
+
+    :param stmt:    An AIL statement.
+    :return:        True if the statement is the conditional jump of a head-controlled loop, False otherwise.
+    """
+
+    if not isinstance(stmt, ConditionalJump):
+        return False
+    ins_addr = stmt.tags.get("ins_addr")
+    return (
+        ins_addr is not None
+        and isinstance(stmt.true_target, Const)
+        and isinstance(stmt.false_target, Const)
+        and ins_addr in (stmt.true_target.value, stmt.false_target.value)
+    )
 
 
 def extract_partial_expr(base_expr: Expression, off: int, size: int, ail_manager, byte_width: int = 8) -> Expression:

--- a/tests/analyses/decompiler/test_head_controlled_loops.py
+++ b/tests/analyses/decompiler/test_head_controlled_loops.py
@@ -41,6 +41,22 @@ class TestHeadControlledLoops(unittest.TestCase):
             t = dec.codegen.text.replace(m.group(0), "--REPLACED--")
         assert "12" not in t and "0xc" not in t
 
+    def test_head_controlled_loop_mips_delay_slot_false_positive(self):
+        # MIPS puts the branch delay slot instruction after the conditional jump in the same AIL block, so a block can
+        # hold statements past a conditional jump that are not a loop body. Treating such a block as a head-controlled
+        # loop hands each successor the state from before those statements, and the read of gp in the next block then
+        # has no virtual variable. What this test catches is the crash that follows: KeyError 240 out of
+        # SimEngineSSARewriting._expr_to_vvar, since tests decompile with fail_fast on. The text assertion below only
+        # guards against a degenerate empty result; it does not distinguish the two behaviors on its own.
+        bin_path = os.path.join(test_location, "mips64", "ld.so.1")
+        proj, cfg = load_project_with_scoped_cfg(bin_path, 0x402568, project_kwargs={"auto_load_libs": False})
+        func = cfg.functions[0x402568]
+        assert func is not None
+        dec = proj.analyses.Decompiler(func, cfg=cfg)
+        assert dec.codegen is not None and dec.codegen.text is not None
+        print_decompilation_result(dec)
+        assert "audit_list" in dec.codegen.text
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Decompiling `process_dl_audit` at `0x402568` in `binaries/tests/mips64/ld.so.1` raises out of SSA
construction, before any structuring runs:

```text
SimEngineSSARewriting._handle_expr_Register
  -> SimEngineSSARewriting._expr_to_vvar
  -> self.state.registers[expr.reg_offset]
KeyError: 240
```

Offset 240 is `gp` on MIPS64. With `fail_fast` off, `_expr_to_vvar` guesses a virtual variable for
the missing register instead, so the function decompiles to something the machine code does not do.

Over the first 150 functions of that binary, 9 fail this way and 5 more fail with an
`AssertionError` out of `Phoenix._match_cyclic_while`, which the same misidentification causes.

### Root cause

Three places asked whether a mid-block conditional jump starts a head-controlled loop, and they
gave three different answers.

`SimEngineSSATraversal` asked whether the jump targets the instruction it belongs to.
`SimEngineSSARewriting._is_head_controlled_loop_jump` asked whether any of the jump's concrete
targets lies outside the block:

```python
return not all(block.addr <= t < block.addr + block.original_size for t in concrete_targets)
```

which is true of every mid-block conditional jump that leaves its block. `is_head_controlled_loop_block`
in `angr/utils/ail.py` asked whether the block ends in something other than a `ConditionalJump` and
holds a `ConditionalJump` somewhere before its last statement, which says nothing about where that
jump goes.

A branch delay slot leaves such a jump in the middle of a block. Block `0x402edc` of `sub_402ea8`
in the same binary is `bnel $v0, $zero, 0x402a6c` followed by its delay slot
`ld $t9, -0x7ef8($gp)`, and lifts to

```text
3 if ((t3 CmpEQ 0)) { Goto 0x402ee4 } else { Goto 0x402a6c }
4 t5 = reg240
5 t4 = (t5 Sub 32504)
6 t6 = Load(addr=(t5 Sub 32504), size=8, endness=Iend_BE)
7 reg216 = t6
```

The rewriting engine read that as a head-controlled loop, copied the state at statement 3 and gave
that copy to every successor, so the virtual variable statement 4 defines for `gp` reached neither.
The traversal engine did not treat the block that way, so it had already recorded that definition as
reaching, and the use at `0x402ee4` had no entry in `def_to_udef` either. `_expr_to_vvar` fell
through to its emergency lookup with nothing to find.

The disagreement does not stay in SSA. Phoenix, `SLiveness` and `ConditionProcessor` all ask
`is_head_controlled_loop_block`, which was the loosest of the three tests.

### Fix

One test, `is_head_controlled_loop_jump`, beside `is_head_controlled_loop_block` in
`angr/utils/ail.py`: a `ConditionalJump` with two constant targets, one of which is the jump's own
`ins_addr`. Both engines and the block-level predicate ask that, and the two private copies are
gone. `46a3654d0` narrowed the rewriting engine's copy once before, for the conditional jumps VEX
emits for x86 `xchg`; the delay slot is the next case it did not exclude.

The old test was over-broad on every architecture, not only the ones with delay slots. Over the
first 120 functions of `binaries/tests/x86_64/cvs` the rewriting engine meets 40 mid-block
conditional jumps; its old test called all 40 head-controlled loops and the new one calls 2. The 38
that change are `repe cmpsb` blocks that end in a conditional back-jump, which the traversal engine
was already refusing, so this makes the two agree. Seven of those 120 functions decompile
differently, each losing every `if (0)` and every `_ccall(` it carried -- 19 and 26, both to zero --
with the `while`, `for` and `goto` counts unchanged. `test_decompiling_rep_stosq`, which asserts the
shape `rep stosq` is recovered as, passes unchanged.

The same narrowing recovers an inlined `repne scasb`. In `sub_41fefa` of
`binaries/tests/x86_64/libc.so.6`, master emits the string length as a loop with no counter, no
pointer walk and no exit, and folds the length to zero, so everything computed from it is wrong:

```c
+    v3 = 0xffffffffffffffff;
     i = a2;
     do
     {
-        if (0)
+        if (!v3)
             break;
-    } while (*(a2));
-    v4 = ~(0xffffffffffffffff);
+        v3 -= 1;
+        v6 = a2 + 1;
+        a2 = v6;
+    } while (*(v5));
+    v7 = ~(v3);
```

`or rcx, -1` / `repne scasb` / `mov rbx, rcx; not rbx` is what the machine does, so the counter and
the pointer walk belong there. The candidate's guard reads `v5`, which it declares and never
assigns; that is wrong too, and master had no loop there to compare it against. Of 60 functions
sampled from each of `binaries/tests/{x86_64,i386}/libc.so.6`, 11 change text and all 11 this way.

Two things this does not fix. `bnel` nullifies its delay slot when not taken, and angr lifts the
delay slot as unconditional statements after the jump, so one successor is always given a write the
hardware did not perform -- the taken edge before this change, the not-taken edge after it.
Modelling that per edge belongs in the lifter, not in SSA construction, which has to agree with
whatever the lifter produced. And more definitions reaching the structurer means more surviving into
code it cannot place: over the 150 MIPS64 functions with text on both sides, those carrying a `goto`
to a label they do not define go from 30 to 39, `init_tls` at `0x402040` among them. That shape predates this change and is
worse here.

### Testing

`tests/analyses/decompiler/test_head_controlled_loops.py` gains a case beside the `xchg` one:
`process_dl_audit` at `0x402568` in the already-tracked `binaries/tests/mips64/ld.so.1`, which
raises `KeyError: 240` on master and decompiles here. Over the first 150 functions of that binary
with `fail_fast`, decompilation goes from 120 functions to 131 and no function that decompiled on
master fails here.

Validation: https://github.com/angr/angr/pull/7154#issuecomment-5621963805

session: sharpen
