### PR TITLE
clarirs: read z3's internal division and remainder forms back

### DIFF
--- a/native/clarirs-z3/src/astext.rs
+++ b/native/clarirs-z3/src/astext.rs
@@ -729,19 +729,22 @@ impl<'c> AstExtZ3<'c> for AstRef<'c> {
                             AstRef::from_z3(ctx, arg(0)?)?,
                             AstRef::from_z3(ctx, arg(1)?)?,
                         ),
-                        DeclKind::Budiv => ctx.udiv(
+                        // z3's rewriter replaces these four with its internal
+                        // total forms, so anything read back out of a solver
+                        // carries the _i spelling rather than the base one.
+                        DeclKind::Budiv | DeclKind::BudivI => ctx.udiv(
                             AstRef::from_z3(ctx, arg(0)?)?,
                             AstRef::from_z3(ctx, arg(1)?)?,
                         ),
-                        DeclKind::Bsdiv => ctx.sdiv(
+                        DeclKind::Bsdiv | DeclKind::BsdivI => ctx.sdiv(
                             AstRef::from_z3(ctx, arg(0)?)?,
                             AstRef::from_z3(ctx, arg(1)?)?,
                         ),
-                        DeclKind::Burem => ctx.urem(
+                        DeclKind::Burem | DeclKind::BuremI => ctx.urem(
                             AstRef::from_z3(ctx, arg(0)?)?,
                             AstRef::from_z3(ctx, arg(1)?)?,
                         ),
-                        DeclKind::Bsrem => ctx.srem(
+                        DeclKind::Bsrem | DeclKind::BsremI => ctx.srem(
                             AstRef::from_z3(ctx, arg(0)?)?,
                             AstRef::from_z3(ctx, arg(1)?)?,
                         ),

--- a/native/clarirs-z3/src/astext/test_bv.rs
+++ b/native/clarirs-z3/src/astext/test_bv.rs
@@ -561,12 +561,15 @@ mod from_z3 {
             let x = RcAst::mk_bv("x", 8);
             let y = RcAst::mk_bv("y", 8);
             let z3_ast = RcAst::try_from(Z3_mk_bvudiv(*z3_ctx, *x, *y)).unwrap();
+            let simplified = RcAst::try_from(Z3_simplify(*z3_ctx, *z3_ast)).unwrap();
+            assert_eq!(simplified.decl_kind(), DeclKind::BudivI);
 
             let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
             let expected = ctx
                 .udiv(ctx.bvs("x", 8).unwrap(), ctx.bvs("y", 8).unwrap())
                 .unwrap();
             assert_eq!(result, expected);
+            assert_eq!(AstRef::from_z3(&ctx, simplified).unwrap(), expected);
         });
     }
 
@@ -577,12 +580,15 @@ mod from_z3 {
             let x = RcAst::mk_bv("x", 8);
             let y = RcAst::mk_bv("y", 8);
             let z3_ast = RcAst::try_from(Z3_mk_bvsdiv(*z3_ctx, *x, *y)).unwrap();
+            let simplified = RcAst::try_from(Z3_simplify(*z3_ctx, *z3_ast)).unwrap();
+            assert_eq!(simplified.decl_kind(), DeclKind::BsdivI);
 
             let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
             let expected = ctx
                 .sdiv(ctx.bvs("x", 8).unwrap(), ctx.bvs("y", 8).unwrap())
                 .unwrap();
             assert_eq!(result, expected);
+            assert_eq!(AstRef::from_z3(&ctx, simplified).unwrap(), expected);
         });
     }
 
@@ -593,12 +599,15 @@ mod from_z3 {
             let x = RcAst::mk_bv("x", 8);
             let y = RcAst::mk_bv("y", 8);
             let z3_ast = RcAst::try_from(Z3_mk_bvurem(*z3_ctx, *x, *y)).unwrap();
+            let simplified = RcAst::try_from(Z3_simplify(*z3_ctx, *z3_ast)).unwrap();
+            assert_eq!(simplified.decl_kind(), DeclKind::BuremI);
 
             let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
             let expected = ctx
                 .urem(ctx.bvs("x", 8).unwrap(), ctx.bvs("y", 8).unwrap())
                 .unwrap();
             assert_eq!(result, expected);
+            assert_eq!(AstRef::from_z3(&ctx, simplified).unwrap(), expected);
         });
     }
 
@@ -609,12 +618,15 @@ mod from_z3 {
             let x = RcAst::mk_bv("x", 8);
             let y = RcAst::mk_bv("y", 8);
             let z3_ast = RcAst::try_from(Z3_mk_bvsrem(*z3_ctx, *x, *y)).unwrap();
+            let simplified = RcAst::try_from(Z3_simplify(*z3_ctx, *z3_ast)).unwrap();
+            assert_eq!(simplified.decl_kind(), DeclKind::BsremI);
 
             let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
             let expected = ctx
                 .srem(ctx.bvs("x", 8).unwrap(), ctx.bvs("y", 8).unwrap())
                 .unwrap();
             assert_eq!(result, expected);
+            assert_eq!(AstRef::from_z3(&ctx, simplified).unwrap(), expected);
         });
     }
 

--- a/tests/claripy/test_bv_ops.py
+++ b/tests/claripy/test_bv_ops.py
@@ -130,6 +130,28 @@ class TestBVOperations(unittest.TestCase):
         result = self.bv1.SMod(self.bv_neg)
         self._check_equal(result, 0)
 
+    def test_symbolic_div_and_mod_eval(self):
+        """Evaluate a symbolic quotient and remainder through z3.
+
+        z3 rewrites bvudiv, bvsdiv, bvurem and bvsrem into its internal total
+        forms bvudiv_i, bvsdiv_i, bvurem_i and bvsrem_i, so an expression read
+        back out of the solver carries the _i spelling.
+        """
+        x = claripy.BVS("dividend", 32)
+        divisor = claripy.BVV(7, 32)
+
+        def value(expr):
+            # A fresh solver each time: the first successful eval fills the
+            # model cache, which then answers the rest without converting.
+            solver = claripy.SolverZ3()
+            solver.add(x == 100)
+            return solver.eval(expr, 1)[0]
+
+        self.assertEqual(value(x // divisor), 14)
+        self.assertEqual(value(x % divisor), 2)
+        self.assertEqual(value(x.SDiv(divisor)), 14)
+        self.assertEqual(value(x.SMod(divisor)), 2)
+
     def test_and(self):
         """Test bitwise AND"""
         result = self.bv1 & self.bv2


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`SolverZ3` cannot evaluate a symbolic quotient or a symbolic remainder. On
angr master `b4ad96cd33260bee3a34c5338ceb42eaca730314`:

```python
import angr.claripy as claripy

x = claripy.BVS("x", 32)
d = claripy.BVV(7, 32)
s = claripy.Solver()
s.add(x == 100)
s.eval(x % d, 1)
```

```
angr.rustylib.claripy.errors.ClaripyError: Clarirs error: Conversion error:
"Failed converting from z3: unknown decl kind:
 (declare-fun bvurem_i ((_ BitVec 32) (_ BitVec 32)) (_ BitVec 32))"
```

`x / d`, `x.SDiv(d)` and `x.SMod(d)` fail the same way on a fresh solver,
naming `bvudiv_i`, `bvsdiv_i` and `bvsrem_i`. The same script with `x + d` in
place of `x % d` returns `[107]`, which is the control: the conversion path
itself works. It has to be a fresh solver each time — the first eval that
succeeds fills the solver's model cache, and later evals are answered from
there without converting anything.

The same failure reaches a state stepped over a real division. On
`tests/x86_64/ALLSTAR_9base_awk` in angr/binaries, at the `div edi` at
`0x40469a`, with the general-purpose registers made symbolic and one
instruction stepped, `state.solver.eval(state.regs.rax)` raises:

```
angr.errors.SimSolverModeError: Claripy threw an error
  caused by ClaripyError: Clarirs error: Conversion error: "Failed converting
  from z3: unknown decl kind: (declare-fun bvudiv_i ((_ BitVec 64)
  (_ BitVec 64)) (_ BitVec 64))"
```

`claripy.Solver` is the solver `SimState` builds by default
and it is the same `DynSolver::Z3` stack as `SolverZ3`, so this is not confined
to the explicit backend. `Solver`, `SolverZ3`, `SolverCacheless` and
`SolverComposite` all raise, and through a state `state.solver.eval()` turns it
into `SimSolverModeError`. `SolverHybrid` does not raise — it falls back to the
approximate backend and answers `[0]` for `100 % 7`, which is worse.

Sending a division *into* z3 still works: `satisfiable()`, `max()`, `min()`,
`simplify()` and evaluating a *different* variable under a constraint holding a
division all return normally. What fails is reading the division term back —
`eval`, `batch_eval` and `is_true` of the expression itself — which is what any
consumer asking for the value of a quotient or a remainder does.

### Root cause

`native/clarirs-z3/src/astext.rs` converts a z3 AST back to clarirs by matching
on the z3 decl kind. It has arms for `Budiv`, `Bsdiv`, `Burem` and `Bsrem`, and
those are the SMT-LIB spellings that clarirs *sends* to z3. z3's bitvector
rewriter replaces each of them with its internal total form — `bvudiv_i`,
`bvsdiv_i`, `bvurem_i`, `bvsrem_i` — so the expression that comes back out of a
solver never carries the spelling the converter is looking for. All four fall
through to the fallback at the end of the match, which raises
`ConversionError`.

The Python backend already had this. `claripy/backends/backend_z3.py` maps every
`_I` decl kind onto the same operation as its base form, and every `_0` form
onto `None`:

```python
"Z3_OP_BUDIV": "__floordiv__",   "Z3_OP_BUDIV_I": "__floordiv__",   "Z3_OP_BUDIV0": None,
"Z3_OP_BUREM": "__mod__",        "Z3_OP_BUREM_I": "__mod__",        "Z3_OP_BUREM0": None,
"Z3_OP_BSDIV": "SDiv",           "Z3_OP_BSDIV_I": "SDiv",           "Z3_OP_BSDIV0": None,
"Z3_OP_BSREM": "SMod",           "Z3_OP_BSREM_I": "SMod",           "Z3_OP_BSREM0": None,
```

The Rust port carried the four base rows and dropped the `_I` ones.

### Fix

The four existing arms gain their `_i` sibling, which is the same table the
Python backend has:

```rust
DeclKind::Budiv | DeclKind::BudivI => ctx.udiv(...),
DeclKind::Bsdiv | DeclKind::BsdivI => ctx.sdiv(...),
DeclKind::Burem | DeclKind::BuremI => ctx.urem(...),
DeclKind::Bsrem | DeclKind::BsremI => ctx.srem(...),
```

Four cases is the whole set, not a sample. `astext.rs` emits exactly four z3
division and remainder operators on the way in — `Z3_mk_bvudiv`, `Z3_mk_bvsdiv`,
`Z3_mk_bvurem`, `Z3_mk_bvsrem`, and never `Z3_mk_bvsmod` — each has one internal
counterpart, and none of the four was handled on the way back.

Deliberately not done:

- **`bvsmod`, `bvsmod_i`.** clarirs has no signed-modulo operator and never
  emits `bvsmod`, so z3 has nothing to rewrite into those kinds.
- **`bvudiv0`, `bvsdiv0`, `bvurem0`, `bvsrem0`.** z3 introduces the unary
  divide-by-zero forms only with `hi_div0` off, and the symbolic-divisor cases
  above come back as a plain `bvudiv_i`, not as an `ite` over `bvudiv0`. The
  Python backend maps these to `None` for the same reason.


### Testing

`tests/claripy/test_bv_ops.py::TestBVOperations::test_symbolic_div_and_mod_eval`
evaluates a symbolic dividend through `SolverZ3` for `//`, `%`, `SDiv` and
`SMod`. It fails on master with the `bvudiv_i` conversion error above — not with
an assertion mismatch — and passes here; the four pre-existing division and
remainder tests in the same file pass on both sides, because their operands are
concrete and never reach z3 at all.

The four `from_z3` unit tests for these operators in
`native/clarirs-z3/src/astext/test_bv.rs` now run `Z3_simplify` before
converting, and assert the simplified node's decl kind is the `_i` form. They
passed on master because `Z3_mk_bvudiv` builds the node directly and never runs
the rewriter, which is why the gap survived.

42 expressions covering the bitvector, float, string and boolean operators,
each evaluated through a fresh `SolverZ3`, give 8 failures before this change
and 0 after; the 8 are exactly these four operations with a symbolic and with a
constant divisor. 600 random concrete operand pairs agree with reference
semantics in 600 of 600.

The `ALLSTAR_9base_awk` probe above evaluates cleanly with this change, at
`0x40469a` and at the `div esi` at `0x404769`. In a random sample of 1,000
binaries drawn from six collections, 830 loaded and 597 of those hold at least
one instruction that lifts to a VEX integer divide or remainder; that is a
floor, because the detector matches mnemonics spelled `div` or `rem` and misses
the s390 spellings.

Validation: https://github.com/angr/angr/pull/7155#issuecomment-5623388684

session: sharpen
