### PR TITLE
CCA: Apply the 64-bit return-value narrowing only to integer data

### DIFF
--- a/angr/analyses/calling_convention/fact_collector.py
+++ b/angr/analyses/calling_convention/fact_collector.py
@@ -733,7 +733,11 @@ class FactCollector(Analysis):
                         size = stmt.data.result_size(block.vex.tyenv) // self.project.arch.byte_width
 
                         # check if this 64-bit write is actually a sign/zero-extended 32-bit value.
-                        if size == 8 and self.project.arch.bits == 64:
+                        if (
+                            size == 8
+                            and self.project.arch.bits == 64
+                            and stmt.data.result_type(block.vex.tyenv) == "Ity_I64"
+                        ):
                             expr = stmt.data
 
                             if isinstance(expr, pyvex.IRExpr.RdTmp):

--- a/tests/analyses/test_fact_collector.py
+++ b/tests/analyses/test_fact_collector.py
@@ -113,6 +113,27 @@ class TestFactCollector(unittest.TestCase):
 
         self.assertEqual(facts.retval_size, 8)
 
+    def test_s390x_float_constant_write_does_not_break_retval_size(self):
+        # atan2 compares its argument against zero loaded by lzdr, which lifts to an 8-byte Put of an
+        # Ity_F64 constant. The return-value size check masked such a constant against
+        # 0xFFFF_FFFF_0000_0000, and a float constant carries a Python float.
+        binary_path = os.path.join(test_location, "s390x", "libm.so.6")
+        proj = angr.Project(binary_path, auto_load_libs=False)
+        atan2 = proj.loader.find_symbol("atan2")
+        assert atan2 is not None
+
+        cfg = proj.analyses.CFGFast(
+            normalize=True,
+            regions=[(atan2.rebased_addr, atan2.rebased_addr + atan2.size)],
+            function_starts=[atan2.rebased_addr],
+            start_at_entry=False,
+            symbols=False,
+            force_smart_scan=False,
+        )
+        facts = proj.analyses.FunctionFactCollector(cfg.kb.functions[atan2.rebased_addr])
+
+        self.assertEqual(facts.retval_size, 8)
+
     def _run_fauxware(self, arch, function_and_cc_list):
         binary_path = os.path.join(test_location, arch, "fauxware")
         fauxware = angr.Project(binary_path, auto_load_libs=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`FunctionFactCollector` raises `TypeError` on a 64-bit function whose
return-value scan reaches an 8-byte register write of a floating-point
constant. `atan2` in `binaries/tests/s390x/libm.so.6` is one:

```
  File ".../angr/analyses/calling_convention/fact_collector.py", line 745, in _analyze_endpoints_for_retval_size
    if isinstance(expr, pyvex.IRExpr.Const) and expr.con.value & 0xFFFF_FFFF_0000_0000 == 0:
                                                ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for &: 'float' and 'int'
```

`CallingConventionAnalysis` collects facts in `CompleteCallingConventions`'s
default mode, and nothing catches the exception: with the default `workers=0`
it comes out of `CompleteCallingConventions` itself. 71 of the 872 functions in
that library raise it.

### Root cause

`_analyze_endpoints_for_retval_size` decides whether an 8-byte write to the
return register is really a widened 32-bit value. It tests what kind of
expression the write carries, and never what type the value has:

```python
                        size = stmt.data.result_size(block.vex.tyenv) // self.project.arch.byte_width

                        # check if this 64-bit write is actually a sign/zero-extended 32-bit value.
                        if size == 8 and self.project.arch.bits == 64:
                            expr = stmt.data

                            if isinstance(expr, pyvex.IRExpr.RdTmp):
                                expr = tmp_definitions.get(expr.tmp, expr)

                            if isinstance(expr, pyvex.IRExpr.Unop) and expr.op in {"Iop_32Sto64", "Iop_32Uto64"}:
                                size = 4

                            if isinstance(expr, pyvex.IRExpr.Const) and expr.con.value & 0xFFFF_FFFF_0000_0000 == 0:
                                size = 4
```

`pyvex.const.F64` and `F64i` hold a Python `float`, so the mask raises. The loop
walks every `Put` in the block before comparing the offset against the return
register, so a float write to any register is enough. `atan2` compares its
argument against zero with `lzdr %f2; cdbr %f0, %f2`, and s390x's `lzdr` -- load
zero into a floating-point register -- lifts to `PUT(f2) = 0.000000`, an
`Ity_F64` constant.

### Fix

Ask the IR what type the write has, and apply the 32-bit narrowing only to
`Ity_I64` data. pyvex has exactly three 64-bit `IRConst` classes: `U64`, which is
`Ity_I64` and holds an `int`, and `F64` and `F64i`, both `Ity_F64` and both
holding a `float`. So the branch could only ever see an integer constant, which
is unchanged, or a float constant, which raised. `atan2` now reports
`retval_size: 8` and `input_args: [<f2>, <f0>, <a0>, <a1>]`.

The block still computes `size` for every `Put` rather than only for the return
register; narrowing that is a separate change with its own effect on
`overflow_retreg_offset`.

### Testing

`tests/analyses/test_fact_collector.py::TestFactCollector::test_s390x_float_constant_write_does_not_break_retval_size`
runs `FunctionFactCollector` on `atan2` and asserts the recovered return-value
size; on master it fails with the `TypeError` above. The integer side of the same
branch is already covered by `test_stack_canary_comparison_preserves_real_return_value`
in that file, for a 32-bit and for a 64-bit return value.

Over six 64-bit ELF objects in `angr/binaries` -- `s390x/libm.so.6`,
`s390x/test-instr_s390x`, `s390x/fauxware`, `ppc64/libc.so.6`,
`aarch64/libc.so.6` and `x86_64/fauxware`, 15,459 functions -- 72 functions stop
raising, none starts raising, and no function's recovered arguments,
`retval_size` or `extra_pop` changes.

Those 71 s390x functions do not recover a prototype yet: `find_cc` then hits the
unrelated `ArchError: Arch s390x must be big endian` that #7144 fixes, in a
different file and after the fact collector, so that change cannot reach them
while this one is missing. The regression therefore asserts on
`FunctionFactCollector` rather than on a prototype.

Validation: https://github.com/angr/angr/pull/7163#issuecomment-5631221317

session: sharpen
