### PR TITLE
DuplicationReverter: Replace split blocks in a predecessors-first order.

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/ail_merge_graph.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/ail_merge_graph.py
@@ -186,6 +186,18 @@ class AILMergeGraph:
         for block in base_to_split:
             if block not in subgraph:
                 return None
+        # maintain a split order so that we can replace split blocks in an order where a predecessor is always
+        # replaced before its successor. this avoids consulting the graph using the old node.
+        split_order = nx.DiGraph()
+        split_order.add_nodes_from(base_to_split)
+        for block in base_to_split:
+            for succ in subgraph.successors(block):
+                if succ in base_to_split and succ is not block:
+                    split_order.add_edge(block, succ)
+        if not nx.is_directed_acyclic_graph(split_order):
+            _l.debug("The blocks to split form a cycle, which is not supported; skipping this candidate")
+            return None
+        base_to_split = {block: base_to_split[block] for block in nx.topological_sort(split_order)}
         self.graph, update_blocks = self.clone_graph_replace_splits(subgraph, base_to_split)
         self._update_all_split_refs(update_blocks)
         for update_block, new_block in update_blocks.items():

--- a/tests/analyses/decompiler/test_duplication_reverter.py
+++ b/tests/analyses/decompiler/test_duplication_reverter.py
@@ -16,6 +16,12 @@ from tests.common import bin_location, load_project_with_scoped_cfg
 TRUE_BIN = os.path.join(bin_location, "tests", "x86_64", "true")
 TRUE_FUNC = 0x401D30
 
+# sub_140003a50 has a duplicate candidate whose blocks to split form a two-block loop of partial matches. Replacing
+# split blocks rewires their predecessors by copying them, so with a loop one split block is always copied away before
+# its own turn, and its own turn then looked it up by an identity no longer in the graph.
+CANCEL_BIN = os.path.join(bin_location, "tests", "x86_64", "windows", "cancel.sys")
+CANCEL_FUNC = 0x140003A50
+
 
 class TestDuplicationReverter(TestCase):
     def test_a_call_that_forks_the_flow_is_an_unsupported_candidate(self):
@@ -41,6 +47,13 @@ class TestDuplicationReverter(TestCase):
         assert pass_._share_subregion([b, c])
         assert not pass_._share_subregion([a, c])
         assert not pass_._share_subregion([a, Block(0x2000, 4, statements=[])])
+
+    def test_a_loop_of_split_blocks_is_skipped_not_raised(self):
+        proj, cfg = load_project_with_scoped_cfg(CANCEL_BIN, CANCEL_FUNC)
+        func = cfg.functions[CANCEL_FUNC]
+
+        dec = proj.analyses[Decompiler].prep(fail_fast=True)(func, cfg=cfg.model, preset="full")
+        assert dec.codegen is not None and dec.codegen.text is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This avoids NetworkXError caused by querying the graph with old nodes when they have been replaced already.