### PR TITLE
Stop StackPointerTracker raising in block mode on p-code architectures

### DIFF
--- a/angr/analyses/stack_pointer_tracker.py
+++ b/angr/analyses/stack_pointer_tracker.py
@@ -971,7 +971,7 @@ class StackPointerTracker(Analysis, ForwardAnalysis):
                 except CouldNotResolveException:
                     pass
             # who are we calling?
-            callees = self._find_callees(node)
+            callees = [] if self._func is None else self._find_callees(node)
             if callees:
                 callee_cleanups = [
                     callee

--- a/tests/analyses/test_stack_pointer_tracker.py
+++ b/tests/analyses/test_stack_pointer_tracker.py
@@ -76,6 +76,20 @@ class TestStackPointerTracker(unittest.TestCase):
         sp_result = sptracker.offset_before_block(0x400700, sp)
         assert sp_result is None
 
+    def test_stack_pointer_tracker_block_mode_pcode_call(self):
+        """Block mode has no function to look callees up in, so the p-code path must not ask for one."""
+        p = angr.Project(os.path.join(test_location, "m68k", "mul_add_sub_xor_m68k_be"), auto_load_libs=False)
+        sp = p.arch.sp_offset
+        call_addr = 0x80000156  # a lone "jsr" instruction
+        block = p.factory.block(call_addr)
+        assert block.vex.jumpkind == "Ijk_Call"
+        sptracker = p.analyses.StackPointerTracker(None, {sp}, block=block, track_memory=False)
+        before = sptracker.offset_before(call_addr, sp)
+        after = sptracker.offset_after(call_addr, sp)
+        assert before is not None
+        assert after is not None
+        assert after - before == (p.arch.bytes if p.arch.call_pushes_ret else 0)
+
     def test_stack_pointer_tracker_offset_mask(self):
         # SPTracker should treat 0xfffffff8 as a bitmask
         proj = angr.Project(


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`StackPointerTracker` raises on any p-code architecture when it is asked about a
single block that contains a call and told to track the stack pointer — which is
what both of its block-mode callers ask for. On `tests/m68k/mul_add_sub_xor_m68k_be` in
`angr/binaries`, the block at `0x80000156` is one instruction, `jsr
-0x7ffffb6c.l`:

```python
proj = angr.Project("tests/m68k/mul_add_sub_xor_m68k_be", auto_load_libs=False)
block = proj.factory.block(0x80000156)
proj.analyses.StackPointerTracker(None, {proj.arch.sp_offset}, block=block, track_memory=False)
```

```
  File "angr/analyses/stack_pointer_tracker.py", line 974, in _process_pcode_irsb
    callees = self._find_callees(node)
  File "angr/analyses/stack_pointer_tracker.py", line 1006, in _find_callees
    raise ValueError("find_callees() is only supported in function mode")
ValueError: find_callees() is only supported in function mode
```

Nothing inside this repository walks into it today. Two callers build the
tracker in block mode, and neither reaches p-code. `JumpTableResolver.filter`
returns `False` for any p-code IRSB — it warns `JumpTableResolver does not
support P-Code IR yet; CFG may be incomplete.` once and declines — and `cfg_base.py` calls `resolve()`
only when `filter` passes, so its `_sp_moved_up` check never runs there at all.
`FactCollector._analyze_endpoints_for_extrapop` returns early unless
`arch.call_pushes_ret`, and `ArchPcode` never assigns it, so every sleigh
language inherits `Arch.call_pushes_ret = False`. Instrumenting `_find_callees`
to record instead of raise, and running `CFGFast` and `CompleteCallingConventions`
over 67 M68k ELF objects at this base, agrees: 1,528 tracker constructions and
4,853 callee lookups, every lookup in function mode and not one in block mode.
The same instrument counts 16 block-mode constructions on
`tests/x86_64/fauxware`, so the zero is an observation rather than a blind
counter.

The second of those screens is an `archinfo` default, not something angr
decides. Sleigh compiler specs do state the call's stack shift — 68000's says
`stackshift="4"` — and setting `call_pushes_ret` to `True` for that language by
hand is enough to make `CFGFast` plus `CompleteCallingConventions` on the
fixture above die on the same `ValueError`, reached from
`_analyze_endpoints_for_extrapop` through nine more frames. With `_find_callees`
instrumented to record rather than raise, that one binary reaches it in block
mode 665 times.

### Root cause

`StackPointerTracker` has two statement handlers, one per IR, and they are meant
to be equivalent. The VEX one guards the callee lookup because block mode has no
function to look in:

```python
# angr/analyses/stack_pointer_tracker.py:817, _process_vex_irsb
callees = [] if self._func is None else self._find_callees(node)
```

The p-code one does not:

```python
# angr/analyses/stack_pointer_tracker.py:974, _process_pcode_irsb
callees = self._find_callees(node)
```

Block mode is the `func=None`, `block=` construction added in `0372847` along
with `SingleNodeGraphVisitor`. That commit added the guard to the VEX handler
and not to the p-code handler, which had been written earlier in `ab18687`. Since then the
p-code handler has been able to be given `self._func is None`, and
`_find_callees` raises unconditionally in that state.

Nothing about the failure is architecture-specific beyond the IR: it fires on
any p-code language, for any block whose p-code contains a `CALL`, whenever
the tracker was asked for `sp_offset`.

### Fix

Give the p-code handler the guard the VEX handler has, so the two IRs agree
about what block mode can answer. The tracker still applies the call's stack
adjustment in block mode, exactly as the VEX side does; only the callee-cleanup
refinement, which needs a function, is skipped.

With the change, the reproducer above returns instead of raising:

```
offset_before = 0
offset_after  = 0
```

Deliberately not done: the p-code handler's callee-cleanup branch is left as it
is. It is unreachable in block mode by construction and this change does not
alter it in function mode.

### Testing

`tests/analyses/test_stack_pointer_tracker.py::TestStackPointerTracker::test_stack_pointer_tracker_block_mode_pcode_call`
builds the tracker in block mode over that `jsr` block, asserts the block really
is a call block so the test cannot stop covering the path silently, and asserts
the tracker answers with an offset on each side of the instruction rather than
raising. It raises
`ValueError: find_callees() is only supported in function mode` on master and
passes with this change. The assertion is written as
`after - before == (arch.bytes if arch.call_pushes_ret else 0)`, so it states
what this repository computes given the architecture rather than pinning a
number that belongs to `archinfo`, and it stays green whichever way `archinfo`
answers.

Validation: https://github.com/angr/angr/pull/7165#issuecomment-5634554508

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

session: sharpen
