### PR TITLE
clarirs: Stop to_unsigned panicking on a value beyond the bit width

### DIFF
--- a/native/clarirs-vsa/src/strided_interval.rs
+++ b/native/clarirs-vsa/src/strided_interval.rs
@@ -3360,6 +3360,20 @@ mod si_arithmetic_op_tests {
         assert_eq!(result, StridedInterval::range(32, 5u32, 25u32));
         assert!(!result.is_integer());
     }
+
+    #[test]
+    fn test_mul_product_beyond_the_width() {
+        // psplit leaves 127[0xff, 0xfd] with the piece 127[0x7e, 0x01], which
+        // still wraps, so wrapped_signed_mul reads its signed bounds as
+        // (126, 1) and picks the corner (1 * -128, 126 * -127). The overflow
+        // check above the conversion assumes the bounds are ordered, so -16002
+        // reached to_unsigned and panicked.
+        let a = StridedInterval::new(8, 127u32, 0xffu32, 0xfdu32);
+        let b = StridedInterval::new(8, 1u32, 0x80u32, 0x81u32);
+        let result = a.mul(&b);
+        assert_eq!(result.bits(), 8);
+        assert!(!result.is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/native/clarirs-vsa/src/strided_interval/modular_arithmetic.rs
+++ b/native/clarirs-vsa/src/strided_interval/modular_arithmetic.rs
@@ -1,5 +1,5 @@
 use num_bigint::{BigInt, BigUint, ToBigInt};
-use num_traits::{One, Zero};
+use num_traits::{One, Signed, Zero};
 
 /// Returns the maximum unsigned integer representable with the given bits
 pub(crate) fn max_int(bits: u32) -> BigUint {
@@ -186,11 +186,50 @@ pub(crate) fn to_signed(v: &BigUint, bits: u32) -> BigInt {
 
 /// Helper to convert signed BigInt to unsigned BigUint
 pub(crate) fn to_unsigned(v: &BigInt, bits: u32) -> BigUint {
-    if v < &BigInt::zero() {
-        let modulus = BigInt::one() << bits;
-        let result = (modulus + v) % (BigInt::one() << bits);
-        result.to_biguint().unwrap()
+    let modulus = BigUint::one() << bits;
+    let magnitude = v.magnitude() % &modulus;
+    if v.is_negative() && !magnitude.is_zero() {
+        modulus - magnitude
     } else {
-        v.to_biguint().unwrap() & max_int(bits)
+        magnitude
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_unsigned_beyond_the_width() {
+        // wrapped_signed_mul multiplies two signed bounds, so it can reach here
+        // with a product whose magnitude exceeds 2**bits. Adding the modulus
+        // once only reaches down to -2**bits. Below that the sum stayed
+        // negative unless 2**bits divided the value exactly, % truncates toward
+        // zero rather than flooring, and to_biguint answers None on a negative
+        // value: the first and third of these panicked, the other two did not.
+        assert_eq!(to_unsigned(&BigInt::from(-16002), 8), BigUint::from(126u32));
+        assert_eq!(to_unsigned(&BigInt::from(-256), 8), BigUint::zero());
+        assert_eq!(to_unsigned(&BigInt::from(-257), 8), BigUint::from(255u32));
+        assert_eq!(to_unsigned(&BigInt::from(-16384), 8), BigUint::zero());
+    }
+
+    #[test]
+    fn test_to_unsigned_within_the_width() {
+        assert_eq!(to_unsigned(&BigInt::from(0), 8), BigUint::zero());
+        assert_eq!(to_unsigned(&BigInt::from(127), 8), BigUint::from(127u32));
+        assert_eq!(to_unsigned(&BigInt::from(-1), 8), BigUint::from(255u32));
+        assert_eq!(to_unsigned(&BigInt::from(-128), 8), BigUint::from(128u32));
+
+        // sdiv passes -2**(bits-1) / -1 here, which is out of signed range, and
+        // relies on the reduction to give the two's-complement answer.
+        assert_eq!(to_unsigned(&BigInt::from(128), 8), BigUint::from(128u32));
+    }
+
+    #[test]
+    fn test_to_unsigned_inverts_to_signed() {
+        for value in 0u32..256 {
+            let unsigned = BigUint::from(value);
+            assert_eq!(to_unsigned(&to_signed(&unsigned, 8), 8), unsigned);
+        }
     }
 }

--- a/tests/claripy/test_vsa_bv_ops.py
+++ b/tests/claripy/test_vsa_bv_ops.py
@@ -154,6 +154,24 @@ class TestVSABVOperations(unittest.TestCase):
         # Check that we have both large (potentially negative) and small values
         self.assertTrue(len(values) > 0)
 
+    def test_multiplication_beyond_the_signed_range(self):
+        """Multiplying a wrapping interval used to panic the Rust VSA backend."""
+        # psplit leaves 127[0xFF, 0xFD] with the piece 127[0x7E, 0x01], which
+        # still wraps, so wrapped_signed_mul reads its signed bounds as (126, 1)
+        # and takes the corner 126 * -127 = -16002. That is below -2**8, where
+        # to_unsigned added the modulus once, was left with a negative value,
+        # and got None back from to_biguint.
+        result = claripy.SI(bits=8, stride=127, lower_bound=0xFF, upper_bound=0xFD) * claripy.SI(
+            bits=8, stride=1, lower_bound=0x80, upper_bound=0x81
+        )
+        self.assertEqual(len(self.solver.eval(result, 1)), 1)
+
+        # The same shape at another width.
+        result = claripy.SI(bits=4, stride=7, lower_bound=0xF, upper_bound=0xD) * claripy.SI(
+            bits=4, stride=1, lower_bound=0x8, upper_bound=0x9
+        )
+        self.assertEqual(len(self.solver.eval(result, 1)), 1)
+
     def test_basic_division(self):
         """Test basic division operations."""
         # Concrete division


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Multiplying two strided intervals in the VSA backend can take the whole analysis
down:

```python
from angr import claripy

a = claripy.SI(bits=8, stride=127, lower_bound=0xFF, upper_bound=0xFD)
b = claripy.SI(bits=8, stride=1, lower_bound=0x80, upper_bound=0x81)
claripy.SolverVSA().min(a * b)
```

That raises, over a Rust panic on stderr at
`native/clarirs-vsa/src/strided_interval/modular_arithmetic.rs:192:29`:

```
pyo3_runtime.PanicException: called `Option::unwrap()` on a `None` value
```

`min`, `max`, `eval`, `is_false` and `claripy.vsa.simplify` all reach it; the
output comment has all five, before and after. Both operands are ordinary
strided intervals, each reaching its upper bound from its lower bound by whole
strides: `0xff + 2*127` is `0xfd` mod 256, and `0x80 + 1` is `0x81`.

`PanicException.__mro__` is `(PanicException, BaseException, object)`, so
`except Exception` does not catch it -- measured, it escapes -- and nothing in
angr catches it either: the package has no bare `except:` and no
`except BaseException`. `JumpTableResolver` hands a jump-table address to
`claripy.vsa.simplify` at `jumptable.py:2016`, inside a `try` that catches only
`claripy.ClaripyError`.

### Root cause

`StridedInterval::mul` splits both operands at the poles and multiplies the
signed bounds of each pair of pieces, so the bounds it computes are products of
two signed bounds and can be far wider than the bit width holds.

`psplit` does not always give it the non-wrapping pieces that arithmetic assumes.
`ssplit`'s second part is `[a_upper + stride mod 2**bits, upper_bound]`, and that
lower end can land above `upper_bound`: 8-bit `127[0xff, 0xfd]` psplits into
`0[0xff, 0xff]`, `127[0x7e, 0x01]` and `127[0x80, 0xfd]`, and the middle piece is
still a wrapping interval. `wrapped_signed_mul` reads its signed bounds as
`(126, 1)` -- lower above upper -- and for a negative other operand it takes the
corner `(s_ub * o_lb, s_lb * o_ub)`, here `(1 * -128, 126 * -127)` =
`(-128, -16002)`.

The overflow check right above the conversion assumes the pair is ordered:

```rust
                // Check for overflow
                let max_val_signed = signed_max_int(bits).to_bigint().unwrap();
                let min_val_signed = -(BigInt::one() << (bits - 1));
                if lb < min_val_signed || ub > max_val_signed || &ub - &lb > max_val_signed {
                    return Self::top(bits);
                }
```

With `lb = -128` and `ub = -16002` all three clauses are false -- `ub - lb` is
negative -- so `-16002` reaches `to_unsigned`:

```rust
/// Helper to convert signed BigInt to unsigned BigUint
pub(crate) fn to_unsigned(v: &BigInt, bits: u32) -> BigUint {
    if v < &BigInt::zero() {
        let modulus = BigInt::one() << bits;
        let result = (modulus + v) % (BigInt::one() << bits);
        result.to_biguint().unwrap()
    } else {
        v.to_biguint().unwrap() & max_int(bits)
    }
}
```

Adding the modulus once only covers values down to `-2**bits`, and `%` on a
`BigInt` truncates toward zero as it does on Rust's primitive integers, so
`(256 + -16002) % 256` is `-130` and not `126`. `to_biguint()` on a negative
value is `None`, and the `unwrap` panics.

### Fix

The other branch already reduces modulo `2**bits`, masking with
`max_int(bits)`, and `sdiv` depends on that: its both-constants branch computes
`-2**(bits-1) / -1`, which is out of signed range, and the mask turns it into
the two's-complement answer `bvsdiv` is defined to give. The negative branch
never implemented the same rule, so the function disagrees with itself. Reduce
for either sign, which is what `to_signed_i` in
`native/angr/src/ailment/mod.rs` already does for the other direction.

The new code answers exactly what the old code answered on every input the old
code did not panic on. A non-negative value is reduced as before; for
`-2**bits <= v < 0` the old `modulus + v` is that same value modulo `2**bits`;
and below that the old code only got an answer where `2**bits` divides the
value, where both give `0`. So this turns a crash into an answer and changes
nothing else.

The expression above now answers `0` for `min` and `255` for `max`, and
`claripy.vsa.simplify` gives `SI8_1_128_126`.

### Testing

Five tests, load-bearing in both directions. Two fail on master with the panic
above -- `test_to_unsigned_beyond_the_width`, which panics on master at its
first assertion, and `test_mul_product_beyond_the_width`, which multiplies the
intervals from the Root cause -- and so does the Python regression in
`tests/claripy/test_vsa_bv_ops.py`, which goes through the public solver API at
two bit widths. The other two Rust tests pass on master and still
pass here, which is the point of them: `test_to_unsigned_within_the_width` pins
the in-range answers including the `sdiv` case above, and
`test_to_unsigned_inverts_to_signed` round-trips every 8-bit value through
`to_signed` and back.

A scan across 4-bit strided intervals, 110,592 multiplications forced through
`SolverVSA.min` and `.max` in both argument orders, panics 2,496 times on master
and never with this change, and every combination that answered on master
answers identically here. The validation record has the table and the scan's
shape.

Validation: https://github.com/angr/angr/pull/7166#issuecomment-5638486720

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen
