### PR TITLE
JumpTableResolver: give each indirect jump a time limit

### DIFF
--- a/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
+++ b/angr/analyses/cfg/indirect_jump_resolvers/jumptable.py
@@ -4,6 +4,7 @@ import contextlib
 import enum
 import functools
 import logging
+import time
 from collections import OrderedDict, defaultdict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal, cast
@@ -42,6 +43,14 @@ if TYPE_CHECKING:
     from angr.knowledge_plugins import Function
 
 l = logging.getLogger(name=__name__)
+
+
+class OutOfTimeNotification(AngrError):
+    """
+    Raised from inside the slice's symbolic execution when the resolver's time limit is up. A single block of
+    undecoded bytes can cost minutes on its own, so the limit has to be checked between statements and not only
+    between steps.
+    """
 
 
 class NotAJumpTableNotification(AngrError):
@@ -841,6 +850,9 @@ class MIPSGPHook:
 #
 
 
+DEFAULT_TIME_LIMIT = 30.0
+
+
 class JumpTableResolver(IndirectJumpResolver):
     """
     A generic jump table resolver.
@@ -851,12 +863,17 @@ class JumpTableResolver(IndirectJumpResolver):
 
     Progressively larger program slices will be analyzed to determine jump table location and size. If the size of the
     table cannot be determined, a *guess* will be made based on how many entries in the table *appear* valid.
+
+    Each indirect jump gets at most ``time_limit`` seconds of symbolic execution. A jump that runs out of time is
+    reported unresolved, the same as one the resolver cannot make sense of. Pass ``time_limit=None`` to let a jump run
+    for as long as it takes.
     """
 
-    def __init__(self, project, resolve_calls: bool = True):
+    def __init__(self, project, resolve_calls: bool = True, time_limit: float | None = DEFAULT_TIME_LIMIT):
         super().__init__(project, timeless=False)
 
         self.resolve_calls = resolve_calls
+        self.time_limit = time_limit
 
         self._bss_regions = None
         # the maximum number of resolved targets. Will be initialized from CFG.
@@ -913,7 +930,12 @@ class JumpTableResolver(IndirectJumpResolver):
         else:
             cv_manager = None
 
+        deadline = None if self.time_limit is None else time.monotonic() + self.time_limit
+
         for slice_steps in range(1, 5):
+            if self._out_of_time(deadline, addr):
+                return False, None
+
             # Perform a backward slicing from the jump target
             # Important: Do not go across function call boundaries
             b = Blade(
@@ -932,12 +954,22 @@ class JumpTableResolver(IndirectJumpResolver):
 
             l.debug("Try resolving %#x with a %d-level backward slice...", addr, slice_steps)
             r, targets = self._resolve(
-                cfg, addr, func, b, cv_manager, potential_call_table=False, func_graph_complete=func_graph_complete
+                cfg,
+                addr,
+                func,
+                b,
+                cv_manager,
+                potential_call_table=False,
+                func_graph_complete=func_graph_complete,
+                deadline=deadline,
             )
             if r:
                 return r, targets
 
         if potential_call_table:
+            if self._out_of_time(deadline, addr):
+                return False, None
+
             b = Blade(
                 cfg.graph,
                 addr,
@@ -952,7 +984,14 @@ class JumpTableResolver(IndirectJumpResolver):
                 cross_insn_opt=True,
             )
             return self._resolve(
-                cfg, addr, func, b, cv_manager, potential_call_table=True, func_graph_complete=func_graph_complete
+                cfg,
+                addr,
+                func,
+                b,
+                cv_manager,
+                potential_call_table=True,
+                func_graph_complete=func_graph_complete,
+                deadline=deadline,
             )
 
         return False, None
@@ -960,6 +999,13 @@ class JumpTableResolver(IndirectJumpResolver):
     #
     # Private methods
     #
+
+    @staticmethod
+    def _out_of_time(deadline: float | None, addr: int) -> bool:
+        if deadline is None or time.monotonic() < deadline:
+            return False
+        l.debug("Ran out of time while resolving the indirect jump at %#x.", addr)
+        return True
 
     def _resolve(
         self,
@@ -970,6 +1016,7 @@ class JumpTableResolver(IndirectJumpResolver):
         cv_manager: ConstantValueManager | None,
         potential_call_table: bool = False,
         func_graph_complete: bool = True,
+        deadline: float | None = None,
     ) -> tuple[bool, Sequence[int] | None]:
         """
         Internal method for resolving jump tables.
@@ -978,6 +1025,7 @@ class JumpTableResolver(IndirectJumpResolver):
         :param addr:      Address of the block where the indirect jump is.
         :param func:      The Function instance.
         :param b:         The generated backward slice.
+        :param deadline:  A ``time.monotonic()`` reading past which to give up, or None for no limit.
         :return:          A bool indicating whether the indirect jump is resolved successfully, and a list of
                           resolved targets.
         """
@@ -1118,8 +1166,16 @@ class JumpTableResolver(IndirectJumpResolver):
         annotatedcfg = AnnotatedCFG(project, None, detect_loops=False)
         annotatedcfg.from_digraph(b.slice)
 
+        def out_of_time_bp(_state):
+            assert deadline is not None
+            if time.monotonic() >= deadline:
+                raise OutOfTimeNotification
+
         # pylint: disable=too-many-nested-blocks
         for block_addr, _ in sources:
+            if self._out_of_time(deadline, addr):
+                return False, None
+
             # Use slicecutor to execute each one, and get the address
             # We simply give up if any exception occurs on the way
             start_state = self._initial_state(block_addr, cfg, func_addr)
@@ -1134,6 +1190,9 @@ class JumpTableResolver(IndirectJumpResolver):
             # rewrite folded bound-check constraints (Shr(x, k) == 0) into forms that VSA can narrow x with
             shr_bounds_bp = BP(when=BP_BEFORE, enabled=True, action=ShrBoundsConstraintHook.hook)
             start_state.inspect.add_breakpoint("constraints", shr_bounds_bp)
+
+            if deadline is not None:
+                start_state.inspect.add_breakpoint("statement", BP(when=BP_BEFORE, enabled=True, action=out_of_time_bp))
 
             # constant value manager
             if cv_manager is not None:
@@ -1161,7 +1220,7 @@ class JumpTableResolver(IndirectJumpResolver):
 
             # Run it!
             try:
-                simgr.run()
+                simgr.run(until=None if deadline is None else lambda _: time.monotonic() >= deadline)
             except KeyError as ex:
                 # This is because the program slice is incomplete.
                 # Blade will support more IRExprs and IRStmts in the future
@@ -1170,6 +1229,9 @@ class JumpTableResolver(IndirectJumpResolver):
 
             # Get the jumping targets
             for r in simgr.found:
+                if self._out_of_time(deadline, addr):
+                    return False, None
+
                 jt2, jt2_addr, jt2_entrysize, jt2_size = None, None, None, None
                 entries_guessed = False
                 if load_stmt is not None:

--- a/tests/analyses/cfg/test_jumptables.py
+++ b/tests/analyses/cfg/test_jumptables.py
@@ -13,6 +13,7 @@ import pyvex
 import angr
 from angr.analyses.cfg import CFGFast
 from angr.analyses.cfg.indirect_jump_resolvers import JumpTableResolver
+from angr.analyses.cfg.indirect_jump_resolvers.default_resolvers import default_indirect_jump_resolvers
 from angr.knowledge_plugins.cfg import IndirectJumpType
 
 if TYPE_CHECKING:
@@ -2756,6 +2757,25 @@ class TestJumpTableResolver(unittest.TestCase):
     #
     # The jump table should be occupied and marked as data
     #
+
+    def test_jumptable_resolver_time_limit(self):
+        # A jump table the resolver runs out of time on is reported unresolved, the same as one it cannot make sense
+        # of. Without a limit the resolver runs unbounded symbolic execution over the slice.
+
+        p = angr.Project(os.path.join(test_location, "i386", "windows", "printenv.exe"), auto_load_libs=False)
+
+        cfg = p.analyses.CFGFast()
+        assert cfg.indirect_jumps[0x402E4D].jumptable is True
+        assert 0x402E4D not in cfg.kb.unresolved_indirect_jumps
+
+        resolvers = default_indirect_jump_resolvers(p.loader.main_object, p)
+        for resolver in resolvers:
+            if isinstance(resolver, JumpTableResolver):
+                resolver.time_limit = 0.0
+        cfg = p.analyses.CFGFast(indirect_jump_resolvers=resolvers)
+
+        assert cfg.indirect_jumps[0x402E4D].jumptable is not True
+        assert 0x402E4D in cfg.kb.unresolved_indirect_jumps
 
     def test_jumptable_occupied_as_data(self):
         # GitHub issue #1671


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` can stop making progress inside `JumpTableResolver.resolve` and never come back. On a 32-bit Windows executable here, the fifth indirect jump of the binary entered the resolver and was still inside a single `project.factory.successors()` call when the run was killed:

```
outcome                              killed at a 900 s CPU budget
cpu                                  1038.7 s        wall 1191.1 s
resolve() calls that returned        4, longest 0.004 s
```

Nothing degrades gracefully: the resolver is never entered again, the analysis never returns, and there is no CFG at the end of it. With the limit in place the same binary enters it 389 times and finishes.

### Root cause

The resolver runs symbolic execution over a backward slice of the jump and nothing bounds how long that takes. `Slicecutor` and `LocalLoopSeer(bound=1)` bound the number of steps; neither bounds the cost of one. A single basic block is enough, because the claripy model of the x86 BCD helper `x86g_calculate_daa_das_aaa_aas` builds a nest of `claripy.If` expressions per instruction, driving the AST twelve levels deeper each time, and then extracts each of the low eight bits of the result in `calc_paritybit`. Each such instruction in the block roughly quadruples the cost of the next ccall. Chaining them on a symbolic `flags_and_AX`, which is what the resolver does when the scan decoded those bytes out of data:

```
chained BCD instructions    one ccall       AST depth
                        8      1.945 s               97
                        9      8.194 s              109
                       10     33.380 s              121
                       11    134.776 s              133
```

The last row is one VEX statement. `0x27`, `0x2f`, `0x37` and `0x3f` are ordinary data bytes, and a run of them is what the scan hands the resolver wherever it decodes something that is not code.

### Fix

Give the resolver a wall-clock budget for each indirect jump: `time_limit`, thirty seconds by default, switched off with `None`. A jump that runs out of time is reported unresolved, which is what the resolver already returns for a jump it cannot make sense of, so `CFGFast` records it through `_indirect_jump_unresolved` and carries on. One case is deliberately left: `resolve` does not clear the deferred flag when it runs out of time, so a jump already deferred to the final pass is retried there with a fresh budget and can cost twice the limit. Clearing it would move the tree every measurement here was taken on, so it is a follow-up rather than an oversight.

The budget is checked between the four slice sizes and the call-table pass, between simulation steps, and before every VEX statement of the slice through a breakpoint on the resolver's own start state. The last of those is not belt and braces. Instrumenting the same stall shows the simulation manager had completed exactly one step and the second `factory.successors()` call had then been running for about 590 seconds, so a step counter or a between-steps deadline would never have fired. What the budget bounds is therefore the limit plus whatever was running when it expired — a VEX statement, or the slice construction and the pre-checks before the loop, none of which is interrupted. The worst overshoot measured is 60.7 s past the limit.

A wall clock makes a jump's fate depend on the machine, which is worth saying out loud, and a jump that would have resolved in longer than the limit loses its answer. A step or iteration count cannot bound this, because the cost is claripy rewriting rather than solving and lands inside one statement; process CPU time would bound it and is the obvious alternative if you would rather the limit did not move with load. Over the 140 tracked fixtures in `angr/binaries` and the inputs attached to three public issues, 104,278 timed `resolve` calls, no call on 139 of the fixtures exceeds 1.57 s and none on the issue inputs exceeds 1.90 s. The exception is `tests/x86_64/windows/7107ab06...7e1bd5`, where the cost is cumulative rather than per call: the resolver is entered 58,822 times for about 1,700 s of a 63-minute run, which a per-jump limit neither addresses nor fires on.

The ccall model's growth is a separate problem and this does not address it.

### Testing

`tests/analyses/cfg/test_jumptables.py::TestJumpTableResolver::test_jumptable_resolver_time_limit` loads the already-tracked `tests/i386/windows/printenv.exe`, resolves its jump table at `0x402e4d` with the default budget, then rebuilds the CFG with `time_limit=0.0` and asserts the same jump is in `cfg.kb.unresolved_indirect_jumps`. On master it fails one assertion earlier, at `cfg.indirect_jumps[0x402e4d].jumptable is not True`, because the resolver ignores the attribute and still resolves the table.

Twelve objects that stall here were run on both revisions under the same 900 s CPU cap. On the baseline all twelve were killed at the cap having produced no CFG at all, and three single `resolve` calls returned after 243.5 s, 949.0 s and 998.3 s. On this branch eleven of the twelve finish, in 60.6 to 170.6 s of CPU; the twelfth still exceeds the cap, for a reason outside this resolver, its longest resolve being 0.353 s. On six tracked fixtures the function set, block set, jump-table map and unresolved set are identical before and after. I could not build a public reproducer for the stall itself; the corpus the twelve come from cannot be published, and no tracked fixture I measured comes close.

Validation: https://github.com/angr/angr/pull/7175#issuecomment-5640609631

session: sharpen
