### PR TITLE
DuplicationReverter: Do not uniquify the address of the function entry block.

### DIFF
--- a/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
+++ b/angr/analyses/decompiler/optimization_passes/duplication_reverter/duplication_reverter.py
@@ -326,7 +326,9 @@ class DuplicationReverter(StructuringOptimizationPass):
                 self.write_graph.add_edge(orig_pred, new_succ)
 
         self.write_graph = self._correct_all_broken_jumps(self.write_graph)
-        self.write_graph = self._uniquify_addrs(self.write_graph)
+        # do not change the address of the function entry block
+        entry_blocks = {node for node in self.read_graph.nodes if node.addr == self._func.addr}
+        self.write_graph = self._uniquify_addrs(self.write_graph, keep=entry_blocks)
         _l.info("Candidate merge successful on blocks: %s", candidate)
         return True
 
@@ -334,7 +336,10 @@ class DuplicationReverter(StructuringOptimizationPass):
     # Helpers
     #
 
-    def _uniquify_addrs(self, graph):
+    def _uniquify_addrs(self, graph, keep: set[Block] | None = None):
+        """
+        Assign every block a unique address.
+        """
         new_graph = nx.DiGraph()
         new_nodes = {}
         nodes_by_addr = defaultdict(list)
@@ -347,6 +352,10 @@ class DuplicationReverter(StructuringOptimizationPass):
 
             # we have multiple nodes with the same address
             duplicate_addr_nodes = sorted(nodes, reverse=True)
+            if keep is not None:
+                kept = [node for node in duplicate_addr_nodes if node in keep]
+                if len(kept) == 1:
+                    duplicate_addr_nodes = [node for node in duplicate_addr_nodes if node is not kept[0]]
             for duplicate_node in duplicate_addr_nodes:
                 new_node = duplicate_node.copy()
                 new_node.idx = None

--- a/tests/analyses/decompiler/test_duplication_reverter.py
+++ b/tests/analyses/decompiler/test_duplication_reverter.py
@@ -6,7 +6,11 @@ import os.path
 import unittest
 from unittest import TestCase
 
+import networkx
+
 from angr.ailment import Block
+from angr.ailment.expression import Const
+from angr.ailment.statement import ConditionalJump, Jump, Label, Return
 from angr.analyses.decompiler.decompiler import Decompiler
 from angr.analyses.decompiler.optimization_passes.duplication_reverter.duplication_reverter import DuplicationReverter
 from tests.common import bin_location, load_project_with_scoped_cfg
@@ -54,6 +58,46 @@ class TestDuplicationReverter(TestCase):
 
         dec = proj.analyses[Decompiler].prep(fail_fast=True)(func, cfg=cfg.model, preset="full")
         assert dec.codegen is not None and dec.codegen.text is not None
+
+    def test_the_entry_block_keeps_its_address_when_a_merged_block_borrows_it(self):
+        # The merged conditional block is minted with the address of the candidates' shared conditional dominator.
+        # When that dominator is the function entry, two blocks carry the entry's address; renaming both left the
+        # graph without an entry block, and region identification then failed to find a start node
+        # (busybox setinputfile). The entry stays; the new block moves, and the jump into it follows.
+
+        def _label(addr):
+            return Label(0, f"LABEL_{addr:x}", ins_addr=addr, block_idx=None)
+
+        entry = Block(0x1000, 8, statements=[_label(0x1000), Jump(0, Const(0, 0x1010, 64), ins_addr=0x1000)])
+        mid = Block(0x1010, 8, statements=[_label(0x1010), Jump(0, Const(0, 0x1000, 64), ins_addr=0x1010)])
+        merged = Block(
+            0x1000,
+            0,
+            statements=[
+                ConditionalJump(0, Const(0, 1, 1), Const(0, 0x1020, 64), Const(0, 0x1030, 64), ins_addr=0x1000),
+            ],
+            idx=2,
+        )
+        left = Block(0x1020, 4, statements=[_label(0x1020), Return(0, [], ins_addr=0x1020)])
+        right = Block(0x1030, 4, statements=[_label(0x1030), Return(0, [], ins_addr=0x1030)])
+        graph = networkx.DiGraph()
+        for a, b in ((entry, mid), (mid, merged), (merged, left), (merged, right)):
+            graph.add_edge(a, b)
+
+        class _Minter:
+            def new_block_addr(self):
+                return 0x2000
+
+        out = DuplicationReverter._uniquify_addrs(_Minter(), graph, keep={entry})
+
+        at_entry = [n for n in out if n.addr == 0x1000]
+        assert len(at_entry) == 1
+        assert isinstance(at_entry[0].statements[-1], Jump)
+        (moved,) = (n for n in out if n.addr == 0x2000)
+        assert isinstance(moved.statements[-1], ConditionalJump)
+        (new_mid,) = (n for n in out if n.addr == 0x1010)
+        assert new_mid.statements[-1].target.value == 0x2000
+        assert list(out.successors(new_mid)) == [moved]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
... otherwise the function will have no entry block at the function address, and future analyses will crash.