### PR TITLE
Fix SimTypeRef handling after AngrDB reload. Close #7156.

### DIFF
--- a/angr/analyses/decompiler/clinic.py
+++ b/angr/analyses/decompiler/clinic.py
@@ -2493,12 +2493,7 @@ class Clinic(Analysis, Serializable):
     @timethis
     def _make_argument_list(self) -> list[SimVariable]:
         if self.function.calling_convention is not None and self.function.prototype is not None:
-            proto = (
-                dereference_simtype_by_lib(self.function.prototype, self.function.prototype_libname)
-                if self.function.prototype_libname
-                else self.function.prototype
-            )
-            args: list[SimFunctionArgument] = self.function.calling_convention.arg_locs(proto)
+            args: list[SimFunctionArgument] = self.function.calling_convention.arg_locs(self.function.prototype)
             if self._flatten_args:
                 new_args = []
                 for arg in args:
@@ -2719,7 +2714,8 @@ class Clinic(Analysis, Serializable):
                 for tv in vr.var_to_typevars[variable]:
                     groundtruth[tv] = vartype
 
-        if self.function.prototype is not None and not self.function.is_prototype_guessed:
+        if self.function.is_prototype_groundtruth:
+            assert self.function.prototype is not None
             for arg_i, (_, variable) in arg_vvars.items():
                 if arg_i < len(self.function.prototype.args):
                     for tv in vr.var_to_typevars[variable]:

--- a/angr/analyses/decompiler/decompiler.py
+++ b/angr/analyses/decompiler/decompiler.py
@@ -924,7 +924,8 @@ class Decompiler(Analysis):
                     for typevar in var_to_typevar[variable]:
                         groundtruth[typevar] = vartype
 
-        if self.func.prototype is not None and not self.func.is_prototype_guessed:
+        if self.func.is_prototype_groundtruth:
+            assert self.func.prototype is not None
             for arg_i, (_, variable) in arg_vvars.items():
                 if arg_i < len(self.func.prototype.args):
                     for tv in var_to_typevar[variable]:

--- a/angr/analyses/decompiler/structured_codegen/c.py
+++ b/angr/analyses/decompiler/structured_codegen/c.py
@@ -6,7 +6,7 @@ import re
 import struct
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from angr.ailment import Block, Expr, Stmt, Tmp
 from angr.ailment.block_walker import _dispatch_key
@@ -74,7 +74,7 @@ from angr.utils.constants import should_use_hex
 from angr.utils.library import get_cpp_function_name
 from angr.utils.loader import is_in_readonly_section, is_in_readonly_segment
 from angr.utils.strings import decode_utf16_string
-from angr.utils.types import dereference_simtype_by_lib, unpack_pointer_and_array, unpack_typeref
+from angr.utils.types import unpack_pointer_and_array, unpack_typeref
 
 from .base import (
     BaseStructuredCodeGenerator,
@@ -1679,11 +1679,7 @@ class CFunctionCall(CExpression):
     @property
     def prototype(self) -> SimTypeFunction | None:  # TODO there should be a prototype for each callsite!
         if self.callee_func is not None and self.callee_func.prototype is not None:
-            proto = self.callee_func.prototype
-            if self.callee_func.prototype_libname is not None:
-                # we need to deref the prototype in case it uses SimTypeRef internally
-                proto = cast(SimTypeFunction, dereference_simtype_by_lib(proto, self.callee_func.prototype_libname))
-            return proto
+            return self.callee_func.prototype
         returnty = SimTypeInt(signed=False)
         return SimTypeFunction([arg.type for arg in self.args], returnty).with_arch(self.codegen.project.arch)
 
@@ -3985,8 +3981,6 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
                     and i < len(target_func.prototype.args)
                 ):
                     type_ = target_func.prototype.args[i].with_arch(self.project.arch)
-                    if target_func.prototype_libname is not None:
-                        type_ = dereference_simtype_by_lib(type_, target_func.prototype_libname)
 
                 if isinstance(arg, Expr.Const):
                     if isinstance(arg.value, int) and (
@@ -4064,8 +4058,6 @@ class CStructuredCodeGenerator(BaseStructuredCodeGenerator, Analysis, Serializab
                     and i < len(target_func.prototype.args)
                 ):
                     type_ = target_func.prototype.args[i].with_arch(self.project.arch)
-                    if target_func.prototype_libname is not None:
-                        type_ = dereference_simtype_by_lib(type_, target_func.prototype_libname)
 
                 if isinstance(arg, Expr.Const):
                     if isinstance(arg.value, int) and (

--- a/angr/analyses/typehoon/translator.py
+++ b/angr/analyses/typehoon/translator.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from angr import sim_type
 from angr.sim_type import SimType, TypeRef
+from angr.utils.types import type_collections_for_lib
 
 from . import typeconsts
 from .typeconsts import TypeConstant
@@ -361,16 +362,25 @@ class TypeTranslator:
         return typeconsts.Int16(name=st.label)
 
     def _translate_SimTypeRef(self, st: sim_type.SimTypeRef) -> typeconsts.TypeConstant | typeconsts.BottomType:
-        # we really should not get SimTypeRef here, but if we do, we conduct a best-effort translation of SimTypeRef to
-        # a type constant.
-        l.error(
-            "TypeTranslator encountered an unexpected SimTypeRef. You probably forgot to call "
-            "dereference_simtype() to translate a SimTypeRef to a SimType!"
-        )
         type_key = self._simstruct_cppclass_to_memo_key(st)
         if type_key is not None and type_key in self.memo:
+            # a reference to a struct that is being translated (e.g., a self-referential field)
             return self.memo[type_key]
 
+        # resolve the reference against the loaded type collections
+        if st.name is not None:
+            for tc in type_collections_for_lib(None):
+                if st.name in tc:
+                    real_type = tc.get(st.name)
+                    if self.arch is not None:
+                        real_type = real_type.with_arch(self.arch)
+                    return self._simtype2tc(real_type)
+
+        l.error(
+            "TypeTranslator encountered an unresolvable SimTypeRef %s. Make sure the type library that defines it is "
+            "loaded.",
+            st.name,
+        )
         if st.original_type is sim_type.SimStruct:
             obj = typeconsts.Struct(fields={}, name=st.name)
             if type_key is not None:

--- a/angr/angrdb/db.py
+++ b/angr/angrdb/db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
@@ -11,7 +12,8 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
 from angr.errors import AngrCorruptDBError, AngrDBError, AngrIncompatibleDBError
-from angr.procedures import SIM_PROCEDURES
+from angr.procedures import SIM_PROCEDURES, SIM_TYPE_COLLECTIONS
+from angr.procedures.definitions import load_type_collections
 from angr.project import Project
 
 from .models import Base, DbInformation
@@ -19,6 +21,9 @@ from .serializers import KnowledgeBaseSerializer, LoaderSerializer
 
 if TYPE_CHECKING:
     from angr.knowledge_base import KnowledgeBase
+
+
+l = logging.getLogger(__name__)
 
 
 class AngrDB:
@@ -84,6 +89,36 @@ class AngrDB:
         else:
             db_info = DbInformation(key=key, value=value)
             session.add(db_info)
+
+    @staticmethod
+    def loaded_type_collection_names() -> list[str]:
+        """
+        Primary names of all loaded type collections.
+        """
+        names: list[str] = []
+        seen: set[int] = set()
+        for tc in SIM_TYPE_COLLECTIONS.values():
+            if id(tc) in seen or not tc.names:
+                continue
+            seen.add(id(tc))
+            names.append(tc.names[0])
+        return sorted(names)
+
+    @staticmethod
+    def load_type_collections(names: list[str]) -> None:
+        """
+        Make sure the type collections `names` are loaded; warn about the ones that cannot be found.
+        """
+        missing = [name for name in names if name not in SIM_TYPE_COLLECTIONS]
+        if missing:
+            load_type_collections(only=set(missing))
+            missing = [name for name in missing if name not in SIM_TYPE_COLLECTIONS]
+        if missing:
+            l.warning(
+                "Type collections %s were loaded when this database was created but are not available now. Struct "
+                "references to types they define cannot be resolved.",
+                missing,
+            )
 
     @staticmethod
     def get_info(session, key):
@@ -198,6 +233,10 @@ class AngrDB:
             if jump_target_addrs:
                 self.save_info(session, "unresolvable_jump_target_addrs", json.dumps(jump_target_addrs))
 
+            # Save the names of loaded type collections. Named structs in prototypes are stored as references, which
+            # can only be resolved after loading if the same type collections are available.
+            self.save_info(session, "type_collections", json.dumps(self.loaded_type_collection_names()))
+
             # Update the information
             self.update_dbinfo(session, extra_info=extra_info)
 
@@ -217,6 +256,11 @@ class AngrDB:
                 raise AngrIncompatibleDBError(
                     "Version {} is incompatible with the current version of angr.".format(dbinfo.get("version", None))
                 )
+
+            # Load type collections that were available when the database was created
+            type_collections_str = self.get_info(session, "type_collections")
+            if type_collections_str:
+                self.load_type_collections(json.loads(type_collections_str))
 
             # Load the loader
             loader = LoaderSerializer.load(session)

--- a/angr/knowledge_plugins/functions/function.py
+++ b/angr/knowledge_plugins/functions/function.py
@@ -31,6 +31,7 @@ from angr.rust.utils.demangler import demangle
 from angr.serializable import Serializable
 from angr.sim_type import SimTypeFunction, parse_defns
 from angr.utils.library import get_cpp_function_name_and_metadata
+from angr.utils.types import dereference_simtype, find_type_refs, type_collections_for_lib
 from angr.utils.vex import block_branch_ins_addr
 
 from .function_parser import FunctionParser
@@ -144,6 +145,8 @@ class Function(Serializable):
         "_project",
         "_prototype",
         "_prototype_libname",
+        "_prototype_ref_warned",
+        "_prototype_resolved",
         "_prototype_source",
         "_ret_sites",
         "_retout_sites",
@@ -228,8 +231,11 @@ class Function(Serializable):
         self.sp_delta = 0
         # Calling convention
         self._calling_convention = calling_convention
-        # Function prototype
+        # Function prototype. Prototypes may contain SimTypeRefs (e.g., when loaded from a library definition or an
+        # angrdb); they are dereferenced lazily on the first read of .prototype.
         self._prototype = prototype
+        self._prototype_resolved = False
+        self._prototype_ref_warned = False
         self._prototype_libname = prototype_libname
         if prototype_source is None:
             self._prototype_source = (
@@ -406,7 +412,35 @@ class Function(Serializable):
 
     @property
     def prototype(self) -> SimTypeFunction | None:
+        if self._prototype is None or self._prototype_resolved:
+            return self._prototype
+        self._resolve_prototype()
         return self._prototype
+
+    def _resolve_prototype(self) -> None:
+        """
+        Dereference SimTypeRefs in the prototype using the loaded type collections. Unresolvable references are kept
+        and retried on the next read.
+        """
+        assert self._prototype is not None
+        refs = find_type_refs(self._prototype)
+        if refs:
+            proto = dereference_simtype(
+                self._prototype, type_collections_for_lib(self._prototype_libname), keep_missing=True
+            )
+            assert isinstance(proto, SimTypeFunction)
+            self._prototype = proto
+            refs = find_type_refs(proto)
+        if refs:
+            if not self._prototype_ref_warned:
+                self._prototype_ref_warned = True
+                l.warning(
+                    "Prototype of function %s references unknown types %s; load the type library that defines them.",
+                    self.name,
+                    sorted(refs),
+                )
+        else:
+            self._prototype_resolved = True
 
     @prototype.setter
     @dirty_func
@@ -433,6 +467,8 @@ class Function(Serializable):
                         arg_names.append(f"a{i}")
             proto.arg_names = tuple(arg_names)
         self._prototype = proto
+        self._prototype_resolved = False
+        self._prototype_ref_warned = False
 
     @property
     def prototype_libname(self):
@@ -443,11 +479,22 @@ class Function(Serializable):
         if self._prototype_libname == libname:
             return
         self._prototype_libname = libname
+        self._prototype_resolved = False
+        self._prototype_ref_warned = False
         self.mark_dirty()
 
     @property
     def is_prototype_guessed(self) -> bool:
         return self._prototype_source in {PrototypeSource.NONE, PrototypeSource.GUESSED, PrototypeSource.CCA_LOW}
+
+    @property
+    def is_prototype_groundtruth(self) -> bool:
+        """
+        True if the prototype comes from outside of the decompiler (SimProcedures, signatures, or the user) and may be
+        fed back into type inference as ground truth. Prototypes inferred by the decompiler itself are excluded so that
+        re-decompiling a function does not freeze its own earlier guess.
+        """
+        return self._prototype is not None and self._prototype_source > PrototypeSource.CCA_DECOMPILER
 
     @property
     def prototype_source(self) -> PrototypeSource:

--- a/angr/knowledge_plugins/functions/function_parser.py
+++ b/angr/knowledge_plugins/functions/function_parser.py
@@ -16,7 +16,7 @@ from angr.utils.enums_conv import (
     func_edge_type_from_pb,
     func_edge_type_to_pb,
 )
-from angr.utils.types import make_type_reference
+from angr.utils.types import make_type_reference, type_collections_for_lib
 
 l = logging.getLogger(name=__name__)
 
@@ -77,8 +77,10 @@ class FunctionParser:
         if function.prototype is None:
             obj.prototype = b""
         else:
-            # convert all named structs in the prototype to typerefs; they will be dereferenced when used
-            prototype_ref = make_type_reference(function.prototype)
+            # convert library-defined structs in the prototype to typerefs; Function.prototype dereferences them lazily
+            prototype_ref = make_type_reference(
+                function.prototype, type_collections=type_collections_for_lib(function.prototype_libname)
+            )
             obj.prototype = json.dumps(prototype_ref.to_json()).encode("utf-8")
         obj.prototype_libname = (function.prototype_libname or "").encode()
         obj.prototype_source = function.prototype_source.value

--- a/angr/knowledge_plugins/variables/variable_manager.py
+++ b/angr/knowledge_plugins/variables/variable_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections import defaultdict
 from collections.abc import Iterator
 from itertools import chain, count
@@ -39,7 +40,7 @@ from angr.sim_variable import (
 )
 from angr.utils.ail import is_phi_assignment
 from angr.utils.orderedset import OrderedSet
-from angr.utils.types import replace_pointer_pts_to, unpack_pointer
+from angr.utils.types import relink_typerefs, replace_pointer_pts_to, unpack_pointer
 
 from .spilling_vardict import USE_SPILLING_DVARS, SpillingVariableInternalDict
 from .variable_access import VariableAccess, VariableAccessSort
@@ -313,6 +314,21 @@ class VariableManagerInternal(Serializable):
             entry.manual = var in self.variables_with_manual_types
             type_entries.append(entry)
         cmsg.types.extend(type_entries)
+
+        # Named local types (self.types): the TypeRef targets, interned into the same pool
+        local_type_entries = []
+        for name in self.types.iter_own_keys():
+            type_json = json.dumps(self.types.get_own(name).type.to_json())
+            ref = type_ref_by_json.get(type_json)
+            if ref is None:
+                type_pool.append(type_json)
+                ref = len(type_pool)
+                type_ref_by_json[type_json] = ref
+            entry = variables_pb2.LocalType()  # type: ignore[reportAttributeAccessIssue]
+            entry.name = name
+            entry.type_ref = ref
+            local_type_entries.append(entry)
+        cmsg.local_types.extend(local_type_entries)
         cmsg.type_pool.extend(type_pool)
 
         # TODO: vvarid_to_varialbes & variable_to_vvarids
@@ -437,6 +453,24 @@ class VariableManagerInternal(Serializable):
         for ref, type_json in enumerate(cmsg.type_pool, start=1):
             var_type = SimType.from_json(json.loads(type_json))
             type_by_ref[ref] = var_type.with_arch(arch) if arch is not None else var_type
+
+        # Named local types come back as fresh TypeRefs owned by model.types; TypeRefs of the same name inside the
+        # decoded types are relinked to them so that the store stays the single owner of each named type.
+        typerefs: dict[str, TypeRef] = {}
+        if model.manager is not None:
+            for local_type_pb2 in cmsg.local_types:
+                ty = type_by_ref.get(local_type_pb2.type_ref)
+                if ty is None:
+                    continue
+                if isinstance(ty, TypeRef):
+                    ty = ty.type
+                typerefs[local_type_pb2.name] = TypeRef(local_type_pb2.name, ty)
+            for name, typeref in typerefs.items():
+                relink_typerefs(typeref.type, typerefs)
+                model.types[name] = typeref
+            for ref, ty in type_by_ref.items():
+                type_by_ref[ref] = relink_typerefs(ty, typerefs)
+
         for type_pb2 in cmsg.types:
             var = variable_by_ident.get(type_pb2.ident) or unified_variable_by_ident.get(type_pb2.ident)
             var_type = type_by_ref.get(type_pb2.type_ref)
@@ -464,6 +498,17 @@ class VariableManagerInternal(Serializable):
             region.add_variable(offset, var)
 
         model._variables_without_writes = set(model.get_variables_without_writes())
+
+        # restore the ident counters so that new variables never reuse the ident of a loaded one
+        prefix_to_sort = {"r": "register", "s": "stack", "arg": "argument", "g": "global", "c": "constant", "m": "phi"}
+        for var in chain(model._variables, model._phi_variables, model._unified_variables):
+            if var.ident is None:
+                continue
+            m = re.fullmatch(r"i([a-z]+)_(\d+)", var.ident)
+            if m is None or m.group(1) not in prefix_to_sort:
+                continue
+            sort = prefix_to_sort[m.group(1)]
+            model._variable_counters[sort] = max(model._variable_counters[sort], int(m.group(2)) + 1)
 
         return model
 

--- a/angr/protos/variables.proto
+++ b/angr/protos/variables.proto
@@ -85,6 +85,11 @@ message Phi2Var {
     string          var_ident = 2;
 }
 
+message LocalType {
+    string          name = 1;
+    uint32          type_ref = 2;  // index+1 into VariableManagerInternal.type_pool
+}
+
 
 message VariableManagerInternal {
     // Variables of each type
@@ -107,4 +112,6 @@ message VariableManagerInternal {
     repeated string type_pool = 14;
     // Phi variables
     repeated Phi2Var phi2var = 12;
+    // Named local types (VariableManagerInternal.types), e.g., structs recovered by type inference
+    repeated LocalType local_types = 15;
 }

--- a/angr/sim_type.py
+++ b/angr/sim_type.py
@@ -207,23 +207,61 @@ class SimType:
         return d
 
     @staticmethod
-    def from_json(d: dict[str, Any], type_collection: SimTypeCollection | None = None, memo: set[str] | None = None):
+    def from_json(
+        d: dict[str, Any],
+        type_collection: SimTypeCollection | None = None,
+        memo: set[str] | None = None,
+        decoded: dict[str, SimType] | None = None,
+    ):
         """
         Deserialize a type class from a JSON-compatible dictionary.
+
+        :param type_collection: Resolve type references against this collection.
+        :param memo:            Names of types that are being loaded from the type collection (recursion guard).
+        :param decoded:         Named structs decoded so far in this document. to_json() emits a reference for every
+                                repeated occurrence of a named struct, which is resolved here.
         """
         if memo is None:
             memo = set()
+        if decoded is None:
+            decoded = {}
 
         assert "_t" in d
         cls = IDENT_TO_CLS.get(d["_t"])  # pylint: disable=redefined-outer-name
         assert cls is not None, f"Unknown SimType class identifier {d['_t']}"
         if getattr(cls, "from_json", SimType.from_json) is not SimType.from_json:
             t = cls.from_json(d)
-            if isinstance(t, SimTypeRef) and type_collection is not None and t.name is not None and t.name not in memo:
-                # attempt to resolve the type ref
-                with contextlib.suppress(AngrMissingTypeError):
-                    return type_collection.get(t.name, memo=memo)
+            if isinstance(t, SimTypeRef) and t.name is not None:
+                if t.name in decoded:
+                    return decoded[t.name]
+                if type_collection is not None and t.name not in memo:
+                    # attempt to resolve the type ref
+                    with contextlib.suppress(AngrMissingTypeError):
+                        return type_collection.get(t.name, memo=memo)
             return t
+
+        def _decode(value):
+            if isinstance(value, dict):
+                if "_t" in value:
+                    return SimType.from_json(value, type_collection=type_collection, memo=memo, decoded=decoded)
+                return {
+                    k: (
+                        SimType.from_json(v, type_collection=type_collection, memo=memo, decoded=decoded)
+                        if isinstance(v, dict) and "_t" in v
+                        else v
+                    )
+                    for k, v in value.items()
+                }
+            if isinstance(value, list):
+                return [
+                    (
+                        SimType.from_json(v, type_collection=type_collection, memo=memo, decoded=decoded)
+                        if isinstance(v, dict) and "_t" in v
+                        else v
+                    )
+                    for v in value
+                ]
+            return value
 
         kwargs = {}
         if "name" in d:
@@ -233,28 +271,22 @@ class SimType:
             field_key = "disp" if field == "disposition" else field
             if field_key not in d:
                 continue
-            value = d[field_key]
-            if isinstance(value, dict):
-                if "_t" in value:
-                    value = SimType.from_json(value, type_collection=type_collection, memo=memo)
-                else:
-                    new_value = {}
-                    for k, v in value.items():
-                        if isinstance(v, dict) and "_t" in v:
-                            new_value[k] = SimType.from_json(v, type_collection=type_collection, memo=memo)
-                        else:
-                            new_value[k] = v
-                    value = new_value
-            elif isinstance(value, list):
-                new_value = []
-                for v in value:
-                    if isinstance(v, dict) and "_t" in v:
-                        new_value.append(SimType.from_json(v, type_collection=type_collection, memo=memo))
-                    else:
-                        new_value.append(v)
-                value = new_value
-            kwargs[field] = value
-        return cls(**kwargs)
+            kwargs[field] = d[field_key]
+
+        if cls is SimStruct and kwargs.get("name"):
+            # construct the struct before decoding its fields so that references back to it resolve to this object
+            fields_json = kwargs.pop("fields", {})
+            obj = SimStruct(OrderedDict(), **kwargs)
+            decoded[obj.name] = obj
+            obj.fields = OrderedDict(_decode(fields_json))
+            return obj
+
+        for field, value in kwargs.items():
+            kwargs[field] = _decode(value)
+        obj = cls(**kwargs)
+        if isinstance(obj, SimStruct) and obj.name:
+            decoded[obj.name] = obj
+        return obj
 
 
 class TypeRef(SimType):

--- a/angr/utils/types.py
+++ b/angr/utils/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from angr.errors import AngrMissingTypeError
@@ -78,8 +79,17 @@ def squash_array_reference(ty):
 
 
 def dereference_simtype(
-    t: SimType, type_collections: list[SimTypeCollection], memo: dict[str | int, SimType] | None = None
+    t: SimType,
+    type_collections: list[SimTypeCollection],
+    memo: dict[str | int, SimType] | None = None,
+    keep_missing: bool = False,
 ) -> SimType:
+    """
+    Replace every SimTypeRef inside `t` with the real type from `type_collections`.
+
+    :param keep_missing:    Leave a SimTypeRef in place when no collection defines it, instead of raising
+                            AngrMissingTypeError.
+    """
     if memo is None:
         memo = {}
 
@@ -97,10 +107,12 @@ def dereference_simtype(
                 except AngrMissingTypeError:
                     continue
         if real_type is None:
+            if keep_missing:
+                return t
             raise AngrMissingTypeError(t.name)
         if t._arch is not None:
             real_type = real_type.with_arch(t._arch)
-        return dereference_simtype(real_type, type_collections, memo=memo)
+        return dereference_simtype(real_type, type_collections, memo=memo, keep_missing=keep_missing)
 
     # the following code prepares a real_type SimType object that will be returned at the end of this method
     if isinstance(t, SimStruct):
@@ -109,25 +121,33 @@ def dereference_simtype(
 
         real_type = t.copy()
         memo[t.name if not t.anonymous else id(t)] = real_type
-        fields = OrderedDict((k, dereference_simtype(v, type_collections, memo=memo)) for k, v in t.fields.items())
+        fields = OrderedDict(
+            (k, dereference_simtype(v, type_collections, memo=memo, keep_missing=keep_missing))
+            for k, v in t.fields.items()
+        )
         real_type.fields = fields
     elif isinstance(t, SimTypePointer):
-        real_pts_to = dereference_simtype(t.pts_to, type_collections, memo=memo)
+        real_pts_to = dereference_simtype(t.pts_to, type_collections, memo=memo, keep_missing=keep_missing)
         real_type = t.copy()
         real_type.pts_to = real_pts_to
     elif isinstance(t, SimTypeArray):
-        real_elem_type = dereference_simtype(t.elem_type, type_collections, memo=memo)
+        real_elem_type = dereference_simtype(t.elem_type, type_collections, memo=memo, keep_missing=keep_missing)
         real_type = t.copy()
         real_type.elem_type = real_elem_type
     elif isinstance(t, SimUnion):
         memo[t.name] = t
-        real_members = {k: dereference_simtype(v, type_collections, memo=memo) for k, v in t.members.items()}
+        real_members = {
+            k: dereference_simtype(v, type_collections, memo=memo, keep_missing=keep_missing)
+            for k, v in t.members.items()
+        }
         real_type = t.copy()
         real_type.members = real_members
     elif isinstance(t, SimTypeFunction):
-        real_args = [dereference_simtype(arg, type_collections, memo=memo) for arg in t.args]
+        real_args = [dereference_simtype(arg, type_collections, memo=memo, keep_missing=keep_missing) for arg in t.args]
         real_return_type = (
-            dereference_simtype(t.returnty, type_collections, memo=memo) if t.returnty is not None else None
+            dereference_simtype(t.returnty, type_collections, memo=memo, keep_missing=keep_missing)
+            if t.returnty is not None
+            else None
         )
         real_type = t.copy()
         real_type.args = tuple(real_args)
@@ -138,6 +158,26 @@ def dereference_simtype(
     if t._arch is not None:
         real_type = real_type.with_arch(t._arch)
     return real_type
+
+
+def type_collections_for_lib(libname: str | None) -> list[SimTypeCollection]:
+    """
+    The type collections that prototypes of library `libname` refer to. Falls back to every loaded type collection
+    when the library is unknown or declares no type collections.
+    """
+    type_collections: list[SimTypeCollection] = []
+    if libname is not None and libname in SIM_LIBRARIES:
+        for prototype_lib in SIM_LIBRARIES[libname]:
+            for typelib_name in prototype_lib.type_collection_names:
+                if typelib_name in SIM_TYPE_COLLECTIONS:
+                    type_collections.append(SIM_TYPE_COLLECTIONS[typelib_name])
+    if not type_collections:
+        seen: set[int] = set()
+        for tc in SIM_TYPE_COLLECTIONS.values():
+            if id(tc) not in seen:
+                seen.add(id(tc))
+                type_collections.append(tc)
+    return type_collections
 
 
 def dereference_simtype_by_lib(t: SimType, libname: str) -> SimType:
@@ -154,37 +194,112 @@ def dereference_simtype_by_lib(t: SimType, libname: str) -> SimType:
     return t
 
 
-def make_type_reference(t: SimType, memo: dict[str, SimTypeRef] | None = None) -> SimType:
+def relink_typerefs(t: SimType, typerefs: dict[str, TypeRef], _seen: dict[int, SimType] | None = None) -> SimType:
     """
-    Take a SimType and convert all SimStruct instances to SimTypeRefs.
+    Replace every TypeRef inside `t` whose name is in `typerefs` with the TypeRef object from `typerefs`, so that
+    deserialized types share the TypeRef objects owned by a TypesStore again. The TypeRef targets themselves are not
+    descended into; `t` is updated in place.
+    """
+    if _seen is None:
+        _seen = {}
+    if id(t) in _seen:
+        return _seen[id(t)]
+    _seen[id(t)] = t
 
-    :param t:   The SimType instance to convert.
-    :return:    A converted SimType instance.
+    if isinstance(t, TypeRef):
+        if t.name in typerefs:
+            _seen[id(t)] = typerefs[t.name]
+            return typerefs[t.name]
+        return t
+    if isinstance(t, SimStruct):
+        t.fields = OrderedDict((k, relink_typerefs(v, typerefs, _seen)) for k, v in t.fields.items())
+    elif isinstance(t, SimUnion):
+        t.members = {k: relink_typerefs(v, typerefs, _seen) for k, v in t.members.items()}
+    elif isinstance(t, SimTypePointer):
+        t.pts_to = relink_typerefs(t.pts_to, typerefs, _seen)
+    elif isinstance(t, SimTypeArray):
+        t.elem_type = relink_typerefs(t.elem_type, typerefs, _seen)
+    elif isinstance(t, SimTypeFunction):
+        t.args = tuple(relink_typerefs(arg, typerefs, _seen) for arg in t.args)
+        if t.returnty is not None:
+            t.returnty = relink_typerefs(t.returnty, typerefs, _seen)
+    return t
+
+
+def find_type_refs(t: SimType, _seen: set[int] | None = None) -> set[str]:
+    """
+    Collect the names of all SimTypeRef nodes reachable from `t`.
+    """
+    if _seen is None:
+        _seen = set()
+    if id(t) in _seen:
+        return set()
+    _seen.add(id(t))
+
+    if isinstance(t, SimTypeRef):
+        return {t.name} if t.name is not None else {""}
+    if isinstance(t, SimStruct):
+        subtypes: Iterable[SimType] = t.fields.values()
+    elif isinstance(t, SimUnion):
+        subtypes = t.members.values()
+    elif isinstance(t, SimTypePointer):
+        subtypes = (t.pts_to,)
+    elif isinstance(t, SimTypeArray):
+        subtypes = (t.elem_type,)
+    elif isinstance(t, SimTypeFunction):
+        subtypes = (*t.args, t.returnty) if t.returnty is not None else t.args
+    else:
+        return set()
+
+    refs: set[str] = set()
+    for sub in subtypes:
+        refs |= find_type_refs(sub, _seen)
+    return refs
+
+
+def make_type_reference(
+    t: SimType,
+    memo: dict[str, SimTypeRef] | None = None,
+    type_collections: list[SimTypeCollection] | None = None,
+) -> SimType:
+    """
+    Take a SimType and convert named SimStruct instances to SimTypeRefs.
+
+    :param t:                   The SimType instance to convert.
+    :param type_collections:    Only structs defined in one of these collections are converted, so that the references
+                                can be resolved later. None converts every named struct.
+    :return:                    A converted SimType instance.
     """
 
     if memo is None:
         memo = {}
 
-    if type(t) is SimStruct and t.name:
+    if type(t) is SimStruct and t.name and (type_collections is None or any(t.name in tc for tc in type_collections)):
         if t.name in memo:
             ref_t = memo[t.name]
         else:
             ref_t = SimTypeRef(t.name, SimStruct)
             memo[t.name] = ref_t
     elif isinstance(t, SimTypePointer):
-        ref_pts_to = make_type_reference(t.pts_to, memo=memo)
+        ref_pts_to = make_type_reference(t.pts_to, memo=memo, type_collections=type_collections)
         ref_t = t.copy()
         ref_t.pts_to = ref_pts_to
     elif isinstance(t, SimTypeArray):
-        ref_elem_type = make_type_reference(t.elem_type, memo=memo)
+        ref_elem_type = make_type_reference(t.elem_type, memo=memo, type_collections=type_collections)
         ref_t = t.copy()
         ref_t.elem_type = ref_elem_type
     elif isinstance(t, SimUnion):
-        ref_members = {k: make_type_reference(v, memo=memo) for k, v in t.members.items()}
+        ref_members = {
+            k: make_type_reference(v, memo=memo, type_collections=type_collections) for k, v in t.members.items()
+        }
         ref_t = SimUnion(ref_members, label=t.label)
     elif isinstance(t, SimTypeFunction):
-        ref_args = [make_type_reference(arg, memo=memo) for arg in t.args]
-        ref_return_type = make_type_reference(t.returnty, memo=memo) if t.returnty is not None else None
+        ref_args = [make_type_reference(arg, memo=memo, type_collections=type_collections) for arg in t.args]
+        ref_return_type = (
+            make_type_reference(t.returnty, memo=memo, type_collections=type_collections)
+            if t.returnty is not None
+            else None
+        )
         ref_t = t.copy()
         ref_t.args = tuple(ref_args)
         ref_t.returnty = ref_return_type

--- a/tests/serialization/test_db.py
+++ b/tests/serialization/test_db.py
@@ -21,6 +21,9 @@ from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGener
 from angr.analyses.decompiler.structured_codegen.c import CConstant
 from angr.angrdb import AngrDB
 from angr.knowledge_plugins.structured_code import SpillingDecompilationDict
+from angr.procedures.definitions import SIM_TYPE_COLLECTIONS, SimTypeCollection
+from angr.sim_type import SimStruct, SimTypePointer
+from angr.utils.types import find_type_refs
 from tests.common import bin_location, print_decompilation_result
 
 test_location = os.path.join(bin_location, "tests")
@@ -981,6 +984,66 @@ class TestDb(unittest.TestCase):
 
         assert set(restored_kbs) == {"other"}
         assert set(restored_kbs["other"].functions) == set(other.functions)
+
+    def test_angrdb_decompiled_prototypes_roundtrip(self):
+        # Regression test for GitHub issue #7156: named structs in function prototypes are stored as SimTypeRefs, and
+        # after loading they were never dereferenced, so re-decompiling on the reloaded project lost struct field
+        # accesses (e.g., idx->DriverStartIo degraded to idx->MajorFunction[0]).
+        bin_path = os.path.join(test_location, "x86_64", "windows", "cancel.sys")
+        func_addr = 0x140001020
+
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        cfg = proj.analyses.CFGFast(normalize=True)
+        dec = proj.analyses.Decompiler(func_addr, cfg=cfg.model, use_cache=False)
+        assert dec.codegen is not None
+        text = dec.codegen.text
+        assert "DriverStartIo" in text
+        assert "->MajorFunction[" not in text
+
+        with tempfile.TemporaryDirectory() as td:
+            new_proj = self._roundtrip_angrdb(proj, os.path.join(td, "cancel.adb"))
+
+        # every prototype is dereferenced lazily on first read
+        for func in new_proj.kb.functions.values():
+            if func.prototype is not None:
+                assert not find_type_refs(func.prototype), f"{func.name}: {func.prototype!r}"
+        callee = new_proj.kb.functions["IoAcquireRemoveLockEx"]
+        assert callee.prototype_libname is not None
+        assert callee.prototype is not None
+        arg0 = callee.prototype.args[0]
+        assert isinstance(arg0, SimTypePointer)
+        assert isinstance(arg0.pts_to, SimStruct)
+        assert arg0.pts_to.name == "IO_REMOVE_LOCK"
+
+        # the cached decompilation and a fresh decompilation on the reloaded project both match the original
+        cached = new_proj.kb.decompilations[(func_addr, "pseudocode")]
+        assert cached.codegen is not None
+        assert cached.codegen.text == text
+
+        with self.assertNoLogs("angr.analyses.typehoon.translator", level="ERROR"):
+            new_dec = new_proj.analyses.Decompiler(func_addr, cfg=new_proj.kb.cfgs.get_most_accurate(), use_cache=False)
+        assert new_dec.codegen is not None
+        assert new_dec.codegen.text == text
+
+    def test_angrdb_type_collections_roundtrip(self):
+        # the names of loaded type collections are stored in the database; a missing collection is reported on load
+        bin_path = os.path.join(test_location, "x86_64", "fauxware")
+        proj = angr.Project(bin_path, auto_load_libs=False)
+        proj.analyses.CFGFast()
+
+        dummy = SimTypeCollection()
+        dummy.set_names("angrdb_test_dummy_typelib")
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                db_file = os.path.join(td, "fauxware.adb")
+                AngrDB(proj, nullpool=True).dump(db_file)
+                del SIM_TYPE_COLLECTIONS["angrdb_test_dummy_typelib"]
+                with self.assertLogs("angr.angrdb.db", level="WARNING") as cm:
+                    new_proj = AngrDB(nullpool=True).load(db_file)
+            assert any("angrdb_test_dummy_typelib" in msg for msg in cm.output)
+            assert len(new_proj.kb.functions) == len(proj.kb.functions)
+        finally:
+            SIM_TYPE_COLLECTIONS.pop("angrdb_test_dummy_typelib", None)
 
 
 if __name__ == "__main__":

--- a/tests/types/test_types.py
+++ b/tests/types/test_types.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-class-docstring,no-self-use,line-too-long
 from __future__ import annotations
 
+import json
 import unittest
 from typing import cast
 
@@ -468,6 +469,26 @@ class TestTypes(unittest.TestCase):
         new_t = SimType.from_json(d)
         deref_new_t = dereference_simtype(new_t, [angr.SIM_TYPE_COLLECTIONS["win32"]])
         assert deref_t == deref_new_t
+
+    def test_from_json_resolves_repeated_and_recursive_structs(self):
+        # to_json() emits a reference for every repeated occurrence of a named struct; from_json() must resolve those
+        # references (including references back to a struct that is still being decoded) to the same object
+        s0 = SimStruct({"a": SimTypeInt()}, name="struct_0")
+        s0.fields["self"] = SimTypePointer(s0)
+        s1 = SimStruct({"p": SimTypePointer(s0)}, name="struct_1")
+        s0.fields["other"] = SimTypePointer(s1)
+        proto = SimTypeFunction([SimTypePointer(s0), SimTypePointer(s1)], SimTypePointer(s0))
+
+        back = SimType.from_json(json.loads(json.dumps(proto.to_json())))
+        assert isinstance(back, SimTypeFunction)
+        b0 = cast(SimTypePointer, back.args[0]).pts_to
+        b1 = cast(SimTypePointer, back.args[1]).pts_to
+        assert isinstance(b0, SimStruct) and isinstance(b1, SimStruct)
+        assert cast(SimTypePointer, b0.fields["self"]).pts_to is b0
+        assert cast(SimTypePointer, b0.fields["other"]).pts_to is b1
+        assert cast(SimTypePointer, b1.fields["p"]).pts_to is b0
+        assert cast(SimTypePointer, back.returnty).pts_to is b0
+        assert back == proto
 
     def test_simstruct_cmp_recursion_error(self):
         t0 = SimStruct(fields={"a": SimTypeBottom()})


### PR DESCRIPTION
When storing function prototypes in angrdb, named `SimStructs` are converted to `SimTypeRefs`, but they are not dereferenced after loading the angrdb. As a result, re-decompiling functions after loading angrdb loses struct fields in decompilation.

This PR makes the following changes:

- Function.prototype dereferences SimTypeRefs lazily on first read; unresolvable references are kept and warned about.
- AngrDB stores the names of loaded type collections, reloads them on load, and warns about collections that are no longer available.
- make_type_reference only converts structs that a loaded type collection defines; decompiler-inferred structs (even if they are named by users afterwards) are serialized in full.
- TypeTranslator resolves stray SimTypeRefs against loaded collections before reporting them.
- VariableManagerInternal persists its named local types (TypesStore) and its ident counters, so reloaded functions keep their struct names and never reuse the ident of a loaded variable.
- Decompiler-inferred prototypes (CCA_DECOMPILER) are no longer fed back into type inference as ground truth. This behavior froze a function's own earlier guess on re-decompilation.